### PR TITLE
Issue 48442: Sample import or update from file to multiple sample types causes errors if > 1000 rows for any given sample type

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2613,6 +2613,7 @@ public class ExpDataIterators
             try (FileWriter writer = new FileWriter(typeData.dataFile, true))
             {
                 writer.write(StringUtils.join(typeData.dataRows, System.lineSeparator()));
+                writer.write(System.lineSeparator()); // Issue 48442: add a new line to the end so the next written rows start on a new line
                 typeData.dataRows.clear();
             }
             catch (IOException e)


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48442

While doing the multi sample type import and update, we write out the separate per-sample type data files to the temp directory. We do this in batches so that after we gather up 1000 rows for a given sample type, we write out those rows and then continue with parsing the original file. However, we aren't adding a new line after a batch is written so the next set of lines written to this text file end up starting on the same line as the last written line. The resulting files look something like this:

Name
S-0001
...
S-0998
S-0999S-1000
S-1001
S-1002
S-1003

This PR fixes this by writing out a new line at the end of each batch.


#### Changes
- add a new line to the end so the next written rows start on a new line
