### PR TITLE
Issue 48274: ArrayIndexOutOfBounds calling AssayListMap.toString()

### DIFF
--- a/api/src/org/labkey/api/collections/ArrayListMap.java
+++ b/api/src/org/labkey/api/collections/ArrayListMap.java
@@ -365,7 +365,8 @@ public class ArrayListMap<K, V> extends AbstractMap<K, V> implements Iterable<V>
         {
             Map.Entry e = (Map.Entry) i.next();
             Object key = e.getKey();
-            Object value = _row.get(((Integer) e.getValue()).intValue());
+            int index = ((Integer) e.getValue()).intValue();
+            Object value = index >= _row.size() ? null : _row.get(index);
             if (key == this)
                 buf.append("(this Map)");
             else


### PR DESCRIPTION
#### Rationale
The list for a given row may be shorter than the total list of possible properties. We check its length everywhere except in toString().

#### Changes
* Check if the size of the list and return null if we don't have any values at that index