### PR TITLE
Issue 48262: pass through format string to display column for ancestor lookup

### DIFF
--- a/experiment/src/org/labkey/experiment/api/AncestorLookupDisplayColumn.java
+++ b/experiment/src/org/labkey/experiment/api/AncestorLookupDisplayColumn.java
@@ -43,6 +43,14 @@ public class AncestorLookupDisplayColumn extends DataColumn
     }
 
     @Override
+    public void setFormatString(String formatString)
+    {
+        super.setFormatString(formatString);
+        if (_dc != null)
+            _dc.setFormatString(formatString);
+    }
+
+    @Override
     public @NotNull HtmlString getFormattedHtml(RenderContext ctx)
     {
         Integer lookupKey = getLookupId(ctx);


### PR DESCRIPTION
#### Rationale
[Issue 48262](https://www.labkey.org/home/Developer/issues/issues-update.view?issueId=48262): We want to respect the format strings set on columns when displaying ancestor lookup fields.

#### Changes
* When setting the format string for the AncestorLookupDisplayColumn, pass it through to the underlying display column so it will actually get used.
