### PR TITLE
Improve password rules based on feedback

### DIFF
--- a/api/src/org/labkey/api/security/EntropyPasswordValidator.java
+++ b/api/src/org/labkey/api/security/EntropyPasswordValidator.java
@@ -38,6 +38,12 @@ public abstract class EntropyPasswordValidator implements PasswordValidator
         return true;
     }
 
+    @Override
+    public boolean isDeprecated()
+    {
+        return false;
+    }
+
     private static final double BASE2_LOG = Math.log(2);
 
     public static double score(String password, User user)

--- a/api/src/org/labkey/api/security/GoodPasswordValidator.java
+++ b/api/src/org/labkey/api/security/GoodPasswordValidator.java
@@ -45,7 +45,7 @@ public class GoodPasswordValidator extends RuleBasedPasswordValidator
     }
 
     @Override
-    protected boolean isInappropriateForProduction()
+    protected boolean isDeprecated()
     {
         return false;
     }

--- a/api/src/org/labkey/api/security/GoodPasswordValidator.java
+++ b/api/src/org/labkey/api/security/GoodPasswordValidator.java
@@ -45,7 +45,7 @@ public class GoodPasswordValidator extends RuleBasedPasswordValidator
     }
 
     @Override
-    protected boolean isDeprecated()
+    public boolean isDeprecated()
     {
         return false;
     }

--- a/api/src/org/labkey/api/security/PasswordRule.java
+++ b/api/src/org/labkey/api/security/PasswordRule.java
@@ -96,4 +96,9 @@ public enum PasswordRule
 
         return isValidForLogin(password1, user, messages);
     }
+
+    public boolean isDeprecated()
+    {
+        return _validator.isDeprecated();
+    }
 }

--- a/api/src/org/labkey/api/security/PasswordValidator.java
+++ b/api/src/org/labkey/api/security/PasswordValidator.java
@@ -15,4 +15,5 @@ public interface PasswordValidator
     @NotNull HtmlString getSummaryRuleHtml();
     boolean isValidForLogin(@NotNull String password, @NotNull User user, @Nullable Collection<String> messages);
     boolean isPreviousPasswordForbidden();
+    boolean isDeprecated();
 }

--- a/api/src/org/labkey/api/security/RuleBasedPasswordValidator.java
+++ b/api/src/org/labkey/api/security/RuleBasedPasswordValidator.java
@@ -72,7 +72,7 @@ abstract class RuleBasedPasswordValidator implements PasswordValidator
                 _patternRequirement != null ? DOM.LI("Must " + _patternRequirement) : null,
                 DOM.LI(getPersonalInfoRule()),
                 isPreviousPasswordForbidden() ? PREVIOUS_PASSWORD_BULLET : null,
-                isInappropriateForProduction() ? DOM.LI(cl("labkey-error"), "This password strength is not appropriate for production deployments") : null
+                isDeprecated() ? DOM.LI(cl("labkey-error"), "This password strength is not appropriate for production deployments and will be removed shortly.") : null
             )
         ));
     }
@@ -175,7 +175,7 @@ abstract class RuleBasedPasswordValidator implements PasswordValidator
 
     protected abstract int getRequiredCharacterTypeCount();
 
-    protected abstract boolean isInappropriateForProduction();
+    protected abstract boolean isDeprecated();
 
     @Override
     @NotNull

--- a/api/src/org/labkey/api/security/RuleBasedPasswordValidator.java
+++ b/api/src/org/labkey/api/security/RuleBasedPasswordValidator.java
@@ -175,8 +175,6 @@ abstract class RuleBasedPasswordValidator implements PasswordValidator
 
     protected abstract int getRequiredCharacterTypeCount();
 
-    protected abstract boolean isDeprecated();
-
     @Override
     @NotNull
     public HtmlString getFullRuleHtml()

--- a/api/src/org/labkey/api/security/WeakPasswordValidator.java
+++ b/api/src/org/labkey/api/security/WeakPasswordValidator.java
@@ -51,7 +51,7 @@ public class WeakPasswordValidator extends RuleBasedPasswordValidator
     }
 
     @Override
-    protected boolean isInappropriateForProduction()
+    protected boolean isDeprecated()
     {
         return true;
     }

--- a/api/src/org/labkey/api/security/WeakPasswordValidator.java
+++ b/api/src/org/labkey/api/security/WeakPasswordValidator.java
@@ -51,7 +51,7 @@ public class WeakPasswordValidator extends RuleBasedPasswordValidator
     }
 
     @Override
-    protected boolean isDeprecated()
+    public boolean isDeprecated()
     {
         return true;
     }

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -191,8 +191,8 @@ public class CoreWarningProvider implements WarningProvider
 
     private void getPasswordRuleWarnings(Warnings warnings, boolean showAllWarnings)
     {
-        if (showAllWarnings || (!AppProps.getInstance().isDevMode() && DbLoginManager.getPasswordRule() == PasswordRule.Weak))
-            warnings.add(HtmlString.of("Database authentication is configured with \"Weak\" strength, which is not appropriate for a production deployment. This option will be removed shortly."));
+        if (showAllWarnings || (!AppProps.getInstance().isDevMode() && DbLoginManager.getPasswordRule().isDeprecated()))
+            warnings.add(HtmlString.of("Database authentication is configured with \"" + DbLoginManager.getPasswordRule().name() + "\" strength, which is not appropriate for a production deployment. This option will be removed shortly."));
     }
 
     private void getHeapSizeWarnings(Warnings warnings, boolean showAllWarnings)

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -192,7 +192,7 @@ public class CoreWarningProvider implements WarningProvider
     private void getPasswordRuleWarnings(Warnings warnings, boolean showAllWarnings)
     {
         if (showAllWarnings || (!AppProps.getInstance().isDevMode() && DbLoginManager.getPasswordRule() == PasswordRule.Weak))
-            warnings.add(HtmlString.of("Database authentication is configured with \"Weak\" strength, which is not appropriate for a production deployment."));
+            warnings.add(HtmlString.of("Database authentication is configured with \"Weak\" strength, which is not appropriate for a production deployment. This option will be removed shortly."));
     }
 
     private void getHeapSizeWarnings(Warnings warnings, boolean showAllWarnings)


### PR DESCRIPTION
#### Rationale
Address a few late-breaking requests on the password rules

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4707

#### Changes
* Make all entropy-rule filtering case-insensitive. "aAa" -> "a", "wxYZ" -> "w", personal info is removed regardless of casing, etc.
* Filter out the reverse common sequences as well. "4321" -> "4", "zyxw" -> "z", "ytrewq" -> "y", etc.
* Add unit tests for filtering changes.
* Indicate in the dialog and admin warning that the Weak rule is going away soon.