### PR TITLE
Issue 48270: SQLException from MothershipManager.ensureSoftwareRelease()  

### DIFF
--- a/mothership/resources/schemas/dbscripts/postgresql/mothership-23.000-23.001.sql
+++ b/mothership/resources/schemas/dbscripts/postgresql/mothership-23.000-23.001.sql
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Issue 48270 - dedupe redundant rows in SoftwareRelease that have NULLs for VcsTag
+UPDATE mothership.serversession s SET softwarereleaseid =
+                  (SELECT MaxId
+                   FROM mothership.softwarerelease sr1
+                            INNER JOIN (SELECT MAX(SoftwareReleaseId) AS MaxId,
+                                               VcsUrl,
+                                               VcsRevision,
+                                               VcsTag,
+                                               VcsBranch,
+                                               BuildTime
+                                        FROM mothership.softwarerelease
+                                        GROUP BY VcsUrl, VcsRevision, VcsTag, VcsBranch, BuildTime) sr2
+                                       ON
+                                               (sr1.VcsUrl = sr2.VcsUrl OR (sr1.VcsUrl IS NULL AND sr2.VcsUrl IS NULL)) AND
+                                               (sr1.VcsRevision = sr2.VcsRevision OR
+                                                (sr1.VcsRevision IS NULL AND sr2.VcsRevision IS NULL)) AND
+                                               (sr1.VcsTag = sr2.VcsTag OR (sr1.VcsTag IS NULL AND sr2.VcsTag IS NULL)) AND
+                                               (sr1.VcsBranch = sr2.VcsBranch OR
+                                                (sr1.VcsBranch IS NULL AND sr2.VcsBranch IS NULL)) AND
+                                               (sr1.BuildTime = sr2.BuildTime OR
+                                                (sr1.BuildTime IS NULL AND sr2.BuildTime IS NULL))
+                   WHERE s.SoftwareReleaseId = sr1.SoftwareReleaseId);
+
+DELETE FROM mothership.softwarerelease WHERE SoftwareReleaseId NOT IN
+                                             (SELECT DISTINCT SoftwareReleaseId FROM mothership.serversession);
+

--- a/mothership/resources/schemas/dbscripts/postgresql/mothership-23.000-23.001.sql
+++ b/mothership/resources/schemas/dbscripts/postgresql/mothership-23.000-23.001.sql
@@ -39,11 +39,13 @@ INSERT INTO mothership.Dedupe (MaxId, SoftwareReleaseId)
                               (sr1.BuildTime IS NULL AND sr2.BuildTime IS NULL)
                     );
 
+-- Drop and recreate FK afterwards to speed up the DELETE constraint checking
+ALTER TABLE mothership.ServerSession DROP CONSTRAINT FK_ServerSession_SoftwareRelease;
+
+CREATE INDEX IDX_SoftwareReleaseId ON mothership.Dedupe(SoftwareReleaseId);
+
 UPDATE mothership.serversession s SET softwarereleaseid = (SELECT MaxId FROM mothership.Dedupe d
                    WHERE s.SoftwareReleaseId = d.SoftwareReleaseId);
-
--- Drop and recreate FK to speed up the DELETE constraint checking
-ALTER TABLE mothership.ServerSession DROP CONSTRAINT FK_ServerSession_SoftwareRelease;
 
 DELETE FROM mothership.softwarerelease WHERE SoftwareReleaseId NOT IN
                                              (SELECT DISTINCT MaxId FROM mothership.Dedupe);

--- a/mothership/resources/schemas/dbscripts/postgresql/mothership-23.000-23.001.sql
+++ b/mothership/resources/schemas/dbscripts/postgresql/mothership-23.000-23.001.sql
@@ -42,8 +42,14 @@ INSERT INTO mothership.Dedupe (MaxId, SoftwareReleaseId)
 UPDATE mothership.serversession s SET softwarereleaseid = (SELECT MaxId FROM mothership.Dedupe d
                    WHERE s.SoftwareReleaseId = d.SoftwareReleaseId);
 
-DROP TABLE mothership.Dedupe;
+-- Drop and recreate FK to speed up the DELETE constraint checking
+ALTER TABLE mothership.ServerSession DROP CONSTRAINT FK_ServerSession_SoftwareRelease;
 
 DELETE FROM mothership.softwarerelease WHERE SoftwareReleaseId NOT IN
-                                             (SELECT DISTINCT SoftwareReleaseId FROM mothership.serversession);
+                                             (SELECT DISTINCT MaxId FROM mothership.Dedupe);
+
+ALTER TABLE mothership.ServerSession ADD CONSTRAINT FK_ServerSession_SoftwareRelease FOREIGN KEY (SoftwareReleaseId) REFERENCES mothership.SoftwareRelease(SoftwareReleaseId);
+
+DROP TABLE mothership.Dedupe;
+
 

--- a/mothership/resources/schemas/dbscripts/postgresql/mothership-23.000-23.001.sql
+++ b/mothership/resources/schemas/dbscripts/postgresql/mothership-23.000-23.001.sql
@@ -15,27 +15,34 @@
  */
 
 -- Issue 48270 - dedupe redundant rows in SoftwareRelease that have NULLs for VcsTag
-UPDATE mothership.serversession s SET softwarereleaseid =
-                  (SELECT MaxId
-                   FROM mothership.softwarerelease sr1
-                            INNER JOIN (SELECT MAX(SoftwareReleaseId) AS MaxId,
-                                               VcsUrl,
-                                               VcsRevision,
-                                               VcsTag,
-                                               VcsBranch,
-                                               BuildTime
-                                        FROM mothership.softwarerelease
-                                        GROUP BY VcsUrl, VcsRevision, VcsTag, VcsBranch, BuildTime) sr2
-                                       ON
-                                               (sr1.VcsUrl = sr2.VcsUrl OR (sr1.VcsUrl IS NULL AND sr2.VcsUrl IS NULL)) AND
-                                               (sr1.VcsRevision = sr2.VcsRevision OR
-                                                (sr1.VcsRevision IS NULL AND sr2.VcsRevision IS NULL)) AND
-                                               (sr1.VcsTag = sr2.VcsTag OR (sr1.VcsTag IS NULL AND sr2.VcsTag IS NULL)) AND
-                                               (sr1.VcsBranch = sr2.VcsBranch OR
-                                                (sr1.VcsBranch IS NULL AND sr2.VcsBranch IS NULL)) AND
-                                               (sr1.BuildTime = sr2.BuildTime OR
-                                                (sr1.BuildTime IS NULL AND sr2.BuildTime IS NULL))
-                   WHERE s.SoftwareReleaseId = sr1.SoftwareReleaseId);
+CREATE TABLE mothership.Dedupe (MaxId INT NOT NULL, SoftwareReleaseId INT NOT NULL);
+
+INSERT INTO mothership.Dedupe (MaxId, SoftwareReleaseId)
+    SELECT MaxId, sr1.SoftwareReleaseId
+        FROM mothership.softwarerelease sr1
+        INNER JOIN (SELECT MAX(SoftwareReleaseId) AS MaxId,
+                             VcsUrl,
+                             VcsRevision,
+                             VcsTag,
+                             VcsBranch,
+                             BuildTime
+                      FROM mothership.softwarerelease
+                      GROUP BY VcsUrl, VcsRevision, VcsTag, VcsBranch, BuildTime) sr2
+                     ON
+                             (sr1.VcsUrl = sr2.VcsUrl OR (sr1.VcsUrl IS NULL AND sr2.VcsUrl IS NULL)) AND
+                             (sr1.VcsRevision = sr2.VcsRevision OR
+                              (sr1.VcsRevision IS NULL AND sr2.VcsRevision IS NULL)) AND
+                             (sr1.VcsTag = sr2.VcsTag OR (sr1.VcsTag IS NULL AND sr2.VcsTag IS NULL)) AND
+                             (sr1.VcsBranch = sr2.VcsBranch OR
+                              (sr1.VcsBranch IS NULL AND sr2.VcsBranch IS NULL)) AND
+                             (sr1.BuildTime = sr2.BuildTime OR
+                              (sr1.BuildTime IS NULL AND sr2.BuildTime IS NULL)
+                    );
+
+UPDATE mothership.serversession s SET softwarereleaseid = (SELECT MaxId FROM mothership.Dedupe d
+                   WHERE s.SoftwareReleaseId = d.SoftwareReleaseId);
+
+DROP TABLE mothership.Dedupe;
 
 DELETE FROM mothership.softwarerelease WHERE SoftwareReleaseId NOT IN
                                              (SELECT DISTINCT SoftwareReleaseId FROM mothership.serversession);

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -74,7 +74,7 @@ public class MothershipModule extends DefaultModule
     @Override
     public Double getSchemaVersion()
     {
-        return 23.000;
+        return 23.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Due to a bug related to null vs empty strings, we've accumulated many duplicate rows in `mothership.SoftwareRelease`. A 23.7 change has made this actively cause problems.

#### Changes
* Remove duplicate rows in `mothership.SoftwareRelease`
* Stop inserting duplicate rows