### PR TITLE
Issue 48161: Query tracker uses lots of RAM on server w/ big SQL

### DIFF
--- a/api/src/org/labkey/api/data/queryprofiler/Query.java
+++ b/api/src/org/labkey/api/data/queryprofiler/Query.java
@@ -38,6 +38,7 @@ public class Query
     private final @Nullable
     DbScope _scope;
     private final String _sql;
+    private boolean _truncated;
     private final @Nullable
     List<Object> _parameters;
     private final long _elapsed;
@@ -129,7 +130,7 @@ public class Query
 
     private static final Pattern TEMP_TABLE_PATTERN = Pattern.compile("([ix_|temp\\.][\\w]+)\\$?\\p{XDigit}{32}");
     private static final Pattern SPECIMEN_TEMP_TABLE_PATTERN = Pattern.compile("(SpecimenUpload)\\d{9}");
-    private static final int MAX_SQL_LENGTH = 1000000;  // Arbitrary limit to avoid saving insane SQL, #16646
+    private static final int MAX_SQL_LENGTH = 1_000_000;  // Arbitrary limit to avoid saving insane SQL, #16646
 
     // Transform the SQL to improve coalescing, etc.
     private String transform(String in)
@@ -139,6 +140,7 @@ public class Query
         if (in.length() > MAX_SQL_LENGTH)
         {
             out = in.substring(0, MAX_SQL_LENGTH);
+            _truncated = true;
         }
         else
         {
@@ -150,5 +152,10 @@ public class Query
         _validSql = out.equals(in);   // If we changed the SQL then it's no longer valid
 
         return out;
+    }
+
+    public boolean isTruncated()
+    {
+        return _truncated;
     }
 }

--- a/api/src/org/labkey/api/data/queryprofiler/QueryTracker.java
+++ b/api/src/org/labkey/api/data/queryprofiler/QueryTracker.java
@@ -141,7 +141,7 @@ class QueryTracker
 
     public boolean canShowExecutionPlan(ExecutionPlanType type)
     {
-        return null != _scope && _scope.getSqlDialect().canShowExecutionPlan(type) && _validSql && Table.isSelect(_sql);
+        return null != _scope && _scope.getSqlDialect().canShowExecutionPlan(type) && _validSql && !_truncated && Table.isSelect(_sql);
     }
 
     public long getCount()

--- a/api/src/org/labkey/api/data/queryprofiler/QueryTracker.java
+++ b/api/src/org/labkey/api/data/queryprofiler/QueryTracker.java
@@ -27,8 +27,10 @@ import org.labkey.api.data.TSVWriter;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.dialect.SqlDialect.ExecutionPlanType;
 import org.labkey.api.util.Compress;
+import org.labkey.api.util.DOM;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.Formats;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
@@ -40,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.DataFormatException;
 
@@ -50,8 +53,10 @@ import java.util.zip.DataFormatException;
 class QueryTracker
 {
     private final @Nullable DbScope _scope;
-    private final String _sql;
-    private final boolean _validSql;
+    private String _sql;
+    private boolean _truncated;
+    private final String _hash;
+    private boolean _validSql;
     private final long _firstInvocation;
     private final Map<ByteArrayHashKey, AtomicInteger> _stackTraces = new ReferenceMap<>(ReferenceStrength.SOFT, ReferenceStrength.HARD, true); // Not sure about purgeValues
 
@@ -62,12 +67,14 @@ class QueryTracker
     private long _cumulative = 0;
     private long _lastInvocation;
 
-    QueryTracker(@Nullable DbScope scope, @NotNull String sql, long elapsed, String stackTrace, boolean validSql)
+    QueryTracker(@Nullable DbScope scope, @NotNull String sql, @NotNull String hash, long elapsed, String stackTrace, boolean validSql, boolean truncated)
     {
         _scope = scope;
         _sql = sql;
+        _hash = hash;
         _validSql = validSql;
         _firstInvocation = System.currentTimeMillis();
+        _truncated = truncated;
 
         addInvocation(elapsed, stackTrace);
     }
@@ -94,6 +101,16 @@ class QueryTracker
     public DbScope getScope()
     {
         return _scope;
+    }
+
+    public String getHash()
+    {
+        return _hash;
+    }
+
+    public boolean isTruncated()
+    {
+        return _truncated;
     }
 
     public String getSql()
@@ -162,7 +179,7 @@ class QueryTracker
         return _stackTraces.size();
     }
 
-    public void renderStackTraces(PrintWriter out)
+    public DOM.Renderable renderStackTraces()
     {
         // Descending order by occurrences (the value)
         Set<Pair<String, AtomicInteger>> set = new TreeSet<>((e1, e2) ->
@@ -192,8 +209,8 @@ class QueryTracker
             }
         }
 
-        int commonLength = 0;
-        String formattedCommonPrefix = "";
+        int commonLength;
+        DOM.Renderable formattedCommonPrefix;
 
         if (set.size() > 1)
         {
@@ -203,24 +220,37 @@ class QueryTracker
             if (-1 != idx)
             {
                 commonLength = idx;
-                formattedCommonPrefix = "<b>" + PageFlowUtil.filter(commonPrefix.substring(0, commonLength), true) + "</b>";
+                formattedCommonPrefix = DOM.STRONG(HtmlString.of(commonPrefix.substring(0, commonLength), true));
+            }
+            else
+            {
+                commonLength = 0;
+                formattedCommonPrefix = HtmlString.EMPTY_STRING;
             }
         }
-
-        out.println("<tr><td><strong>Count</strong></td><td style=\"padding-left:1em;\"><strong>Traces</strong></td></tr>\n");
-
-        int alt = 0;
-        String[] classes = new String[]{"labkey-alternate-row", "labkey-row"};
-
-        for (Map.Entry<String, AtomicInteger> entry : set)
+        else
         {
-            String stackTrace = entry.getKey();
-            String formattedStackTrace = formattedCommonPrefix + PageFlowUtil.filter(stackTrace.substring(commonLength), true);
-            int count = entry.getValue().get();
-
-            out.println("<tr class=\"" + classes[alt] + "\"><td valign=top align=right>" + count + "</td><td style=\"padding-left:1em;\">" + formattedStackTrace + "</td></tr>\n");
-            alt = 1 - alt;
+            commonLength = 0;
+            formattedCommonPrefix = HtmlString.EMPTY_STRING;
         }
+
+        AtomicBoolean alt = new AtomicBoolean();
+
+        return DOM.TABLE(
+                DOM.TR(
+                        DOM.TD(DOM.STRONG("Count")),
+                        DOM.TD(DOM.STRONG(DOM.at(DOM.Attribute.style, "padding-left: 1em;"), "Traces"))
+                ),
+                set.stream().map(entry -> {
+                    String stackTrace = entry.getKey();
+                    int count = entry.getValue().get();
+                    alt.set(!alt.get());
+                    return DOM.TR(DOM.cl(alt.get() ? "labkey-alternate-row" : "labkey-row"),
+                            DOM.TD(DOM.at(DOM.Attribute.style, "text-align: right; vertical-align: top"), count),
+                            DOM.TD(DOM.at(DOM.Attribute.style, "padding-left: 1em;"), formattedCommonPrefix, HtmlString.of(stackTrace.substring(commonLength), true))
+                            );
+                })
+        );
     }
 
     @Override
@@ -299,7 +329,7 @@ class QueryTracker
             if (set.shouldDisplay())
                 out.println("<td style=\"text-align:right;vertical-align:top;\">" + ((QueryTrackerComparator) set.comparator()).getFormattedPrimaryStatistic(this) + "</td>");
 
-        ActionURL url = factory.getActionURL(getSql());
+        ActionURL url = factory.getActionURL(getHash());
         out.println("<td style=\"text-align:right;vertical-align:top;\"><a href=\"" + PageFlowUtil.filter(url.getLocalURIString()) + "\">" + Formats.commaf0.format(getStackTraceCount()) + "</a></td>");
         // In the full grid view, limit SQL to 2,000 characters (before encoding). Individual detail view still shows full SQL with and without parameters. See #29642.
         out.println("<td style=\"padding-left:10;\">" + PageFlowUtil.filter(StringUtils.abbreviate(getSql(), 2000), true) + "</td>");
@@ -324,5 +354,16 @@ class QueryTracker
         out.print(tab);
         out.print(tsvWriter.quoteValue(getSql()));
         out.print('\n');
+    }
+
+    public void truncate(int longSqlLimit)
+    {
+        if (_sql.length() > longSqlLimit)
+        {
+            _truncated = true;
+            _validSql = false;
+            _sql = _sql.substring(0, longSqlLimit);
+        }
+
     }
 }

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -2500,7 +2500,7 @@ public class AdminController extends SpringActionController
             buttonHTML += PageFlowUtil.button("Export").href(getExportQueriesURL()) + "<br/><br/>";
 
             return QueryProfiler.getInstance().getReportView(form.getStat(), buttonHTML, AdminController::getQueriesURL,
-                    sql -> getQueryStackTracesURL(sql.hashCode()));
+                    AdminController::getQueryStackTracesURL);
         }
 
         @Override
@@ -2528,10 +2528,10 @@ public class AdminController extends SpringActionController
     }
 
 
-    private static ActionURL getQueryStackTracesURL(int hashCode)
+    private static ActionURL getQueryStackTracesURL(String sqlHash)
     {
         ActionURL url = new ActionURL(QueryStackTracesAction.class, ContainerManager.getRoot());
-        url.addParameter("sqlHashCode", hashCode);
+        url.addParameter("sqlHash", sqlHash);
         return url;
     }
 
@@ -2542,7 +2542,7 @@ public class AdminController extends SpringActionController
         @Override
         public ModelAndView getView(QueryForm form, BindException errors)
         {
-            return QueryProfiler.getInstance().getStackTraceView(form.getSqlHashCode(), AdminController::getExecutionPlanURL);
+            return QueryProfiler.getInstance().getStackTraceView(form.getSqlHash(), AdminController::getExecutionPlanURL);
         }
 
         @Override
@@ -2554,10 +2554,10 @@ public class AdminController extends SpringActionController
     }
 
 
-    private static ActionURL getExecutionPlanURL(String sql)
+    private static ActionURL getExecutionPlanURL(String sqlHash)
     {
         ActionURL url = new ActionURL(ExecutionPlanAction.class, ContainerManager.getRoot());
-        url.addParameter("sqlHashCode", sql.hashCode());
+        url.addParameter("sqlHash", sqlHash);
         return url;
     }
 
@@ -2565,25 +2565,25 @@ public class AdminController extends SpringActionController
     @AdminConsoleAction
     public class ExecutionPlanAction extends SimpleViewAction<QueryForm>
     {
-        private int _hashCode;
+        private String _sqlHash;
         private ExecutionPlanType _type;
 
         @Override
         public ModelAndView getView(QueryForm form, BindException errors)
         {
-            _hashCode = form.getSqlHashCode();
+            _sqlHash = form.getSqlHash();
             _type = EnumUtils.getEnum(ExecutionPlanType.class, form.getType());
             if (null == _type)
                 throw new NotFoundException("Unknown execution plan type");
 
-            return QueryProfiler.getInstance().getExecutionPlanView(form.getSqlHashCode(), _type);
+            return QueryProfiler.getInstance().getExecutionPlanView(form.getSqlHash(), _type);
         }
 
         @Override
         public void addNavTrail(NavTree root)
         {
             addAdminNavTrail(root, "Queries", QueriesAction.class);
-            root.addChild("Query Stack Traces", getQueryStackTracesURL(_hashCode));
+            root.addChild("Query Stack Traces", getQueryStackTracesURL(_sqlHash));
             root.addChild(_type.getDescription());
         }
     }
@@ -2591,18 +2591,18 @@ public class AdminController extends SpringActionController
 
     public static class QueryForm
     {
-        private int _sqlHashCode;
+        private String _sqlHash;
         private String _type = "Estimated"; // All dialects support Estimated
 
-        public int getSqlHashCode()
+        public String getSqlHash()
         {
-            return _sqlHashCode;
+            return _sqlHash;
         }
 
         @SuppressWarnings({"UnusedDeclaration"})
-        public void setSqlHashCode(int sqlHashCode)
+        public void setSqlHash(String sqlHash)
         {
-            _sqlHashCode = sqlHashCode;
+            _sqlHash = sqlHash;
         }
 
         public String getType()


### PR DESCRIPTION
#### Rationale
We don't want to spend hundreds of MB of memory remembering long SQL queries

#### Changes
* Limit the number of queries where we remember up to 1 MB of SQL
* Truncate older long queries to a mere 100KB
* Use DOM renderer in Java code
* Easy link to copy execution plan to clipboard
* Use a longer hash instead of Java's `hashCode()` for tracking queries