### PR TITLE
Support assay run import of plate based metadata

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -63,7 +63,6 @@ import org.labkey.api.reader.ColumnDescriptor;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reader.TabLoader;
 import org.labkey.api.security.User;
-import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.study.ParticipantVisit;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
@@ -179,11 +178,15 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         AssayProvider provider = AssayService.get().getProvider(protocol);
         boolean plateMetadataEnabled = provider.isPlateMetadataEnabled(protocol);
         File plateMetadataFile = null;
+        Map<String, AssayPlateMetadataService.MetadataLayer> rawPlateMetadata = null;
 
         if (plateMetadataEnabled)
         {
             if (context instanceof AssayUploadXarContext assayContext)
             {
+                // the plate metadata will either be uploaded as a file or in a raw, already parsed form depending on
+                // how the run is imported.
+                rawPlateMetadata = assayContext.getContext().getRawPlateMetadata();
                 plateMetadataFile = (File)assayContext.getContext().getUploadedData().get(AssayDataCollector.PLATE_METADATA_FILE);
                 if (plateMetadataFile != null)
                 {
@@ -208,21 +211,28 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
             // assays with plate metadata support will merge the plate metadata with the data rows to make it easier for
             // transform scripts to perform metadata related calculations
-            if (plateMetadataEnabled && plateMetadataFile != null)
+            AssayPlateMetadataService svc = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE);
+            if (svc != null)
             {
-                AssayPlateMetadataService svc = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE);
-                if (svc != null)
+                if (plateMetadataEnabled)
                 {
-                    Map<String, AssayPlateMetadataService.MetadataLayer> plateMetadata = svc.parsePlateMetadata(plateMetadataFile);
+                    Map<String, AssayPlateMetadataService.MetadataLayer> plateMetadata = null;
+                    if (plateMetadataFile != null || rawPlateMetadata != null)
+                    {
+                        plateMetadata = plateMetadataFile != null
+                                ? svc.parsePlateMetadata(plateMetadataFile)
+                                : rawPlateMetadata;
+                    }
                     Domain runDomain = provider.getRunDomain(protocol);
                     DomainProperty property = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME);
                     if (property != null)
                     {
                         Object lsid = ((AssayUploadXarContext)context).getContext().getRunProperties().get(property);
-                        dataRows = svc.mergePlateMetadata(Lsid.parse(String.valueOf(lsid)), dataRows, plateMetadata, protocol);
+                        dataRows = svc.mergePlateMetadata(context.getContainer(), context.getUser(), Lsid.parse(String.valueOf(lsid)), dataRows, plateMetadata, protocol);
                     }
                 }
             }
+
             datas.put(getDataType(), dataRows);
             return datas;
         }
@@ -651,7 +661,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         else
         {
             // plate metadata is optional if the experimental plate flag is enabled
-            if (!ExperimentalFeatureService.get().isFeatureEnabled("experimental-app-plate-support"))
+            if (!AssayPlateMetadataService.isExperimentalAppPlateEnabled())
                 throw new ExperimentException("Unable to locate the ExpData with the plate metadata");
         }
     }

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -63,6 +63,7 @@ import org.labkey.api.reader.ColumnDescriptor;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reader.TabLoader;
 import org.labkey.api.security.User;
+import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.study.ParticipantVisit;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
@@ -648,7 +649,11 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 throw new ExperimentException("No PlateMetadataService registered for data type : " + plateData.getDataType().toString());
         }
         else
-            throw new ExperimentException("Unable to locate the ExpData with the plate metadata");
+        {
+            // plate metadata is optional if the experimental plate flag is enabled
+            if (!ExperimentalFeatureService.get().isFeatureEnabled("experimental-app-plate-support"))
+                throw new ExperimentException("Unable to locate the ExpData with the plate metadata");
+        }
     }
 
     protected ParticipantVisitResolver createResolver(User user, ExpRun run, ExpProtocol protocol, AssayProvider provider, Container container)

--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -13,6 +13,7 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.security.User;
+import org.labkey.api.settings.ExperimentalFeatureService;
 
 import java.io.File;
 import java.util.HashMap;
@@ -32,6 +33,11 @@ public interface AssayPlateMetadataService
         }
         else
             throw new RuntimeException("The specified assay data type is null");
+    }
+
+    static boolean isExperimentalAppPlateEnabled()
+    {
+        return ExperimentalFeatureService.get().isFeatureEnabled("experimental-app-plate-support");
     }
 
     @Nullable
@@ -64,7 +70,7 @@ public interface AssayPlateMetadataService
      *
      * @return the merged rows
      */
-    List<Map<String, Object>> mergePlateMetadata(Lsid plateLsid, List<Map<String, Object>> rows, Map<String, MetadataLayer> plateMetadata,
+    List<Map<String, Object>> mergePlateMetadata(Container container, User user, Lsid plateLsid, List<Map<String, Object>> rows, @Nullable Map<String, MetadataLayer> plateMetadata,
                                                  ExpProtocol protocol) throws ExperimentException;
 
     /**

--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -1,5 +1,6 @@
 package org.labkey.api.assay.plate;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.assay.AssayDataType;
@@ -83,6 +84,7 @@ public interface AssayPlateMetadataService
      * Returns an import helper to help join assay results data to well data and metadata that is associated
      * with the plate used in the assay run import
      */
+    @NotNull
     OntologyManager.UpdateableTableImportHelper getImportHelper(Container container, User user, ExpRun run, ExpData data, ExpProtocol protocol, AssayProvider provider) throws ExperimentException;
 
     interface MetadataLayer

--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -7,6 +7,7 @@ import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
+import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
@@ -71,6 +72,12 @@ public interface AssayPlateMetadataService
      */
     Map<String, MetadataLayer> parsePlateMetadata(JSONObject json) throws ExperimentException;
     Map<String, MetadataLayer> parsePlateMetadata(File jsonData) throws ExperimentException;
+
+    /**
+     * Returns an import helper to help join assay results data to well data and metadata that is associated
+     * with the plate used in the assay run import
+     */
+    OntologyManager.UpdateableTableImportHelper getImportHelper(Container container, User user, ExpRun run, ExpData data, ExpProtocol protocol, AssayProvider provider) throws ExperimentException;
 
     interface MetadataLayer
     {

--- a/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
+++ b/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
@@ -306,21 +306,18 @@ public class TsvDataExchangeHandler implements DataExchangeHandler
             File runData = new File(scriptDir, RUN_DATA_FILE);
             result.add(runData);
 
-            if (rawPlateMetadata != null)
+            AssayPlateMetadataService svc = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE);
+            if (svc != null)
             {
-                AssayPlateMetadataService svc = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE);
-                if (svc != null)
-                {
-                    ExpProtocol protocol = run.getProtocol();
-                    AssayProvider provider = AssayService.get().getProvider(protocol);
+                ExpProtocol protocol = run.getProtocol();
+                AssayProvider provider = AssayService.get().getProvider(protocol);
 
-                    Domain runDomain = provider.getRunDomain(protocol);
-                    DomainProperty property = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME);
-                    if (property != null)
-                    {
-                        Object lsid = context.getRunProperties().get(property);
-                        rawData = svc.mergePlateMetadata(Lsid.parse(String.valueOf(lsid)), rawData, rawPlateMetadata, protocol);
-                    }
+                Domain runDomain = provider.getRunDomain(protocol);
+                DomainProperty property = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME);
+                if (property != null)
+                {
+                    Object lsid = context.getRunProperties().get(property);
+                    rawData = svc.mergePlateMetadata(context.getContainer(), context.getUser(), Lsid.parse(String.valueOf(lsid)), rawData, rawPlateMetadata, protocol);
                 }
             }
             addToMergedMap(mergedDataMap, Map.of(dataType, rawData));

--- a/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
@@ -45,6 +45,7 @@ import static org.labkey.api.data.Table.MODIFIED_COLUMN_NAME;
 public class AssayResultDomainKind extends AssayDomainKind
 {
     public static final String WELL_LOCATION_COLUMN_NAME = "WellLocation";
+    public static final String WELL_LSID_COLUMN_NAME = "WellLsid";
 
     public AssayResultDomainKind()
     {
@@ -137,6 +138,7 @@ public class AssayResultDomainKind extends AssayDomainKind
                 if (provider.isPlateMetadataEnabled(protocol))
                 {
                     mandatoryNames.add(WELL_LOCATION_COLUMN_NAME);
+                    mandatoryNames.add(WELL_LSID_COLUMN_NAME);
                 }
             }
         }

--- a/assay/api-src/org/labkey/api/assay/plate/Plate.java
+++ b/assay/api-src/org/labkey/api/assay/plate/Plate.java
@@ -41,6 +41,8 @@ public interface Plate extends PropertySet, Identifiable
 
     Well getWell(int row, int col);
 
+    Well getWell(int rowId);
+
     WellGroup getWellGroup(WellGroup.Type type, String wellGroupName);
 
     @Nullable WellGroup getWellGroup(int rowId);

--- a/assay/api-src/org/labkey/api/assay/plate/Position.java
+++ b/assay/api-src/org/labkey/api/assay/plate/Position.java
@@ -25,6 +25,8 @@ public interface Position
 {
     Integer getRowId();
 
+    String getLsid();
+
     int getColumn();
 
     int getRow();

--- a/assay/api-src/org/labkey/api/assay/plate/PositionImpl.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PositionImpl.java
@@ -125,6 +125,7 @@ public class PositionImpl implements Position
         _row = row;
     }
 
+    @Override
     public String getLsid()
     {
         return _lsid;

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -57,8 +57,9 @@ import org.labkey.api.vocabulary.security.DesignVocabularyPermission;
 import org.labkey.assay.plate.PlateDataServiceImpl;
 import org.labkey.assay.plate.PlateManager;
 import org.labkey.assay.plate.PlateUrls;
-import org.labkey.assay.plate.model.PlateField;
+import org.labkey.assay.plate.model.PlateCustomField;
 import org.labkey.assay.plate.model.PlateType;
+import org.labkey.assay.plate.model.WellCustomField;
 import org.labkey.assay.view.AssayGWTView;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
@@ -660,7 +661,7 @@ public class PlateController extends SpringActionController
         @Override
         public Object execute(CreatePlateMetadataFieldsForm form, BindException errors) throws Exception
         {
-            List<PlateField> newFields = PlateManager.get().createPlateMetadataFields(getContainer(), getUser(), form.getFields());
+            List<PlateCustomField> newFields = PlateManager.get().createPlateMetadataFields(getContainer(), getUser(), form.getFields());
             return success(newFields);
         }
     }
@@ -677,14 +678,14 @@ public class PlateController extends SpringActionController
 
     public static class DeletePlateMetadataFieldsForm
     {
-        private List<PlateField> _fields;
+        private List<PlateCustomField> _fields;
 
-        public List<PlateField> getFields()
+        public List<PlateCustomField> getFields()
         {
             return _fields;
         }
 
-        public void setFields(List<PlateField> fields)
+        public void setFields(List<PlateCustomField> fields)
         {
             _fields = fields;
         }
@@ -749,6 +750,42 @@ public class PlateController extends SpringActionController
         public Object execute(CustomFieldsForm form, BindException errors) throws Exception
         {
             return success(PlateManager.get().removeFields(getContainer(), getUser(), form.getPlateId(), form.getFields()));
+        }
+    }
+
+    public static class SetFieldsForm extends CustomFieldsForm
+    {
+        private Integer _wellId;
+        private List<WellCustomField> _wellFields;
+
+        public Integer getWellId()
+        {
+            return _wellId;
+        }
+
+        public void setWellId(Integer wellId)
+        {
+            _wellId = wellId;
+        }
+
+        public List<WellCustomField> getWellFields()
+        {
+            return _wellFields;
+        }
+
+        public void setWellFields(List<WellCustomField> wellFields)
+        {
+            _wellFields = wellFields;
+        }
+    }
+
+    @RequiresPermission(UpdatePermission.class)
+    public class SetFieldsAction extends MutatingApiAction<SetFieldsForm>
+    {
+        @Override
+        public Object execute(SetFieldsForm form, BindException errors) throws Exception
+        {
+            return success(PlateManager.get().setFields(getContainer(), getUser(), form.getPlateId(), form.getWellId(), form.getWellFields()));
         }
     }
 }

--- a/assay/src/org/labkey/assay/TsvAssayProvider.java
+++ b/assay/src/org/labkey/assay/TsvAssayProvider.java
@@ -85,6 +85,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * User: brittp
@@ -364,15 +365,29 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
             Domain resultsDomain = getResultsDomain(protocol);
             if (resultsDomain != null && resultsDomain.getTypeURI().equals(update.getDomainURI()))
             {
-                if (update.getFields().stream().noneMatch(field -> field.getName().equals(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME)))
+                ArrayList<GWTPropertyDescriptor> newFields = new ArrayList<>();
+                Set<String> existingFields = update.getFields().stream().map(GWTPropertyDescriptor::getName).collect(Collectors.toSet());
+
+                if (!existingFields.contains(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME))
                 {
                     GWTPropertyDescriptor wellLocation = new GWTPropertyDescriptor(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME, PropertyType.STRING.getTypeUri());
                     wellLocation.setShownInUpdateView(false);
 
-                    ArrayList<GWTPropertyDescriptor> newFields = new ArrayList<>();
                     newFields.add(wellLocation);
-                    newFields.addAll(update.getFields());
+                }
 
+                if (!existingFields.contains(AssayResultDomainKind.WELL_LSID_COLUMN_NAME))
+                {
+                    GWTPropertyDescriptor wellLsid = new GWTPropertyDescriptor(AssayResultDomainKind.WELL_LSID_COLUMN_NAME, PropertyType.STRING.getTypeUri());
+                    wellLsid.setShownInUpdateView(false);
+                    wellLsid.setHidden(true);
+
+                    newFields.add(wellLsid);
+                }
+
+                if (!newFields.isEmpty())
+                {
+                    newFields.addAll(update.getFields());
                     update.setFields(newFields);
                 }
             }

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -2,6 +2,7 @@ package org.labkey.assay.plate;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.assay.AssayProtocolSchema;
@@ -422,6 +423,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
     }
 
     @Override
+    @NotNull
     public OntologyManager.UpdateableTableImportHelper getImportHelper(
             Container container,
             User user,

--- a/assay/src/org/labkey/assay/plate/PlateImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateImpl.java
@@ -514,8 +514,8 @@ public class PlateImpl extends PropertySetImpl implements Plate
 
         // create a rowId to well map
         _wellMap = new HashMap<>();
-        Arrays.stream(_wells).toList().forEach(w -> {
-            Arrays.stream(w).toList().forEach(well -> {
+        Arrays.stream(_wells).forEach(w -> {
+            Arrays.stream(w).forEach(well -> {
                 if (well != null)
                     _wellMap.put(well.getRowId(), well);
             });

--- a/assay/src/org/labkey/assay/plate/PlateImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateImpl.java
@@ -24,6 +24,7 @@ import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.PositionImpl;
+import org.labkey.api.assay.plate.Well;
 import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.Transient;
@@ -33,6 +34,7 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.assay.PlateController;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -59,6 +61,8 @@ public class PlateImpl extends PropertySetImpl implements Plate
     private List<WellGroupImpl> _deletedGroups;
 
     private WellImpl[][] _wells;
+    private Map<Integer, WellImpl> _wellMap;
+
     private int _runId;      // NO_RUNID means no run yet, well data comes from file, dilution data must be calculated
     private int _plateNumber;
 
@@ -480,6 +484,13 @@ public class PlateImpl extends PropertySetImpl implements Plate
         }
     }
 
+    @Override
+    @Nullable
+    public Well getWell(int rowId)
+    {
+        return _wellMap != null ? _wellMap.get(rowId) : null;
+    }
+
     @JsonIgnore
     @Override
     public WellGroup getWellGroup(WellGroup.Type type, String wellGroupName)
@@ -500,6 +511,12 @@ public class PlateImpl extends PropertySetImpl implements Plate
     public void setWells(WellImpl[][] wells)
     {
         _wells = wells;
+
+        // create a rowId to well map
+        _wellMap = new HashMap<>();
+        Arrays.stream(_wells).toList().forEach(w -> {
+            Arrays.stream(w).toList().forEach(well -> _wellMap.put(well.getRowId(), well));
+        });
     }
 
     @JsonIgnore

--- a/assay/src/org/labkey/assay/plate/PlateImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateImpl.java
@@ -515,7 +515,10 @@ public class PlateImpl extends PropertySetImpl implements Plate
         // create a rowId to well map
         _wellMap = new HashMap<>();
         Arrays.stream(_wells).toList().forEach(w -> {
-            Arrays.stream(w).toList().forEach(well -> _wellMap.put(well.getRowId(), well));
+            Arrays.stream(w).toList().forEach(well -> {
+                if (well != null)
+                    _wellMap.put(well.getRowId(), well);
+            });
         });
     }
 

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -82,8 +82,9 @@ import org.labkey.api.util.TestContext;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.webdav.WebdavResource;
 import org.labkey.assay.TsvAssayProvider;
-import org.labkey.assay.plate.model.PlateField;
+import org.labkey.assay.plate.model.PlateCustomField;
 import org.labkey.assay.plate.model.PlateType;
+import org.labkey.assay.plate.model.WellCustomField;
 import org.labkey.assay.plate.model.WellGroupBean;
 import org.labkey.assay.plate.query.PlateSchema;
 import org.labkey.assay.plate.query.PlateTable;
@@ -416,15 +417,6 @@ public class PlateManager implements PlateService
         // set plate properties:
         setProperties(plate.getContainer(), plate);
 
-        Position[][] positionArray;
-        if (plate.isTemplate())
-            positionArray = new Position[plate.getRows()][plate.getColumns()];
-        else
-            positionArray = new WellImpl[plate.getRows()][plate.getColumns()];
-
-        // get position objects
-        PositionImpl[] positions = getPositions(plate);
-
         // query for all well to well group mappings on the plate
         SQLFragment sql = new SQLFragment();
         sql.append("SELECT wgp.wellId, wgp.wellGroupId FROM ")
@@ -449,24 +441,24 @@ public class PlateManager implements PlateService
 
         // construct groupIdToPositions: map of wellGroupId -> List of PositionImpl
         Map<Integer, List<PositionImpl>> groupIdToPositions = new HashMap<>();
-        for (PositionImpl position : positions)
+        WellImpl[] wells = getWells(plate);
+        WellImpl[][] wellArray = new WellImpl[plate.getRows()][plate.getColumns()];
+        for (WellImpl well : wells)
         {
-            positionArray[position.getRow()][position.getColumn()] = position;
+            wellArray[well.getRow()][well.getColumn()] = well;
 
-            Set<Integer> wellGroupIds = wellToWellGroups.get(position.getRowId());
+            Set<Integer> wellGroupIds = wellToWellGroups.get(well.getRowId());
             if (wellGroupIds != null)
             {
                 for (Integer wellGroupId : wellGroupIds)
                 {
                     List<PositionImpl> groupPositions = groupIdToPositions.computeIfAbsent(wellGroupId, k -> new ArrayList<>());
-                    groupPositions.add(position);
+                    groupPositions.add(well);
                 }
             }
         }
-
-        // not sure if this would ever be true
-        if (positionArray instanceof WellImpl[][] wells)
-            plate.setWells(wells);
+        // add the wells to the plate
+        plate.setWells(wellArray);
 
         // populate well groups: assign all positions to the well group object
         WellGroupImpl[] wellgroups = getWellGroups(plate);
@@ -486,12 +478,11 @@ public class PlateManager implements PlateService
             plate.addWellGroup(group);
     }
 
-    private PositionImpl[] getPositions(Plate plate)
+    private WellImpl[] getWells(Plate plate)
     {
         SimpleFilter plateFilter = new SimpleFilter(FieldKey.fromParts("PlateId"), plate.getRowId());
         Sort sort = new Sort("Col,Row");
-        Class<? extends PositionImpl> clazz = plate.isTemplate() ? PositionImpl.class : WellImpl.class;
-        return new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), plateFilter, sort).getArray(clazz);
+        return new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), plateFilter, sort).getArray(WellImpl.class);
 
     }
 
@@ -620,7 +611,7 @@ public class PlateManager implements PlateService
             Map<Pair<Integer, Integer>, PositionImpl> existingPositionMap = new HashMap<>();
             if (updateExisting)
             {
-                for (PositionImpl existingPosition : getPositions(plate))
+                for (PositionImpl existingPosition : getWells(plate))
                 {
                     existingPositionMap.put(Pair.of(existingPosition.getRow(), existingPosition.getCol()), existingPosition);
                 }
@@ -780,14 +771,14 @@ public class PlateManager implements PlateService
         PlateImpl plate = new TableSelector(schema.getTableInfoPlate(),
                 plateFilter, null).getObject(PlateImpl.class);
         WellGroupImpl[] wellgroups = getWellGroups(plate);
-        PositionImpl[] positions = getPositions(plate);
+        WellImpl[] wells = getWells(plate);
 
         List<String> lsids = new ArrayList<>();
         lsids.add(plate.getLSID());
         for (WellGroupImpl wellgroup : wellgroups)
             lsids.add(wellgroup.getLSID());
-        for (PositionImpl position : positions)
-            lsids.add(position.getLsid());
+        for (WellImpl well : wells)
+            lsids.add(well.getLsid());
 
         SimpleFilter plateIdFilter = SimpleFilter.createContainerFilter(container);
         plateIdFilter.addCondition(FieldKey.fromParts("PlateId"), plate.getRowId());
@@ -1243,7 +1234,7 @@ public class PlateManager implements PlateService
     /**
      * Adds custom fields to the well domain
      */
-    public @NotNull List<PlateField> createPlateMetadataFields(Container container, User user, List<GWTPropertyDescriptor> fields) throws Exception
+    public @NotNull List<PlateCustomField> createPlateMetadataFields(Container container, User user, List<GWTPropertyDescriptor> fields) throws Exception
     {
         Domain vocabDomain = ensurePlateMetadataDomain(container, user);
         DomainKind domainKind = vocabDomain.getDomainKind();
@@ -1273,7 +1264,7 @@ public class PlateManager implements PlateService
         return getPlateMetadataFields(container, user);
     }
 
-    public @NotNull List<PlateField> deletePlateMetadataFields(Container container, User user, List<PlateField> fields) throws Exception
+    public @NotNull List<PlateCustomField> deletePlateMetadataFields(Container container, User user, List<PlateCustomField> fields) throws Exception
     {
         Domain vocabDomain = getPlateMetadataDomain(container, user);
 
@@ -1286,7 +1277,7 @@ public class PlateManager implements PlateService
         if (!fields.isEmpty())
         {
             List<String> propertyURIs = new ArrayList<>();
-            for (PlateField field : fields)
+            for (PlateCustomField field : fields)
             {
                 if (field.getPropertyURI() == null)
                     throw new IllegalStateException("Unable to remove fields, the property URI must be specified.");
@@ -1304,7 +1295,7 @@ public class PlateManager implements PlateService
             try (DbScope.Transaction tx = ExperimentService.get().ensureTransaction())
             {
                 Set<String> existingProperties = vocabDomain.getProperties().stream().map(ImportAliasable::getPropertyURI).collect(Collectors.toSet());
-                for (PlateField field : fields)
+                for (PlateCustomField field : fields)
                 {
                     if (!existingProperties.contains(field.getPropertyURI()))
                         throw new IllegalStateException(String.format("Unable to remove field: %s on domain: %s. The field does not exist.", field.getName(), vocabDomain.getTypeURI()));
@@ -1319,20 +1310,20 @@ public class PlateManager implements PlateService
         return getPlateMetadataFields(container, user);
     }
 
-    public @NotNull List<PlateField> getPlateMetadataFields(Container container, User user)
+    public @NotNull List<PlateCustomField> getPlateMetadataFields(Container container, User user)
     {
         Domain vocabDomain = getPlateMetadataDomain(container, user);
         if (vocabDomain != null)
         {
-            List<PlateField> fields = vocabDomain.getProperties().stream().map(PlateField::new).toList();
+            List<PlateCustomField> fields = vocabDomain.getProperties().stream().map(PlateCustomField::new).toList();
             return fields.stream()
-                    .sorted(Comparator.comparing(PlateField::getName))
+                    .sorted(Comparator.comparing(PlateCustomField::getName))
                     .collect(Collectors.toList());
         }
         return Collections.emptyList();
     }
 
-    public @NotNull List<PlateField> addFields(Container container, User user, Integer plateId, List<PlateField> fields) throws SQLException
+    public @NotNull List<PlateCustomField> addFields(Container container, User user, Integer plateId, List<PlateCustomField> fields) throws SQLException
     {
         if (plateId == null)
             throw new IllegalArgumentException("Failed to add plate custom fields. Invalid plateId provided.");
@@ -1350,7 +1341,7 @@ public class PlateManager implements PlateService
 
         List<DomainProperty> fieldsToAdd = new ArrayList<>();
         // validate fields
-        for (PlateField field : fields)
+        for (PlateCustomField field : fields)
         {
             DomainProperty dp = domain.getPropertyByURI(field.getPropertyURI());
             if (dp == null)
@@ -1389,7 +1380,18 @@ public class PlateManager implements PlateService
         return getFields(container, user, plateId);
     }
 
-    public List<PlateField> getFields(Container container, User user, Integer plateId)
+    public List<PlateCustomField> getFields(Container container, User user, Integer plateId)
+    {
+        List<PlateCustomField> fields = _getFields(container, user, plateId).stream().map(PlateCustomField::new).toList();
+        return fields.stream()
+                .sorted(Comparator.comparing(PlateCustomField::getName))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the list of custom properties associated with a plate
+     */
+    private List<DomainProperty> _getFields(Container container, User user, Integer plateId)
     {
         Plate plate = getPlate(container, plateId);
         if (plate == null)
@@ -1402,22 +1404,35 @@ public class PlateManager implements PlateService
         SQLFragment sql = new SQLFragment("SELECT PropertyURI FROM ").append(AssayDbSchema.getInstance().getTableInfoPlateProperty(), "PP")
                 .append(" WHERE PlateId = ?").add(plateId);
 
-        List<PlateField> fields = new ArrayList<>();
+        List<DomainProperty> fields = new ArrayList<>();
         for (String uri : new SqlSelector(AssayDbSchema.getInstance().getSchema(), sql).getArrayList(String.class))
         {
             DomainProperty dp = domain.getPropertyByURI(uri);
             if (dp == null)
                 throw new IllegalArgumentException("Failed to get plate custom field. \"" + uri + "\" does not exist on domain.");
 
-            fields.add(new PlateField(dp));
+            fields.add(dp);
         }
+        return fields;
+    }
 
+    private List<WellCustomField> getWellCustomFields(Container container, User user, Integer plateId, Integer wellId)
+    {
+        List<WellCustomField> fields = _getFields(container, user, plateId).stream().map(WellCustomField::new).toList();
+
+        // need to get the well values associated with each custom field
+        Plate plate = getPlate(container, plateId);
+        Well well = plate.getWell(wellId);
+        if (well == null)
+            throw new IllegalArgumentException("Failed to get well custom fields. Well id \"" + wellId   + "\" not found.");
+
+        Map<String, Object> properties = OntologyManager.getProperties(container, well.getLsid());
         return fields.stream()
-                .sorted(Comparator.comparing(PlateField::getName))
+                .sorted(Comparator.comparing(PlateCustomField::getName))
                 .collect(Collectors.toList());
     }
 
-    public List<PlateField> removeFields(Container container, User user, Integer plateId, List<PlateField> fields)
+    public List<PlateCustomField> removeFields(Container container, User user, Integer plateId, List<PlateCustomField> fields)
     {
         Plate plate = getPlate(container, plateId);
         if (plate == null)
@@ -1429,7 +1444,7 @@ public class PlateManager implements PlateService
 
         List<DomainProperty> fieldsToRemove = new ArrayList<>();
         // validate fields
-        for (PlateField field : fields)
+        for (PlateCustomField field : fields)
         {
             DomainProperty dp = domain.getPropertyByURI(field.getPropertyURI());
             if (dp == null)
@@ -1449,6 +1464,45 @@ public class PlateManager implements PlateService
             new SqlExecutor(AssayDbSchema.getInstance().getSchema()).execute(sql);
         }
         return getFields(container, user, plateId);
+    }
+
+    public List<WellCustomField> setFields(Container container, User user, Integer plateId, Integer wellId, List<WellCustomField> fields) throws ValidationException
+    {
+        Plate plate = getPlate(container, plateId);
+        if (plate == null)
+            throw new IllegalArgumentException("Failed to set plate custom field values. Plate id \"" + plateId + "\" not found.");
+
+        WellImpl well = (WellImpl) plate.getWell(wellId);
+        if (well == null)
+            throw new IllegalArgumentException("Failed to set plate custom field values. Well id \"" + wellId + "\" not found.");
+
+        Domain domain = getPlateMetadataDomain(container, user);
+        if (domain == null)
+            throw new IllegalArgumentException("Failed to set plate custom field values. Custom fields domain does not exist. Try creating fields first.");
+
+        // verify the fields have been configured for the plate
+        Set<String> configuredProps = new HashSet<>();
+        SQLFragment sql = new SQLFragment("SELECT PropertyURI FROM ").append(AssayDbSchema.getInstance().getTableInfoPlateProperty(), "")
+                .append(" WHERE PlateId = ?").add(plateId);
+        new SqlSelector(AssayDbSchema.getInstance().getSchema(), sql).forEach(String.class, configuredProps::add);
+
+        try (DbScope.Transaction transaction = ExperimentService.get().ensureTransaction())
+        {
+            for (WellCustomField field : fields)
+            {
+                if (!configuredProps.contains(field.getPropertyURI()))
+                    throw new IllegalArgumentException("Failed to set plate custom field value. Custom field \"" + field.getPropertyURI() + "\" is not configured for this plate.");
+
+                DomainProperty dp = domain.getPropertyByURI(field.getPropertyURI());
+                if (dp == null)
+                    throw new IllegalArgumentException("Failed to set plate custom field values. Custom field \"" + field.getPropertyURI() + "\" not found.");
+
+                OntologyManager.updateObjectProperty(user, container, dp.getPropertyDescriptor(), well.getLsid(), field.getValue(), null, true);
+            }
+            transaction.commit();
+        }
+
+        return getWellCustomFields(container, user, plateId, wellId);
     }
 
     public static final class TestCase

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1483,14 +1483,14 @@ public class PlateManager implements PlateService
         if (domain == null)
             throw new IllegalArgumentException("Failed to set plate custom field values. Custom fields domain does not exist. Try creating fields first.");
 
-        // verify the fields have been configured for the plate
-        Set<String> configuredProps = new HashSet<>();
-        SQLFragment sql = new SQLFragment("SELECT PropertyURI FROM ").append(AssayDbSchema.getInstance().getTableInfoPlateProperty(), "")
-                .append(" WHERE PlateId = ?").add(plateId);
-        new SqlSelector(AssayDbSchema.getInstance().getSchema(), sql).forEach(String.class, configuredProps::add);
-
         try (DbScope.Transaction transaction = ExperimentService.get().ensureTransaction())
         {
+            // verify the fields have been configured for the plate
+            Set<String> configuredProps = new HashSet<>();
+            SQLFragment sql = new SQLFragment("SELECT PropertyURI FROM ").append(AssayDbSchema.getInstance().getTableInfoPlateProperty(), "")
+                    .append(" WHERE PlateId = ?").add(plateId);
+            new SqlSelector(AssayDbSchema.getInstance().getSchema(), sql).forEach(String.class, configuredProps::add);
+
             for (WellCustomField field : fields)
             {
                 if (!configuredProps.contains(field.getPropertyURI()))

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1427,6 +1427,9 @@ public class PlateManager implements PlateService
             throw new IllegalArgumentException("Failed to get well custom fields. Well id \"" + wellId   + "\" not found.");
 
         Map<String, Object> properties = OntologyManager.getProperties(container, well.getLsid());
+        for (WellCustomField field : fields)
+            field.setValue(properties.get(field.getPropertyURI()));
+
         return fields.stream()
                 .sorted(Comparator.comparing(PlateCustomField::getName))
                 .collect(Collectors.toList());

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -483,7 +483,6 @@ public class PlateManager implements PlateService
         SimpleFilter plateFilter = new SimpleFilter(FieldKey.fromParts("PlateId"), plate.getRowId());
         Sort sort = new Sort("Col,Row");
         return new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), plateFilter, sort).getArray(WellImpl.class);
-
     }
 
     private WellGroupImpl[] getWellGroups(Plate plate)
@@ -1417,7 +1416,7 @@ public class PlateManager implements PlateService
         return fields;
     }
 
-    private List<WellCustomField> getWellCustomFields(Container container, User user, Integer plateId, Integer wellId)
+    public List<WellCustomField> getWellCustomFields(Container container, User user, Integer plateId, Integer wellId)
     {
         List<WellCustomField> fields = _getFields(container, user, plateId).stream().map(WellCustomField::new).toList();
 

--- a/assay/src/org/labkey/assay/plate/model/PlateCustomField.java
+++ b/assay/src/org/labkey/assay/plate/model/PlateCustomField.java
@@ -3,8 +3,11 @@ package org.labkey.assay.plate.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.labkey.api.exp.property.DomainProperty;
 
+/**
+ * Represents a custom field that is configured for a specific plate
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class PlateField
+public class PlateCustomField
 {
     private String _label;
     private String _name;
@@ -12,11 +15,11 @@ public class PlateField
     private String _rangeURI;
     private String _container;
 
-    public PlateField()
+    public PlateCustomField()
     {
     }
 
-    public PlateField(DomainProperty prop)
+    public PlateCustomField(DomainProperty prop)
     {
         _name = prop.getName();
         _label = prop.getLabel();

--- a/assay/src/org/labkey/assay/plate/model/Well.java
+++ b/assay/src/org/labkey/assay/plate/model/Well.java
@@ -1,0 +1,77 @@
+package org.labkey.assay.plate.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Represents a row in the plate.well table
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Well
+{
+    private Integer _rowId;
+    private String _lsid;
+    private Integer _plateId;
+    private Integer _row;
+    private Integer _col;
+    private String _container;
+
+    public Integer getRowId()
+    {
+        return _rowId;
+    }
+
+    public void setRowId(Integer rowId)
+    {
+        _rowId = rowId;
+    }
+
+    public String getLsid()
+    {
+        return _lsid;
+    }
+
+    public void setLsid(String lsid)
+    {
+        _lsid = lsid;
+    }
+
+    public Integer getPlateId()
+    {
+        return _plateId;
+    }
+
+    public void setPlateId(Integer plateId)
+    {
+        _plateId = plateId;
+    }
+
+    public Integer getRow()
+    {
+        return _row;
+    }
+
+    public void setRow(Integer row)
+    {
+        _row = row;
+    }
+
+    public Integer getCol()
+    {
+        return _col;
+    }
+
+    public void setCol(Integer col)
+    {
+        _col = col;
+    }
+
+    public String getContainer()
+    {
+        return _container;
+    }
+
+    public void setContainer(String container)
+    {
+        _container = container;
+    }
+}

--- a/assay/src/org/labkey/assay/plate/model/WellCustomField.java
+++ b/assay/src/org/labkey/assay/plate/model/WellCustomField.java
@@ -1,0 +1,30 @@
+package org.labkey.assay.plate.model;
+
+import org.labkey.api.exp.property.DomainProperty;
+
+/**
+ * Represents a custom field, including value, that is assigned to a well location
+ */
+public class WellCustomField extends PlateCustomField
+{
+    private Object _value;
+
+    public WellCustomField()
+    {
+    }
+
+    public WellCustomField(DomainProperty dp)
+    {
+        super(dp);
+    }
+
+    public Object getValue()
+    {
+        return _value;
+    }
+
+    public void setValue(Object value)
+    {
+        _value = value;
+    }
+}

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -583,6 +583,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
                         assayMetrics.put(assayProvider.getName(), protocolMetrics);
                     }
                     assayMetrics.put("autoLinkedAssayCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.protocol EP JOIN exp.objectPropertiesView OP ON EP.lsid = OP.objecturi WHERE OP.propertyuri = 'terms.labkey.org#AutoCopyTargetContainer'").getObject(Long.class));
+                    assayMetrics.put("standardAssayWithPlateSupportCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.protocol EP JOIN exp.objectPropertiesView OP ON EP.lsid = OP.objecturi WHERE OP.name = 'PlateMetadata' AND floatValue = 1").getObject(Long.class));
 
                     Map<String, Object> sampleLookupCountMetrics = new HashMap<>();
                     SQLFragment baseAssaySampleLookupSQL = new SQLFragment("SELECT COUNT(*) FROM exp.propertydescriptor WHERE (lookupschema = 'samples' OR (lookupschema = 'exp' AND lookupquery =  'Materials')) AND propertyuri LIKE ?");


### PR DESCRIPTION
#### Rationale
This iteration of plate metadata support builds on prior work which added a vocabulary domain in order to support custom fields for wells on a plate. In this PR we now fully support the ability to add custom fields to a plate and add values to the custom fields on a per well basis. This plate can now be imported into an assay run and the custom well values are joined to the assay results. This is in contrast to the prior plate metadata support where JSON metadata was needed to at run import time in order to combine plate and assay results. For now both methods are supported but in the apps, the JSON file is no longer required if the `app plate` experimental flag is enabled.

Additionally transform script support is added for metadata introduced directly via a plate. Similar to the legacy JSON metadata transform script support, the plate metadata is combined with the assay results and made available to the transform script via the `runData.tsv` file. The plate metadata values cannot but updated by a transform script but those values can be used to help compute or validate assay result field values. While not a primary scenario, plate metadata furnished both by JSON or plate wells can be provided in the same run. 

A metric was added to determine how many protocols have plate support enabled which will help guide future support of the legacy JSON method.

#### Changes
- Add a new endpoint to set `WellCustomField` values for a specific well location on a plate. A `WellCustomField` is a field that has been configured for a plate and contains the value to set for the well.
- On assay import, if plate based metadata exists, the `lsid` for the `Well` row is injected into the assay result row. The vocab domain is already joined to the `Well` table in order to pull in vocab properties. This occurs via the `ImportHelper` class that is created by the `AssayPlateMetadataService`.
- Inject plate metadata values into the run data that is handed to transform scripts.
- Fixed a bug where JSON based plate metadata was not working for transform scripts for import via the apps. See line 187 of `AbstractAssayTsvDataHandler`.
