### PR TITLE
Issue 48498: Container-based LKSM deployments are not pinging mothership

### DIFF
--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -334,7 +334,7 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
         if (context != null)
         {
             String serverGUID = context.getInitParameter(SERVER_GUID_XML_PARAMETER_NAME);
-            if (serverGUID != null)
+            if (StringUtils.isNotBlank(serverGUID))
             {
                 return serverGUID;
             }


### PR DESCRIPTION
#### Rationale
We're getting a blank (empty string) value for the server GUID property, which isn't intentional. We want to fall through to what's stored in the DB

#### Changes
* Treat empty strings the same way we've been treating nulls