### PR TITLE
Add 24-hour rollup of indexed document history

### DIFF
--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.search.model;
 
+import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multiset.Entry;
 import org.apache.commons.collections4.MultiValuedMap;
@@ -44,6 +45,7 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.ShutdownListener;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.SystemMaintenance;
 import org.labkey.api.util.SystemMaintenance.MaintenanceTask;
 import org.labkey.api.util.URLHelper;
@@ -62,6 +64,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -1330,20 +1333,23 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
     public Map<String, Object> getIndexerStats()
     {
-        HashMap<String, Object> map = new HashMap<>();
-
+        Map<String, Object> map = new LinkedHashMap<>();
         ArrayList<IndexerRateAccumulator> history;
+        long initialStart;
 
         synchronized (_commitLock)
         {
             history = new ArrayList<>(_history.size() + 1);
-            history.add(new IndexerRateAccumulator(_current.getStart(), _current.getCounter()));
+            initialStart = _current.getStart();
+            history.add(new IndexerRateAccumulator(initialStart, HashMultiset.create(_current.getCounter())));
             history.addAll(_history);
         }
 
+        IndexerRateAccumulator dayAccumulator = new IndexerRateAccumulator(initialStart);
         SimpleDateFormat f = new SimpleDateFormat("h:mm a");
-        StringBuilder sb = new StringBuilder();
-        sb.append("<table>");
+        StringBuilder hourly = new StringBuilder();
+        hourly.append("<table>");
+        int hourCount = history.size();
 
         for (IndexerRateAccumulator r : history)
         {
@@ -1351,17 +1357,28 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             start -= start % (60*60*1000);
             String fStart = f.format(start);
             String fCount = Formats.commaf0.format(r.getCount());
-            sb.append("<tr><td align=right>").append(fStart).append("&nbsp;</td>");
-            sb.append("<td align=right>").append(fCount).append(getPopup(fStart + " " + fCount + " documents", r)).append("</td></tr>");
+            hourly.append("<tr><td align=right>").append(fStart).append("&nbsp;</td>");
+            hourly.append("<td align=right>").append(fCount).append(getPopup(fStart + " " + StringUtilsLabKey.pluralize(r.getCount(), "document"), r)).append("</td></tr>");
+            // If more than one hour, accumulate all history into a single counter
+            if (hourCount > 1)
+                r.getCounter().forEach(dayAccumulator::accumulate);
         }
 
-        sb.append("</table>");
-        map.put("Indexing history added/updated", sb.toString());
+        hourly.append("</table>");
+
+        long totalDocCount = dayAccumulator.getCount();
+
+        // If we've accumulated multiple hours (usually 24) of history, display it as a single roll-up
+        if (totalDocCount > 0)
+        {
+            String fCount = StringUtilsLabKey.pluralize(totalDocCount, "document");
+            map.put("Indexing history added/updated (total for " + history.size() + " hours)", fCount + getPopup(fCount, dayAccumulator));
+        }
+        map.put("Indexing history added/updated (each hour)", hourly.toString());
         map.put("Maximum allowed document size", getFileSizeLimit());
 
         return map;
     }
-    
 
     private String getPopup(String title, IndexerRateAccumulator r)
     {
@@ -1378,7 +1395,6 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
         return PageFlowUtil.helpPopup(title, html.toString(), true);
     }
-
 
     public abstract Map<String, Double> getSearchStats();
 

--- a/search/src/org/labkey/search/view/indexerStats.jsp
+++ b/search/src/org/labkey/search/view/indexerStats.jsp
@@ -54,7 +54,7 @@ else
             if (v instanceof Integer || v instanceof Long)
                 v = Formats.commaf0.format(((Number)v).longValue());
             v = null==v ? "" : String.valueOf(v);
-            out.print(text("<tr><td valign=\"top\">" + h(l) + "</td><td>" + v + "</td></tr>\n"));
+            out.print(text("<tr><td valign=\"top\">" + h(l) + "&nbsp;&nbsp;</td><td>" + v + "</td></tr>\n"));
         }
     }
 %>


### PR DESCRIPTION
#### Rationale
A breakdown of documents indexed in the last 24 hours by type will be handy for investigating indexing issues

#### Changes
* Add "last 24 hours" rollup of indexed documents in addition to current per-hour tallies
* Fix `IndexerRateAccumulator` copy to clone underlying counter (thread safety)
