### PR TITLE
Hide names in notebooks and timeline entries when users don't have permission to see them

### DIFF
--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -93,6 +93,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 
 /**
@@ -1694,7 +1695,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
     }
 
     /**
-     * Returns the subfolder count of the project container, if product projects feature is enabled in project
+     * Returns true if produt projects feature is enabled and the subfolder count of the project container is > 0
      */
     public boolean hasProductProjects()
     {
@@ -1708,6 +1709,18 @@ public class Container implements Serializable, Comparable<Container>, Securable
 
         // need to exclude the notebook folders in particular here
         return project.getChildren().stream().anyMatch(c -> c.getContainerType().isInFolderNav());
+    }
+
+    public List<Container> getProductProjects()
+    {
+        if (!isProductProjectsEnabled())
+            return Collections.singletonList(this);
+
+        Container project = getProject();
+        if (project == null)
+            return Collections.emptyList();
+
+        return project.getChildren().stream().filter(c -> c.getContainerType().isInFolderNav()).collect(Collectors.toList());
     }
 
     public ContainerFilter getProductProjectsDataContainerFilter(User user)

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1695,7 +1695,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
     }
 
     /**
-     * Returns true if produt projects feature is enabled and the subfolder count of the project container is > 0
+     * Returns true if product projects feature is enabled and the subfolder count of the project container is > 0
      */
     public boolean hasProductProjects()
     {
@@ -1714,7 +1714,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
     public List<Container> getProductProjects()
     {
         if (!isProductProjectsEnabled())
-            return Collections.singletonList(this);
+            return Collections.emptyList();
 
         Container project = getProject();
         if (project == null)


### PR DESCRIPTION
#### Rationale
When notebooks contain references to entities a user does not have permission to see, we want to hide these notebooks altogether from these users. The initial check here will check permissions on the product projects containers in general so most people won't need to go further than that.

#### Related Pull Requests

- https://github.com/LabKey/labbook/pull/511
- https://github.com/LabKey/labkey-ui-components/pull/1227
- https://github.com/LabKey/labkey-ui-premium/pull/129
- https://github.com/LabKey/sampleManagement/pull/1939
- https://github.com/LabKey/biologics/pull/2222

#### Changes
* add `getProductProjects` method
