### PR TITLE
Issue 48388: QuerySnapshotDependencyThread not setting Query environment

### DIFF
--- a/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
@@ -700,6 +700,9 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
                     SnapshotDependency.SourceDataType data = QUEUE.take();
                     try
                     {
+                        // Issue 48388 - set the environment for compliance logging purposes
+                        QueryService.get().setEnvironment(QueryService.Environment.CONTAINER, data.getContainer());
+                        QueryService.get().setEnvironment(QueryService.Environment.USER, User.getSearchUser());
                         List<QuerySnapshotDefinition> dependencies = getDependencies(data);
                         for (QuerySnapshotDefinition snapshotDef : dependencies)
                         {
@@ -711,6 +714,10 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
                     {
                         LOG.error(e);
                         ExceptionUtil.logExceptionToMothership(null, e);
+                    }
+                    finally
+                    {
+                        QueryService.get().clearEnvironment();
                     }
                 }
             }


### PR DESCRIPTION
#### Rationale
We should support query snapshots on servers that have the Compliance module deployed

#### Changes
* Set the environment so that we can figure out if/how to log