### PR TITLE
Issue 48134: JDBC date and timestamp escape syntax fail SQLFragment validation

### DIFF
--- a/query/src/org/labkey/query/QueryTestCase.jsp
+++ b/query/src/org/labkey/query/QueryTestCase.jsp
@@ -968,7 +968,10 @@ d,seven,twelve,day,month,date,duration,guid
                         new SqlTest("SELECT f FROM (SELECT CAST(jsonb_insert('{\"a\": [0,1,2]}', '{a, 1}', '\"new_value\"', true) AS VARCHAR) AS f) X WHERE f = '{\"a\": [0, 1, \"new_value\", 2]}'", 1, 1),
 
                         // TEST CTE handling with undocumented test-only methods
-                        new SqlTest("SELECT __cte_two__() as two, __cte_three__() as three, __cte_two__() * __cte_three__() as six_simple, __cte_times__(__cte_two__(), __cte_three__()) as six_complex", 4, 1)
+                        new SqlTest("SELECT __cte_two__() as two, __cte_three__() as three, __cte_two__() * __cte_three__() as six_simple, __cte_times__(__cte_two__(), __cte_three__()) as six_complex", 4, 1),
+
+                        // JDBC escape sequences
+                        new SqlTest("SELECT * FROM (SELECT CAST({ts '2023-06-02 00:00:00'} AS DATE) AS d) x WHERE d = {d '2023-06-02'}", 1, 1)
                 ));
 
         if (majorVersion >= 12)

--- a/query/src/org/labkey/query/sql/QDate.java
+++ b/query/src/org/labkey/query/sql/QDate.java
@@ -47,7 +47,7 @@ public class QDate extends QExpr implements IConstant
     @Override
     public void appendSql(SqlBuilder builder, Query query)
     {
-        builder.append("{d '").append(DateUtil.toISO(_value).substring(0, 10)).append("'}");
+        builder.append("{d '" + DateUtil.toISO(_value).substring(0, 10) + "'}");
     }
 
     @Override

--- a/query/src/org/labkey/query/sql/QTimestamp.java
+++ b/query/src/org/labkey/query/sql/QTimestamp.java
@@ -48,7 +48,7 @@ public class QTimestamp extends QExpr implements IConstant
     @Override
     public void appendSql(SqlBuilder builder, Query query)
     {
-        builder.append("{ts '").append(DateUtil.toISO(_value)).append("'}");
+        builder.append("{ts '" + DateUtil.toISO(_value) + "'}");
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We're failing to generate SQL on legal JDBC escape sequences

#### Changes
* Use a single call to `append` so that we get both the open and closing quote together