### PR TITLE
Reduce DB queries by reusing study visits, NAb runs and sample props

### DIFF
--- a/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/DilutionDataHandler.java
@@ -138,7 +138,7 @@ public abstract class DilutionDataHandler extends AbstractExperimentDataHandler
             DilutionAssayRun assayResults = getAssayResults(run, user, dataFile, null, useRunForPlates, recalculateStats);
             List<Map<String, Object>> results = new ArrayList<>();
             ExpProtocol protocol = ExperimentService.get().getExpProtocol(run.getProtocol().getLSID());
-            DilutionAssayProvider provider = (DilutionAssayProvider) AssayService.get().getProvider(protocol);
+            DilutionAssayProvider<?> provider = (DilutionAssayProvider<?>) AssayService.get().getProvider(protocol);
 
             for (int summaryIndex = 0; summaryIndex < assayResults.getSummaries().length; summaryIndex++)
             {
@@ -392,10 +392,9 @@ public abstract class DilutionDataHandler extends AbstractExperimentDataHandler
         return false;
     }
 
-    protected void applyDilution(List<? extends WellData> wells, ExpMaterial sampleInput, Map<String, DomainProperty> sampleProperties, boolean reverseDirection) throws ExperimentException
+    protected void applyDilution(List<? extends WellData> wells, ExpMaterial sampleInput, Map<String, DomainProperty> sampleProperties, boolean reverseDirection, Map<PropertyDescriptor,Object> sampleValues) throws ExperimentException
     {
         boolean first = true;
-        Map<PropertyDescriptor,Object> sampleValues = sampleInput.getPropertyValues();
         Double dilution = (Double) sampleValues.get(sampleProperties.get(DilutionAssayProvider.SAMPLE_INITIAL_DILUTION_PROPERTY_NAME).getPropertyDescriptor());
         Double factor = (Double) sampleValues.get(sampleProperties.get(DilutionAssayProvider.SAMPLE_DILUTION_FACTOR_PROPERTY_NAME).getPropertyDescriptor());
         String methodString = (String) sampleValues.get(sampleProperties.get(DilutionAssayProvider.SAMPLE_METHOD_PROPERTY_NAME).getPropertyDescriptor());
@@ -439,7 +438,7 @@ public abstract class DilutionDataHandler extends AbstractExperimentDataHandler
 
     protected abstract void prepareWellGroups(List<WellGroup> wellgroups, ExpMaterial material, Map<String, DomainProperty> samplePropertyMap) throws ExperimentException;
 
-    protected Map<ExpMaterial, List<WellGroup>> getMaterialWellGroupMapping(DilutionAssayProvider provider, List<Plate> plates, Map<ExpMaterial,String> sampleInputs)throws ExperimentException
+    protected Map<ExpMaterial, List<WellGroup>> getMaterialWellGroupMapping(DilutionAssayProvider<?> provider, List<Plate> plates, Map<ExpMaterial,String> sampleInputs)throws ExperimentException
     {
         Plate plate = plates.get(0);
         List<? extends WellGroup> wellgroups = plate.getWellGroups(WellGroup.Type.SPECIMEN);
@@ -462,7 +461,7 @@ public abstract class DilutionDataHandler extends AbstractExperimentDataHandler
         return mapping;
     }
 
-    protected abstract DilutionAssayRun createDilutionAssayRun(DilutionAssayProvider provider, ExpRun run, List<Plate> plates, User user,
+    protected abstract DilutionAssayRun createDilutionAssayRun(DilutionAssayProvider<?> provider, ExpRun run, List<Plate> plates, User user,
                                                                List<Integer> sortedCutoffs, StatsService.CurveFitType fit);
 
     public abstract Map<DilutionSummary, DilutionAssayRun> getDilutionSummaries(User user, StatsService.CurveFitType fit, int... dataObjectIds) throws ExperimentException, SQLException;

--- a/assay/api-src/org/labkey/api/assay/dilution/DilutionSummary.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/DilutionSummary.java
@@ -23,8 +23,6 @@ import org.labkey.api.data.statistics.CurveFit;
 import org.labkey.api.data.statistics.DoublePoint;
 import org.labkey.api.data.statistics.FitFailedException;
 import org.labkey.api.data.statistics.StatsService;
-import org.labkey.api.exp.api.ExpRun;
-import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.WellData;
 import org.labkey.api.assay.plate.WellGroup;
@@ -46,23 +44,23 @@ import java.util.Map;
  */
 public class DilutionSummary implements Serializable
 {
-    private List<WellGroup> _sampleGroups;
-    private WellGroup _firstGroup;
-    private Map<StatsService.CurveFitType, DilutionCurve> _dilutionCurve = new HashMap<>() ;
-    private Luc5Assay _assay;
-    private String _lsid;
-    private StatsService.CurveFitType _curveFitType;
+    private final List<WellGroup> _sampleGroups;
+    private final WellGroup _firstGroup;
+    private final Map<StatsService.CurveFitType, DilutionCurve> _dilutionCurve = new HashMap<>() ;
+    private final Luc5Assay _assay;
+    private final String _lsid;
+    private final StatsService.CurveFitType _curveFitType;
     protected DilutionMaterialKey _materialKey = null;
-    protected Container _container;
+    protected final Container _container;
     public static final DilutionMaterialKey BLANK_NAB_MATERIAL = new DilutionMaterialKey(ContainerManager.getRoot(), "Blank", null, null, null, null);
 
 
-    public DilutionSummary(Luc5Assay assay, WellGroup sampleGroup, String lsid, StatsService.CurveFitType curveFitType)
+    public DilutionSummary(Luc5Assay assay, WellGroup sampleGroup, String lsid, StatsService.CurveFitType curveFitType, Container container)
     {
-        this(assay, Collections.singletonList(sampleGroup), lsid, curveFitType);
+        this(assay, Collections.singletonList(sampleGroup), lsid, curveFitType, container);
     }
 
-    public DilutionSummary(Luc5Assay assay, List<WellGroup> sampleGroups, String lsid, StatsService.CurveFitType curveFitType)
+    public DilutionSummary(Luc5Assay assay, List<WellGroup> sampleGroups, String lsid, StatsService.CurveFitType curveFitType, Container container)
     {
         assert sampleGroups != null && !sampleGroups.isEmpty() : "sampleGroups cannot be null or empty";
         assert assay != null : "assay cannot be null";
@@ -72,18 +70,7 @@ public class DilutionSummary implements Serializable
         _firstGroup = sampleGroups.get(0);
         _assay = assay;
         _lsid = lsid;
-
-        if (assay.getRunRowId() != null)
-        {
-            ExpRun run = ExperimentService.get().getExpRun(assay.getRunRowId());
-            if (run != null)
-                _container = run.getContainer();
-        }
-        else
-        {
-            // legacy nab assay instances do not use the run row id
-            _container = ContainerManager.getRoot();
-        }
+        _container = container;
     }
 
     private void ensureSameSample(List<WellGroup> groups)

--- a/assay/api-src/org/labkey/api/assay/nab/Luc5Assay.java
+++ b/assay/api-src/org/labkey/api/assay/nab/Luc5Assay.java
@@ -20,6 +20,7 @@ import org.labkey.api.assay.dilution.DilutionManager;
 import org.labkey.api.assay.dilution.DilutionCurve;
 import org.labkey.api.assay.dilution.DilutionSummary;
 import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.data.Container;
 import org.labkey.api.data.statistics.FitFailedException;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.assay.plate.Plate;
@@ -38,8 +39,8 @@ import java.util.Map;
  */
 public abstract class Luc5Assay implements Serializable, DilutionCurve.PercentCalculator
 {
-    private Integer _runRowId;
-    private int[] _cutoffs;
+    private final Integer _runRowId;
+    private final int[] _cutoffs;
     private Map<Integer, String> _cutoffFormats;
     private File _dataFile;
     protected StatsService.CurveFitType _renderedCurveFitType;
@@ -65,12 +66,12 @@ public abstract class Luc5Assay implements Serializable, DilutionCurve.PercentCa
         return cutoffArray;
     }
 
-    protected DilutionSummary[] getDilutionSumariesForWellGroups(List<? extends WellGroup> specimenGroups)
+    protected DilutionSummary[] getDilutionSummariesForWellGroups(List<? extends WellGroup> specimenGroups, Container container)
     {
         int sampleIndex = 0;
         DilutionSummary[] dilutionSummaries = new DilutionSummary[specimenGroups.size()];
         for (WellGroup specimenGroup : specimenGroups)
-            dilutionSummaries[sampleIndex++] = new DilutionSummary(this, specimenGroup, null, _renderedCurveFitType);
+            dilutionSummaries[sampleIndex++] = new DilutionSummary(this, specimenGroup, null, _renderedCurveFitType, container);
         return dilutionSummaries;
     }
 

--- a/study/src/org/labkey/study/query/BaseStudyTable.java
+++ b/study/src/org/labkey/study/query/BaseStudyTable.java
@@ -22,10 +22,7 @@ import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerForeignKey;
 import org.labkey.api.data.DataColumn;
-import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.RenderContext;
@@ -55,6 +52,7 @@ import org.labkey.api.specimen.security.permissions.EditSpecimenDataPermission;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.TimepointType;
+import org.labkey.api.study.Visit;
 import org.labkey.api.util.DemoMode;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
@@ -72,8 +70,10 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -172,14 +172,7 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
 
         if (DemoMode.isDemoMode(_userSchema.getContainer(), _userSchema.getUser()))
         {
-            participantColumn.setDisplayColumnFactory(new DisplayColumnFactory()
-            {
-                @Override
-                public DisplayColumn createRenderer(ColumnInfo column)
-                {
-                    return new PtidObfuscatingDisplayColumn(column);
-                }
-            });
+            participantColumn.setDisplayColumnFactory(PtidObfuscatingDisplayColumn::new);
         }
 
         return addColumn(participantColumn);
@@ -211,8 +204,7 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
             @Override
             public TableInfo getLookupTableInfo()
             {
-                LocationTable result = new LocationTable(_userSchema, _userSchema.allowSetContainerFilter() ? getContainerFilter() : null);
-                return result;
+                return new LocationTable(_userSchema, _userSchema.allowSetContainerFilter() ? getContainerFilter() : null);
             }
         });
         return addColumn(locationColumn);
@@ -249,15 +241,15 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
             @Override
             public TableInfo getLookupTableInfo()
             {
-                BaseStudyTable result;
-                if (rootTableColumnName.equals("PrimaryTypeId"))
-                    result = new PrimaryTypeTable(_userSchema, getLookupContainerFilter());
-                else if (rootTableColumnName.equals("DerivativeTypeId") || rootTableColumnName.equals("DerivativeTypeId2"))
-                    result = new DerivativeTypeTable(_userSchema, getLookupContainerFilter());
-                else if (rootTableColumnName.equals("AdditiveTypeId"))
-                    result = new AdditiveTypeTable(_userSchema, getLookupContainerFilter());
-                else
-                    throw new IllegalStateException(rootTableColumnName + " is not recognized as a valid specimen type column.");
+                BaseStudyTable result = switch (rootTableColumnName)
+                {
+                    case "PrimaryTypeId" -> new PrimaryTypeTable(_userSchema, getLookupContainerFilter());
+                    case "DerivativeTypeId", "DerivativeTypeId2" ->
+                            new DerivativeTypeTable(_userSchema, getLookupContainerFilter());
+                    case "AdditiveTypeId" -> new AdditiveTypeTable(_userSchema, getLookupContainerFilter());
+                    default ->
+                            throw new IllegalStateException(rootTableColumnName + " is not recognized as a valid specimen type column.");
+                };
                 if (_userSchema.allowSetContainerFilter())
                     result.setContainerFilter(getLookupContainerFilter());
                 return result;
@@ -277,7 +269,7 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
 
     protected ColumnInfo addSpecimenVisitColumn(TimepointType timepointType, MutableColumnInfo aliasVisitColumn, boolean isProvisioned)
     {
-        MutableColumnInfo visitColumn = null;
+        MutableColumnInfo visitColumn;
         var visitDescriptionColumn = addWrapColumn(_rootTable.getColumn("VisitDescription"));
 
         // add the sequenceNum column so we have it for later queries
@@ -314,21 +306,15 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
         visitColumn.setFk(visitFK);
         // Don't setKeyField. Use addQueryFieldKeys where needed
 
-        visitColumn.setDisplayColumnFactory(new DisplayColumnFactory()
-        {
-            @Override
-            public DisplayColumn createRenderer(ColumnInfo col)
-            {
-                return new VisitDisplayColumn(col, FieldKey.fromParts("SequenceNum"));
-            }
-        });
+        visitColumn.setDisplayColumnFactory(col -> new VisitDisplayColumn(col, FieldKey.fromParts("SequenceNum")));
 
         return visitColumn;
     }
 
     public static class VisitDisplayColumn extends DataColumn
     {
-        private FieldKey _seqNumMinFieldKey;
+        private final FieldKey _seqNumMinFieldKey;
+        private Map<Integer, VisitImpl> _visits;
 
         public VisitDisplayColumn(ColumnInfo col, FieldKey seqNumMinFieldKey)
         {
@@ -370,12 +356,26 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
             Study study = StudyManager.getInstance().getStudy(ctx.getContainer());
             if (study != null && ctx.get(getColumnInfo().getAlias()) != null)
             {
-                VisitImpl visit = StudyManager.getInstance().getVisitForRowId(study, Integer.parseInt(ctx.get(getColumnInfo().getAlias()).toString()));
+                VisitImpl visit = getVisits(study).get(Integer.parseInt(ctx.get(getColumnInfo().getAlias()).toString()));
                 if (visit != null && (visit.getDescription() != null || visit.getLabel() != null))
                     return PageFlowUtil.filter(visit.getDescription() != null ? visit.getDescription() : visit.getLabel());
             }
 
             return null;
+        }
+
+        /** Fetch the visits all at once, not once per row */
+        private Map<Integer, VisitImpl> getVisits(Study study)
+        {
+            if (_visits == null)
+            {
+                _visits = new HashMap<>();
+                for (VisitImpl visit : StudyManager.getInstance().getVisits(study, Visit.Order.SEQUENCE_NUM))
+                {
+                    _visits.put(visit.getRowId(), visit);
+                }
+            }
+            return _visits;
         }
 
         @Override
@@ -491,7 +491,7 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
         private final boolean _includeVialComments;
         private final Container _container;
 
-        public SpecimenCommentColumn(FilteredTable parent, TableInfo ptidCommentTable, String ptidCommentProperty,
+        public SpecimenCommentColumn(BaseStudyTable parent, TableInfo ptidCommentTable, String ptidCommentProperty,
                                      TableInfo ptidVisitCommentTable, String ptidVisitCommentProperty, String name,
                                      boolean includeVialComments, boolean hidden)
         {
@@ -571,19 +571,22 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
             {
                 switch (commentFields.size())
                 {
-                    case 1:
+                    case 1 ->
+                    {
                         sb.append("CASE");
                         appendCommentCaseSQL(sb, commentFields);
                         sb.append(" ELSE NULL END");
-                        break;
-                    case 2:
+                    }
+                    case 2 ->
+                    {
                         sb.append("CASE");
                         appendCommentCaseSQL(sb, commentFields);
                         appendCommentCaseSQL(sb, Collections.singletonList(commentFields.get(0)));
                         appendCommentCaseSQL(sb, Collections.singletonList(commentFields.get(1)));
                         sb.append(" ELSE NULL END");
-                        break;
-                    case 3:
+                    }
+                    case 3 ->
+                    {
                         sb.append("CASE");
                         appendCommentCaseSQL(sb, commentFields);
                         appendCommentCaseSQL(sb, Arrays.asList(commentFields.get(0), commentFields.get(1)));
@@ -593,11 +596,11 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
                         appendCommentCaseSQL(sb, Collections.singletonList(commentFields.get(1)));
                         appendCommentCaseSQL(sb, Collections.singletonList(commentFields.get(2)));
                         sb.append(" ELSE NULL END");
-                        break;
+                    }
                 }
             }
             sql.append("(");
-            if (sb.length() > 0)
+            if (!sb.isEmpty())
                 sql.append(sb.toString());
             else
                 sql.append("' '");
@@ -704,18 +707,15 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
         public Object getDisplayValue(RenderContext ctx)
         {
             Object value = getDisplayColumn().getValue(ctx);
-            if (value == null)
-                return "";
-            else
-                return value;
+            return Objects.requireNonNullElse(value, "");
         }
 
         @Override
         public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
         {
             Object value = getDisplayColumn().getValue(ctx);
-            if (value != null && value instanceof String)
-                out.write((String) value);
+            if (value instanceof String s)
+                out.write(s);
         }
     }
 
@@ -749,7 +749,7 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
         String subjectNoun = StudyService.get().getSubjectNounSingular(ctx.getContainer());
         if (participantComment instanceof String)
         {
-            if (sb.length() > 0)
+            if (!sb.isEmpty())
                 sb.append(lineSeparator);
             if (renderHtml)
             {
@@ -765,7 +765,7 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
         }
         if (participantVisitComment instanceof String)
         {
-            if (sb.length() > 0)
+            if (!sb.isEmpty())
                 sb.append(lineSeparator);
 
             if (renderHtml)


### PR DESCRIPTION
#### Rationale
Datadog showed that we were running a lot of redundant queries.

#### Changes
* Fetch all study visits in bulk when rendering visit columns instead of loading (or reloading) for every row
* Pass in container to DilutionSummary instead of making it fetch it via the ExpRun
* Assorted code cleanup