### PR TITLE
Issue 47679: Graal warnings on server startup

### DIFF
--- a/core/src/org/labkey/core/wiki/MarkdownServiceImpl.java
+++ b/core/src/org/labkey/core/wiki/MarkdownServiceImpl.java
@@ -50,6 +50,9 @@ public class MarkdownServiceImpl implements MarkdownService
 
     private static class PoolFactory implements KeyedPoolableObjectFactory<Map<Options, Boolean>, MarkdownInvocable>
     {
+
+        public static final String POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY = "polyglot.engine.WarnInterpreterOnly";
+
         @Override
         public MarkdownInvocable makeObject(Map<Options, Boolean> options) throws Exception
         {
@@ -57,6 +60,14 @@ public class MarkdownServiceImpl implements MarkdownService
             LabKeyScriptEngineManager svc = LabKeyScriptEngineManager.get();
             if (null == svc)
                 throw new ConfigurationException("LabKeyScriptEngineManager service not found.");
+
+            // Issue 47679 - suppress stdout logging from Graal about compilation mode, due to significant difficulties
+            // in getting the VM configured to use compilation mode
+            if (System.getProperty(POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY) == null)
+            {
+                System.setProperty(POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY, "false");
+            }
+
             ScriptEngine engine = svc.getEngineByName("graal.js");
             if (null == engine)
                 throw new ConfigurationException("Graal.js engine not found");


### PR DESCRIPTION
#### Rationale
For optimal performance, Graal wants to use a runtime compilation approach. We don't use it extensively, and it would require major revamp to how we deploy and startup to configure the compilation.

#### Changes
* Suppress the warning that's logged to stdout