### PR TITLE
use `caseInsensitive` method for getting comment out of response

### DIFF
--- a/experiment/src/client/test/integration/MoveSamplesAction.ispec.ts
+++ b/experiment/src/client/test/integration/MoveSamplesAction.ispec.ts
@@ -527,7 +527,7 @@ describe('ExperimentController', () => {
             expect(sampleEventsInTop).toHaveLength(0);
             const sampleEventsInSub1 = await getSampleTimelineAuditLogs(sampleRowId, subfolder1Options);
             expect(sampleEventsInSub1).toHaveLength(1);
-            expect(sampleEventsInSub1[0].Comment).toEqual("Sample was registered.");
+            expect(caseInsensitive(sampleEventsInSub1[0], 'Comment')).toEqual("Sample was registered.");
         });
 
         it('success, move sample from subfolder to parent project', async () => {

--- a/experiment/src/client/test/integration/MoveSourcesAction.ispec.ts
+++ b/experiment/src/client/test/integration/MoveSourcesAction.ispec.ts
@@ -525,7 +525,7 @@ describe('ExperimentController', () => {
             expect(eventsInTop).toHaveLength(0);
             const eventsInSub1 = await getDetailedQueryUpdateAuditLogs(sourceRowId, subfolder1Options);
             expect(eventsInSub1).toHaveLength(1);
-            expect(eventsInSub1[0].Comment).toEqual("A row was inserted.");
+            expect(caseInsensitive(eventsInSub1[0], 'Comment')).toEqual("A row was inserted.");
         });
 
         it('success, move from subfolder to parent project', async () => {


### PR DESCRIPTION
#### Rationale
Tests are failing.

#### Changes
* Update test to use `caseInsensitive` for getting the comment field
