### PR TITLE
Folder export/import option updates (test automation fixes)

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/DataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/DataClassFolderImporter.java
@@ -1,9 +1,9 @@
 package org.labkey.experiment.samples;
 
-import org.labkey.api.admin.FolderArchiveDataTypes;
 import org.labkey.api.admin.FolderImportContext;
 import org.labkey.api.admin.FolderImporter;
 import org.labkey.api.admin.FolderImporterFactory;
+import org.labkey.api.admin.ImportException;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.query.ExpSchema;
@@ -48,7 +48,7 @@ public class DataClassFolderImporter extends AbstractExpFolderImporter
 
     public String getDataType()
     {
-        return FolderArchiveDataTypes.DATA_CLASS_DATA;
+        return "Data Classes";
     }
 
     @Override
@@ -95,6 +95,12 @@ public class DataClassFolderImporter extends AbstractExpFolderImporter
 
             importTsvData(ctx, xarContext, ExpSchema.SCHEMA_EXP_DATA.toString(), sortedDataClasses, dataClassDataFiles, xarDir, true, false);
         }
+    }
+
+    @Override
+    public boolean isValidForImportArchive(FolderImportContext ctx) throws ImportException
+    {
+        return ctx.getDir(DataClassFolderWriter.DEFAULT_DIRECTORY) != null;
     }
 
     public static class Factory implements FolderImporterFactory

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeFolderImporter.java
@@ -1,9 +1,9 @@
 package org.labkey.experiment.samples;
 
-import org.labkey.api.admin.FolderArchiveDataTypes;
 import org.labkey.api.admin.FolderImportContext;
 import org.labkey.api.admin.FolderImporter;
 import org.labkey.api.admin.FolderImporterFactory;
+import org.labkey.api.admin.ImportException;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.util.FileUtil;
@@ -28,7 +28,7 @@ public class SampleTypeFolderImporter extends AbstractExpFolderImporter
     @Override
     public String getDataType()
     {
-        return FolderArchiveDataTypes.SAMPLE_TYPE_DATA;
+        return "Sample Types";
     }
 
     @Override
@@ -75,6 +75,12 @@ public class SampleTypeFolderImporter extends AbstractExpFolderImporter
         {
             importTsvData(ctx, xarContext, SamplesSchema.SCHEMA_NAME, typesReader.getSampleTypes(), sampleTypeDataFiles, xarDir, true, false);
         }
+    }
+
+    @Override
+    public boolean isValidForImportArchive(FolderImportContext ctx) throws ImportException
+    {
+        return ctx.getDir(DEFAULT_DIRECTORY) != null;
     }
 
     public static class Factory implements FolderImporterFactory

--- a/list/src/org/labkey/list/model/FolderListImporter.java
+++ b/list/src/org/labkey/list/model/FolderListImporter.java
@@ -38,7 +38,7 @@ public class FolderListImporter implements FolderImporter
     @Override
     public String getDataType()
     {
-        return FolderArchiveDataTypes.LIST_DATA;
+        return "Lists";
     }
 
     @Override

--- a/study/src/org/labkey/study/writer/AssayDatasetData.java
+++ b/study/src/org/labkey/study/writer/AssayDatasetData.java
@@ -21,6 +21,12 @@ public class AssayDatasetData implements InternalStudyWriter
     }
 
     @Override
+    public boolean includeWithTemplate()
+    {
+        return false;
+    }
+
+    @Override
     public boolean selectedByDefault(AbstractFolderContext.ExportType type, boolean forTemplate)
     {
         return !forTemplate;

--- a/study/src/org/labkey/study/writer/SampleTypeDatasetData.java
+++ b/study/src/org/labkey/study/writer/SampleTypeDatasetData.java
@@ -21,6 +21,12 @@ public class SampleTypeDatasetData implements InternalStudyWriter
     }
 
     @Override
+    public boolean includeWithTemplate()
+    {
+        return false;
+    }
+
+    @Override
     public boolean selectedByDefault(AbstractFolderContext.ExportType type, boolean forTemplate)
     {
         return !forTemplate;

--- a/study/src/org/labkey/study/writer/StudyDatasetData.java
+++ b/study/src/org/labkey/study/writer/StudyDatasetData.java
@@ -21,6 +21,12 @@ public class StudyDatasetData implements InternalStudyWriter
     }
 
     @Override
+    public boolean includeWithTemplate()
+    {
+        return false;
+    }
+
+    @Override
     public boolean selectedByDefault(AbstractFolderContext.ExportType type, boolean forTemplate)
     {
         return !forTemplate;


### PR DESCRIPTION
#### Rationale
A recent [PR](https://github.com/LabKey/platform/pull/4468) resulted in some test automation failures. Specifically around the two folder import workflows that allow importing from an existing folder.

This change does a few things:
- Restores the prior behavior of not allowing assay, sample type, and dataset data to be exported when importing from an existing folder.
- Update the data type names for the list, sample type, and data class folder importers to be a little more informative when the list of importers are presented to the user (only in the one place that I can tell)
- Update the `isValidForImportArchive` method for sample types and data classes to follow the common pattern of returning `true` only when there is data to import.