### PR TITLE
Don't specify password when creating integration test users

### DIFF
--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
-        "@labkey/test": "1.2.0",
+        "@labkey/test": "1.3.0-createUserPassword.0",
         "@types/jest": "29.2.0",
         "@types/react": "16.14.34",
         "@types/react-dom": "16.9.17",
@@ -3062,9 +3062,9 @@
       }
     },
     "node_modules/@labkey/test": {
-      "version": "1.2.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.2.0.tgz",
-      "integrity": "sha512-hunBlrroQBU8Q8ehCgscD4SoSZY/OPn2CqMbfMpVxnHqsaxrYCRAkIpgnF3L6vd4g4ntbfsnqLga4LA+fgnnvA==",
+      "version": "1.3.0-createUserPassword.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.3.0-createUserPassword.0.tgz",
+      "integrity": "sha512-MmzTT+VFmLrgahusIhC6dB3ppDfGnw7+TOkYTC3OfodOuc4qlSceThJEaciGLW1PUPJor6ucVhbf4PkpbyLmLA==",
       "dev": true,
       "dependencies": {
         "properties-reader": "2.2.0",
@@ -16630,9 +16630,9 @@
       }
     },
     "@labkey/test": {
-      "version": "1.2.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.2.0.tgz",
-      "integrity": "sha512-hunBlrroQBU8Q8ehCgscD4SoSZY/OPn2CqMbfMpVxnHqsaxrYCRAkIpgnF3L6vd4g4ntbfsnqLga4LA+fgnnvA==",
+      "version": "1.3.0-createUserPassword.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.3.0-createUserPassword.0.tgz",
+      "integrity": "sha512-MmzTT+VFmLrgahusIhC6dB3ppDfGnw7+TOkYTC3OfodOuc4qlSceThJEaciGLW1PUPJor6ucVhbf4PkpbyLmLA==",
       "dev": true,
       "requires": {
         "properties-reader": "2.2.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
-        "@labkey/test": "1.3.0-createUserPassword.0",
+        "@labkey/test": "1.3.0",
         "@types/jest": "29.2.0",
         "@types/react": "16.14.34",
         "@types/react-dom": "16.9.17",
@@ -3062,9 +3062,9 @@
       }
     },
     "node_modules/@labkey/test": {
-      "version": "1.3.0-createUserPassword.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.3.0-createUserPassword.0.tgz",
-      "integrity": "sha512-MmzTT+VFmLrgahusIhC6dB3ppDfGnw7+TOkYTC3OfodOuc4qlSceThJEaciGLW1PUPJor6ucVhbf4PkpbyLmLA==",
+      "version": "1.3.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.3.0.tgz",
+      "integrity": "sha512-AQj3lPTjGZwVfar8ecMsxSXfmKls2y64kcFYqlzCZLItIVEyKXeNtPTrkHWpxpC7xGwYIDfjPtV0Vt+rTC+47w==",
       "dev": true,
       "dependencies": {
         "properties-reader": "2.2.0",
@@ -16630,9 +16630,9 @@
       }
     },
     "@labkey/test": {
-      "version": "1.3.0-createUserPassword.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.3.0-createUserPassword.0.tgz",
-      "integrity": "sha512-MmzTT+VFmLrgahusIhC6dB3ppDfGnw7+TOkYTC3OfodOuc4qlSceThJEaciGLW1PUPJor6ucVhbf4PkpbyLmLA==",
+      "version": "1.3.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.3.0.tgz",
+      "integrity": "sha512-AQj3lPTjGZwVfar8ecMsxSXfmKls2y64kcFYqlzCZLItIVEyKXeNtPTrkHWpxpC7xGwYIDfjPtV0Vt+rTC+47w==",
       "dev": true,
       "requires": {
         "properties-reader": "2.2.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",
-    "@labkey/test": "1.3.0-createUserPassword.0",
+    "@labkey/test": "1.3.0",
     "@types/jest": "29.2.0",
     "@types/react": "16.14.34",
     "@types/react-dom": "16.9.17",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",
-    "@labkey/test": "1.2.0",
+    "@labkey/test": "1.3.0-createUserPassword.0",
     "@types/jest": "29.2.0",
     "@types/react": "16.14.34",
     "@types/react-dom": "16.9.17",

--- a/experiment/src/client/test/integration/MoveAssayRunsAction.ispec.ts
+++ b/experiment/src/client/test/integration/MoveAssayRunsAction.ispec.ts
@@ -81,25 +81,25 @@ beforeAll(async () => {
     subfolder2Options = { containerPath: subfolder2.path };
 
     // create users with different permissions
-    editorUser = await server.createUser('test_editor@expctrltest.com', 'pwSuperA1!');
+    editorUser = await server.createUser('test_editor@expctrltest.com');
     await server.addUserToRole(editorUser.username, PermissionRoles.Editor, PROJECT_NAME);
     await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder1.path);
     await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder2.path);
     editorUserOptions = { requestContext: await server.createRequestContext(editorUser) };
 
-    const subEditorUser = await server.createUser('test_subeditor@expctrltest.com', 'pwSuperA1!');
+    const subEditorUser = await server.createUser('test_subeditor@expctrltest.com');
     await server.addUserToRole(subEditorUser.username, PermissionRoles.Reader, PROJECT_NAME);
     await server.addUserToRole(subEditorUser.username, PermissionRoles.Editor, subfolder1.path);
     await server.addUserToRole(subEditorUser.username, PermissionRoles.Editor, subfolder2.path);
     subEditorUserOptions = { requestContext: await server.createRequestContext(subEditorUser) };
 
-    const authorUser = await server.createUser('test_author@expctrltest.com', 'pwSuperA1!');
+    const authorUser = await server.createUser('test_author@expctrltest.com');
     await server.addUserToRole(authorUser.username, PermissionRoles.Author, PROJECT_NAME);
     await server.addUserToRole(authorUser.username, PermissionRoles.Author, subfolder1.path);
     await server.addUserToRole(authorUser.username, PermissionRoles.Author, subfolder2.path);
     authorUserOptions = { requestContext: await server.createRequestContext(authorUser) };
 
-    const noPermsUser = await server.createUser('test_no_perms@expctrltest.com', 'pwSuperA1!');
+    const noPermsUser = await server.createUser('test_no_perms@expctrltest.com');
     noPermsUserOptions = { requestContext: await server.createRequestContext(noPermsUser) };
 
     const runFileField = {

--- a/experiment/src/client/test/integration/MoveSamplesAction.ispec.ts
+++ b/experiment/src/client/test/integration/MoveSamplesAction.ispec.ts
@@ -45,25 +45,25 @@ beforeAll(async () => {
     subfolder2Options = { containerPath: subfolder2.path };
 
     // create users with different permissions
-    editorUser = await server.createUser('test_editor@expctrltest.com', 'pwSuperA1!');
+    editorUser = await server.createUser('test_editor@expctrltest.com');
     await server.addUserToRole(editorUser.username, PermissionRoles.Editor, PROJECT_NAME);
     await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder1.path);
     await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder2.path);
     editorUserOptions = { requestContext: await server.createRequestContext(editorUser) };
 
-    const subEditorUser = await server.createUser('test_subeditor@expctrltest.com', 'pwSuperA1!');
+    const subEditorUser = await server.createUser('test_subeditor@expctrltest.com');
     await server.addUserToRole(subEditorUser.username, PermissionRoles.Reader, PROJECT_NAME);
     await server.addUserToRole(subEditorUser.username, PermissionRoles.Editor, subfolder1.path);
     await server.addUserToRole(subEditorUser.username, PermissionRoles.Editor, subfolder2.path);
     subEditorUserOptions = { requestContext: await server.createRequestContext(subEditorUser) };
 
-    const authorUser = await server.createUser('test_author@expctrltest.com', 'pwSuperA1!');
+    const authorUser = await server.createUser('test_author@expctrltest.com');
     await server.addUserToRole(authorUser.username, PermissionRoles.Author, PROJECT_NAME);
     await server.addUserToRole(authorUser.username, PermissionRoles.Author, subfolder1.path);
     await server.addUserToRole(authorUser.username, PermissionRoles.Author, subfolder2.path);
     authorUserOptions = { requestContext: await server.createRequestContext(authorUser) };
 
-    const noPermsUser = await server.createUser('test_no_perms@expctrltest.com', 'pwSuperA1!');
+    const noPermsUser = await server.createUser('test_no_perms@expctrltest.com');
     noPermsUserOptions = { requestContext: await server.createRequestContext(noPermsUser) };
 
     // create a sample type at project container for use in tests

--- a/experiment/src/client/test/integration/MoveSourcesAction.ispec.ts
+++ b/experiment/src/client/test/integration/MoveSourcesAction.ispec.ts
@@ -48,25 +48,25 @@ beforeAll(async () => {
     subfolder2Options = { containerPath: subfolder2.path };
 
     // create users with different permissions
-    editorUser = await server.createUser('test_editor@expctrltest.com', 'pwSuperA1!');
+    editorUser = await server.createUser('test_editor@expctrltest.com');
     await server.addUserToRole(editorUser.username, PermissionRoles.Editor, PROJECT_NAME);
     await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder1.path);
     await server.addUserToRole(editorUser.username, PermissionRoles.Editor, subfolder2.path);
     editorUserOptions = { requestContext: await server.createRequestContext(editorUser) };
 
-    const subEditorUser = await server.createUser('test_subeditor@expctrltest.com', 'pwSuperA1!');
+    const subEditorUser = await server.createUser('test_subeditor@expctrltest.com');
     await server.addUserToRole(subEditorUser.username, PermissionRoles.Reader, PROJECT_NAME);
     await server.addUserToRole(subEditorUser.username, PermissionRoles.Editor, subfolder1.path);
     await server.addUserToRole(subEditorUser.username, PermissionRoles.Editor, subfolder2.path);
     subEditorUserOptions = { requestContext: await server.createRequestContext(subEditorUser) };
 
-    const authorUser = await server.createUser('test_author@expctrltest.com', 'pwSuperA1!');
+    const authorUser = await server.createUser('test_author@expctrltest.com');
     await server.addUserToRole(authorUser.username, PermissionRoles.Author, PROJECT_NAME);
     await server.addUserToRole(authorUser.username, PermissionRoles.Author, subfolder1.path);
     await server.addUserToRole(authorUser.username, PermissionRoles.Author, subfolder2.path);
     authorUserOptions = { requestContext: await server.createRequestContext(authorUser) };
 
-    const noPermsUser = await server.createUser('test_no_perms@expctrltest.com', 'pwSuperA1!');
+    const noPermsUser = await server.createUser('test_no_perms@expctrltest.com');
     noPermsUserOptions = { requestContext: await server.createRequestContext(noPermsUser) };
 
     // create a source types for use in tests


### PR DESCRIPTION
#### Rationale
These test passwords don't meet new complexity requirements. New version of `@labkey/test` doesn't need/allow you to specify a password.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1278
- https://github.com/LabKey/platform/pull/4707

#### Changes
- Update to new version of `@labkey/test`