### PR TITLE
Fix participant indexing when participant aliases are configured

### DIFF
--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4408,8 +4408,8 @@ public class StudyManager
         SimpleFilter filter = SimpleFilter.createContainerFilter(c);
 
         @Nullable final TableInfo aliasTable = StudyQuerySchema.createSchema(study, User.getSearchUser()).getParticipantAliasesTable();
-        LastIndexedClause standardLastIndexedClause = new LastIndexedClause(StudySchema.getInstance().getTableInfoParticipant(), modifiedSince, "p");
-        if (!standardLastIndexedClause.isEmpty())
+        LastIndexedClause lastIndexedClause = new LastIndexedClause(StudySchema.getInstance().getTableInfoParticipant(), modifiedSince, "p");
+        if (!lastIndexedClause.isEmpty())
         {
             if (null != aliasTable)
             {
@@ -4417,11 +4417,11 @@ public class StudyManager
                 SQLFragment aliasFragment = new SQLFragment().append("ParticipantId IN (\nSELECT ParticipantId FROM\n")
                     .append(aliasTable.getFromSQL("aliases"))
                     .append("WHERE aliases.Modified > p.LastIndexed)");
-                filter.addClause(new OrClause(standardLastIndexedClause, new SQLClause(aliasFragment)));
+                filter.addClause(new OrClause(lastIndexedClause, new SQLClause(aliasFragment)));
             }
             else
             {
-                filter.addClause(standardLastIndexedClause);
+                filter.addClause(lastIndexedClause);
             }
         }
 


### PR DESCRIPTION
#### Rationale
The filter to select participants for full-text search indexing is too strict when a participant alias dataset is configured.

When the PTID list is null we should select all participants. Currently, however, when an alias table is present, we're adding an overly restrictive condition about modified aliases. Instead, we should add this condition only if we're selecting specific participants (i.e., the `lastIndexedClause` is not empty).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4577