### PR TITLE
Issue 48442: Sample import or update from file to multiple sample types causes errors if > 1000 rows for any given sample type

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2585,6 +2585,7 @@ public class ExpDataIterators
             try (FileWriter writer = new FileWriter(typeData.dataFile, true))
             {
                 writer.write(StringUtils.join(typeData.dataRows, System.lineSeparator()));
+                writer.write(System.lineSeparator()); // Issue 48442: add a new line to the end so the next written rows start on a new line
                 typeData.dataRows.clear();
             }
             catch (IOException e)


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48442

Backporting fix from 23.8 to 23.7. See related PR for further details.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4663

#### Changes
- add a new line to the end so the next written rows start on a new line
