### PR TITLE
PlateManager: remove cached templates check when getting a plate

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -353,41 +353,21 @@ public class PlateManager implements PlateService
     @Override
     public @Nullable PlateImpl getPlate(Container container, int rowId)
     {
-        PlateImpl plate = (PlateImpl) getCachedPlateTemplate(container, rowId);
-        if (plate != null)
-            return plate;
-        plate = new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate()).getObject(rowId, PlateImpl.class);
-        if (plate == null)
-            return null;
-        populatePlate(plate);
-        cache(plate);
-        return plate;
+        return new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate()).getObject(rowId, PlateImpl.class);
     }
 
     @Override
     public @Nullable PlateImpl getPlate(Container container, String lsid)
     {
-        PlateImpl plate = (PlateImpl) getCachedPlateTemplate(container, lsid);
-        if (plate != null)
-            return plate;
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("Container"), container)
                 .addCondition(FieldKey.fromParts("lsid"), lsid);
-        plate = new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(), filter, null).getObject(PlateImpl.class);
-        if (plate == null)
-            return null;
-        populatePlate(plate);
-        cache(plate);
-        return plate;
+        return new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(), filter, null).getObject(PlateImpl.class);
     }
 
     public @Nullable PlateImpl getPlate(String lsid)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("lsid"), lsid);
-        PlateImpl plate = new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(), filter, null).getObject(PlateImpl.class);
-        if (plate == null)
-            return null;
-        populatePlate(plate);
-        return plate;
+        return new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(), filter, null).getObject(PlateImpl.class);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
When fetching a plate no longer utilize the plate template cache as `PlateTemplateImpl` instances are put in the cache. I would take it further, however, the caching layer is being revamped in the next story. This addresses the immediate test failures.

#### Changes
- Remove calls to `getCachedPlateTemplate()` within `getPlate()`