### PR TITLE
Issue 48048, 47985 and 47785

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -1515,12 +1515,16 @@ public class NameGenerator
                     sampleCounts = getSampleCountsFunction.apply(null);
                 }
 
-                boolean skipRootSampleCount = altExpression != null; // so far altExpression is not null only when generating aliquots
-                if (!skipRootSampleCount && _rootCounterSequence != null)
+                if (_rootCounterSequence != null)
                 {
                     if (sampleCounts == null)
                         sampleCounts = new HashMap<>();
-                    sampleCounts.put("rootSampleCount", _rootCounterSequence.next());
+
+                    boolean skipRootSampleCount = altExpression != null; // so far altExpression is not null only when generating aliquots
+                    if (!skipRootSampleCount)
+                        sampleCounts.put("rootSampleCount", _rootCounterSequence.next());
+                    else
+                        sampleCounts.put("rootSampleCount", _rootCounterSequence.current());
                 }
             }
 
@@ -2839,6 +2843,8 @@ public class NameGenerator
             validateNameResult("S-MaterialInputs/lookupfield", withWarnings("S-MaterialInputs/lookupfield","The 'MaterialInputs' substitution pattern starting at position 2 should be preceded by the string '${'."));
 
             validateNameResult("AliquotedFrom-001", withWarnings("AliquotedFrom-001", "The 'AliquotedFrom' substitution pattern starting at position 0 should be preceded by the string '${'."));
+
+            validateNameResult("S-rootSampleCount", withWarnings("S-rootSampleCount", "The 'rootSampleCount' substitution pattern starting at position 2 should be preceded by the string '${'."));
         }
 
         @Test

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -1397,7 +1397,7 @@ public class NameGenerator
                 if (exprHasSampleRootCounter || rootCountSeq.current() > 0) // if ${rootSampleCount} is present, or if ${rootSampleCount} was previously evaluated
                 {
                     _rootCounterSequence = rootCountSeq;
-                    if (exprHasSampleRootCounter && rootCountSeq.current() == 0) // initialize existing count when ${rootSampleCount} is first encountered for a server
+                    if (rootCountSeq.current() == 0) // initialize existing count when ${rootSampleCount} is first encountered for a server
                         _rootCounterSequence.ensureMinimum(SampleTypeService.get().getRootSampleCount());
                 }
                 else

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -161,6 +161,7 @@ public class NameGenerator
         batchRandomId(3294),
         containerPath("containerPathValue"),
         contextPath("contextPathValue"),
+        rootSampleCount(124),
         dailySampleCount(14), // sample counts can both be SubstitutionValue as well as modifiers
         dataRegionName("dataRegionNameValue"),
         genId(1001),
@@ -220,6 +221,7 @@ public class NameGenerator
     private final FieldKeyStringExpression _parsedNameExpression;
 
     // extracted from name expression after parsing
+    private boolean _exprHasSampleRootCounter = false;
     private boolean _exprHasSampleCounterFormats = false;
     private boolean _exprHasLineageInputs = false;
     private boolean _exprHasLineageLookup = false;
@@ -673,6 +675,11 @@ public class NameGenerator
         return true;
     }
 
+    public static boolean isRootSampleCountToken(FieldKey token)
+    {
+        return SubstitutionFormat.rootSampleCount.name().equalsIgnoreCase(token.toString());
+    }
+
     public static boolean isLineageToken(Object token, @Nullable Map<String, String> importAliases)
     {
         String sTok = token.toString();
@@ -847,6 +854,7 @@ public class NameGenerator
         boolean hasSampleCounterFormat = false;
         boolean hasLineageInputs = false;
         boolean hasLineageLookup = false;
+        boolean hasSampleRootCounter = false;
         List<FieldKey> lookups = new ArrayList<>();
         Map<String, List<String>> lineageLookupFields = new CaseInsensitiveHashMap<>();
         Set<String> substitutionValues = new CaseInsensitiveHashSet();
@@ -932,6 +940,9 @@ public class NameGenerator
                     // for simple token with no lookups, e.g. ${genId}, don't need to do anything special
                     if (fieldParts.size() == 1)
                     {
+                        if (isRootSampleCountToken(fkTok))
+                            hasSampleRootCounter = true;
+
                         if (_validateSyntax)
                         {
                             String fieldName = fieldParts.get(0);
@@ -1173,6 +1184,7 @@ public class NameGenerator
             _exprLookups = fieldKeyLookup;
         }
 
+        _exprHasSampleRootCounter = hasSampleRootCounter;
         _exprHasSampleCounterFormats = hasSampleCounterFormat;
         _exprHasLineageInputs = hasLineageInputs;
         _exprHasLineageLookup = hasLineageLookup;
@@ -1336,7 +1348,7 @@ public class NameGenerator
     @NotNull
     public State createState(boolean incrementSampleCounts)
     {
-        return new State(incrementSampleCounts);
+        return new State(incrementSampleCounts, _exprHasSampleRootCounter);
     }
 
     public String generateName(@NotNull State state, @NotNull Map<String, Object> rowMap) throws NameGenerationException
@@ -1371,11 +1383,28 @@ public class NameGenerator
         private final Map<String, ArrayList<Object>> _ancestorCache;
         private final Map<String, Map<String, DbSequence>> _prefixCounterSequences;
 
+        private final DbSequence _rootCounterSequence;
+
         private boolean _prefixCounterSequencesCleaned = false;
 
-        private State(boolean incrementSampleCounts)
+        private State(boolean incrementSampleCounts, boolean exprHasSampleRootCounter)
         {
             _incrementSampleCounts = incrementSampleCounts;
+
+            if (incrementSampleCounts) // determine if need to incrementRootSampleCount
+            {
+                DbSequence rootCountSeq = SampleTypeService.get().getRootSampleSequence();
+                if (exprHasSampleRootCounter || rootCountSeq.current() > 0) // if ${rootSampleCount} is present, or if ${rootSampleCount} was previously evaluated
+                {
+                    _rootCounterSequence = rootCountSeq;
+                    if (exprHasSampleRootCounter && rootCountSeq.current() == 0) // initialize existing count when ${rootSampleCount} is first encountered for a server
+                        _rootCounterSequence.ensureMinimum(SampleTypeService.get().getRootSampleCount());
+                }
+                else
+                    _rootCounterSequence = null;
+            }
+            else
+                _rootCounterSequence = null;
 
             // Create the name expression context shared for the entire batch of rows
             Map<String, Object> batchContext = new CaseInsensitiveHashMap<>();
@@ -1388,6 +1417,16 @@ public class NameGenerator
             _prefixCounterSequences = new HashMap<>();
         }
 
+        public boolean isIncrementSampleCounts()
+        {
+            return _incrementSampleCounts;
+        }
+
+        public DbSequence getRootCounterSequence()
+        {
+            return _rootCounterSequence;
+        }
+
         public Map<String, Map<String, DbSequence>> getPrefixCounterSequences()
         {
             return _prefixCounterSequences;
@@ -1397,6 +1436,9 @@ public class NameGenerator
         {
             if (_prefixCounterSequencesCleaned)
                 return;
+
+            if (_rootCounterSequence != null)
+                _rootCounterSequence.sync();
 
             for (Map<String, DbSequence> counterSequences : _prefixCounterSequences.values())
             {
@@ -1461,14 +1503,25 @@ public class NameGenerator
             // and put the sample counts into the context so that any sample counters not bound to a column will be replaced; e.g, "${dailySampleCount}".
             // It is important to do this even if a "name" is explicitly provided so the sample counts are accurate.
             Map<String, Long> sampleCounts = null;
-            if (_incrementSampleCounts && !_exprHasSampleCounterFormats)
+            if (_incrementSampleCounts)
             {
-                if (null == getSampleCountsFunction)
+                if (!_exprHasSampleCounterFormats)
                 {
-                    Date now = (Date)_batchExpressionContext.get("now");
-                    getSampleCountsFunction = SampleTypeService.get().getSampleCountsFunction(now);
+                    if (null == getSampleCountsFunction)
+                    {
+                        Date now = (Date)_batchExpressionContext.get("now");
+                        getSampleCountsFunction = SampleTypeService.get().getSampleCountsFunction(now);
+                    }
+                    sampleCounts = getSampleCountsFunction.apply(null);
                 }
-                sampleCounts = getSampleCountsFunction.apply(null);
+
+                boolean skipRootSampleCount = altExpression != null; // so far altExpression is not null only when generating aliquots
+                if (!skipRootSampleCount && _rootCounterSequence != null)
+                {
+                    if (sampleCounts == null)
+                        sampleCounts = new HashMap<>();
+                    sampleCounts.put("rootSampleCount", _rootCounterSequence.next());
+                }
             }
 
             // Always execute the extraPropsFns, if available, to increment the ${genId} counter in the non-QueryUpdateService code path.

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.DbSequence;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.TemplateInfo;
@@ -203,6 +204,10 @@ public interface SampleTypeService
 
     // used by DomainKind.invalidate()
     void indexSampleType(ExpSampleType sampleType);
+
+    DbSequence getRootSampleSequence();
+
+    long getRootSampleCount();
 
     ValidationException updateSampleType(GWTDomain<? extends GWTPropertyDescriptor> original, GWTDomain<? extends GWTPropertyDescriptor> update, SampleTypeDomainKindProperties options, Container container, User user, boolean includeWarnings);
 

--- a/api/src/org/labkey/api/util/SubstitutionFormat.java
+++ b/api/src/org/labkey/api/util/SubstitutionFormat.java
@@ -475,6 +475,7 @@ public class SubstitutionFormat
     public static SampleCountSubstitutionFormat monthlySampleCount = new SampleCountSubstitutionFormat("monthlySampleCount", NameGenerator.SubstitutionValue.monthlySampleCount.getPreviewValue());
     public static SampleCountSubstitutionFormat yearlySampleCount = new SampleCountSubstitutionFormat("yearlySampleCount", NameGenerator.SubstitutionValue.yearlySampleCount.getPreviewValue());
 
+    public static SampleCountSubstitutionFormat rootSampleCount = new SampleCountSubstitutionFormat("rootSampleCount", NameGenerator.SubstitutionValue.rootSampleCount.getPreviewValue());
 
     final String _name;
     final String _shortName;

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -223,8 +223,8 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
 
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_RESOLVE_PROPERTY_URI_COLUMNS, "Resolve property URIs as columns on experiment tables",
                 "If a column is not found on an experiment table, attempt to resolve the column name as a Property URI and add it as a property column", false);
-        AdminConsole.addExperimentalFeatureFlag(NameGenerator.EXPERIMENTAL_WITH_COUNTER, "Use strict incremental withCounter expression",
-                "When withCounter is used in name expression, make sure the count increments one-by-one and does not jump.", false);
+        AdminConsole.addExperimentalFeatureFlag(NameGenerator.EXPERIMENTAL_WITH_COUNTER, "Use strict incremental withCounter and rootSampleCount expression",
+                "When withCounter or rootSampleCount is used in name expression, make sure the count increments one-by-one and does not jump.", false);
 
         RoleManager.registerPermission(new DesignVocabularyPermission(), true);
 

--- a/experiment/src/org/labkey/experiment/api/AncestorLookupDisplayColumn.java
+++ b/experiment/src/org/labkey/experiment/api/AncestorLookupDisplayColumn.java
@@ -89,10 +89,12 @@ public class AncestorLookupDisplayColumn extends DataColumn
         if (lookupKey != null && lookupKey < 0)
             return lookupKey;
 
-        if (_dc != null)
-            return _dc.getValue(ctx);
+        Object value = super.getValue(ctx);
 
-        return super.getValue(ctx);
+        if (value == null)
+            value = ctx.get(getBoundColumn().getFieldKey().getParent());
+
+        return value;
     }
 
     @Override
@@ -101,9 +103,6 @@ public class AncestorLookupDisplayColumn extends DataColumn
         Integer lookupKey = getLookupId(ctx);
         if (lookupKey != null && lookupKey < 0)
             return null;
-
-        if (_dc != null)
-            return _dc.renderURL(ctx);
 
         return super.renderURL(ctx);
     }

--- a/experiment/src/org/labkey/experiment/api/AncestorLookupDisplayColumn.java
+++ b/experiment/src/org/labkey/experiment/api/AncestorLookupDisplayColumn.java
@@ -89,10 +89,12 @@ public class AncestorLookupDisplayColumn extends DataColumn
         if (lookupKey != null && lookupKey < 0)
             return lookupKey;
 
-        Object value = super.getValue(ctx);
+        Object value = null;
+        if (_dc != null)
+            value = _dc.getValue(ctx);
 
         if (value == null)
-            value = ctx.get(getBoundColumn().getFieldKey().getParent());
+            value = super.getValue(ctx);
 
         return value;
     }
@@ -103,6 +105,9 @@ public class AncestorLookupDisplayColumn extends DataColumn
         Integer lookupKey = getLookupId(ctx);
         if (lookupKey != null && lookupKey < 0)
             return null;
+
+        if (_dc != null)
+            return _dc.renderURL(ctx);
 
         return super.renderURL(ctx);
     }

--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -11,6 +11,7 @@ import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
+import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MaterializedQueryHelper;
 import org.labkey.api.data.MutableColumnInfo;
@@ -213,7 +214,8 @@ public class ClosureQueryHelper
                 {
                     if (ret.getConceptURI() == null)
                         ret.setConceptURI(CONCEPT_URI);
-                    ret.setDisplayColumnFactory(colInfo -> new AncestorLookupDisplayColumn(foreignKey, colInfo));
+                    DisplayColumnFactory originalDisplayColumnFactory = ret.getDisplayColumnFactory();
+                    ret.setDisplayColumnFactory(colInfo -> new AncestorLookupDisplayColumn(foreignKey, colInfo, originalDisplayColumnFactory));
                 }
                 return ret;
             }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -7307,6 +7307,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (parent == null)
             throw new IllegalArgumentException("You must create aliquot from a parent material or aliquot");
 
+        if (aliquots.contains(parent))
+            throw new ExperimentException("The material " + parent.getName() + " cannot be its own aliquot.");
+
         ExpProtocol protocol = ensureSampleAliquotProtocol(info.getUser());
         ExpRunImpl run = createExperimentRun(info.getContainer(), getAliquotRunName(parent, aliquots.size()));
         run.setProtocol(protocol);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -977,7 +977,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             return DbSequenceManager.getReclaimable(ContainerManager.getRoot(), ROOT_SAMPLE_COUNT_SEQ_NAME, 0);
 
         // Reclaimable preallocates must call sync as part of the transaction they are in
-        return DbSequenceManager.getReclaimablePreallocateSequence(ContainerManager.getRoot(), ROOT_SAMPLE_COUNT_SEQ_NAME, 0, 100);
+        return DbSequenceManager.getPreallocatingSequence(ContainerManager.getRoot(), ROOT_SAMPLE_COUNT_SEQ_NAME, 0, 100);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -976,7 +976,6 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         if (AppProps.getInstance().isExperimentalFeatureEnabled(EXPERIMENTAL_WITH_COUNTER))
             return DbSequenceManager.getReclaimable(ContainerManager.getRoot(), ROOT_SAMPLE_COUNT_SEQ_NAME, 0);
 
-        // Reclaimable preallocates must call sync as part of the transaction they are in
         return DbSequenceManager.getPreallocatingSequence(ContainerManager.getRoot(), ROOT_SAMPLE_COUNT_SEQ_NAME, 0, 100);
     }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -1436,10 +1436,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             boolean skipDuplicateCheck = context.getConfigParameterBoolean(SkipMaxSampleCounterFunction);
             nameGen = sampleType.getNameGenerator(dataContainer, user, skipDuplicateCheck);
             aliquotNameGen = sampleType.getAliquotNameGenerator(dataContainer, user, skipDuplicateCheck);
-            if (nameGen != null)
-                nameState = nameGen.createState(true);
-            else
-                nameState = null;
+            nameState = nameGen != null ? nameGen.createState(true) : null;
             lsidBuilder = sampleType.generateSampleLSID();
             _container = sampleType.getContainer();
             _batchSize = batchSize;


### PR DESCRIPTION
#### Rationale
Issue 48048: LKSM: Can create a sample that is its own aliquot
Issue 47985: Ancestor fields in grid display nothing in grids unless the Ancestor type is also included
Issue 47785: LKSM: Create new naming pattern for root/primary sample counter

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/1913

#### Changes
* Issue 48048: modified ExperimentService.createAliquotRun to check for self!=parent
* Issue 47985: addQueryFieldKeys for lookupFk, delegate to underlying displayColumn for rendering
* Issue 47785: 
   * updated Experimental flag "Use strict incremental withCounter and rootSampleCount expression"
   * support new ${rootSampleCount} substitution token
 