### PR TITLE
48605: NullPointerException in org.labkey.survey.SurveyManager.getSurveyResponsesTableInfo()

### DIFF
--- a/survey/src/org/labkey/survey/SurveyManager.java
+++ b/survey/src/org/labkey/survey/SurveyManager.java
@@ -610,6 +610,7 @@ public class SurveyManager
         return null;
     }
 
+    @Nullable
     public TableInfo getSurveyResponsesTableInfo(Container container, User user, SurveyDesign survey, AuditBehaviorType abt)
     {
         if (container != null)
@@ -619,10 +620,13 @@ public class SurveyManager
             if (schema != null)
             {
                 TableInfo table = schema.getTable(survey.getQueryName(), null, true, true);
-                if (table.supportsAuditTracking())
-                    ((AuditConfigurable)table).setAuditBehavior(AuditBehaviorType.DETAILED);
-                table.setLocked(true);
-                return table;
+                if (table != null)
+                {
+                    if (table.supportsAuditTracking())
+                        ((AuditConfigurable)table).setAuditBehavior(AuditBehaviorType.DETAILED);
+                    table.setLocked(true);
+                    return table;
+                }
             }
         }
         return null;


### PR DESCRIPTION
[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48605)

#### Rationale
This showed up in mothership, the account manager thinks this may have been related to permissions. Just adding a simple null check here so the controller action can deal with it.
