### PR TITLE
Issues : add consistency to the duplicate field handling

### DIFF
--- a/issues/src/org/labkey/issue/IssueServiceImpl.java
+++ b/issues/src/org/labkey/issue/IssueServiceImpl.java
@@ -72,15 +72,18 @@ public class IssueServiceImpl implements IssueService
                         issueObject.open(container, user);
                         prevIssue.open(container, user);
                     }
-                    case update -> issueObject.change(user);
-                    case resolve -> {
+                    case update, resolve -> {
+                        if (action == Issue.action.update)
+                            issueObject.change(user);
+                        else
+                            issueObject.resolve(user);
+
                         if (resolution.equals("Duplicate") &&
                                 issueObject.getDuplicate() != null &&
                                 !issueObject.getDuplicate().equals(prevIssue.getDuplicate()))
                         {
                             duplicateOf = IssueManager.getIssue(null, user, issueObject.getDuplicate());
                         }
-                        issueObject.resolve(user);
                     }
                     case reopen -> {
                         // issue 46952 ensure resolution is cleared on reopen
@@ -245,9 +248,8 @@ public class IssueServiceImpl implements IssueService
             issueObject.beforeReOpen(container);
         }
 
-        if (action == Issue.action.resolve)
+        if (action == Issue.action.resolve || action == Issue.action.update)
         {
-            //IssueObject issue = form.getBean();
             String resolution = issueObject.getResolution() != null ? issueObject.getResolution() : "Fixed";
 
             if (resolution.equals("Duplicate"))

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -1024,9 +1024,12 @@ public class IssuesController extends SpringActionController
 
             switch (action)
             {
-                case update, resolve, close, reopen -> {
+                case update, resolve, close -> {
                     visible.add("resolution");
                     visible.add("duplicate");
+                }
+                case reopen -> {
+                    visible.add("resolution");
                 }
             }
 
@@ -1044,7 +1047,6 @@ public class IssuesController extends SpringActionController
             {
                 case update, reopen -> {
                     readOnly.add("resolution");
-                    readOnly.add("duplicate");
                 }
                 case close -> {
                     readOnly.add("resolution");


### PR DESCRIPTION
[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47450)

#### Rationale
If an issue has been resolved as a duplicate we still want to allow value to be updated but still include all of the existing validation (required, be a valid id, not be a duplicate of itself). 

If a issue that has been resolved as a duplicate is reopened, we treat it similar to the new issue case: the duplicate value is removed and the field is hidden.