### PR TITLE
Issue 48274: ArrayIndexOutOfBounds calling AssayListMap.toString()

### DIFF
--- a/api/src/org/labkey/api/collections/ArrayListMap.java
+++ b/api/src/org/labkey/api/collections/ArrayListMap.java
@@ -146,13 +146,13 @@ public class ArrayListMap<K, V> extends AbstractMap<K, V> implements Iterable<V>
 
     public ArrayListMap()
     {
-        this(new FindMap<>(new HashMap<K, Integer>()), new ArrayList<V>());
+        this(new FindMap<>(new HashMap<>()), new ArrayList<>());
     }
 
 
     public ArrayListMap(int columnCount)
     {
-        this(new FindMap<>(new HashMap<K, Integer>(columnCount * 2)), new ArrayList<V>(columnCount));
+        this(new FindMap<>(new HashMap<>(columnCount * 2)), new ArrayList<>(columnCount));
     }
 
 
@@ -164,7 +164,7 @@ public class ArrayListMap<K, V> extends AbstractMap<K, V> implements Iterable<V>
 
     public ArrayListMap(FindMap<K> findMap)
     {
-        this(findMap, new ArrayList<V>(findMap.size()));
+        this(findMap, new ArrayList<>(findMap.size()));
     }
 
 

--- a/api/src/org/labkey/api/collections/ArrayListMap.java
+++ b/api/src/org/labkey/api/collections/ArrayListMap.java
@@ -354,18 +354,19 @@ public class ArrayListMap<K, V> extends AbstractMap<K, V> implements Iterable<V>
 
 
     // need to override toString() since we don't implement entrySet()
+    @Override
     public String toString()
     {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append("{");
 
-        Iterator i = _findMap.entrySet().iterator();
+        Iterator<Map.Entry<K, Integer>> i = _findMap.entrySet().iterator();
         boolean hasNext = i.hasNext();
         while (hasNext)
         {
-            Map.Entry e = (Map.Entry) i.next();
+            Map.Entry<K, Integer> e = i.next();
             Object key = e.getKey();
-            int index = ((Integer) e.getValue()).intValue();
+            int index = e.getValue().intValue();
             Object value = index >= _row.size() ? null : _row.get(index);
             if (key == this)
                 buf.append("(this Map)");

--- a/api/src/org/labkey/api/collections/ArrayListMap.java
+++ b/api/src/org/labkey/api/collections/ArrayListMap.java
@@ -365,7 +365,8 @@ public class ArrayListMap<K, V> extends AbstractMap<K, V> implements Iterable<V>
         {
             Map.Entry e = (Map.Entry) i.next();
             Object key = e.getKey();
-            Object value = _row.get(((Integer) e.getValue()).intValue());
+            int index = ((Integer) e.getValue()).intValue();
+            Object value = index >= _row.size() ? null : _row.get(index);
             if (key == this)
                 buf.append("(this Map)");
             else


### PR DESCRIPTION
#### Rationale
The list for a given row may be shorter than the total list of possible properties. We check its length everywhere except in toString().

#### Changes
* Check if the size of the list and return null if we don't have any values at that index