### PR TITLE
Tests should set and use the standard password

### DIFF
--- a/devtools/test/src/org/labkey/test/tests/devtools/SecondaryAuthenticationTest.java
+++ b/devtools/test/src/org/labkey/test/tests/devtools/SecondaryAuthenticationTest.java
@@ -120,7 +120,7 @@ public class SecondaryAuthenticationTest extends BaseWebDriverTest
         String relativeURLBeforeSignIn = getCurrentRelativeURL();
 
             //Sign In - Primary Authentication before Secondary Authentication
-            attemptSignIn(PasswordUtil.getUsername(), PasswordUtil.getPassword());
+            attemptSignIn();
 
             /* Secondary Authentication */
 


### PR DESCRIPTION
#### Rationale
Tests should call the variants that always use the standard password. This makes identifying outliers easier.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1628