### PR TITLE
buildTime and serverStartupTime substitutions for page headers

### DIFF
--- a/api/schemas/tableInfo.xsd
+++ b/api/schemas/tableInfo.xsd
@@ -1082,6 +1082,11 @@
                                     <xs:documentation>Null or missing fields will be replaced with the string "null".</xs:documentation>
                                 </xs:annotation>
                             </xs:enumeration>
+                            <xs:enumeration value="keepSubstitution">
+                                <xs:annotation>
+                                    <xs:documentation>Retains the original text of the substitution parameter.</xs:documentation>
+                                </xs:annotation>
+                            </xs:enumeration>
                         </xs:restriction>
                     </xs:simpleType>
                 </xs:attribute>

--- a/api/src/org/labkey/api/admin/AdminBean.java
+++ b/api/src/org/labkey/api/admin/AdminBean.java
@@ -21,12 +21,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.LabKeyCollectors;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.MothershipReport;
@@ -75,6 +77,10 @@ public class AdminBean
     public static final String serverGuid = AppProps.getInstance().getServerGUID();
     public static final String serverSessionGuid = AppProps.getInstance().getServerSessionGUID();
     public static final String servletContainer = ModuleLoader.getServletContext().getServerInfo();
+    @SuppressWarnings("unused") // Available substitution property, not used directly in code
+    public static final String buildTime = ModuleLoader.getInstance().getCoreModule().getBuildTime();
+    @SuppressWarnings("unused") // Available substitution property, not used directly in code
+    public static final String serverStartupTime = DateUtil.formatDateTime(ContainerManager.getRoot());
     public static final List<Module> modules;
 
     public static String asserts = "disabled";

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -2253,14 +2253,15 @@ public class NameGenerator
             ArrayList<StringExpressionFactory.StringPart> parts = getParsedExpression();
             if (parts.size() == 1)
             {
+                StringExpressionFactory.StringPart part = parts.get(0);
                 try
                 {
-                    if (parts.get(0) instanceof CounterExpressionPart)
+                    if (part instanceof CounterExpressionPart counterExpressionPart)
                     {
                         Map<String, DbSequence> counterSequences = prefixCounterSequences == null ? null : prefixCounterSequences.computeIfAbsent(_counterSeqPrefix,  (s) -> new HashMap<>());
-                        return nullFilter(((CounterExpressionPart) parts.get(0)).getValue(context, counterSequences));
+                        return nullFilter(counterExpressionPart.getValue(context, counterSequences), part);
                     }
-                    return nullFilter(parts.get(0).getValue(context));
+                    return nullFilter(part.getValue(context), part);
                 }
                 catch (StopIteratingException e)
                 {
@@ -2271,17 +2272,16 @@ public class NameGenerator
             try
             {
                 StringBuilder builder = new StringBuilder();
-                for (int i = 0; i < parts.size(); i++)
+                for (StringExpressionFactory.StringPart part : parts)
                 {
-                    StringExpressionFactory.StringPart part = parts.get(i);
                     String value;
-                    if (part instanceof CounterExpressionPart)
+                    if (part instanceof CounterExpressionPart counterExpressionPart)
                     {
-                        Map<String, DbSequence> counterSequences = prefixCounterSequences == null ? null : prefixCounterSequences.computeIfAbsent(_counterSeqPrefix,  (s) -> new HashMap<>());
-                        value = nullFilter(((CounterExpressionPart) part).getValue(context, counterSequences));
+                        Map<String, DbSequence> counterSequences = prefixCounterSequences == null ? null : prefixCounterSequences.computeIfAbsent(_counterSeqPrefix, (s) -> new HashMap<>());
+                        value = nullFilter(counterExpressionPart.getValue(context, counterSequences), part);
                     }
                     else
-                        value = nullFilter(part.getValue(context));
+                        value = nullFilter(part.getValue(context), part);
                     builder.append(value);
                 }
                 return builder.toString();

--- a/api/src/org/labkey/api/settings/LookAndFeelProperties.java
+++ b/api/src/org/labkey/api/settings/LookAndFeelProperties.java
@@ -164,7 +164,7 @@ public class LookAndFeelProperties extends LookAndFeelFolderProperties
     public String getShortName()
     {
         return SHORT_NAME_CACHE.get(_settingsContainer, null,
-            (key, argument) -> StringExpressionFactory.create(getUnsubstitutedShortName()).eval(AdminBean.getPropertyMap()));
+            (key, argument) -> StringExpressionFactory.create(getUnsubstitutedShortName(), false, StringExpressionFactory.AbstractStringExpression.NullValueBehavior.KeepSubstitution).eval(AdminBean.getPropertyMap()));
     }
 
     public String getThemeName()

--- a/api/src/org/labkey/api/settings/LookAndFeelProperties.java
+++ b/api/src/org/labkey/api/settings/LookAndFeelProperties.java
@@ -15,7 +15,7 @@
  */
 package org.labkey.api.settings;
 
-import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.Constants;
 import org.labkey.api.admin.AdminBean;
@@ -27,6 +27,7 @@ import org.labkey.api.util.FolderDisplayMode;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.SafeToRenderEnum;
 import org.labkey.api.util.StringExpressionFactory;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.util.Arrays;
 
@@ -42,6 +43,7 @@ import static org.labkey.api.settings.LookAndFeelProperties.Properties.*;
 public class LookAndFeelProperties extends LookAndFeelFolderProperties
 {
     private static final Cache<Container, String> SHORT_NAME_CACHE = CacheManager.getBlockingCache(Constants.getMaxProjects(), CacheManager.YEAR, "Short name", null);
+    private static final Logger LOG = LogHelper.getLogger(LookAndFeelProperties.class, "Manages site-wide and project-scoped look and feel settings");
 
     // Defined in the same order they appear on the Site-level Look and Feel Settings page
     public enum Properties implements StartupProperty, SafeToRenderEnum
@@ -225,7 +227,7 @@ public class LookAndFeelProperties extends LookAndFeelFolderProperties
         //initial login will be used as the default value. During setup user will be prompted to change.
         String emailAddress = lookupStringValue(systemEmailAddress, "");
         if (emailAddress.isEmpty())
-            LogManager.getLogger(this.getClass()).error(String.format("System Email Address became unset somehow. Visit '%s/admin-projectSettings.view' to fix it",
+            LOG.error(String.format("System Email Address became unset somehow. Visit '%s/admin-projectSettings.view' to fix it",
                     _settingsContainer.getTitle().isEmpty() ? "" : _settingsContainer.getPath()));
         return emailAddress;
     }

--- a/core/src/org/labkey/core/admin/admin.jsp
+++ b/core/src/org/labkey/core/admin/admin.jsp
@@ -109,10 +109,12 @@
                 <tr class="<%=getShadeRowClass(row++)%>"><td>User Home Dir</td><td><%=h(AdminBean.userHomeDir)%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Webapp Dir</td><td><%=h(AdminBean.webappDir)%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Distribution</td><td><%=h(AdminBean.distribution)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Build Time</td><td><%=h(AdminBean.buildTime)%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>OS</td><td><%=h(AdminBean.osName)%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Working Dir</td><td><%=h(AdminBean.workingDir)%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Server GUID</td><td style="font-family:monospace"><%=h(AdminBean.serverGuid)%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Server Session GUID</td><td style="font-family:monospace"><%=h(AdminBean.serverSessionGuid)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Server Startup Time</td><td<%=style%>><%=h(AdminBean.serverStartupTime)%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Web Server Time</td><td<%=style%>><%=h(serverTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")))%><%=warning%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Database Server Time</td><td<%=style%>><%=h(databaseTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")))%><%=warning%></td></tr>
             </table>


### PR DESCRIPTION
#### Rationale
Some new properties that admins can use for a dynamic site short name: `buildTime` (from the Core module) and `serverStartTime`

#### Changes
* Add the new properties
* Don't return null (yielding NPEs) if there's an unrecognized substitution in the header expression
* New StringExpression option to pass unrecognized substitution properties through as-is
* Minor code cleanup