### PR TITLE
Plates: Metadata In-App Editing

### DIFF
--- a/assay/api-src/org/labkey/api/assay/plate/PlateCustomField.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateCustomField.java
@@ -3,6 +3,8 @@ package org.labkey.api.assay.plate;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.labkey.api.exp.property.DomainProperty;
 
+import java.util.Objects;
+
 /**
  * Represents a custom field that is configured for a specific plate
  */
@@ -76,5 +78,28 @@ public class PlateCustomField
     public void setContainer(String container)
     {
         _container = container;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(_name, _label, _propertyURI, _rangeURI, _container);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final PlateCustomField field = (PlateCustomField) o;
+
+        return (
+            Objects.equals(this.getName(), field.getName()) &&
+            Objects.equals(this.getPropertyURI(), field.getPropertyURI()) &&
+            Objects.equals(this.getRangeURI(), field.getRangeURI()) &&
+            Objects.equals(this.getLabel(), field.getLabel()) &&
+            Objects.equals(this.getContainer(), field.getContainer())
+        );
     }
 }

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.365.3-fb-plate-editing.1"
+        "@labkey/components": "2.365.3-fb-plate-editing.2"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2351,9 +2351,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
-      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
+      "version": "2.365.3-fb-plate-editing.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
+      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -12361,9 +12361,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
-      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
+      "version": "2.365.3-fb-plate-editing.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
+      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.358.2-fb-test-stability.0"
+        "@labkey/components": "2.365.3-fb-plate-editing.1"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2312,9 +2312,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.23.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.23.0.tgz",
-      "integrity": "sha512-wZj62pN30b+JjVIj7GB4im+FhG8TdrO8lfMgCh7l0OVehMGU5PW1ThekYYtzEawmc/WoNlzT4ytRYqxZ5GHTDA=="
+      "version": "1.24.1-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
+      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
     },
     "node_modules/@labkey/build": {
       "version": "6.12.0",
@@ -2351,11 +2351,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.358.2-fb-test-stability.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.358.2-fb-test-stability.0.tgz",
-      "integrity": "sha512-GFzXesMGK/jvXH2luShhz2SC1STBoNKuzI3PuAvo1Z+vp1KKhX7tpN1S/py05OWsu8pQSANBYhBJK28yJKHHMw==",
+      "version": "2.365.3-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
+      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
       "dependencies": {
-        "@labkey/api": "1.23.0",
+        "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -12322,9 +12322,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.23.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.23.0.tgz",
-      "integrity": "sha512-wZj62pN30b+JjVIj7GB4im+FhG8TdrO8lfMgCh7l0OVehMGU5PW1ThekYYtzEawmc/WoNlzT4ytRYqxZ5GHTDA=="
+      "version": "1.24.1-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
+      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
     },
     "@labkey/build": {
       "version": "6.12.0",
@@ -12361,11 +12361,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.358.2-fb-test-stability.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.358.2-fb-test-stability.0.tgz",
-      "integrity": "sha512-GFzXesMGK/jvXH2luShhz2SC1STBoNKuzI3PuAvo1Z+vp1KKhX7tpN1S/py05OWsu8pQSANBYhBJK28yJKHHMw==",
+      "version": "2.365.3-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
+      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
       "requires": {
-        "@labkey/api": "1.23.0",
+        "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.365.3-fb-plate-editing.2"
+        "@labkey/components": "2.365.3-fb-plate-editing.3"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2351,9 +2351,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
-      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
+      "version": "2.365.3-fb-plate-editing.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
+      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -12361,9 +12361,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
-      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
+      "version": "2.365.3-fb-plate-editing.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
+      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.366.1-fb-plate-editing.0"
+        "@labkey/components": "2.367.0"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2312,9 +2312,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.24.1-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
-      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
+      "version": "1.24.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.2.tgz",
+      "integrity": "sha512-7j/OBYaZOwCl5i5r8c3pr+mYNhR5g4mamKq2mQ3peAdjG9LIfouJXAUWI4nZ3Czhw3Yp0EyumPgpqjwZN5DDjw=="
     },
     "node_modules/@labkey/build": {
       "version": "6.12.0",
@@ -2351,11 +2351,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.366.1-fb-plate-editing.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
-      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
+      "version": "2.367.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.367.0.tgz",
+      "integrity": "sha512-mfRRoeG0UWSb5Xt2Q6wOScmqQK0qkT7ITCWs+ftjZ7zuAc2KAxJ6DvGxjAxNDksJu0XV6wZx1lhzO1k70esaog==",
       "dependencies": {
-        "@labkey/api": "1.24.1-fb-plate-editing.1",
+        "@labkey/api": "1.24.2",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -12322,9 +12322,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.24.1-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
-      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
+      "version": "1.24.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.2.tgz",
+      "integrity": "sha512-7j/OBYaZOwCl5i5r8c3pr+mYNhR5g4mamKq2mQ3peAdjG9LIfouJXAUWI4nZ3Czhw3Yp0EyumPgpqjwZN5DDjw=="
     },
     "@labkey/build": {
       "version": "6.12.0",
@@ -12361,11 +12361,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.366.1-fb-plate-editing.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
-      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
+      "version": "2.367.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.367.0.tgz",
+      "integrity": "sha512-mfRRoeG0UWSb5Xt2Q6wOScmqQK0qkT7ITCWs+ftjZ7zuAc2KAxJ6DvGxjAxNDksJu0XV6wZx1lhzO1k70esaog==",
       "requires": {
-        "@labkey/api": "1.24.1-fb-plate-editing.1",
+        "@labkey/api": "1.24.2",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.365.3-fb-plate-editing.3"
+        "@labkey/components": "2.366.1-fb-plate-editing.0"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2351,9 +2351,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
-      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
+      "version": "2.366.1-fb-plate-editing.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
+      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -12361,9 +12361,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
-      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
+      "version": "2.366.1-fb-plate-editing.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
+      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.358.2-fb-test-stability.0"
+    "@labkey/components": "2.365.3-fb-plate-editing.1"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.365.3-fb-plate-editing.2"
+    "@labkey/components": "2.365.3-fb-plate-editing.3"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.366.1-fb-plate-editing.0"
+    "@labkey/components": "2.367.0"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.365.3-fb-plate-editing.3"
+    "@labkey/components": "2.366.1-fb-plate-editing.0"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.365.3-fb-plate-editing.1"
+    "@labkey/components": "2.365.3-fb-plate-editing.2"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -751,6 +751,16 @@ public class PlateController extends SpringActionController
         }
     }
 
+    @RequiresPermission(UpdatePermission.class)
+    public static class SetFieldsAction extends MutatingApiAction<CustomFieldsForm>
+    {
+        @Override
+        public Object execute(CustomFieldsForm form, BindException errors) throws Exception
+        {
+            return success(PlateManager.get().setFields(getContainer(), getUser(), form.getPlateId(), form.getFields()));
+        }
+    }
+
     @RequiresPermission(DesignVocabularyPermission.class)
     public static class EnsurePlateMetadataDomainAction extends MutatingApiAction<Object>
     {

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -109,6 +109,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
@@ -352,6 +353,21 @@ public class PlateManager implements PlateService
                 return PlateCache.getPlate(c, lsid);
         }
         return null;
+    }
+
+    private @NotNull Plate requirePlate(Container container, int plateRowId, @Nullable String errorPrefix)
+    {
+        Plate plate = getPlate(container, plateRowId);
+        if (plate == null)
+        {
+            String error = "Plate id \"" + plateRowId + "\" not found.";
+            String errorPrefix_ = StringUtils.trimToEmpty(errorPrefix);
+            if (!errorPrefix_.isEmpty())
+                error = errorPrefix_ + " " + error;
+            throw new IllegalArgumentException(error);
+        }
+
+        return plate;
     }
 
     /**
@@ -1230,7 +1246,7 @@ public class PlateManager implements PlateService
      */
     public @Nullable Domain getPlateMetadataDomain(Container container, User user)
     {
-        DomainKind vocabDomainKind = PropertyService.get().getDomainKindByName("Vocabulary");
+        DomainKind<?> vocabDomainKind = PropertyService.get().getDomainKindByName("Vocabulary");
 
         if (vocabDomainKind == null)
             return null;
@@ -1255,7 +1271,7 @@ public class PlateManager implements PlateService
 
         if (vocabDomain == null)
         {
-            DomainKind domainKind = PropertyService.get().getDomainKindByName("Vocabulary");
+            DomainKind<?> domainKind = PropertyService.get().getDomainKindByName("Vocabulary");
             Container domainContainer = getPlateMetadataDomainContainer(container);
 
             if (!domainKind.canCreateDefinition(user, domainContainer))
@@ -1272,10 +1288,7 @@ public class PlateManager implements PlateService
     public @NotNull List<PlateCustomField> createPlateMetadataFields(Container container, User user, List<GWTPropertyDescriptor> fields) throws Exception
     {
         Domain vocabDomain = ensurePlateMetadataDomain(container, user);
-        DomainKind domainKind = vocabDomain.getDomainKind();
-
-        if (vocabDomain == null)
-            throw new IllegalArgumentException("Unable to create fields on the domain, the domain was not found.");
+        DomainKind<?> domainKind = vocabDomain.getDomainKind();
 
         if (!domainKind.canEditDefinition(user, vocabDomain))
             throw new IllegalArgumentException("Unable to create field on domain \"" + vocabDomain.getTypeURI() + "\". Insufficient permissions.");
@@ -1348,14 +1361,14 @@ public class PlateManager implements PlateService
     public @NotNull List<PlateCustomField> getPlateMetadataFields(Container container, User user)
     {
         Domain vocabDomain = getPlateMetadataDomain(container, user);
-        if (vocabDomain != null)
-        {
-            List<PlateCustomField> fields = vocabDomain.getProperties().stream().map(PlateCustomField::new).toList();
-            return fields.stream()
-                    .sorted(Comparator.comparing(PlateCustomField::getName))
-                    .collect(Collectors.toList());
-        }
-        return Collections.emptyList();
+        if (vocabDomain == null)
+            return Collections.emptyList();
+
+        return vocabDomain.getProperties()
+                .stream()
+                .map(PlateCustomField::new)
+                .sorted(Comparator.comparing(PlateCustomField::getName))
+                .collect(Collectors.toList());
     }
 
     public @NotNull List<PlateCustomField> addFields(Container container, User user, Integer plateId, List<PlateCustomField> fields) throws SQLException
@@ -1366,9 +1379,7 @@ public class PlateManager implements PlateService
         if (fields == null || fields.size() == 0)
             throw new IllegalArgumentException("Failed to add plate custom fields. No fields specified.");
 
-        Plate plate = getPlate(container, plateId);
-        if (plate == null)
-            throw new IllegalArgumentException("Failed to add plate custom fields. Plate id \"" + plateId + "\" not found.");
+        Plate plate = requirePlate(container, plateId, "Failed to add plate custom fields.");
 
         Domain domain = getPlateMetadataDomain(container, user);
         if (domain == null)
@@ -1414,12 +1425,9 @@ public class PlateManager implements PlateService
         return getFields(container, plateId);
     }
 
-    public List<PlateCustomField> getFields(Container container, Integer plateId)
+    public @NotNull List<PlateCustomField> getFields(Container container, Integer plateId)
     {
-        Plate plate = getPlate(container, plateId);
-        if (plate == null)
-            throw new IllegalArgumentException("Failed to get plate custom fields. Plate id \"" + plateId + "\" not found.");
-
+        Plate plate = requirePlate(container, plateId, "Failed to get plate custom fields.");
         return plate.getCustomFields();
     }
 
@@ -1428,10 +1436,6 @@ public class PlateManager implements PlateService
      */
     private List<DomainProperty> _getFields(Container container, User user, Integer plateId)
     {
-        Plate plate = getPlate(container, plateId);
-        if (plate == null)
-            throw new IllegalArgumentException("Failed to get plate custom fields. Plate id \"" + plateId + "\" not found.");
-
         Domain domain = getPlateMetadataDomain(container, user);
         if (domain == null)
             throw new IllegalArgumentException("Failed to get plate custom fields. Custom fields domain does not exist. Try creating fields first.");
@@ -1453,14 +1457,15 @@ public class PlateManager implements PlateService
 
     public List<WellCustomField> getWellCustomFields(Container container, User user, Integer plateId, Integer wellId)
     {
-        List<WellCustomField> fields = _getFields(container, user, plateId).stream().map(WellCustomField::new).toList();
+        Plate plate = requirePlate(container, plateId, "Failed to get well custom fields.");
 
-        // need to get the well values associated with each custom field
-        Plate plate = getPlate(container, plateId);
         Well well = plate.getWell(wellId);
         if (well == null)
             throw new IllegalArgumentException("Failed to get well custom fields. Well id \"" + wellId   + "\" not found.");
 
+        List<WellCustomField> fields = _getFields(container, user, plateId).stream().map(WellCustomField::new).toList();
+
+        // need to get the well values associated with each custom field
         Map<String, Object> properties = OntologyManager.getProperties(container, well.getLsid());
         for (WellCustomField field : fields)
             field.setValue(properties.get(field.getPropertyURI()));
@@ -1472,9 +1477,7 @@ public class PlateManager implements PlateService
 
     public List<PlateCustomField> removeFields(Container container, User user, Integer plateId, List<PlateCustomField> fields)
     {
-        Plate plate = getPlate(container, plateId);
-        if (plate == null)
-            throw new IllegalArgumentException("Failed to remove plate custom fields. Plate id \"" + plateId + "\" not found.");
+        Plate plate = requirePlate(container, plateId, "Failed to remove plate custom fields.");
 
         Domain domain = getPlateMetadataDomain(container, user);
         if (domain == null)
@@ -1514,6 +1517,53 @@ public class PlateManager implements PlateService
             }
         }
         return getFields(container, plateId);
+    }
+
+    public List<PlateCustomField> setFields(Container container, User user, Integer plateRowId, List<PlateCustomField> fields) throws SQLException
+    {
+        requirePlate(container, plateRowId, "Failed to set plate custom fields.");
+
+        List<PlateCustomField> allFields = getPlateMetadataFields(container, user);
+        Set<PlateCustomField> currentFields = new HashSet<>(getFields(container, plateRowId));
+
+        Set<PlateCustomField> desiredFields = new HashSet<>();
+        List<PlateCustomField> fieldsToAdd = new ArrayList<>();
+        List<PlateCustomField> fieldsToRemove = new ArrayList<>();
+
+        for (PlateCustomField partialField : fields)
+        {
+            Optional<PlateCustomField> opt = allFields.stream().filter(f -> f.getName().equals(partialField.getName()) || f.getPropertyURI().equals(partialField.getPropertyURI())).findFirst();
+            if (opt.isEmpty())
+                throw new IllegalArgumentException("Failed to set plate custom fields. Unable to resolve field with (name, propertyURI) (%s, %s)".formatted(partialField.getName(), partialField.getPropertyURI()));
+
+            PlateCustomField field = opt.get();
+            desiredFields.add(field);
+
+            if (currentFields.contains(field))
+                currentFields.remove(field);
+            else
+                fieldsToAdd.add(field);
+        }
+
+        for (PlateCustomField currentField : currentFields)
+        {
+            if (!desiredFields.contains(currentField))
+                fieldsToRemove.add(currentField);
+        }
+
+        if (!fieldsToAdd.isEmpty() || !fieldsToRemove.isEmpty())
+        {
+            try (DbScope.Transaction tx = ExperimentService.get().ensureTransaction())
+            {
+                if (!fieldsToRemove.isEmpty())
+                    removeFields(container, user, plateRowId, fieldsToRemove);
+                if (!fieldsToAdd.isEmpty())
+                    addFields(container, user, plateRowId, fieldsToAdd);
+                tx.commit();
+            }
+        }
+
+        return getFields(container, plateRowId);
     }
 
     public static final class TestCase
@@ -1705,13 +1755,13 @@ public class PlateManager implements PlateService
             List<PlateCustomField> fields = PlateManager.get().createPlateMetadataFields(c, user, customFields);
 
             // Verify returned sorted by name
-            assertTrue("Expected plate custom fields", fields.size() == 3);
-            assertTrue("Expected barcode custom field", fields.get(0).getName().equals("barcode"));
-            assertTrue("Expected concentration custom field", fields.get(1).getName().equals("concentration"));
-            assertTrue("Expected negativeControl custom field", fields.get(2).getName().equals("negativeControl"));
+            assertEquals("Expected plate custom fields", 3, fields.size());
+            assertEquals("Expected barcode custom field", "barcode", fields.get(0).getName());
+            assertEquals("Expected concentration custom field", "concentration", fields.get(1).getName());
+            assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(2).getName());
 
             // assign custom fields to the plate
-            assertTrue("Expected custom fields to be added to the plate", PlateManager.get().addFields(c, user, plateId, fields).size() == 3);
+            assertEquals("Expected custom fields to be added to the plate", 3, PlateManager.get().addFields(c, user, plateId, fields).size());
 
             // verification when adding custom fields to the plate
             try
@@ -1721,14 +1771,14 @@ public class PlateManager implements PlateService
             }
             catch (IllegalArgumentException e)
             {
-                assertTrue("Expected validation exception", e.getMessage().equals("Failed to add plate custom fields. Custom field \"barcode\" already is associated with this plate."));
+                assertEquals("Expected validation exception", "Failed to add plate custom fields. Custom field \"barcode\" already is associated with this plate.", e.getMessage());
             }
 
             // remove a plate custom field
             fields = PlateManager.get().removeFields(c, user, plateId, List.of(fields.get(0)));
-            assertTrue("Expected 2 plate custom fields", fields.size() == 2);
-            assertTrue("Expected concentration custom field", fields.get(0).getName().equals("concentration"));
-            assertTrue("Expected negativeControl custom field", fields.get(1).getName().equals("negativeControl"));
+            assertEquals("Expected 2 plate custom fields", 2, fields.size());
+            assertEquals("Expected concentration custom field", "concentration", fields.get(0).getName());
+            assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(1).getName());
 
             // select wells
             SimpleFilter filter = SimpleFilter.createContainerFilter(c);
@@ -1736,11 +1786,12 @@ public class PlateManager implements PlateService
             filter.addCondition(FieldKey.fromParts("Row"), 0);
             List< org.labkey.assay.plate.model.Well> wells = new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), filter, new Sort("Col")).getArrayList(org.labkey.assay.plate.model.Well.class);
 
-            assertTrue("Expected 24 wells to be returned", wells.size() == 24);
+            assertEquals("Expected 24 wells to be returned", 24, wells.size());
 
             // update
             TableInfo wellTable = QueryService.get().getUserSchema(user, c, PlateSchema.SCHEMA_NAME).getTable(WellTable.NAME);
             QueryUpdateService qus = wellTable.getUpdateService();
+            assertNotNull(qus);
             BatchValidationException errors = new BatchValidationException();
 
             // verify metadata update works for Property URI as well as field key

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1368,7 +1368,7 @@ public class PlateManager implements PlateService
                 .stream()
                 .map(PlateCustomField::new)
                 .sorted(Comparator.comparing(PlateCustomField::getName))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public @NotNull List<PlateCustomField> addFields(Container container, User user, Integer plateId, List<PlateCustomField> fields) throws SQLException

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
-        "@labkey/components": "2.365.2-fb-plate-editing.0",
+        "@labkey/components": "2.365.3-fb-plate-editing.1",
         "@labkey/themes": "1.3.1"
       },
       "devDependencies": {
@@ -3053,9 +3053,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.2-fb-plate-editing.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.2-fb-plate-editing.0.tgz",
-      "integrity": "sha512-cOSYSqQcipTFi+wS8F8Nx6trJn3BIL3O44oK4fV8tUh27gsS3xVFQZucX/tkOrhvmEUXTYCbspjd/7LcINGrRA==",
+      "version": "2.365.3-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
+      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -17692,9 +17692,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.2-fb-plate-editing.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.2-fb-plate-editing.0.tgz",
-      "integrity": "sha512-cOSYSqQcipTFi+wS8F8Nx6trJn3BIL3O44oK4fV8tUh27gsS3xVFQZucX/tkOrhvmEUXTYCbspjd/7LcINGrRA==",
+      "version": "2.365.3-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
+      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,8 +8,8 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/api": "1.24.1-fb-plate-editing.1",
-        "@labkey/components": "2.366.1-fb-plate-editing.0",
+        "@labkey/api": "1.24.2",
+        "@labkey/components": "2.367.0",
         "@labkey/themes": "1.3.1"
       },
       "devDependencies": {
@@ -3014,9 +3014,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.24.1-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
-      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
+      "version": "1.24.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.2.tgz",
+      "integrity": "sha512-7j/OBYaZOwCl5i5r8c3pr+mYNhR5g4mamKq2mQ3peAdjG9LIfouJXAUWI4nZ3Czhw3Yp0EyumPgpqjwZN5DDjw=="
     },
     "node_modules/@labkey/build": {
       "version": "6.12.0",
@@ -3053,11 +3053,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.366.1-fb-plate-editing.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
-      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
+      "version": "2.367.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.367.0.tgz",
+      "integrity": "sha512-mfRRoeG0UWSb5Xt2Q6wOScmqQK0qkT7ITCWs+ftjZ7zuAc2KAxJ6DvGxjAxNDksJu0XV6wZx1lhzO1k70esaog==",
       "dependencies": {
-        "@labkey/api": "1.24.1-fb-plate-editing.1",
+        "@labkey/api": "1.24.2",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -17653,9 +17653,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.24.1-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
-      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
+      "version": "1.24.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.2.tgz",
+      "integrity": "sha512-7j/OBYaZOwCl5i5r8c3pr+mYNhR5g4mamKq2mQ3peAdjG9LIfouJXAUWI4nZ3Czhw3Yp0EyumPgpqjwZN5DDjw=="
     },
     "@labkey/build": {
       "version": "6.12.0",
@@ -17692,11 +17692,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.366.1-fb-plate-editing.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
-      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
+      "version": "2.367.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.367.0.tgz",
+      "integrity": "sha512-mfRRoeG0UWSb5Xt2Q6wOScmqQK0qkT7ITCWs+ftjZ7zuAc2KAxJ6DvGxjAxNDksJu0XV6wZx1lhzO1k70esaog==",
       "requires": {
-        "@labkey/api": "1.24.1-fb-plate-editing.1",
+        "@labkey/api": "1.24.2",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
-        "@labkey/components": "2.365.3-fb-plate-editing.1",
+        "@labkey/components": "2.365.3-fb-plate-editing.2",
         "@labkey/themes": "1.3.1"
       },
       "devDependencies": {
@@ -3053,9 +3053,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
-      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
+      "version": "2.365.3-fb-plate-editing.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
+      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -17692,9 +17692,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
-      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
+      "version": "2.365.3-fb-plate-editing.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
+      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
-        "@labkey/components": "2.365.3-fb-plate-editing.2",
+        "@labkey/components": "2.365.3-fb-plate-editing.3",
         "@labkey/themes": "1.3.1"
       },
       "devDependencies": {
@@ -3053,9 +3053,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
-      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
+      "version": "2.365.3-fb-plate-editing.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
+      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -17692,9 +17692,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
-      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
+      "version": "2.365.3-fb-plate-editing.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
+      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,8 +8,8 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/api": "1.24.1",
-        "@labkey/components": "2.362.3",
+        "@labkey/api": "1.24.1-fb-plate-editing.1",
+        "@labkey/components": "2.365.2-fb-plate-editing.0",
         "@labkey/themes": "1.3.1"
       },
       "devDependencies": {
@@ -3014,9 +3014,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.24.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1.tgz",
-      "integrity": "sha512-wMZ7DVtPPpxGn089Q1rlkfSrrWW6iH3d1AXM+azpb7X6ZRz6s/eNeLKQLTE4j4WgoHVTc6AK3RyIt1i/wtAQxA=="
+      "version": "1.24.1-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
+      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
     },
     "node_modules/@labkey/build": {
       "version": "6.12.0",
@@ -3053,11 +3053,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.362.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.362.3.tgz",
-      "integrity": "sha512-4OOTEoFV16bv9s8Uwaib1UiXJya7lu+EcY3vJur3Q5Ob7gnflLbaEaI0olTHBKOIkTsyeWP4UN9vEW7X0bz1iQ==",
+      "version": "2.365.2-fb-plate-editing.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.2-fb-plate-editing.0.tgz",
+      "integrity": "sha512-cOSYSqQcipTFi+wS8F8Nx6trJn3BIL3O44oK4fV8tUh27gsS3xVFQZucX/tkOrhvmEUXTYCbspjd/7LcINGrRA==",
       "dependencies": {
-        "@labkey/api": "1.24.1",
+        "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -17653,9 +17653,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.24.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1.tgz",
-      "integrity": "sha512-wMZ7DVtPPpxGn089Q1rlkfSrrWW6iH3d1AXM+azpb7X6ZRz6s/eNeLKQLTE4j4WgoHVTc6AK3RyIt1i/wtAQxA=="
+      "version": "1.24.1-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
+      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
     },
     "@labkey/build": {
       "version": "6.12.0",
@@ -17692,11 +17692,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.362.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.362.3.tgz",
-      "integrity": "sha512-4OOTEoFV16bv9s8Uwaib1UiXJya7lu+EcY3vJur3Q5Ob7gnflLbaEaI0olTHBKOIkTsyeWP4UN9vEW7X0bz1iQ==",
+      "version": "2.365.2-fb-plate-editing.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.2-fb-plate-editing.0.tgz",
+      "integrity": "sha512-cOSYSqQcipTFi+wS8F8Nx6trJn3BIL3O44oK4fV8tUh27gsS3xVFQZucX/tkOrhvmEUXTYCbspjd/7LcINGrRA==",
       "requires": {
-        "@labkey/api": "1.24.1",
+        "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
-        "@labkey/components": "2.365.3-fb-plate-editing.3",
+        "@labkey/components": "2.366.1-fb-plate-editing.0",
         "@labkey/themes": "1.3.1"
       },
       "devDependencies": {
@@ -3053,9 +3053,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
-      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
+      "version": "2.366.1-fb-plate-editing.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
+      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -17692,9 +17692,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
-      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
+      "version": "2.366.1-fb-plate-editing.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
+      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.24.1-fb-plate-editing.1",
-    "@labkey/components": "2.365.3-fb-plate-editing.3",
+    "@labkey/components": "2.366.1-fb-plate-editing.0",
     "@labkey/themes": "1.3.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.24.1-fb-plate-editing.1",
-    "@labkey/components": "2.365.3-fb-plate-editing.1",
+    "@labkey/components": "2.365.3-fb-plate-editing.2",
     "@labkey/themes": "1.3.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,8 +54,8 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "1.24.1",
-    "@labkey/components": "2.362.3",
+    "@labkey/api": "1.24.1-fb-plate-editing.1",
+    "@labkey/components": "2.365.2-fb-plate-editing.0",
     "@labkey/themes": "1.3.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.24.1-fb-plate-editing.1",
-    "@labkey/components": "2.365.3-fb-plate-editing.2",
+    "@labkey/components": "2.365.3-fb-plate-editing.3",
     "@labkey/themes": "1.3.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,8 +54,8 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "1.24.1-fb-plate-editing.1",
-    "@labkey/components": "2.366.1-fb-plate-editing.0",
+    "@labkey/api": "1.24.2",
+    "@labkey/components": "2.367.0",
     "@labkey/themes": "1.3.1"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.24.1-fb-plate-editing.1",
-    "@labkey/components": "2.365.2-fb-plate-editing.0",
+    "@labkey/components": "2.365.3-fb-plate-editing.1",
     "@labkey/themes": "1.3.1"
   },
   "devDependencies": {

--- a/core/src/client/DomainDesigner/DomainDesigner.tsx
+++ b/core/src/client/DomainDesigner/DomainDesigner.tsx
@@ -90,7 +90,7 @@ export class App extends React.PureComponent<any, Partial<IAppState>> {
 
         this.setState(() => ({submitting: true}));
 
-        saveDomain(domain, undefined, {domainId: domain.domainId}, undefined,  includeWarnings)
+        saveDomain({ domain, options: { domainId: domain.domainId }, includeWarnings })
             .then((savedDomain) => {
                 this.setState(() => ({
                     domain: savedDomain,

--- a/core/src/client/LabKeyUIComponentsPage/EditableGridPage.tsx
+++ b/core/src/client/LabKeyUIComponentsPage/EditableGridPage.tsx
@@ -46,7 +46,7 @@ const EditableGridPageBody: FC<InjectedQueryModels> = memo(props => {
         })();
     }, [model]);
 
-    const onGridChange = useCallback<EditableGridChange>((changes, dataKeys?, data?) => {
+    const onGridChange = useCallback<EditableGridChange>((event, changes, dataKeys?, data?) => {
         setModels(models_ => {
             const { dataModels, editorModels } = applyEditableGridChangesToModels(
                 [models_.dataModel],

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.365.3-fb-plate-editing.2"
+        "@labkey/components": "2.365.3-fb-plate-editing.3"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -3020,9 +3020,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
-      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
+      "version": "2.365.3-fb-plate-editing.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
+      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -16594,9 +16594,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
-      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
+      "version": "2.365.3-fb-plate-editing.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
+      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.365.3-fb-plate-editing.1"
+        "@labkey/components": "2.365.3-fb-plate-editing.2"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -3020,9 +3020,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
-      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
+      "version": "2.365.3-fb-plate-editing.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
+      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -16594,9 +16594,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
-      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
+      "version": "2.365.3-fb-plate-editing.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
+      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.362.3"
+        "@labkey/components": "2.365.3-fb-plate-editing.1"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2981,9 +2981,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.24.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1.tgz",
-      "integrity": "sha512-wMZ7DVtPPpxGn089Q1rlkfSrrWW6iH3d1AXM+azpb7X6ZRz6s/eNeLKQLTE4j4WgoHVTc6AK3RyIt1i/wtAQxA=="
+      "version": "1.24.1-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
+      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
     },
     "node_modules/@labkey/build": {
       "version": "6.12.0",
@@ -3020,11 +3020,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.362.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.362.3.tgz",
-      "integrity": "sha512-4OOTEoFV16bv9s8Uwaib1UiXJya7lu+EcY3vJur3Q5Ob7gnflLbaEaI0olTHBKOIkTsyeWP4UN9vEW7X0bz1iQ==",
+      "version": "2.365.3-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
+      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
       "dependencies": {
-        "@labkey/api": "1.24.1",
+        "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -16555,9 +16555,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.24.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1.tgz",
-      "integrity": "sha512-wMZ7DVtPPpxGn089Q1rlkfSrrWW6iH3d1AXM+azpb7X6ZRz6s/eNeLKQLTE4j4WgoHVTc6AK3RyIt1i/wtAQxA=="
+      "version": "1.24.1-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
+      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
     },
     "@labkey/build": {
       "version": "6.12.0",
@@ -16594,11 +16594,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.362.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.362.3.tgz",
-      "integrity": "sha512-4OOTEoFV16bv9s8Uwaib1UiXJya7lu+EcY3vJur3Q5Ob7gnflLbaEaI0olTHBKOIkTsyeWP4UN9vEW7X0bz1iQ==",
+      "version": "2.365.3-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
+      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
       "requires": {
-        "@labkey/api": "1.24.1",
+        "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.365.3-fb-plate-editing.3"
+        "@labkey/components": "2.366.1-fb-plate-editing.0"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -3020,9 +3020,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
-      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
+      "version": "2.366.1-fb-plate-editing.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
+      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -16594,9 +16594,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
-      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
+      "version": "2.366.1-fb-plate-editing.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
+      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.366.1-fb-plate-editing.0"
+        "@labkey/components": "2.367.0"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2981,9 +2981,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.24.1-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
-      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
+      "version": "1.24.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.2.tgz",
+      "integrity": "sha512-7j/OBYaZOwCl5i5r8c3pr+mYNhR5g4mamKq2mQ3peAdjG9LIfouJXAUWI4nZ3Czhw3Yp0EyumPgpqjwZN5DDjw=="
     },
     "node_modules/@labkey/build": {
       "version": "6.12.0",
@@ -3020,11 +3020,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.366.1-fb-plate-editing.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
-      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
+      "version": "2.367.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.367.0.tgz",
+      "integrity": "sha512-mfRRoeG0UWSb5Xt2Q6wOScmqQK0qkT7ITCWs+ftjZ7zuAc2KAxJ6DvGxjAxNDksJu0XV6wZx1lhzO1k70esaog==",
       "dependencies": {
-        "@labkey/api": "1.24.1-fb-plate-editing.1",
+        "@labkey/api": "1.24.2",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -16555,9 +16555,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.24.1-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
-      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
+      "version": "1.24.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.2.tgz",
+      "integrity": "sha512-7j/OBYaZOwCl5i5r8c3pr+mYNhR5g4mamKq2mQ3peAdjG9LIfouJXAUWI4nZ3Czhw3Yp0EyumPgpqjwZN5DDjw=="
     },
     "@labkey/build": {
       "version": "6.12.0",
@@ -16594,11 +16594,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.366.1-fb-plate-editing.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
-      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
+      "version": "2.367.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.367.0.tgz",
+      "integrity": "sha512-mfRRoeG0UWSb5Xt2Q6wOScmqQK0qkT7ITCWs+ftjZ7zuAc2KAxJ6DvGxjAxNDksJu0XV6wZx1lhzO1k70esaog==",
       "requires": {
-        "@labkey/api": "1.24.1-fb-plate-editing.1",
+        "@labkey/api": "1.24.2",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "2.365.3-fb-plate-editing.1"
+    "@labkey/components": "2.365.3-fb-plate-editing.2"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "2.365.3-fb-plate-editing.2"
+    "@labkey/components": "2.365.3-fb-plate-editing.3"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "2.365.3-fb-plate-editing.3"
+    "@labkey/components": "2.366.1-fb-plate-editing.0"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "2.366.1-fb-plate-editing.0"
+    "@labkey/components": "2.367.0"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "2.362.3"
+    "@labkey/components": "2.365.3-fb-plate-editing.1"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.366.1-fb-plate-editing.0"
+        "@labkey/components": "2.367.0"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2386,9 +2386,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.24.1-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
-      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
+      "version": "1.24.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.2.tgz",
+      "integrity": "sha512-7j/OBYaZOwCl5i5r8c3pr+mYNhR5g4mamKq2mQ3peAdjG9LIfouJXAUWI4nZ3Czhw3Yp0EyumPgpqjwZN5DDjw=="
     },
     "node_modules/@labkey/build": {
       "version": "6.12.0",
@@ -2425,11 +2425,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.366.1-fb-plate-editing.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
-      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
+      "version": "2.367.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.367.0.tgz",
+      "integrity": "sha512-mfRRoeG0UWSb5Xt2Q6wOScmqQK0qkT7ITCWs+ftjZ7zuAc2KAxJ6DvGxjAxNDksJu0XV6wZx1lhzO1k70esaog==",
       "dependencies": {
-        "@labkey/api": "1.24.1-fb-plate-editing.1",
+        "@labkey/api": "1.24.2",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -13747,9 +13747,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.24.1-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
-      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
+      "version": "1.24.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.2.tgz",
+      "integrity": "sha512-7j/OBYaZOwCl5i5r8c3pr+mYNhR5g4mamKq2mQ3peAdjG9LIfouJXAUWI4nZ3Czhw3Yp0EyumPgpqjwZN5DDjw=="
     },
     "@labkey/build": {
       "version": "6.12.0",
@@ -13786,11 +13786,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.366.1-fb-plate-editing.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
-      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
+      "version": "2.367.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.367.0.tgz",
+      "integrity": "sha512-mfRRoeG0UWSb5Xt2Q6wOScmqQK0qkT7ITCWs+ftjZ7zuAc2KAxJ6DvGxjAxNDksJu0XV6wZx1lhzO1k70esaog==",
       "requires": {
-        "@labkey/api": "1.24.1-fb-plate-editing.1",
+        "@labkey/api": "1.24.2",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.365.3-fb-plate-editing.3"
+        "@labkey/components": "2.366.1-fb-plate-editing.0"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2425,9 +2425,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
-      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
+      "version": "2.366.1-fb-plate-editing.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
+      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -13786,9 +13786,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
-      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
+      "version": "2.366.1-fb-plate-editing.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.366.1-fb-plate-editing.0.tgz",
+      "integrity": "sha512-qwce0FofsmhgERHEM8rR1DYdO3c5duD9RGCJ0AClBX9o8bRIerZDJw2ihUhPsJ0BaqYQGCKvbb9igZFejIPtAA==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.365.3-fb-plate-editing.2"
+        "@labkey/components": "2.365.3-fb-plate-editing.3"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2425,9 +2425,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
-      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
+      "version": "2.365.3-fb-plate-editing.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
+      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -13786,9 +13786,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
-      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
+      "version": "2.365.3-fb-plate-editing.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.3.tgz",
+      "integrity": "sha512-VZkup209kAbuhIq/smDhflYusNnmobCH6qCSgQ95Z3jX+9YMHe+WIrYBbTUZ6GPUf8Xo/31dFSPBYypwAMOzTg==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.365.3-fb-plate-editing.1"
+        "@labkey/components": "2.365.3-fb-plate-editing.2"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2425,9 +2425,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
-      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
+      "version": "2.365.3-fb-plate-editing.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
+      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
       "dependencies": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
@@ -13786,9 +13786,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.365.3-fb-plate-editing.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
-      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
+      "version": "2.365.3-fb-plate-editing.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.2.tgz",
+      "integrity": "sha512-h/AsOqUC9Ar2K2zE0iyYhREI7DPfRNVwp5/RHoJixNgiGwK8gjUhu7ZYI5qMWAd04Wfn1kLzHWEPaCFVgAFq1A==",
       "requires": {
         "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.358.2-fb-test-stability.0"
+        "@labkey/components": "2.365.3-fb-plate-editing.1"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2386,9 +2386,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.23.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.23.0.tgz",
-      "integrity": "sha512-wZj62pN30b+JjVIj7GB4im+FhG8TdrO8lfMgCh7l0OVehMGU5PW1ThekYYtzEawmc/WoNlzT4ytRYqxZ5GHTDA=="
+      "version": "1.24.1-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
+      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
     },
     "node_modules/@labkey/build": {
       "version": "6.12.0",
@@ -2425,11 +2425,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.358.2-fb-test-stability.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.358.2-fb-test-stability.0.tgz",
-      "integrity": "sha512-GFzXesMGK/jvXH2luShhz2SC1STBoNKuzI3PuAvo1Z+vp1KKhX7tpN1S/py05OWsu8pQSANBYhBJK28yJKHHMw==",
+      "version": "2.365.3-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
+      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
       "dependencies": {
-        "@labkey/api": "1.23.0",
+        "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -13747,9 +13747,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.23.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.23.0.tgz",
-      "integrity": "sha512-wZj62pN30b+JjVIj7GB4im+FhG8TdrO8lfMgCh7l0OVehMGU5PW1ThekYYtzEawmc/WoNlzT4ytRYqxZ5GHTDA=="
+      "version": "1.24.1-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1-fb-plate-editing.1.tgz",
+      "integrity": "sha512-gFoTJ+yYZUYkrPB3RzSKR03k7/IbgWiDZxcazoTB+W5K3h5U1pwxKaEXzJU89GYVeA4A1SOP1S3XPCV1tTx0Zw=="
     },
     "@labkey/build": {
       "version": "6.12.0",
@@ -13786,11 +13786,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.358.2-fb-test-stability.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.358.2-fb-test-stability.0.tgz",
-      "integrity": "sha512-GFzXesMGK/jvXH2luShhz2SC1STBoNKuzI3PuAvo1Z+vp1KKhX7tpN1S/py05OWsu8pQSANBYhBJK28yJKHHMw==",
+      "version": "2.365.3-fb-plate-editing.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.365.3-fb-plate-editing.1.tgz",
+      "integrity": "sha512-pJ/SJ7+HKwmtBT3WFU7B7WHuGK0YrgZk7t+b/J2oCeOpe3lfciRrT/8aV0U8kowFVmBJTSQEfqoNzwlOpoESlg==",
       "requires": {
-        "@labkey/api": "1.23.0",
+        "@labkey/api": "1.24.1-fb-plate-editing.1",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.365.3-fb-plate-editing.2"
+    "@labkey/components": "2.365.3-fb-plate-editing.3"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.366.1-fb-plate-editing.0"
+    "@labkey/components": "2.367.0"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.358.2-fb-test-stability.0"
+    "@labkey/components": "2.365.3-fb-plate-editing.1"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.365.3-fb-plate-editing.1"
+    "@labkey/components": "2.365.3-fb-plate-editing.2"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.365.3-fb-plate-editing.3"
+    "@labkey/components": "2.366.1-fb-plate-editing.0"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -100,10 +100,11 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
             throw new NotFoundException("SchemaName not specified");
 
         QuerySchema querySchema = DefaultSchema.get(user, container, form.getSchemaName());
-        if (!(querySchema instanceof UserSchema))
-            // Don't echo the provided schema name. See #44528.
+        if (!(querySchema instanceof UserSchema schema))
+        {
+            // Issue 44528: Don't echo the provided schema name.
             throw new NotFoundException("Could not find the specified schema in the folder '" + container.getPath() + "'");
-        UserSchema schema = (UserSchema)querySchema;
+        }
 
         QuerySettings settings = schema.getSettings(getViewContext(), QueryView.DATAREGIONNAME_DEFAULT, form.getQueryName());
         QueryDefinition queryDef = settings.getQueryDef(schema);
@@ -179,8 +180,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
         resp.put("title", tinfo.getTitle());
         resp.put("titleColumn", tinfo.getTitleColumn());
 
-
-        //8649: let the table provide the view data url
+        // Issue 8649: let the table provide the view data url
         ActionURL viewDataUrl = schema.urlFor(QueryAction.executeQuery, queryDef);
         if (null != viewDataUrl)
             resp.put("viewDataUrl", viewDataUrl);
@@ -323,7 +323,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
             Map<String, CustomView> allViews = queryDef.getCustomViews(getUser(), getViewContext().getRequest(), true, false);
             Set<String> viewNames = new CaseInsensitiveHashSet("");
             if (form.getViewName() != null)
-                viewNames.addAll(Arrays.stream(form.getViewName()).map(StringUtils::trimToEmpty).collect(toList()));
+                viewNames.addAll(Arrays.stream(form.getViewName()).map(StringUtils::trimToEmpty).toList());
 
             if (viewNames.contains("*"))
             {


### PR DESCRIPTION
#### Rationale
This adds the `plate-setFields.api` endpoint to support specifying plate fields in bulk.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-js/pull/160
* https://github.com/LabKey/labkey-ui-components/pull/1280
* https://github.com/LabKey/labkey-ui-premium/pull/177
* https://github.com/LabKey/biologics/pull/2349
* https://github.com/LabKey/sampleManagement/pull/2072
* https://github.com/LabKey/inventory/pull/1004
* https://github.com/LabKey/platform/pull/4729

#### Changes
* Add `SetFieldsAction` on `PlateController`.
* Implement `setFields` on `PlateManager`.
* Add utility method `requirePlate` for ensuring a plate is available.
* Override `hashCode` and `equals` for `PlateCustomField`
* Bump `@labkey` packages
