### PR TITLE
Issue 48657: LKSM/LKB: Loading selections for large grids is very slow

### DIFF
--- a/api/src/org/labkey/api/data/DataRegionSelection.java
+++ b/api/src/org/labkey/api/data/DataRegionSelection.java
@@ -468,6 +468,7 @@ public class DataRegionSelection
         var ctx = dataRegionContext.second;
 
         // Issue 48657: no need to query for all region results if we are only interested in a subset, filter for just those
+        // Note: this only currently applies for tables with a single PK col. Consider altering this for multi-pk tables.
         List<ColumnInfo> pkCols = rgn.getTable().getPkColumns();
         if (pkCols.size() == 1)
         {

--- a/api/src/org/labkey/api/data/DataRegionSelection.java
+++ b/api/src/org/labkey/api/data/DataRegionSelection.java
@@ -467,7 +467,7 @@ public class DataRegionSelection
         var rgn = dataRegionContext.first;
         var ctx = dataRegionContext.second;
 
-        // Issue 48657: no need to query for all region results if we are only interested in a subset, filter for just those
+        // Issue 48657: no need to query for all region results if we are only interested in a subset, filter for just those we want to verify
         // Note: this only currently applies for tables with a single PK col. Consider altering this for multi-pk tables.
         List<ColumnInfo> pkCols = rgn.getTable().getPkColumns();
         if (pkCols.size() == 1)

--- a/api/src/org/labkey/api/data/DataRegionSelection.java
+++ b/api/src/org/labkey/api/data/DataRegionSelection.java
@@ -459,9 +459,21 @@ public class DataRegionSelection
      */
     private static List<String> getSelectedItems(QueryView view, @NotNull Collection<String> selectedValues) throws IOException
     {
+        // Issue 48657: no need to query the region result set if we have no selectedValues
+        if (selectedValues.size() == 0)
+            return new LinkedList<>();
+
         var dataRegionContext = getDataRegionContext(view);
         var rgn = dataRegionContext.first;
         var ctx = dataRegionContext.second;
+
+        // Issue 48657: no need to query for all region results if we are only interested in a subset, filter for just those
+        List<ColumnInfo> pkCols = rgn.getTable().getPkColumns();
+        if (pkCols.size() == 1)
+        {
+            ColumnInfo pkCol = pkCols.get(0);
+            ctx.setBaseFilter(new SimpleFilter(pkCol.getFieldKey(), pkCol.isNumericType() ? selectedValues.stream().map(Integer::parseInt).toList() : selectedValues, CompareType.IN));
+        }
 
         try (Timing ignored = MiniProfiler.step("getSelected"); Results rs = rgn.getResults(ctx))
         {

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -6117,7 +6117,10 @@ public class QueryController extends SpringActionController
             }
             else
             {
-                int count = DataRegionSelection.setSelectionForAll(form, false);
+                // Note: DataRegionSelection.setSelectionForAll(form, false) will query for all rows in the region to remove those in context.
+                // Instead, get the selected values in context and then "uncheck" them directly
+                List<String> currentCtxSelection = DataRegionSelection.getSelected(form, false);
+                int count = DataRegionSelection.setSelected(getViewContext(), form.getQuerySettings().getSelectionKey(), currentCtxSelection, false);
                 return new DataRegionSelection.SelectionResponse(count);
             }
         }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48657

When setting the grid selection or clearing selections, there are a couple scenarios where we query for all PK values in a data region context so that we can verify if the selected keys are valid. This causes perf issues for large tables which are querying for a large set of data just to look for a small set. This PR fixes that by using the selected keys as a query filter for the "validate if the pks being selected are still valid" scenario on select or clear.

#### Changes
* DataRegionSelection.getSelectedItems() changes
  * no need to query the region result set if we have no selectedValues
  * no need to query for all region results if we are only interested in a subset, filter for just those
* QueryController.SelectNoneAction update to replace setSelectionForAll() with query for just the selected IDs to be removed from the context
