### PR TITLE
GA4 app support

### DIFF
--- a/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
@@ -235,7 +235,7 @@ public class AnalyticsServiceImpl implements AnalyticsService
         String controller = url.getController();
         String action = url.getAction();
         Boolean sendPageView = true;
-        Boolean isAppController = controller.equalsIgnoreCase("biologics") || controller.equalsIgnoreCase("sampleManagement") || controller.equalsIgnoreCase("freezermanager");
+        Boolean isAppController = controller.equalsIgnoreCase("biologics") || controller.equalsIgnoreCase("sampleManager") || controller.equalsIgnoreCase("freezermanager");
         Boolean isAppAction = action.equalsIgnoreCase("app") || action.equalsIgnoreCase("appDev");
 
         if (isAppController && isAppAction)

--- a/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
@@ -210,7 +210,7 @@ public class AnalyticsServiceImpl implements AnalyticsService
                       function gtag(){dataLayer.push(arguments);}
                       gtag('js', new Date());
                     
-                      gtag('config', ${MEASUREMENT_ID:jsString});
+                      gtag('config', ${MEASUREMENT_ID:jsString}, { 'send_page_view': ${SEND_PAGE_VIEW} });
                     </script>
                     """;
 
@@ -232,6 +232,14 @@ public class AnalyticsServiceImpl implements AnalyticsService
             return "";
 
         String ga4JS = "https://www.googletagmanager.com/gtag/js?id=" + getMeasurementId();
+        String controller = url.getController();
+        String action = url.getAction();
+        Boolean sendPageView = true;
+        Boolean isAppController = controller.equalsIgnoreCase("biologics") || controller.equalsIgnoreCase("sampleManagement") || controller.equalsIgnoreCase("freezermanager");
+        Boolean isAppAction = action.equalsIgnoreCase("app") || action.equalsIgnoreCase("appDev");
+
+        if (isAppController && isAppAction)
+            sendPageView = false;
 
         StringBuilder sb = new StringBuilder();
         for (TrackingStatus trackingStatus : getTrackingStatus())
@@ -240,7 +248,8 @@ public class AnalyticsServiceImpl implements AnalyticsService
             sb.append(se.eval(PageFlowUtil.map(
                     "PAGE_URL", getSanitizedUrl(context),
                     "GA4_JS", ga4JS,
-                    "MEASUREMENT_ID", getMeasurementId())));
+                    "MEASUREMENT_ID", getMeasurementId(),
+                    "SEND_PAGE_VIEW", sendPageView)));
         }
         return sb.toString();
     }


### PR DESCRIPTION
#### Rationale
Google Analytics 4 doesn't send particularly useful information for our apps when using the default configuration. This PR updates the injected GA4 script to not send page views for our Apps, so they can manually send page view events in a way that better captures page views.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/123
- https://github.com/LabKey/platform/pull/4553
- https://github.com/LabKey/biologics/pull/2212
- https://github.com/LabKey/inventory/pull/909
- https://github.com/LabKey/sampleManagement/pull/1930
- https://github.com/LabKey/labbook/pull/510

#### Changes
* AnalyticsServiceImpl::getTrackingScript - Do not send page views for app actions
