### PR TITLE
Fix a few more tests failing because of DatabaseCache changes

### DIFF
--- a/api/src/org/labkey/api/cache/TransactionCache.java
+++ b/api/src/org/labkey/api/cache/TransactionCache.java
@@ -31,7 +31,7 @@ import java.util.Set;
  * (put or remove) occurs on that entry, at which point only the private cache is consulted for this entry for the
  * remainder of the transaction. This should provide good performance while avoiding pollution of the shared cache
  * during the transaction and in the case of a rollback. On successful commit, remove and clear operations are replayed
- * into the shared cache and load operations are replayed on the special BlockingCache that wraps this.
+ * into the shared cache. Using a BlockingDatabaseCache ensures that load() operations are also replayed.
  */
 public class TransactionCache<K, V> implements Cache<K, V>
 {

--- a/api/src/org/labkey/api/data/DatabaseCache.java
+++ b/api/src/org/labkey/api/data/DatabaseCache.java
@@ -49,12 +49,14 @@ public class DatabaseCache<K, V> implements Cache<K, V>
     private final Cache<K, V> _sharedCache;
     private final DbScope _scope;
 
+    @Deprecated // Use the factory methods that return a BlockingDatabaseCache instead
     public DatabaseCache(DbScope scope, int maxSize, long defaultTimeToLive, String debugName)
     {
         _sharedCache = createSharedCache(maxSize, defaultTimeToLive, debugName);
         _scope = scope;
     }
 
+    @Deprecated // Use the factory methods that return a BlockingDatabaseCache instead
     public DatabaseCache(DbScope scope, int maxSize, String debugName)
     {
         // TODO: UNLIMITED default TTL seems aggressive, but that's what we've used for years...
@@ -71,6 +73,11 @@ public class DatabaseCache<K, V> implements Cache<K, V>
         return new BlockingDatabaseCache<>(new DatabaseCache<>(scope, maxSize, debugName), cacheLoader);
     }
 
+    /**
+     * A DatabaseCache wrapped by a BlockingCache that knows how to replay load() events that take place on a
+     * transaction's private cache into the shared cache after successful commit. This can result in a big performance
+     * improvement, particularly for operations that always take place inside a transaction.
+     */
     private static class BlockingDatabaseCache<K, V> extends BlockingCache<K, V>
     {
         private final DatabaseCache<K, Wrapper<V>> _databaseCache;
@@ -94,6 +101,12 @@ public class DatabaseCache<K, V> implements Cache<K, V>
             }
 
             return value;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "BlockingDatabaseCache over \"" + _databaseCache._sharedCache.toString() + "\"";
         }
     }
 

--- a/api/src/org/labkey/api/data/DatabaseCache.java
+++ b/api/src/org/labkey/api/data/DatabaseCache.java
@@ -44,8 +44,6 @@ import java.util.Set;
  */
 public class DatabaseCache<K, V> implements Cache<K, V>
 {
-    private static final Logger LOG = LogHelper.getLogger(DatabaseCache.class, "DatabaseCache misses");
-
     private final Cache<K, V> _sharedCache;
     private final DbScope _scope;
 
@@ -80,6 +78,8 @@ public class DatabaseCache<K, V> implements Cache<K, V>
      */
     private static class BlockingDatabaseCache<K, V> extends BlockingCache<K, V>
     {
+        private static final Logger LOG = LogHelper.getLogger(BlockingDatabaseCache.class, "BlockingDatabaseCache loads");
+
         private final DatabaseCache<K, Wrapper<V>> _databaseCache;
 
         public BlockingDatabaseCache(DatabaseCache<K, Wrapper<V>> cache, @Nullable CacheLoader<K, V> loader)


### PR DESCRIPTION
#### Rationale
After my `DatabaseCache` changes, `StudyPHIExportTest` and `DataViewsTest` are failing with `ERROR: insert or update on table "propertydomain" violates foreign key constraint "fk_propertydomain_property"`. Switch the property descriptor cache back to a plain old `DatabaseCache` for now.

`AuditInsertionFailureTestCase` is now failing because it intentionally trashes the connection which means the replay tasks throw. Catch and log these exceptions in `handleAuditFailure()` so the test continues to see the exception it expects.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4739