### PR TITLE
Issue 48437: Error rendering NAb results grid with PercentNeutralizationInitialDilution when well group doesn't have a single min dilution row

### DIFF
--- a/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
+++ b/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
@@ -120,7 +120,8 @@ public class NAbSpecimenTable extends FilteredTable<AssayProtocolSchema>
 
     private SQLFragment getPercentNeutralizationInitialDilution()
     {
-        return new SQLFragment("(SELECT PercentNeutralization FROM ")
+        // Issue 48437: Use AVG() since we can't guarantee that there will be just a single DilutionData row for the min dilution
+        return new SQLFragment("(SELECT AVG(PercentNeutralization) FROM ")
             .append(DilutionManager.getTableInfoDilutionData(), "dd")
             .append(" WHERE dd.RunDataId = ").append(ExprColumn.STR_TABLE_ALIAS + ".RowId")
             .append(" AND dd.Dilution = dd.MinDilution)");


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48437
backport from develop

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4666

#### Changes
- use AVG() since we can't guarantee that there will be just a single DilutionData row for the min dilution
