### PR TITLE
23.3 Fix cache miss logic for RemapCache and reduce initial bulk load size

### DIFF
--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -417,7 +417,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
 
         private TableSelector createSelector(ColumnInfo pkCol, ColumnInfo altKeyCol, SimpleFilter filter)
         {
-            return new TableSelector(_targetTable, Arrays.asList(altKeyCol, pkCol), filter, null).setMaxRows(10_000);
+            return new TableSelector(_targetTable, Arrays.asList(altKeyCol, pkCol), filter, null).setMaxRows(100_000);
         }
 
 

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -334,7 +334,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                     bulkLoaded = map.get(k);
                 }
 
-                if (bulkLoaded == null)
+                if (bulkLoaded == null || bulkLoaded.isEmpty())
                 {
                     TableSelector ts = createSelector(pkCol, altKeyCol, k);
                     ts.fillMultiValuedMap(map);
@@ -417,7 +417,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
 
         private TableSelector createSelector(ColumnInfo pkCol, ColumnInfo altKeyCol, SimpleFilter filter)
         {
-            return new TableSelector(_targetTable, Arrays.asList(altKeyCol, pkCol), filter, null).setMaxRows(1_000_000);
+            return new TableSelector(_targetTable, Arrays.asList(altKeyCol, pkCol), filter, null).setMaxRows(10_000);
         }
 
 

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -334,6 +334,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                     bulkLoaded = map.get(k);
                 }
 
+                // ArrayListValuedHashMap returns an empty collection if 'k' is not in the map.
                 if (bulkLoaded == null || bulkLoaded.isEmpty())
                 {
                     TableSelector ts = createSelector(pkCol, altKeyCol, k);
@@ -417,6 +418,8 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
 
         private TableSelector createSelector(ColumnInfo pkCol, ColumnInfo altKeyCol, SimpleFilter filter)
         {
+            // Load a bunch of rows in the hopes of not needing to fetch for every value we encounter,
+            // but if we have a miss, we'll do per-value fetches as needed
             return new TableSelector(_targetTable, Arrays.asList(altKeyCol, pkCol), filter, null).setMaxRows(100_000);
         }
 


### PR DESCRIPTION
#### Rationale
The `RemapCache` used during sample imports with derivations is initialized with a query limited to 1,000,000 rows. When a sample type (or data class, or ...) has more rows than that, our cache miss logic was not finding some rows because the empty object returned is an empty list not a null value. Here we reduce the size of that initial query by an order of magnitude and fix the cache miss logic.


#### Changes
* Reduce table selection row limit for initial population of the cache
* Check for empty object as well as null value
