### PR TITLE
Only site admins should see encryption key warnings

### DIFF
--- a/api/src/org/labkey/api/security/Encryption.java
+++ b/api/src/org/labkey/api/security/Encryption.java
@@ -59,11 +59,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Easy to use wrappers for common encryption algorithms. Also includes related helper methods for shared operations
  * such as generating salts & keys, and for retrieving & saving the labkey.xml encryption key and standard salt.
- *
  * WARNING: Do not change the core algorithms or parameters of existing implementations; changes will likely
  * render existing data irrecoverable.
- * User: adam
- * Date: 10/19/13
 */
 
 public class Encryption
@@ -82,11 +79,14 @@ public class Encryption
             @Override
             public void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context, boolean showAllWarnings)
             {
-                int count = DECRYPTION_EXCEPTIONS.get();
+                if (context.getUser().hasSiteAdminPermission())
+                {
+                    int count = DECRYPTION_EXCEPTIONS.get();
 
-                if (count > 0 || showAllWarnings)
-                    warnings.add(HtmlString.of("On " + StringUtilsLabKey.pluralize(count, "attempt") + " the server failed to decrypt encrypted content using the " + ENCRYPTION_KEY_CHANGED +
-                        " An administrator should change the encryption key back to the previous value or be prepared to re-enter and re-save all saved credentials."));
+                    if (count > 0 || showAllWarnings)
+                        warnings.add(HtmlString.of("On " + StringUtilsLabKey.pluralize(count, "attempt") + " the server failed to decrypt encrypted content using the " + ENCRYPTION_KEY_CHANGED +
+                                " An administrator should change the encryption key back to the previous value or be prepared to re-enter and re-save all saved credentials."));
+                }
             }
         });
     }

--- a/api/src/org/labkey/api/view/template/WarningProvider.java
+++ b/api/src/org/labkey/api/view/template/WarningProvider.java
@@ -35,7 +35,8 @@ public interface WarningProvider
      * the context to limit who sees the warning(s); otherwise, ALL users (including guests) will see the warning(s).
      * @param warnings A @NotNull Warnings collector
      * @param context A @NotNull ViewContext that also guarantees a @NotNull getUser() and @NotNull getRequest()
-     * @param showAllWarnings A flag for testing that indicates the provider should unconditionally add all warnings
+     * @param showAllWarnings A flag for testing that indicates the provider should add all warnings if its standard
+     *                        permissions check passes.
      */
     default void addDynamicWarnings(@NotNull Warnings warnings, @NotNull ViewContext context, boolean showAllWarnings)
     {


### PR DESCRIPTION
#### Rationale
Encryption key warning needs a permission check. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48296