### PR TITLE
48142: Created and Created By fields are overwritten when existing data is updated via file upload

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -2301,14 +2301,11 @@ public class DatasetDefinition extends AbstractStudyEntity<Dataset> implements C
         DataIteratorBuilder persist = null;
 
         persist = ((UpdateableTableInfo)table).persistRows(existing, context);
-
-        if (context.getInsertOption() != QueryUpdateService.InsertOption.UPDATE)
+        if (persist instanceof TableInsertDataIteratorBuilder tiDib)
         {
             // TODO this feels like a hack, shouldn't this be handled by table.persistRows()???
-            CaseInsensitiveHashSet dontUpdate = new CaseInsensitiveHashSet("Created", "CreatedBy");
-            ((TableInsertDataIteratorBuilder) persist).setDontUpdate(dontUpdate);
+            tiDib.setDontUpdate(new CaseInsensitiveHashSet("Created", "CreatedBy"));
         }
-
         DataIteratorBuilder audit = DetailedAuditLogDataIterator.getDataIteratorBuilder(table, persist, context.getInsertOption(), user, target);
         return LoggingDataIterator.wrap(audit);
     }


### PR DESCRIPTION
#### Rationale
This [PR](https://github.com/LabKey/platform/pull/3949) altered the handling of `created` and `createdBy` fields for bulk insert/update. It appears that the logic may be inverted and may have been intended to be : 
```
if (context.getInsertOption() == QueryUpdateService.InsertOption.UPDATE)
```
But it seems like it would be better if those columns were always in the don't update list, which was the previous behavior unless that was causing issues.

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48142)
