### PR TITLE
Fix folder import for sample status values

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -1859,7 +1859,7 @@ public class ExpDataIterators
                  }
                 else
                 {
-                    String lsid = (String) get(_lsidCol);
+                    String lsid = _lsidCol == null ? null : (String) get(_lsidCol);
                     if (null != lsid)
                         _lsids.add(lsid);
                 }

--- a/experiment/src/org/labkey/experiment/samples/SampleStatusFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleStatusFolderImporter.java
@@ -7,7 +7,9 @@ import org.labkey.api.admin.FolderImporter;
 import org.labkey.api.admin.FolderImporterFactory;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.exp.XarContext;
+import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.util.FileUtil;
@@ -16,7 +18,9 @@ import org.labkey.experiment.XarReader;
 
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.DEFAULT_DIRECTORY;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_TYPES_NAME;
@@ -81,9 +85,12 @@ public class SampleStatusFolderImporter extends SampleTypeAndDataClassFolderImpo
                 {
                     XarReader typesReader = getXarReader(job, ctx, root, typesXarFile);
                     XarContext xarContext = typesReader.getXarSource().getXarContext();
+                    List<String> sampleTypeNames = typesReader.getSampleTypeNames();
+                    List<ExpSampleType> sampleTypes = SampleTypeService.get().getSampleTypes(ctx.getContainer(), ctx.getUser(), false)
+                            .stream().filter(sampleType -> sampleTypeNames.contains(sampleType.getName())).collect(Collectors.toList());
 
                     // process any sample status data files
-                    importTsvData(ctx, xarContext, SamplesSchema.SCHEMA_NAME, typesReader.getSampleTypes(), sampleStatusDataFiles, xarDir, false, true);
+                    importTsvData(ctx, xarContext, SamplesSchema.SCHEMA_NAME, sampleTypes, sampleStatusDataFiles, xarDir, false, true);
                 }
                 else
                     log.info("No sample types XAR file to process.");

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -313,7 +313,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                                     options.put(SampleTypeService.ConfigParameters.DeferAliquotRuns, true);
                                     if (isUpdate)
                                         options.put(QueryUpdateService.ConfigParameters.SkipRequiredFieldValidation, true);
-                                    options.put(ExperimentService.QueryOptions.UseLsidForUpdate, true);
+                                    options.put(ExperimentService.QueryOptions.UseLsidForUpdate, !isUpdate);
                                     context.setConfigParameters(options);
 
                                     Map<String, Object> extraContext = null;


### PR DESCRIPTION
#### Rationale
Recent changes to fix folder import treatment of LSIDs introduced problems with importing sample status values since the sample status export files do not contain LSIDs, only names and because we now need actual sample type objects to pass to  the importer, not just the names.

#### Related Pull Requests
#4463

#### Changes
* Update logic for importing sample statuses during folder import
