### PR TITLE
Backport ApiXmlWriter JSON library update - DO NOT MERGE FORWARD

### DIFF
--- a/api/src/org/labkey/api/action/ApiXmlWriter.java
+++ b/api/src/org/labkey/api/action/ApiXmlWriter.java
@@ -99,9 +99,17 @@ public class ApiXmlWriter extends ApiResponseWriter
             {
                 writeJsonObjInternal((JSONObject) value);
             }
+            else if (value instanceof org.json.JSONObject)
+            {
+                writeJsonObjInternal((org.json.JSONObject) value);
+            }
             else if (value instanceof JSONArray)
             {
                 writeJsonArray((JSONArray) value);
+            }
+            else if (value instanceof org.json.JSONArray)
+            {
+                writeJsonArray((org.json.JSONArray) value);
             }
             else if (value instanceof Map)
             {
@@ -150,6 +158,17 @@ public class ApiXmlWriter extends ApiResponseWriter
         }
     }
 
+    private void writeJsonArray(org.json.JSONArray jsonArray) throws XMLStreamException, IOException
+    {
+        verifyOpen();
+        for (int i = 0; i < jsonArray.length(); i++)
+        {
+            _xmlWriter.writeStartElement(ARRAY_ELEMENT_NAME);
+            writeObject(jsonArray.get(i));
+            _xmlWriter.writeEndElement();
+        }
+    }
+
 
     @Override
     public void close() throws IOException
@@ -176,6 +195,17 @@ public class ApiXmlWriter extends ApiResponseWriter
         {
             _xmlWriter.writeStartElement(escapeElementName(entry.getKey()));
             writeObject(entry.getValue());
+            _xmlWriter.writeEndElement();
+        }
+    }
+
+    protected void writeJsonObjInternal(org.json.JSONObject json) throws IOException, XMLStreamException
+    {
+        verifyOpen();
+        for (String key : json.keySet())
+        {
+            _xmlWriter.writeStartElement(escapeElementName(key));
+            writeObject(json.get(key));
             _xmlWriter.writeEndElement();
         }
     }

--- a/api/src/org/labkey/api/action/ApiXmlWriter.java
+++ b/api/src/org/labkey/api/action/ApiXmlWriter.java
@@ -99,18 +99,24 @@ public class ApiXmlWriter extends ApiResponseWriter
             {
                 writeJsonObjInternal((JSONObject) value);
             }
+            // --------------------------------
+            // DO NOT MERGE THIS FORWARD
             else if (value instanceof org.json.JSONObject jo)
             {
                 writeJsonObjInternal(jo);
             }
+            //---------------------------------
             else if (value instanceof JSONArray)
             {
                 writeJsonArray((JSONArray) value);
             }
+            // --------------------------------
+            // DO NOT MERGE THIS FORWARD
             else if (value instanceof org.json.JSONArray ja)
             {
                 writeJsonArray(ja);
             }
+            //---------------------------------
             else if (value instanceof Map)
             {
                 writeJsonObjInternal(new JSONObject((Map) value));
@@ -158,6 +164,8 @@ public class ApiXmlWriter extends ApiResponseWriter
         }
     }
 
+    // --------------------------------
+    // DO NOT MERGE THIS FORWARD
     private void writeJsonArray(org.json.JSONArray jsonArray) throws XMLStreamException, IOException
     {
         verifyOpen();
@@ -168,7 +176,7 @@ public class ApiXmlWriter extends ApiResponseWriter
             _xmlWriter.writeEndElement();
         }
     }
-
+    // --------------------------------
 
     @Override
     public void close() throws IOException
@@ -199,6 +207,8 @@ public class ApiXmlWriter extends ApiResponseWriter
         }
     }
 
+    // --------------------------------
+    // DO NOT MERGE THIS FORWARD
     protected void writeJsonObjInternal(org.json.JSONObject json) throws IOException, XMLStreamException
     {
         verifyOpen();
@@ -209,7 +219,7 @@ public class ApiXmlWriter extends ApiResponseWriter
             _xmlWriter.writeEndElement();
         }
     }
-
+    // --------------------------------
 
     @Override
     public void startResponse()

--- a/api/src/org/labkey/api/action/ApiXmlWriter.java
+++ b/api/src/org/labkey/api/action/ApiXmlWriter.java
@@ -99,17 +99,17 @@ public class ApiXmlWriter extends ApiResponseWriter
             {
                 writeJsonObjInternal((JSONObject) value);
             }
-            else if (value instanceof org.json.JSONObject)
+            else if (value instanceof org.json.JSONObject jo)
             {
-                writeJsonObjInternal((org.json.JSONObject) value);
+                writeJsonObjInternal(jo);
             }
             else if (value instanceof JSONArray)
             {
                 writeJsonArray((JSONArray) value);
             }
-            else if (value instanceof org.json.JSONArray)
+            else if (value instanceof org.json.JSONArray ja)
             {
-                writeJsonArray((org.json.JSONArray) value);
+                writeJsonArray(ja);
             }
             else if (value instanceof Map)
             {


### PR DESCRIPTION
#### Rationale
EHR controller was converted to the new JSON object library in 23.3. The ApiXmlWriter didn't get converted until 23.7. There is one use case in the EHR using the ApiXmlWriter for an EHR action. This PR partially backports the JSON conversion of ApiXmlWriter to 23.3 so it will handle both the new and old JSON library. 

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/748

#### Changes
* Handle new JSONObject type
* Handle new JSONArray type
