### PR TITLE
Use correct event name and add assertion to catch similar errors

### DIFF
--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -102,8 +102,9 @@ public class PageConfig
     private record EventHandler(String id, String selector, @NotNull String event, @NotNull String handler) {
         public EventHandler {
             assert (null==id) != (null==selector) : "exactly one of id or selector must be non-null";
-            assert id == null || !id.contains(" ") : "id cannot contain any spaces";
-            assert !event.startsWith("on") : "event shouldn't include the 'on' prefix";
+            assert !StringUtils.containsWhitespace(id) : "id should not contain any whitespace";
+            assert !StringUtils.containsWhitespace(event) : "event name should not contain any whitespace";
+            assert !event.startsWith("on") : "event name should not include the 'on' prefix";
         }
 
         public String getKey()

--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -103,11 +103,13 @@ public class PageConfig
         public EventHandler {
             // exactly one of id or selector must be non-null
             assert (null==id) != (null==selector);
+            // event shouldn't include the "on" prefix
+            assert !event.startsWith("on");
         }
 
         public String getKey()
         {
-            return null!=id ? ("id:" + id + "." + event) : ("selector:" + selector + "." + event);
+            return null!=id ? ("#" + id + "." + event) : (selector + "." + event);
         }
     }
 

--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -103,6 +103,8 @@ public class PageConfig
         public EventHandler {
             // exactly one of id or selector must be non-null
             assert (null==id) != (null==selector);
+            // id cannot contain any spaces
+            assert id == null || !id.contains(" ");
             // event shouldn't include the "on" prefix
             assert !event.startsWith("on");
         }

--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -101,12 +101,9 @@ public class PageConfig
 
     private record EventHandler(String id, String selector, @NotNull String event, @NotNull String handler) {
         public EventHandler {
-            // exactly one of id or selector must be non-null
-            assert (null==id) != (null==selector);
-            // id cannot contain any spaces
-            assert id == null || !id.contains(" ");
-            // event shouldn't include the "on" prefix
-            assert !event.startsWith("on");
+            assert (null==id) != (null==selector) : "exactly one of id or selector must be non-null";
+            assert id == null || !id.contains(" ") : "id cannot contain any spaces";
+            assert !event.startsWith("on") : "event shouldn't include the 'on' prefix";
         }
 
         public String getKey()

--- a/core/src/org/labkey/core/admin/view/filesProjectSettings.jsp
+++ b/core/src/org/labkey/core/admin/view/filesProjectSettings.jsp
@@ -146,7 +146,7 @@
                                 <%  } %>
                             </select>
                         </td>
-                        <% addHandler("optionCloudRoot", "onclick", "return updateSelection(" + !FileRootProp.cloudRoot.name().equals(bean.getFileRootOption()) + ");"); %>
+                        <% addHandler("optionCloudRoot", "click", "return updateSelection(" + !FileRootProp.cloudRoot.name().equals(bean.getFileRootOption()) + ");"); %>
                     </tr>
                     <% } %>
                     <tr style="height: 1.75em" id="migrateFilesRow">


### PR DESCRIPTION
#### Rationale
There was a recent change to remove many inline javascript event handlers. The replacement method for attaching these event handlers takes the event name. If you do include "on" in the event name (e.g. "`onclick`" vs "`click`"), the event handler won't work.
`PageConfig.addHandler` takes an event name but doesn't check whether its a valid event. This change also adds an assertion that specified events don't start with "on".

#### Related Pull Requests
* #4683 

#### Changes
* Use correct event name in `filesProjectSettings`
* Add assertion for correct event names
* Add assertion to check for bad element ids
* Check for event handler collisions between `id` and `selector` based handlers
