### PR TITLE
Fix broken PanoramaPublic tests

### DIFF
--- a/api/src/org/labkey/api/admin/FolderArchiveDataTypes.java
+++ b/api/src/org/labkey/api/admin/FolderArchiveDataTypes.java
@@ -29,6 +29,7 @@ public class FolderArchiveDataTypes
     public static final String WEBPART_PROPERTIES_AND_LAYOUT = "Webpart properties and layout";
     public static final String CONTAINER_SPECIFIC_MODULE_PROPERTIES = "Container specific module properties";
     public static final String EXPERIMENTS_AND_RUNS = "Experiments, Protocols, and Runs";
+    public static final String EXPERIMENT_RUNS = "Experiment Runs";
     public static final String LIST_DESIGN = "List Designs";
     public static final String LIST_DATA = "List Data";
     public static final String QUERIES = "Queries";

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -52,7 +52,6 @@ public class FolderXarWriterFactory implements FolderWriterFactory
     public static final String XAR_DIRECTORY = "xar";
     private static final String XAR_FILE_NAME = "experiments_and_runs.xar";
     private static final String XAR_XML_FILE_NAME = XAR_FILE_NAME + ".xml";
-    private static final String EXPERIMENT_RUNS = "Experiment Runs";
     private static List<Writer> CHILD_WRITERS = Arrays.asList(new ExperimentRunsWriter());
 
     @Override
@@ -168,7 +167,7 @@ public class FolderXarWriterFactory implements FolderWriterFactory
 
             selection.addProtocolIds(getProtocols(c));
 
-            if (ctx.getDataTypes().contains(EXPERIMENT_RUNS))
+            if (ctx.getDataTypes().contains(FolderArchiveDataTypes.EXPERIMENT_RUNS))
                 selection.addRuns(getRuns(ctx, c));
 
             ctx.getXml().addNewXar().setDir(XAR_DIRECTORY);
@@ -194,7 +193,7 @@ public class FolderXarWriterFactory implements FolderWriterFactory
         @Override
         public @Nullable String getDataType()
         {
-            return EXPERIMENT_RUNS;
+            return FolderArchiveDataTypes.EXPERIMENT_RUNS;
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
PanoramaPublic tests are failing due to the changes in this PR: https://github.com/LabKey/platform/pull/4468
[Issue 47818: Ability to export folder archives with only metadata](https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=47818)
We need to include runs in the ExperimentExportTask of the PanoramaPublic pipeline.

#### Changes
Moved `EXPERIMENT_RUNS` constant from `FolderXarWriterFactory` to the API class `FolderArchiveDataTypes`