### PR TITLE
return false, so that we don't push location onto the location history.

### DIFF
--- a/api/src/org/labkey/api/data/PanelButton.java
+++ b/api/src/org/labkey/api/data/PanelButton.java
@@ -69,7 +69,7 @@ public class PanelButton extends ActionButton
                 .dropdown(true)
                 .href("#")
                 .iconCls(getIconCls())
-                .onClick("(function(el) { " + DataRegion.getJavaScriptObjectReference(_dataRegionName) + ".toggleButtonPanelHandler(el); })(this);")
+                .onClick("(function(el) { " + DataRegion.getJavaScriptObjectReference(_dataRegionName) + ".toggleButtonPanelHandler(el);})(this); return false;")
                 .attributes(attributes)
                 .toString();
 


### PR DESCRIPTION
#### Rationale
fix for MS2Test
return false from event handler, so that we don't push location onto the location history.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
