### PR TITLE
Add support for generating assay data and more specifics for sample types

### DIFF
--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -402,7 +402,7 @@ public class DataGenerator<T extends DataGenerator.Config>
     {
         if (_config.getMaxAliquotsPerParent() <= 0)
         {
-            _log.info(String.format("Generating no aliquots because maxAliquotsPerParent is %d", _config.getMaxAliquotsPerParent()));
+            _log.info(String.format("Generating no aliquots because %s is %d", Config.MAX_ALIQUOTS_PER_SAMPLE, _config.getMaxAliquotsPerParent()));
             return 0;
         }
 
@@ -427,6 +427,7 @@ public class DataGenerator<T extends DataGenerator.Config>
             List<Map<String, Object>> parents = getRandomSamples(sampleType, Math.min(10, Math.max(quantity, quantity / 100)));
             numGenerated = generateAliquotsForParents(parents, svc, quantity - totalAliquots, 0, 1, randomInt(1, _config.getMaxGenerations()), sampleStatuses);
             totalAliquots += numGenerated;
+            _log.info("... " + totalAliquots);
             iterations++;
         }
         while (totalAliquots < quantity && numGenerated > 0);
@@ -479,7 +480,7 @@ public class DataGenerator<T extends DataGenerator.Config>
             if (errors.hasErrors())
                 throw errors;
         }
-        _log.info(String.format("... %d (generation %d)", (numGenerated + generatedCount), generation));
+//        _log.info(String.format("... %d (generation %d)", (numGenerated + generatedCount), generation));
         // for some of the aliquots, possibly generate further aliquot generations
         if (generatedCount < quantity && generation < maxGenerations)
         {

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -323,6 +323,7 @@ public class DataGenerator<T extends DataGenerator.Config>
             return;
         }
         List<String> parentTypes = new ArrayList<>(config.getSampleTypeParents());
+        boolean hasParentTypes = !parentTypes.isEmpty();
         List<String> dataClassParents = new ArrayList<>(config.getDataClassParents());
         for (ExpSampleType sampleType : getSampleTypes(_config.getSampleTypeNames()))
         {
@@ -334,7 +335,8 @@ public class DataGenerator<T extends DataGenerator.Config>
             _log.info(String.format("Generating %d samples for sample type '%s' took %s.", numGenerated, sampleType.getName(), timer.getDuration()));
 
             numSamples = Math.min(numSamples + sampleIncrement, config.getMaxSamples());
-            parentTypes.add(sampleType.getName());
+            if (!hasParentTypes)
+                parentTypes.add(sampleType.getName());
         }
     }
 

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -1,11 +1,13 @@
 package org.labkey.api.data.generator;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
@@ -46,9 +48,11 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +63,8 @@ import java.util.stream.Collectors;
 
 public class DataGenerator<T extends DataGenerator.Config>
 {
+    private static final String SEARCH_FIELD_NAME = "Search";
+    private static final String USED_FIELD_NAME = "Used";
     private static final List<String> UNITS = List.of("g", "mg", "uL", "mL", "unit");
     private static final List<String> LABEL_COLORS = new ArrayList<>();
     static {
@@ -95,10 +101,12 @@ public class DataGenerator<T extends DataGenerator.Config>
     protected List<ExpSampleType> _sampleTypes = new ArrayList<>();
 
     protected Map<Integer, Long> _sampleTypeCounts = new HashMap<>();
+    protected Map<Integer, Long> _dataClassCounts = new HashMap<>();
 
     public record NamingPatternData(String prefix, Long startGenId) {};
 
     // Map from type name to a pair of name prefix and suffix (genId) start value
+    // TODO perhaps not needed anymore since we can select somewhat randomly from existing samples?
     protected final Map<String, NamingPatternData> _nameData = new HashMap<>();
 
     protected List<ExpDataClass> _customDataClasses = new ArrayList<>();
@@ -192,6 +200,18 @@ public class DataGenerator<T extends DataGenerator.Config>
 
     public List<? extends ExpSampleType> getSampleTypes()
     {
+        if (_sampleTypes.isEmpty())
+        {
+            SampleTypeService service = SampleTypeService.get();
+            if (_config.getSampleTypeNames().isEmpty())
+                _sampleTypes.addAll(service.getSampleTypes(getContainer(), getUser(), false));
+            else
+            {
+                _config.getSampleTypeNames().forEach(typeName -> {
+                    _sampleTypes.add(service.getSampleType(getContainer(), getUser(), typeName));
+                });
+            }
+        }
         return _sampleTypes;
     }
 
@@ -280,16 +300,18 @@ public class DataGenerator<T extends DataGenerator.Config>
     {
         List<GWTPropertyDescriptor> props = new ArrayList<>();
         props.add(new GWTPropertyDescriptor("Name", "string"));
+        props.add(new GWTPropertyDescriptor(SEARCH_FIELD_NAME, "string"));
+        props.add(new GWTPropertyDescriptor(USED_FIELD_NAME, "boolean"));
         addDomainProperties(props, numFields);
 
         SampleTypeService service = SampleTypeService.get();
-        _log.info(String.format("Creating Sample Type '%s' with %d fields", sampleTypeName, numFields));
+        _log.info(String.format("Creating Sample Type '%s' with %d fields", sampleTypeName, numFields+2));
         return service.createSampleType(_container, _user, sampleTypeName,
                 "Generated sample type", props, List.of(), -1, -1, -1, -1, namingPattern, null, null, null,
                 randomIndex(LABEL_COLORS), randomIndex(UNITS));
     }
 
-    public void generateSamplesForAllTypes(List<String> dataClassParents) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
+    public void generateSamplesForAllTypes() throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
     {
         DataGenerator.Config config = getConfig();
 
@@ -300,8 +322,9 @@ public class DataGenerator<T extends DataGenerator.Config>
             _log.info(String.format("No samples generated because %s=%d and %s=%d", Config.MIN_SAMPLES, numSamples, Config.MAX_SAMPLES, config.getMaxSamples()));
             return;
         }
-        List<String> parentTypes = new ArrayList<>();
-        for (ExpSampleType sampleType : _sampleTypes)
+        List<String> parentTypes = new ArrayList<>(config.getSampleTypeParents());
+        List<String> dataClassParents = new ArrayList<>(config.getDataClassParents());
+        for (ExpSampleType sampleType : getSampleTypes())
         {
             _log.info(String.format("Generating %d samples for sample type '%s'.", numSamples, sampleType.getName()));
             CPUTimer timer = addTimer(String.format("%d '%s' samples", numSamples, sampleType.getName()));
@@ -332,10 +355,25 @@ public class DataGenerator<T extends DataGenerator.Config>
         {
             _log.info(String.format("Generating %d samples derived from data class objects.", numDerivedFromDataClass));
 
-            int numPerParentType = numDerivedFromDataClass / dataClassParentTypes.size();
+            int numPerParentGroup = numDerivedFromDataClass / dataClassParentTypes.size();
+            int numTypesPer = randomInt(_config.getMinDataClassParentTypesPerSample(), Math.min(_config.getMaxDataClassParentTypesPerSample(), dataClassParentTypes.size()));
             for (String parentType : dataClassParentTypes)
             {
-                numGenerated += generateDerivedSamples(sampleType, parentType, true, numPerParentType, _container);
+                Set<String> sampleParentTypes = new HashSet<>();
+                sampleParentTypes.add(parentType);
+                int iterationCount = 0;
+                if (numTypesPer == dataClassParentTypes.size())
+                    sampleParentTypes.addAll(dataClassParentTypes);
+                else
+                {
+                    while (sampleParentTypes.size() < numTypesPer && iterationCount < dataClassParentTypes.size() * 2)
+                    {
+                        sampleParentTypes.add(randomIndex(dataClassParentTypes));
+                        iterationCount++;
+                    }
+                }
+
+                numGenerated += generateDerivedSamples(sampleType, sampleParentTypes, true, numPerParentGroup, _container);
             }
         }
 
@@ -348,7 +386,7 @@ public class DataGenerator<T extends DataGenerator.Config>
             int numPerParentType = numDerivedFromSamples / sampleTypeParents.size();
             for (String parentType : sampleTypeParents)
             {
-                numGenerated += generateDerivedSamples(sampleType, parentType, false, numPerParentType, _container);
+                numGenerated += generateDerivedSamples(sampleType, Set.of(parentType), false, numPerParentType, _container);
             }
         }
         // TODO create some % of the pooled samples
@@ -448,32 +486,93 @@ public class DataGenerator<T extends DataGenerator.Config>
         return generatedCount;
     }
 
-    public List<Integer> selectExistingSamples(ExpSampleType sampleType, int limit, long totalSampleCount)
+    public List<Integer> selectExistingSampleIds(int limit, long totalSampleCount, ContainerFilter containerFilter)
+    {
+        if (limit <= 0)
+            return Collections.emptyList();
+
+        TableInfo tableInfo = ExpSchema.TableType.Materials.createTable(new ExpSchema(getUser(), getContainer()), ExpSchema.TableType.Materials.toString(), containerFilter);
+        SQLFragment sql = limitFromOffsetSqlFrag(tableInfo, "RowId", limit, totalSampleCount);
+        return new SqlSelector(tableInfo.getSchema(), sql).getArrayList(Integer.class);
+    }
+
+    public List<Integer> selectExistingSamplesIds(ExpSampleType sampleType, int limit, long totalSampleCount, ContainerFilter containerFilter)
+    {
+        if (limit <= 0)
+            return Collections.emptyList();
+
+        TableInfo tableInfo = getSamplesSchema().getTable(sampleType.getName(), containerFilter);
+        SQLFragment sql = limitFromOffsetSqlFrag(tableInfo, "RowId", limit, totalSampleCount);
+        return new SqlSelector(tableInfo.getSchema(), sql).getArrayList(Integer.class);
+    }
+
+    private SQLFragment limitFromOffsetSqlFrag(TableInfo tableInfo, String columns, int limit, long totalCount)
+    {
+        if (limit <= 0)
+            return null;
+
+        SQLFragment sql = new SQLFragment("SELECT " + columns + " FROM ")
+                .append(tableInfo, "dc")
+                .append(" LIMIT ")
+                .appendValue(limit);
+        if (totalCount > limit)
+            sql.append(" OFFSET ")
+                    .appendValue(randomLong(0, totalCount-limit));
+        return sql;
+    }
+
+    public List<Map<String, Object>> selectExistingSamples(ExpSampleType sampleType, int limit, long totalSampleCount)
     {
         if (limit <= 0)
             return Collections.emptyList();
 
         TableInfo tableInfo = getSamplesSchema().getTable(sampleType.getName());
-        SQLFragment sql = new SQLFragment("SELECT RowId FROM ")
-                .append(tableInfo)
-                .append(" LIMIT ")
-                .appendValue(limit);
-        if (totalSampleCount > limit)
-            sql.append(" OFFSET ")
-                .appendValue(randomLong(0, totalSampleCount-limit));
-        return new SqlSelector(tableInfo.getSchema(), sql).getArrayList(Integer.class);
+        if (tableInfo == null)
+        {
+            _log.warn("Sample type '" + sampleType.getName() + "' not found.");
+            return Collections.emptyList();
+        }
+        SQLFragment sql = limitFromOffsetSqlFrag(tableInfo, "RowId, Name", limit, totalSampleCount);
+        return Arrays.stream(new SqlSelector(tableInfo.getSchema(), sql).getMapArray()).toList();
+    }
+
+    public List<Map<String, Object>> selectExistingDataClassObjects(ExpDataClass dataClass, int limit, long totalSampleCount)
+    {
+        if (limit <= 0)
+            return Collections.emptyList();
+
+        TableInfo tableInfo = getDataClassSchema().getTable(dataClass.getName());
+        if (tableInfo == null)
+        {
+            _log.warn("Data class '" + dataClass.getName() + "' not found.");
+            return Collections.emptyList();
+        }
+        SQLFragment sql = limitFromOffsetSqlFrag(tableInfo, "RowId, Name", limit, totalSampleCount);
+        return Arrays.stream(new SqlSelector(tableInfo.getSchema(), sql).getMapArray()).toList();
     }
 
     private List<Map<String, Object>> getRandomSamples(ExpSampleType sampleType, int quantity)
     {
         TableInfo tableInfo = getSamplesSchema().getTable(sampleType.getName());
-        return getRowsByRandomNames(tableInfo, _nameData.get(sampleType.getName()), sampleType.getCurrentGenId(), quantity, Set.of("Name", "RowId"));
+        if (_nameData.containsKey(sampleType.getName()))
+            return getRowsByRandomNames(tableInfo, _nameData.get(sampleType.getName()), sampleType.getCurrentGenId(), quantity, Set.of("Name", "RowId"));
+        else
+        {
+            _sampleTypeCounts.computeIfAbsent(sampleType.getRowId(), t -> sampleType.getSamplesCount(getContainer(), null));
+            return selectExistingSamples(sampleType, quantity, _sampleTypeCounts.get(sampleType.getRowId()));
+        }
     }
 
     private List<Map<String, Object>> getRandomDataClassObjects(ExpDataClass dataClass, int quantity)
     {
         TableInfo tableInfo = getDataClassSchema().getTable(dataClass.getName());
-        return getRowsByRandomNames(tableInfo, _nameData.get(dataClass.getName()), dataClass.getCurrentGenId(), quantity, Set.of("Name", "RowId"));
+        if (_nameData.containsKey(dataClass.getName()))
+            return getRowsByRandomNames(tableInfo, _nameData.get(dataClass.getName()), dataClass.getCurrentGenId(), quantity, Set.of("Name", "RowId"));
+        else
+        {
+            _dataClassCounts.computeIfAbsent(dataClass.getRowId(), t -> dataClass.getDataCount(getContainer(), null));
+            return selectExistingDataClassObjects(dataClass, quantity, _dataClassCounts.get(dataClass.getRowId()));
+        }
     }
 
     protected List<Map<String, Object>> getRowsByRandomNames(TableInfo tableInfo, NamingPatternData namingData, long endIndex, int quantity, Set<String> columns)
@@ -560,7 +659,7 @@ public class DataGenerator<T extends DataGenerator.Config>
         return generateDomainData(numObjects, svc, dataClass.getDomain(), _container);
     }
 
-    public int generateDerivedSamples(ExpSampleType sampleType, String parentQueryName, boolean isDataClass, int quantity, Container container) throws SQLException, BatchValidationException
+    public int generateDerivedSamples(ExpSampleType sampleType, Collection<String> parentQueryNames, boolean isDataClass, int quantity, Container container) throws SQLException, BatchValidationException
     {
         if (_config.getMaxChildrenPerParent() <= 0)
         {
@@ -569,19 +668,28 @@ public class DataGenerator<T extends DataGenerator.Config>
         }
 
         String parentInput;
-        ExpObject parentObject;
+        List<ExpObject> parentObjects = new ArrayList<>();
         if (isDataClass)
         {
             parentInput = "DataInputs";
-            parentObject = ExperimentService.get().getDataClass(_container, _user, parentQueryName);
+            parentQueryNames.forEach(parentQueryName -> {
+                ExpObject parentObject = ExperimentService.get().getDataClass(_container, _user, parentQueryName);
+                if (parentObject != null)
+                    parentObjects.add(parentObject);
+            });
         }
         else
         {
             parentInput = "MaterialInputs";
-            parentObject = SampleTypeService.get().getSampleType(_container, _user, parentQueryName);
+            parentQueryNames.forEach(parentQueryName -> {
+                ExpObject parentObject = SampleTypeService.get().getSampleType(_container, _user, parentQueryName);
+                if (parentObject != null)
+                    parentObjects.add(parentObject);
+            });
+
         }
-        _log.info(String.format("Generating %d '%s' samples derived from '%s/%s' ...", quantity, sampleType.getName(), parentInput, parentQueryName));
-        CPUTimer timer = addTimer(String.format("%d '%s/%s' derived samples", quantity, parentInput, parentQueryName));
+        _log.info(String.format("Generating %d '%s' samples derived from '%s/%s' ...", quantity, sampleType.getName(), parentInput, parentQueryNames));
+        CPUTimer timer = addTimer(String.format("%d '%s/%s' derived samples", quantity, parentInput, parentQueryNames));
         timer.start();
         BatchValidationException errors = new BatchValidationException();
         TableInfo tableInfo = getSamplesSchema().getTable(sampleType.getName());
@@ -593,19 +701,30 @@ public class DataGenerator<T extends DataGenerator.Config>
         {
             int numRows = Math.min(batchSize, quantity - totalImported);
             List<Map<String, Object>> rows = createRows(numRows, sampleType.getDomain());
-            // choose a random set of object names from the parent type
-            List<Map<String, Object>> parents = isDataClass ?
-                    getRandomDataClassObjects((ExpDataClass) parentObject, batchSize) :
-                    getRandomSamples((ExpSampleType) parentObject, batchSize);
+            Map<String, List<Map<String, Object>>> parentLists = new HashMap<>();
+            int minParentsSize = -1;
+            for (ExpObject parentObject : parentObjects)
+            {
+                // choose a random set of object names from the parent type
+                List<Map<String, Object>> parents = isDataClass ?
+                        getRandomDataClassObjects((ExpDataClass) parentObject, batchSize) :
+                        getRandomSamples((ExpSampleType) parentObject, batchSize);
+                parentLists.put(parentObject.getName(), parents);
+                if (minParentsSize < 0 || parents.size() < minParentsSize)
+                    minParentsSize = parents.size();
+            }
+
             int rowNum = 0;
             int p = 0;
-            while (rowNum < rows.size() && p < parents.size())
+            while (rowNum < rows.size() && p < minParentsSize)
             {
                 // choose a random number of derivatives for the current parent
                 int numDerivatives = randomInt(1, _config.getMaxChildrenPerParent());
                 for (int i = 0; i < numDerivatives && rowNum < rows.size(); i++)
                 {
-                    rows.get(rowNum).put(parentInput + "/" + parentQueryName, parents.get(p).get("name"));
+                    Map<String, Object> row = rows.get(rowNum);
+                    for (Map.Entry<String, List<Map<String, Object>>> parentEntry : parentLists.entrySet())
+                        row.put(parentInput + "/" + parentEntry.getKey(), parentEntry.getValue().get(p).get("name"));
                     rowNum++;
                 }
                 p++;
@@ -618,7 +737,7 @@ public class DataGenerator<T extends DataGenerator.Config>
         }
         timer.stop();
 
-        _log.info(String.format("Generating %d '%s' samples derived from '%s/%s' took %s.", quantity, sampleType.getName(), parentInput, parentQueryName, timer.getDuration()));
+        _log.info(String.format("Generating %d '%s' samples derived from '%s/%s' took %s.", quantity, sampleType.getName(), parentInput, parentQueryNames, timer.getDuration()));
         return totalImported;
     }
 
@@ -672,7 +791,7 @@ public class DataGenerator<T extends DataGenerator.Config>
         }
     }
 
-    private List<Map<String, Object>> createRows(int numRows, Domain domain)
+    protected List<Map<String, Object>> createRows(int numRows, Domain domain)
     {
         List<Map<String, Object>> rows = new ArrayList<>();
         for (int i = 1; i <= numRows; i++)
@@ -750,6 +869,11 @@ public class DataGenerator<T extends DataGenerator.Config>
         public static final String MAX_GENERATIONS = "maxGenerations";
         public static final String MIN_NUM_FIELDS = "minFields";
         public static final String MAX_NUM_FIELDS = "maxFields";
+        public static final String SAMPLE_TYPE_NAMES = "sampleTypeNames";
+        public static final String DATA_CLASS_PARENTS = "dataClassParents";
+        public static final String SAMPLE_TYPE_PARENTS = "sampleTypeParents";
+        public static final String MIN_DATA_CLASS_PARENT_TYPES_PER_SAMPLE = "minDataClassParentTypesPerSample";
+        public static final String MAX_DATA_CLASS_PARENT_TYPES_PER_SAMPLE = "maxDataClassParentTypesPerSample";
 
         int _numFolders;
         int _numSampleTypes;
@@ -765,6 +889,21 @@ public class DataGenerator<T extends DataGenerator.Config>
         int _maxChildrenPerParent;
         int _minFields;
         int _maxFields;
+        List<String> _sampleTypeNames;
+        List<String> _dataClassParents;
+        List<String> _sampleTypeParents;
+        int _minDataClassParentTypesPerSample;
+        int _maxDataClassParentTypesPerSample;
+
+        public List<String> getSampleTypeNames()
+        {
+            return _sampleTypeNames;
+        }
+
+        public void setSampleTypeNames(List<String> sampleTypeNames)
+        {
+            _sampleTypeNames = sampleTypeNames;
+        }
 
         public Config(Properties properties)
         {
@@ -785,6 +924,22 @@ public class DataGenerator<T extends DataGenerator.Config>
             _minFields = Integer.parseInt(properties.getProperty(MIN_NUM_FIELDS, "1"));
             _maxFields = Math.max(Integer.parseInt(properties.getProperty(MAX_NUM_FIELDS, "1")), _minFields);
 
+            _sampleTypeNames = parseNameList(properties, SAMPLE_TYPE_NAMES);
+            _dataClassParents = parseNameList(properties, DATA_CLASS_PARENTS);
+            _sampleTypeParents = parseNameList(properties, SAMPLE_TYPE_PARENTS);
+            _minDataClassParentTypesPerSample = Integer.parseInt(properties.getProperty(MIN_DATA_CLASS_PARENT_TYPES_PER_SAMPLE, "0"));
+            _maxDataClassParentTypesPerSample = Integer.parseInt(properties.getProperty(MAX_DATA_CLASS_PARENT_TYPES_PER_SAMPLE, "1"));
+
+        }
+
+        protected List<String> parseNameList(Properties properties, String propertyName)
+        {
+            String parentConfigProp = properties.getProperty(propertyName);
+            if (!StringUtils.isEmpty(parentConfigProp))
+            {
+                return Arrays.stream(parentConfigProp.split(";")).toList();
+            }
+            return Collections.emptyList();
         }
 
         public int getNumFolders()
@@ -925,6 +1080,46 @@ public class DataGenerator<T extends DataGenerator.Config>
         public void setMaxFields(int maxFields)
         {
             _maxFields = maxFields;
+        }
+
+        public List<String> getDataClassParents()
+        {
+            return _dataClassParents;
+        }
+
+        public void setDataClassParents(List<String> dataClassParents)
+        {
+            _dataClassParents = dataClassParents;
+        }
+
+        public List<String> getSampleTypeParents()
+        {
+            return _sampleTypeParents;
+        }
+
+        public void setSampleTypeParents(List<String> sampleTypeParents)
+        {
+            _sampleTypeParents = sampleTypeParents;
+        }
+
+        public int getMinDataClassParentTypesPerSample()
+        {
+            return _minDataClassParentTypesPerSample;
+        }
+
+        public void setMinDataClassParentTypesPerSample(int minDataClassParentTypesPerSample)
+        {
+            _minDataClassParentTypesPerSample = minDataClassParentTypesPerSample;
+        }
+
+        public int getMaxDataClassParentTypesPerSample()
+        {
+            return _maxDataClassParentTypesPerSample;
+        }
+
+        public void setMaxDataClassParentTypesPerSample(int maxDataClassParentTypesPerSample)
+        {
+            _maxDataClassParentTypesPerSample = maxDataClassParentTypesPerSample;
         }
     }
 

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -480,7 +480,6 @@ public class DataGenerator<T extends DataGenerator.Config>
             if (errors.hasErrors())
                 throw errors;
         }
-//        _log.info(String.format("... %d (generation %d)", (numGenerated + generatedCount), generation));
         // for some of the aliquots, possibly generate further aliquot generations
         if (generatedCount < quantity && generation < maxGenerations)
         {

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -480,6 +480,7 @@ public class DataGenerator<T extends DataGenerator.Config>
             if (errors.hasErrors())
                 throw errors;
         }
+        _log.info(String.format("...... %d (generation %d)", (numGenerated + generatedCount), generation));
         // for some of the aliquots, possibly generate further aliquot generations
         if (generatedCount < quantity && generation < maxGenerations)
         {

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -198,16 +198,16 @@ public class DataGenerator<T extends DataGenerator.Config>
         _config = config;
     }
 
-    public List<? extends ExpSampleType> getSampleTypes()
+    public List<? extends ExpSampleType> getSampleTypes(List<String> sampleTypeNames)
     {
         if (_sampleTypes.isEmpty())
         {
             SampleTypeService service = SampleTypeService.get();
-            if (_config.getSampleTypeNames().isEmpty())
+            if (sampleTypeNames.isEmpty())
                 _sampleTypes.addAll(service.getSampleTypes(getContainer(), getUser(), false));
             else
             {
-                _config.getSampleTypeNames().forEach(typeName -> {
+                sampleTypeNames.forEach(typeName -> {
                     _sampleTypes.add(service.getSampleType(getContainer(), getUser(), typeName));
                 });
             }
@@ -324,7 +324,7 @@ public class DataGenerator<T extends DataGenerator.Config>
         }
         List<String> parentTypes = new ArrayList<>(config.getSampleTypeParents());
         List<String> dataClassParents = new ArrayList<>(config.getDataClassParents());
-        for (ExpSampleType sampleType : getSampleTypes())
+        for (ExpSampleType sampleType : getSampleTypes(_config.getSampleTypeNames()))
         {
             _log.info(String.format("Generating %d samples for sample type '%s'.", numSamples, sampleType.getName()));
             CPUTimer timer = addTimer(String.format("%d '%s' samples", numSamples, sampleType.getName()));

--- a/api/src/org/labkey/api/data/generator/DataGeneratorRegistry.java
+++ b/api/src/org/labkey/api/data/generator/DataGeneratorRegistry.java
@@ -7,6 +7,7 @@ public class DataGeneratorRegistry
 {
     public enum DataType {
         AssayDesigns,
+        AssayRunData,
         StorageHierarchy,
         SamplesInStorage,
         WorkflowJobs,

--- a/api/src/org/labkey/api/exp/api/ExpDataClass.java
+++ b/api/src/org/labkey/api/exp/api/ExpDataClass.java
@@ -18,6 +18,7 @@ package org.labkey.api.exp.api;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.security.User;
@@ -50,6 +51,8 @@ public interface ExpDataClass extends ExpObject
     List<? extends ExpData> getDatas();
 
     ExpData getData(Container c, String name);
+
+    long getDataCount(Container c, @Nullable ContainerFilter cf);
 
     /** Get the SampleType related to this ExpDataClass. */
     @Nullable

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -69,7 +69,7 @@ public class ExpSchema extends AbstractExpSchema
 
     public static final SchemaKey SCHEMA_EXP = SchemaKey.fromParts(ExpSchema.SCHEMA_NAME);
     public static final SchemaKey SCHEMA_EXP_DATA = SchemaKey.fromString(SCHEMA_EXP, ExpSchema.NestedSchemas.data.name());
-    private static final Set<String> ADDITIONAL_SOURES_AUDIT_FIELDS = new CaseInsensitiveHashSet("Name");
+    private static final Set<String> ADDITIONAL_SOURCES_AUDIT_FIELDS = new CaseInsensitiveHashSet("Name");
 
     public enum NestedSchemas
     {
@@ -120,8 +120,6 @@ public class ExpSchema extends AbstractExpSchema
             @Override
             public TableInfo createTable(ExpSchema expSchema, String queryName, ContainerFilter cf)
             {
-                SamplesSchema schema = new SamplesSchema(expSchema.getPath(), expSchema.getUser(), expSchema.getContainer());
-                schema.setContainerFilter(expSchema._containerFilter);
                 ExpMaterialTable ret = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), expSchema, cf);
                 ret.populate(null, true);
                 return ret;
@@ -406,7 +404,7 @@ public class ExpSchema extends AbstractExpSchema
     {
         registry(null, null),
         media(null, null),
-        sources(AuditBehaviorType.DETAILED, ADDITIONAL_SOURES_AUDIT_FIELDS);
+        sources(AuditBehaviorType.DETAILED, ADDITIONAL_SOURCES_AUDIT_FIELDS);
 
         public AuditBehaviorType defaultBehavior;
         public Set<String> additionalAuditFields;

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -63,6 +63,7 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.assay.data.generator.AssayDesignGenerator;
+import org.labkey.assay.data.generator.AssayRunDataGenerator;
 import org.labkey.assay.pipeline.AssayImportRunTask;
 import org.labkey.assay.plate.AssayPlateDataDomainKind;
 import org.labkey.assay.plate.AssayPlateMetadataServiceImpl;
@@ -160,6 +161,7 @@ public class AssayModule extends SpringModule
         RoleManager.registerRole(new AssayDesignerRole());
 
         DataGeneratorRegistry.registerGenerator(DataGeneratorRegistry.DataType.AssayDesigns, new AssayDesignGenerator.Driver());
+        DataGeneratorRegistry.registerGenerator(DataGeneratorRegistry.DataType.AssayRunData, new AssayRunDataGenerator.Driver());
     }
 
     @Override

--- a/assay/src/org/labkey/assay/data/generator/AssayRunDataGenerator.java
+++ b/assay/src/org/labkey/assay/data/generator/AssayRunDataGenerator.java
@@ -1,0 +1,236 @@
+package org.labkey.assay.data.generator;
+
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssayService;
+import org.labkey.api.assay.DefaultAssayRunCreator;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.generator.DataGenerator;
+import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ExpSampleType;
+import org.labkey.api.exp.api.SampleTypeService;
+import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.exp.query.SamplesSchema;
+import org.labkey.api.gwt.client.assay.AssayException;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.query.SchemaKey;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.util.CPUTimer;
+import org.labkey.api.view.ViewContext;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import static org.labkey.api.gwt.client.ui.PropertyType.SAMPLE_CONCEPT_URI;
+
+public class AssayRunDataGenerator extends DataGenerator<AssayRunDataGenerator.Config>
+{
+
+    public AssayRunDataGenerator(PipelineJob job, Config config)
+    {
+        super(job, config);
+    }
+
+    public void generateAssayRunData() throws ValidationException, AssayException, ExperimentException
+    {
+        AssayProvider provider = AssayService.get().getProvider("General");
+        if (provider == null)
+            throw new ValidationException("No provider for 'General' assays.");
+        List<String> designNames = _config.getAssayDesignNames();
+        List<ExpProtocol>  protocols = AssayService.get().getAssayProtocols(getContainer(), provider);
+        if (!designNames.isEmpty())
+        {
+            protocols = protocols.stream().filter(protocol -> designNames.contains(protocol.getName())).toList();
+        }
+        if (protocols.isEmpty())
+        {
+            _log.info("No assay run data generated because no protocols found matching parameters.");
+            return;
+        }
+        if (_config.getMaxRunsPerDesign() <= 0)
+        {
+            _log.info(String.format("No assay run data generated because %s=%d.", Config.MAX_RUNS_PER_DESIGN, _config.getMaxRunsPerDesign()));
+            return;
+        }
+        if (_config.getMaxRunsPerDesign() < _config.getMinRunsPerDesign())
+        {
+            _log.info(String.format("No assay run data generated because %s (%d) is less than %s (%d).", Config.MAX_RUNS_PER_DESIGN, _config.getMaxRunsPerDesign(), Config.MIN_RUNS_PER_DESIGN, _config.getMinRunsPerDesign()));
+            return;
+        }
+        if (_config.getMaxRowsPerRun() <= 0)
+        {
+            _log.info(String.format("No assay run data generated because %s=%s.", Config.MAX_ROWS_PER_RUN, _config.getMaxRowsPerRun()));
+            return;
+        }
+        if (_config.getMaxRowsPerRun() < _config.getMinRowsPerRun())
+        {
+            _log.info(String.format("No assay run data generated because %s (%d) is less than %s (%d).", Config.MAX_ROWS_PER_RUN, _config.getMaxRowsPerRun(), Config.MIN_ROWS_PER_RUN, _config.getMinRowsPerRun()));
+            return;
+        }
+        ViewContext context = new ViewContext();
+        context.setUser(getUser());
+        context.setContainer(getContainer());
+
+        for (ExpProtocol protocol : protocols)
+        {
+            int numRuns = randomInt(_config.getMinRunsPerDesign(), _config.getMaxRunsPerDesign());
+            CPUTimer timer = addTimer(String.format("%d '%s' assay runs", numRuns, protocol.getName()));
+            timer.start();
+            Domain resultsDomain = provider.getResultsDomain(protocol);
+            for (int i = 0; i < numRuns; i++)
+            {
+                checkAlive(_job);
+                int numRows = randomInt(_config.getMinRowsPerRun(), _config.getMaxRowsPerRun());
+                _log.info(String.format("Generating %d rows of run data for run %d of design %s", numRows, i, protocol.getName()));
+                List<Map<String, Object>> rawData = createRows(numRows, resultsDomain);
+                updateSampleProps(protocol.getName(), rawData, resultsDomain);
+                var factory = provider.createRunUploadFactory(protocol, context)
+                        .setName(protocol.getName() + " - Run " + (i+1) )
+                        .setJobDescription("Run with " + rawData.size() + " results.")
+                        .setRawData(rawData)
+                        .setUploadedData(Collections.emptyMap());
+                Map<Object, String> outputData = new HashMap<>();
+                // Create an ExpData for the results
+                DefaultAssayRunCreator.generateResultData(getUser(), getContainer(), provider, rawData, outputData, null);
+                factory.setOutputDatas(outputData);
+                provider.getRunCreator().saveExperimentRun(factory.create(), null);
+            }
+            timer.stop();
+        };
+    }
+
+    private void updateSampleProps(String protocolName, List<Map<String, Object>> rawData, Domain resultsDomain)
+    {
+        ContainerFilter currentCf = ContainerFilter.current(getContainer());
+        List<DomainProperty> sampleProps = resultsDomain.getProperties().stream().filter(prop -> SAMPLE_CONCEPT_URI.equals(prop.getConceptURI())).collect(Collectors.toList());
+        // Find the sample type for each sample field.
+        for (DomainProperty sampleProp : sampleProps)
+        {
+            if (sampleProp.getLookup().getSchemaKey().equals(SchemaKey.fromParts(SamplesSchema.SCHEMA_NAME)))
+            {
+                String sampleTypeName = sampleProp.getLookup().getQueryName();
+                ExpSampleType sampleType = SampleTypeService.get().getSampleType(getContainer(), sampleTypeName);
+                if (sampleType == null)
+                {
+                    _log.warn(String.format("Sample type '%s' referenced in assay design %s not found.", sampleTypeName, protocolName));
+                    // remove the values set by the default data generator for the row since they won't be valid sample ids.
+                    rawData.forEach(row -> {
+                        row.put(sampleProp.getName(), null);
+                    });
+                }
+                else
+                {
+                    List<Integer> sampleIds = new ArrayList<>();
+                    while (sampleIds.size() < rawData.size())
+                    {
+                        _sampleTypeCounts.computeIfAbsent(sampleType.getRowId(), t -> sampleType.getSamplesCount(getContainer(), null));
+                        sampleIds.addAll(selectExistingSamplesIds(sampleType, Math.min(5, rawData.size() - sampleIds.size()), _sampleTypeCounts.get(sampleType.getRowId()), currentCf));
+                    }
+                    for (int i = 0; i < rawData.size(); i++)
+                        rawData.get(i).put(sampleProp.getName(), sampleIds.get(i));
+                }
+            }
+            else
+            {
+                List<Integer> sampleIds = new ArrayList<>();
+                long totalSampleCount = SampleTypeService.get().getProjectSampleCount(getContainer());
+                while (sampleIds.size() < rawData.size())
+                    sampleIds.addAll(selectExistingSampleIds(Math.min(5, rawData.size() - sampleIds.size()), totalSampleCount, currentCf));
+                for (int i = 0; i < rawData.size(); i++)
+                    rawData.get(i).put(sampleProp.getName(), sampleIds.get(i));
+            }
+        }
+    }
+
+    public static class Config extends DataGenerator.Config
+    {
+        public static final String MIN_RUNS_PER_DESIGN = "minRunsPerDesign";
+        public static final String MAX_RUNS_PER_DESIGN = "maxRunsPerDesign";
+        public static final String MIN_ROWS_PER_RUN = "minRowsPerRun";
+        public static final String MAX_ROWS_PER_RUN = "maxRowsPerRun";
+        public static final String ASSAY_DESIGNS = "assayDesignNames";
+        List<String> _assayDesignNames;
+        int _minRunsPerDesign;
+        int _maxRunsPerDesign;
+        int _minRowsPerRun;
+        int _maxRowsPerRun;
+
+
+        public Config(Properties properties)
+        {
+            super(properties);
+            _minRunsPerDesign = Integer.parseInt(properties.getProperty(MIN_RUNS_PER_DESIGN, "0"));
+            _maxRunsPerDesign = Integer.parseInt(properties.getProperty(MAX_RUNS_PER_DESIGN, "0"));
+            _assayDesignNames = parseNameList(properties, ASSAY_DESIGNS);
+            _minRowsPerRun = Integer.parseInt(properties.getProperty(MIN_ROWS_PER_RUN, "0"));
+            _maxRowsPerRun = Integer.parseInt(properties.getProperty(MAX_ROWS_PER_RUN, "0"));
+        }
+
+        public List<String> getAssayDesignNames()
+        {
+            return _assayDesignNames;
+        }
+
+        public void setAssayDesignNames(List<String> assayDesignNames)
+        {
+            _assayDesignNames = assayDesignNames;
+        }
+
+        public int getMinRunsPerDesign()
+        {
+            return _minRunsPerDesign;
+        }
+
+        public void setMinRunsPerDesign(int minRunsPerDesign)
+        {
+            _minRunsPerDesign = minRunsPerDesign;
+        }
+
+        public int getMaxRunsPerDesign()
+        {
+            return _maxRunsPerDesign;
+        }
+
+        public void setMaxRunsPerDesign(int maxRunsPerDesign)
+        {
+            _maxRunsPerDesign = maxRunsPerDesign;
+        }
+
+        public int getMinRowsPerRun()
+        {
+            return _minRowsPerRun;
+        }
+
+        public void setMinRowsPerRun(int minRowsPerRun)
+        {
+            _minRowsPerRun = minRowsPerRun;
+        }
+
+        public int getMaxRowsPerRun()
+        {
+            return _maxRowsPerRun;
+        }
+
+        public void setMaxRowsPerRun(int maxRowsPerRun)
+        {
+            _maxRowsPerRun = maxRowsPerRun;
+        }
+    }
+
+    public static class Driver implements DataGenerationDriver
+    {
+        @Override
+        public List<CPUTimer> generateData(PipelineJob job, Properties properties) throws ValidationException, AssayException, ExperimentException
+        {
+            AssayRunDataGenerator generator = new AssayRunDataGenerator(job, new AssayRunDataGenerator.Config(properties));
+            generator.generateAssayRunData();
+            return generator.getTimers();
+        }
+    }
+}

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
@@ -22,10 +22,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSequence;
 import org.labkey.api.data.DbSequenceManager;
 import org.labkey.api.data.NameGenerator;
+import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.ChangePropertyDescriptorException;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
@@ -42,6 +45,7 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.query.ExpSchema;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.RuntimeValidationException;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
@@ -217,6 +221,18 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
     public ExpDataImpl getData(Container c, String name)
     {
         return ExperimentServiceImpl.get().getExpData(this, /*c, */ name);
+    }
+
+    @Override
+    public long getDataCount(Container c, @Nullable ContainerFilter cf)
+    {
+        SimpleFilter filter = SimpleFilter.createContainerFilter(c);
+        filter.addCondition(FieldKey.fromParts("CpasType"), getLSID());
+        if (cf != null)
+            filter.addCondition(cf.createFilterClause(ExperimentServiceImpl.get().getExpSchema(), FieldKey.fromParts("Container")));
+
+        TableInfo tInfo = ExperimentServiceImpl.get().getTinfoData();
+        return new TableSelector(tInfo, tInfo.getPkColumns(), filter, null).getRowCount();
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
For testing application behavior and performance in the face of large sample types, we want to be able to do more incremental data generation, specifying existing sample types and data classes to use in the process where it makes sense. We also want to have assay run data for the samples to be able to assess application performance with this data. 

#### Related Pull Requests
- https://github.com/LabKey/inventory/pull/1003
- https://github.com/LabKey/labbook/pull/534
- https://github.com/LabKey/biologics/pull/2346
- https://github.com/LabKey/sampleManagement/pull/2069


#### Changes
* Add new `DataType.AssayRunData` for data generation
* Update `AssayDesignDataGenerator` to properly wire up the sampleID fields
* Add `AssayRunDataGenerator`
