### PR TITLE
Remove old MySQL workaround

### DIFF
--- a/api/src/org/labkey/api/data/ResultSetMetaDataImpl.java
+++ b/api/src/org/labkey/api/data/ResultSetMetaDataImpl.java
@@ -249,8 +249,7 @@ public class ResultSetMetaDataImpl implements ResultSetMetaData
         {
             catalogName = md.getCatalogName(i);
             isAutoIncrement = md.isAutoIncrement(i);
-            // HACK to work around MySQL 5.7 bug. See #24800. Revisit once MySQL fixes https://bugs.mysql.com/bug.php?id=74723 and/or http://bugs.mysql.com/bug.php?id=79449
-            isCaseSensitive = !"com.mysql.jdbc.ResultSetMetaData".equals(md.getClass().getName()) && md.isCaseSensitive(i);
+            isCaseSensitive = md.isCaseSensitive(i);
             isSearchable = md.isSearchable(i);
             isCurrency = md.isCurrency(i);
             isNullable = md.isNullable(i);


### PR DESCRIPTION
#### Rationale
MySQL server-side bug was fixed long ago, so the workaround is no longer needed. In addition, the specified class no longer exists in the driver (it was renamed), so the workaround hasn't worked for years.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=24800
