### PR TITLE
Update other references use ObjectToXml custom subclass

### DIFF
--- a/pipeline/src/org/labkey/pipeline/mule/config/clusterRemoteMuleConfig.xml
+++ b/pipeline/src/org/labkey/pipeline/mule/config/clusterRemoteMuleConfig.xml
@@ -35,8 +35,8 @@
     </endpoint-identifiers>
 
     <transformers>
-        <transformer name="StatusToXML" className="org.mule.transformers.xml.ObjectToXml"
-            returnClass="java.lang.String"/>
+        <transformer name="StatusToXML" className="org.labkey.pipeline.mule.transformers.ObjectToXml"
+                     returnClass="java.lang.String"/>
         <transformer name="XMLToJMSMessage" className="org.mule.providers.jms.transformers.ObjectToJMSMessage"
             returnClass="javax.jms.TextMessage" />
     </transformers>

--- a/pipeline/src/org/labkey/pipeline/mule/config/remoteMuleConfig.xml
+++ b/pipeline/src/org/labkey/pipeline/mule/config/remoteMuleConfig.xml
@@ -53,8 +53,8 @@
             returnClass="javax.jms.TextMessage"/>
         <transformer name="JMSMessageToJob" className="org.labkey.pipeline.mule.transformers.JMSMessageToPipelineJob"
             returnClass="org.labkey.api.pipeline.PipelineJob"/>
-        <transformer name="StatusToXML" className="org.mule.transformers.xml.ObjectToXml"
-            returnClass="java.lang.String"/>
+        <transformer name="StatusToXML" className="org.labkey.pipeline.mule.transformers.ObjectToXml"
+                     returnClass="java.lang.String"/>
         <transformer name="XMLToJMSMessage" className="org.mule.providers.jms.transformers.ObjectToJMSMessage"
             returnClass="javax.jms.TextMessage" />
         <transformer name="NoOpTransformer" className="org.labkey.pipeline.mule.transformers.NoOpTransformer"


### PR DESCRIPTION
#### Rationale
With the XStream update in 23.7, we need to consistently use a custom serializer subclass

#### Changes
* Apply edit already made earlier to `webserverMuleConfig.xml`