### PR TITLE
Fix some failing Daily tests

### DIFF
--- a/api/src/org/labkey/api/data/DatabaseCache.java
+++ b/api/src/org/labkey/api/data/DatabaseCache.java
@@ -251,12 +251,7 @@ public class DatabaseCache<K, V> implements Cache<K, V>
         @Override
         public void run()
         {
-            // Workaround for nested transaction behavior... replay only if the database transaction has been committed
-            TransactionImpl transaction = DbScope.getLabKeyScope().getCurrentTransactionImpl();
-            if (null != transaction)
-                transaction.addCommitTask(this, DbScope.CommitTaskOption.POSTCOMMIT);
-            else
-                getCache().get(_key, _arg, _loader);
+            getCache().get(_key, _arg, _loader);
         }
     }
 

--- a/api/src/org/labkey/api/data/DatabaseCache.java
+++ b/api/src/org/labkey/api/data/DatabaseCache.java
@@ -251,7 +251,12 @@ public class DatabaseCache<K, V> implements Cache<K, V>
         @Override
         public void run()
         {
-            getCache().get(_key, _arg, _loader);
+            // Workaround for nested transaction behavior... replay only if the database transaction has been committed
+            TransactionImpl transaction = DbScope.getLabKeyScope().getCurrentTransactionImpl();
+            if (null != transaction)
+                transaction.addCommitTask(this, DbScope.CommitTaskOption.POSTCOMMIT);
+            else
+                getCache().get(_key, _arg, _loader);
         }
     }
 

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -886,7 +886,20 @@ public class OntologyManager
     public static int ensureObject(Container container, String objectURI, Integer ownerId)
     {
         //TODO: (marki) Transact?
-        return OBJECT_ID_CACHE.get(objectURI, Pair.of(container, ownerId));
+        Integer objId = OBJECT_ID_CACHE.get(objectURI, container);
+
+        if (null == objId)
+        {
+            OntologyObject obj = new OntologyObject();
+            obj.setContainer(container);
+            obj.setObjectURI(objectURI);
+            if (ownerId != null && ownerId > 0)
+                obj.setOwnerObjectId(ownerId);
+            obj = Table.insert(null, getTinfoObject(), obj);
+            objId = obj.getObjectId();
+        }
+
+        return objId;
     }
 
     private static class ObjectIdCacheLoader implements CacheLoader<String, Integer>
@@ -894,25 +907,14 @@ public class OntologyManager
         @Override
         public Integer load(@NotNull String objectURI, @Nullable Object argument)
         {
-            Pair<Container, Integer> pair = (Pair<Container, Integer>)argument;
-            Container container = pair.first;
-            Integer ownerId = pair.second;
-            OntologyObject o = getOntologyObject(container, objectURI);
-            if (null == o)
-            {
-                o = new OntologyObject();
-                o.setContainer(container);
-                o.setObjectURI(objectURI);
-                if (ownerId != null && ownerId > 0)
-                    o.setOwnerObjectId(ownerId);
-                o = Table.insert(null, getTinfoObject(), o);
-            }
+            Container container = (Container)argument;
+            OntologyObject obj = getOntologyObject(container, objectURI);
 
-            return o.getObjectId();
+            return obj == null ? null : obj.getObjectId();
         }
     }
 
-    public static OntologyObject getOntologyObject(Container container, String uri)
+    public static @Nullable OntologyObject getOntologyObject(Container container, String uri)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("ObjectURI"), uri);
         if (container != null)

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -897,6 +897,7 @@ public class OntologyManager
                 obj.setOwnerObjectId(ownerId);
             obj = Table.insert(null, getTinfoObject(), obj);
             objId = obj.getObjectId();
+            OBJECT_ID_CACHE.remove(objectURI);
         }
 
         return objId;


### PR DESCRIPTION
#### Rationale
The new `OBJECT_ID_CACHE` cache loader attempted to insert a new row in the database if the requested object wasn't found (ensure pattern). This fails on container delete during a transaction when, for example, an object ID is retrieved, the container is deleted, and the object ID retrieval is replayed: the object isn't found so the loader attempts to insert a row with a non-existent container. Solution is to move the insert outside of the cache loader, which better matches the previous code.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4739