### PR TITLE
Fix SMProSamplesCreateAndUpdateTest.testUpdateErrorImport

### DIFF
--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -168,7 +168,11 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
             _unwrapped.mark();  // unwrapped _delegate
         boolean ret = super.next();
         if (!_context.getErrors().hasErrors() && ret && !pkColumns.isEmpty())
+        {
             prefetchExisting();
+            if (_context.getErrors().hasErrors())
+                return false;
+        }
         return ret;
     }
 


### PR DESCRIPTION
#### Rationale
A change was made in https://github.com/LabKey/platform/pull/4627 to no longer throw unexpected server exception when a sample that doesn't belong to the current container is found during ExistingRecordData check. ExistingRecordData.next() should return false when such error happens. 

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4627

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
