### PR TITLE
Fix ext4 storeid for lookups

### DIFF
--- a/api/webapp/clientapi/ext4/Util.js
+++ b/api/webapp/clientapi/ext4/Util.js
@@ -865,13 +865,17 @@
             }
 
             if (c.lookup) {
-                return c.lookup.storeId || [
-                    c.lookup.schemaName || c.lookup.schema,
+                if (c.lookup.storeId) {
+                    return c.lookup.storeId;
+                }
+                let storeId = [c.lookup.schemaName || c.lookup.schema,
                     c.lookup.queryName || c.lookup.table,
                     c.lookup.keyColumn,
-                    c.lookup.displayColumn,
-                    c.lookup.viewName
-                ].join('||');
+                    c.lookup.displayColumn];
+                if (c.lookup.viewName) {
+                    storeId.push(c.lookup.viewName);
+                }
+                return storeId.join('||');
             }
 
             return c.name;


### PR DESCRIPTION
#### Rationale
The change in related PR to include viewName in the lookup storeId caused the store Id to end in "||" as the lookups may not have a viewName defined in metadata that caused some lookups to not resolve to the displayColumn.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4344

#### Changes
* check for existence of viewName in lookup definition

