### PR TITLE
Issue 46468: "View Raw Schema Metadata" for assay types gives error page

### DIFF
--- a/query/webapp/query/browser/view/SchemaDetails.js
+++ b/query/webapp/query/browser/view/SchemaDetails.js
@@ -171,7 +171,7 @@ Ext4.define('LABKEY.query.browser.view.SchemaDetails', {
 
         if (LABKEY.devMode || LABKEY.Security.currentUser.isDeveloper) {
             children.push(LABKEY.Utils.textLink({
-                href: LABKEY.ActionURL.buildURL('query', 'rawSchemaMetaData', undefined, {schemaName: schema.schemaName}),
+                href: LABKEY.ActionURL.buildURL('query', 'rawSchemaMetaData', undefined, {schemaName: schema.fullyQualifiedName}),
                 text: 'view raw schema metadata'
             }));
         }


### PR DESCRIPTION
#### Rationale
We need to pass the fully schema name, not just the child name

#### Changes
* Use `fullyQualifiedName`