### PR TITLE
Ratchet down reindexing of lists and datasets

### DIFF
--- a/api/src/org/labkey/api/attachments/AttachmentService.java
+++ b/api/src/org/labkey/api/attachments/AttachmentService.java
@@ -131,6 +131,8 @@ public interface AttachmentService
 
     void deleteIndexedAttachments(AttachmentParent parent);
 
+    void clearLastIndexed(List<String> parentIds);
+
     void registerAttachmentType(AttachmentType type);
 
     HttpView getAdminView(ActionURL currentUrl);

--- a/api/src/org/labkey/api/data/SimpleFilter.java
+++ b/api/src/org/labkey/api/data/SimpleFilter.java
@@ -529,7 +529,7 @@ public class SimpleFilter implements Filter
 
     public static class NotClause extends FilterClause
     {
-        private FilterClause _clause;
+        private final FilterClause _clause;
 
         public NotClause(FilterClause clause)
         {
@@ -576,7 +576,7 @@ public class SimpleFilter implements Filter
         public static final String SEPARATOR = ";";
         public static final int MAX_FILTER_VALUES_TO_DISPLAY = 10;
 
-        private CompareType _comparison;
+        private final CompareType _comparison;
 
         public MultiValuedFilterClause(@NotNull FieldKey fieldKey, CompareType comparison, Collection<?> params, boolean negated)
         {

--- a/api/src/org/labkey/api/data/SimpleFilter.java
+++ b/api/src/org/labkey/api/data/SimpleFilter.java
@@ -479,7 +479,7 @@ public class SimpleFilter implements Filter
             }
         }
 
-        protected List<FilterClause> getClauses()
+        public List<FilterClause> getClauses()
         {
             return _clauses;
         }

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -389,6 +389,16 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
         }
     }
 
+    @Override
+    public void clearLastIndexed(List<String> parentIds)
+    {
+        SimpleFilter filter = new SimpleFilter(new SimpleFilter.InClause(FieldKey.fromParts("Parent"), parentIds))
+            .addClause(new SimpleFilter.SQLClause("LastIndexed IS NOT NULL", null));
+        SQLFragment sql = new SQLFragment("UPDATE core.Documents SET LastIndexed = NULL ")
+            .append(filter.getSQLFragment(CoreSchema.getInstance().getSqlDialect()));
+        new SqlExecutor(CoreSchema.getInstance().getSchema()).execute(sql);
+    }
+
     private void deleteIndexedAttachment(AttachmentParent parent, String name)
     {
         deleteIndexedAttachment(parent.getEntityId(), name);
@@ -400,7 +410,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
         if (ss != null)
             ss.deleteResource(makeDocId(parent, name));
         new SqlExecutor(CoreSchema.getInstance().getSchema()).execute(new SQLFragment(
-            "UPDATE core.Documents SET LastIndexed = NULL WHERE Parent = ? and DocumentName = ?", parent, name)
+            "UPDATE core.Documents SET LastIndexed = NULL WHERE LastIndexed IS NOT NULL AND Parent = ? AND DocumentName = ?", parent, name)
         );
     }
 

--- a/list/src/org/labkey/list/model/ListDefinitionImpl.java
+++ b/list/src/org/labkey/list/model/ListDefinitionImpl.java
@@ -425,7 +425,7 @@ public class ListDefinitionImpl implements ListDefinition
         _domain = null;
         getDomain();
 
-        ListManager.get().indexList(_def, true);
+        ListManager.get().indexList(_def);
     }
 
     private void ensureKey()

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -698,7 +698,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
 
         ListDefinition list = ListService.get().getList(domain);
         if (list != null)
-            ListManager.get().indexList(list, true);
+            ListManager.get().indexList(list);
     }
 
     @Override

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -174,7 +174,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
             }
 
             if (result.size() > 0 && !errors.hasErrors())
-                mgr.indexList(_list, false);
+                mgr.indexList(_list);
         }
 
         return result;
@@ -245,7 +245,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
                     if (imported > 0)
                         ListManager.get().addAuditEvent(_list, updatedUser, "Bulk " + (insertOption.updateOnly ? "updated " : (insertOption.mergeRows ? "imported " : "inserted ")) + imported + " rows to list.");
 
-                    transaction.addCommitTask(() -> ListManager.get().indexList(_list, false), DbScope.CommitTaskOption.POSTCOMMIT);
+                    transaction.addCommitTask(() -> ListManager.get().indexList(_list), DbScope.CommitTaskOption.POSTCOMMIT);
                     transaction.commit();
 
                     return imported;
@@ -280,7 +280,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         DataIteratorContext context = getDataIteratorContext(errors, InsertOption.IMPORT, configParameters);
         int count = _importRowsUsingDIB(getListUser(user, container), container, rows, null, context, extraScriptContext);
         if (count > 0 && !errors.hasErrors())
-            ListManager.get().indexList(_list, false);
+            ListManager.get().indexList(_list);
         return count;
     }
 
@@ -294,7 +294,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
 
         List<Map<String, Object>> result = super.updateRows(getListUser(user, container), container, rows, oldKeys, errors, configParameters, extraScriptContext);
         if (result.size() > 0)
-            ListManager.get().indexList(_list, false);
+            ListManager.get().indexList(_list);
         return result;
     }
 

--- a/list/src/org/labkey/list/model/ListServiceImpl.java
+++ b/list/src/org/labkey/list/model/ListServiceImpl.java
@@ -31,7 +31,6 @@ import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -17,6 +17,7 @@
 package org.labkey.study.model;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -43,6 +44,7 @@ import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.*;
 import org.labkey.api.data.DbScope.CommitTaskOption;
 import org.labkey.api.data.DbScope.Transaction;
+import org.labkey.api.data.SimpleFilter.FilterClause;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.dataiterator.BeanDataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
@@ -4278,7 +4280,6 @@ public class StudyManager
         }
     }
 
-
     // Return a source->alias map for the specified participant
     public Map<String, String> getAliasMap(StudyImpl study, User user, String ptid)
     {
@@ -4301,7 +4302,6 @@ public class StudyManager
         if (null != ss)
             ss.deleteResource(docid);
     }
-
 
     public static void indexDatasets(IndexTask task, Container c, Date modifiedSince)
     {
@@ -4349,7 +4349,7 @@ public class StudyManager
                 return;
             task = ss.defaultTask();
         }
-        String docid = "dataset:" + new Path(dsd.getContainer().getId(), String.valueOf(dsd.getDatasetId())).toString();
+        String docid = "dataset:" + new Path(dsd.getContainer().getId(), String.valueOf(dsd.getDatasetId()));
 
         StringBuilder body = new StringBuilder();
         Map<String, Object> props = new HashMap<>();
@@ -4394,106 +4394,109 @@ public class StudyManager
         if (null != ptids && ptids.size() == 0)
             return;
 
-        final int BATCH_SIZE = 500;
-        if (null != ptids && ptids.size() > BATCH_SIZE)
-        {
-            ArrayList<String> list = new ArrayList<>(BATCH_SIZE);
-            for (String ptid : ptids)
-            {
-                list.add(ptid);
-                if (list.size() == BATCH_SIZE)
-                {
-                    final ArrayList<String> l = list;
-                    Runnable r = () -> indexParticipants(task, c, l, modifiedSince);
-                    task.addRunnable(r, SearchService.PRIORITY.bulk);
-                    list = new ArrayList<>(BATCH_SIZE);
-                }
-            }
-            indexParticipants(task, c, list, modifiedSince);
-            return;
-        }
-
         final StudyImpl study = StudyManager.getInstance().getStudy(c);
         if (null == study)
             return;
+
         final String nav = NavTree.toJS(Collections.singleton(new NavTree("study", PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(c))), null, false).toString();
 
-        SQLFragment f = new SQLFragment();
+        SQLFragment baseFragment = new SQLFragment();
+        baseFragment.append("SELECT Container, ParticipantId FROM ");
+        baseFragment.append(StudySchema.getInstance().getTableInfoParticipant(), "p");
 
-        f.append("SELECT Container, ParticipantId FROM ");
-        f.append(StudySchema.getInstance().getTableInfoParticipant(), "p");
-        f.append(" WHERE Container = ?");
-        f.add(c);
+        SimpleFilter filter = SimpleFilter.createContainerFilter(c);
 
-        if (null != ptids)
-        {
-            f.append(" AND ParticipantId ");
-            StudySchema.getInstance().getSqlDialect().appendInClauseSql(f, ptids);
-        }
-
-        SQLFragment lastIndexedFragment = new LastIndexedClause(StudySchema.getInstance().getTableInfoParticipant(), modifiedSince, "p").toSQLFragment(null, null);
-        if (!lastIndexedFragment.isEmpty())
-            f.append(" AND ").append(lastIndexedFragment);
-
+        SimpleFilter.OrClause lastIndexedOrClause = new SimpleFilter.OrClause();
+        LastIndexedClause standardLastIndexedClause = new LastIndexedClause(StudySchema.getInstance().getTableInfoParticipant(), modifiedSince, "p");
+        if (!standardLastIndexedClause.isEmpty())
+            lastIndexedOrClause.addClause(standardLastIndexedClause);
         @Nullable final TableInfo aliasTable = StudyQuerySchema.createSchema(study, User.getSearchUser()).getParticipantAliasesTable();
-
         if (null != aliasTable)
         {
             // Need to reindex participants whose aliases have changed
-            f.append(" OR ParticipantId IN (\nSELECT ParticipantId FROM\n")
+            SQLFragment aliasFragment = new SQLFragment().append("ParticipantId IN (\nSELECT ParticipantId FROM\n")
                 .append(aliasTable.getFromSQL("aliases"))
                 .append("WHERE aliases.Modified > p.LastIndexed)");
+            lastIndexedOrClause.addClause(new SimpleFilter.SQLClause(aliasFragment));
         }
+        if (!lastIndexedOrClause.getClauses().isEmpty())
+            filter.addClause(lastIndexedOrClause);
+
+        baseFragment
+            .append(" ")
+            .append(filter.getSQLFragment(StudySchema.getInstance().getSqlDialect()));
 
         final ActionURL executeURL = new ActionURL(StudyController.ParticipantAction.class, c);
         executeURL.setExtraPath(c.getId());
 
-        new SqlSelector(StudySchema.getInstance().getSchema(), f).forEach(rs -> {
-            final String ptid = rs.getString(2);
-            String displayTitle = "Study " + study.getLabel() + " -- " +
-                    StudyService.get().getSubjectNounSingular(study.getContainer()) + " " + ptid;
-            ActionURL execute = executeURL.clone().addParameter("participantId", String.valueOf(ptid));
-            Path p = new Path(c.getId(), ptid);
-            String docid = "participant:" + p;
+        final int BATCH_SIZE = 500;
+        List<List<String>> batches = ptids != null ? ListUtils.partition(ptids, BATCH_SIZE) : Collections.singletonList(null);
 
-            String uniqueIds = ptid;
+        batches.forEach(batch -> {
+            Runnable runnable = () -> {
+                SQLFragment sql;
 
-            if (null != aliasTable)
-            {
-                // Add all participant aliases as high priority uniqueIds
-                Map<String, String> aliasMap = StudyManager.getInstance().getAliasMap(study, User.getSearchUser(), ptid);
-
-                if (!aliasMap.isEmpty())
-                    uniqueIds = uniqueIds + " " + StringUtils.join(aliasMap.values(), " ");
-            }
-
-            Map<String, Object> props = new HashMap<>();
-            props.put(SearchService.PROPERTY.categories.toString(), subjectCategory.getName());
-            props.put(SearchService.PROPERTY.title.toString(), displayTitle);
-            props.put(SearchService.PROPERTY.identifiersHi.toString(), uniqueIds);
-            props.put(SearchService.PROPERTY.navtrail.toString(), nav);
-
-            // Index a barebones participant document for now TODO: Figure out if it's safe to include demographic data or not (can all study users see it?)
-
-            // SimpleDocument
-            SimpleDocumentResource r = new SimpleDocumentResource(
-                    p, docid,
-                    c.getId(),
-                    "text/plain",
-                    displayTitle,
-                    execute, props
-            )
-            {
-                @Override
-                public void setLastIndexed(long ms, long modified)
+                if (null != batch)
                 {
-                    StudySchema ss = StudySchema.getInstance();
-                    SQLFragment update = new SQLFragment("UPDATE ").append(ss.getTableInfoParticipant()).append(" SET LastIndexed = ? WHERE Container = ? AND ParticipantId = ?");
-                    update.addAll(new Timestamp(ms), c, ptid);
-                    new SqlExecutor(ss.getSchema()).execute(update);
+                    sql = new SQLFragment(baseFragment); // Clone the base fragment before modifying
+                    sql.append(" AND ParticipantId ");
+                    StudySchema.getInstance().getSqlDialect().appendInClauseSql(sql, batch);
                 }
+                else
+                {
+                    sql = baseFragment;
+                }
+
+                new SqlSelector(StudySchema.getInstance().getSchema(), sql).forEach(rs -> {
+                    final String ptid = rs.getString(2);
+                    String displayTitle = "Study " + study.getLabel() + " -- " +
+                        StudyService.get().getSubjectNounSingular(study.getContainer()) + " " + ptid;
+                    ActionURL execute = executeURL.clone().addParameter("participantId", String.valueOf(ptid));
+                    Path p = new Path(c.getId(), ptid);
+                    String docid = "participant:" + p;
+
+                    String uniqueIds = ptid;
+
+                    if (null != aliasTable)
+                    {
+                        // Add all participant aliases as high priority uniqueIds
+                        Map<String, String> aliasMap = StudyManager.getInstance().getAliasMap(study, User.getSearchUser(), ptid);
+
+                        if (!aliasMap.isEmpty())
+                            uniqueIds = uniqueIds + " " + StringUtils.join(aliasMap.values(), " ");
+                    }
+
+                    Map<String, Object> props = new HashMap<>();
+                    props.put(SearchService.PROPERTY.categories.toString(), subjectCategory.getName());
+                    props.put(SearchService.PROPERTY.title.toString(), displayTitle);
+                    props.put(SearchService.PROPERTY.identifiersHi.toString(), uniqueIds);
+                    props.put(SearchService.PROPERTY.navtrail.toString(), nav);
+
+                    // Index a barebones participant document for now TODO: Figure out if it's safe to include demographic data or not (can all study users see it?)
+
+                    // SimpleDocument
+                    SimpleDocumentResource r = new SimpleDocumentResource(
+                        p, docid,
+                        c.getId(),
+                        "text/plain",
+                        displayTitle,
+                        execute, props
+                    )
+                    {
+                        @Override
+                        public void setLastIndexed(long ms, long modified)
+                        {
+                            StudySchema ss = StudySchema.getInstance();
+                            SQLFragment update = new SQLFragment("UPDATE ").append(ss.getTableInfoParticipant()).append(" SET LastIndexed = ? WHERE Container = ? AND ParticipantId = ?");
+                            update.addAll(new Timestamp(ms), c, ptid);
+                            new SqlExecutor(ss.getSchema()).execute(update);
+                        }
+                    };
+                    task.addResource(r, SearchService.PRIORITY.item);
+                });
             };
-            task.addResource(r, SearchService.PRIORITY.item);
+
+            task.addRunnable(runnable, SearchService.PRIORITY.bulk);
         });
     }
 

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4296,7 +4296,7 @@ public class StudyManager
 
     private void unindexDataset(DatasetDefinition ds)
     {
-        String docid = "dataset:" + new Path(ds.getContainer().getId(), String.valueOf(ds.getDatasetId())).toString();
+        String docid = "dataset:" + new Path(ds.getContainer().getId(), String.valueOf(ds.getDatasetId()));
         SearchService ss = SearchService.get();
         if (null != ss)
             ss.deleteResource(docid);
@@ -4309,12 +4309,11 @@ public class StudyManager
         if (null == ss)
             return;
 
-        SQLFragment f = new SQLFragment("SELECT Container, DatasetId FROM " + StudySchema.getInstance().getTableInfoDataset());
-        if (null != c)
-        {
-            f.append(" WHERE Container = ?");
-            f.add(c);
-        }
+        SimpleFilter filter = (null != c ? SimpleFilter.createContainerFilter(c) : new SimpleFilter());
+        if (null != modifiedSince)
+            filter.addCondition(FieldKey.fromParts("Modified"), modifiedSince, CompareType.DATE_GT);
+        SQLFragment f = new SQLFragment("SELECT Container, DatasetId FROM " + StudySchema.getInstance().getTableInfoDataset() + " ")
+            .append(filter.getSQLFragment(StudySchema.getInstance().getSqlDialect()));
 
         new SqlSelector(StudySchema.getInstance().getSchema(), f).forEach(rs ->
         {
@@ -4455,7 +4454,7 @@ public class StudyManager
                     StudyService.get().getSubjectNounSingular(study.getContainer()) + " " + ptid;
             ActionURL execute = executeURL.clone().addParameter("participantId", String.valueOf(ptid));
             Path p = new Path(c.getId(), ptid);
-            String docid = "participant:" + p.toString();
+            String docid = "participant:" + p;
 
             String uniqueIds = ptid;
 


### PR DESCRIPTION
#### Rationale
For a variety of reasons, lists and datasets are being reindexed unnecessarily. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45624

#### Changes
* Lists:
  * Fix overly aggressive definition of `reindex`
  * Clear `ListDef` cache entry after setting `LastIndexed` to avoid checks on stale values
  * When turning on attachment indexing, clear `core.Documents.LastIndexed` rows associated with that list, not the list's own `LastIndexed` column
  * Conditionalize the handling of subsettings on the primary indexing settings (e.g., don't reindex if a template changes but the corresponding indexing setting is off)
  * Remove unused `designChange` boolean parameter
  * Rework list indexing settings transition checks for better readability (IMO)
* Datasets: Filter indexed datasets on `Modified` > `modifiedSince`.
* Participants: Simplify batching of participants. Fix completely broken alias filter in participant query; move to `SimpleFilter` instead of manually building `WHERE` clause via `SQLFragment`.
* General: Ensure that `setLastIndexed()` is always called with a value that's greater than or equal to Modified, to avoid pointless reindexing