### PR TITLE
Fix user details button order & support identity maps

### DIFF
--- a/api/src/org/labkey/api/data/BaseSelector.java
+++ b/api/src/org/labkey/api/data/BaseSelector.java
@@ -569,7 +569,7 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
         return factory;
     }
 
-    // Unfortunately, Map and MultiValuedMap don't share an interface for the put method so we have to pass in a method reference instead.
+    // Unfortunately, Map and MultiValuedMap don't share an interface for the put method, so we have to pass in a method reference.
     private <K, V> void fillValues(BiFunction<K, V, ?> fn)
     {
         // Using a ResultSetIterator ensures that standard type conversion happens (vs. ResultSet enumeration and rs.getObject())
@@ -582,7 +582,8 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
 
             while (iter.hasNext())
             {
-                RowMap rowMap = (RowMap)iter.next();
+                RowMap<?> rowMap = (RowMap<?>)iter.next();
+                //noinspection unchecked
                 K key = (K)rowMap.get(1);
                 //noinspection unchecked
                 fn.apply(key, (V)(1 == columnCount ? key : rowMap.get(2))); // One column => treat as an identity map
@@ -625,8 +626,8 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
             ResultSetIterator iter = new ResultSetIterator(rs);
             while (iter.hasNext())
             {
-                RowMap rowMap = (RowMap)iter.next();
                 //noinspection unchecked
+                RowMap<K> rowMap = (RowMap<K>)iter.next();
                 fillSet.add((K)rowMap.get(1));
             }
             return null;

--- a/api/src/org/labkey/api/data/BaseSelector.java
+++ b/api/src/org/labkey/api/data/BaseSelector.java
@@ -574,16 +574,18 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
     {
         // Using a ResultSetIterator ensures that standard type conversion happens (vs. ResultSet enumeration and rs.getObject())
         getStandardResultSetFactory().handleResultSet((rs, conn) -> {
-            if (rs.getMetaData().getColumnCount() < 2)
-                throw new IllegalStateException("Must select at least two columns to use fillValueMap() or getValueMap()");
+            int columnCount = rs.getMetaData().getColumnCount();
+            if (columnCount < 1)
+                throw new IllegalStateException("Must select at least one column to use fillValueMap() or getValueMap()");
 
             ResultSetIterator iter = new ResultSetIterator(rs);
 
             while (iter.hasNext())
             {
                 RowMap rowMap = (RowMap)iter.next();
+                K key = (K)rowMap.get(1);
                 //noinspection unchecked
-                fn.apply((K)rowMap.get(1), (V)rowMap.get(2));
+                fn.apply(key, (V)(1 == columnCount ? key : rowMap.get(2))); // One column => treat as an identity map
             }
 
             return null;

--- a/api/src/org/labkey/api/data/BaseSelector.java
+++ b/api/src/org/labkey/api/data/BaseSelector.java
@@ -575,9 +575,6 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
         // Using a ResultSetIterator ensures that standard type conversion happens (vs. ResultSet enumeration and rs.getObject())
         getStandardResultSetFactory().handleResultSet((rs, conn) -> {
             int columnCount = rs.getMetaData().getColumnCount();
-            if (columnCount < 1)
-                throw new IllegalStateException("Must select at least one column to use fillValueMap() or getValueMap()");
-
             ResultSetIterator iter = new ResultSetIterator(rs);
 
             while (iter.hasNext())

--- a/api/src/org/labkey/api/data/Selector.java
+++ b/api/src/org/labkey/api/data/Selector.java
@@ -30,8 +30,6 @@ import java.util.stream.Stream;
 
 /**
  * Base-level interface for getting results from the database.
- * User: adam
- * Date: Sep 3, 2011
  */
 public interface Selector
 {
@@ -144,28 +142,28 @@ public interface Selector
     <T> void forEachBatch(Class<T> clazz, int batchSize, ForEachBatchBlock<T> batchBlock);
 
     /**
-     * Return a new value map from a query. If the result has a single column, return an identity map. If the result has
-     * multiple columns, the first column is the key, the second column is the value.
+     * Return a new value map. If the query selects a single column, return an identity map. If the query selects
+     * multiple columns, the first column is the key, the second column is the value. Subsequent columns are ignored.
      */
     @NotNull <K, V> Map<K, V> getValueMap();
 
     /**
-     * Populate an existing map from a query. If the result has a single column, populate an identity map. If the result
-     * has multiple columns, the first column is the key, the second column is the value.
+     * Populate an existing map. If the query selects a single column, populate as an identity map. If the query selects
+     * multiple columns, the first column is the key, the second column is the value. Subsequent columns are ignored.
      */
     @NotNull <K, V> Map<K, V> fillValueMap(@NotNull Map<K, V> map);
 
     /**
-     * Return a new MultiValuedMap from a query. If the result has a single column, return an identity map. If the
-     * result has multiple columns, the first column is the key, the second column is the value, of which there may be
-     * more than one for each key.
+     * Return a new MultiValuedMap. If the query selects a single column, return an identity map. If the query selects
+     * multiple columns, the first column is the key, the second column is the value, of which there may be more than
+     * one for each key. Subsequent columns are ignored.
      */
     @NotNull <K, V> MultiValuedMap<K, V> getMultiValuedMap();
 
     /**
-     * Populate an existing MultiValuedMap from a query. If the result has a single column, return an identity map. If
-     * the result has multiple columns, the first column is the key, the second column is the value, of which there may
-     * be more than one for each key.
+     * Populate an existing MultiValuedMap. If the query selects a single column, return an identity map. If the query
+     * selects multiple columns, the first column is the key, the second column is the value, of which there may be more
+     * than one for each key. Subsequent columns are ignored.
      */
     @NotNull <K, V> MultiValuedMap<K, V> fillMultiValuedMap(@NotNull final MultiValuedMap<K, V> multiMap);
 

--- a/api/src/org/labkey/api/data/Selector.java
+++ b/api/src/org/labkey/api/data/Selector.java
@@ -38,10 +38,8 @@ public interface Selector
     /**
      * If no transaction is active and the SQL statement is a SELECT, this method assumes it is safe to tweak
      * connection parameters (such as disabling auto-commit, and never committing) to optimize memory and other
-     * resource usage.
-     *
-     * If you are, for example, invoking a stored procedure that will have side effects via a SELECT statement,
-     * you must explicitly start your own transaction and commit it.
+     * resource usage. If you are, for example, invoking a stored procedure that will have side effects via a SELECT
+     * statement, you must explicitly start your own transaction and commit it.
      */
     TableResultSet getResultSet();
 
@@ -76,9 +74,7 @@ public interface Selector
      * Returns an uncached sequential Stream of objects representing rows from the database. Converts each result row into
      * an object of the specified class. The Stream is backed by a live ResultSet with an open Connection, so <b>it must be
      * closed</b>, typically using try-with-resources. This is less convenient than a cached Stream, but useful when large
-     * results are expected.
-     *
-     * An example showing proper closing:
+     * results are expected. An example showing proper closing:
      *
      * <pre>{@code
      *
@@ -147,18 +143,33 @@ public interface Selector
      */
     <T> void forEachBatch(Class<T> clazz, int batchSize, ForEachBatchBlock<T> batchBlock);
 
-    /** Return a new map from a two-column query; the first column is the key, the second column is the value. */
+    /**
+     * Return a new value map from a query. If the result has a single column, return an identity map. If the result has
+     * multiple columns, the first column is the key, the second column is the value.
+     */
     @NotNull <K, V> Map<K, V> getValueMap();
 
-    /** Populate an existing map from a two-column query; the first column is the key, the second column is the value. */
+    /**
+     * Populate an existing map from a query. If the result has a single column, populate an identity map. If the result
+     * has multiple columns, the first column is the key, the second column is the value.
+     */
     @NotNull <K, V> Map<K, V> fillValueMap(@NotNull Map<K, V> map);
 
-    /** Return a new MultiValuedMap from a two-column query; the first column is the key, the second column is the value of which there may be more than one for the key. */
+    /**
+     * Return a new MultiValuedMap from a query. If the result has a single column, return an identity map. If the
+     * result has multiple columns, the first column is the key, the second column is the value, of which there may be
+     * more than one for each key.
+     */
     @NotNull <K, V> MultiValuedMap<K, V> getMultiValuedMap();
 
-    /** Populate an existing MultiValuedMap from a two-column query; the first column is the key, the second column is the value of which there may be more than one for the key. */
+    /**
+     * Populate an existing MultiValuedMap from a query. If the result has a single column, return an identity map. If
+     * the result has multiple columns, the first column is the key, the second column is the value, of which there may
+     * be more than one for each key.
+     */
     @NotNull <K, V> MultiValuedMap<K, V> fillMultiValuedMap(@NotNull final MultiValuedMap<K, V> multiMap);
 
+    @SuppressWarnings("UnusedReturnValue")
     @NotNull <K> Set<K> fillSet(@NotNull final Set<K> fillSet);
 
     /** Callback interface for dealing with objects streamed from the database one-by-one */

--- a/api/src/org/labkey/api/data/SqlExecutingSelector.java
+++ b/api/src/org/labkey/api/data/SqlExecutingSelector.java
@@ -235,13 +235,11 @@ public abstract class SqlExecutingSelector<FACTORY extends SqlFactory, SELECTOR 
     }
 
     /**
-     * If no transaction is active and the SQL statement is a SELECT, this method assumes it is safe to tweak
-     * connection parameters (such as disabling auto-commit, and never committing) to optimize memory and other
-     * resource usage.
-     *
-     * If you are, for example, invoking a stored procedure that will have side effects via a SELECT statement,
-     * you must explicitly start your own transaction and commit it.
-     */
+     * If no transaction is active and the SQL statement is a SELECT, this method assumes it is safe to tweak connection
+     * parameters (such as disabling auto-commit, and never committing) to optimize memory and other resource usage. If
+     * you are, for example, invoking a stored procedure that will have side effects via a SELECT statement, you must
+     * explicitly start your own transaction and commit it.
+     * */
     public TableResultSet getResultSet(boolean cache, boolean scrollable)
     {
         SqlFactory sqlFactory = getSqlFactory(true);

--- a/api/src/org/labkey/api/data/SqlSelectorTestCase.java
+++ b/api/src/org/labkey/api/data/SqlSelectorTestCase.java
@@ -22,6 +22,7 @@ import org.labkey.api.data.dialect.SqlDialect;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.sql.Connection.TRANSACTION_READ_COMMITTED;
@@ -43,15 +44,8 @@ public class SqlSelectorTestCase extends AbstractSelectorTestCase<SqlSelector>
             assertEquals(0, count.intValue());
         }
 
-        try
-        {
-            new SqlSelector(CoreSchema.getInstance().getSchema(), "SELECT RowId FROM comm.Announcements").getValueMap();
-            fail("Expected getValueMap() call with a single column to fail");
-        }
-        catch (IllegalStateException e)
-        {
-            assertTrue(e.getMessage().startsWith("Must select at least two columns"));
-        }
+        Map<Integer, Integer> identityMap = new SqlSelector(CoreSchema.getInstance().getSchema(), "SELECT RowId FROM comm.Announcements").getValueMap();
+        assertTrue("Expected an identity map!", identityMap.entrySet().stream().allMatch(entry -> entry.getKey().equals(entry.getValue())));
 
         // Verify that we can generate the supported execution plans
         for (SqlDialect.ExecutionPlanType type : SqlDialect.ExecutionPlanType.values())

--- a/api/src/org/labkey/api/data/TableSelectorTestCase.java
+++ b/api/src/org/labkey/api/data/TableSelectorTestCase.java
@@ -25,7 +25,6 @@ import org.labkey.api.module.ModuleContext;
 import org.labkey.api.security.User;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.TestContext;
 import org.springframework.jdbc.UncategorizedSQLException;
 
@@ -334,17 +333,14 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
             assertFalse("Expected getCollection() with primitive to succeed with stable column ordering", stable);
         }
 
-        int columnCount = selector.getColumnCount();
-
         try
         {
             assertEquals(count, selector.getValueMap().size());
             assertTrue("Expected getValueMap() to fail with unstable column ordering", stable);
-            assertTrue("Expected getValueMap() to fail with " + StringUtilsLabKey.pluralize(columnCount, "column"), columnCount > 0);
         }
         catch (IllegalStateException e)
         {
-            assertFalse("Expected getValueMap() to succeed with stable column ordering and " + StringUtilsLabKey.pluralize(columnCount, "column"), stable && columnCount > 1);
+            assertFalse("Expected getValueMap() to succeed with stable column ordering", stable);
         }
 
         try
@@ -353,11 +349,10 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
             selector.fillValueMap(map);
             assertEquals(count, map.size());
             assertTrue("Expected fillValueMap() to fail with unstable column ordering", stable);
-            assertTrue("Expected fillValueMap() to fail with " + StringUtilsLabKey.pluralize(columnCount, "column"), columnCount > 0);
         }
         catch (IllegalStateException e)
         {
-            assertFalse("Expected fillValueMap() to succeed with stable column ordering and " + StringUtilsLabKey.pluralize(columnCount, "column"), stable && columnCount > 1);
+            assertFalse("Expected fillValueMap() to succeed with stable column ordering", stable);
         }
 
         //noinspection UnusedDeclaration
@@ -382,6 +377,7 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
 
         try
         {
+            int columnCount = selector.getColumnCount();
             MutableInt forEachResultsCount = new MutableInt(0);
             selector.forEachResults(results -> {
                 assertEquals(columnCount, results.getFieldIndexMap().size());

--- a/api/src/org/labkey/api/data/TableSelectorTestCase.java
+++ b/api/src/org/labkey/api/data/TableSelectorTestCase.java
@@ -40,7 +40,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -266,7 +265,7 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
         {
             List<String> emails = stream
                 .map(User::getEmail)
-                .collect(Collectors.toList());
+                .toList();
             assertEquals(count, emails.size());
         }
 
@@ -274,7 +273,7 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
         try (Stream<String> stream = selector.uncachedStream(String.class))
         {
             List<String> emails = stream
-                .collect(Collectors.toList());
+                .toList();
             assertEquals(count, emails.size());
         }
 
@@ -293,7 +292,7 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
 
         List<String> emails = selector.stream(User.class)
             .map(User::getEmail)
-            .collect(Collectors.toList());
+            .toList();
         assertEquals(count, emails.size());
 
         // findFirst() should work and shouldn't cause any problems (e.g., shouldn't log a not closed exception)
@@ -341,7 +340,7 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
         {
             assertEquals(count, selector.getValueMap().size());
             assertTrue("Expected getValueMap() to fail with unstable column ordering", stable);
-            assertTrue("Expected getValueMap() to fail with " + StringUtilsLabKey.pluralize(columnCount, "column"), columnCount > 1);
+            assertTrue("Expected getValueMap() to fail with " + StringUtilsLabKey.pluralize(columnCount, "column"), columnCount > 0);
         }
         catch (IllegalStateException e)
         {
@@ -354,7 +353,7 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
             selector.fillValueMap(map);
             assertEquals(count, map.size());
             assertTrue("Expected fillValueMap() to fail with unstable column ordering", stable);
-            assertTrue("Expected fillValueMap() to fail with " + StringUtilsLabKey.pluralize(columnCount, "column"), columnCount > 1);
+            assertTrue("Expected fillValueMap() to fail with " + StringUtilsLabKey.pluralize(columnCount, "column"), columnCount > 0);
         }
         catch (IllegalStateException e)
         {

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -1741,7 +1741,10 @@ public class UserController extends SpringActionController
 
             if (isProjectAdminOrBetter)
             {
-                bb.add(getShowGridButton(c));
+                ActionButton showGrid = getShowGridButton(c);
+                if (!isOwnRecord)
+                    showGrid.setPrimary(true);
+                bb.add(showGrid);
             }
 
             if (isOwnRecord)
@@ -1767,6 +1770,7 @@ public class UserController extends SpringActionController
                 }
 
                 doneButton.addContextualRole(OwnerRole.class);
+                doneButton.setPrimary(true);
                 bb.add(doneButton);
                 bb.addContextualRole(OwnerRole.class);
             }


### PR DESCRIPTION
#### Rationale
Fix two unrelated issues:
* User details / My Account page: Move "Done" button to far right, per our best practices. Also, "Show Users" / "Show Project Users" button is effectively an alternative "Done" button (sometimes the only "Done" button), so move it to the right as well (just to the left of the "Done" button, if present). https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48276
* Adjust `Selector` methods `getValueMap()`, `fillValueMap()`, `getMultiValuedMap()`, and `fillMultiValuedMap()` to support single-column queries instead of throwing `IllegalStateException`. A single column result set implies an identify map (each key maps to a value that equals the key). https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=48054

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4292