### PR TITLE
Remove config options for deprecated Universal Google Analytics

### DIFF
--- a/core/src/org/labkey/core/analytics/AnalyticsController.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsController.java
@@ -51,17 +51,11 @@ public class AnalyticsController extends SpringActionController
         AdminConsole.addLink(SettingsLinkType.Configuration, "analytics settings", new ActionURL(BeginAction.class, ContainerManager.getRoot()));
     }
 
-    static public class SettingsForm extends ViewForm
+    public static class SettingsForm extends ViewForm
     {
         public Set<AnalyticsServiceImpl.TrackingStatus> ff_trackingStatus = AnalyticsServiceImpl.get().getTrackingStatus();
-        public String ff_accountId = AnalyticsServiceImpl.get().getAccountId();
         public String ff_measurementId = AnalyticsServiceImpl.get().getMeasurementId();
         public String ff_trackingScript = AnalyticsServiceImpl.get().getSavedScript();
-
-        public void setFf_accountId(String ff_accountId)
-        {
-            this.ff_accountId = ff_accountId;
-        }
 
         public void setFf_trackingStatus(String[] statuses)
         {
@@ -88,7 +82,7 @@ public class AnalyticsController extends SpringActionController
     }
 
     @AdminConsoleAction(AdminOperationsPermission.class)
-    public class BeginAction extends FormViewAction<SettingsForm>
+    public static class BeginAction extends FormViewAction<SettingsForm>
     {
         @Override
         public void addNavTrail(NavTree root)
@@ -104,12 +98,6 @@ public class AnalyticsController extends SpringActionController
             {
                 errors.reject("form", "Please specify a Measurement ID when using GA4");
             }
-
-            if (target.ff_trackingStatus.contains(AnalyticsServiceImpl.TrackingStatus.enabled) &&
-                    target.ff_trackingStatus.contains(AnalyticsServiceImpl.TrackingStatus.enabledFullURL))
-            {
-                errors.reject("form", "Please choose only one Universal Google Analytics option");
-            }
         }
 
         @Override
@@ -122,7 +110,7 @@ public class AnalyticsController extends SpringActionController
         @Override
         public boolean handlePost(SettingsForm settingsForm, BindException errors)
         {
-            AnalyticsServiceImpl.get().setSettings(settingsForm.ff_trackingStatus, settingsForm.ff_accountId, settingsForm.ff_measurementId, settingsForm.ff_trackingScript, getUser());
+            AnalyticsServiceImpl.get().setSettings(settingsForm.ff_trackingStatus, settingsForm.ff_measurementId, settingsForm.ff_trackingScript, getUser());
             return true;
         }
 

--- a/core/src/org/labkey/core/analytics/analyticsSettings.jsp
+++ b/core/src/org/labkey/core/analytics/analyticsSettings.jsp
@@ -38,12 +38,12 @@
     <table style="width: 60em;">
         <tr>
             <td style="vertical-align: top;">
-                <labkey:checkbox onChange="disableCheckboxes()" name="ff_trackingStatus" checked="<%= settingsForm.ff_trackingStatus.contains(AnalyticsServiceImpl.TrackingStatus.ga4FullUrl)%>" value="<%= AnalyticsServiceImpl.TrackingStatus.ga4FullUrl.toString() %>" id="ga4fullURL" />
+                <labkey:checkbox name="ff_trackingStatus" checked="<%= settingsForm.ff_trackingStatus.contains(AnalyticsServiceImpl.TrackingStatus.ga4FullUrl)%>" value="<%= AnalyticsServiceImpl.TrackingStatus.ga4FullUrl.toString() %>" id="ga4fullURL" />
             </td>
             <td style="padding-left: 1em;"><strong><label for="ga4fullURL">Google Analytics 4</label></strong>
                 <p>
                     This is the most recent version of Google Analytics directly supported by LabKey Server.
-                    It always reports the full page URL, regardless of the folder's permissions.
+                    It reports using the full page URL.
                 </p>
             </td>
         </tr>
@@ -55,57 +55,8 @@
                     Create your own Measurement ID by signing up with Google Analytics.
                 </p>
                 <p>
-                    <label for="ff_accountId">Measurement ID</label>:
+                    <label for="ff_measurementId">Measurement ID</label>:
                     <input <%=unsafe(hasAdminOpsPerms?"":"disabled=\"disabled\"")%> type="text" id="ff_measurementId" name="ff_measurementId" value="<%=h(settingsForm.ff_measurementId)%>"/>
-                </p>
-            </td>
-        </tr>
-
-        <tr><td>&nbsp;</td></tr>
-
-        <tr>
-            <td style="vertical-align: top;">
-                <labkey:checkbox onChange="disableCheckboxes()" name="ff_trackingStatus" checked="<%= settingsForm.ff_trackingStatus.contains(AnalyticsServiceImpl.TrackingStatus.enabled)%>" value="<%= AnalyticsServiceImpl.TrackingStatus.enabled.toString() %>" id="modifiedURL" />
-            </td>
-
-            <td style="padding-left: 1em;">
-                <strong><label for="modifiedURL">Universal Google Analytics, with redacted URL</label></strong>
-                <p >
-                    Google has deprecated this version of Google Analytics. It stops accepting new data on July 1, 2023.
-                </p>
-                <p>
-                    The full page URL will only be reported when it is accessible to Guest users.
-                    When a project/folder is secured, LabKey Server will report a unique identifier
-                    (the folder's EntityId, available through Admin->Folder->Management->Information)
-                    instead of the folder path. Additionally, HTTP GET parameters will
-                    be stripped. Both are efforts to ensure that sensitive data is not included.
-                </p>
-            </td>
-        </tr>
-        <tr>
-            <td style="vertical-align: top">
-                <strong><label><labkey:checkbox onChange="disableCheckboxes()" name="ff_trackingStatus" checked="<%= settingsForm.ff_trackingStatus.contains(AnalyticsServiceImpl.TrackingStatus.enabledFullURL)%>" value="<%= AnalyticsServiceImpl.TrackingStatus.enabledFullURL.toString() %>" id="fullURL" />
-            </td>
-
-            <td style="padding-left: 1em;">
-                <strong><label for="fullURL">Universal Google Analytics, with full URL</label></strong>
-                <p>
-                    Google has deprecated this version of Google Analytics. It stops accepting new data on July 1, 2023.
-                </p>
-                <p>Always report the full page URL, regardless of the folder's permissions.</p></td>
-        </tr>
-        <tr>
-            <td></td>
-            <td style="padding-left: 1em;">
-                <p>
-                    Universal Google Analytics reporting is based on an Account
-                    ID. LabKey monitors the Account ID
-                    <code><%=h(AnalyticsServiceImpl.DEFAULT_ACCOUNT_ID)%></code> to understand usage and prioritize
-                    development efforts. You can get own Account ID by signing up with Google Analytics.
-                </p>
-                <p>
-                    <label for="ff_accountId">Account ID</label>:
-                    <input <%=unsafe(hasAdminOpsPerms?"":"disabled=\"disabled\"")%> type="text" id="ff_accountId" name="ff_accountId" value="<%=h(settingsForm.ff_accountId)%>"/>
                 </p>
             </td>
         </tr>
@@ -149,12 +100,3 @@
     </table>
 
 </labkey:form>
-
-<script>
-    function disableCheckboxes() {
-        document.getElementById('fullURL').disabled = document.getElementById('modifiedURL').checked;
-        document.getElementById('modifiedURL').disabled = document.getElementById('fullURL').checked;
-    }
-
-    disableCheckboxes();
-</script>


### PR DESCRIPTION
#### Rationale
The universe was too restricting, so Google has switched to Google Analytics 4. Universal Google Analytics stops accepting new data July 1, so there's no need to retain our integration for 23.7 and beyond

#### Changes
* Purge Universal Google Analytics settings and code
* Minor code cleanup