### PR TITLE
Issue 48284: Set content type before making query for getSelected

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -225,6 +225,7 @@ import java.util.zip.GZIPOutputStream;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+import static org.labkey.api.action.ApiJsonWriter.CONTENT_TYPE_JSON;
 import static org.labkey.api.data.DbScope.NO_OP_TRANSACTION;
 import static org.labkey.api.util.DOM.BR;
 import static org.labkey.api.util.DOM.DIV;
@@ -6151,6 +6152,7 @@ public class QueryController extends SpringActionController
         @Override
         public ApiResponse execute(final SelectForm form, BindException errors) throws Exception
         {
+            getViewContext().getResponse().setHeader("Content-Type", CONTENT_TYPE_JSON);
             if (form.getQueryName() == null)
             {
                 Set<String> selected = DataRegionSelection.getSelected(getViewContext(), form.getKey(), form.isClearSelected());


### PR DESCRIPTION
#### Rationale
[Issue 48284](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48284): We can send back a content type header for the getSelected API call that is inaccurate if getting the selected items takes too long because the "live client" checker will respond first with the default (text/html) content type.  This PR sets the content header earlier for the GetSelected API call since we know we'll be sending back JSON.  

A more general solution would push this setting of the header further down in the class hierarchy, but in the interest of time I'm making this more targeted fix at the moment.  I don't think this is a critical fix for 23.8, so we could decide to implement something better and have the fix in 23.9.  Or we can do that with a separate PR.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Set the content type for the API response before making the query.
