### PR TITLE
Issue 48508: Check for invalid elements in query XML metadata

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.xmlbeans.XmlError;
 import org.apache.xmlbeans.XmlException;
+import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlOptions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -194,6 +195,9 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -202,6 +206,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.io.StringReader;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -1339,17 +1344,47 @@ public class QueryController extends SpringActionController
                 }
 
                 String metadataText = StringUtils.trimToNull(form.ff_metadataText);
-                if (queryDef.isMetadataEditable())
+                if (!Objects.equals(metadataText, queryDef.getMetadataXml()))
                 {
-                    if (!Objects.equals(metadataText, queryDef.getMetadataXml()) && !queryDef.canEditMetadata(getUser()))
-                        throw new UnauthorizedException("Edit metadata permissions are required.");
+                    if (queryDef.isMetadataEditable())
+                    {
+                        if (!queryDef.canEditMetadata(getUser()))
+                            throw new UnauthorizedException("Edit metadata permissions are required.");
 
-                    queryDef.setMetadataXml(metadataText);
-                }
-                else
-                {
-                    if (metadataText != null)
-                        throw new UnsupportedOperationException("Query metadata is not editable.");
+                        if (!getUser().isTrustedBrowserDev())
+                        {
+                            try
+                            {
+                                XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+                                XMLStreamReader reader = inputFactory.createXMLStreamReader(new StringReader(metadataText));
+                                while (reader.hasNext())
+                                {
+                                    reader.next();
+                                    if (reader.isStartElement())
+                                    {
+                                        String localPath = reader.getName().getLocalPart();
+                                        // These three elements directly include JavaScript or pointers to script files
+                                        if ("onClick".equalsIgnoreCase(localPath) ||
+                                                "onRender".equalsIgnoreCase(localPath) ||
+                                                "includeScript".equalsIgnoreCase(localPath))
+                                        {
+                                            throw new UnauthorizedException("Illegal element <" + localPath + ">. For permissions to use this element, contact your system administrator");
+                                        }
+                                    }
+                                }
+                            }
+                            catch (XMLStreamException ignored)
+                            {
+                            }
+                        }
+
+                        queryDef.setMetadataXml(metadataText);
+                    }
+                    else
+                    {
+                        if (metadataText != null)
+                            throw new UnsupportedOperationException("Query metadata is not editable.");
+                    }
                 }
 
                 queryDef.save(getUser(), getContainer());

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1375,6 +1375,7 @@ public class QueryController extends SpringActionController
                             }
                             catch (XMLStreamException ignored)
                             {
+                                // Let other XML validation and error feedback handle malformed XML
                             }
                         }
 

--- a/query/src/org/labkey/query/view/sourceQuery.jsp
+++ b/query/src/org/labkey/query/view/sourceQuery.jsp
@@ -129,14 +129,14 @@
 
         var setError = function(msg) {
             var elem = Ext4.get('status');
-            elem.update(msg);
+            elem.update(LABKEY.Utils.encodeHtml(msg));
             elem.dom.className = 'labkey-status-error';
             elem.setVisible(true);
         };
 
         var setStatus = function(msg, autoClear) {
             var elem = Ext4.get('status');
-            elem.update(msg);
+            elem.update(LABKEY.Utils.encodeHtml(msg));
             elem.dom.className = 'labkey-status-info';
             elem.setDisplayed(true);
             elem.setVisible(true);


### PR DESCRIPTION
#### Rationale
There are a handful of XML metadata snippets that not all users with permission to save queries and metadata more generally should be able to save

#### Changes
* Check and reject invalid elements
* Improve error formatting