### PR TITLE
Improve full-text search export, history, and logging

### DIFF
--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -419,6 +419,7 @@ public interface SearchService
     void addPathToCrawl(Path path, @Nullable Date nextCrawl);
 
     IndexTask indexContainer(@Nullable IndexTask task, Container c, Date since);
+    // TODO: Remove? This is never called
     IndexTask indexProject(@Nullable IndexTask task, Container project /*boolean incremental*/);
     void indexFull(boolean force);
 

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Multiset;
 import com.google.common.collect.Multiset.Entry;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DateUtils;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -77,8 +79,22 @@ import java.util.concurrent.TimeUnit;
 public abstract class AbstractSearchService implements SearchService, ShutdownListener
 {
     private static final Logger _log = LogHelper.getLogger(AbstractSearchService.class, "Full-text search indexing events");
+    // Search categories that are candidates for logging. Each category gets a logger that can be enabled by setting it
+    // to DEBUG on the Loggers page. It will then log indexing data for each document having that category.
+    private static final Set<String> CATEGORIES_TO_LOG = Set.of("navigation", "assay");
 
-    // Runnables go here, and get pulled off in a single threaded manner (assumption is that Runnables can create work very quickly)
+    static
+    {
+        // This adds each desired logger to the Loggers page
+        CATEGORIES_TO_LOG.forEach(AbstractSearchService::getLoggerForCategory);
+    }
+
+    private static Logger getLoggerForCategory(String category)
+    {
+        return LogManager.getLogger(SearchCategory.class.getName() + "." + category);
+    }
+
+    // Runnables go here, and get pulled off in a single-threaded manner (assumption is that Runnables can create work very quickly)
     final PriorityBlockingQueue<Item> _runQueue = new PriorityBlockingQueue<>(1000, itemCompare);
 
     // Resources go here for preprocessing (this can be multi-threaded)
@@ -206,7 +222,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         {
             if (_isReady)
             {
-                assert _subtasks.size() == 0;
+                assert _subtasks.isEmpty();
                 return _tasks.remove(this);
             }
             return false;
@@ -327,7 +343,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     @Override
     public boolean isBusy()
     {
-        if (_runQueue.size() > 0)
+        if (!_runQueue.isEmpty())
             return true;
         int n = _itemQueue.size();
         return n > 100;
@@ -341,7 +357,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     @Override
     public void waitForIdle() throws InterruptedException
     {
-        if (_runQueue.size() == 0 && _itemQueue.size() < 4)
+        if (_runQueue.isEmpty() && _itemQueue.size() < 4)
             return;
         synchronized (_idleEvent)
         {
@@ -353,7 +369,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
     private void checkIdle()
     {
-        if (_runQueue.size() == 0 && _itemQueue.size() == 0)
+        if (_runQueue.isEmpty() && _itemQueue.isEmpty())
         {
             synchronized (_idleEvent)
             {
@@ -1120,6 +1136,14 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                     _lastIndexedTime = ms;
                     if (_countIndexedSinceCommit > 10000)
                         commit();
+                    Logger categoryLogger = getLoggerForCategory(category);
+                    if (categoryLogger.isDebugEnabled())
+                    {
+                        String containerId = i._res.getContainerId();
+                        Container c = ContainerManager.getForId(containerId);
+                        String containerPath = c != null ? c.getPath() : "UNKNOWN PATH: Container not found!";
+                        categoryLogger.debug(category + " " + i._res.getDocumentId() + " " + containerPath + " " + containerId);
+                    }
                 }
             }
             else
@@ -1197,7 +1221,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             }
         }
 
-        if (usedCats.size() > 0)
+        if (!usedCats.isEmpty())
         {
             return usedCats;
         }
@@ -1260,6 +1284,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     }
 
 
+    // TODO: Remove? This is never called
     // UNDONE: get last crawl time from Crawler? support incrementals
     @Override
     public IndexTask indexProject(IndexTask in, final Container c)
@@ -1302,13 +1327,13 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     private final LinkedList<IndexerRateAccumulator> _history = new LinkedList<>();
 
     private IndexerRateAccumulator _current = new IndexerRateAccumulator(System.currentTimeMillis());
-    private long _currentHour = _current.getStart() / (60*60*1000L);
+    private long _currentHour = _current.getStart() / DateUtils.MILLIS_PER_HOUR;
 
     // call when holding _commitLock
-    private void incrementIndexStat(long now, String type)
+    private void incrementIndexStat(long now, String category)
     {
         assert Thread.holdsLock(_commitLock);
-        long hour = now / (60*60*1000L);
+        long hour = now / DateUtils.MILLIS_PER_HOUR;
         if (hour > _currentHour)
         {
             _history.addFirst(_current);
@@ -1317,7 +1342,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             while (_history.size() > 24)
                 _history.removeLast();
         }
-        _current.accumulate(type);
+        _current.accumulate(category);
     }
 
     
@@ -1339,44 +1364,47 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     {
         Map<String, Object> map = new LinkedHashMap<>();
         ArrayList<IndexerRateAccumulator> history;
-        long initialStart;
+        long currentStart;
 
         synchronized (_commitLock)
         {
             history = new ArrayList<>(_history.size() + 1);
-            initialStart = _current.getStart();
-            history.add(new IndexerRateAccumulator(initialStart, HashMultiset.create(_current.getCounter())));
+            currentStart = _current.getStart();
+            history.add(new IndexerRateAccumulator(currentStart, HashMultiset.create(_current.getCounter())));
             history.addAll(_history);
         }
 
-        IndexerRateAccumulator dayAccumulator = new IndexerRateAccumulator(initialStart);
+        IndexerRateAccumulator historyAccumulator = new IndexerRateAccumulator(history.get(history.size() - 1).getStart());
         SimpleDateFormat f = new SimpleDateFormat("h:mm a");
         StringBuilder hourly = new StringBuilder();
         hourly.append("<table>");
-        int hourCount = history.size();
+        int completedHours = 0;
+        long currentHour = System.currentTimeMillis();
+        currentHour -= currentHour % DateUtils.MILLIS_PER_HOUR; // Not the same as _currentHour if indexing hasn't yet taken place this hour
 
         for (IndexerRateAccumulator r : history)
         {
             long start = r.getStart();
-            start -= start % (60*60*1000);
+            start -= start % DateUtils.MILLIS_PER_HOUR;
             String fStart = f.format(start);
             String fCount = Formats.commaf0.format(r.getCount());
             hourly.append("<tr><td align=right>").append(fStart).append("&nbsp;</td>");
             hourly.append("<td align=right>").append(fCount).append(getPopup(fStart + " " + StringUtilsLabKey.pluralize(r.getCount(), "document"), r)).append("</td></tr>");
-            // If more than one hour, accumulate all history into a single counter
-            if (hourCount > 1)
-                r.getCounter().forEach(dayAccumulator::accumulate);
+            // Accumulate all history into a single counter, skipping the current hour's accumulator since it's incomplete
+            if (start < currentHour)
+            {
+                r.getCounter().forEach(historyAccumulator::accumulate);
+                completedHours++;
+            }
         }
 
         hourly.append("</table>");
 
-        long totalDocCount = dayAccumulator.getCount();
-
         // If we've accumulated multiple hours (usually 24) of history, display it as a single roll-up
-        if (totalDocCount > 0)
+        if (completedHours > 1)
         {
-            String fCount = StringUtilsLabKey.pluralize(totalDocCount, "document");
-            map.put("Indexing history added/updated (total for " + history.size() + " hours)", fCount + getPopup(fCount, dayAccumulator));
+            String fCount = StringUtilsLabKey.pluralize(historyAccumulator.getCount(), "document");
+            map.put("Indexing history added/updated (total for " + completedHours + " completed hours)", fCount + getPopup(fCount, historyAccumulator));
         }
         map.put("Indexing history added/updated (each hour)", hourly.toString());
         map.put("Maximum allowed document size", getFileSizeLimit());

--- a/search/src/org/labkey/search/model/IndexInspector.java
+++ b/search/src/org/labkey/search/model/IndexInspector.java
@@ -55,6 +55,13 @@ public class IndexInspector
             {
                 setDelimiterCharacter(DELIM.COMMA);
             }
+
+            // We want the "Export to Excel" option to open Excel and load the file. We're providing Excel content type
+            // but CSV file name and format because that seems to work and exporting in an Excel-native format would
+            // require a bit of a rewrite to the below, since ExcelWriter and TSVWriter don't share any useful
+            // interfaces. I haven't found a definitive reference that says this content type + extension discrepancy
+            // always works, but here's an old post that suggests it's reasonable:
+            // https://stackoverflow.com/questions/393647/response-content-type-as-csv#1719233
             @Override
             protected String getContentType()
             {

--- a/search/src/org/labkey/search/model/IndexInspector.java
+++ b/search/src/org/labkey/search/model/IndexInspector.java
@@ -20,10 +20,14 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.PostingsEnum;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Bits;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CsvSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -34,12 +38,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
-
-/**
- * User: adam
- * Date: 7/1/2014
- * Time: 10:30 AM
- */
 
 // Analyzes LabKey-generated Lucene indexes and displays/exports their contents. Output generally includes a row for each
 // document in the index listing title, type, folder path, url, and an approximation of its size in the index. Much of this
@@ -54,6 +52,9 @@ public class IndexInspector
     public void export(HttpServletResponse response, final String format) throws IOException
     {
         try (TSVIndexWriter writer = !"Excel".equals(format) ? new TSVIndexWriter() : new TSVIndexWriter() {
+            {
+                setDelimiterCharacter(DELIM.COMMA);
+            }
             @Override
             protected String getContentType()
             {
@@ -63,7 +64,7 @@ public class IndexInspector
             @Override
             protected String getFilenameExtension()
             {
-                return "xls";
+                return "csv";
             }
         })
         {
@@ -72,14 +73,14 @@ public class IndexInspector
         }
     }
 
-    private static String getType(String uid)
-    {
-        return uid.substring(0, uid.indexOf(':'));
-    }
-
     private static Path getIndexDirectory()
     {
         return LuceneSearchServiceImpl.getIndexDirectory().toPath();
+    }
+
+    private static boolean isLive(@Nullable Bits liveDocs, int docId)
+    {
+        return null == liveDocs || liveDocs.get(docId);
     }
 
     private static class TSVIndexWriter extends TSVWriter
@@ -87,7 +88,7 @@ public class IndexInspector
         @Override
         protected void writeColumnHeaders()
         {
-            writeLine(new CsvSet("Title,Type,Folder,URL,NavTrail,UniqueId,Body Terms,Summary"));
+            writeLine(new CsvSet("Title,Category,Folder,URL,NavTrail,UniqueId,Body Terms"));
         }
 
         @Override
@@ -96,9 +97,12 @@ public class IndexInspector
             try (Directory directory = WritableIndexManagerImpl.openDirectory(getIndexDirectory());
                  IndexReader reader = DirectoryReader.open(directory))
             {
+                int docCount = reader.maxDoc();
+                Bits liveDocs = MultiBits.getLiveDocs(reader);
+
                 // Lucene provides no way to query a document for its size in the index, so we enumerate the terms and increment
-                // term counts on each document to calculate a proxy for doc size.
-                int[] termCountPerDoc = new int[reader.maxDoc()];
+                // term counts on each live document to calculate a proxy for doc size.
+                int[] termCountPerDoc = new int[docCount];
 
                 for (LeafReaderContext arc : reader.leaves())
                 {
@@ -117,39 +121,41 @@ public class IndexInspector
 
                             while ((doc = pe.nextDoc()) != PostingsEnum.NO_MORE_DOCS)
                             {
-                                termCountPerDoc[doc]++;
+                                if (isLive(liveDocs, doc))
+                                    termCountPerDoc[doc]++;
                             }
                         }
                     }
                 }
 
-                int docCount = reader.maxDoc();
+                StoredFields stored = reader.storedFields();
 
-                // The stored terms are much easier to get. For each document, output stored fields plus the statistics computed above
+                // The stored terms are much easier to get. For each live document, output stored fields plus the statistics computed above
                 for (int i = 0; i < docCount; i++)
                 {
-                    Document doc = reader.document(i);
-                    String[] titles = doc.getValues("title");
-                    String[] urls = doc.getValues("url");
-                    String[] navtrails = doc.getValues("navtrail");
-                    String[] uniqueIds = doc.getValues("uniqueId");
-                    String[] containerIds = doc.getValues("container");
-                    String[] summarys = doc.getValues("summary");
-
-                    if (titles.length != 1 || urls.length != 1 || uniqueIds.length != 1 || containerIds.length != 1)
+                    if (isLive(liveDocs, i)) // Skip deleted docs
                     {
-                        throw new IOException("Incorrect number of term values found for document " + i);
+                        Document doc = stored.document(i);
+                        String[] titles = doc.getValues("title");
+                        String[] categories = doc.getValues("searchCategories");
+                        String[] urls = doc.getValues("url");
+                        String[] navTrails = doc.getValues("navtrail");
+                        String[] uniqueIds = doc.getValues("uniqueId");
+                        String[] containerIds = doc.getValues("container");
+
+                        if (titles.length != 1 || urls.length != 1 || uniqueIds.length != 1 || containerIds.length != 1)
+                        {
+                            throw new IOException("Incorrect number of term values found for document " + i);
+                        }
+
+                        Container c = ContainerManager.getForId(containerIds[0]);
+                        String path = null != c ? c.getPath() : "UNKNOWN: " + containerIds[0];
+
+                        String navTrail = navTrails != null && navTrails.length > 0 ? navTrails[0] : null;
+                        String category = categories.length == 1 ? categories[0] : Arrays.toString(categories);
+
+                        writeLine(Arrays.asList(titles[0], category, path, urls[0], navTrail, uniqueIds[0], String.valueOf(termCountPerDoc[i])));
                     }
-
-                    String type = getType(uniqueIds[0]);
-
-                    Container c = ContainerManager.getForId(containerIds[0]);
-                    String path = null != c ? c.getPath() : "UNKNOWN: " + containerIds[0];
-
-                    String navtrail = navtrails != null && navtrails.length > 0 ? navtrails[0] : null;
-                    String summary = summarys != null && summarys.length > 0 ? summarys[0] : null;
-
-                    writeLine(Arrays.asList(titles[0], type, path, urls[0], navtrail, uniqueIds[0], String.valueOf(termCountPerDoc[i]), summary));
                 }
 
                 return docCount;

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -1304,7 +1304,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
         {
             Query query = new TermQuery(new Term(FIELD_NAME.container.toString(), id));
 
-            // Run the query before delete, but only if Log4J debug level is set
+            // Count the docs and log before deleting them, but only if Log4J debug level is set
             if (_log.isDebugEnabled() && _indexManager.isReal())
             {
                 _log.debug("Deleting " + getDocCount(query) + " docs from container " + id);

--- a/search/src/org/labkey/search/view/exportContents.jsp
+++ b/search/src/org/labkey/search/view/exportContents.jsp
@@ -31,6 +31,5 @@ term count. Body term count is an approximate, relative measure of the size of t
 <p>Use Excel or your favorite tool to sort, filter, and pivot the data. For example, sort by term count to identify the largest
 documents in the index. Or sum body terms by folder path to determine folders contributing the most to index size.</p>
 
-<p>Note: A file format warning message may appear when exporting to Excel; click "Yes" and the data should correctly appear.</p>
 <%=button("Export to Text").href(textURL).build()%>
 <%=button("Export to Excel").href(excelURL).build()%>


### PR DESCRIPTION
#### Rationale
Using the "Export Index Contents" feature while investigating https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48415 revealed a number of problems.

Added the option to log indexing of documents within one or more specific categories to a separate log file.

The recently added accumulated history feature on the admin page was less than perfect, in that it included the current hour in the totals, typically meaning 24 completed hours plus a 25th partial hour.

#### Changes
* Export "Category" (very useful) instead of "Type" (less useful and already part of the unique ID)
* Stop including "Summary," which isn't very useful and seems to confuse Excel
* Switch to using a `StoredFields`, which now seems to be the sanctioned way to retrieve stored data
* Filter out deleted docs
* Export to Excel using CSV, which seems to work better than TSV (eliminates errors about format conversion, hanging, and errors about content too large)
* Fix some discrepancies with accumulated history feature
* Add option to log document indexing on a per-category basis