### PR TITLE
Issue 48335: Newline For Multi-Select Followup

### DIFF
--- a/api/webapp/clientapi/ext3/FilterDialog.js
+++ b/api/webapp/clientapi/ext3/FilterDialog.js
@@ -695,6 +695,12 @@ LABKEY.FilterDialog.View.Default = Ext.extend(LABKEY.FilterDialog.ViewPanel, {
             inputField.disable();
             inputField.setValue();
             inputField.blur();
+            if (textAreaField)
+            {
+                textAreaField.disable();
+                textAreaField.setValue();
+                textAreaField.blur();
+            }
         }
         else {
             if (filter.isMultiValued() && (urlSuffix !== 'notbetween' && urlSuffix !== 'between')) {
@@ -1550,7 +1556,12 @@ LABKEY.FilterDialog.View.ConceptFilter = Ext.extend(LABKEY.FilterDialog.View.Def
             onFilterChange: function(filterValue) {
                 // Inputs may be set after app load, so look it up at execution time
                 const inputs = scope.inputs;
-                const targetInput = inputs ? inputs[index]: undefined;
+                if (!inputs)
+                    return;
+
+                const textInput = inputs[index * 2]; // one text input, one textarea input
+                const textAreaInput = inputs[index * 2 + 1];
+                const targetInput = textInput && !textInput.hidden ? textInput: textAreaInput;
 
                 // push values selected in tree to the target input control
                 if (targetInput && !targetInput.disabled) {

--- a/core/webapp/internal/ViewDesigner/tab/FilterTab.js
+++ b/core/webapp/internal/ViewDesigner/tab/FilterTab.js
@@ -228,15 +228,29 @@ Ext4.define('LABKEY.internal.ViewDesigner.tab.FilterTab', {
         var clauseIndex = combo.clauseIndex;
 
         var filterType = combo.getFilterType();
+        if (filterType === null)
+            return;
         // HACK: need to find the text field associated with this filter item
         var cs = this.getList().getComponents(combo);
         for (var i = 0; i < cs.length; i++)
         {
             var c = cs[i];
-            if (c.clauseIndex == clauseIndex && c instanceof LABKEY.internal.ViewDesigner.field.FilterTextValue)
+            if (c.clauseIndex == clauseIndex &&
+                    (c instanceof LABKEY.internal.ViewDesigner.field.FilterTextValue
+                            || c instanceof LABKEY.internal.ViewDesigner.field.FilterTextAreaValue
+                    )
+            )
             {
-                c.setVisible(filterType != null && filterType.isDataValueRequired());
-                break;
+                if (filterType.isDataValueRequired())
+                {
+                    var urlSuffix = filterType.getURLSuffix();
+                    if (filterType.isMultiValued() && (urlSuffix !== 'notbetween' && urlSuffix !== 'between'))
+                        c.setVisible(c instanceof LABKEY.internal.ViewDesigner.field.FilterTextAreaValue);
+                    else
+                        c.setVisible(c instanceof LABKEY.internal.ViewDesigner.field.FilterTextValue);
+                }
+                else
+                    c.setVisible(false);
             }
         }
     },


### PR DESCRIPTION
#### Rationale
This PR fixes a few issues with the ext3 based fitlerdialog as well as the ext4 based custom filter tab related to newline filter value support. 

Additionally, an issue with ontology filter: 
Test failure: [OntologyFieldAnnotationTest.testSearchMultiValuedFilterType](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_GitPostgres/2561297?buildTab=overview&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true)

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Fix ontology filter
* fix 48335 issues