### PR TITLE
48185: Update of the User table clears any non-specified custom fields

### DIFF
--- a/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
@@ -515,7 +515,8 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
                 PropertyDescriptor pd = pc.getPropertyDescriptor();
                 tableProperties.add(pd);
 
-                if (lsid != null && hasProperty(oldRow, pd))
+                // clear out the old value if it exists and is contained in the new row (it may be incoming as null)
+                if (lsid != null && (hasProperty(row, pd) && hasProperty(oldRow, pd)))
                     OntologyManager.deleteProperty(lsid, pd.getPropertyURI(), getDomainObjContainer(c), getDomainContainer(c));
 
                 Object value = getPropertyValue(row, pd);


### PR DESCRIPTION
#### Rationale
I'm a bit surprised that we haven't run into this earlier but perhaps it's because form updates wouldn't expose this, many datatypes already override this method and maybe there aren't that many extensible tables running this code?

[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48185)