### PR TITLE
Issue 48225: Deadlock when updating module

### DIFF
--- a/api/src/org/labkey/api/data/WrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/WrappedColumnInfo.java
@@ -21,6 +21,10 @@ public class WrappedColumnInfo
 {
     public static MutableColumnInfo wrap(ColumnInfo delegate)
     {
+        if (delegate == null)
+        {
+            throw new NullPointerException("Cannot wrap a null column");
+        }
         return new MutableColumnInfoWrapper(delegate);
     }
 


### PR DESCRIPTION
#### Rationale
See the issue for details of a deadlock when updating a module, caused by ModuleLoader synchronization.

#### Changes
* Reduce code inside of the synchronized blocks, including firing the moduleChangedEvent
* Improve error handling in WrappedColumnInfo by reporting an error when creating a column instead of when it's used