### PR TITLE
Validate HTML view metadata XML unconditionally

### DIFF
--- a/query/src/org/labkey/query/ExternalSchemaDefImporterFactory.java
+++ b/query/src/org/labkey/query/ExternalSchemaDefImporterFactory.java
@@ -121,9 +121,8 @@ public class ExternalSchemaDefImporterFactory extends AbstractFolderImportFactor
                 form.setTypedValue("indexable", schemaXml.getIndexable());
                 form.setTypedValue("fastCacheRefresh", schemaXml.getFastCacheRefresh());
             }
-            else if (schemaXmlFile instanceof LinkedSchemaDocument)
+            else if (schemaXmlFile instanceof LinkedSchemaDocument schemaDoc)
             {
-                LinkedSchemaDocument schemaDoc = (LinkedSchemaDocument)schemaXmlFile;
                 XmlBeansUtil.validateXmlDocument(schemaDoc, relativePath);
 
                 LinkedSchemaType schemaXml = schemaDoc.getLinkedSchema();

--- a/query/src/org/labkey/query/QueryImporter.java
+++ b/query/src/org/labkey/query/QueryImporter.java
@@ -113,9 +113,8 @@ public class QueryImporter implements FolderImporter
                     XmlObject metaXml = queriesDir.getXmlBean(fileName);
                     try
                     {
-                        if (metaXml instanceof QueryDocument)
+                        if (metaXml instanceof QueryDocument queryDoc)
                         {
-                            QueryDocument queryDoc = (QueryDocument)metaXml;
                             XmlBeansUtil.validateXmlDocument(queryDoc, fileName);
                             metaFilesMap.put(fileName, queryDoc);
                         }

--- a/study/src/org/labkey/study/importer/StudyImporterFactory.java
+++ b/study/src/org/labkey/study/importer/StudyImporterFactory.java
@@ -16,7 +16,6 @@
 package org.labkey.study.importer;
 
 import org.apache.xmlbeans.XmlObject;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.NullSafeBindException;
 import org.labkey.api.admin.AbstractFolderImportFactory;
@@ -28,7 +27,6 @@ import org.labkey.api.admin.InvalidFileException;
 import org.labkey.api.cloud.CloudArchiveImporterSupport;
 import org.labkey.api.data.Container;
 import org.labkey.api.pipeline.PipelineJob;
-import org.labkey.api.pipeline.PipelineJobWarning;
 import org.labkey.api.security.User;
 import org.labkey.api.specimen.SpecimenMigrationService;
 import org.labkey.api.study.SpecimenService;
@@ -50,8 +48,6 @@ import org.springframework.validation.BindException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;

--- a/study/src/org/labkey/study/importer/StudyViewsImporter.java
+++ b/study/src/org/labkey/study/importer/StudyViewsImporter.java
@@ -67,10 +67,10 @@ public class StudyViewsImporter implements InternalStudyImporter
             if (settingsFileName != null)
             {
                 XmlObject doc = folder.getXmlBean(settingsFileName);
-                if (doc instanceof ViewsDocument)
+                if (doc instanceof ViewsDocument viewsDocument)
                 {
-                    XmlBeansUtil.validateXmlDocument(doc, "Validating ViewsDocument during study import");
-                    ViewsDocument.Views views = ((ViewsDocument) doc).getViews();
+                    XmlBeansUtil.validateXmlDocument(viewsDocument, "Validating ViewsDocument during study import");
+                    ViewsDocument.Views views = viewsDocument.getViews();
                     if (views != null)
                     {
                         ViewsDocument.Views.ParticipantView participantView = views.getParticipantView();


### PR DESCRIPTION
#### Rationale
All other module XML resources are schema validated in production and development mode; this seems to be the only dev-mode only validation. I can't think of a good reason for this inconsistency and it's causing some client confusion: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48363

Also, switch to pattern variables and fix a couple warnings