### PR TITLE
Update JSONDataLoader to use jdbcType

### DIFF
--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -101,6 +101,7 @@ public class JsonWriter
         props.put("jsonType", dc.getJsonTypeName());
         props.put("sqlType", cinfo == null ? null : cinfo.getSqlTypeName());
         props.put("defaultValue", cinfo == null ? null : cinfo.getDefaultValue());
+        props.put("jdbcType", cinfo == null ? null : cinfo.getJdbcType().name());
 
         if (includeDomainFormat)
         {

--- a/api/src/org/labkey/api/reader/JSONDataLoader.java
+++ b/api/src/org/labkey/api/reader/JSONDataLoader.java
@@ -36,6 +36,7 @@ import org.labkey.api.action.ExtendedApiQueryResponse;
 import org.labkey.api.action.ExtendedApiQueryResponse.ColMapEntry;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.JdbcType;
 import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.iterator.CloseableIterator;
@@ -412,11 +413,31 @@ public class JSONDataLoader extends DataLoader
 
                 parser.nextToken();
             }
-            else if (fieldName.equals("type"))
+//            else if (fieldName.equals("type"))
+//            {
+//                type = parser.getValueAsString();
+////                if (type.equals("float"))
+////                {
+////                    type = "double";
+////                }
+//                if (type == null)
+//                    throw new JsonParseException("Failed to parse type property", loc);
+//
+//                parser.nextToken();
+//            }
+            else if (fieldName.equals("jdbcType"))
             {
-                type = parser.getValueAsString();
-                if (type == null)
-                    throw new JsonParseException("Failed to parse type property", loc);
+                String value = parser.getValueAsString();
+
+                if (value == null)
+                    throw new JsonParseException("Failed to parse jdbc type property", loc);
+
+                JdbcType jdbcType = JdbcType.valueOf(type);
+
+                if (jdbcType == null)
+                    throw new JsonParseException("Failed to parse jdbc type property", loc);
+
+                type = jdbcType.getJavaClass().getName();
 
                 parser.nextToken();
             }

--- a/api/src/org/labkey/api/reader/JSONDataLoader.java
+++ b/api/src/org/labkey/api/reader/JSONDataLoader.java
@@ -399,7 +399,7 @@ public class JSONDataLoader extends DataLoader
 
         FieldKey fieldKey = null;
         String type = null;
-        Class jdbcType = null;
+        Class jdbcTypeClass = null;
         Boolean mvEnabled = Boolean.FALSE;
 
         while (parser.getCurrentToken() == JsonToken.FIELD_NAME)
@@ -431,11 +431,11 @@ public class JSONDataLoader extends DataLoader
                 if (value == null)
                     throw new JsonParseException("Failed to find jdbc type property", loc);
 
-                JdbcType jdbc = JdbcType.valueOf(value);
+                JdbcType jdbcType = JdbcType.valueOf(value);
 
-                if (jdbc != null)
+                if (jdbcType != null)
                 {
-                    jdbcType = jdbc.getJavaClass();
+                    jdbcTypeClass = jdbcType.getJavaClass();
                 }
                 else
                 {
@@ -461,9 +461,9 @@ public class JSONDataLoader extends DataLoader
         {
             col = new ColumnDescriptor(fieldKey.toString());
 
-            if (jdbcType != null)
+            if (jdbcTypeClass != null)
             {
-                col.clazz = jdbcType;
+                col.clazz = jdbcTypeClass;
             }
             else
             {


### PR DESCRIPTION
#### Rationale
When loading JSON data via remote api some types are being coerced into types that lose precision or in some cases change values. Using "type" in column metadata is very general and does not specify the Java type to use to prevent precision issues. The metadata value "jdbcType" was added in the related PR. This more accurately identifies the correct type. This PR backports that additional metadata field and uses that to identify the correct Java class to use when converting JSON.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4305

#### Changes
* Backport jdbcType metadata addition
* JSONDataLoader checks for "jdbcType" first, if that doesn't exist then fallback to "type"
* Update some unit tests
