### PR TITLE
Don't use element name as part of automated id

### DIFF
--- a/api/src/org/labkey/api/util/element/Input.java
+++ b/api/src/org/labkey/api/util/element/Input.java
@@ -581,7 +581,7 @@ public class Input extends DisplayElement implements HasHtmlString, SafeToRender
         if (null != id)
             return id;
         var pageConfig = HttpView.currentPageConfig();
-        return pageConfig.makeId(StringUtils.defaultIfBlank(getName(), prefix));
+        return pageConfig.makeId(prefix);
     }
 
     protected void doStyles(Appendable sb) throws IOException


### PR DESCRIPTION
#### Rationale
When an input element doesn't have an explicitly provided id, an id will be generated using the element's name as prefix. This is problematic as the name attribute might contain illegal characters for ids, such as whitespaces. PageConfig.makeId is already using uid.incrementAndGet() to guarantee the uniqueness of ids, the inclusion of name won't help with additional uniqueness but mainly for human readability purpose. This pr would no longer include name in auto generated ids.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4683

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
