### PR TITLE
Issue 48091: Input sample type name with special characters causes an error when deriving

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -41,6 +41,7 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.RuntimeValidationException;
 import org.labkey.api.query.UserSchema;
@@ -1960,7 +1961,7 @@ public class NameGenerator
             if (isMaterialParent || isDataParent)
             {
                 for (String parent : parentNames(value, colName))
-                    addLineageLookupContext(parts[1], parent, isMaterialParent, parentImportAliases, inputLookupValues);
+                    addLineageLookupContext(QueryKey.decodePart(parts[1]), parent, isMaterialParent, parentImportAliases, inputLookupValues);
             }
         }
 


### PR DESCRIPTION
#### Rationale
For the insertRows calls, field names are querykey encoded to allow special chars in columns. A parent input from "Fresh/frozen" sample would be "MaterialInputs/Fresh$Sfrozen". To find the matching sample type, the field part needs to be decoded.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* decode data type name field key before querying for data type