### PR TITLE
Reset encryption key test property if "newinstall" file is detected

### DIFF
--- a/api/src/org/labkey/api/security/Encryption.java
+++ b/api/src/org/labkey/api/security/Encryption.java
@@ -132,7 +132,9 @@ public class Encryption
                 // This will likely throw if the encryption key has changed
                 PropertyMap map = PropertyManager.getEncryptedStore().getWritableProperties(TEST_ENCRYPTION_CATEGORY, true);
 
-                if (map.isEmpty())
+                // Second check is important for trial deployments, where encryption key can change between initial
+                // bootstrap and the "new install" startup. See Issue 48346.
+                if (map.isEmpty() || ModuleLoader.getInstance().isNewInstall())
                 {
                     byte[] randomBytes = generateRandomBytes(TEST_BYTES_LENGTH);
                     MessageDigest sha1 = MessageDigest.getInstance("SHA1");

--- a/api/src/org/labkey/api/security/Encryption.java
+++ b/api/src/org/labkey/api/security/Encryption.java
@@ -129,12 +129,15 @@ public class Encryption
 
             try
             {
+                // On trial deployments, encryption key can change between initial bootstrap and the "new install"
+                // startup, so always delete if "newinstall" file is present. See Issue 48346.
+                if (ModuleLoader.getInstance().isNewInstall())
+                    PropertyManager.getEncryptedStore().deletePropertySet(TEST_ENCRYPTION_CATEGORY);
+
                 // This will likely throw if the encryption key has changed
                 PropertyMap map = PropertyManager.getEncryptedStore().getWritableProperties(TEST_ENCRYPTION_CATEGORY, true);
 
-                // Second check is important for trial deployments, where encryption key can change between initial
-                // bootstrap and the "new install" startup. See Issue 48346.
-                if (map.isEmpty() || ModuleLoader.getInstance().isNewInstall())
+                if (map.isEmpty())
                 {
                     byte[] randomBytes = generateRandomBytes(TEST_BYTES_LENGTH);
                     MessageDigest sha1 = MessageDigest.getInstance("SHA1");


### PR DESCRIPTION
#### Rationale
In our trial deployments, the encryption key can change between initial bootstrap and the "new install" startup. Resetting the test property if the `newInstall` flag is set suppresses the test failure in this case.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4635
* https://github.com/LabKey/platform/pull/4640
