### PR TITLE
Add missing reserved field names for sample types and make menu section more robust

### DIFF
--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -100,6 +100,8 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
 
         RESERVED_NAMES = BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet());
         RESERVED_NAMES.addAll(Arrays.stream(ExpSampleTypeTable.Column.values()).map(ExpSampleTypeTable.Column::name).toList());
+        RESERVED_NAMES.add("Protocol"); // alias for "SourceProtocolApplication"
+        RESERVED_NAMES.add("SampleTypeUnits"); // alias for MetricUnit
         RESERVED_NAMES.add("CpasType");
         RESERVED_NAMES.add("IsAliquot");
         RESERVED_NAMES.add(ExpMaterial.ALIQUOTED_FROM_INPUT);

--- a/core/api-src/org/labkey/api/products/MenuSection.java
+++ b/core/api-src/org/labkey/api/products/MenuSection.java
@@ -145,11 +145,19 @@ public abstract class MenuSection
 
     protected String getLabel(UserSchema schema, String queryName)
     {
-        TableInfo tableInfo = getTableInfo(schema, queryName);
-        String label = tableInfo.getTitle();
-        if (label == null)
-            label = tableInfo.getName();
-        return label;
+        try
+        {
+            TableInfo tableInfo = getTableInfo(schema, queryName);
+            String label = tableInfo.getTitle();
+            if (label == null)
+                label = tableInfo.getName();
+            return label;
+        }
+        catch (Throwable e)
+        {
+            // if the domain was created using reserved names, we won't get a TableInfo, so we'll default to the queryName
+            return queryName;
+        }
     }
 
     public String getSectionKey()


### PR DESCRIPTION
#### Rationale
The fields `Protocol` and `SampleTypeUnits` are aliases for other fields that are reserved for sample types. If you happen to create a sample type with these field names, the application becomes very unhappy because we allow the sample domain to be saved (See this [comment](https://github.com/LabKey/platform/blob/42bd895e3ad82cfc786ad7a9f9a790c66bf948aa/api/src/org/labkey/api/data/AbstractTableInfo.java#L703) in `AbstractTableInfo`.), but then cannot load the sample type to do anything with it.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/133
- https://github.com/LabKey/sampleManagement/pull/1953
- https://github.com/LabKey/biologics/pull/2233

#### Changes
* Add the missing reserved field name aliases
* Make `getLabel` in `MenuSection` more robust to failures to retrieve the tableInfo for a query
