### PR TITLE
Avoid conflicting eigenbase dependencies from different groups

### DIFF
--- a/query/build.gradle
+++ b/query/build.gradle
@@ -1,5 +1,4 @@
 import org.labkey.gradle.util.BuildUtils
-import org.labkey.gradle.util.ExternalDependency
 
 plugins {
     id 'org.labkey.build.module'
@@ -85,6 +84,11 @@ dependencies {
                 exclude group: "log4j", module:"log4j"
                 // Avoid classloader conflicts with Tomcat's copy
                 exclude group: 'javax.activation', module: 'javax.activation-api'
+
+                // Avoid conflicts with declared dependencies on the newer versions from 'net.hydromatic'
+                exclude group: 'eigenbase', module: 'eigenbase-properties'
+                exclude group: 'eigenbase', module: 'eigenbase-resgen'
+                exclude group: 'eigenbase', module: 'eigenbase-xom'
             }
     )
 

--- a/query/build.gradle
+++ b/query/build.gradle
@@ -1,4 +1,5 @@
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.ExternalDependency
 
 plugins {
     id 'org.labkey.build.module'


### PR DESCRIPTION
#### Rationale
Changing the maven group for our declared `eigenbase` dependencies is causing a conflict with the transitive dependencies pulled in with mondrian which use the old group.
```
Execution failed for task ':server:modules:platform:query:checkModuleJarVersions'. org.gradle.api.GradleException: Artifact versioning problem(s) in directory /mnt/teamcity/work/d4c14c1d04e8fe58/build/modules/query/explodedModule/lib:
  Multiple existing eigenbase-xom jar files.
  Multiple existing eigenbase-resgen jar files.
  Multiple existing eigenbase-properties jar files.
  Conflicting version of eigenbase-xom jar file (1.3.5 in directory vs. 1.3.6 from build).
  Conflicting version of eigenbase-resgen jar file (1.3.7 in directory vs. 1.3.1 from build).
  Conflicting version of eigenbase-properties jar file (1.1.6 in directory vs. 1.1.2 from build).
```

#### Related Pull Requests
* #4675 

#### Changes
* Exclude transitive `eigenbase` dependencies
