### PR TITLE
Stop annotating IssueObject. Test User JSON serialization format.

### DIFF
--- a/api/src/org/labkey/api/issues/Issue.java
+++ b/api/src/org/labkey/api/issues/Issue.java
@@ -261,6 +261,7 @@ public interface Issue
             private String _related;
 
             // for ObjectFactory
+            @SuppressWarnings("unused")
             public IssueImpl()
             {
             }

--- a/api/src/org/labkey/api/reader/JSONDataLoader.java
+++ b/api/src/org/labkey/api/reader/JSONDataLoader.java
@@ -301,7 +301,7 @@ public class JSONDataLoader extends DataLoader
         }
 
         if (!(_parser.getCurrentToken() == JsonToken.START_ARRAY && _parser.getCurrentName().equals("rows")))
-            throw new JsonParseException("Expected 'rows' field", _parser.getTokenLocation());
+            throw new JsonParseException(_parser, "Expected 'rows' field", _parser.getTokenLocation());
     }
 
     /**
@@ -346,7 +346,7 @@ public class JSONDataLoader extends DataLoader
         JsonLocation loc = expectArrayStart(parser);
 
         if (isArrayEnd(parser))
-            throw new JsonParseException("Expected array of fields, got empty array", loc);
+            throw new JsonParseException(parser, "Expected array of fields, got empty array", loc);
 
         List<ColumnDescriptor> cols = new ArrayList<>();
 
@@ -408,7 +408,7 @@ public class JSONDataLoader extends DataLoader
             {
                 fieldKey = parser.readValueAs(FieldKey.class);
                 if (fieldKey == null)
-                    throw new JsonParseException("Failed to parse " + fieldName + " property", loc);
+                    throw new JsonParseException(parser, "Failed to parse " + fieldName + " property", loc);
 
                 parser.nextToken();
             }
@@ -416,7 +416,7 @@ public class JSONDataLoader extends DataLoader
             {
                 type = parser.getValueAsString();
                 if (type == null)
-                    throw new JsonParseException("Failed to parse type property", loc);
+                    throw new JsonParseException(parser, "Failed to parse type property", loc);
 
                 parser.nextToken();
             }

--- a/api/src/org/labkey/api/util/JsonUtil.java
+++ b/api/src/org/labkey/api/util/JsonUtil.java
@@ -32,6 +32,7 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.data.Container;
+import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
@@ -71,7 +72,7 @@ public class JsonUtil
     public static JsonLocation expectObjectStart(JsonParser p) throws IOException
     {
         if (p.getCurrentToken() != JsonToken.START_OBJECT)
-            throw new JsonParseException("Expected object start '{', got '" + p.getCurrentToken() + "'", p.getTokenLocation());
+            throw new JsonParseException(p, "Expected object start '{', got '" + p.getCurrentToken() + "'", p.getTokenLocation());
 
         JsonLocation loc = p.getTokenLocation();
         p.nextToken();
@@ -81,7 +82,7 @@ public class JsonUtil
     public static void expectObjectEnd(JsonParser p) throws IOException
     {
         if (p.getCurrentToken() != JsonToken.END_OBJECT)
-            throw new JsonParseException("Expected object end '}', got '" + p.getCurrentToken() + "'", p.getTokenLocation());
+            throw new JsonParseException(p, "Expected object end '}', got '" + p.getCurrentToken() + "'", p.getTokenLocation());
 
         p.nextToken();
     }
@@ -89,7 +90,7 @@ public class JsonUtil
     public static JsonLocation expectArrayStart(JsonParser p) throws IOException
     {
         if (p.getCurrentToken() != JsonToken.START_ARRAY)
-            throw new JsonParseException("Expected array start '[', got '" + p.getCurrentToken() + "'", p.getTokenLocation());
+            throw new JsonParseException(p, "Expected array start '[', got '" + p.getCurrentToken() + "'", p.getTokenLocation());
 
         JsonLocation loc = p.getTokenLocation();
         p.nextToken();
@@ -99,7 +100,7 @@ public class JsonUtil
     public static void expectArrayEnd(JsonParser p) throws IOException
     {
         if (!isArrayEnd(p))
-            throw new JsonParseException("Expected array end ']', got '" + p.getCurrentToken() + "'", p.getTokenLocation());
+            throw new JsonParseException(p, "Expected array end ']', got '" + p.getCurrentToken() + "'", p.getTokenLocation());
 
         p.nextToken();
     }
@@ -126,7 +127,7 @@ public class JsonUtil
         }
 
         if (!n.isValueNode())
-            throw new JsonParseException("Expected value node", null);
+            throw new JsonParseException("Expected value node");
 
         if (n.isNull())
             return null;
@@ -140,7 +141,7 @@ public class JsonUtil
         if (n.isTextual())
             return n.textValue();
 
-        throw new JsonParseException("Unexpected value type: " + n.getNodeType(), null);
+        throw new JsonParseException("Unexpected value type: " + n.getNodeType());
     }
 
     public static String[] getStringArray(JSONObject json, String propName)
@@ -408,6 +409,8 @@ public class JsonUtil
             json.put("actionUrl", url);
             HtmlString html = HtmlString.unsafe("<html><table><td>Hello</td></table>");
             json.put("htmlString", html);
+            User u = TestContext.get().getUser();
+            json.put("user", u);
 
             // Round trip to ensure all these JSONString implementations produce valid JSON
             JSONObject roundTripJson = new JSONObject(json.toString());
@@ -417,6 +420,7 @@ public class JsonUtil
             assertEquals(guid.toString(), roundTripJson.get("guid"));
             assertEquals(url.toString(), roundTripJson.get("actionUrl"));
             assertEquals(html.toString(), roundTripJson.get("htmlString"));
+            assertEquals(u.getUserId(), roundTripJson.get("user"));
         }
     }
 }

--- a/issues/src/org/labkey/issue/model/IssueObject.java
+++ b/issues/src/org/labkey/issue/model/IssueObject.java
@@ -18,14 +18,12 @@ package org.labkey.issue.model;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONPropertyIgnore;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.Entity;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.Sort;
-import org.labkey.api.data.Transient;
 import org.labkey.api.issues.Issue;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
@@ -406,14 +404,12 @@ public class IssueObject extends Entity implements Serializable, Cloneable, Issu
         _properties.put("closed", closed);
     }
 
-    @JSONPropertyIgnore
     @Override
     public Collection<Comment> getComments()
     {
         return new ArrayList<>(getCommentObjects());
     }
 
-    @JSONPropertyIgnore
     public Collection<CommentObject> getCommentObjects()
     {
         List<CommentObject> result = new ArrayList<>(_comments);
@@ -425,7 +421,6 @@ public class IssueObject extends Entity implements Serializable, Cloneable, Issu
         return new ArrayList<>(result);
     }
 
-    @JSONPropertyIgnore
     public CommentObject getLastComment()
     {
         if (null == _comments || _comments.isEmpty())
@@ -508,7 +503,6 @@ public class IssueObject extends Entity implements Serializable, Cloneable, Issu
         return _issueDefName;
     }
 
-    @JSONPropertyIgnore
     public Container getContainerFromId()
     {
         return ContainerManager.getForId(getContainerId());
@@ -550,8 +544,6 @@ public class IssueObject extends Entity implements Serializable, Cloneable, Issu
         return getNotifyListEmail(getNotifyList(), null);
     }
 
-    @Transient
-    @JSONPropertyIgnore
     @Override
     public List<Pair<User, ValidEmail>> getNotifyListUserEmail()
     {
@@ -613,6 +605,7 @@ public class IssueObject extends Entity implements Serializable, Cloneable, Issu
         return ret;
     }
 
+    @Override
     public Map<String, Object> getProperties()
     {
         return _properties;

--- a/issues/src/org/labkey/issue/model/IssueObject.java
+++ b/issues/src/org/labkey/issue/model/IssueObject.java
@@ -18,6 +18,7 @@ package org.labkey.issue.model;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONPropertyIgnore;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -404,12 +405,14 @@ public class IssueObject extends Entity implements Serializable, Cloneable, Issu
         _properties.put("closed", closed);
     }
 
+    @JSONPropertyIgnore
     @Override
     public Collection<Comment> getComments()
     {
         return new ArrayList<>(getCommentObjects());
     }
 
+    @JSONPropertyIgnore
     public Collection<CommentObject> getCommentObjects()
     {
         List<CommentObject> result = new ArrayList<>(_comments);
@@ -421,6 +424,7 @@ public class IssueObject extends Entity implements Serializable, Cloneable, Issu
         return new ArrayList<>(result);
     }
 
+    @JSONPropertyIgnore
     public CommentObject getLastComment()
     {
         if (null == _comments || _comments.isEmpty())
@@ -503,6 +507,7 @@ public class IssueObject extends Entity implements Serializable, Cloneable, Issu
         return _issueDefName;
     }
 
+    @JSONPropertyIgnore
     public Container getContainerFromId()
     {
         return ContainerManager.getForId(getContainerId());
@@ -544,6 +549,7 @@ public class IssueObject extends Entity implements Serializable, Cloneable, Issu
         return getNotifyListEmail(getNotifyList(), null);
     }
 
+    @JSONPropertyIgnore
     @Override
     public List<Pair<User, ValidEmail>> getNotifyListUserEmail()
     {


### PR DESCRIPTION
#### Rationale
We no longer serialize `IssueObject` into upgrade forms, so remove `BeanUtils` serialization annotations

Add a test for expected JSON serialization of `User`

Clean up deprecation warnings for `JsonParseException` constructors 
