### PR TITLE
Fix bug in getContainersForFilePath(java.nio.file.Path path)

### DIFF
--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -165,12 +165,20 @@ public class FileContentServiceImpl implements FileContentService
                     // check if there exists a child container that matches the next path segment
                     java.nio.file.Path top = rel.subpath(0, 1);
                     assert top != null;
-                    Container child = root.getChild(top.getFileName().toString());
+                    Container child = next.getChild(top.getFileName().toString());
                     if (child == null)
                         break;
 
                     next = child;
-                    rel = rel.subpath(1, rel.getNameCount() - 1);
+
+                    if(rel.getNameCount() > 1)
+                    {
+                        rel = rel.subpath(1, rel.getNameCount());
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
 
                 if (next != null && !next.equals(root))


### PR DESCRIPTION
#### Rationale
getContainersForFilePath() gets the Container only for the first element in the path because it always tries to get the child container relative to the root. 



