### PR TITLE
Misc cleanup, container filter support, deprecate retrieving plate by name.

### DIFF
--- a/assay/api-src/org/labkey/api/assay/plate/AbstractPlateBasedAssayProvider.java
+++ b/assay/api-src/org/labkey/api/assay/plate/AbstractPlateBasedAssayProvider.java
@@ -32,6 +32,7 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpMaterial;
@@ -71,6 +72,7 @@ public abstract class AbstractPlateBasedAssayProvider extends AbstractTsvAssayPr
     public static final String SAMPLE_METADATA_INPUT_ROLE = "Sample Metadata";
     public static final String METADATA_INPUT_FORMAT_SUFFIX = "#SampleMetadataInputFormat";
     public static final String VIRUS_WELL_GROUP_NAME = "VirusWellGroupName";
+    public static final String PLATE_TEMPLATE_SUFFIX = "#PlateTemplate";
 
     public AbstractPlateBasedAssayProvider(String protocolLSIDPrefix, String runLSIDPrefix, String resultRowLsidPrefix, AssayDataType dataType, Module declaringModule)
     {
@@ -78,13 +80,13 @@ public abstract class AbstractPlateBasedAssayProvider extends AbstractTsvAssayPr
     }
 
     @Override
-    public void setPlate(Container container, ExpProtocol protocol, Plate template)
+    public void setPlate(Container container, ExpProtocol protocol, Plate plate)
     {
         if (!isPlateBased())
-            throw new IllegalStateException("Only plate-based assays may store a plate template.");
+            throw new IllegalStateException("Only plate-based assays may store a plate.");
         Map<String, ObjectProperty> props = new HashMap<>(protocol.getObjectProperties());
         ObjectProperty prop = new ObjectProperty(protocol.getLSID(), protocol.getContainer(),
-                protocol.getLSID() + "#PlateTemplate", template.getName());
+                protocol.getLSID() + PLATE_TEMPLATE_SUFFIX, plate.getLSID());
         props.put(prop.getPropertyURI(), prop);
         protocol.setObjectProperties(props);
     }
@@ -93,8 +95,8 @@ public abstract class AbstractPlateBasedAssayProvider extends AbstractTsvAssayPr
     @Nullable
     public Plate getPlate(Container container, ExpProtocol protocol)
     {
-        ObjectProperty prop = protocol.getObjectProperties().get(protocol.getLSID() + "#PlateTemplate");
-        return prop != null ? PlateService.get().getPlate(protocol.getContainer(), prop.getStringValue()) : null;
+        ObjectProperty prop = protocol.getObjectProperties().get(protocol.getLSID() + PLATE_TEMPLATE_SUFFIX);
+        return prop != null ? PlateService.get().getPlate(protocol.getContainer(), Lsid.parse(prop.getStringValue())) : null;
     }
 
     public boolean isPlateBased()

--- a/assay/api-src/org/labkey/api/assay/plate/Plate.java
+++ b/assay/api-src/org/labkey/api/assay/plate/Plate.java
@@ -40,31 +40,35 @@ public interface Plate extends PropertySet, Identifiable
 
     boolean isTemplate();
 
-    Well getWell(int row, int col);
+    /**
+     * Returns an existing well, or creates a new well if one
+     * had not previously existed.
+     */
+    @NotNull Well getWell(int row, int col);
 
-    Well getWell(int rowId);
+    @Nullable Well getWell(int rowId);
 
-    List<Well> getWells();
+    @NotNull List<Well> getWells();
 
-    WellGroup getWellGroup(WellGroup.Type type, String wellGroupName);
+    @Nullable WellGroup getWellGroup(WellGroup.Type type, String wellGroupName);
 
     @Nullable WellGroup getWellGroup(int rowId);
 
-    List<WellGroup> getWellGroups();
+    @NotNull List<WellGroup> getWellGroups();
 
-    List<WellGroup> getWellGroups(Position position);
+    @NotNull List<WellGroup> getWellGroups(Position position);
 
-    List<WellGroup> getWellGroups(WellGroup.Type type);
+    @NotNull List<WellGroup> getWellGroups(WellGroup.Type type);
 
-    Map<WellGroup.Type, Map<String, WellGroup>> getWellGroupTemplateMap();
+    @NotNull Map<WellGroup.Type, Map<String, WellGroup>> getWellGroupMap();
 
-    WellGroup addWellGroup(String name, WellGroup.Type type, Position upperLeft, Position lowerRight);
+    @NotNull WellGroup addWellGroup(String name, WellGroup.Type type, Position upperLeft, Position lowerRight);
 
-    WellGroup addWellGroup(String name, WellGroup.Type type, List<Position> positions);
+    @NotNull WellGroup addWellGroup(String name, WellGroup.Type type, List<Position> positions);
 
-    Integer getRowId();
+    @Nullable Integer getRowId();
 
-    Position getPosition(int row, int col);
+    @NotNull Position getPosition(int row, int col);
 
     int getWellGroupCount();
 
@@ -85,6 +89,5 @@ public interface Plate extends PropertySet, Identifiable
     /**
      * Returns the domain ID for the plate metadata domain.
      */
-    @Nullable
-    Integer getMetadataDomainId();
+    @Nullable Integer getMetadataDomainId();
 }

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -119,14 +119,6 @@ public interface PlateService
     /**
      * Gets an existing plate.
      * @param container The plate's container.
-     * @param plateName The plate's name.
-     * @return  The requested plate, or null if no template exists with the specified name in the specified container.
-     */
-    @Nullable Plate getPlate(Container container, String plateName);
-
-    /**
-     * Gets an existing plate.
-     * @param container The plate's container.
      * @param lsid The plate's lsid.
      * @return  The requested plate, or null if no plate exists with the specified name in the specified container.
      */

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.dilution.DilutionCurve;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.statistics.FitFailedException;
 import org.labkey.api.data.statistics.StatsService;
@@ -138,6 +139,14 @@ public interface PlateService
      * @return The requested plate, or null if no plate exists with the specified row id.
      */
     @Nullable Plate getPlate(Container container, int rowId);
+
+    /**
+     * Gets a plate instance object by row id.
+     * @param cf The container filter to find the plate
+     * @param rowId The row id of the plate.
+     * @return The requested plate, or null if no plate exists with the specified row id.
+     */
+    @Nullable Plate getPlate(ContainerFilter cf, int rowId);
 
     /**
      * Gets all plate templates for the specified container. Plate templates are Plate instances

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -141,6 +141,14 @@ public interface PlateService
     @Nullable Plate getPlate(ContainerFilter cf, int rowId);
 
     /**
+     * Gets a plate instance object by lsid.
+     * @param cf The container filter to find the plate
+     * @param lsid The lsid of the plate.
+     * @return The requested plate, or null if no plate exists with the specified row id.
+     */
+    @Nullable Plate getPlate(ContainerFilter cf, Lsid lsid);
+
+    /**
      * Gets all plate templates for the specified container. Plate templates are Plate instances
      * which have their template field set to TRUE.
      *

--- a/assay/resources/schemas/dbscripts/postgresql/assay-23.002-23.003.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-23.002-23.003.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('updateProtocolPlateTemplate');

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-23.002-23.003.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-23.002-23.003.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'updateProtocolPlateTemplate';

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -61,8 +61,8 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.PlatformDeveloperPermission;
-import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.study.assay.SampleMetadataInputFormat;
+import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -71,6 +71,7 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewContext;
 import org.labkey.assay.actions.SetDefaultValuesAssayAction;
+import org.labkey.assay.plate.PlateManager;
 import org.labkey.assay.query.AssayDbSchema;
 
 import java.io.File;
@@ -460,11 +461,11 @@ public class AssayDomainServiceImpl extends DomainEditorServiceBase implements A
                     if (provider instanceof PlateBasedAssayProvider && assay.getSelectedPlateTemplate() != null)
                     {
                         PlateBasedAssayProvider plateProvider = (PlateBasedAssayProvider)provider;
-                        Plate template = PlateService.get().getPlate(getContainer(), assay.getSelectedPlateTemplate());
-                        if (template != null)
-                            plateProvider.setPlate(getContainer(), protocol, template);
+                        Plate plate = PlateManager.get().getPlate(getContainer(), assay.getSelectedPlateTemplate());
+                        if (plate != null)
+                            plateProvider.setPlate(getContainer(), protocol, plate);
                         else
-                            throw new AssayException("The selected plate template could not be found.  Perhaps it was deleted by another user?");
+                            throw new AssayException("The selected plate could not be found.  Perhaps it was deleted by another user?");
 
                         String selectedFormat = assay.getSelectedMetadataInputFormat();
                         SampleMetadataInputFormat inputFormat = SampleMetadataInputFormat.valueOf(selectedFormat);

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -106,7 +106,7 @@ public class AssayModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 23.002;
+        return 23.003;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -2,9 +2,13 @@ package org.labkey.assay;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayResultDomainKind;
 import org.labkey.api.assay.AssayService;
+import org.labkey.api.assay.plate.AbstractPlateBasedAssayProvider;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateBasedAssayProvider;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -15,6 +19,7 @@ import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.data.SchemaTableInfo;
 import org.labkey.api.data.UpgradeCode;
 import org.labkey.api.exp.Lsid;
+import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.StorageProvisioner;
@@ -25,6 +30,8 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.roles.SiteAdminRole;
 import org.labkey.api.util.Pair;
+import org.labkey.assay.plate.PlateManager;
+import org.labkey.assay.query.AssayDbSchema;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -135,5 +142,57 @@ public class AssayUpgradeCode implements UpgradeCode
         StorageProvisioner.get().addStorageProperties(domain, Arrays.asList(colProp), true);
         _log.info("Added '" + colName + "' column to '" + protocol.getName() + " provisioned result table.");
 
+    }
+
+    /**
+     * Called from assay-23.002-23.003.sql
+     *
+     * Switch from storing the protocol plate template by name to the plate lsid.
+     */
+    @DeferredUpgrade
+    public static void updateProtocolPlateTemplate(ModuleContext ctx) throws Exception
+    {
+        if (ctx.isNewInstall())
+            return;
+
+        DbScope scope = AssayDbSchema.getInstance().getSchema().getScope();
+        try (DbScope.Transaction tx = scope.ensureTransaction())
+        {
+            Set<ExpProtocol> protocols = new HashSet<>();
+            for (Container container : ContainerManager.getAllChildren(ContainerManager.getRoot()))
+            {
+                if (container != null)
+                    protocols.addAll(AssayService.get().getAssayProtocols(container));
+            }
+
+            for (ExpProtocol protocol : protocols)
+            {
+                AssayProvider provider = AssayService.get().getProvider(protocol);
+                if (provider != null)
+                {
+                    if (provider instanceof PlateBasedAssayProvider plateProvider)
+                    {
+                        Plate plate = getPlate(protocol);
+                        if (plate != null)
+                        {
+                            // get a mutable version of the protocol
+                            ExpProtocol mutableProtocol = ExperimentService.get().getExpProtocol(protocol.getRowId());
+                            _log.info("Adjusting plate template storage for assay: " + mutableProtocol.getName());
+                            plateProvider.setPlate(mutableProtocol.getContainer(), mutableProtocol, plate);
+                            mutableProtocol.save(User.getSearchUser());
+                        }
+                    }
+                }
+            }
+            tx.commit();
+        }
+    }
+
+    @Nullable
+    private static Plate getPlate(ExpProtocol protocol)
+    {
+        // resolve plate by the legacy deprecated plate name method
+        ObjectProperty prop = protocol.getObjectProperties().get(protocol.getLSID() + AbstractPlateBasedAssayProvider.PLATE_TEMPLATE_SUFFIX);
+        return prop != null ? PlateManager.get().getPlate(protocol.getContainer(), prop.getStringValue()) : null;
     }
 }

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -179,7 +179,7 @@ public class AssayUpgradeCode implements UpgradeCode
                             ExpProtocol mutableProtocol = ExperimentService.get().getExpProtocol(protocol.getRowId());
                             _log.info("Adjusting plate template storage for assay: " + mutableProtocol.getName());
                             plateProvider.setPlate(mutableProtocol.getContainer(), mutableProtocol, plate);
-                            mutableProtocol.save(User.getSearchUser());
+                            mutableProtocol.save(User.getAdminServiceUser());
                         }
                     }
                 }

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -33,6 +33,7 @@ import org.labkey.api.assay.plate.PlateCustomField;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.security.DesignAssayPermission;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.gwt.server.BaseRemoteService;
@@ -774,6 +775,7 @@ public class PlateController extends SpringActionController
     public static class GetPlateForm
     {
         private Integer _rowId;
+        private ContainerFilter.Type _containerFilter;
 
         public Integer getRowId()
         {
@@ -783,6 +785,16 @@ public class PlateController extends SpringActionController
         public void setRowId(Integer rowId)
         {
             _rowId = rowId;
+        }
+
+        public ContainerFilter.Type getContainerFilter()
+        {
+            return _containerFilter;
+        }
+
+        public void setContainerFilter(ContainerFilter.Type containerFilter)
+        {
+            _containerFilter = containerFilter;
         }
     }
 
@@ -799,7 +811,13 @@ public class PlateController extends SpringActionController
         @Override
         public Object execute(GetPlateForm form, BindException errors) throws Exception
         {
-            return PlateManager.get().getPlate(getContainer(), form.getRowId());
+            ContainerFilter cf = ContainerFilter.Type.Current.create(getViewContext());
+
+            // if an optional container filter is specified
+            if (form.getContainerFilter() != null)
+                cf = form.getContainerFilter().create(getViewContext());
+
+            return PlateManager.get().getPlate(cf, form.getRowId());
         }
     }
 }

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -268,13 +268,16 @@ public class PlateController extends SpringActionController
     public static class CopyTemplateBean
     {
         private final HtmlString _treeHtml;
-        private final String _templateName;
+        private final Plate _plate;
         private final String _selectedDestination;
         private List<Plate> _destinationTemplates;
 
-        public CopyTemplateBean(final Container container, final User user, final String templateName, final String selectedDestination)
+        public CopyTemplateBean(final Container container, final User user, final Integer plateId, final String selectedDestination)
         {
-            _templateName = templateName;
+            _plate = PlateService.get().getPlate(container, plateId);
+            if (_plate == null)
+                throw new IllegalStateException("Could not resolve the plate with ID : " + plateId);
+
             _selectedDestination = selectedDestination;
 
             //Copy and Add to another folder requires InsertPermissions
@@ -284,7 +287,7 @@ public class PlateController extends SpringActionController
                 protected void renderCellContents(StringBuilder html, Container c, ActionURL url)
                 {
                     ActionURL copyURL = new ActionURL(CopyTemplateAction.class, container);
-                    copyURL.addParameter("templateName", templateName);
+                    copyURL.addParameter("plateId", _plate.getRowId());
                     copyURL.addParameter("destination", c.getPath());
                     boolean selected = c.getPath().equals(selectedDestination);
                     if (selected)
@@ -321,9 +324,9 @@ public class PlateController extends SpringActionController
             return _treeHtml;
         }
 
-        public String getTemplateName()
+        public Plate getPlate()
         {
-            return _templateName;
+            return _plate;
         }
 
         public List<? extends Plate> getDestinationTemplates()
@@ -338,16 +341,15 @@ public class PlateController extends SpringActionController
         @Override
         public void validateCommand(CopyForm form, Errors errors)
         {
+            if (form.getPlateId() == null)
+                errors.reject(ERROR_REQUIRED, "Plate ID must not be blank");
         }
 
         @Override
         public ModelAndView getView(CopyForm form, boolean reshow, BindException errors)
         {
-            if (form.getTemplateName() == null || form.getTemplateName().length() == 0)
-                return HttpView.redirect(new ActionURL(BeginAction.class, getContainer()));
-
             return new JspView<>("/org/labkey/assay/plate/view/copyTemplate.jsp",
-                    new CopyTemplateBean(getContainer(), getUser(), form.getTemplateName(), form.getDestination()), errors);
+                    new CopyTemplateBean(getContainer(), getUser(), form.getPlateId(), form.getDestination()), errors);
         }
 
         @Override
@@ -372,45 +374,28 @@ public class PlateController extends SpringActionController
     @RequiresAnyOf({InsertPermission.class, DesignAssayPermission.class})
     public class HandleCopyAction extends CopyTemplateAction
     {
+        private Plate _plate;
+        private Container _destination;
+
         @Override
         public void validateCommand(CopyForm form, Errors errors)
         {
-            Container destination = ContainerManager.getForPath(form.getDestination());
-            if (destination == null || !destination.hasPermission(getUser(), InsertPermission.class))
+            _destination = ContainerManager.getForPath(form.getDestination());
+            if (_destination == null || !_destination.hasPermission(getUser(), InsertPermission.class))
                 errors.reject("copyForm", "Destination container does not exist or permission is denied.");
 
-            Plate destinationTemplate = PlateService.get().getPlate(destination, form.getTemplateName());
+            _plate = PlateService.get().getPlate(getContainer(), form.getPlateId());
+            if (_plate == null)
+                errors.reject(ERROR_REQUIRED, "Unable to retrieve source plate with ID : " + form.getPlateId());
 
-            if (destinationTemplate != null)
+            if (PlateManager.get().plateExists(_destination, _plate.getName()))
                 errors.reject("copyForm", "A plate template with the same name already exists in the destination folder.");
         }
 
         @Override
         public boolean handlePost(CopyForm form, BindException errors) throws Exception
         {
-            Container destination = ContainerManager.getForPath(form.getDestination());
-            // earlier validation should prevent a null or inaccessible destination container:
-            if (destination == null || !destination.hasPermission(getUser(), InsertPermission.class))
-            {
-                errors.reject("copyForm", "The destination is invalid or you do not have INSERT privileges on the specified container");
-                return false;
-            }
-            // earlier validation should prevent a missing source template:
-            Plate template = PlateService.get().getPlate(getContainer(), form.getTemplateName());
-            if (template == null)
-            {
-                errors.reject("copyForm", "Plate " + form.getTemplateName() + " does not exist in source container.");
-                return false;
-            }
-
-            // earlier validation should prevent an already-existing destination template:
-            Plate destinationTemplate = PlateService.get().getPlate(destination, form.getTemplateName());
-            if (destinationTemplate != null)
-            {
-                errors.reject("copyForm", "Plate " + form.getTemplateName() + " already exists in destination container.");
-                return false;
-            }
-            PlateService.get().copyPlate(template, getUser(), destination);
+            PlateService.get().copyPlate(_plate, getUser(), _destination);
             return true;
         }
 
@@ -526,7 +511,7 @@ public class PlateController extends SpringActionController
     public static class CopyForm
     {
         private String _destination;
-        private String _templateName;
+        private Integer _plateId;
 
         public String getDestination()
         {
@@ -538,14 +523,14 @@ public class PlateController extends SpringActionController
             _destination = destination;
         }
 
-        public String getTemplateName()
+        public Integer getPlateId()
         {
-            return _templateName;
+            return _plateId;
         }
 
-        public void setTemplateName(String templateName)
+        public void setPlateId(Integer plateId)
         {
-            _templateName = templateName;
+            _plateId = plateId;
         }
     }
 

--- a/assay/src/org/labkey/assay/plate/PlateCache.java
+++ b/assay/src/org/labkey/assay/plate/PlateCache.java
@@ -10,6 +10,7 @@ import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableSelector;
@@ -91,6 +92,28 @@ public class PlateCache
         // We allow plates to be mutated, return a copy of the cached object which still references the
         // original wells and well groups
         return plate != null ? plate.copy() : null;
+    }
+
+    public static @Nullable Plate getPlate(ContainerFilter cf, int rowId)
+    {
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("RowId"), rowId);
+        filter.addClause(cf.createFilterClause(AssayDbSchema.getInstance().getSchema(), FieldKey.fromParts("Container")));
+
+        List<String> containers = new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(),
+                Collections.singleton("Container"),
+                filter, null).getArrayList(String.class);
+
+        if (containers.size() > 1)
+            throw new IllegalStateException("More than one Plate found for the specified row ID : " + rowId);
+
+        if (containers.size() == 1)
+        {
+            Container c = ContainerManager.getForId(containers.get(0));
+            if (c != null)
+                return PLATE_CACHE.get(PlateCacheKey.getCacheKey(c, rowId));
+        }
+
+        return null;
     }
 
     public static @Nullable Plate getPlate(Container c, String name)

--- a/assay/src/org/labkey/assay/plate/PlateDataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateDataServiceImpl.java
@@ -38,7 +38,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -158,8 +157,7 @@ public class PlateDataServiceImpl extends BaseRemoteService implements PlateData
                     throw new Exception("Plate template not found: " + gwtPlate.getRowId());
 
                 // check another plate of the same name doesn't already exist
-                Plate other = PlateManager.get().getPlate(getContainer(), gwtPlate.getName());
-                if (other != null && !Objects.equals(other.getRowId(), template.getRowId()) && !replaceIfExisting)
+                if (PlateManager.get().plateExists(getContainer(), gwtPlate.getName()) && !replaceIfExisting)
                     throw new Exception("A plate template with name '" + gwtPlate.getName() + "' already exists.");
 
                 if (!template.getType().equals(gwtPlate.getType()))

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -347,6 +347,12 @@ public class PlateManager implements PlateService
     }
 
     @Override
+    public @Nullable Plate getPlate(ContainerFilter cf, Lsid lsid)
+    {
+        return PlateCache.getPlate(cf, lsid);
+    }
+
+    @Override
     public @Nullable Plate getPlate(Container container, Lsid lsid)
     {
         return PlateCache.getPlate(container, lsid);

--- a/assay/src/org/labkey/assay/plate/query/PlateTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTable.java
@@ -186,13 +186,7 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
 
             // generate a value for the lsid
             lsidGenerator.addColumn(plateTable.getColumn("lsid"),
-                    (Supplier) () -> {
-                        Object isTemplate = lsidGenerator.get(nameMap.get("template"));
-                        if (isTemplate instanceof String template)
-                            isTemplate = Boolean.valueOf(template);
-
-                        return PlateManager.get().getLsid(Plate.class, container, (Boolean)isTemplate, true);
-                    });
+                    (Supplier) () -> PlateManager.get().getLsid(Plate.class, container));
 
             // generate the data file id if not provided
             if (!nameMap.containsKey("dataFileId"))

--- a/assay/src/org/labkey/assay/plate/query/WellGroupTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellGroupTable.java
@@ -158,7 +158,7 @@ public class WellGroupTable extends SimpleUserSchema.SimpleTable<UserSchema>
 
             // generate a value for the lsid
             lsidGenerator.addColumn(wellGroupTable.getColumn("lsid"),
-                    (Supplier) () -> PlateManager.get().getLsid(WellGroup.class, container, true, true));
+                    (Supplier) () -> PlateManager.get().getLsid(WellGroup.class, container));
 
             DataIteratorBuilder dib = StandardDataIteratorBuilder.forInsert(wellGroupTable, lsidGenerator, container, user, context);
             dib = new TableInsertDataIteratorBuilder(dib, wellGroupTable, container)

--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -233,7 +233,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<UserSchema>
                         Object row = lsidGenerator.get(nameMap.get("row"));
                         Object col = lsidGenerator.get(nameMap.get("col"));
 
-                        Lsid lsid = PlateManager.get().getLsid(Well.class, container, true, true);
+                        Lsid lsid = PlateManager.get().getLsid(Well.class, container);
                         return String.format("%s-well-%s-%s", lsid.toString(), row, col);
                     });
 

--- a/assay/src/org/labkey/assay/plate/view/AssayPlateMetadataTemplateAction.java
+++ b/assay/src/org/labkey/assay/plate/view/AssayPlateMetadataTemplateAction.java
@@ -60,7 +60,7 @@ public class AssayPlateMetadataTemplateAction extends ExportAction<AssayPlateMet
                 Random rand = new Random();
 
                 JSONObject json = new JSONObject();
-                var wellGroupMap = plateTemplate.getWellGroupTemplateMap();
+                var wellGroupMap = plateTemplate.getWellGroupMap();
                 for (var typeGroupEntry : wellGroupMap.entrySet())
                 {
                     var type = typeGroupEntry.getKey();

--- a/assay/src/org/labkey/assay/plate/view/copyTemplate.jsp
+++ b/assay/src/org/labkey/assay/plate/view/copyTemplate.jsp
@@ -32,7 +32,7 @@
 <labkey:errors />
 <table>
     <tr>
-        <td>Copy <b><%= h(bean.getTemplateName()) %></b> to:</td>
+        <td>Copy <b><%= h(bean.getPlate().getName()) %></b> to:</td>
     </tr>
     <%=bean.getTreeHtml()%>
     <tr>
@@ -40,7 +40,7 @@
             <br>
             <labkey:form action="<%=urlFor(HandleCopyAction.class)%>" method="POST">
                 <input type="hidden" name="destination" value="<%= h(bean.getSelectedDestination()) %>">
-                <input type="hidden" name="templateName" value="<%= h(bean.getTemplateName()) %>">
+                <input type="hidden" name="plateId" value="<%= bean.getPlate().getRowId() %>">
                 <%= button("Cancel").href(PlateTemplateListAction.class, getContainer()) %>
                 <%= bean.getSelectedDestination() != null ? button("Copy").submit(true) : button("Copy").submit(true).onClick("alert('Please select a destination folder.'); return false;") %>
             </labkey:form>

--- a/assay/src/org/labkey/assay/plate/view/plateTemplateList.jsp
+++ b/assay/src/org/labkey/assay/plate/view/plateTemplateList.jsp
@@ -156,7 +156,6 @@
             {
         %>
             <%= link("copy to another folder", new ActionURL(PlateController.CopyTemplateAction.class, getContainer()).
-                addParameter("templateName", template.getName()).
                 addParameter("plateId", template.getRowId())) %>
         <%
             }


### PR DESCRIPTION
#### Rationale
This PR supports a variety of changes related to plates:
- **Nomenclature clean up**
  - Stop referring to `WellGroups` as `WellGroupTemplate`, the latter is no longer a thing and template versus instance is slowly becoming a thing of the past. Distinct classes and interfaces were merged a while ago and `Plate.isTemplate` is used to currently distinguish between template/non-template.
- **ContainerFilter support**
  - We now allow retrieving a plate using a `ContainerFilter` and either a `PlateId` or `Lsid`.
  - Retrieval is delegated to the `PlateCache` and the `getPlate.api` now supports an optional `ContainerFilter` parameter.
- **Deprecate resolving by plate name**
  - We don't want to rely on plate names especially in the cross folder scenarios. `PlateId` and `Lsid` are more favorable since they are unique across the site.
  - Deprecate the `getPlate(Container, String plateName)` method and remove it from `PlateService`.
  - Convert methods which used name to use either `PlateId` or `Lsid`
  - Upgrade existing plate based protocols to store the associated plate using the `Lsid`
 
#### Related Pull Requests
- https://github.com/LabKey/commonAssays/pull/635