### PR TITLE
New wrapper class PrincipalArray replaces dangerous int[] use

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -106,7 +106,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
         this.domainKind = domainKind;
 
         // Issue 20310: initialize AuditTypeProvider when registered during startup
-        User auditUser = new LimitedUser(UserManager.getGuestUser(), new int[0], Collections.singleton(RoleManager.getRole(ReaderRole.class)), false);
+        User auditUser = new LimitedUser(UserManager.getGuestUser(), Collections.singleton(RoleManager.getRole(ReaderRole.class)));
         initializeProvider(auditUser);
     }
 

--- a/api/src/org/labkey/api/cache/CacheManager.java
+++ b/api/src/org/labkey/api/cache/CacheManager.java
@@ -173,10 +173,6 @@ public class CacheManager
 
         String description = CollectionUtils.getModifiableCollectionMapOrArrayType(value);
 
-        // TODO: Stop caching arrays and remove this array check
-        if (null != value && value.getClass().isArray())
-            return;
-
         if (null != description)
         {
             LOG.warn(debugName + " attempted to cache " + description + ", which could be mutated by callers!");
@@ -184,7 +180,7 @@ public class CacheManager
     }
 
 
-    /* This interface allows a Collection to declare it self immutable when being added to a cache */
+    /* This interface allows a Collection to declare itself immutable when being added to a cache */
     public interface Sealable
     {
         boolean isSealed();

--- a/api/src/org/labkey/api/security/Group.java
+++ b/api/src/org/labkey/api/security/Group.java
@@ -19,15 +19,12 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.roles.Role;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
  * A group may be scoped to either the entire server or a specific project. It is a collection of users and/or
  * nested groups.
- * User: arauch
- * Date: Jul 5, 2005
  */
 public class Group extends UserPrincipal
 {
@@ -119,7 +116,7 @@ public class Group extends UserPrincipal
     }
 
     @Override
-    public int[] getGroups()
+    public PrincipalArray getGroups()
     {
         return GroupManager.getAllGroupsForPrincipal(this);
     }
@@ -127,8 +124,7 @@ public class Group extends UserPrincipal
     @Override
     public boolean isInGroup(int group)
     {
-        int i = Arrays.binarySearch(getGroups(), group);
-        return i >= 0;
+        return getGroups().contains(group);
     }
 
     @Override

--- a/api/src/org/labkey/api/security/GroupManager.java
+++ b/api/src/org/labkey/api/security/GroupManager.java
@@ -60,7 +60,6 @@ import org.labkey.security.xml.UserRefsType;
 
 import java.beans.PropertyChangeEvent;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -69,16 +68,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-/**
- * User: adam
- * Date: Jul 19, 2006
- * Time: 11:13:21 PM
- */
 public class GroupManager
 {
     private static final Logger _log = LogManager.getLogger(GroupManager.class);
     private static final CoreSchema _core = CoreSchema.getInstance();
-    private static final int[] EMPTY_INT_ARRAY = new int[0];
 
     public static final String GROUP_AUDIT_EVENT = "GroupAuditEvent";
 
@@ -88,10 +81,10 @@ public class GroupManager
     }
 
     // Returns the expanded group list for this principal
-    public static int[] getAllGroupsForPrincipal(@Nullable UserPrincipal user)
+    public static PrincipalArray getAllGroupsForPrincipal(@Nullable UserPrincipal user)
     {
         if (user == null)
-            return EMPTY_INT_ARRAY;
+            return PrincipalArray.getEmptyPrincipalArray();
 
         return GroupMembershipCache.getAllGroupMemberships(user);
     }
@@ -590,13 +583,11 @@ public class GroupManager
             assertFalse(np.hasPermission(_groupA, ReadPermission.class));
             assertFalse(np.hasPermission(_groupB, ReadPermission.class));
 
-            int[] members = GroupManager.getAllGroupsForPrincipal(newGroupB);
-            Arrays.sort(members);
-            assertTrue(Arrays.binarySearch(members, newGroupA.getUserId()) > -1);
+            PrincipalArray groups = GroupManager.getAllGroupsForPrincipal(newGroupB);
+            assertTrue(groups.contains(newGroupA.getUserId()));
 
-            members = GroupManager.getAllGroupsForPrincipal(getUser());
-            Arrays.sort(members);
-            assertTrue(Arrays.binarySearch(members, newGroupB.getUserId()) > -1);
+            groups = GroupManager.getAllGroupsForPrincipal(getUser());
+            assertTrue(groups.contains(newGroupB.getUserId()));
 
             assertTrue(np.hasPermission(newGroupA, ReadPermission.class));
             assertTrue(np.hasPermission(newGroupB, ReadPermission.class));

--- a/api/src/org/labkey/api/security/GuestUser.java
+++ b/api/src/org/labkey/api/security/GuestUser.java
@@ -16,18 +16,20 @@
 
 package org.labkey.api.security;
 
+import java.util.List;
+
 /**
  * A special kind of user, representing anonymous access.
  * That is, users who have not authenticated with an account.
  */
 class GuestUser extends User
 {
-    private static final int[] _guestGroups = new int[]{Group.groupGuests};
+    private static final PrincipalArray GUEST_GROUPS = new PrincipalArray(List.of(Group.groupGuests));
 
     GuestUser(String name, String displayName)
     {
         super(name, 0);
-        _groups = _guestGroups;
+        _groups = GUEST_GROUPS;
         setDisplayName(displayName);
     }
 

--- a/api/src/org/labkey/api/security/LimitedUser.java
+++ b/api/src/org/labkey/api/security/LimitedUser.java
@@ -16,24 +16,36 @@
 
 package org.labkey.api.security;
 
+import org.labkey.api.security.roles.AbstractRootContainerRole;
 import org.labkey.api.security.roles.Role;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
  * A wrapper around another user that limits the permissions associated that that user, and thus
  * the operations that the user is allowed to perform.
- * User: adam
- * Date: Sep 10, 2011
  */
 public class LimitedUser extends User
 {
-    private final int[] _groups;
+    private final PrincipalArray _groups;
     private final Set<Role> _roles;
     private final boolean _allowedGlobalRoles;
 
+    // LimitedUser with no groups, only a set of explicit roles. Presence of any site role determines if global roles are allowed.
+    public LimitedUser(User user, Set<Role> roles)
+    {
+        this(user, PrincipalArray.getEmptyPrincipalArray(), roles, roles.stream().anyMatch(r -> r instanceof AbstractRootContainerRole));
+    }
+
+    @Deprecated // Leave in place temporarily until the many uses in other repos have been converted
     public LimitedUser(User user, int[] groups, Set<Role> roles, boolean allowedGlobalRoles)
+    {
+        this(user, new PrincipalArray(Arrays.stream(groups).boxed().toList()), roles, allowedGlobalRoles);
+    }
+
+    public LimitedUser(User user, PrincipalArray groups, Set<Role> roles, boolean allowedGlobalRoles)
     {
         super(user.getEmail(), user.getUserId());
         setFirstName(user.getFirstName());
@@ -54,7 +66,7 @@ public class LimitedUser extends User
     }
 
     @Override
-    public int[] getGroups()
+    public PrincipalArray getGroups()
     {
         return _groups;
     }

--- a/api/src/org/labkey/api/security/PrincipalArray.java
+++ b/api/src/org/labkey/api/security/PrincipalArray.java
@@ -1,0 +1,54 @@
+package org.labkey.api.security;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+/*
+    Simple wrapper around int[] that limits the ability to mutate the array and ensures it's sorted, searched quickly, etc.
+    Can represent a list of groups to which a user (or group) belongs OR a list of members of a group.
+ */
+public class PrincipalArray
+{
+    private static final PrincipalArray EMPTY_PRINCIPAL_ARRAY = new PrincipalArray(Collections.emptyList());
+
+    private final int[] _principals; // Always sorted
+
+    public PrincipalArray(Collection<Integer> principals)
+    {
+        _principals = new int[principals.size()];
+        int i = 0;
+        for (int group : principals)
+            _principals[i++] = group;
+        Arrays.sort(_principals);
+    }
+
+    public boolean contains(int groupId)
+    {
+        return Arrays.binarySearch(_principals, groupId) >= 0;
+    }
+
+    // Package private: for now, allow security classes to access underlying int[] for performance
+    int[] getPrincipals()
+    {
+        return _principals;
+    }
+
+    // Preferred method for accessing the principal IDs
+    public Stream<Integer> stream()
+    {
+        return Arrays.stream(_principals).boxed();
+    }
+
+    public static PrincipalArray getEmptyPrincipalArray()
+    {
+        return EMPTY_PRINCIPAL_ARRAY;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "PrincipalArray" + Arrays.toString(_principals);
+    }
+}

--- a/api/src/org/labkey/api/security/PrincipalArray.java
+++ b/api/src/org/labkey/api/security/PrincipalArray.java
@@ -24,6 +24,12 @@ public class PrincipalArray
         Arrays.sort(_principals);
     }
 
+    // Needed for pipeline deserialization
+    public PrincipalArray()
+    {
+        _principals = null;
+    }
+
     public boolean contains(int groupId)
     {
         return Arrays.binarySearch(_principals, groupId) >= 0;

--- a/api/src/org/labkey/api/security/PrincipalArray.java
+++ b/api/src/org/labkey/api/security/PrincipalArray.java
@@ -6,8 +6,8 @@ import java.util.Collections;
 import java.util.stream.Stream;
 
 /*
-    Simple wrapper around int[] that limits the ability to mutate the array and ensures it's sorted, searched quickly, etc.
-    Can represent a list of groups to which a user (or group) belongs OR a list of members of a group.
+    Simple wrapper that limits the ability to mutate the int[] and ensures it's sorted, searched efficiently, etc.
+    Can represent a group's membership list OR user's list of group memberships.
  */
 public class PrincipalArray
 {
@@ -29,7 +29,7 @@ public class PrincipalArray
         return Arrays.binarySearch(_principals, groupId) >= 0;
     }
 
-    // Package private: for now, allow security classes to access underlying int[] for performance
+    // Package private: for now, security classes can access underlying int[] for performance
     int[] getPrincipals()
     {
         return _principals;

--- a/api/src/org/labkey/api/security/SecurityPolicy.java
+++ b/api/src/org/labkey/api/security/SecurityPolicy.java
@@ -223,8 +223,9 @@ public class SecurityPolicy
 
     /* Does not inspect any contextual roles, just the roles explicitly given by this SecurityPolicy */
     @NotNull
-    private Set<Class<? extends Permission>> getOwnPermissions(@NotNull int[] principals)
+    private Set<Class<? extends Permission>> getOwnPermissions(PrincipalArray principalArray)
     {
+        int[] principals = principalArray.getPrincipals();
         Set<Class<? extends Permission>> perms = new HashSet<>();
 
         //role assignments are sorted by user id,
@@ -254,8 +255,9 @@ public class SecurityPolicy
 
 
     @NotNull
-    protected Set<Role> getRoles(@NotNull int[] principals)
+    protected Set<Role> getRoles(PrincipalArray principalArray)
     {
+        int[] principals = principalArray.getPrincipals();
         Set<Role> roles = new HashSet<>();
 
         //role assignments are sorted by user id,
@@ -395,7 +397,7 @@ public class SecurityPolicy
 
     public boolean hasNonInheritedPermission(@NotNull UserPrincipal principal, Class<? extends Permission> perm)
     {
-        for (Role role : getRoles(new int[]{principal.getUserId()}))
+        for (Role role : getRoles(new PrincipalArray(List.of(principal.getUserId()))))
         {
             if (role.getPermissions().contains(perm))
                 return true;

--- a/api/src/org/labkey/api/security/SecurityPolicy.java
+++ b/api/src/org/labkey/api/security/SecurityPolicy.java
@@ -194,7 +194,7 @@ public class SecurityPolicy
      */
     public boolean isEmpty()
     {
-        return _assignments.size() == 0;
+        return _assignments.isEmpty();
     }
 
 

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -73,7 +73,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
     private Integer _createdBy;
     private Date _created;
     private String _displayName = null;
-    protected int[] _groups = null;
+    protected PrincipalArray _groups = null;
     private Date _lastLogin = null;
     private Date _lastActivity = null;
     private boolean _active = false;
@@ -93,7 +93,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
     public static final User guest = new GuestUser("guest", "guest");
 
     // 'nobody' is a guest user who cannot be assigned permissions
-    public static final User nobody = new LimitedUser(guest, new int[0], Collections.emptySet(), false)
+    public static final User nobody = new LimitedUser(guest, Collections.emptySet())
     {
         @Override
         public boolean isGuest()
@@ -118,7 +118,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
     {
         AdminServiceUser()
         {
-            super(new User("@serviceUserAdmin", User.guest.getUserId()), new int[0], Collections.singleton(RoleManager.getRole(SiteAdminRole.class)), true);
+            super(new User("@serviceUserAdmin", User.guest.getUserId()), PrincipalArray.getEmptyPrincipalArray(), Collections.singleton(RoleManager.getRole(SiteAdminRole.class)), true);
             setPrincipalType(PrincipalType.SERVICE);
         }
 
@@ -240,7 +240,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
 
 
     @Override
-    public int[] getGroups()
+    public PrincipalArray getGroups()
     {
         if (_groups == null)
             _groups = _impersonationContext.getGroups(this);
@@ -418,8 +418,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
     @Override
     public boolean isInGroup(int group)
     {
-        int i = Arrays.binarySearch(getGroups(), group);
-        return i >= 0;
+        return getGroups().contains(group);
     }
 
     @Override
@@ -529,7 +528,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
     {
         if (search == null)
         {
-            search = new LimitedUser(new GuestUser("@search"), new int[0], Collections.singleton(RoleManager.getRole(ReaderRole.class)), false);
+            search = new LimitedUser(new GuestUser("@search"), Collections.singleton(RoleManager.getRole(ReaderRole.class)));
             search.setPrincipalType(PrincipalType.SERVICE);
         }
         return search;

--- a/api/src/org/labkey/api/security/UserPrincipal.java
+++ b/api/src/org/labkey/api/security/UserPrincipal.java
@@ -97,7 +97,7 @@ public abstract class UserPrincipal implements Principal, Parameter.JdbcParamete
             throw new IllegalArgumentException("Unrecognized type specified. Must be one of 'u', 'g', 'm', or 's'.");
     }
 
-    public abstract int[] getGroups();
+    public abstract PrincipalArray getGroups();
 
     /**
      * @return the roles that the user is assumed to embody, which may go beyond the basic set of roles that the

--- a/api/src/org/labkey/api/security/impersonation/DisallowGlobalRolesContext.java
+++ b/api/src/org/labkey/api/security/impersonation/DisallowGlobalRolesContext.java
@@ -15,13 +15,15 @@
  */
 package org.labkey.api.security.impersonation;
 
-/**
- * A "not impersonating" context that disallows all global roles (i.e., Site Admin and Developer)
- * Created by adam on 10/30/2015.
+/*
+  A "not impersonating" context that disallows global roles (i.e., Site Admin and Developer)
  */
-import org.apache.commons.lang3.ArrayUtils;
+
 import org.labkey.api.security.Group;
+import org.labkey.api.security.PrincipalArray;
 import org.labkey.api.security.User;
+
+import java.util.Set;
 
 public class DisallowGlobalRolesContext extends NotImpersonatingContext
 {
@@ -48,10 +50,13 @@ public class DisallowGlobalRolesContext extends NotImpersonatingContext
         return "DisallowGlobalRoles";
     }
 
+    private static final Set<Integer> FORBIDDEN_ROLES = Set.of(Group.groupAdministrators, Group.groupDevelopers);
+
     @Override
-    public int[] getGroups(User user)
+    public PrincipalArray getGroups(User user)
     {
-        int[] groups = super.getGroups(user);
-        return ArrayUtils.removeElements(groups, Group.groupAdministrators, Group.groupDevelopers);
+        return new PrincipalArray(super.getGroups(user).stream()
+            .filter(id -> !FORBIDDEN_ROLES.contains(id))
+            .toList());
     }
 }

--- a/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
@@ -22,6 +22,7 @@ import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.Group;
+import org.labkey.api.security.PrincipalArray;
 import org.labkey.api.security.GroupMembershipCache;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
@@ -43,10 +44,6 @@ import java.util.Set;
 /**
  * Used to indicate that a user is impersonating a specific group (site or project), and are not operating as their
  * normal logged-in self.
- *
- * User: adam
- * Date: 11/9/11
- * Time: 10:23 PM
  */
 public class GroupImpersonationContextFactory extends AbstractImpersonationContextFactory implements ImpersonationContextFactory
 {
@@ -180,14 +177,14 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
     private static class GroupImpersonationContext extends AbstractImpersonationContext
     {
         private final Group _group;
-        private final int[] _groups;
+        private final PrincipalArray _groups;
 
         @JsonCreator
         protected GroupImpersonationContext(
                 @JsonProperty("_project") @Nullable Container project,
                 @JsonProperty("_adminUser") User adminUser,
                 @JsonProperty("_group") Group group,
-                @JsonProperty("_groups") int[] groups,
+                @JsonProperty("_groups") PrincipalArray groups,
                 @JsonProperty("_returnURL") ActionURL returnURL,
                 @JsonProperty("_factory") ImpersonationContextFactory factory)
 
@@ -236,7 +233,7 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
         }
 
         @Override
-        public int[] getGroups(User user)
+        public PrincipalArray getGroups(User user)
         {
             return _groups;
         }

--- a/api/src/org/labkey/api/security/impersonation/ImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/ImpersonationContext.java
@@ -17,6 +17,7 @@ package org.labkey.api.security.impersonation;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.security.PrincipalArray;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.Permission;
@@ -46,7 +47,7 @@ public interface ImpersonationContext extends Serializable
     String getCacheKey();  // Caching permission-related state is very tricky with impersonation; context provides a cache key suffix that captures the current impersonation state
     /** @return the URL to which the user should be returned when impersonation is over */
     ActionURL getReturnURL();
-    int[] getGroups(User user);
+    PrincipalArray getGroups(User user);
     Set<Role> getContextualRoles(User user, SecurityPolicy policy);
     ImpersonationContextFactory getFactory();
     /** Responsible for adding menu items to allow the user to initiate or stop impersonating, based on the current state */

--- a/api/src/org/labkey/api/security/impersonation/ImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/ImpersonationContext.java
@@ -31,9 +31,6 @@ import java.util.Set;
 /**
  * Context that describes the way in which a user is operating within the system. They may be logged in normally,
  * or they may be impersonating a specific user or a group, depending on the implementation.
- *
- * User: adam
- * Date: 11/8/11
  */
 public interface ImpersonationContext extends Serializable
 {

--- a/api/src/org/labkey/api/security/impersonation/NotImpersonatingContext.java
+++ b/api/src/org/labkey/api/security/impersonation/NotImpersonatingContext.java
@@ -17,6 +17,7 @@ package org.labkey.api.security.impersonation;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.security.PrincipalArray;
 import org.labkey.api.security.GroupManager;
 import org.labkey.api.security.LoginUrls;
 import org.labkey.api.security.SecurityPolicy;
@@ -32,9 +33,6 @@ import java.util.Set;
 /**
  * Used for when a user is not impersonating another user. That is, they are logged in normally, and operating
  * as themselves.
- *
- * User: adam
- * Date: 11/9/11
  */
 public class NotImpersonatingContext implements ImpersonationContext
 {
@@ -92,7 +90,7 @@ public class NotImpersonatingContext implements ImpersonationContext
     }
 
     @Override
-    public int[] getGroups(User user)
+    public PrincipalArray getGroups(User user)
     {
         return GroupManager.getAllGroupsForPrincipal(user);
     }

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.security.PrincipalArray;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
@@ -253,9 +254,9 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         }
 
         @Override
-        public int[] getGroups(User user)
+        public PrincipalArray getGroups(User user)
         {
-            return new int[0];
+            return PrincipalArray.getEmptyPrincipalArray();
         }
 
         // TODO: More expensive than it needs to be... should actually hold onto a Set<Roles> and use custom serialization (using unique names)

--- a/api/src/org/labkey/api/security/impersonation/UnauthorizedImpersonationException.java
+++ b/api/src/org/labkey/api/security/impersonation/UnauthorizedImpersonationException.java
@@ -21,8 +21,6 @@ import org.labkey.api.view.UnauthorizedException;
 /**
  * Thrown to indicate that someone attempted to impersonate in an invalid way - such as a project admin attempting to
  * impersonate someone who's not a project user in this project.
- * User: adam
- * Date: 5/6/12
  */
 public class UnauthorizedImpersonationException extends UnauthorizedException
 {

--- a/api/src/org/labkey/api/security/impersonation/UserImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/UserImpersonationContextFactory.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.security.PrincipalArray;
 import org.labkey.api.security.GroupManager;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
@@ -230,7 +231,7 @@ public class UserImpersonationContextFactory extends AbstractImpersonationContex
         }
 
         @Override
-        public int[] getGroups(User user)
+        public PrincipalArray getGroups(User user)
         {
             return GroupManager.getAllGroupsForPrincipal(user);
         }

--- a/api/src/org/labkey/api/security/impersonation/WrappedImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/WrappedImpersonationContext.java
@@ -17,16 +17,11 @@ package org.labkey.api.security.impersonation;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
-import org.labkey.api.security.GroupManager;
-import org.labkey.api.security.LoginUrls;
+import org.labkey.api.security.PrincipalArray;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
-import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.roles.EditorRole;
 import org.labkey.api.security.roles.Role;
-import org.labkey.api.security.roles.RoleManager;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 
@@ -34,13 +29,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Used for when a user is not impersonating another user. That is, they are logged in normally, and operating
- * as themselves.  This class can be used to grant a user a contextual role for the duration of a request.
- * This should not be first tool to reach for.  It is usually better to find a way to provide the additional contextual
- * roles in a more limited scope.
- *
- * User: adam
- * Date: 11/9/11
+ * Used for when a user is not impersonating another user. That is, they are logged in normally, and operating as
+ * themselves. This class can be used to grant a user a contextual role for the duration of a request. This should not
+ * be first tool to reach for. It is usually better to find a way to provide the additional contextual roles in a more
+ * limited scope.
  */
 public class WrappedImpersonationContext implements ImpersonationContext
 {
@@ -97,7 +89,7 @@ public class WrappedImpersonationContext implements ImpersonationContext
     }
 
     @Override
-    public int[] getGroups(User user)
+    public PrincipalArray getGroups(User user)
     {
         return delegate.getGroups(user);
     }

--- a/api/src/org/labkey/api/security/roles/AbstractRootContainerRole.java
+++ b/api/src/org/labkey/api/security/roles/AbstractRootContainerRole.java
@@ -23,7 +23,6 @@ import org.labkey.api.security.permissions.Permission;
 
 /**
  * A base class for Roles that are only available in the root container.
- * Created by Josh on 1/25/2016.
  */
 public abstract class AbstractRootContainerRole extends AbstractRole
 {

--- a/api/src/org/labkey/api/webdav/FileSystemResource.java
+++ b/api/src/org/labkey/api/webdav/FileSystemResource.java
@@ -27,13 +27,9 @@ import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.AuditTypeEvent;
 import org.labkey.api.audit.provider.FileSystemAuditProvider;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
-import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableSelector;
-import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.api.ExpData;
-import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.PropertyService;
@@ -73,7 +69,6 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -88,12 +83,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
-* User: matthewb
-* Date: Oct 21, 2008
-* Time: 10:00:49 AM
-*
-*   Base class for file-system based resources
-*/
+ *  Base class for file-system based resources
+ */
 public class FileSystemResource extends AbstractWebdavResource
 {
     private static final Logger _log = LogManager.getLogger(FileSystemResource.class);
@@ -619,7 +610,7 @@ public class FileSystemResource extends AbstractWebdavResource
         HashSet<Role> roles = new HashSet<>();
         roles.add(RoleManager.getRole(ReaderRole.class));
         roles.add(RoleManager.getRole(CanSeeAuditLogRole.class));
-        User user = new LimitedUser(UserManager.getGuestUser(), new int[0], roles, true);
+        User user = new LimitedUser(UserManager.getGuestUser(), roles);
 
         List<AuditTypeEvent> logs = AuditLogService.get().getAuditEvents(getContainer(), user, FileSystemAuditProvider.EVENT_TYPE, filter, null);
         if (null == logs)
@@ -627,8 +618,8 @@ public class FileSystemResource extends AbstractWebdavResource
 
         List<WebdavResolver.History> history = new ArrayList<>(logs.size());
         history.addAll(logs.stream()
-                .map(e -> new HistoryImpl(e.getCreatedBy().getUserId(), e.getCreated(), e.getComment(), null))
-                .collect(Collectors.toList()));
+            .map(e -> new HistoryImpl(e.getCreatedBy().getUserId(), e.getCreated(), e.getComment(), null))
+            .toList());
         return history;
     }
 

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -82,7 +82,7 @@ public class AssayUpgradeCode implements UpgradeCode
                 protocolsByContainer.get(container).add(new Pair<>(protocol, resultsDomain));
             }
 
-            User upgradeUser = new LimitedUser(UserManager.getGuestUser(), new int[0], Collections.singleton(RoleManager.getRole(SiteAdminRole.class)), false);
+            User upgradeUser = new LimitedUser(UserManager.getGuestUser(), Collections.singleton(RoleManager.getRole(SiteAdminRole.class)));
             for (Container container : protocolsByContainer.keySet())
             {
                 List<Pair<ExpProtocol, Domain>> protocolDomains = protocolsByContainer.get(container);

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1076,7 +1076,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             results.put("analyticsTrackingStatus", AnalyticsServiceImpl.get().getTrackingStatus().toString());
 
             // Report the total number of login entries in the audit log
-            User user = new LimitedUser(User.getSearchUser(), new int[0], Set.of(RoleManager.getRole(CanSeeAuditLogRole.class)), true);
+            User user = new LimitedUser(User.getSearchUser(), Set.of(RoleManager.getRole(CanSeeAuditLogRole.class)));
             UserSchema auditSchema = AuditLogService.get().createSchema(user, ContainerManager.getRoot());
             TableInfo userAuditTable = auditSchema.getTableOrThrow(UserManager.USER_AUDIT_EVENT);
             results.put("totalLogins", new TableSelector(userAuditTable, new SimpleFilter(FieldKey.fromParts("comment"), UserManager.UserAuditEvent.LOGGED_IN, CompareType.CONTAINS), null).getRowCount());

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -210,10 +210,8 @@ public class SecurityApiActions
 
                 if (container.hasPermission(getUser(), AdminPermission.class))
                 {
-                    int[] parentGroupIds = group.getGroups();
                     List<Map<String, Object>> parentGroupInfos = new ArrayList<>();
-                    for (int parentGroupId : parentGroupIds)
-                    {
+                    group.getGroups().stream().forEach(parentGroupId -> {
                         Group parentGroup = SecurityManager.getGroup(parentGroupId);
                         if (parentGroup != null && parentGroup.getUserId() != group.getUserId())
                         {
@@ -224,7 +222,7 @@ public class SecurityApiActions
                             groupInfo.put("isSystemGroup", parentGroup.isSystemGroup());
                             parentGroupInfos.add(groupInfo);
                         }
-                    }
+                    });
                     groupPerms.put("groups", parentGroupInfos);
                 }
 

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -120,6 +120,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.BiConsumer;
@@ -1565,15 +1566,10 @@ public class SecurityController extends SpringActionController
 
     private void handleGroups(User user, Consumer<Group> consumer)
     {
-        for (int groupId : GroupMembershipCache.getGroupMemberships(user.getUserId()))
-        {
-            final Group group = SecurityManager.getGroup(groupId);
-
-            if (group != null)
-            {
-                consumer.accept(group);
-            }
-        }
+        GroupMembershipCache.getGroupMemberships(user.getUserId()).stream()
+            .map(SecurityManager::getGroup)
+            .filter(Objects::nonNull)
+            .forEach(consumer);
     }
 
     private void handleDirectRoleAssignments(User user, BiConsumer<MutableSecurityPolicy, Collection<Role>> consumer)

--- a/filecontent/src/org/labkey/filecontent/message/FileContentDigestProvider.java
+++ b/filecontent/src/org/labkey/filecontent/message/FileContentDigestProvider.java
@@ -88,7 +88,7 @@ public class FileContentDigestProvider implements MessageDigest.Provider
     {
         Set<Container> containers = new HashSet<>();
 
-        User user = new LimitedUser(UserManager.getGuestUser(), new int[0], Collections.singleton(RoleManager.getRole(ReaderRole.class)), true);
+        User user = new LimitedUser(UserManager.getGuestUser(), Collections.singleton(RoleManager.getRole(ReaderRole.class)));
         UserSchema userSchema = AuditLogService.getAuditLogSchema(user, ContainerManager.getSharedContainer());
         FilteredTable table = (FilteredTable)userSchema.getTable(FileSystemAuditProvider.EVENT_TYPE);
 
@@ -114,7 +114,7 @@ public class FileContentDigestProvider implements MessageDigest.Provider
         HashSet<Role> roles = new HashSet<>();
         roles.add(RoleManager.getRole(ReaderRole.class));
         roles.add(RoleManager.getRole(CanSeeAuditLogRole.class));
-        return new LimitedUser(UserManager.getGuestUser(), new int[0], roles, true);
+        return new LimitedUser(UserManager.getGuestUser(), roles);
     }
 
     private List<FileSystemAuditEvent> getAuditEvents(Container container, Date start, Date end)

--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -933,7 +933,7 @@ public class IssueManager
         @Override
         public void run()
         {
-            User user = new LimitedUser(UserManager.getGuestUser(), new int[0], Collections.singleton(RoleManager.getRole(ReaderRole.class)), false);
+            User user = new LimitedUser(UserManager.getGuestUser(), Collections.singleton(RoleManager.getRole(ReaderRole.class)));
             indexIssues(null, user, _task, _ids);
         }
     }

--- a/query/src/org/labkey/query/ExternalSchema.java
+++ b/query/src/org/labkey/query/ExternalSchema.java
@@ -80,9 +80,9 @@ public class ExternalSchema extends SimpleUserSchema
     // Adaptor for DbSchema and UserSchema.
     protected interface TableSource
     {
-        public Collection<String> getTableNames();
-        public Collection<String> getQueryNames();
-        public boolean isTableAvailable(String tableName);
+        Collection<String> getTableNames();
+        Collection<String> getQueryNames();
+        boolean isTableAvailable(String tableName);
     }
 
     protected final AbstractExternalSchemaDef _def;

--- a/query/src/org/labkey/query/LinkedSchema.java
+++ b/query/src/org/labkey/query/LinkedSchema.java
@@ -239,7 +239,7 @@ public class LinkedSchema extends ExternalSchema
     @NotNull
     public Map<String, QueryDefinition> getQueryDefs(@Nullable String nameFilter)
     {
-        if (_availableQueries.size() == 0)
+        if (_availableQueries.isEmpty())
             return super.getQueryDefs();
 
         if (nameFilter == null && _resolvedAllQueries)
@@ -588,13 +588,11 @@ public class LinkedSchema extends ExternalSchema
 
     private static class LinkedSchemaUserWrapper extends LimitedUser
     {
-        private static final int[] NO_GROUPS = new int[0];
-
         private final Set<String> _allowedPolicyResourceIds = new HashSet<>();
 
         public LinkedSchemaUserWrapper(User realUser, Container sourceContainer, String sourceSchemaName)
         {
-            super(realUser, NO_GROUPS, getContextualRoleForTargetSchema(sourceSchemaName), false);
+            super(realUser, getContextualRoleForTargetSchema(sourceSchemaName));
 
             // Current container policy and (if it exists) current study policy are the only policies that get
             // overridden here. No need to handle dataset policies; when the study policy claims read, all per-group

--- a/query/src/org/labkey/query/jdbc/QueryDriver.java
+++ b/query/src/org/labkey/query/jdbc/QueryDriver.java
@@ -85,7 +85,7 @@ public class QueryDriver implements Driver
 
         // NOTE: This code is only accessible from within LabKey Server when using components that require their own
         //JDBC Connection (e.g. Mondrian). The user must currently be a limited service user that cannot update
-        User user = new LimitedUser(User.guest, new int[0], Collections.singleton(RoleManager.getRole(ReaderRole.class)), false);
+        User user = new LimitedUser(User.guest, Collections.singleton(RoleManager.getRole(ReaderRole.class)));
         user.setPrincipalType(PrincipalType.SERVICE);
         user.setDisplayName("Internal JDBC Service User");
         user.setEmail("internaljdbc@labkey.org");

--- a/query/src/org/labkey/query/olap/BitSetQueryImpl.java
+++ b/query/src/org/labkey/query/olap/BitSetQueryImpl.java
@@ -77,14 +77,13 @@ import static org.labkey.query.olap.QubeQuery.OP;
 
 /**
  * Created by matthew on 3/13/14.
- *
  */
 public class BitSetQueryImpl
 {
     private final boolean mondrianCompatibleNullHandling = false;
 
     private static Logger _log = LogManager.getLogger(BitSetQueryImpl.class);
-    private final static User olapServiceUser = new LimitedUser(User.guest, new int[0], Collections.singleton(RoleManager.getRole(ReaderRole.class)), false);
+    private final static User olapServiceUser = new LimitedUser(User.guest, Collections.singleton(RoleManager.getRole(ReaderRole.class)));
     static
     {
         olapServiceUser.setPrincipalType(PrincipalType.SERVICE);

--- a/query/src/org/labkey/query/olap/ServerManager.java
+++ b/query/src/org/labkey/query/olap/ServerManager.java
@@ -417,7 +417,7 @@ public class ServerManager
             else
             {
                 // OK: to leave OlapConnection null as it is not used in any configuration except Mondrian
-                warmCubeUser = new LimitedUser(User.guest, new int[0], Collections.singleton(RoleManager.getRole(ReaderRole.class)), false);
+                warmCubeUser = new LimitedUser(User.guest, Collections.singleton(RoleManager.getRole(ReaderRole.class)));
                 warmCubeUser.setPrincipalType(PrincipalType.SERVICE);
                 warmCubeUser.setDisplayName("Warm OLAP Cache User");
                 warmCubeUser.setEmail("warmolapcache@labkey.org");

--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -45,6 +45,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.Queryable;
 import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.PrincipalArray;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.GUID;
@@ -60,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import static org.labkey.query.sql.Method.TimestampDiffInterval.SQL_TSI_FRAC_SECOND;
 import static org.labkey.query.sql.antlr.SqlBaseParser.IS;
@@ -1263,12 +1265,13 @@ public abstract class Method
                 //Current UserID gets put in QueryService.getEnvironment() by AuthFilter
                 // NOTE: ideally this should be calculated at RUN time not compile time. (see UserIdInfo)
                 // However, we are generating an IN () clause here, and it's easier to do this way
-                User user =  (User)QueryServiceImpl.get().getEnvironment(QueryService.Environment.USER);
+                User user = (User)QueryServiceImpl.get().getEnvironment(QueryService.Environment.USER);
                 if (null == user)
                     throw new IllegalStateException("Query environment has not been set");
-                Object[] groupIds = ArrayUtils.toObject(user.getGroups());
                 SQLFragment ret = new SQLFragment();
-                ret.append("(").append(groupArg).append(") IN (").append(StringUtils.join(groupIds, ",")).append(")");
+                ret.append("(").append(groupArg).append(") IN (").append(
+                    user.getGroups().stream().map(i -> Integer.toString(i)).collect(Collectors.joining(","))
+                ).append(")");
                 return ret;
             }
 

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -187,7 +187,7 @@ public class SearchModule extends DefaultModule
         UsageMetricsService.get().registerUsageMetrics(getName(), () ->
         {
             // Report the total number of search entries in the audit log
-            User user = new LimitedUser(User.getSearchUser(), new int[0], Set.of(RoleManager.getRole(CanSeeAuditLogRole.class)), true);
+            User user = new LimitedUser(User.getSearchUser(), Set.of(RoleManager.getRole(CanSeeAuditLogRole.class)));
             UserSchema auditSchema = AuditLogService.get().createSchema(user, ContainerManager.getRoot());
             TableInfo auditTable = auditSchema.getTableOrThrow(SearchAuditProvider.EVENT_TYPE, ContainerFilter.EVERYTHING);
 


### PR DESCRIPTION
#### Rationale
We've always used `int[]` to represent both group member lists and user group lists. We cache them, pass them around, and occasionally mutate them (e.g., `DisallowGlobalRolesContext`). Many code paths have implemented searching of these arrays in efficient and not-so-efficient ways. The arrays may be sorted or may not... no one seems to know.

#### Changes
* Replace nearly all use of principal ID int arrays with `PrincipalArray`, a wrapper class that limits access to the underlying `int[]`, ensures it's sorted, and implements an efficient search mechanism that all code paths now use
* The underlying int[] is accessible by only a few security classes; all other interested parties use `contains()` or `stream()`, which ensures efficiency & prevents mutation
* Introduce a simpler `LimitedUser(User, Set<Role>)` constructor for the very common case where we're not setting any groups. This constructor infers whether global roles are allowed or not based on the supplied roles.