### PR TITLE
Restore attribute to target web part as anchor within page

### DIFF
--- a/core/src/org/labkey/core/view/template/bootstrap/ViewServiceImpl.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/ViewServiceImpl.java
@@ -610,7 +610,7 @@ public class ViewServiceImpl implements ViewService
                 out.print(PageFlowUtil.filter(title));
                 out.print("\"");
             }
-            out.print("><a id=\"" + PageFlowUtil.filter(title) + "\" class=\"labkey-anchor-disabled\">");
+            out.print("><a id=\"" + PageFlowUtil.makeHtmlId(title) + "\" class=\"labkey-anchor-disabled\">");
             if (getConfig()._isCollapsible)
                 renderCollapsiblePortalTitle(out);
             else

--- a/core/src/org/labkey/core/view/template/bootstrap/ViewServiceImpl.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/ViewServiceImpl.java
@@ -610,12 +610,12 @@ public class ViewServiceImpl implements ViewService
                 out.print(PageFlowUtil.filter(title));
                 out.print("\"");
             }
-            out.print("><span name=\"" + PageFlowUtil.filter(title) + "\" class=\"labkey-anchor-disabled\">");
+            out.print("><a id=\"" + PageFlowUtil.filter(title) + "\" class=\"labkey-anchor-disabled\">");
             if (getConfig()._isCollapsible)
                 renderCollapsiblePortalTitle(out);
             else
                 renderNonCollapsiblePortalTitle(out);
-            out.print("</span></h3>");
+            out.print("</a></h3>");
         }
 
         public void renderWebpartHeaderEnd(PrintWriter out)


### PR DESCRIPTION
#### Rationale
A recent PR (https://github.com/LabKey/platform/pull/4683 to be specific) switched from `<a name="x">` to `<span name="x">` in the title of framed web parts. The means it's no longer a targetable anchor. We should keep using `<a>` but switch to `id` as the attribute

#### Changes
* Restore the `<a>` and use `id` instead of `name`