### PR TITLE
DatabaseCache replay of put operations into shared cache

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -25,6 +25,7 @@ import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.attachments.LookAndFeelResourceType;
 import org.labkey.api.attachments.SecureDocumentType;
 import org.labkey.api.cache.BlockingCache;
+import org.labkey.api.cache.CachingTestCase;
 import org.labkey.api.collections.ArrayListMap;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;

--- a/api/src/org/labkey/api/action/ApiQueryResponse.java
+++ b/api/src/org/labkey/api/action/ApiQueryResponse.java
@@ -384,7 +384,7 @@ public class ApiQueryResponse implements ApiResponse
                 sortInfo.put("direction", dir);
                 array.put(array.length(), sortInfo);
             }
-            if (array.length() > 0)
+            if (!array.isEmpty())
             {
                 metaData.put("sortInfo", array.get(0));
                 metaData.put("sortInfoArray", array);
@@ -404,7 +404,7 @@ public class ApiQueryResponse implements ApiResponse
 
         JSONArray templates = new JSONArray();
         List<Pair<String, String>> it = _tinfo.getImportTemplates(_ctx.getViewContext());
-        if(it != null && it.size() > 0)
+        if (it != null && !it.isEmpty())
         {
             for (Pair<String, String> pair : it)
             {

--- a/api/src/org/labkey/api/cache/CachingTestCase.java
+++ b/api/src/org/labkey/api/cache/CachingTestCase.java
@@ -1,8 +1,12 @@
-package org.labkey.api.data;
+package org.labkey.api.cache;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.cache.DbCache;
+import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.data.Table;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TestSchema;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.TestContext;
 

--- a/api/src/org/labkey/api/cache/DbCache.java
+++ b/api/src/org/labkey/api/cache/DbCache.java
@@ -29,9 +29,6 @@ import java.util.Map;
  * use DatabaseCaches directly and handle invalidation themselves.
  *
  * Use CacheManager.getCache() or DatabaseCache instead.
- *
- * User: migra
- * Date: Nov 30, 2005
  */
 @Deprecated
 public class DbCache

--- a/api/src/org/labkey/api/cache/DbCache.java
+++ b/api/src/org/labkey/api/cache/DbCache.java
@@ -24,11 +24,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * DbCache associates a DatabaseCache with each participating TableInfo. The Table layer then invalidates the entire
- * cache anytime it touches (insert, update, delete) that TableInfo. This is easy, but very inefficient. Managers should
- * use DatabaseCaches directly and handle invalidation themselves.
  *
- * Use CacheManager.getCache() or DatabaseCache instead.
+ * Don't use this! Use CacheManager.getCache() or DatabaseCache instead. DbCache associates a DatabaseCache with each
+ * participating TableInfo. The Table layer then invalidates the entire cache anytime it touches (insert, update, delete)
+ * that TableInfo. This is easy, but very inefficient. Managers should use DatabaseCaches directly and handle
+ * invalidation themselves.
  */
 @Deprecated
 public class DbCache
@@ -54,13 +54,11 @@ public class DbCache
         }
     }
 
-
     public static void put(TableInfo tinfo, String name, Object obj)
     {
         DatabaseCache<String, Object> cache = getCache(tinfo, true);
         cache.put(name, obj);
     }
-
 
     public static void put(TableInfo tinfo, String name, Object obj, long millisToLive)
     {
@@ -68,13 +66,11 @@ public class DbCache
         cache.put(name, obj, millisToLive);
     }
 
-
     public static Object get(TableInfo tinfo, String name)
     {
         DatabaseCache<String, Object> cache = getCache(tinfo, false);
         return null == cache ? null : cache.get(name);
     }
-    
 
     public static void remove(TableInfo tinfo, String name)
     {
@@ -82,7 +78,6 @@ public class DbCache
         if (null != cache)
             cache.remove(name);
     }
-
 
     /** used by Table */
     public static void invalidateAll(TableInfo tinfo)
@@ -92,7 +87,6 @@ public class DbCache
             cache.clear();
     }
 
-
     public static void clear(TableInfo tinfo)
     {
         DatabaseCache<String, Object> cache = getCache(tinfo, false);
@@ -100,17 +94,10 @@ public class DbCache
             cache.clear();
     }
 
-
     public static void removeUsingPrefix(TableInfo tinfo, String name)
     {
         DatabaseCache<String, Object> cache = getCache(tinfo, false);
         if (null != cache)
             cache.removeUsingFilter(new Cache.StringPrefixFilter(name));
-    }
-
-    // Temporary helper to assist with DbCache removal process
-    public static boolean hasCache(TableInfo tinfo)
-    {
-        return null != getCache(tinfo, false);
     }
 }

--- a/api/src/org/labkey/api/data/DatabaseCache.java
+++ b/api/src/org/labkey/api/data/DatabaseCache.java
@@ -63,24 +63,19 @@ public class DatabaseCache<K, V> implements Cache<K, V>
 
     public static <K, V> BlockingCache<K, V> get(DbScope scope, int maxSize, long defaultTimeToLive, String debugName, CacheLoader<K, V> cacheLoader)
     {
-        return getBlockingCache(new DatabaseCache<>(scope, maxSize, defaultTimeToLive, debugName), cacheLoader);
+        return new BlockingDatabaseCache<>(new DatabaseCache<>(scope, maxSize, defaultTimeToLive, debugName), cacheLoader);
     }
 
     public static <K, V> BlockingCache<K, V> get(DbScope scope, int maxSize, String debugName, CacheLoader<K, V> cacheLoader)
     {
-        return getBlockingCache(new DatabaseCache<>(scope, maxSize, debugName), cacheLoader);
+        return new BlockingDatabaseCache<>(new DatabaseCache<>(scope, maxSize, debugName), cacheLoader);
     }
 
-    private static <K, V> BlockingCache<K, V> getBlockingCache(DatabaseCache<K, Wrapper<V>> databaseCache, CacheLoader<K, V> cacheLoader)
-    {
-        return new ReplayBlockingCache<>(databaseCache, cacheLoader);
-    }
-
-    private static class ReplayBlockingCache<K, V> extends BlockingCache<K, V>
+    private static class BlockingDatabaseCache<K, V> extends BlockingCache<K, V>
     {
         private final DatabaseCache<K, Wrapper<V>> _databaseCache;
 
-        public ReplayBlockingCache(DatabaseCache<K, Wrapper<V>> cache, @Nullable CacheLoader<K, V> loader)
+        public BlockingDatabaseCache(DatabaseCache<K, Wrapper<V>> cache, @Nullable CacheLoader<K, V> loader)
         {
             super(cache, loader);
             _databaseCache = cache;

--- a/api/src/org/labkey/api/data/DatabaseCache.java
+++ b/api/src/org/labkey/api/data/DatabaseCache.java
@@ -27,7 +27,10 @@ import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.cache.TrackingCache;
 import org.labkey.api.cache.TransactionCache;
+import org.labkey.api.cache.Wrapper;
+import org.labkey.api.data.DbScope.TransactionImpl;
 import org.labkey.api.util.Filter;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -41,6 +44,8 @@ import java.util.Set;
  */
 public class DatabaseCache<K, V> implements Cache<K, V>
 {
+    private static final Logger LOG = LogHelper.getLogger(DatabaseCache.class, "DatabaseCache misses");
+
     private final Cache<K, V> _sharedCache;
     private final DbScope _scope;
 
@@ -58,12 +63,43 @@ public class DatabaseCache<K, V> implements Cache<K, V>
 
     public static <K, V> BlockingCache<K, V> get(DbScope scope, int maxSize, long defaultTimeToLive, String debugName, CacheLoader<K, V> cacheLoader)
     {
-        return new BlockingCache<>(new DatabaseCache<>(scope, maxSize, defaultTimeToLive, debugName), cacheLoader);
+        return getBlockingCache(new DatabaseCache<>(scope, maxSize, defaultTimeToLive, debugName), cacheLoader);
     }
 
     public static <K, V> BlockingCache<K, V> get(DbScope scope, int maxSize, String debugName, CacheLoader<K, V> cacheLoader)
     {
-        return new BlockingCache<>(new DatabaseCache<>(scope, maxSize, debugName), cacheLoader);
+        return getBlockingCache(new DatabaseCache<>(scope, maxSize, debugName), cacheLoader);
+    }
+
+    private static <K, V> BlockingCache<K, V> getBlockingCache(DatabaseCache<K, Wrapper<V>> databaseCache, CacheLoader<K, V> cacheLoader)
+    {
+        return new ReplayBlockingCache<>(databaseCache, cacheLoader);
+    }
+
+    private static class ReplayBlockingCache<K, V> extends BlockingCache<K, V>
+    {
+        private final DatabaseCache<K, Wrapper<V>> _databaseCache;
+
+        public ReplayBlockingCache(DatabaseCache<K, Wrapper<V>> cache, @Nullable CacheLoader<K, V> loader)
+        {
+            super(cache, loader);
+            _databaseCache = cache;
+        }
+
+        @Override
+        protected V load(@NotNull K key, @Nullable Object argument, CacheLoader<K, V> loader)
+        {
+            V value = super.load(key, argument, loader);
+            LOG.debug("Just loaded: " + key + " (" + getTrackingCache().getDebugName() + ")");
+            TransactionImpl t = _databaseCache.getCurrentTransaction();
+
+            if (null != t)
+            {
+                t.addCommitTask(new CacheReloadCommitTask<>(this, key, argument, loader), DbScope.CommitTaskOption.POSTCOMMIT);
+            }
+
+            return value;
+        }
     }
 
     protected Cache<K, V> createSharedCache(int maxSize, long defaultTimeToLive, String debugName)
@@ -77,16 +113,19 @@ public class DatabaseCache<K, V> implements Cache<K, V>
         return createTemporaryCache(getTrackingCache());
     }
 
-    // Note: No need to subclass and override this method. If you want to set a default CacheLoader then wrap the
-    // DatabaseCache with a BlockingCache
-    protected final Cache<K, V> createTemporaryCache(TrackingCache<K, V> trackingCache)
+    private Cache<K, V> createTemporaryCache(TrackingCache<K, V> trackingCache)
     {
         return CacheManager.getTemporaryCache(trackingCache.getLimit(), trackingCache.getDefaultExpires(), "transaction cache: " + trackingCache.getDebugName(), trackingCache.getTransactionStats());
     }
 
+    protected @Nullable TransactionImpl getCurrentTransaction()
+    {
+        return _scope.getCurrentTransactionImpl();
+    }
+
     public Cache<K, V> getCache()
     {
-        DbScope.TransactionImpl t = _scope.getCurrentTransactionImpl();
+        TransactionImpl t = getCurrentTransaction();
 
         if (null != t)
         {
@@ -170,6 +209,55 @@ public class DatabaseCache<K, V> implements Cache<K, V>
     public String toString()
     {
         return "DatabaseCache over \"" + _sharedCache.toString() + "\"";
+    }
+
+    // This is added as a commit task when load operations take place inside a transaction, ensuring that they are
+    // re-played on successful commit.
+    public static class CacheReloadCommitTask<K, V> implements Runnable
+    {
+        private final Cache<K, V> _cache;
+        private final K _key;
+        private final Object _arg;
+        private final CacheLoader<K, V> _loader;
+
+        public CacheReloadCommitTask(Cache<K, V> cache, K key, Object arg, CacheLoader<K, V> loader)
+        {
+            _cache = cache;
+            _key = key;
+            _arg = arg;
+            _loader = loader;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            CacheReloadCommitTask that = (CacheReloadCommitTask) o;
+
+            if (!getCache().equals(that.getCache())) return false;
+            return Objects.equals(_key, that._key);
+        }
+
+        protected Cache<K, V> getCache()
+        {
+            return _cache;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = getCache().hashCode();
+            result = 31 * result + (_key != null ? _key.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public void run()
+        {
+            getCache().get(_key, _arg, _loader);
+        }
     }
 
     public static class TestCase extends Assert
@@ -288,7 +376,6 @@ public class DatabaseCache<K, V> implements Cache<K, V>
             }
         }
 
-
         private static class MyScope extends DbScope
         {
             private Boolean overrideTransactionActive = null;
@@ -331,7 +418,6 @@ public class DatabaseCache<K, V> implements Cache<K, V>
             public void releaseConnection(Connection conn)
             {
             }
-
 
             @Override
             public boolean isTransactionActive()

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1252,6 +1252,7 @@ public class DbScope
         return getTableInfoCache(options.getSchema().getType()).get(options);
     }
 
+    // This is expensive... use only for debugging and troubleshooting
     public <OptionType extends SchemaTableOptions> boolean isCached(OptionType options)
     {
         return getTableInfoCache(options.getSchema().getType()).isCached(options);

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1252,7 +1252,7 @@ public class DbScope
         return getTableInfoCache(options.getSchema().getType()).get(options);
     }
 
-    // This is expensive... use only for debugging and troubleshooting
+    /** This is expensive... use only for debugging and troubleshooting */
     public <OptionType extends SchemaTableOptions> boolean isCached(OptionType options)
     {
         return getTableInfoCache(options.getSchema().getType()).isCached(options);

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1252,6 +1252,11 @@ public class DbScope
         return getTableInfoCache(options.getSchema().getType()).get(options);
     }
 
+    public <OptionType extends SchemaTableOptions> boolean isCached(OptionType options)
+    {
+        return getTableInfoCache(options.getSchema().getType()).isCached(options);
+    }
+
     private SchemaTableInfoCache getTableInfoCache(DbSchemaType type)
     {
         return type == DbSchemaType.Provisioned ? _provisionedTableCache : _nonProvisionedTableCache;

--- a/api/src/org/labkey/api/data/PropertyCache.java
+++ b/api/src/org/labkey/api/data/PropertyCache.java
@@ -16,33 +16,27 @@
 package org.labkey.api.data;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.PropertyManager.PropertyMap;
 import org.labkey.api.security.User;
 
-/**
- * User: adam
- * Date: 11/30/12
- * Time: 10:46 PM
- */
 public class PropertyCache
 {
-    private final DatabaseCache<String, PropertyManager.PropertyMap> _blockingCache;
-    private final CacheLoader<String, PropertyManager.PropertyMap> _loader;
+    private final BlockingCache<String, PropertyMap> _blockingCache;
 
-    PropertyCache(String name, CacheLoader<String, PropertyManager.PropertyMap> propertyLoader)
+    PropertyCache(String name, CacheLoader<String, PropertyMap> propertyLoader)
     {
-        _loader = propertyLoader;
-        _blockingCache = new DatabaseCache<>(CoreSchema.getInstance().getScope(), CacheManager.UNLIMITED, CacheManager.DAY, name);
+        _blockingCache = DatabaseCache.get(CoreSchema.getInstance().getScope(), CacheManager.UNLIMITED, CacheManager.DAY, name, propertyLoader);
     }
 
-    @Nullable PropertyManager.PropertyMap getProperties(User user, Container container, String category)
+    @Nullable PropertyMap getProperties(User user, Container container, String category)
     {
         String key = getCacheKey(container, user, category);
 
-        return _blockingCache.get(key, new Object[]{container, user, category}, _loader);
+        return _blockingCache.get(key, new Object[]{container, user, category});
     }
 
     void remove(PropertyMap map)
@@ -67,6 +61,6 @@ public class PropertyCache
 
     private static String getCacheKey(String containerId, int userId, String category)
     {
-        return String.valueOf(containerId) + "/" + String.valueOf(userId) + "/" + category;
+        return containerId + "/" + userId + "/" + category;
     }
 }

--- a/api/src/org/labkey/api/data/SchemaTableInfoCache.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfoCache.java
@@ -43,7 +43,7 @@ public class SchemaTableInfoCache
     @SuppressWarnings("DataFlowIssue")
     private static final CacheTimeChooser<String> TABLE_CACHE_TIME_CHOOSER = (key, argument) -> ((SchemaTableOptions)argument).getSchema().getType().getCacheTimeToLive();
 
-    // This is expensive... use only for debugging and troubleshooting
+    /** This is expensive... use only for debugging and troubleshooting */
     public <OptionType extends SchemaTableOptions> boolean isCached(@NotNull OptionType options)
     {
         DbSchema schema = options.getSchema();

--- a/api/src/org/labkey/api/data/SchemaTableInfoCache.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfoCache.java
@@ -43,6 +43,7 @@ public class SchemaTableInfoCache
     @SuppressWarnings("DataFlowIssue")
     private static final CacheTimeChooser<String> TABLE_CACHE_TIME_CHOOSER = (key, argument) -> ((SchemaTableOptions)argument).getSchema().getType().getCacheTimeToLive();
 
+    // This is expensive... use only for debugging and troubleshooting
     public <OptionType extends SchemaTableOptions> boolean isCached(@NotNull OptionType options)
     {
         DbSchema schema = options.getSchema();

--- a/api/src/org/labkey/api/data/SchemaTableInfoCache.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfoCache.java
@@ -23,16 +23,10 @@ import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.cache.CacheTimeChooser;
-import org.labkey.api.cache.Wrapper;
 import org.labkey.api.data.DbScope.SchemaTableOptions;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.logging.LogHelper;
 
-/*
-* User: adam
-* Date: Mar 25, 2011
-* Time: 5:56:47 AM
-*/
 public class SchemaTableInfoCache
 {
     private static final Logger LOG = LogHelper.getLogger(SchemaTableInfoCache.class, "Loading of schema and table metadata from database schemas");
@@ -41,7 +35,19 @@ public class SchemaTableInfoCache
 
     public SchemaTableInfoCache(DbScope scope, boolean provisioned)
     {
-        _blockingCache = new SchemaTableInfoBlockingCache(scope, provisioned);
+        _blockingCache = createCache(scope, provisioned);
+        _blockingCache.setCacheTimeChooser(TABLE_CACHE_TIME_CHOOSER);
+    }
+
+    // Ask the DbSchemaType how long to cache each table
+    @SuppressWarnings("DataFlowIssue")
+    private static final CacheTimeChooser<String> TABLE_CACHE_TIME_CHOOSER = (key, argument) -> ((SchemaTableOptions)argument).getSchema().getType().getCacheTimeToLive();
+
+    public <OptionType extends SchemaTableOptions> boolean isCached(@NotNull OptionType options)
+    {
+        DbSchema schema = options.getSchema();
+        String key = getCacheKey(schema.getName(), options.getTableName(), schema.getType());
+        return _blockingCache.getKeys().contains(key);
     }
 
     <OptionType extends SchemaTableOptions> SchemaTableInfo get(@NotNull OptionType options)
@@ -96,27 +102,13 @@ public class SchemaTableInfoCache
         }
     }
 
-    // Ask the DbSchemaType how long to cache each table
-    @SuppressWarnings("DataFlowIssue")
-    private static final CacheTimeChooser<String> TABLE_CACHE_TIME_CHOOSER = (key, argument) -> ((SchemaTableOptions)argument).getSchema().getType().getCacheTimeToLive();
-
-    private static class SchemaTableInfoBlockingCache extends BlockingCache<String, SchemaTableInfo>
-    {
-        private SchemaTableInfoBlockingCache(DbScope scope, boolean transactionAware)
-        {
-            super(createCache(scope, transactionAware), new SchemaTableLoader());
-            setCacheTimeChooser(TABLE_CACHE_TIME_CHOOSER);
-        }
-    }
-
-    private static Cache<String, Wrapper<SchemaTableInfo>> createCache(DbScope scope, boolean provisioned)
+    private static BlockingCache<String, SchemaTableInfo> createCache(DbScope scope, boolean provisioned)
     {
         String comment = "SchemaTableInfos for " + (provisioned ? "provisioned" : "non-provisioned") + " schemas in scope " + scope.getDisplayName();
 
         // We modify provisioned tables inside of transactions, so use a DatabaseCache to help with proper invalidation. See #46951.
-        if (provisioned)
-            return new DatabaseCache<>(scope, 10000, CacheManager.UNLIMITED, comment);
-        else
-            return CacheManager.getStringKeyCache(10000, CacheManager.UNLIMITED, comment);
+        return provisioned ?
+            DatabaseCache.get(scope, 10000, CacheManager.UNLIMITED, comment, new SchemaTableLoader()) :
+            new BlockingCache<>(CacheManager.getStringKeyCache(10000, CacheManager.UNLIMITED, comment), new SchemaTableLoader());
     }
 }

--- a/api/src/org/labkey/api/data/TestSchema.java
+++ b/api/src/org/labkey/api/data/TestSchema.java
@@ -19,9 +19,6 @@ import org.labkey.api.data.dialect.SqlDialect;
 
 /**
  * A simple wrapper over a database schema that can be used for integration or other testing purposes.
- * User: arauch
- * Date: Sep 24, 2005
- * Time: 10:46:35 PM
  */
 public class TestSchema
 {

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -89,12 +89,9 @@ import static java.util.stream.Collectors.joining;
 
 /**
  * Lots of static methods for dealing with domains and property descriptors. Tends to operate primarily on the bean-style
- * classes like {@link PropertyDescriptor} and {@link DomainDescriptor}.
- *
- * When possible, it's usually preferable to use {@link PropertyService}, {@link Domain}, and {@link DomainProperty}
- * instead as they tend to provide higher-level abstractions.
- * User: migra
- * Date: Jun 14, 2005
+ * classes like {@link PropertyDescriptor} and {@link DomainDescriptor}. When possible, it's usually preferable to use
+ * {@link PropertyService}, {@link Domain}, and {@link DomainProperty} instead as they tend to provide higher-level
+ * abstractions.
  */
 public class OntologyManager
 {
@@ -185,16 +182,16 @@ public class OntologyManager
             if (null == c)
                 return Collections.emptyList();
             SQLFragment sql = new SQLFragment(" SELECT PD.*,Required " +
-                    " FROM " + getTinfoPropertyDescriptor() + " PD " +
-                    "   INNER JOIN " + getTinfoPropertyDomain() + " PDM ON (PD.PropertyId = PDM.PropertyId) " +
-                    "   INNER JOIN " + getTinfoDomainDescriptor() + " DD ON (DD.DomainId = PDM.DomainId) " +
-                    "  WHERE DD.DomainURI = ?  AND DD.Project IN (?,?) ORDER BY PDM.SortOrder, PD.PropertyId");
+                " FROM " + getTinfoPropertyDescriptor() + " PD " +
+                "   INNER JOIN " + getTinfoPropertyDomain() + " PDM ON (PD.PropertyId = PDM.PropertyId) " +
+                "   INNER JOIN " + getTinfoDomainDescriptor() + " DD ON (DD.DomainId = PDM.DomainId) " +
+                "  WHERE DD.DomainURI = ?  AND DD.Project IN (?,?) ORDER BY PDM.SortOrder, PD.PropertyId");
 
             sql.addAll(
-                    typeURI,
-                    // protect against null project, just double-up shared project
-                    c.isRoot() ? c.getId() : (c.getProject() == null ? _sharedContainer.getProject().getId() : c.getProject().getId()),
-                    _sharedContainer.getProject().getId()
+                typeURI,
+                // protect against null project, just double-up shared project
+                c.isRoot() ? c.getId() : (c.getProject() == null ? _sharedContainer.getProject().getId() : c.getProject().getId()),
+                _sharedContainer.getProject().getId()
             );
             List<PropertyDescriptor> pds = unmodifiableList(new SqlSelector(getExpSchema(), sql).getArrayList(PropertyDescriptor.class));
             //NOTE: cached descriptors may have differing values of isRequired() as that is a per-domain setting
@@ -400,10 +397,10 @@ public class OntologyManager
         }
 
         assert total.stop();
-        _log.debug("\t" + total.toString());
-        _log.debug("\t" + before.toString());
-        _log.debug("\t" + ensure.toString());
-        _log.debug("\t" + insert.toString());
+        _log.debug("\t" + total);
+        _log.debug("\t" + before);
+        _log.debug("\t" + ensure);
+        _log.debug("\t" + insert);
 
         return resultingLsids;
     }

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -101,7 +101,7 @@ public class OntologyManager
     private static final Logger _log = LogManager.getLogger(OntologyManager.class);
     private static final Cache<Pair<String, String>, Map<String, ObjectProperty>> mapCache = new DatabaseCache<>(getExpSchema().getScope(), 100000, "Property maps");
     private static final Cache<String, Integer> objectIdCache = new DatabaseCache<>(getExpSchema().getScope(), 2000, "ObjectIds");
-    private static final Cache<Pair<String, GUID>, PropertyDescriptor> propDescCache = new BlockingCache<>(new DatabaseCache<>(getExpSchema().getScope(), 40000, CacheManager.UNLIMITED, "Property descriptors"), new CacheLoader<>()
+    private static final Cache<Pair<String, GUID>, PropertyDescriptor> propDescCache = DatabaseCache.get(getExpSchema().getScope(), 40000, CacheManager.UNLIMITED, "Property descriptors", new CacheLoader<>()
     {
         @Override
         public PropertyDescriptor load(@NotNull Pair<String, GUID> key, @Nullable Object argument)
@@ -133,7 +133,7 @@ public class OntologyManager
         }
     });
     /** DomainURI, ContainerEntityId -> DomainDescriptor */
-    private static final Cache<Pair<String, GUID>, DomainDescriptor> domainDescByURICache = new BlockingCache<>(new DatabaseCache<>(getExpSchema().getScope(), 2000, CacheManager.UNLIMITED, "Domain descriptors by URI"), (key, argument) -> {
+    private static final Cache<Pair<String, GUID>, DomainDescriptor> domainDescByURICache = DatabaseCache.get(getExpSchema().getScope(), 2000, CacheManager.UNLIMITED, "Domain descriptors by URI", (key, argument) -> {
         String domainURI = key.first;
         Container c = ContainerManager.getForId(key.second);
 
@@ -174,8 +174,8 @@ public class OntologyManager
         return dd;
     }
 
-    private static final BlockingCache<Integer, DomainDescriptor> domainDescByIDCache = new BlockingCache<>(new DatabaseCache<>(getExpSchema().getScope(),2000, CacheManager.UNLIMITED,"Domain descriptors by ID"), new DomainDescriptorLoader());
-    private static final BlockingCache<Pair<String, GUID>, List<Pair<String, Boolean>>> domainPropertiesCache = new BlockingCache<>(new DatabaseCache<>(getExpSchema().getScope(), 5000, CacheManager.UNLIMITED, "Domain properties"), new CacheLoader<>()
+    private static final BlockingCache<Integer, DomainDescriptor> domainDescByIDCache = DatabaseCache.get(getExpSchema().getScope(),2000, CacheManager.UNLIMITED,"Domain descriptors by ID", new DomainDescriptorLoader());
+    private static final BlockingCache<Pair<String, GUID>, List<Pair<String, Boolean>>> domainPropertiesCache = DatabaseCache.get(getExpSchema().getScope(), 5000, CacheManager.UNLIMITED, "Domain properties", new CacheLoader<>()
     {
         @Override
         public List<Pair<String, Boolean>> load(@NotNull Pair<String, GUID> key, @Nullable Object argument)

--- a/api/src/org/labkey/api/reports/model/ViewCategoryCache.java
+++ b/api/src/org/labkey/api/reports/model/ViewCategoryCache.java
@@ -18,7 +18,6 @@ package org.labkey.api.reports.model;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.CoreSchema;
@@ -44,7 +43,7 @@ public class ViewCategoryCache
 {
     private static final ViewCategoryCache INSTANCE = new ViewCategoryCache();
 
-    private final Cache<String, ViewCategoryCollections> VIEW_CATEGORY_CACHE = new BlockingCache<>(new DatabaseCache<>(CoreSchema.getInstance().getSchema().getScope(), 300, "View categories"), (key, argument) -> new ViewCategoryCollections(key));
+    private final Cache<String, ViewCategoryCollections> VIEW_CATEGORY_CACHE = DatabaseCache.get(CoreSchema.getInstance().getSchema().getScope(), 300, "View categories", (key, argument) -> new ViewCategoryCollections(key));
 
     private ViewCategoryCache()
     {

--- a/api/src/org/labkey/api/security/UserCache.java
+++ b/api/src/org/labkey/api/security/UserCache.java
@@ -17,7 +17,6 @@ package org.labkey.api.security;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
@@ -48,7 +47,7 @@ class UserCache
     private static final CoreSchema CORE = CoreSchema.getInstance();
     private static final String KEY = "USER_COLLECTIONS";
 
-    private static final Cache<String, UserCollections> CACHE = new BlockingCache<>(new DatabaseCache<>(CORE.getSchema().getScope(), 2, CacheManager.DAY, "User collections"), new UserCollectionsLoader());
+    private static final Cache<String, UserCollections> CACHE = DatabaseCache.get(CORE.getSchema().getScope(), 2, CacheManager.DAY, "User collections", new UserCollectionsLoader());
 
     private UserCache()
     {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1005,7 +1005,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return toExpProtocol(p);
     }
 
-
     @Override
     public ExpProtocolImpl getExpProtocol(String lsid)
     {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -81,6 +81,7 @@ import org.labkey.api.exp.query.ExpSampleTypeTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.exp.query.SampleStatusTable;
 import org.labkey.api.exp.query.SamplesSchema;
+import org.labkey.api.exp.xar.LSIDRelativizer;
 import org.labkey.api.exp.xar.LsidUtils;
 import org.labkey.api.exp.xar.XarConstants;
 import org.labkey.api.files.FileContentService;
@@ -138,7 +139,6 @@ import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.view.ViewContext;
 import org.labkey.experiment.ExperimentAuditProvider;
-import org.labkey.api.exp.xar.LSIDRelativizer;
 import org.labkey.experiment.XarExportType;
 import org.labkey.experiment.XarExporter;
 import org.labkey.experiment.XarReader;
@@ -203,7 +203,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 {
     private static final Logger LOG = LogHelper.getLogger(ExperimentServiceImpl.class, "Experiment infrastructure including maintaining runs and lineage");
 
-    private Cache<String, ExpProtocolImpl> protocolCache;
+    private static final Cache<String, ExpProtocolImpl> PROTOCOL_CACHE = new DatabaseCache<>(getExpSchema().getScope(), CacheManager.UNLIMITED, CacheManager.HOUR, "Protocol");
 
     private final Cache<String, SortedSet<DataClass>> dataClassCache = CacheManager.getBlockingStringKeyCache(CacheManager.UNLIMITED, CacheManager.DAY, "Data classes", (containerId, argument) ->
     {
@@ -245,15 +245,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             dataClassCache.clear();
         else
             dataClassCache.remove(c.getId());
-    }
-
-    synchronized Cache<String, ExpProtocolImpl> getProtocolCache()
-    {
-        if (protocolCache == null)
-        {
-            protocolCache = new DatabaseCache<>(getExpSchema().getScope(), CacheManager.UNLIMITED, CacheManager.HOUR, "Protocol");
-        }
-        return protocolCache;
     }
 
     @Override
@@ -757,10 +748,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         filter.addClause(clause);
 
         return new TableSelector(getTinfoMaterial(), filter, null)
-                .getArrayList(Material.class)
-                .stream()
-                .map(ExpMaterialImpl::new)
-                .collect(toList());
+            .getArrayList(Material.class)
+            .stream()
+            .map(ExpMaterialImpl::new)
+            .toList();
     }
 
     @Override
@@ -926,12 +917,12 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         TableInfo table = dataClass.getTinfo();
         // Index all ExpData that have never been indexed OR where either the ExpDataClass definition or ExpData itself has changed since last indexed
         SQLFragment sql = new SQLFragment()
-                .append("SELECT * FROM ").append(getTinfoData(), "d")
-                .append(", ").append(table, "t")
-                .append(" WHERE t.lsid = d.lsid")
-                .append(" AND d.classId = ?").add(dataClass.getRowId())
-                .append(" AND (d.lastIndexed IS NULL OR d.lastIndexed < ? OR (d.modified IS NOT NULL AND d.lastIndexed < d.modified))")
-                .add(dataClass.getModified());
+            .append("SELECT * FROM ").append(getTinfoData(), "d")
+            .append(", ").append(table, "t")
+            .append(" WHERE t.lsid = d.lsid")
+            .append(" AND d.classId = ?").add(dataClass.getRowId())
+            .append(" AND (d.lastIndexed IS NULL OR d.lastIndexed < ? OR (d.modified IS NOT NULL AND d.lastIndexed < d.modified))")
+            .add(dataClass.getModified());
 
         new SqlSelector(table.getSchema().getScope(), sql).forEachBatch(Data.class, 1000, batch -> {
             for (Data data : batch)
@@ -946,10 +937,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     {
         // Index the data class if it has never been indexed OR it has changed since it was last indexed
         SQLFragment sql = new SQLFragment("SELECT * FROM ")
-                .append(getTinfoDataClass(), "dc")
-                .append(" WHERE dc.LSID = ?").add(expDataClass.getLSID())
-                .append(" AND (dc.lastIndexed IS NULL OR dc.lastIndexed < ?)")
-                .add(expDataClass.getModified());
+            .append(getTinfoDataClass(), "dc")
+            .append(" WHERE dc.LSID = ?").add(expDataClass.getLSID())
+            .append(" AND (dc.lastIndexed IS NULL OR dc.lastIndexed < ?)")
+            .add(expDataClass.getModified());
 
         DataClass dClass = new SqlSelector(getExpSchema().getScope(), sql).getObject(DataClass.class);
         if (dClass != null)
@@ -1003,73 +994,54 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public ExpProtocolImpl getExpProtocol(int rowid)
     {
-        return getExpProtocol(rowid, true);
-    }
+        ExpProtocolImpl result;
 
-    public ExpProtocolImpl getExpProtocol(int rowid, boolean useCache)
-    {
-        ExpProtocolImpl result = null;
-
-        if (useCache)
-        {
-            result = getProtocolCache().get("ROWID/" + rowid);
-            if (null != result)
-                return result;
-        }
+        result = PROTOCOL_CACHE.get("ROWID/" + rowid);
+        if (null != result)
+            return result;
 
         Protocol p = new TableSelector(getTinfoProtocol(), new SimpleFilter(FieldKey.fromParts("RowId"), rowid), null).getObject(Protocol.class);
 
-        return toExpProtocol(p, useCache);
+        return toExpProtocol(p);
     }
 
 
     @Override
     public ExpProtocolImpl getExpProtocol(String lsid)
     {
-        return getExpProtocol(lsid, true);
-    }
-
-    public ExpProtocolImpl getExpProtocol(String lsid, boolean useCache)
-    {
-        if (useCache)
-        {
-            ExpProtocolImpl result = getProtocolCache().get(getCacheKey(lsid));
-            if (null != result)
-                return result;
-        }
+        ExpProtocolImpl result = PROTOCOL_CACHE.get(getCacheKey(lsid));
+        if (null != result)
+            return result;
 
         Protocol p = new TableSelector(getTinfoProtocol(), new SimpleFilter(FieldKey.fromParts("LSID"), lsid), null).getObject(Protocol.class);
 
-        return toExpProtocol(p, useCache);
+        return toExpProtocol(p);
     }
 
     @NotNull
-    private ExpProtocolImpl toExpProtocol(@Nullable Protocol p, boolean cache)
+    private ExpProtocolImpl toExpProtocol(@Nullable Protocol p)
     {
         ExpProtocolImpl result = p == null ? null : new ExpProtocolImpl(p);
-        if (cache && result != null)
+        if (result != null)
         {
-            Cache<String, ExpProtocolImpl> c = getProtocolCache();
-            c.put(getCacheKey(result.getLSID()), result);
-            c.put("ROWID/" + result.getRowId(), result);
+            PROTOCOL_CACHE.put(getCacheKey(result.getLSID()), result);
+            PROTOCOL_CACHE.put("ROWID/" + result.getRowId(), result);
         }
         return result;
     }
 
     private void uncacheProtocol(Protocol p)
     {
-        Cache<String, ExpProtocolImpl> c = getProtocolCache();
+        Cache<String, ExpProtocolImpl> c = PROTOCOL_CACHE;
         c.remove(getCacheKey(p.getLSID()));
         c.remove("ROWID/" + p.getRowId());
     }
-
 
     @Override
     public ExpProtocolImpl getExpProtocol(Container container, String name)
     {
         return getExpProtocol(generateLSID(container, ExpProtocol.class, name));
     }
-
 
     @Override
     public ExpProtocolImpl createExpProtocol(Container container, ExpProtocol.ApplicationType type, String name)
@@ -3636,7 +3608,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
 
-    public DbSchema getExpSchema()
+    public static DbSchema getExpSchema()
     {
         return DbSchema.get("exp", DbSchemaType.Module);
     }
@@ -3919,7 +3891,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     {
         ((SampleTypeServiceImpl) SampleTypeService.get()).clearMaterialSourceCache(null);
         getDataClassCache().clear();
-        getProtocolCache().clear();
+        PROTOCOL_CACHE.clear();
         DomainPropertyManager.clearCaches();
     }
 

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyManager.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyManager.java
@@ -76,7 +76,7 @@ public class DomainPropertyManager
     }
 
     private static final ConditionalFormatLoader CONDITIONAL_FORMAT_LOADER = new ConditionalFormatLoader();
-    private static final DatabaseCache<Container, List<ConditionalFormatWithPropertyId>> CONDITIONAL_FORMAT_CACHE = new DatabaseCache<>(getExpSchema().getScope(), Constants.getMaxContainers(), CacheManager.DAY, "Conditional formats");
+    private static final BlockingCache<Container, List<ConditionalFormatWithPropertyId>> CONDITIONAL_FORMAT_CACHE = DatabaseCache.get(getExpSchema().getScope(), Constants.getMaxContainers(), CacheManager.DAY, "Conditional formats", CONDITIONAL_FORMAT_LOADER);
 
     private DomainPropertyManager(){}
 
@@ -154,7 +154,7 @@ public class DomainPropertyManager
 
     public List<ConditionalFormatWithPropertyId> getConditionalFormats(Container container)
     {
-        return CONDITIONAL_FORMAT_CACHE.get(container, null, CONDITIONAL_FORMAT_LOADER);
+        return CONDITIONAL_FORMAT_CACHE.get(container);
     }
 
     // Container -> PropertyId -> Collection<PropertyValidator>
@@ -174,7 +174,7 @@ public class DomainPropertyManager
         return validators.isEmpty() ? MultiMapUtils.emptyMultiValuedMap() : MultiMapUtils.unmodifiableMultiValuedMap(validators);
     };
 
-    private static final Cache<Container, MultiValuedMap<Integer, PropertyValidator>> VALIDATOR_CACHE = new BlockingCache<>(new DatabaseCache<>(getExpSchema().getScope(), Constants.getMaxContainers(), CacheManager.HOUR, "Property validators"), PV_LOADER);
+    private static final Cache<Container, MultiValuedMap<Integer, PropertyValidator>> VALIDATOR_CACHE = DatabaseCache.get(getExpSchema().getScope(), Constants.getMaxContainers(), CacheManager.HOUR, "Property validators", PV_LOADER);
     private static final Collection<PropertyValidator> EMPTY_COLLECTION = Collections.emptyList();
 
 

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -578,9 +578,6 @@ public class StorageProvisionerImpl implements StorageProvisioner
     private SchemaTableInfo getSchemaTableInfo(@NotNull Domain domain, String schemaName, String tableName, DbSchema schema)
     {
         ProvisionedSchemaOptions options = new ProvisionedSchemaOptions(schema, tableName, domain);
-        if (!schema.getScope().isCached(options))
-            log.warn(schema.getName() + "." + tableName + " is NOT cached!");
-
         SchemaTableInfo sti = schema.getTable(options);
         if (null == sti)
             throw new TableNotFoundException(schemaName, tableName);

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -28,7 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.audit.AuditLogService;
-import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
@@ -100,7 +99,7 @@ public class ListManager implements SearchService.DocumentProvider
     public static final String LISTID_FIELD_NAME = "listId";
 
 
-    private final Cache<String, List<ListDef>> _listDefCache = new BlockingCache<>(new DatabaseCache<>(CoreSchema.getInstance().getScope(), CacheManager.UNLIMITED, CacheManager.DAY, "List definitions"), new ListDefCacheLoader()) ;
+    private final Cache<String, List<ListDef>> _listDefCache = DatabaseCache.get(CoreSchema.getInstance().getScope(), CacheManager.UNLIMITED, CacheManager.DAY, "List definitions", new ListDefCacheLoader()) ;
 
     private class ListDefCacheLoader implements CacheLoader<String,List<ListDef>>
     {

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -73,7 +73,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
 @RequiresPermission(ReadPermission.class)
@@ -248,7 +247,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
 
             JSONArray templates = new JSONArray();
             List<Pair<String, String>> it = tinfo.getImportTemplates(getViewContext());
-            if (null != it && it.size() > 0)
+            if (null != it && !it.isEmpty())
             {
                 for (Pair<String, String> pair : it)
                 {

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -1325,13 +1325,13 @@ public class LuceneSearchServiceImpl extends AbstractSearchService
         try
         {
             BooleanQuery query = new BooleanQuery.Builder()
-                    // Add container filter
-                    .add(new TermQuery(new Term(FIELD_NAME.container.toString(), container.getId())), BooleanClause.Occur.MUST)
-                    // Add files filter
-                    .add(new TermQuery(new Term(FIELD_NAME.searchCategories.toString(), "file")), BooleanClause.Occur.MUST)
-                    //Limit to just dav files and not attachments or other files
-                    .add(new WildcardQuery(new Term(FIELD_NAME.uniqueId.toString(), davPrefix + "*")), BooleanClause.Occur.MUST)
-                    .build();
+                // Add container filter
+                .add(new TermQuery(new Term(FIELD_NAME.container.toString(), container.getId())), BooleanClause.Occur.MUST)
+                // Add files filter
+                .add(new TermQuery(new Term(FIELD_NAME.searchCategories.toString(), "file")), BooleanClause.Occur.MUST)
+                //Limit to just dav files and not attachments or other files
+                .add(new WildcardQuery(new Term(FIELD_NAME.uniqueId.toString(), davPrefix + "*")), BooleanClause.Occur.MUST)
+                .build();
 
             // Run the query before delete, but only if Log4J debug level is set
             if (_log.isDebugEnabled() && _indexManager.isReal())


### PR DESCRIPTION
#### Rationale
When a `DatabaseCache` is used within a transaction, all remove and clear operations are replayed into the shared cache after successful commit. Put operations are not replayed, however. The inherent assumption has been that those objects will be loaded at some point by non-transacted code paths. It turns out we have code paths (e.g., dataset provisioned table metadata loading) that always access DatabaseCaches inside a transaction, which means their objects are effectively never cached. This is discussed in detail here: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48663

This PR makes a small change to `BlockingCache` that allows subclasses to intercept load operations that occur before put() is called. `DatabaseCache` then overrides this `load()` method to add a reload commit task on the BlockingCache if a transaction is active. This ensures that entries added during the transaction will be loaded into the shared cache immediately after commit.

This also moves many `DatabaseCache` usages to a more standard `BlockingCache` with static `CacheLoader` pattern that's required for put() replays.