### PR TITLE
Update @labkey/components dependencies

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.358.2-fb-test-stability.0"
+        "@labkey/components": "2.362.3"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2312,9 +2312,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.23.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.23.0.tgz",
-      "integrity": "sha512-wZj62pN30b+JjVIj7GB4im+FhG8TdrO8lfMgCh7l0OVehMGU5PW1ThekYYtzEawmc/WoNlzT4ytRYqxZ5GHTDA=="
+      "version": "1.24.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1.tgz",
+      "integrity": "sha512-wMZ7DVtPPpxGn089Q1rlkfSrrWW6iH3d1AXM+azpb7X6ZRz6s/eNeLKQLTE4j4WgoHVTc6AK3RyIt1i/wtAQxA=="
     },
     "node_modules/@labkey/build": {
       "version": "6.12.0",
@@ -2351,11 +2351,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.358.2-fb-test-stability.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.358.2-fb-test-stability.0.tgz",
-      "integrity": "sha512-GFzXesMGK/jvXH2luShhz2SC1STBoNKuzI3PuAvo1Z+vp1KKhX7tpN1S/py05OWsu8pQSANBYhBJK28yJKHHMw==",
+      "version": "2.362.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.362.3.tgz",
+      "integrity": "sha512-4OOTEoFV16bv9s8Uwaib1UiXJya7lu+EcY3vJur3Q5Ob7gnflLbaEaI0olTHBKOIkTsyeWP4UN9vEW7X0bz1iQ==",
       "dependencies": {
-        "@labkey/api": "1.23.0",
+        "@labkey/api": "1.24.1",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -12322,9 +12322,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.23.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.23.0.tgz",
-      "integrity": "sha512-wZj62pN30b+JjVIj7GB4im+FhG8TdrO8lfMgCh7l0OVehMGU5PW1ThekYYtzEawmc/WoNlzT4ytRYqxZ5GHTDA=="
+      "version": "1.24.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1.tgz",
+      "integrity": "sha512-wMZ7DVtPPpxGn089Q1rlkfSrrWW6iH3d1AXM+azpb7X6ZRz6s/eNeLKQLTE4j4WgoHVTc6AK3RyIt1i/wtAQxA=="
     },
     "@labkey/build": {
       "version": "6.12.0",
@@ -12361,11 +12361,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.358.2-fb-test-stability.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.358.2-fb-test-stability.0.tgz",
-      "integrity": "sha512-GFzXesMGK/jvXH2luShhz2SC1STBoNKuzI3PuAvo1Z+vp1KKhX7tpN1S/py05OWsu8pQSANBYhBJK28yJKHHMw==",
+      "version": "2.362.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.362.3.tgz",
+      "integrity": "sha512-4OOTEoFV16bv9s8Uwaib1UiXJya7lu+EcY3vJur3Q5Ob7gnflLbaEaI0olTHBKOIkTsyeWP4UN9vEW7X0bz1iQ==",
       "requires": {
-        "@labkey/api": "1.23.0",
+        "@labkey/api": "1.24.1",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "2.358.2-fb-test-stability.0"
+    "@labkey/components": "2.362.3"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.358.2-fb-test-stability.0"
+        "@labkey/components": "2.362.3"
       },
       "devDependencies": {
         "@labkey/build": "6.12.0",
@@ -2386,9 +2386,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.23.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.23.0.tgz",
-      "integrity": "sha512-wZj62pN30b+JjVIj7GB4im+FhG8TdrO8lfMgCh7l0OVehMGU5PW1ThekYYtzEawmc/WoNlzT4ytRYqxZ5GHTDA=="
+      "version": "1.24.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1.tgz",
+      "integrity": "sha512-wMZ7DVtPPpxGn089Q1rlkfSrrWW6iH3d1AXM+azpb7X6ZRz6s/eNeLKQLTE4j4WgoHVTc6AK3RyIt1i/wtAQxA=="
     },
     "node_modules/@labkey/build": {
       "version": "6.12.0",
@@ -2425,11 +2425,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.358.2-fb-test-stability.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.358.2-fb-test-stability.0.tgz",
-      "integrity": "sha512-GFzXesMGK/jvXH2luShhz2SC1STBoNKuzI3PuAvo1Z+vp1KKhX7tpN1S/py05OWsu8pQSANBYhBJK28yJKHHMw==",
+      "version": "2.362.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.362.3.tgz",
+      "integrity": "sha512-4OOTEoFV16bv9s8Uwaib1UiXJya7lu+EcY3vJur3Q5Ob7gnflLbaEaI0olTHBKOIkTsyeWP4UN9vEW7X0bz1iQ==",
       "dependencies": {
-        "@labkey/api": "1.23.0",
+        "@labkey/api": "1.24.1",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -13747,9 +13747,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.23.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.23.0.tgz",
-      "integrity": "sha512-wZj62pN30b+JjVIj7GB4im+FhG8TdrO8lfMgCh7l0OVehMGU5PW1ThekYYtzEawmc/WoNlzT4ytRYqxZ5GHTDA=="
+      "version": "1.24.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.24.1.tgz",
+      "integrity": "sha512-wMZ7DVtPPpxGn089Q1rlkfSrrWW6iH3d1AXM+azpb7X6ZRz6s/eNeLKQLTE4j4WgoHVTc6AK3RyIt1i/wtAQxA=="
     },
     "@labkey/build": {
       "version": "6.12.0",
@@ -13786,11 +13786,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.358.2-fb-test-stability.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.358.2-fb-test-stability.0.tgz",
-      "integrity": "sha512-GFzXesMGK/jvXH2luShhz2SC1STBoNKuzI3PuAvo1Z+vp1KKhX7tpN1S/py05OWsu8pQSANBYhBJK28yJKHHMw==",
+      "version": "2.362.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.362.3.tgz",
+      "integrity": "sha512-4OOTEoFV16bv9s8Uwaib1UiXJya7lu+EcY3vJur3Q5Ob7gnflLbaEaI0olTHBKOIkTsyeWP4UN9vEW7X0bz1iQ==",
       "requires": {
-        "@labkey/api": "1.23.0",
+        "@labkey/api": "1.24.1",
         "@testing-library/jest-dom": "~5.16.5",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "2.358.2-fb-test-stability.0"
+    "@labkey/components": "2.362.3"
   },
   "devDependencies": {
     "@labkey/build": "6.12.0",


### PR DESCRIPTION
#### Rationale
This updates a couple of alpha-version dependencies that slipped into our release. Post-merge this alpha version will be cleaned up on artifactory so as to prevent a interstitial build break in CI for the release.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4665

#### Changes
* Update `assay` and `pipeline` module dependencies on `@labkey/components` to match the version specified for the core module.
