### PR TITLE
Fix LSID template was not fully resolved

### DIFF
--- a/api/src/org/labkey/api/exp/FileXarSource.java
+++ b/api/src/org/labkey/api/exp/FileXarSource.java
@@ -16,11 +16,13 @@
 
 package org.labkey.api.exp;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.pipeline.PipelineJob;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
 
 /**
  * User: jeckels
@@ -34,10 +36,15 @@ public class FileXarSource extends AbstractFileXarSource
         _xmlFile = file.normalize();
     }
 
+    public FileXarSource(Path file, PipelineJob job, Container targetContainer, @Nullable Map<String, String> substitutions)
+    {
+        super(job.getDescription(), targetContainer, job.getUser(), job, substitutions);
+        _xmlFile = file;
+    }
+
     public FileXarSource(Path file, PipelineJob job, Container targetContainer)
     {
-        super(job.getDescription(), targetContainer, job.getUser(), job);
-        _xmlFile = file;
+        this(file, job, targetContainer, null);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -387,15 +387,14 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                     _lsidColumnIndex = i;
                     _lsidTemplateSupplier = delegate.getSupplier(i);
                     _lsidResolvedSupplier = () -> {
-//                        try
-//                        {
-                            return "broken";
-//                            return LsidUtils.resolveLsidFromTemplate((String)_lsidTemplateSupplier.get(), _xarContext, _baseType);
-//                        }
-//                        catch (XarFormatException xfe)
-//                        {
-//                            throw UnexpectedException.wrap(xfe);
-//                        }
+                        try
+                        {
+                            return LsidUtils.resolveLsidFromTemplate((String)_lsidTemplateSupplier.get(), _xarContext, _baseType);
+                        }
+                        catch (XarFormatException xfe)
+                        {
+                            throw UnexpectedException.wrap(xfe);
+                        }
                     };
                     break;
                 }

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -58,6 +58,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.labkey.api.admin.FolderImportContext.IS_NEW_FOLDER_IMPORT_KEY;
+import static org.labkey.api.exp.XarContext.XAR_JOB_ID_NAME;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.DEFAULT_DIRECTORY;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.EXCLUDED_TYPES;
 import static org.labkey.experiment.samples.SampleTypeAndDataClassFolderWriter.XAR_RUNS_NAME;
@@ -157,6 +158,9 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                         logFile = CompressedInputStreamXarSource.getLogFileFor(typesXarFile);
                     XarReader typesReader = getXarReader(job, ctx, root, typesXarFile);
                     XarContext xarContext = typesReader.getXarSource().getXarContext();
+                    Map<String, String> xarJobIdContext = ctx.getXarJobIdContext();
+                    if (xarJobIdContext != null)
+                        xarContext.addSubstitution(XAR_JOB_ID_NAME, xarJobIdContext.get(XAR_JOB_ID_NAME));
 
                     typesReader.setStrictValidateExistingSampleType(xarCtx.isStrictValidateExistingSampleType());
                     typesReader.parseAndLoad(false, ctx.getAuditBehaviorType());

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -387,14 +387,15 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                     _lsidColumnIndex = i;
                     _lsidTemplateSupplier = delegate.getSupplier(i);
                     _lsidResolvedSupplier = () -> {
-                        try
-                        {
-                            return LsidUtils.resolveLsidFromTemplate((String)_lsidTemplateSupplier.get(), _xarContext, _baseType);
-                        }
-                        catch (XarFormatException xfe)
-                        {
-                            throw UnexpectedException.wrap(xfe);
-                        }
+//                        try
+//                        {
+                            return "broken";
+//                            return LsidUtils.resolveLsidFromTemplate((String)_lsidTemplateSupplier.get(), _xarContext, _baseType);
+//                        }
+//                        catch (XarFormatException xfe)
+//                        {
+//                            throw UnexpectedException.wrap(xfe);
+//                        }
                     };
                     break;
                 }

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -158,9 +158,6 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                         logFile = CompressedInputStreamXarSource.getLogFileFor(typesXarFile);
                     XarReader typesReader = getXarReader(job, ctx, root, typesXarFile);
                     XarContext xarContext = typesReader.getXarSource().getXarContext();
-                    Map<String, String> xarJobIdContext = ctx.getXarJobIdContext();
-                    if (xarJobIdContext != null)
-                        xarContext.addSubstitution(XAR_JOB_ID_NAME, xarJobIdContext.get(XAR_JOB_ID_NAME));
 
                     typesReader.setStrictValidateExistingSampleType(xarCtx.isStrictValidateExistingSampleType());
                     typesReader.parseAndLoad(false, ctx.getAuditBehaviorType());
@@ -283,6 +280,10 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
         UserSchema userSchema = QueryService.get().getUserSchema(ctx.getUser(), ctx.getContainer(), schemaName);
         if (userSchema != null)
         {
+            Map<String, String> xarJobIdContext = ctx.getXarJobIdContext();
+            if (xarJobIdContext != null)
+                xarContext.addSubstitution(XAR_JOB_ID_NAME, xarJobIdContext.get(XAR_JOB_ID_NAME));
+
             for (ExpObject expObject : expObjects)
             {
                 String tableName = expObject.getName();

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeAndDataClassFolderImporter.java
@@ -173,7 +173,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
                     {
                         XarSource runsXarSource;
                         if (runsXarFile.getFileName().toString().toLowerCase().endsWith(".xar.xml"))
-                            runsXarSource = new FileXarSource(runsXarFile, job, ctx.getContainer());
+                            runsXarSource = new FileXarSource(runsXarFile, job, ctx.getContainer(), ctx.getXarJobIdContext());
                         else
                             runsXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(runsXarFile.getFileName().toString()), runsXarFile, logFile, job, ctx.getUser(), ctx.getContainer(), ctx.getXarJobIdContext());
                         try
@@ -222,7 +222,7 @@ public class SampleTypeAndDataClassFolderImporter implements FolderImporter
         XarSource typesXarSource;
 
         if (typesXarFile.getFileName().toString().toLowerCase().endsWith(".xar.xml"))
-            typesXarSource = new FileXarSource(typesXarFile, job, ctx.getContainer());
+            typesXarSource = new FileXarSource(typesXarFile, job, ctx.getContainer(), ctx.getXarJobIdContext());
         else
             typesXarSource = new CompressedInputStreamXarSource(xarDir.getInputStream(typesXarFile.getFileName().toString()), typesXarFile, logFile, job, ctx.getUser(), ctx.getContainer(), ctx.getXarJobIdContext());
         try

--- a/experiment/src/org/labkey/experiment/xar/FolderXarImporterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarImporterFactory.java
@@ -210,7 +210,8 @@ public class FolderXarImporterFactory extends AbstractFolderImportFactory
                             // get assigned to the subfolder instead of the parent container.
                             // If we were given a non-null job in FolderXarImporter.process(), job.getContainer() will
                             // return the parent container.
-                            _importContext.getContainer());
+                            _importContext.getContainer(),
+                            _importContext.getXarJobIdContext());
                 }
                 else
                 {


### PR DESCRIPTION
#### Rationale
[Trial Eval Integration Test](https://teamcity.labkey.org/buildConfiguration/LabKey_HostingAndEvaluationInfrastructure_AutomatedTest_AutomatedTestForTrunk_AccountsBetaIntegrationTest), [Trial LIMS Integration Test](https://teamcity.labkey.org/buildConfiguration/LabKey_HostingAndEvaluationInfrastructure_AutomatedTest_AutomatedTestForTrunk_TrialBiologicsIntegrationTest) & [Trial SM Integration Test](https://teamcity.labkey.org/buildConfiguration/LabKey_HostingAndEvaluationInfrastructure_AutomatedTest_AutomatedTestForTrunk_TrialSmIntegrationTest)

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add XarJobId to substitutions for ResolveLsidDataIterator
