### PR TITLE
Include the SQL with the execution plan. Option to log the plan.

### DIFF
--- a/api/src/org/labkey/api/data/queryprofiler/QueryProfiler.java
+++ b/api/src/org/labkey/api/data/queryprofiler/QueryProfiler.java
@@ -375,29 +375,33 @@ public class QueryProfiler
             }
 
             HttpView<?> result = new HtmlView(DOM.DIV(
-                    DOM.TABLE(
-                        DOM.at(DOM.Attribute.style, "width: 100%"),
-                        DOM.TR(
-                                DOM.TD(DOM.at(DOM.Attribute.style, "white-space: nowrap; width: 50%;"), DOM.STRONG("SQL" + (tracker.isTruncated() ? " (truncated)" : ""))),
-                                DOM.TD(DOM.at(DOM.Attribute.style, "white-space: nowrap; width: 50%;"), DOM.STRONG("SQL With Parameters" + (tracker.isTruncated() ? " (truncated)" : "")))
-                        ),
-                        DOM.TR(
-                                DOM.TD(copyToClipboardLink("copyToClipboardNoParams", "sqlNoParams")),
-                                DOM.TD(copyToClipboardLink("copyToClipboardWithParams", "sqlWithParams"))
-                        ),
-                        DOM.TR(
-                                DOM.TD(DOM.at(DOM.Attribute.id, "sqlNoParams"),HtmlString.of(tracker.getSql(), true)),
-                                DOM.TD(DOM.at(DOM.Attribute.id, "sqlWithParams"), HtmlString.of(tracker.getSqlAndParameters(), true))
-                        )),
+                DOM.TABLE(
+                    DOM.at(DOM.Attribute.style, "width: 100%"),
+                    DOM.TR(
+                        DOM.TD(DOM.at(DOM.Attribute.style, "white-space: nowrap; width: 50%;"), DOM.STRONG("SQL" + (tracker.isTruncated() ? " (truncated)" : ""))),
+                        DOM.TD(DOM.at(DOM.Attribute.style, "white-space: nowrap; width: 50%;"), DOM.STRONG("SQL With Parameters" + (tracker.isTruncated() ? " (truncated)" : "")))
+                    ),
+                    DOM.TR(
+                        DOM.TD(copyToClipboardLink("copyToClipboardNoParams", "sqlNoParams")),
+                        DOM.TD(copyToClipboardLink("copyToClipboardWithParams", "sqlWithParams"))
+                    ),
+                    DOM.TR(
+                        DOM.TD(DOM.at(DOM.Attribute.id, "sqlNoParams"), HtmlString.of(tracker.getSql(), true)),
+                        DOM.TD(DOM.at(DOM.Attribute.id, "sqlWithParams"), HtmlString.of(tracker.getSqlAndParameters(), true))
+                    )),
 
-                    DOM.SCRIPT(HtmlString.unsafe("new Clipboard('#copyToClipboardNoParams');new Clipboard('#copyToClipboardWithParams');")),
-                    DOM.BR(),
-                    Arrays.stream(ExecutionPlanType.values()).
-                            filter(tracker::canShowExecutionPlan).
-                            map(type -> DOM.DIV(new Link.LinkBuilder("Show " + type.getDescription()).
-                                    href(executeFactory.getActionURL(tracker.getHash()).addParameter("type", type.name())).build())),
-                    DOM.BR(),
-                    tracker.renderStackTraces()
+                DOM.SCRIPT(HtmlString.unsafe("new Clipboard('#copyToClipboardNoParams');new Clipboard('#copyToClipboardWithParams');")),
+                DOM.BR(),
+                Arrays.stream(ExecutionPlanType.values()).
+                    filter(tracker::canShowExecutionPlan).
+                    map(type -> DOM.DIV(
+                        new Link.LinkBuilder("Show " + type.getDescription()).
+                            href(executeFactory.getActionURL(tracker.getHash()).addParameter("type", type.name())).build(),
+                        ExecutionPlanType.Actual == type ? DOM.DIV(new Link.LinkBuilder("Log " + type.getDescription() + " to primary site log").
+                            href(executeFactory.getActionURL(tracker.getHash()).addParameter("type", type.name()).addParameter("log", true)).build()) : null
+                    )),
+                DOM.BR(),
+                tracker.renderStackTraces()
             ));
             result.addClientDependencies(Set.of(ClientDependency.fromPath("internal/clipboard/clipboard-1.5.9.min.js")));
             return result;
@@ -407,15 +411,16 @@ public class QueryProfiler
     private Link copyToClipboardLink(String linkId, String targetId)
     {
         return new Link.LinkBuilder("copy to clipboard").
-                onClick("return false;").
-                id(linkId).
-                attributes(Collections.singletonMap("data-clipboard-target", "#" + targetId)).
-                build();
+            onClick("return false;").
+            id(linkId).
+            attributes(Collections.singletonMap("data-clipboard-target", "#" + targetId)).
+            build();
     }
 
-    public HttpView<?> getExecutionPlanView(String sqlHash, ExecutionPlanType type)
+    public HttpView<?> getExecutionPlanView(String sqlHash, ExecutionPlanType type, boolean log)
     {
         SQLFragment sql;
+        String sqlWithParameters;
         DbScope scope;
 
         // Don't update anything while we're gathering the SQL and parameters
@@ -435,18 +440,33 @@ public class QueryProfiler
                 throw new IllegalStateException("Scope should not be null");
 
             sql = tracker.getSQLFragment();
+            sqlWithParameters = tracker.getSqlAndParameters() + "\n";
         }
 
         Collection<String> executionPlan = scope.getSqlDialect().getExecutionPlan(scope, sql, type);
 
         String fullPlan = StringUtils.join(executionPlan, "\n");
+        final HttpView<?> view;
 
-        HttpView<?> view = new HtmlView(
+        if (log)
+        {
+            // The log option is useful for retrieving actual timing information about very long-running queries when
+            // proxy timeouts prevent viewing the plan via the web page
+            LOG.info("An administrator initiated the logging of this query execution plan with actual timing:\n" + sqlWithParameters + fullPlan);
+            view = new HtmlView(HtmlString.of("Execution plan with actual timing was logged to the primary site log file"));
+        }
+        else
+        {
+            view = new HtmlView(
                 DOM.DIV(
-                        DOM.DIV(copyToClipboardLink("copyToClipboard", "executionPlan")),
-                        DOM.PRE(DOM.at(DOM.Attribute.id, "executionPlan"), fullPlan),
-                        DOM.SCRIPT(HtmlString.unsafe("new Clipboard('#copyToClipboard');"))));
-        view.addClientDependencies(Set.of(ClientDependency.fromPath("internal/clipboard/clipboard-1.5.9.min.js")));
+                    DOM.DIV(copyToClipboardLink("copyToClipboard", "executionPlan")),
+                    DOM.PRE(DOM.at(DOM.Attribute.id, "executionPlan"), sqlWithParameters, fullPlan),
+                    DOM.SCRIPT(HtmlString.unsafe("new Clipboard('#copyToClipboard');"))
+                )
+            );
+            view.addClientDependencies(Set.of(ClientDependency.fromPath("internal/clipboard/clipboard-1.5.9.min.js")));
+        }
+
         return view;
     }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -2606,7 +2606,7 @@ public class AdminController extends SpringActionController
             if (null == _type)
                 throw new NotFoundException("Unknown execution plan type");
 
-            return QueryProfiler.getInstance().getExecutionPlanView(form.getSqlHash(), _type);
+            return QueryProfiler.getInstance().getExecutionPlanView(form.getSqlHash(), _type, form.isLog());
         }
 
         @Override
@@ -2623,6 +2623,7 @@ public class AdminController extends SpringActionController
     {
         private String _sqlHash;
         private String _type = "Estimated"; // All dialects support Estimated
+        private boolean _log = false;
 
         public String getSqlHash()
         {
@@ -2644,6 +2645,16 @@ public class AdminController extends SpringActionController
         public void setType(String type)
         {
             _type = type;
+        }
+
+        public boolean isLog()
+        {
+            return _log;
+        }
+
+        public void setLog(boolean log)
+        {
+            _log = log;
         }
     }
 


### PR DESCRIPTION
#### Rationale
Execution plans are more useful with the SQL that generates them. Include SQL with the execution plan information on the page and in the "copy to clipboard" contents.

Proxy timeouts can prevent clients from retrieving the actual execution plan on very long-running queries. Option to write the SQL and actual execution plan to the site log can be used in that case.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4371