### PR TITLE
Issue 48278: Short fails to convert to boolean in SQLServer ETL

### DIFF
--- a/api/src/org/labkey/api/collections/ArrayListMap.java
+++ b/api/src/org/labkey/api/collections/ArrayListMap.java
@@ -503,24 +503,26 @@ public class ArrayListMap<K, V> extends AbstractMap<K, V> implements Iterable<V>
             assertEquals(a.get("Z"), "one");
             assertEquals(b.get("Z"), "ONE");
 
-            assertTrue(a.containsKey("E"));
+            assertFalse(a.containsKey("E"));
             assertNull(a.get("E"));
+            assertTrue(b.containsKey("E"));
             assertEquals("FIVE", b.get("E"));
             assertNull(a.put("E", "five"));
             assertEquals("five", a.get("E"));
             assertEquals("FIVE", b.get("E"));
 
-            assertTrue(b.containsKey("F"));
+            assertFalse(b.containsKey("F"));
+            assertTrue(a.containsKey("F"));
             assertNull(b.get("F"));
             assertEquals("six", a.get("F"));
             
             assertEquals("SEVEN", b.get("G"));
             assertTrue(b.containsKey("G"));
-            assertEquals(7, b.values().size());
+            assertEquals(3, b.values().size());
             assertEquals("SEVEN", b.remove("G"));
             assertNull(b.get("G"));
             assertFalse(b.containsKey("G"));
-            assertEquals(6, b.values().size());
+            assertEquals(2, b.values().size());
             assertNull(b.put("G","SEVENTY"));
             assertEquals("SEVENTY", b.get("G"));
             assertTrue(b.containsKey("G"));

--- a/api/src/org/labkey/api/data/JdbcType.java
+++ b/api/src/org/labkey/api/data/JdbcType.java
@@ -589,13 +589,11 @@ public enum JdbcType
 
     private static Boolean _toBoolean(Number n)
     {
-        if (n instanceof Integer)
-        {
-            if (0 == n.longValue())
-                return Boolean.FALSE;
-            if (1 == n.longValue())
-                return Boolean.TRUE;
-        }
+        if (0 == n.intValue())
+            return Boolean.FALSE;
+        if (1 == n.intValue())
+            return Boolean.TRUE;
+
         throw new ConversionException("Expected boolean value");
     }
 


### PR DESCRIPTION
#### Rationale
An ETL is failing to coerce a `SHORTINT` value to a `BIT` in a SQLServer-based ETL

#### Changes
* Allow any numeric type that's equal to 0 or 1 for conversion
* Add unit test coverage for recent fixes to `ArrayListMap.toString()`