### PR TITLE
ExcelLoader option to skip using column formats when reading cell con…

### DIFF
--- a/api/src/org/labkey/api/reader/ExcelLoader.java
+++ b/api/src/org/labkey/api/reader/ExcelLoader.java
@@ -124,6 +124,10 @@ public class ExcelLoader extends DataLoader
     private String sheetName;
     private Integer sheetIndex;
 
+    // For Excel sheets that don't have column headers as the first line, the column types can all be seen as Strings.
+    // In that case, the cell contents in readFields() might not get the expected values for numeric columns.
+    private boolean useColumnFormats = true;
+
     // keep track if we created a temp file
     private boolean shouldDeleteFile = false;
 
@@ -290,6 +294,11 @@ public class ExcelLoader extends DataLoader
     {
         this.sheetName = null;
         this.sheetIndex = index;
+    }
+
+    public void setUseColumnFormats(boolean useColumnFormats)
+    {
+        this.useColumnFormats = useColumnFormats;
     }
 
 
@@ -613,7 +622,7 @@ public class ExcelLoader extends DataLoader
                             {
                                 contents = "";
                             }
-                            else if (column.clazz.equals(String.class))
+                            else if (useColumnFormats && column.clazz.equals(String.class))
                             {
                                 contents = ExcelFactory.getCellStringValue(cell);
                             }


### PR DESCRIPTION
#### Rationale
We are creating a filewatcher pipeline job task for processing a specific ELISA file format and importing data into a LabKey standard assay design. Because of the shape of the Excel file contents, using the ExcelLoader for this file results in columns that all "infer" their types as String. This results in a problem within the readFields() code when it gets the cell contents because it then uses the display string for the cell and loses the numeric decimal precision. This PR adds a param to the ExcelLoader that tells the readFields() to skip the columns inferred type and fall back to using the `contents = PropertyType.getFromExcelCell(cell);` else block.

#### Related Pull Requests
- https://github.com/LabKey/niaidElisa/pull/29
- https://github.com/LabKey/platform/pull/4702

#### Changes
- ExcelLoader option to skip using column formats when reading cell contents if all columns "infer" their types as String
