### PR TITLE
@labkey/test: Remove SecurityRole, use PermissionRoles

### DIFF
--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
-        "@labkey/test": "1.1.3",
+        "@labkey/test": "1.1.3-fb-eln-author-delete.0",
         "@types/jest": "29.2.0",
         "@types/react": "16.14.34",
         "@types/react-dom": "16.9.17",
@@ -3062,9 +3062,9 @@
       }
     },
     "node_modules/@labkey/test": {
-      "version": "1.1.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.1.3.tgz",
-      "integrity": "sha512-4nzrHK0QKqhY2msTq3S3neXk5tp23FVXtnQmNtJUHJkQ3zh/PyLmFwAbwDStrR3hTaAETALRYp3YrTwqlDzy7g==",
+      "version": "1.1.3-fb-eln-author-delete.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.1.3-fb-eln-author-delete.0.tgz",
+      "integrity": "sha512-+Y3d84cYLKQ+4DNBs+rl9HWhaQ51REswgLXD/O5jEA67DoOjIAsNu4pmDe/D3G6rJ/8hDDrDRO7obN08NVa5VA==",
       "dev": true,
       "dependencies": {
         "properties-reader": "2.2.0",
@@ -16630,9 +16630,9 @@
       }
     },
     "@labkey/test": {
-      "version": "1.1.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.1.3.tgz",
-      "integrity": "sha512-4nzrHK0QKqhY2msTq3S3neXk5tp23FVXtnQmNtJUHJkQ3zh/PyLmFwAbwDStrR3hTaAETALRYp3YrTwqlDzy7g==",
+      "version": "1.1.3-fb-eln-author-delete.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.1.3-fb-eln-author-delete.0.tgz",
+      "integrity": "sha512-+Y3d84cYLKQ+4DNBs+rl9HWhaQ51REswgLXD/O5jEA67DoOjIAsNu4pmDe/D3G6rJ/8hDDrDRO7obN08NVa5VA==",
       "dev": true,
       "requires": {
         "properties-reader": "2.2.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
-        "@labkey/test": "1.1.3-fb-eln-author-delete.0",
+        "@labkey/test": "1.2.0",
         "@types/jest": "29.2.0",
         "@types/react": "16.14.34",
         "@types/react-dom": "16.9.17",
@@ -3062,9 +3062,9 @@
       }
     },
     "node_modules/@labkey/test": {
-      "version": "1.1.3-fb-eln-author-delete.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.1.3-fb-eln-author-delete.0.tgz",
-      "integrity": "sha512-+Y3d84cYLKQ+4DNBs+rl9HWhaQ51REswgLXD/O5jEA67DoOjIAsNu4pmDe/D3G6rJ/8hDDrDRO7obN08NVa5VA==",
+      "version": "1.2.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.2.0.tgz",
+      "integrity": "sha512-hunBlrroQBU8Q8ehCgscD4SoSZY/OPn2CqMbfMpVxnHqsaxrYCRAkIpgnF3L6vd4g4ntbfsnqLga4LA+fgnnvA==",
       "dev": true,
       "dependencies": {
         "properties-reader": "2.2.0",
@@ -16630,9 +16630,9 @@
       }
     },
     "@labkey/test": {
-      "version": "1.1.3-fb-eln-author-delete.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.1.3-fb-eln-author-delete.0.tgz",
-      "integrity": "sha512-+Y3d84cYLKQ+4DNBs+rl9HWhaQ51REswgLXD/O5jEA67DoOjIAsNu4pmDe/D3G6rJ/8hDDrDRO7obN08NVa5VA==",
+      "version": "1.2.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.2.0.tgz",
+      "integrity": "sha512-hunBlrroQBU8Q8ehCgscD4SoSZY/OPn2CqMbfMpVxnHqsaxrYCRAkIpgnF3L6vd4g4ntbfsnqLga4LA+fgnnvA==",
       "dev": true,
       "requires": {
         "properties-reader": "2.2.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",
-    "@labkey/test": "1.1.3",
+    "@labkey/test": "1.1.3-fb-eln-author-delete.0",
     "@types/jest": "29.2.0",
     "@types/react": "16.14.34",
     "@types/react-dom": "16.9.17",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",
-    "@labkey/test": "1.1.3-fb-eln-author-delete.0",
+    "@labkey/test": "1.2.0",
     "@types/jest": "29.2.0",
     "@types/react": "16.14.34",
     "@types/react-dom": "16.9.17",

--- a/experiment/src/client/test/integration/MoveAssayRunsAction.ispec.ts
+++ b/experiment/src/client/test/integration/MoveAssayRunsAction.ispec.ts
@@ -1,5 +1,6 @@
 import mock from 'mock-fs';
-import { hookServer, RequestOptions, SecurityRole, successfulResponse } from '@labkey/test';
+import { PermissionRoles } from '@labkey/api';
+import { hookServer, RequestOptions, successfulResponse } from '@labkey/test';
 import {
     getAssayResults,
     getAssayRunMovedAuditLogs,
@@ -27,7 +28,7 @@ let noPermsUserOptions: RequestOptions;
 
 let assayAId, assayWithRunFileId, assayWithResultFileId;
 
-const getAssayDesignPayload = (name: string, runFields: [], resultFields: []) => {
+const getAssayDesignPayload = (name: string, runFields: any[], resultFields: any[]) => {
     return {
         "allowEditableResults": true,
         "editableResults": true,
@@ -81,21 +82,21 @@ beforeAll(async () => {
 
     // create users with different permissions
     editorUser = await server.createUser('test_editor@expctrltest.com', 'pwSuperA1!');
-    await server.addUserToRole(editorUser.username, SecurityRole.Editor, PROJECT_NAME);
-    await server.addUserToRole(editorUser.username, SecurityRole.Editor, subfolder1.path);
-    await server.addUserToRole(editorUser.username, SecurityRole.Editor, subfolder2.path);
+    await server.addUserToRole(editorUser.username, PermissionRoles.Editor, PROJECT_NAME);
+    await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder1.path);
+    await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder2.path);
     editorUserOptions = { requestContext: await server.createRequestContext(editorUser) };
 
     const subEditorUser = await server.createUser('test_subeditor@expctrltest.com', 'pwSuperA1!');
-    await server.addUserToRole(subEditorUser.username, SecurityRole.Reader, PROJECT_NAME);
-    await server.addUserToRole(subEditorUser.username, SecurityRole.Editor, subfolder1.path);
-    await server.addUserToRole(subEditorUser.username, SecurityRole.Editor, subfolder2.path);
+    await server.addUserToRole(subEditorUser.username, PermissionRoles.Reader, PROJECT_NAME);
+    await server.addUserToRole(subEditorUser.username, PermissionRoles.Editor, subfolder1.path);
+    await server.addUserToRole(subEditorUser.username, PermissionRoles.Editor, subfolder2.path);
     subEditorUserOptions = { requestContext: await server.createRequestContext(subEditorUser) };
 
     const authorUser = await server.createUser('test_author@expctrltest.com', 'pwSuperA1!');
-    await server.addUserToRole(authorUser.username, SecurityRole.Author, PROJECT_NAME);
-    await server.addUserToRole(authorUser.username, SecurityRole.Author, subfolder1.path);
-    await server.addUserToRole(authorUser.username, SecurityRole.Author, subfolder2.path);
+    await server.addUserToRole(authorUser.username, PermissionRoles.Author, PROJECT_NAME);
+    await server.addUserToRole(authorUser.username, PermissionRoles.Author, subfolder1.path);
+    await server.addUserToRole(authorUser.username, PermissionRoles.Author, subfolder2.path);
     authorUserOptions = { requestContext: await server.createRequestContext(authorUser) };
 
     const noPermsUser = await server.createUser('test_no_perms@expctrltest.com', 'pwSuperA1!');

--- a/experiment/src/client/test/integration/MoveSamplesAction.ispec.ts
+++ b/experiment/src/client/test/integration/MoveSamplesAction.ispec.ts
@@ -1,5 +1,6 @@
 import mock from 'mock-fs';
-import { hookServer, RequestOptions, SecurityRole, successfulResponse } from '@labkey/test';
+import { PermissionRoles } from '@labkey/api';
+import { hookServer, RequestOptions, successfulResponse } from '@labkey/test';
 import { caseInsensitive } from '@labkey/components';
 import {
     createDerivedObjects,
@@ -45,21 +46,21 @@ beforeAll(async () => {
 
     // create users with different permissions
     editorUser = await server.createUser('test_editor@expctrltest.com', 'pwSuperA1!');
-    await server.addUserToRole(editorUser.username, SecurityRole.Editor, PROJECT_NAME);
-    await server.addUserToRole(editorUser.username, SecurityRole.Editor, subfolder1.path);
-    await server.addUserToRole(editorUser.username, SecurityRole.Editor, subfolder2.path);
+    await server.addUserToRole(editorUser.username, PermissionRoles.Editor, PROJECT_NAME);
+    await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder1.path);
+    await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder2.path);
     editorUserOptions = { requestContext: await server.createRequestContext(editorUser) };
 
     const subEditorUser = await server.createUser('test_subeditor@expctrltest.com', 'pwSuperA1!');
-    await server.addUserToRole(subEditorUser.username, SecurityRole.Reader, PROJECT_NAME);
-    await server.addUserToRole(subEditorUser.username, SecurityRole.Editor, subfolder1.path);
-    await server.addUserToRole(subEditorUser.username, SecurityRole.Editor, subfolder2.path);
+    await server.addUserToRole(subEditorUser.username, PermissionRoles.Reader, PROJECT_NAME);
+    await server.addUserToRole(subEditorUser.username, PermissionRoles.Editor, subfolder1.path);
+    await server.addUserToRole(subEditorUser.username, PermissionRoles.Editor, subfolder2.path);
     subEditorUserOptions = { requestContext: await server.createRequestContext(subEditorUser) };
 
     const authorUser = await server.createUser('test_author@expctrltest.com', 'pwSuperA1!');
-    await server.addUserToRole(authorUser.username, SecurityRole.Author, PROJECT_NAME);
-    await server.addUserToRole(authorUser.username, SecurityRole.Author, subfolder1.path);
-    await server.addUserToRole(authorUser.username, SecurityRole.Author, subfolder2.path);
+    await server.addUserToRole(authorUser.username, PermissionRoles.Author, PROJECT_NAME);
+    await server.addUserToRole(authorUser.username, PermissionRoles.Author, subfolder1.path);
+    await server.addUserToRole(authorUser.username, PermissionRoles.Author, subfolder2.path);
     authorUserOptions = { requestContext: await server.createRequestContext(authorUser) };
 
     const noPermsUser = await server.createUser('test_no_perms@expctrltest.com', 'pwSuperA1!');
@@ -803,7 +804,7 @@ describe('ExperimentController', () => {
             const subfolder3 = await server.createTestContainer();
 
             const subfolder3Options = {containerPath: subfolder3.path};
-            await server.addUserToRole(editorUser.username, SecurityRole.Editor, subfolder3.path);
+            await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder3.path);
 
             // create a sample in the top folder
             const sampleRowId1 = await createSample(server, 'top-parent-1', topFolderOptions, editorUserOptions, "DETAILED");
@@ -857,7 +858,7 @@ describe('ExperimentController', () => {
             const subfolder3 = await server.createTestContainer();
 
             const subfolder3Options = {containerPath: subfolder3.path};
-            await server.addUserToRole(editorUser.username, SecurityRole.Editor, subfolder3.path);
+            await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder3.path);
 
             // create a sample in the top folder
             await createSample(server, 'top-parent-2', topFolderOptions, editorUserOptions, "DETAILED");
@@ -919,7 +920,7 @@ describe('ExperimentController', () => {
             const subfolder3 = await server.createTestContainer();
 
             const subfolder3Options = {containerPath: subfolder3.path};
-            await server.addUserToRole(editorUser.username, SecurityRole.Editor, subfolder3.path);
+            await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder3.path);
 
             // create a sample in the top folder
             await createSample(server, 'top-parent-3', editorUserOptions, topFolderOptions);

--- a/experiment/src/client/test/integration/MoveSourcesAction.ispec.ts
+++ b/experiment/src/client/test/integration/MoveSourcesAction.ispec.ts
@@ -1,5 +1,6 @@
 import mock from 'mock-fs';
-import { hookServer, RequestOptions, SecurityRole, successfulResponse } from '@labkey/test';
+import { PermissionRoles } from '@labkey/api';
+import { hookServer, RequestOptions, successfulResponse } from '@labkey/test';
 import { caseInsensitive } from '@labkey/components';
 import {
     ATTACHMENT_FIELD_1_NAME,
@@ -48,21 +49,21 @@ beforeAll(async () => {
 
     // create users with different permissions
     editorUser = await server.createUser('test_editor@expctrltest.com', 'pwSuperA1!');
-    await server.addUserToRole(editorUser.username, SecurityRole.Editor, PROJECT_NAME);
-    await server.addUserToRole(editorUser.username, SecurityRole.Editor, subfolder1.path);
-    await server.addUserToRole(editorUser.username, SecurityRole.Editor, subfolder2.path);
+    await server.addUserToRole(editorUser.username, PermissionRoles.Editor, PROJECT_NAME);
+    await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder1.path);
+    await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder2.path);
     editorUserOptions = { requestContext: await server.createRequestContext(editorUser) };
 
     const subEditorUser = await server.createUser('test_subeditor@expctrltest.com', 'pwSuperA1!');
-    await server.addUserToRole(subEditorUser.username, SecurityRole.Reader, PROJECT_NAME);
-    await server.addUserToRole(subEditorUser.username, SecurityRole.Editor, subfolder1.path);
-    await server.addUserToRole(subEditorUser.username, SecurityRole.Editor, subfolder2.path);
+    await server.addUserToRole(subEditorUser.username, PermissionRoles.Reader, PROJECT_NAME);
+    await server.addUserToRole(subEditorUser.username, PermissionRoles.Editor, subfolder1.path);
+    await server.addUserToRole(subEditorUser.username, PermissionRoles.Editor, subfolder2.path);
     subEditorUserOptions = { requestContext: await server.createRequestContext(subEditorUser) };
 
     const authorUser = await server.createUser('test_author@expctrltest.com', 'pwSuperA1!');
-    await server.addUserToRole(authorUser.username, SecurityRole.Author, PROJECT_NAME);
-    await server.addUserToRole(authorUser.username, SecurityRole.Author, subfolder1.path);
-    await server.addUserToRole(authorUser.username, SecurityRole.Author, subfolder2.path);
+    await server.addUserToRole(authorUser.username, PermissionRoles.Author, PROJECT_NAME);
+    await server.addUserToRole(authorUser.username, PermissionRoles.Author, subfolder1.path);
+    await server.addUserToRole(authorUser.username, PermissionRoles.Author, subfolder2.path);
     authorUserOptions = { requestContext: await server.createRequestContext(authorUser) };
 
     const noPermsUser = await server.createUser('test_no_perms@expctrltest.com', 'pwSuperA1!');
@@ -723,7 +724,7 @@ describe('ExperimentController', () => {
             const subfolder3 = await server.createTestContainer();
 
             const subfolder3Options = { containerPath: subfolder3.path };
-            await server.addUserToRole(editorUser.username, SecurityRole.Editor, subfolder3.path);
+            await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder3.path);
 
             // create a source in the top folder
             const sourceRowId1 = await _createSource('top-parent-1', topFolderOptions, "DETAILED");
@@ -781,7 +782,7 @@ describe('ExperimentController', () => {
             const subfolder3 = await server.createTestContainer();
 
             const subfolder3Options = { containerPath: subfolder3.path };
-            await server.addUserToRole(editorUser.username, SecurityRole.Editor, subfolder3.path);
+            await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder3.path);
 
             // create a sample in the top folder
             await createSample(server, 'top-parent-3', topFolderOptions, editorUserOptions);

--- a/experiment/src/client/test/integration/utils.ts
+++ b/experiment/src/client/test/integration/utils.ts
@@ -116,7 +116,7 @@ export async function getExperimentRun(server: IntegrationTestServer, runId: num
     return response.body.rows;
 }
 
-export async function importRun(server: IntegrationTestServer, assayId: number, runName: string, dataRows: [], folderOptions: RequestOptions, userOptions: RequestOptions, reRunId?: number, batchId?: number) {
+export async function importRun(server: IntegrationTestServer, assayId: number, runName: string, dataRows: any[], folderOptions: RequestOptions, userOptions: RequestOptions, reRunId?: number, batchId?: number) {
     const runResponse = await server.post('assay', 'importRun', {
         assayId: assayId,
         name: runName,


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-ui-components/pull/1235 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1235
- https://github.com/LabKey/platform/pull/4588
- https://github.com/LabKey/labbook/pull/515
- https://github.com/LabKey/biologics/pull/2238
- https://github.com/LabKey/sampleManagement/pull/1968
- https://github.com/LabKey/inventory/pull/924

#### Changes
- Update `@labkey/test`.
- Convert integration test usages to use `PermissionRoles`.
