### PR TITLE
48037: Change Audit Detail Level behavior for dataset events

### DIFF
--- a/study/src/org/labkey/study/StudyServiceImpl.java
+++ b/study/src/org/labkey/study/StudyServiceImpl.java
@@ -81,13 +81,11 @@ import org.labkey.api.view.DataView;
 import org.labkey.study.assay.StudyPublishManager;
 import org.labkey.study.audit.StudyAuditProvider;
 import org.labkey.study.controllers.StudyController;
-import org.labkey.study.dataset.DatasetAuditProvider;
 import org.labkey.study.model.DatasetDefinition;
 import org.labkey.study.model.QCStateSet;
 import org.labkey.study.model.SecurityType;
 import org.labkey.study.model.StudyImpl;
 import org.labkey.study.model.StudyManager;
-import org.labkey.study.model.UploadLog;
 import org.labkey.study.model.VisitImpl;
 import org.labkey.study.query.AdditiveTypeTable;
 import org.labkey.study.query.BaseStudyTable;
@@ -281,21 +279,6 @@ public class StudyServiceImpl implements StudyService
         AuditTypeEvent event = new AuditTypeEvent(StudyAuditProvider.STUDY_AUDIT_EVENT, container, comment);
         AuditLogService.get().addEvent(user, event);
     }
-
-    public static void addDatasetAuditEvent(User u, Container c, Dataset def, String comment, UploadLog ul /*optional*/)
-    {
-        DatasetAuditProvider.DatasetAuditEvent event = new DatasetAuditProvider.DatasetAuditEvent(c.getId(), comment);
-
-        if (c.getProject() != null)
-            event.setProjectId(c.getProject().getId());
-        event.setDatasetId(def.getDatasetId());
-        if (ul != null)
-        {
-            event.setLsid(ul.getFilePath());
-        }
-        AuditLogService.get().addEvent(u,event);
-    }
-
 
     @Override
     public void applyDefaultQCStateFilter(DataView view)

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -29,7 +29,25 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
-import org.labkey.api.action.*;
+import org.labkey.api.action.ApiJsonForm;
+import org.labkey.api.action.ApiResponse;
+import org.labkey.api.action.ApiSimpleResponse;
+import org.labkey.api.action.ConfirmAction;
+import org.labkey.api.action.FormApiAction;
+import org.labkey.api.action.FormHandlerAction;
+import org.labkey.api.action.FormViewAction;
+import org.labkey.api.action.HasAllowBindParameter;
+import org.labkey.api.action.HasViewContext;
+import org.labkey.api.action.Marshal;
+import org.labkey.api.action.Marshaller;
+import org.labkey.api.action.MutatingApiAction;
+import org.labkey.api.action.QueryViewAction;
+import org.labkey.api.action.ReadOnlyApiAction;
+import org.labkey.api.action.ReturnUrlForm;
+import org.labkey.api.action.SimpleErrorView;
+import org.labkey.api.action.SimpleRedirectAction;
+import org.labkey.api.action.SimpleViewAction;
+import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.admin.notification.NotificationService;
 import org.labkey.api.announcements.DiscussionService;
@@ -166,7 +184,6 @@ import org.labkey.study.CohortFilterFactory;
 import org.labkey.study.MasterPatientIndexMaintenanceTask;
 import org.labkey.study.StudyModule;
 import org.labkey.study.StudySchema;
-import org.labkey.study.StudyServiceImpl;
 import org.labkey.study.assay.AssayPublishConfirmAction;
 import org.labkey.study.assay.AssayPublishStartAction;
 import org.labkey.study.assay.StudyPublishManager;
@@ -2510,10 +2527,12 @@ public class StudyController extends BaseStudyController
 
             if (!result.getKey().isEmpty())
             {
-                // Log the import
+                // Log the import when SUMMARY is configured, if DETAILED is configured the DetailedAuditLogDataIterator will handle each row change.
+                // It would be nice in the future to replace the DetailedAuditLogDataIterator with a general purpose AuditLogDataIterator
+                // that can delegate the audit behavior type to the AuditDataHandler, so this code can go away
+                //
                 String comment = "Dataset data imported. " + result.getKey().size() + " rows imported";
-                StudyServiceImpl.addDatasetAuditEvent(
-                        getUser(), getContainer(), _def, comment, result.getValue());
+                new DatasetDefinition.DatasetAuditHandler(_def).addAuditEvent(getUser(), getContainer(), AuditBehaviorType.SUMMARY, comment, result.getValue());
             }
 
             return result.getKey().size();

--- a/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
@@ -38,6 +38,7 @@ import org.labkey.api.data.TSVGridWriter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.query.CustomView;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryDefinition;
@@ -506,7 +507,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
                                     StudyManager.getInstance().getVisitManager(study).updateParticipantVisits(form.getViewContext().getUser(), Collections.singleton(dsDef));
 
                                 ViewContext context = form.getViewContext();
-                                StudyServiceImpl.addDatasetAuditEvent(context.getUser(), context.getContainer(), dsDef,
+                                new DatasetDefinition.DatasetAuditHandler(dsDef).addAuditEvent(context.getUser(), context.getContainer(), AuditBehaviorType.DETAILED,
                                         "Dataset snapshot was updated. " + numRowsDeleted + " rows were removed and replaced with " + newRows.size() + " rows.", null);
 
                                 def.setLastUpdated(new Date());
@@ -523,7 +524,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
                 catch (SQLException | IOException e)
                 {
                     ViewContext context = form.getViewContext();
-                    StudyServiceImpl.addDatasetAuditEvent(context.getUser(), context.getContainer(), dsDef,
+                    new DatasetDefinition.DatasetAuditHandler(dsDef).addAuditEvent(context.getUser(), context.getContainer(), AuditBehaviorType.DETAILED,
                             "Dataset snapshot was not updated. Cause of failure: " + e.getMessage(), null);
                 }
             }

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1790,7 +1790,8 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
          * @param requiredAuditType The expected audit behavior type. If this does not match the type set on the
          *                          dataset, then the event will not be logged.
          */
-        public void addAuditEvent(User user, Container c, AuditBehaviorType requiredAuditType, String comment, UploadLog ul /*optional*/)
+        public void addAuditEvent(User user, Container c, AuditBehaviorType requiredAuditType, String comment, @Nullable UploadLog ul)
+
         {
             TableInfo table = _dataset.getTableInfo(user);
             if (table.getAuditBehavior((AuditBehaviorType)null) != requiredAuditType)

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1794,7 +1794,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
 
         {
             TableInfo table = _dataset.getTableInfo(user);
-            if (table.getAuditBehavior((AuditBehaviorType)null) != requiredAuditType)
+            if (table != null && table.getAuditBehavior((AuditBehaviorType)null) != requiredAuditType)
                 return;
 
             DatasetAuditProvider.DatasetAuditEvent event = new DatasetAuditProvider.DatasetAuditEvent(c.getId(), comment);

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -145,7 +145,6 @@ import org.labkey.api.view.WebPartView;
 import org.labkey.api.webdav.SimpleDocumentResource;
 import org.labkey.api.webdav.WebdavResource;
 import org.labkey.study.StudySchema;
-import org.labkey.study.StudyServiceImpl;
 import org.labkey.study.controllers.BaseStudyController.StudyJspView;
 import org.labkey.study.controllers.StudyController;
 import org.labkey.study.dataset.DatasetAuditProvider;
@@ -2667,8 +2666,7 @@ public class StudyManager
 
         SchemaKey schemaPath = SchemaKey.fromParts(SCHEMA.getSchemaName());
         QueryService.get().fireQueryDeleted(user, study.getContainer(), null, schemaPath, Collections.singleton(ds.getName()));
-        StudyServiceImpl.addDatasetAuditEvent(
-                user, study.getContainer(), ds, "Dataset deleted: " + ds.getName(),null);
+        new DatasetDefinition.DatasetAuditHandler(ds).addAuditEvent(user, study.getContainer(), AuditBehaviorType.DETAILED, "Dataset deleted: " + ds.getName(),null);
 
         unindexDataset(ds);
     }

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -257,7 +257,11 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
         if (_skipAuditLogging)
             context.putConfigParameter(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior, NONE);
         else if (!isBulkLoad())
-            context.putConfigParameter(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior, DETAILED);
+        {
+            // default to DETAILED unless there is a metadata XML override
+            context.putConfigParameter(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior,
+                    getQueryTable().getXmlAuditBehaviorType() != null ? getQueryTable().getXmlAuditBehaviorType() : DETAILED);
+        }
 
         List<Map<String, Object>> result = super._insertRowsUsingDIB(user, container, rows, context, extraScriptContext);
 
@@ -611,7 +615,7 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
             resetCreatedColumnsSQL.add(newLsid);
             new SqlExecutor(_dataset.getStorageTableInfo().getSchema()).execute(resetCreatedColumnsSQL);
 
-            new DatasetDefinition.DatasetAuditHandler(_dataset).addAuditEvent(user, container, null, AuditBehaviorType.DETAILED, null, QueryService.AuditAction.UPDATE,
+            new DatasetDefinition.DatasetAuditHandler(_dataset).addAuditEvent(user, container, target, AuditBehaviorType.DETAILED, null, QueryService.AuditAction.UPDATE,
                     List.of(mergeData), List.of(oldData));
 
             // Successfully updated


### PR DESCRIPTION
#### Rationale
Clean up and add more consistency to the study dataset audit logging in order to get the desired behaviors with respect to audit logging XML metadata overrides. The update service for datasets doesn't consistently go through the data iterator framework and dataset auditing occurs in 3 ways:
- Through the `DetailedAuditLogDataIterator`
- Calls directly into the `DatasetAuditHandler.addAuditEvent`
- Add hoc logging of a `DatatsetAuditEvent`

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48037)

#### Changes
- Be more consistent about passing in the dataset `TableInfo` into `DatasetAuditHandler.addAuditEvent` so that any XML metadata overrides can be respected.
- Move `StudyServiceImpl.addDatasetAuditEvent` into `DatasetAuditHandler`