### PR TITLE
Reduce calls to OntologyManager.getPropertyObjects() by reusing defaults

### DIFF
--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -183,16 +183,9 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         setAlias(rsmd.getColumnName(col));
     }
 
-    @Deprecated
-    public BaseColumnInfo(String name, TableInfo parentTable)
-    {
-//        assert -1 == name.indexOf('/');
-        this(new FieldKey(null, name), parentTable);
-    }
-
     public BaseColumnInfo(String name, TableInfo parentTable, JdbcType type)
     {
-        this(new FieldKey(null, name), parentTable, type);
+        this(FieldKey.fromParts(name), parentTable, type);
     }
 
     public BaseColumnInfo(FieldKey key, TableInfo parentTable, JdbcType type)
@@ -209,7 +202,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
 
     public BaseColumnInfo(ColumnInfo from, TableInfo parent)
     {
-        this(from.getFieldKey(), parent);
+        this(from.getFieldKey(), parent, from.getJdbcType());
         copyAttributesFrom(from);
         copyURLFrom(from, null, null);
     }

--- a/api/src/org/labkey/api/data/NullColumnInfo.java
+++ b/api/src/org/labkey/api/data/NullColumnInfo.java
@@ -39,13 +39,6 @@ public class NullColumnInfo extends BaseColumnInfo
         setReadOnly(true);
     }
 
-    public NullColumnInfo(TableInfo parent, String name, String sqlType)
-    {
-        super(name, parent);
-        setSqlTypeName(sqlType);
-        setReadOnly(true);
-    }
-
     public NullColumnInfo(TableInfo parent, String name, JdbcType jdbcType)
     {
         super(name, parent, jdbcType);

--- a/api/src/org/labkey/api/data/SchemaColumnMetaData.java
+++ b/api/src/org/labkey/api/data/SchemaColumnMetaData.java
@@ -23,6 +23,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.dialect.JdbcMetaDataLocator;
 import org.labkey.api.data.dialect.PkMetaDataReader;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.DebugInfoDumper;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.Pair;
@@ -119,9 +120,9 @@ public class SchemaColumnMetaData
                 }
 
                 if (tinfo.getTableType() != DatabaseTableType.NOT_IN_DB)
-                    colInfo = new VirtualColumnInfo(xmlColumn.getColumnName(), tinfo);
+                    colInfo = new VirtualColumnInfo(FieldKey.fromParts(xmlColumn.getColumnName()), tinfo);
                 else
-                    colInfo = new BaseColumnInfo(xmlColumn.getColumnName(), tinfo);
+                    colInfo = new BaseColumnInfo(FieldKey.fromParts(xmlColumn.getColumnName()), tinfo);
                 colInfo.setNullable(true);
                 loadFromXml(xmlColumn, colInfo, false);
                 addColumn(colInfo);
@@ -538,11 +539,11 @@ public class SchemaColumnMetaData
 
 
     /** On upgrade there may be columns in .xml that are not in the database */
-    private class VirtualColumnInfo extends NullColumnInfo
+    private static class VirtualColumnInfo extends NullColumnInfo
     {
-        VirtualColumnInfo(String name, TableInfo tinfo)
+        VirtualColumnInfo(FieldKey fieldKey, TableInfo tinfo)
         {
-            super(tinfo, name, (String)null);
+            super(tinfo, fieldKey, (String)null);
             setIsUnselectable(true);    // minor hack, to indicate to other code that wants to detect this
         }
     }

--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -158,7 +158,7 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
                         col.setFieldKey(new FieldKey(null, domainProperty.getName()));
                         PropertyDescriptor pd = domainProperty.getPropertyDescriptor();
                         FieldKey pkFieldKey = new FieldKey(null, AbstractTsvAssayProvider.ROW_ID_COLUMN_NAME);
-                        PropertyColumn.copyAttributes(_userSchema.getUser(), col, pd, schema.getContainer(), _userSchema.getSchemaPath(), getPublicName(), pkFieldKey, cf);
+                        PropertyColumn.copyAttributes(_userSchema.getUser(), col, pd, schema.getContainer(), _userSchema.getSchemaPath(), getPublicName(), pkFieldKey, null, cf);
 
                         ExpSampleType st = DefaultAssayRunCreator.getLookupSampleType(domainProperty, getContainer(), getUserSchema().getUser());
                         if (st != null || DefaultAssayRunCreator.isLookupToMaterials(domainProperty))

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -230,7 +230,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     {
         switch (column)
         {
-            case RowId:
+            case RowId ->
             {
                 var c = wrapColumn(alias, getRealTable().getColumn("RowId"));
                 // When no sorts are added by views, QueryServiceImpl.createDefaultSort() adds the primary key's default sort direction
@@ -240,8 +240,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 c.setHidden(true);
                 return c;
             }
-
-            case LSID:
+            case LSID ->
             {
                 var c = wrapColumn(alias, getRealTable().getColumn("LSID"));
                 c.setHidden(true);
@@ -251,8 +250,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 c.setCalculated(true); // So DataIterator won't consider the column as required. See c.isRequiredForInsert()
                 return c;
             }
-
-            case Name:
+            case Name ->
             {
                 var c = wrapColumn(alias, getRealTable().getColumn(column.name()));
                 String nameExpression = _dataClass.getNameExpression();
@@ -267,14 +265,11 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 }
                 return c;
             }
-
-            case Created:
-            case Modified:
-            case Description:
+            case Created, Modified, Description ->
+            {
                 return wrapColumn(alias, getRealTable().getColumn(column.name()));
-
-            case CreatedBy:
-            case ModifiedBy:
+            }
+            case CreatedBy, ModifiedBy ->
             {
                 var c = wrapColumn(alias, getRealTable().getColumn(column.name()));
                 c.setFk(new UserIdForeignKey(getUserSchema()));
@@ -283,8 +278,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 c.setUserEditable(false);
                 return c;
             }
-            case ClassId:
-            case DataClass:
+            case ClassId, DataClass ->
             {
                 var c = wrapColumn(alias, getRealTable().getColumn("classId"));
                 c.setFk(new QueryForeignKey(QueryForeignKey.from(getUserSchema(), getContainerFilter()).schema(ExpSchema.SCHEMA_NAME).to(ExpSchema.TableType.DataClasses.name(), "RowId", "Name"))
@@ -312,43 +306,47 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 c.setUserEditable(false);
                 return c;
             }
-
-            case Flag:
+            case Flag ->
+            {
                 return createFlagColumn(Column.Flag.toString());
-
-            case Folder:
+            }
+            case Folder ->
             {
                 var c = wrapColumn(alias, getRealTable().getColumn("Container"));
                 c.setLabel("Folder");
                 c.setShownInDetailsView(false);
                 return c;
             }
-            case Alias:
+            case Alias ->
+            {
                 return createAliasColumn(alias, ExperimentService.get()::getTinfoDataAliasMap);
-
-            case Inputs:
+            }
+            case Inputs ->
+            {
                 return createLineageColumn(this, alias, true, false);
-
-            case QueryableInputs:
+            }
+            case QueryableInputs ->
+            {
                 return createLineageColumn(this, alias, true, true);
-
-            case Outputs:
+            }
+            case Outputs ->
+            {
                 return createLineageColumn(this, alias, false, false);
-
-            case DataFileUrl:
+            }
+            case DataFileUrl ->
+            {
                 var dataFileUrl = wrapColumn(alias, getRealTable().getColumn("DataFileUrl"));
                 dataFileUrl.setUserEditable(false);
                 dataFileUrl.setHidden(true);
                 DetailsURL url = new DetailsURL(new ActionURL(ExperimentController.ShowFileAction.class, getContainer()), Collections.singletonMap("rowId", "rowId"));
                 dataFileUrl.setDisplayColumnFactory(new FileLinkDisplayColumn.Factory(url, getContainer(), FieldKey.fromParts("RowId")));
-
                 return dataFileUrl;
-
-            case Properties:
-                return (BaseColumnInfo) createPropertiesColumn(alias);
-
-            default:
-                throw new IllegalArgumentException("Unknown column " + column);
+            }
+            case Properties ->
+            {
+                return createPropertiesColumn(alias);
+            }
+            default -> throw new IllegalArgumentException("Unknown column " + column);
         }
     }
 
@@ -402,8 +400,9 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
         FieldKey lsidFieldKey = FieldKey.fromParts(Column.LSID.name());
 
+        Supplier<Map<DomainProperty, Object>> defaultsSupplier = null;
+
         // Add the domain columns
-        Collection<MutableColumnInfo> cols = new ArrayList<>(20);
         Set<String> skipCols = CaseInsensitiveHashSet.of("lsid", "rowid", "name", "classid");
         for (ColumnInfo col : extTable.getColumns())
         {
@@ -444,7 +443,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             PropertyDescriptor pd = (null==dp) ? null : dp.getPropertyDescriptor();
             if (dp != null && pd != null)
             {
-                PropertyColumn.copyAttributes(_userSchema.getUser(), wrapped, dp, getContainer(), lsidFieldKey, getContainerFilter());
+                defaultsSupplier = PropertyColumn.copyAttributes(_userSchema.getUser(), wrapped, dp, getContainer(), lsidFieldKey, getContainerFilter(), defaultsSupplier);
                 wrapped.setFieldKey(FieldKey.fromParts(dp.getName()));
 
                 if (pd.getPropertyType() == PropertyType.ATTACHMENT)
@@ -468,7 +467,6 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             }
 
             addColumn(wrapped);
-            cols.add(wrapped);
 
             if (isVisibleByDefault(col))
                 defaultVisible.add(FieldKey.fromParts(col.getName()));
@@ -594,6 +592,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         return ret;
     }
 
+    @Override
     protected PropertyForeignKey getDomainColumnForeignKey(Domain domain)
     {
         return new PropertyForeignKey(_userSchema, getContainerFilter(), domain)
@@ -743,7 +742,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             }
         }
 
-        if (excludeColumns.size() > 0)
+        if (!excludeColumns.isEmpty())
         {
             List<Pair<String, String>> templates = new ArrayList<>();
             ActionURL url = PageFlowUtil.urlProvider(QueryUrls.class).urlCreateExcelTemplate(ctx.getContainer(), getPublicSchemaName(), getName());
@@ -869,15 +868,13 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             if (null != searchService)
             {
                 // Queue indexing after committing
-                step0.setIndexFunction(lsids ->  propertiesTable.getSchema().getScope().addCommitTask(() -> {
-                        ListUtils.partition(lsids, 100).forEach(sublist ->
-                                searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
-                                {
-                                    for (ExpDataImpl expData : ExperimentServiceImpl.get().getExpDatasByLSID(sublist))
-                                        expData.index(searchService.defaultTask(), this);
-                                })
-                        );
-                    }, DbScope.CommitTaskOption.POSTCOMMIT)
+                step0.setIndexFunction(lsids ->  propertiesTable.getSchema().getScope().addCommitTask(() -> ListUtils.partition(lsids, 100).forEach(sublist ->
+                        searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
+                        {
+                            for (ExpDataImpl expData : ExperimentServiceImpl.get().getExpDatasByLSID(sublist))
+                                expData.index(searchService.defaultTask(), this);
+                        })
+                ), DbScope.CommitTaskOption.POSTCOMMIT)
                 );
             }
             DataIteratorBuilder builder = LoggingDataIterator.wrap(step0);
@@ -1111,8 +1108,8 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             //primary key, it will always be 1, which is not only unnecessary, but confusing, so strip it
             if (null != row)
             {
-                if (row instanceof ArrayListMap)
-                    ((ArrayListMap)row).getFindMap().remove("_row");
+                if (row instanceof ArrayListMap arrayListMap)
+                    arrayListMap.getFindMap().remove("_row");
                 else
                     row.remove("_row");
             }
@@ -1169,9 +1166,8 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             Map<String, Object> rowStripped = new CaseInsensitiveHashMap<>();
             Map<String, Object> attachments = new CaseInsensitiveHashMap<>();
             row.forEach((name, value) -> {
-                if (isAttachmentProperty(name) && value instanceof AttachmentFile)
+                if (isAttachmentProperty(name) && value instanceof AttachmentFile file)
                 {
-                    AttachmentFile file = (AttachmentFile) value;
                     if (null != file.getFilename())
                     {
                         rowStripped.put(name, file.getFilename());
@@ -1403,7 +1399,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 {
                     Object oClassId = keyMap.getValue().get("ClassId");
                     if (oClassId != null)
-                        dataClassId = (Integer) (_converter.convert(Integer.class, oClassId));
+                        dataClassId = _converter.convert(Integer.class, oClassId);
                 }
 
             }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -965,7 +965,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             if (null != dp)
             {
                 PropertyColumn.copyAttributes(schema.getUser(), propColumn, dp.getPropertyDescriptor(), schema.getContainer(),
-                    SchemaKey.fromParts("samples"), st.getName(), FieldKey.fromParts("RowId"), getLookupContainerFilter());
+                    SchemaKey.fromParts("samples"), st.getName(), FieldKey.fromParts("RowId"), null, getLookupContainerFilter());
 
                 if (idCols.contains(dp))
                 {

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -87,6 +87,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * Creates and maintains "hard" tables in the underlying database based on dynamically configured data types.
@@ -1160,7 +1161,8 @@ public class StorageProvisionerImpl implements StorageProvisioner
             c.setName(s.getName());
         }
 
-        HashSet<String> seenProperties = new HashSet<>();
+        Supplier<Map<DomainProperty, Object>> defaultsSupplier = null;
+        Set<String> seenProperties = new HashSet<>();
         for (DomainProperty p : domain.getProperties())
         {
             if (kind.hasPropertiesIncludeBaseProperties() && basePropertyNames.contains(p.getName().toLowerCase()))
@@ -1193,7 +1195,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
             // The columns coming back from JDBC metadata aren't necessarily in the same order that the domain
             // wants them based on its current property order
             ti.setColumnIndex(c, index++);
-            PropertyColumn.copyAttributes(null, c, p, p.getContainer(), null);
+            defaultsSupplier = PropertyColumn.copyAttributes(null, c, p, p.getContainer(), null, defaultsSupplier);
 
             if (p.isMvEnabled())
             {

--- a/study/src/org/labkey/study/StudyUnionTableInfo.java
+++ b/study/src/org/labkey/study/StudyUnionTableInfo.java
@@ -32,6 +32,7 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.study.model.DatasetDefinition;
@@ -326,7 +327,7 @@ public class StudyUnionTableInfo extends VirtualTable<StudyQuerySchema>
 
         for (String name : COLUMN_NAMES)
         {
-            var ci = new BaseColumnInfo(name, this);
+            var ci = new BaseColumnInfo(FieldKey.fromParts(name), this);
             ColumnInfo t = template.getColumn(name);
             if (null != t)
             {
@@ -338,7 +339,7 @@ public class StudyUnionTableInfo extends VirtualTable<StudyQuerySchema>
 
         for (PropertyDescriptor pd : sharedProperties)
         {
-            var ci = new BaseColumnInfo(pd.getName(), this);
+            var ci = new BaseColumnInfo(FieldKey.fromParts(pd.getName()), this, pd.getJdbcType());
             PropertyColumn.copyAttributes(_user, ci, pd, _study.getContainer(), null);
             ci.setSqlTypeName(StudySchema.getInstance().getSqlDialect().getSqlTypeName(pd.getJdbcType()));
             safeAddColumn(ci);
@@ -371,7 +372,7 @@ public class StudyUnionTableInfo extends VirtualTable<StudyQuerySchema>
     }
 
     @Override
-    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class perm)
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         return super.hasPermission(user, perm);
     }

--- a/study/src/org/labkey/study/query/BaseStudyTable.java
+++ b/study/src/org/labkey/study/query/BaseStudyTable.java
@@ -75,6 +75,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
 {
@@ -841,6 +842,7 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
     protected void addOptionalColumns(List<DomainProperty> optionalProperties, boolean editable, @Nullable List<String> readOnlyColumnNames)
     {
         SqlDialect dialect = getSqlDialect();
+        Supplier<Map<DomainProperty, Object>> defaultsSupplier = null;
         for (DomainProperty domainProperty : optionalProperties)
         {
             PropertyDescriptor property = domainProperty.getPropertyDescriptor();
@@ -848,7 +850,7 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
             String legalName = property.getLegalSelectName(dialect);
             sql.append(".").append(legalName);
             var column = new ExprColumn(this, legalName, sql, property.getJdbcType());
-            PropertyColumn.copyAttributes(getUserSchema().getUser(), column, domainProperty, getContainer(), null);
+            defaultsSupplier = PropertyColumn.copyAttributes(getUserSchema().getUser(), column, domainProperty, getContainer(), null, defaultsSupplier);
             if (editable)
             {
                 // Make editable, but some should be read only


### PR DESCRIPTION
#### Rationale
We call `OntologyManager.getPropertyObjects()` a lot. It's usually fast, but not always. One big source is from calling it once per property instead of a single time for the whole domain.

#### Changes
* Use a `CachingSupplier` to make it easy to fetch defaults once per domain instead of once per property
* Adjust callers to reuse the defaults
* Eliminate some deprecated methods and collapse some confusing overloaded methods
* Minor cleanup