### PR TITLE
LABKEY.Query.schemaSelectInput - allow for config.filterFn to be applied to filter the schemas to show in the select options

### DIFF
--- a/api/webapp/clientapi/dom/Query.js
+++ b/api/webapp/clientapi/dom/Query.js
@@ -358,7 +358,12 @@ LABKEY.Query = new function(impl, $) {
         LABKEY.Query.getSchemas({
             includeHidden: false,
             success: function(data) {
-                populateSelect(SCHEMA_SELECT, data.schemas.sort(), null, null, config.initValue, config.isRequired, config.includeBlankOption);
+                var schemas = data.schemas.sort();
+                if (config.filterFn instanceof Function) {
+                    schemas = schemas.filter(config.filterFn);
+                }
+
+                populateSelect(SCHEMA_SELECT, schemas, null, null, config.initValue, config.isRequired, config.includeBlankOption);
 
                 // if there is a selected schema, fire the change event
                 if (SCHEMA_SELECT.val()) {


### PR DESCRIPTION
#### Rationale
A client recently ran into a recursive type error after inadvertently setting the schemaName for a QC Trend Report configuration to the "qctrendreport" schema itself. This PR allows for those schemas to be filtered out of the options for the QC Trend Report configuration page.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4712
* https://github.com/LabKey/premium/pull/408

#### Changes
* allow for config.filterFn to be applied to filter the schemas to show in the select options
