### PR TITLE
Create storage on sample import or update via file in apps

### DIFF
--- a/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
@@ -49,6 +49,7 @@ public class DataIteratorContext
     boolean _supportAutoIncrementKey = false;
     boolean _allowImportLookupByAlternateKey = false;
     boolean _crossTypeImport = false;
+    boolean _allowCreateStorage = false;
     private final Set<String> _passThroughBuiltInColumnNames = new CaseInsensitiveHashSet();
     private final Set<String> _dontUpdateColumnNames = new CaseInsensitiveHashSet();
     private final Set<String> _alternateKeys = new CaseInsensitiveHashSet();
@@ -172,6 +173,16 @@ public class DataIteratorContext
     public void setCrossTypeImport(boolean crossTypeImport)
     {
         _crossTypeImport = crossTypeImport;
+    }
+
+    public boolean isAllowCreateStorage()
+    {
+        return _allowCreateStorage;
+    }
+
+    public void setAllowCreateStorage(boolean allowCreateStorage)
+    {
+        _allowCreateStorage = allowCreateStorage;
     }
 
     /** Normally all built in columns (created, createdBy, etc) are populated with newly calculated values on writing to target.

--- a/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
@@ -54,6 +54,7 @@ public class DataIteratorContext
     private final Set<String> _dontUpdateColumnNames = new CaseInsensitiveHashSet();
     private final Set<String> _alternateKeys = new CaseInsensitiveHashSet();
     private String _dataSource;
+    private Map<String, Object> _responseInfo = new HashMap<>(); // information from the import/loadRows context to be passed back to the API response object
 
     int _maxRowErrors = 1;
 
@@ -243,5 +244,15 @@ public class DataIteratorContext
     public boolean getConfigParameterBoolean(Enum key)
     {
         return Boolean.TRUE == getConfigParameter(key);
+    }
+
+    public Map<String, Object> getResponseInfo()
+    {
+        return _responseInfo;
+    }
+
+    public void putResponseInfo(String key, Object value)
+    {
+        _responseInfo.put(key, value);
     }
 }

--- a/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.dataiterator;
 
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
@@ -54,7 +55,9 @@ public class DataIteratorContext
     private final Set<String> _dontUpdateColumnNames = new CaseInsensitiveHashSet();
     private final Set<String> _alternateKeys = new CaseInsensitiveHashSet();
     private String _dataSource;
-    private Map<String, Object> _responseInfo = new HashMap<>(); // information from the import/loadRows context to be passed back to the API response object
+
+    private final Map<String, Object> _responseInfo = new HashMap<>(); // information from the import/loadRows context to be passed back to the API response object
+    private Logger _logger;
 
     int _maxRowErrors = 1;
 
@@ -254,5 +257,15 @@ public class DataIteratorContext
     public void putResponseInfo(String key, Object value)
     {
         _responseInfo.put(key, value);
+    }
+
+    public Logger getLogger()
+    {
+        return _logger;
+    }
+
+    public void setLogger(Logger logger)
+    {
+        _logger = logger;
     }
 }

--- a/api/src/org/labkey/api/pipeline/AppPipelineJobNotificationProvider.java
+++ b/api/src/org/labkey/api/pipeline/AppPipelineJobNotificationProvider.java
@@ -162,22 +162,21 @@ abstract public class AppPipelineJobNotificationProvider implements PipelineJobN
 
     private String getJobSuccessMsg(PipelineJob job, @NotNull ImportType importType, @Nullable Map<String, Object> info)
     {
-        if (job instanceof QueryImportPipelineJob)
+        if (job instanceof QueryImportPipelineJob queryImportPipelineJob)
         {
-            QueryImportPipelineJob queryImportPipelineJob = (QueryImportPipelineJob) job;
-
             String type = queryImportPipelineJob.getImportContextBuilder().getQueryName();
-            StringBuilder successMsg = new StringBuilder("Successfully imported ");
+            StringBuilder successMsg = new StringBuilder("Successfully");
+            Integer count = null;
             if (info != null)
             {
-                Integer count =  (Integer) info.get("rowCount");
-                if (count != null)
-                {
-                    successMsg.append(count).append(" ");
-                }
+                count = (Integer) info.get("rowCount");
+                if (info.containsKey("terminalStorageCreated"))
+                    successMsg.append(" created ").append(info.get("terminalStorageCreated")).append(" terminal storage unit(s) and");
             }
 
             successMsg
+                    .append(" imported ")
+                    .append(count != null ? count + " " : "")
                     .append(type)
                     .append(" ")
                     .append(importType.name())

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -304,7 +304,8 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         importLookupByAlternateKey,
         format,
         insertOption,
-        crossTypeImport
+        crossTypeImport,
+        allowCreateStorage
     }
 
     @Nullable
@@ -764,7 +765,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         return importData(dl, _target, _updateService, _insertOption, _importLookupByAlternateKey, _importIdentity, false, errors, auditBehaviorType, auditEvent, getUser(), getContainer());
     }
 
-    protected static DataIteratorContext createDataIteratorContext(QueryUpdateService.InsertOption insertOption, boolean importLookupByAlternateKey, boolean importIdentity, boolean crossTypeImport, @Nullable AuditBehaviorType auditBehaviorType, BatchValidationException errors)
+    protected static DataIteratorContext createDataIteratorContext(QueryUpdateService.InsertOption insertOption, boolean importLookupByAlternateKey, boolean importIdentity, boolean crossTypeImport, boolean allowCreateStorage, @Nullable AuditBehaviorType auditBehaviorType, BatchValidationException errors)
     {
         DataIteratorContext context = new DataIteratorContext(errors);
         context.setInsertOption(insertOption);
@@ -779,12 +780,13 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
             context.setSupportAutoIncrementKey(true);
         }
         context.setCrossTypeImport(crossTypeImport);
+        context.setAllowCreateStorage(allowCreateStorage);
         return context;
     }
 
     public static int importData(DataLoader dl, TableInfo target, QueryUpdateService updateService, QueryUpdateService.InsertOption insertOption, boolean importLookupByAlternateKey, boolean importIdentity, boolean crossTypeImport, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent, User user, Container container) throws IOException
     {
-        return importData(dl, target, updateService, createDataIteratorContext(insertOption, importLookupByAlternateKey, importIdentity,  crossTypeImport, auditBehaviorType, errors), auditEvent, user, container);
+        return importData(dl, target, updateService, createDataIteratorContext(insertOption, importLookupByAlternateKey, importIdentity,  crossTypeImport, false, auditBehaviorType, errors), auditEvent, user, container);
     }
 
     public static int importData(DataLoader dl, TableInfo target, QueryUpdateService updateService, @NotNull DataIteratorContext context, TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent, User user, Container container) throws IOException

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -16,6 +16,7 @@
 package org.labkey.api.query;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
@@ -771,10 +772,10 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
     /* TODO change prototype to take DataIteratorBuilder, and DataIteratorContext */
     protected int importData(DataLoader dl, FileStream file, String originalName, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent) throws IOException
     {
-        return importData(dl, _target, _updateService, _insertOption, getOptionParamsMap(), errors, auditBehaviorType, auditEvent, getUser(), getContainer());
+        return importData(dl, _target, _updateService, _insertOption, getOptionParamsMap(), errors, auditBehaviorType, auditEvent, getUser(), getContainer(), null);
     }
 
-    protected static DataIteratorContext createDataIteratorContext(QueryUpdateService.InsertOption insertOption, boolean importLookupByAlternateKey, boolean importIdentity, boolean crossTypeImport, boolean allowCreateStorage, @Nullable AuditBehaviorType auditBehaviorType, BatchValidationException errors)
+    public static DataIteratorContext createDataIteratorContext(QueryUpdateService.InsertOption insertOption, boolean importLookupByAlternateKey, boolean importIdentity, boolean crossTypeImport, boolean allowCreateStorage, @Nullable AuditBehaviorType auditBehaviorType, BatchValidationException errors, @Nullable Logger logger)
     {
         DataIteratorContext context = new DataIteratorContext(errors);
         context.setInsertOption(insertOption);
@@ -790,16 +791,17 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         }
         context.setCrossTypeImport(crossTypeImport);
         context.setAllowCreateStorage(allowCreateStorage);
+        context.setLogger(logger);
         return context;
     }
 
-    public static int importData(DataLoader dl, TableInfo target, QueryUpdateService updateService, QueryUpdateService.InsertOption insertOption, Map<Params, Boolean> optionParamsMap, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent, User user, Container container) throws IOException
+    public static int importData(DataLoader dl, TableInfo target, QueryUpdateService updateService, QueryUpdateService.InsertOption insertOption, Map<Params, Boolean> optionParamsMap, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent, User user, Container container, @Nullable Logger logger) throws IOException
     {
         boolean importLookupByAlternateKey = optionParamsMap.getOrDefault(Params.importLookupByAlternateKey, false);
         boolean importIdentity = optionParamsMap.getOrDefault(Params.importIdentity, false);
         boolean crossTypeImport = optionParamsMap.getOrDefault(Params.crossTypeImport, false);
         boolean allowCreateStorage = optionParamsMap.getOrDefault(Params.allowCreateStorage, false);
-        return importData(dl, target, updateService, createDataIteratorContext(insertOption, importLookupByAlternateKey, importIdentity,  crossTypeImport, allowCreateStorage, auditBehaviorType, errors), auditEvent, user, container);
+        return importData(dl, target, updateService, createDataIteratorContext(insertOption, importLookupByAlternateKey, importIdentity,  crossTypeImport, allowCreateStorage, auditBehaviorType, errors, logger), auditEvent, user, container);
     }
 
     public static int importData(DataLoader dl, TableInfo target, QueryUpdateService updateService, @NotNull DataIteratorContext context, TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent, User user, Container container) throws IOException

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -775,8 +775,13 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         return importData(dl, _target, _updateService, _insertOption, getOptionParamsMap(), errors, auditBehaviorType, auditEvent, getUser(), getContainer(), null);
     }
 
-    public static DataIteratorContext createDataIteratorContext(QueryUpdateService.InsertOption insertOption, boolean importLookupByAlternateKey, boolean importIdentity, boolean crossTypeImport, boolean allowCreateStorage, @Nullable AuditBehaviorType auditBehaviorType, BatchValidationException errors, @Nullable Logger logger)
+    public static DataIteratorContext createDataIteratorContext(QueryUpdateService.InsertOption insertOption, Map<Params, Boolean> optionParamsMap, @Nullable AuditBehaviorType auditBehaviorType, BatchValidationException errors, @Nullable Logger logger)
     {
+        boolean importLookupByAlternateKey = optionParamsMap.getOrDefault(AbstractQueryImportAction.Params.importLookupByAlternateKey, false);
+        boolean importIdentity = optionParamsMap.getOrDefault(AbstractQueryImportAction.Params.importIdentity, false);
+        boolean crossTypeImport = optionParamsMap.getOrDefault(AbstractQueryImportAction.Params.crossTypeImport, false);
+        boolean allowCreateStorage = optionParamsMap.getOrDefault(AbstractQueryImportAction.Params.allowCreateStorage, false);
+
         DataIteratorContext context = new DataIteratorContext(errors);
         context.setInsertOption(insertOption);
         context.setAllowImportLookupByAlternateKey(importLookupByAlternateKey);
@@ -797,11 +802,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
 
     public static int importData(DataLoader dl, TableInfo target, QueryUpdateService updateService, QueryUpdateService.InsertOption insertOption, Map<Params, Boolean> optionParamsMap, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent, User user, Container container, @Nullable Logger logger) throws IOException
     {
-        boolean importLookupByAlternateKey = optionParamsMap.getOrDefault(Params.importLookupByAlternateKey, false);
-        boolean importIdentity = optionParamsMap.getOrDefault(Params.importIdentity, false);
-        boolean crossTypeImport = optionParamsMap.getOrDefault(Params.crossTypeImport, false);
-        boolean allowCreateStorage = optionParamsMap.getOrDefault(Params.allowCreateStorage, false);
-        return importData(dl, target, updateService, createDataIteratorContext(insertOption, importLookupByAlternateKey, importIdentity,  crossTypeImport, allowCreateStorage, auditBehaviorType, errors, logger), auditEvent, user, container);
+        return importData(dl, target, updateService, createDataIteratorContext(insertOption, optionParamsMap, auditBehaviorType, errors, logger), auditEvent, user, container);
     }
 
     public static int importData(DataLoader dl, TableInfo target, QueryUpdateService updateService, @NotNull DataIteratorContext context, TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent, User user, Container container) throws IOException

--- a/api/src/org/labkey/api/query/QueryImportPipelineJob.java
+++ b/api/src/org/labkey/api/query/QueryImportPipelineJob.java
@@ -307,11 +307,7 @@ public class QueryImportPipelineJob extends PipelineJob
 
     private DataIteratorContext createDataIteratorContext(BatchValidationException errors)
     {
-        boolean importLookupByAlternateKey = _importContextBuilder.getOptionParamsMap().getOrDefault(AbstractQueryImportAction.Params.importLookupByAlternateKey, false);
-        boolean importIdentity = _importContextBuilder.getOptionParamsMap().getOrDefault(AbstractQueryImportAction.Params.importIdentity, false);
-        boolean crossTypeImport = _importContextBuilder.getOptionParamsMap().getOrDefault(AbstractQueryImportAction.Params.crossTypeImport, false);
-        boolean allowCreateStorage = _importContextBuilder.getOptionParamsMap().getOrDefault(AbstractQueryImportAction.Params.allowCreateStorage, false);
-        return AbstractQueryImportAction.createDataIteratorContext(_importContextBuilder.getInsertOption(), importLookupByAlternateKey, importIdentity,  crossTypeImport, allowCreateStorage, _importContextBuilder.getAuditBehaviorType(), errors, getLogger());
+        return AbstractQueryImportAction.createDataIteratorContext(_importContextBuilder.getInsertOption(), _importContextBuilder.getOptionParamsMap(), _importContextBuilder.getAuditBehaviorType(), errors, getLogger());
     }
 
     @Override

--- a/api/src/org/labkey/api/query/QueryImportPipelineJob.java
+++ b/api/src/org/labkey/api/query/QueryImportPipelineJob.java
@@ -53,11 +53,8 @@ public class QueryImportPipelineJob extends PipelineJob
 
         QueryUpdateService.InsertOption _insertOption= QueryUpdateService.InsertOption.INSERT;
         AuditBehaviorType _auditBehaviorType = null;
-
-        boolean _importLookupByAlternateKey = false;
-        boolean _importIdentity = false;
         boolean _hasLineageColumns = false;
-        boolean _crossTypeImport = false;
+        Map<AbstractQueryImportAction.Params, Boolean> _optionParamsMap = new HashMap<>();
 
         String _jobDescription;
 
@@ -108,24 +105,14 @@ public class QueryImportPipelineJob extends PipelineJob
             return _auditBehaviorType;
         }
 
-        public boolean isImportLookupByAlternateKey()
+        public Map<AbstractQueryImportAction.Params, Boolean> getOptionParamsMap()
         {
-            return _importLookupByAlternateKey;
-        }
-
-        public boolean isImportIdentity()
-        {
-            return _importIdentity;
+            return _optionParamsMap;
         }
 
         public boolean isHasLineageColumns()
         {
             return _hasLineageColumns;
-        }
-
-        public boolean isCrossTypeImport()
-        {
-            return _crossTypeImport;
         }
 
         public String getJobDescription()
@@ -191,21 +178,9 @@ public class QueryImportPipelineJob extends PipelineJob
             return this;
         }
 
-        public QueryImportAsyncContextBuilder setImportLookupByAlternateKey(boolean importLookupByAlternateKey)
+        public QueryImportAsyncContextBuilder setOptionParamsMap(Map<AbstractQueryImportAction.Params, Boolean> optionParamsMap)
         {
-            _importLookupByAlternateKey = importLookupByAlternateKey;
-            return this;
-        }
-
-        public QueryImportAsyncContextBuilder setCrossTypeImport(boolean crossTypeImport)
-        {
-            _crossTypeImport = crossTypeImport;
-            return this;
-        }
-
-        public QueryImportAsyncContextBuilder setImportIdentity(boolean importIdentity)
-        {
-            _importIdentity = importIdentity;
+            _optionParamsMap = optionParamsMap;
             return this;
         }
 
@@ -289,8 +264,8 @@ public class QueryImportPipelineJob extends PipelineJob
             if (_importContextBuilder.getAuditBehaviorType() != null && _importContextBuilder.getAuditBehaviorType() != AuditBehaviorType.NONE)
                 auditEvent = createTransactionAuditEvent(getContainer(), QueryService.AuditAction.INSERT);
 
-            int importedCount = AbstractQueryImportAction.importData(loader, target, updateService, _importContextBuilder.getInsertOption(), _importContextBuilder.isImportLookupByAlternateKey(),
-                _importContextBuilder.isImportIdentity(), _importContextBuilder.isCrossTypeImport(), ve, _importContextBuilder.getAuditBehaviorType(), auditEvent, getInfo().getUser(), getInfo().getContainer());
+            int importedCount = AbstractQueryImportAction.importData(loader, target, updateService, _importContextBuilder.getInsertOption(), _importContextBuilder.getOptionParamsMap(),
+                    ve, _importContextBuilder.getAuditBehaviorType(), auditEvent, getInfo().getUser(), getInfo().getContainer());
 
             if (ve.hasErrors())
                 throw ve;

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3989,6 +3989,8 @@ public class ExperimentController extends SpringActionController
     @RequiresPermission(InsertPermission.class)
     public class ImportSamplesAction extends AbstractExpDataImportAction
     {
+        DataIteratorContext _context;
+
         @Override
         public void validateForm(QueryForm queryForm, Errors errors)
         {
@@ -4040,7 +4042,7 @@ public class ExperimentController extends SpringActionController
             boolean importIdentity = getOptionParamValue(Params.importIdentity);
             boolean crossTypeImport = getOptionParamValue(Params.crossTypeImport);
             boolean allowCreateStorage = getOptionParamValue(Params.allowCreateStorage);
-            DataIteratorContext context = createDataIteratorContext(_insertOption, importLookupByAlternateKey, importIdentity,  crossTypeImport, allowCreateStorage, auditBehaviorType, errors);
+            _context = createDataIteratorContext(_insertOption, importLookupByAlternateKey, importIdentity,  crossTypeImport, allowCreateStorage, auditBehaviorType, errors);
 
             TableInfo tInfo = _target;
             QueryUpdateService updateService = _updateService;
@@ -4049,7 +4051,7 @@ public class ExperimentController extends SpringActionController
                 tInfo = new ExpMaterialTableImpl(ExpSchema.TableType.Materials.name(), new SamplesSchema(getUser(), getContainer()), ContainerFilter.current(getContainer()));
                 updateService = tInfo.getUpdateService();
             }
-            return importData(dl, tInfo, updateService, context, auditEvent, getUser(), getContainer());
+            return importData(dl, tInfo, updateService, _context, auditEvent, getUser(), getContainer());
         }
 
         @Override
@@ -4072,6 +4074,14 @@ public class ExperimentController extends SpringActionController
             root.addChild("Import Data");
         }
 
+        @Override
+        protected JSONObject createSuccessResponse(int rowCount)
+        {
+            JSONObject json = super.createSuccessResponse(rowCount);
+            if (_context.getResponseInfo().containsKey("terminalStorageCreated"))
+                json.put("terminalStorageCreated", _context.getResponseInfo().get("terminalStorageCreated"));
+            return json;
+        }
     }
 
     public abstract class AbstractExpDataImportAction extends AbstractQueryImportAction<QueryForm>

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3989,12 +3989,15 @@ public class ExperimentController extends SpringActionController
     @RequiresPermission(InsertPermission.class)
     public class ImportSamplesAction extends AbstractExpDataImportAction
     {
+        boolean _allowCreateStorage = false;
+
         @Override
         public void validateForm(QueryForm queryForm, Errors errors)
         {
             _form = queryForm;
             _insertOption = queryForm.getInsertOption();
             _crossTypeImport = Boolean.valueOf(getParam(Params.crossTypeImport));
+            _allowCreateStorage = Boolean.valueOf(getParam(Params.allowCreateStorage));
             _form.setSchemaName(getTargetSchemaName());
             if (_crossTypeImport)
             {
@@ -4037,7 +4040,7 @@ public class ExperimentController extends SpringActionController
         @Override
         protected int importData(DataLoader dl, FileStream file, String originalName, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent) throws IOException
         {
-            DataIteratorContext context = createDataIteratorContext(_insertOption, _importLookupByAlternateKey, _importIdentity,  _crossTypeImport, auditBehaviorType, errors);
+            DataIteratorContext context = createDataIteratorContext(_insertOption, _importLookupByAlternateKey, _importIdentity,  _crossTypeImport, _allowCreateStorage, auditBehaviorType, errors);
 
             TableInfo tInfo = _target;
             QueryUpdateService updateService = _updateService;

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4038,15 +4038,11 @@ public class ExperimentController extends SpringActionController
         @Override
         protected int importData(DataLoader dl, FileStream file, String originalName, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent) throws IOException
         {
-            boolean importLookupByAlternateKey = getOptionParamValue(Params.importLookupByAlternateKey);
-            boolean importIdentity = getOptionParamValue(Params.importIdentity);
-            boolean crossTypeImport = getOptionParamValue(Params.crossTypeImport);
-            boolean allowCreateStorage = getOptionParamValue(Params.allowCreateStorage);
-            _context = createDataIteratorContext(_insertOption, importLookupByAlternateKey, importIdentity,  crossTypeImport, allowCreateStorage, auditBehaviorType, errors, null);
+            _context = createDataIteratorContext(_insertOption, getOptionParamsMap(), auditBehaviorType, errors, null);
 
             TableInfo tInfo = _target;
             QueryUpdateService updateService = _updateService;
-            if (crossTypeImport)
+            if (getOptionParamValue(Params.crossTypeImport))
             {
                 tInfo = new ExpMaterialTableImpl(ExpSchema.TableType.Materials.name(), new SamplesSchema(getUser(), getContainer()), ContainerFilter.current(getContainer()));
                 updateService = tInfo.getUpdateService();

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4042,7 +4042,7 @@ public class ExperimentController extends SpringActionController
             boolean importIdentity = getOptionParamValue(Params.importIdentity);
             boolean crossTypeImport = getOptionParamValue(Params.crossTypeImport);
             boolean allowCreateStorage = getOptionParamValue(Params.allowCreateStorage);
-            _context = createDataIteratorContext(_insertOption, importLookupByAlternateKey, importIdentity,  crossTypeImport, allowCreateStorage, auditBehaviorType, errors);
+            _context = createDataIteratorContext(_insertOption, importLookupByAlternateKey, importIdentity,  crossTypeImport, allowCreateStorage, auditBehaviorType, errors, null);
 
             TableInfo tInfo = _target;
             QueryUpdateService updateService = _updateService;
@@ -4078,8 +4078,11 @@ public class ExperimentController extends SpringActionController
         protected JSONObject createSuccessResponse(int rowCount)
         {
             JSONObject json = super.createSuccessResponse(rowCount);
-            if (_context.getResponseInfo().containsKey("terminalStorageCreated"))
-                json.put("terminalStorageCreated", _context.getResponseInfo().get("terminalStorageCreated"));
+            if (!_context.getResponseInfo().isEmpty())
+            {
+                for (String key : _context.getResponseInfo().keySet())
+                    json.put(key, _context.getResponseInfo().get(key));
+            }
             return json;
         }
     }

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -736,7 +736,7 @@ public class ListController extends SpringActionController
         @Override
         protected int importData(DataLoader dl, FileStream file, String originalName, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, @Nullable TransactionAuditProvider.TransactionAuditEvent auditEvent) throws IOException
         {
-            return _list.importListItems(getUser(), getContainer(), dl, errors, null, null, false, _importLookupByAlternateKey, _insertOption);
+            return _list.importListItems(getUser(), getContainer(), dl, errors, null, null, false, getOptionParamValue(Params.importLookupByAlternateKey), _insertOption);
         }
 
         @Override

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -2525,7 +2525,7 @@ public class StudyController extends BaseStudyController
                 columnMap.put(_form.getSequenceNum(), column);
             }
 
-            Pair<List<String>, UploadLog> result = StudyPublishManager.getInstance().importDatasetTSV(getUser(), _study, _def, dl, _importLookupByAlternateKey, file, originalName, columnMap, errors, _form.getInsertOption(), auditBehaviorType);
+            Pair<List<String>, UploadLog> result = StudyPublishManager.getInstance().importDatasetTSV(getUser(), _study, _def, dl, getOptionParamValue(Params.importLookupByAlternateKey), file, originalName, columnMap, errors, _form.getInsertOption(), auditBehaviorType);
 
             if (!result.getKey().isEmpty())
             {


### PR DESCRIPTION
#### Rationale
This set of PRs allows for the apps to create new storage items (freezers, locations, and boxes) during a sample import/update via file, if the appropriate StorageLocation and StorageUnit columns are provided in the file and the user has the proper permissions. This is something the user has to opt into during the file import (error messages will be shown re: invalid storage locations otherwise). This allows for more streamlined workflows for the users to put new or existing samples into storage without first having to go to the freezer designer and define each locations/box.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1215
- https://github.com/LabKey/labkey-ui-premium/pull/117
- https://github.com/LabKey/platform/pull/4532
- https://github.com/LabKey/inventory/pull/900
- https://github.com/LabKey/sampleManagement/pull/1912
- https://github.com/LabKey/biologics/pull/2192

#### Changes
* support for allowCreateStorage in DataIteratorContext
* refactor how the boolean import option params are passed through to the QueryImportPipelineJob
* include terminal storage creation info in import samples API response
* make pipeline job logger available for sample import context to provide info on terminal storage units created
