### PR TITLE
48257: Unable to create issue from exception report

### DIFF
--- a/issues/src/org/labkey/issue/view/updateView.jsp
+++ b/issues/src/org/labkey/issue/view/updateView.jsp
@@ -447,5 +447,12 @@
     }%>
     <input type="hidden" name="action" value="<%=h(bean.getAction().name())%>">
     <input type="hidden" name="dirty" value="false">
+    <%
+    // ensure that issueDefName is available in the form post
+    if (context.getActionURL().getParameter("issueDefName") == null)
+    {%>
+        <input type="hidden" name="issueDefName" value="<%=h(issueListDef.getName())%>">
+    <%
+    }%>
 </labkey:form>
 <script type="text/javascript" for="window" event="onload">try {document.getElementById(<%=q(focusId)%>).focus();} catch (x) {}</script>


### PR DESCRIPTION
#### Rationale
We recently stopped serializing old beans into the update forms https://github.com/LabKey/platform/pull/4502. In some cases we were relying on that to figure out the `issueDefName` for inserts. Most of the time this information is on the URL, but in the event it isn't we need to add it to the insert/update form.

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48257)