### PR TITLE
Add mechanism for modules to add buttons to the User Details page

### DIFF
--- a/api/src/org/labkey/api/data/ActionButton.java
+++ b/api/src/org/labkey/api/data/ActionButton.java
@@ -54,7 +54,7 @@ public class ActionButton extends DisplayElement implements Cloneable
         /** Run a JavaScript snippet */
         SCRIPT("script");
 
-        private String _description;
+        private final String _description;
 
         Action(String desc)
         {

--- a/core/src/org/labkey/core/user/DeactivateUsersBean.java
+++ b/core/src/org/labkey/core/user/DeactivateUsersBean.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.core.user;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.security.User;
 import org.labkey.api.view.ActionURL;
 
@@ -22,22 +23,17 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/*
-* User: Dave
-* Date: Nov 3, 2008
-* Time: 11:35:35 AM
-*/
 public class DeactivateUsersBean
 {
     private final boolean _activate;
-    private final ActionURL _redirUrl;
+    private final ActionURL _returnUrl;
 
-    private List<User> _users = new ArrayList<>();
+    private final List<User> _users = new ArrayList<>();
 
-    public DeactivateUsersBean(boolean activate, ActionURL redirUrl)
+    public DeactivateUsersBean(boolean activate, @NotNull ActionURL returnUrl)
     {
         _activate = activate;
-        _redirUrl = null != redirUrl ? redirUrl : new UserController.UserUrlsImpl().getSiteUsersURL();
+        _returnUrl = returnUrl;
     }
 
     public boolean isActivate()
@@ -56,8 +52,8 @@ public class DeactivateUsersBean
             _users.add(user);
     }
 
-    public ActionURL getRedirUrl()
+    public ActionURL getReturnUrl()
     {
-        return _redirUrl;
+        return _returnUrl;
     }
 }

--- a/core/src/org/labkey/core/user/deactivateUsers.jsp
+++ b/core/src/org/labkey/core/user/deactivateUsers.jsp
@@ -16,12 +16,12 @@
  */
 %>
 <%@ page import="org.labkey.api.security.User" %>
+<%@ page import="org.labkey.api.security.UserManager" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.core.user.DeactivateUsersBean" %>
-<%@ page import="org.labkey.api.security.UserManager" %>
-<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
@@ -50,7 +50,7 @@
     %>
     </ul>
 <labkey:form action="<%=urlPost%>" method="post">
-    <input type="hidden" name="redirUrl" value="<%=h(bean.getRedirUrl())%>"/>
+    <%=generateReturnUrlFormField(bean.getReturnUrl())%>
     <%
         for (User user : bean.getUsers())
         {
@@ -58,7 +58,7 @@
         }
     %>
     <%= button(bean.isActivate() ? "Reactivate" : "Deactivate").submit(true) %>
-    <%= button("Cancel").href(bean.getRedirUrl()) %>
+    <%= button("Cancel").href(bean.getReturnUrl()) %>
 </labkey:form>
 <% if (bean.isActivate()) { %>
 <p><b>Note:</b> Reactivated users will be able to login normally, and all their previous


### PR DESCRIPTION
#### Rationale
Our TOTP 2FA provider needs to add a "Reset TOTP Settings" button to the User Details / My Profile page.

```
        // Simple example... real implementations need to check permissions
        UserManager.registerUserDetailsButtonProvider(Authentication, (bb, c, user, returnUrl) -> {
            ActionButton button = new ActionButton("Hello World!");
            bb.add(button);
        });
```

#### Changes
* Provide a general mechanism for modules to add custom buttons to the "User Details" button bar
* Migrate non-standard "redirUrl" handling to standard "returnUrl"
* Fix some warnings