### PR TITLE
Create XmlToObject subclass

### DIFF
--- a/pipeline/src/org/labkey/pipeline/mule/config/webserverMuleConfig.xml
+++ b/pipeline/src/org/labkey/pipeline/mule/config/webserverMuleConfig.xml
@@ -137,7 +137,7 @@
             returnClass="org.labkey.api.pipeline.PipelineJob"/>
         <transformer name="JMSMessageToXML" className="org.mule.providers.jms.transformers.JMSMessageToObject"
             returnClass="java.lang.String"/>
-        <transformer name="XMLToStatus" className="org.mule.transformers.xml.XmlToObject"
+        <transformer name="XMLToStatus" className="org.labkey.pipeline.mule.transformers.XmlToObject"
             returnClass="org.labkey.pipeline.mule.StatusRequest"/>
 
         <transformer name="StatusToXML" className="org.labkey.pipeline.mule.transformers.ObjectToXml"

--- a/pipeline/src/org/labkey/pipeline/mule/transformers/XmlToObject.java
+++ b/pipeline/src/org/labkey/pipeline/mule/transformers/XmlToObject.java
@@ -1,0 +1,26 @@
+package org.labkey.pipeline.mule.transformers;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.AnyTypePermission;
+import org.mule.umo.UMOEventContext;
+import org.mule.umo.transformer.TransformerException;
+
+public class XmlToObject extends org.mule.transformers.xml.XmlToObject
+{
+    private boolean _securityInitialized = false;
+
+    @Override
+    public Object transform(Object src, String encoding, UMOEventContext context) throws TransformerException
+    {
+        // Allow XStream to deserialize into any class. We are using this internally and trust the content of
+        // the messages since the JMS endpoint is considered secure.
+        // https://x-stream.github.io/security.html#framework
+        if (!_securityInitialized)
+        {
+            XStream x = getXStream();
+            x.addPermission(AnyTypePermission.ANY);
+            _securityInitialized = true;
+        }
+        return super.transform(src, encoding, context);
+    }
+}


### PR DESCRIPTION
Rationale
With the XStream update in 23.7, we need to consistently use a custom deserializer subclass, analogous to the subclass for ObjectToXml

Changes
Add XmlToObject subclass