### PR TITLE
Use library substitution to prevent Eigenbase conflicts

### DIFF
--- a/query/build.gradle
+++ b/query/build.gradle
@@ -86,10 +86,6 @@ dependencies {
                 // Avoid classloader conflicts with Tomcat's copy
                 exclude group: 'javax.activation', module: 'javax.activation-api'
 
-                // Avoid conflicts with declared dependencies on the newer versions from 'net.hydromatic'
-                exclude group: 'eigenbase', module: 'eigenbase-properties'
-                exclude group: 'eigenbase', module: 'eigenbase-resgen'
-                exclude group: 'eigenbase', module: 'eigenbase-xom'
             }
     )
 

--- a/query/gradle.properties
+++ b/query/gradle.properties
@@ -1,5 +1,3 @@
 antlrVersion=3.5.2
-eigenbasePropertiesVersion=1.1.6
-eigenbaseResgenVersion=1.3.7
 mondrianVersion=9.4.0.1-465
 olap4jVersion=1.2.0


### PR DESCRIPTION
#### Rationale
Use substitution option to prevent library conflicts

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4681
* https://github.com/LabKey/server/pull/551

#### Changes
* change from conflict exclusion to substitution 
