### PR TITLE
Flag all containers as being deleted as soon as requested

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1764,13 +1764,12 @@ public class ContainerManager
                 }
                 containerIds.forEach(id -> deletingContainers.put(id, user.getUserId()));
             }
-            List<Boolean> deleted = new ArrayList<>();
+            boolean deleted = true;
             for (Container c : containers)
             {
-                Boolean delete = delete(c, user, comment);
-                deleted.add(delete);
+                deleted = deleted && delete(c, user, comment);
             }
-            return deleted.stream().allMatch(Boolean::booleanValue);
+            return deleted;
         }
         finally
         {
@@ -1852,6 +1851,10 @@ public class ContainerManager
         if (success)
         {
             LOG.debug("Completed container delete for " + c.getContainerNoun(true) + " " + c.getPath());
+        }
+        else
+        {
+            LOG.warn("Failed to delete container: " + c.getPath());
         }
         return success;
     }

--- a/study/src/org/labkey/study/visitmanager/PurgeParticipantsJob.java
+++ b/study/src/org/labkey/study/visitmanager/PurgeParticipantsJob.java
@@ -141,7 +141,7 @@ public class PurgeParticipantsJob extends PipelineJob
                 }
                 catch (Exception e)
                 {
-                    if (ContainerManager.exists(_container))
+                    if (ContainerManager.exists(_container) && !ContainerManager.isDeleting(_container))
                     {
                         if (SqlDialect.isObjectNotFoundException(e))
                         {

--- a/study/src/org/labkey/study/visitmanager/PurgeParticipantsJob.java
+++ b/study/src/org/labkey/study/visitmanager/PurgeParticipantsJob.java
@@ -153,11 +153,6 @@ public class PurgeParticipantsJob extends PipelineJob
                             _info.accept("Transaction or deadlock exception (" + e.getMessage() + "). Requeuing another participant purge attempt.");
                             retry = true;
                         }
-                        else if (ContainerManager.getAllChildren(_container).stream().anyMatch(ContainerManager::isDeleting))
-                        {
-                            _info.accept("Child container is being deleted. Requeuing another participant purge attempt.");
-                            retry = true;
-                        }
                         else
                         {
                             // Unexpected problem... log it and continue on

--- a/study/src/org/labkey/study/visitmanager/PurgeParticipantsJob.java
+++ b/study/src/org/labkey/study/visitmanager/PurgeParticipantsJob.java
@@ -141,7 +141,7 @@ public class PurgeParticipantsJob extends PipelineJob
                 }
                 catch (Exception e)
                 {
-                    if (ContainerManager.exists(_container) && !ContainerManager.isDeleting(_container))
+                    if (!ContainerManager.isDeleting(_container) && ContainerManager.exists(_container))
                     {
                         if (SqlDialect.isObjectNotFoundException(e))
                         {


### PR DESCRIPTION
#### Rationale
`PurgeParticipantsTask` fails periodically when run during container deletion on TeamCity. This, currently, happens only when the project being deleted has subfolders. `PurgeParticipantsTask` checks whether the target container is being deleted but seems to get tripped up when we're in the process of deleting a whole project tree; only one container at a time is flagged as being deleted during this process.
This change makes `ContainerManager.isDeleting()` return true for any container that is currently being deleted or is about to be deleted.

<details><summary>Stacktrace</summary>

```
ERROR Table                    2023-06-29T11:13:19,543            JobThread-2.4 : SQL Exception with SQLState: 42P01
org.postgresql.util.PSQLException: ERROR: relation "studydataset.c262d257_dem_minus_1" does not exist
  Position: 747
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2676) ~[postgresql-42.5.3.jar:42.5.3]
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2366) ~[postgresql-42.5.3.jar:42.5.3]
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:356) ~[postgresql-42.5.3.jar:42.5.3]
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:496) ~[postgresql-42.5.3.jar:42.5.3]
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:413) ~[postgresql-42.5.3.jar:42.5.3]
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:190) ~[postgresql-42.5.3.jar:42.5.3]
	at org.postgresql.jdbc.PgPreparedStatement.execute(PgPreparedStatement.java:177) ~[postgresql-42.5.3.jar:42.5.3]
	at org.apache.tomcat.dbcp.dbcp2.DelegatingPreparedStatement.execute(DelegatingPreparedStatement.java:94) ~[tomcat-dbcp.jar:9.0.27]
	at org.apache.tomcat.dbcp.dbcp2.DelegatingPreparedStatement.execute(DelegatingPreparedStatement.java:94) ~[tomcat-dbcp.jar:9.0.27]
	at org.labkey.api.data.dialect.StatementWrapper.execute(StatementWrapper.java:1618) ~[api-23.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutor$NormalStatementExecutor.execute(SqlExecutor.java:162) ~[api-23.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutor$NormalStatementExecutor.execute(SqlExecutor.java:136) ~[api-23.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutor.execute(SqlExecutor.java:114) ~[api-23.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutor.execute(SqlExecutor.java:75) ~[api-23.3-SNAPSHOT.jar:?]
	at org.labkey.study.visitmanager.SequenceVisitManager.updateParticipantVisitTable(SequenceVisitManager.java:266) ~[study-23.3-SNAPSHOT.jar:?]
	at org.labkey.study.visitmanager.PurgeParticipantsJob$ParticipantPurger.purgeParticipants(PurgeParticipantsJob.java:128) ~[study-23.3-SNAPSHOT.jar:?]
	at org.labkey.study.visitmanager.PurgeParticipantsJob.run(PurgeParticipantsJob.java:83) ~[study-23.3-SNAPSHOT.jar:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```
</details>
<details><summary>Query</summary>

```
ERROR Table                    2023-06-29T11:13:19,544            JobThread-2.4 : SQL  [13448]
    
    -- <SequenceVisitManager.updateParticipantVisitTable>
    INSERT INTO study.participantvisit (Container, ParticipantId, SequenceNum, ParticipantSequenceNum)
    SELECT CAST(? AS VARCHAR(36)), ParticipantId, SequenceNum, ParticipantSequenceNum
    FROM (SELECT DISTINCT ParticipantId, SequenceNum, ParticipantSequenceNum FROM (
    -- <StudyUnionTableInfo>
    (SELECT CAST('4f34962d-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 1 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d257_dem_minus_1 D) UNION ALL
    (SELECT CAST('da40917c-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 5003 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d346_assay_data_query_snapshot D) UNION ALL
    (SELECT CAST('4f34975a-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 5002 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d238_alt_id_mapping D) UNION ALL
    (SELECT CAST('4f34962f-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 2 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d265_typ D) UNION ALL
    (SELECT CAST('4f349633-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 12 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d271_pre_minus_1 D) UNION ALL
    (SELECT CAST('4f349636-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 14 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d273_urs_minus_1 D) UNION ALL
    (SELECT CAST('4f349638-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 16 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d278_lls_minus_1 D) UNION ALL
    (SELECT CAST('4f34963a-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 17 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d268_lls_minus_2 D) UNION ALL
    (SELECT CAST('4f34963d-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 19 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d269_cps_minus_1 D) UNION ALL
    (SELECT CAST('4f34963f-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 23 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d242_eci_minus_1 D) UNION ALL
    (SELECT CAST('4f349651-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 122 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d279_epx_minus_1 D) UNION ALL
    (SELECT CAST('4f349653-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 124 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d246_enr_minus_1 D) UNION ALL
    (SELECT CAST('4f349655-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 125 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d270_evc_minus_1 D) UNION ALL
    (SELECT CAST('4f349630-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 135 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d249_vac_minus_1 D) UNION ALL
    (SELECT CAST('4f349631-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 136 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d272_apx_minus_1 D) UNION ALL
    (SELECT CAST('4f349634-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 140 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d251_urf_minus_1 D) UNION ALL
    (SELECT CAST('4f349635-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 141 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d256_urf_minus_2 D) UNION ALL
    (SELECT CAST('4f349637-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 143 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d255_llf_minus_1 D) UNION ALL
    (SELECT CAST('4f349639-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 144 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d247_cpf_minus_1 D) UNION ALL
    (SELECT CAST('4f34963e-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 150 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d250_sia_minus_1 D) UNION ALL
    (SELECT CAST('4f349640-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 151 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d243_sil_minus_1 D) UNION ALL
    (SELECT CAST('4f349647-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 171 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d274_bra_minus_1 D) UNION ALL
    (SELECT CAST('4f349648-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 172 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d263_bra_minus_2 D) UNION ALL
    (SELECT CAST('4f34964a-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 173 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d275_otb_minus_1 D) UNION ALL
    (SELECT CAST('4f34964b-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 180 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d280_rcb_minus_1 D) UNION ALL
    (SELECT CAST('4f34964c-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 182 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d248_rcm_minus_1 D) UNION ALL
    (SELECT CAST('4f34964e-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 184 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d262_rce_minus_1 D) UNION ALL
    (SELECT CAST('4f349652-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 186 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d281_rch_minus_1 D) UNION ALL
    (SELECT CAST('4f349654-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 188 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d245_rcf_minus_1 D) UNION ALL
    (SELECT CAST('4f349656-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 190 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d258_rct_minus_1 D) UNION ALL
    (SELECT CAST('4f34962c-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 192 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d277_rcp_minus_1 D) UNION ALL
    (SELECT CAST('4f349632-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 200 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d282_fpx_minus_1 D) UNION ALL
    (SELECT CAST('4f349649-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 300 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d253_dov_minus_1 D) UNION ALL
    (SELECT CAST('4f34964d-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 310 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d252_sp_minus_1 D) UNION ALL
    (SELECT CAST('4f349641-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 350 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d259_iv_minus_1 D) UNION ALL
    (SELECT CAST('4f349644-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 360 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d276_iht_minus_1 D) UNION ALL
    (SELECT CAST('4f349642-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 420 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d266_ae_minus_1 D) UNION ALL
    (SELECT CAST('4f349643-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 423 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d267_cm_minus_1 D) UNION ALL
    (SELECT CAST('4f34964f-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 440 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d254_pr_minus_1 D) UNION ALL
    (SELECT CAST('4f349650-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 441 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d260_po_minus_1 D) UNION ALL
    (SELECT CAST('4f34962e-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 449 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d244_scl_minus_1 D) UNION ALL
    (SELECT CAST('4f349780-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 463 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d240_mv_minus_1 D) UNION ALL
    (SELECT CAST('4f34963b-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 465 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d264_pt_minus_1 D) UNION ALL
    (SELECT CAST('4f34963c-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 466 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d261_prc_minus_1 D) UNION ALL
    (SELECT CAST('4f3497d0-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 487 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d239_pil_minus_1 D) UNION ALL
    (SELECT CAST('4f349645-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 489 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d283_esi_minus_1 D) UNION ALL
    (SELECT CAST('4f349646-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 490 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d284_tm_minus_1 D) UNION ALL
    (SELECT CAST('4f349807-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 501 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d237_qc D) UNION ALL
    (SELECT CAST('4f349752-f8d5-103b-bbc2-a7893f7b64b0' AS VARCHAR(36)) AS dataset, 5001 AS datasetid, CAST(NULL AS TIMESTAMP) AS _visitdate, CAST(NULL AS INTEGER) AS _visitday,  CAST('4f348baf-f8d5-103b-bbc2-a7893f7b64b0' AS UNIQUEIDENTIFIER) AS container, D.sequencenum, D.qcstate, D.created, D._key, D.participantid, D.lsid, D.createdby, D.sourcelsid, D.modified, D.modifiedby, D.participantsequencenum FROM studydataset.c262d241_verifyassay D)
    
    -- </StudyUnionTableInfo>
    ) SD
    WHERE  ParticipantId IS NOT NULL and SequenceNum IS NOT NULL AND ParticipantSequenceNum IS NOT NULL
    EXCEPT
    SELECT DISTINCT ParticipantId, SequenceNum, ParticipantSequenceNum FROM study.participantvisit PV WHERE Container=CAST(? AS VARCHAR(36))
    ) _
    
    -- /<SequenceVisitManager.updateParticipantVisitTable>
    ?[1] org.labkey.api.data.Container@1241472577 /QuerySnapshotProject/054/ 4f348baf-f8d5-103b-bbc2-a7893f7b64b0
    ?[2] org.labkey.api.data.Container@1241472577 /QuerySnapshotProject/054/ 4f348baf-f8d5-103b-bbc2-a7893f7b64b0
```
</details>

#### Related Pull Requests
* #2113 

#### Changes
* Refactor `ContainerManager.delete` and `deleteAll` to flag entire tree as being deleted
