### PR TITLE
LinkReport rendering fix

### DIFF
--- a/query/src/org/labkey/query/reports/LinkReport.java
+++ b/query/src/org/labkey/query/reports/LinkReport.java
@@ -62,9 +62,10 @@ public class LinkReport extends BaseRedirectReport
         {
             return ImageUtil.webThumbnail(url);
         }
-        catch (UnknownHostException uhe)
+        catch (UnknownHostException | ClassCastException e)
         {
-            LogManager.getLogger(LinkReport.class).warn("Error rendering link report thumbnail: " + uhe.getMessage());
+            // ClassCastException is most likely a rendering error in flying saucer
+            LogManager.getLogger(LinkReport.class).warn("Error rendering link report thumbnail: " + e.getMessage());
         }
         catch (Exception e)
         {


### PR DESCRIPTION
#### Rationale
A recent update to the `JTidy` library exposed some new [test failures](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySqlServer/2521882?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests&class=ReportAndDatasetNotificationTest&expandedTest=build%3A%28id%3A2521877%29%2Cid%3A2000000011). 

The problem isn't necessarily that `JTidy` is causing the rendering problems, it's more likely that the updated version is finding fewer documents with errors but then exposing a rendering bug in the `flyingsaucer` library.

#### Changes
Catch the `ClassCastException` and log a warning instead of throwing.