### PR TITLE
Issue 48040: Process JSONObject.NULL sentinel value as null

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -48,6 +48,7 @@ import org.labkey.api.dataiterator.RemoveDuplicatesDataIterator;
 import org.labkey.api.dataiterator.ResultSetDataIterator;
 import org.labkey.api.dataiterator.SimpleTranslator;
 import org.labkey.api.dataiterator.StatementDataIterator;
+import org.labkey.api.exp.api.ExperimentJSONConverter;
 import org.labkey.api.exp.property.DomainTemplateGroup;
 import org.labkey.api.files.FileSystemWatcherImpl;
 import org.labkey.api.iterator.MarkableIterator;
@@ -174,6 +175,7 @@ public class ApiModule extends CodeOnlyModule
             ExcelFactory.ExcelFactoryTestCase.class,
             ExcelLoader.ExcelLoaderTestCase.class,
             ExistingRecordDataIterator.TestCase.class,
+            ExperimentJSONConverter.TestCase.class,
             ExtUtil.TestCase.class,
             FieldKey.TestCase.class,
             FileType.TestCase.class,


### PR DESCRIPTION
#### Rationale
This addresses [Issue 48040](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48040) by updating `ExperimentJSONConverter` to explicitly handle `JSONObject.NULL` values before calling `ConvertUtils.lookup.convert()`. The convert utilities do not know about this sentinel value nor should they.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4492

#### Changes
* Process `JSONObject.NULL` as `null` when calling `ConvertUtils.lookup.convert()` in `ExperimentJSONConverter`.
