### PR TITLE
Guard against NPE

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1220,6 +1220,8 @@ public class PlateManager implements PlateService
     private Container getPlateMetadataDomainContainer(Container container)
     {
         // scope the metadata container to the project
+        if (container.isRoot())
+            return container;
         return container.isProject() ? container : container.getProject();
     }
 


### PR DESCRIPTION
#### Rationale
A recent plate metadata merge is causing [this](https://teamcity.labkey.org/viewLog.html?tab=queuedBuildOverviewTab&buildId=2575314&buildTypeId=LabkeyTrunk_GitPostgres&fromSakuraUI=true#testNameId4388574136575233760) and other similar test failures. We need to be conscious of whether the container is root before returning `getProject()`. 
