### PR TITLE
Make sure that our first and second pings are at least one second apart

### DIFF
--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
@@ -131,6 +131,11 @@ public class MothershipReportTest extends BaseWebDriverTest implements PostgresO
         );
 
         Date lastPing = _mothershipHelper.getLastPing("localhost");
+
+        // These values only have second-level granularity, so wait 1.5 seconds to make sure that the old and
+        // new timestamps are different enough for us to notice
+        Thread.sleep(1500);
+
         // Self-report so that we have some metrics to verify
         beginAt(WebTestHelper.buildRelativeUrl("mothership", "selfReportMetrics"));
         assertTextPresent("success");


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/LabKey_237Release_Community_DailySuites_DailyDPostgres/2597298?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true

The test sometimes fails because everything happens within the same second, and that's the granularity at which we're comparing the old and new timestamps

#### Changes
* Wait long enough to make sure the events won't happen in the same second