### PR TITLE
Wait for data region cell to render

### DIFF
--- a/experiment/test/src/org/labkey/test/tests/experiment/VocabularyViewSupportTest.java
+++ b/experiment/test/src/org/labkey/test/tests/experiment/VocabularyViewSupportTest.java
@@ -25,6 +25,8 @@ import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SampleTypeHelper;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -249,9 +251,8 @@ public class VocabularyViewSupportTest extends ProvenanceAssayHelper
 
         String propertiesValue = propNameLab + "\n" + propNameLocation + "\n" +
                 propValueLab + " " + labLocation;
-        List<String> rowData = runsTable.getRowDataAsText(0);
-
-        Assert.assertTrue("Run does not contain properties property value.", rowData.contains(propertiesValue));
+        WebElement propertiesCell = runsTable.findCell(0, "Properties");
+        shortWait().until(ExpectedConditions.textToBePresentInElement(propertiesCell, propertiesValue));
 
         Assert.assertEquals("Run does not contain " + propNameLab + " vocabulary property.", runsTable.getColumnDataAsText(domainProperty + "/" + propNameLab).get(0), propValueLab);
         Assert.assertEquals("Run does not contain " + propNameLab + " vocabulary property.", runsTable.getColumnDataAsText(domainProperty + "/" + propNameLocation).get(0), labLocation);


### PR DESCRIPTION
#### Rationale
Fixing an intermittent test failure where this nested table hasn't rendered when the test checks for it.
![image](https://github.com/LabKey/platform/assets/5263798/cdf3bb68-b9e1-4033-a39f-d2a13eb9ce9e)
```
java.lang.AssertionError: Run does not contain properties property value.
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.assertTrue(Assert.java:42)
  at org.labkey.test.tests.experiment.VocabularyViewSupportTest.testAssayViewSupport(VocabularyViewSupportTest.java:254)
```

#### Related Pull Requests
* N/A

#### Changes
* Wait for nested table to render
