### PR TITLE
adjust search scope used for ontology searches

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.345.3-fb-ontologyScope.0"
+        "@labkey/components": "2.346.1"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2351,9 +2351,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.345.3-fb-ontologyScope.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
-      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
+      "version": "2.346.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.346.1.tgz",
+      "integrity": "sha512-VYk1/8FSZEcOTyZSdapIWqz4yg31NZe9K0dmTP2NnbCUfbA2Bygas2fuwcr82Ze3RlWJ9cmqK/yqTF9XPAFv+Q==",
       "dependencies": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",
@@ -12361,9 +12361,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.345.3-fb-ontologyScope.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
-      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
+      "version": "2.346.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.346.1.tgz",
+      "integrity": "sha512-VYk1/8FSZEcOTyZSdapIWqz4yg31NZe9K0dmTP2NnbCUfbA2Bygas2fuwcr82Ze3RlWJ9cmqK/yqTF9XPAFv+Q==",
       "requires": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.345.0"
+        "@labkey/components": "2.345.3-fb-ontologyScope.0"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2351,9 +2351,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.345.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.0.tgz",
-      "integrity": "sha512-eBuV1kR2T8JbvModDjiyzWyVmuF2LPnVet7qki1R5HEoaf/TXGW86n0ncMn024zbaWt8n7C0N6mFuM4emyNVRw==",
+      "version": "2.345.3-fb-ontologyScope.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
+      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
       "dependencies": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",
@@ -12361,9 +12361,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.345.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.0.tgz",
-      "integrity": "sha512-eBuV1kR2T8JbvModDjiyzWyVmuF2LPnVet7qki1R5HEoaf/TXGW86n0ncMn024zbaWt8n7C0N6mFuM4emyNVRw==",
+      "version": "2.345.3-fb-ontologyScope.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
+      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
       "requires": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.345.3-fb-ontologyScope.0"
+    "@labkey/components": "2.346.1"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.345.0"
+    "@labkey/components": "2.345.3-fb-ontologyScope.0"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.21.0",
-        "@labkey/components": "2.345.0",
+        "@labkey/components": "2.345.3-fb-ontologyScope.0",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3053,9 +3053,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.345.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.0.tgz",
-      "integrity": "sha512-eBuV1kR2T8JbvModDjiyzWyVmuF2LPnVet7qki1R5HEoaf/TXGW86n0ncMn024zbaWt8n7C0N6mFuM4emyNVRw==",
+      "version": "2.345.3-fb-ontologyScope.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
+      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
       "dependencies": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",
@@ -17692,9 +17692,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.345.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.0.tgz",
-      "integrity": "sha512-eBuV1kR2T8JbvModDjiyzWyVmuF2LPnVet7qki1R5HEoaf/TXGW86n0ncMn024zbaWt8n7C0N6mFuM4emyNVRw==",
+      "version": "2.345.3-fb-ontologyScope.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
+      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
       "requires": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.21.0",
-        "@labkey/components": "2.345.3-fb-ontologyScope.0",
+        "@labkey/components": "2.346.1",
         "@labkey/themes": "1.3.0"
       },
       "devDependencies": {
@@ -3053,9 +3053,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.345.3-fb-ontologyScope.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
-      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
+      "version": "2.346.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.346.1.tgz",
+      "integrity": "sha512-VYk1/8FSZEcOTyZSdapIWqz4yg31NZe9K0dmTP2NnbCUfbA2Bygas2fuwcr82Ze3RlWJ9cmqK/yqTF9XPAFv+Q==",
       "dependencies": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",
@@ -17692,9 +17692,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.345.3-fb-ontologyScope.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
-      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
+      "version": "2.346.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.346.1.tgz",
+      "integrity": "sha512-VYk1/8FSZEcOTyZSdapIWqz4yg31NZe9K0dmTP2NnbCUfbA2Bygas2fuwcr82Ze3RlWJ9cmqK/yqTF9XPAFv+Q==",
       "requires": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.21.0",
-    "@labkey/components": "2.345.3-fb-ontologyScope.0",
+    "@labkey/components": "2.346.1",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.21.0",
-    "@labkey/components": "2.345.0",
+    "@labkey/components": "2.345.3-fb-ontologyScope.0",
     "@labkey/themes": "1.3.0"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.345.3-fb-ontologyScope.0"
+        "@labkey/components": "2.346.1"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -3020,9 +3020,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.345.3-fb-ontologyScope.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
-      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
+      "version": "2.346.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.346.1.tgz",
+      "integrity": "sha512-VYk1/8FSZEcOTyZSdapIWqz4yg31NZe9K0dmTP2NnbCUfbA2Bygas2fuwcr82Ze3RlWJ9cmqK/yqTF9XPAFv+Q==",
       "dependencies": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",
@@ -16594,9 +16594,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.345.3-fb-ontologyScope.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
-      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
+      "version": "2.346.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.346.1.tgz",
+      "integrity": "sha512-VYk1/8FSZEcOTyZSdapIWqz4yg31NZe9K0dmTP2NnbCUfbA2Bygas2fuwcr82Ze3RlWJ9cmqK/yqTF9XPAFv+Q==",
       "requires": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.345.0"
+        "@labkey/components": "2.345.3-fb-ontologyScope.0"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -3020,9 +3020,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.345.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.0.tgz",
-      "integrity": "sha512-eBuV1kR2T8JbvModDjiyzWyVmuF2LPnVet7qki1R5HEoaf/TXGW86n0ncMn024zbaWt8n7C0N6mFuM4emyNVRw==",
+      "version": "2.345.3-fb-ontologyScope.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
+      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
       "dependencies": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",
@@ -16594,9 +16594,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.345.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.0.tgz",
-      "integrity": "sha512-eBuV1kR2T8JbvModDjiyzWyVmuF2LPnVet7qki1R5HEoaf/TXGW86n0ncMn024zbaWt8n7C0N6mFuM4emyNVRw==",
+      "version": "2.345.3-fb-ontologyScope.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
+      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
       "requires": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "2.345.3-fb-ontologyScope.0"
+    "@labkey/components": "2.346.1"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "2.345.0"
+    "@labkey/components": "2.345.3-fb-ontologyScope.0"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.345.3-fb-ontologyScope.0"
+        "@labkey/components": "2.346.1"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2425,9 +2425,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.345.3-fb-ontologyScope.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
-      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
+      "version": "2.346.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.346.1.tgz",
+      "integrity": "sha512-VYk1/8FSZEcOTyZSdapIWqz4yg31NZe9K0dmTP2NnbCUfbA2Bygas2fuwcr82Ze3RlWJ9cmqK/yqTF9XPAFv+Q==",
       "dependencies": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",
@@ -13786,9 +13786,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.345.3-fb-ontologyScope.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
-      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
+      "version": "2.346.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.346.1.tgz",
+      "integrity": "sha512-VYk1/8FSZEcOTyZSdapIWqz4yg31NZe9K0dmTP2NnbCUfbA2Bygas2fuwcr82Ze3RlWJ9cmqK/yqTF9XPAFv+Q==",
       "requires": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.345.0"
+        "@labkey/components": "2.345.3-fb-ontologyScope.0"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2425,9 +2425,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.345.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.0.tgz",
-      "integrity": "sha512-eBuV1kR2T8JbvModDjiyzWyVmuF2LPnVet7qki1R5HEoaf/TXGW86n0ncMn024zbaWt8n7C0N6mFuM4emyNVRw==",
+      "version": "2.345.3-fb-ontologyScope.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
+      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
       "dependencies": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",
@@ -13786,9 +13786,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.345.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.0.tgz",
-      "integrity": "sha512-eBuV1kR2T8JbvModDjiyzWyVmuF2LPnVet7qki1R5HEoaf/TXGW86n0ncMn024zbaWt8n7C0N6mFuM4emyNVRw==",
+      "version": "2.345.3-fb-ontologyScope.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.345.3-fb-ontologyScope.0.tgz",
+      "integrity": "sha512-+VLy1L5gBeL/ilTX6vFXjOF1qgb4/4hvR321+Sat5GyPw8ssx+A9sLw9U6LiCzKCvqZMT+kEKmAKycKdPFkJhg==",
       "requires": {
         "@labkey/api": "1.21.0",
         "@testing-library/jest-dom": "~5.16.5",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.345.0"
+    "@labkey/components": "2.345.3-fb-ontologyScope.0"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.345.3-fb-ontologyScope.0"
+    "@labkey/components": "2.346.1"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",


### PR DESCRIPTION
#### Rationale
Test failures

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1217
- https://github.com/LabKey/platform/pull/4536
- https://github.com/LabKey/biologics/pull/2193
- https://github.com/LabKey/sampleManagement/pull/1915

#### Changes
- add scope that includes Shared folder (where ontologies reside)
- switch from deprecated searchUsingIndex
