### PR TITLE
Refactor API key handling to improve logging, etc.

### DIFF
--- a/api/src/org/labkey/api/security/ApiKeyManager.java
+++ b/api/src/org/labkey/api/security/ApiKeyManager.java
@@ -127,6 +127,11 @@ public class ApiKeyManager
         }
     }
 
+    /**
+     * Returns the User associated with the supplied API key, if API key is valid. User could be inactive.
+     * @param apiKey The API key to validate
+     * @return The User associated with the API key or null if API key is invalid
+     */
     public @Nullable User authenticateFromApiKey(@NotNull String apiKey)
     {
         SimpleFilter filter = new SimpleFilter(getStillValidClause());
@@ -140,10 +145,7 @@ public class ApiKeyManager
             t.commit();
         }
 
-        User user = null != userId ? UserManager.getUser(userId) : null;
-        if (user != null && !user.isActive())
-            return null;
-        return user;
+        return null != userId ? UserManager.getUser(userId) : null;
     }
 
     private static final String API_KEY_SCOPE = "ApiKey";

--- a/api/src/org/labkey/api/security/AuthFilter.java
+++ b/api/src/org/labkey/api/security/AuthFilter.java
@@ -61,13 +61,6 @@ public class AuthFilter implements Filter
     {
     }
 
-
-    @Override
-    public void destroy()
-    {
-    }
-
-
     // This is the first (and last) LabKey code invoked on a request.
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
@@ -103,7 +96,7 @@ public class AuthFilter implements Filter
         // We need to handle it here otherwise the begin page redirect in index.html will fail: issue 25395
 
         // getServletPath() will return an empty String when a URL with a context path but no trailing slash is requested
-        if (req.getServletPath().equals(""))
+        if (req.getServletPath().isEmpty())
         {
             // now check if this is the case where the request URL contains only the context path
             if (req.getContextPath() != null && req.getRequestURL().toString().endsWith(req.getContextPath()))

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -1052,7 +1052,7 @@ public class AuthenticationManager
                 else
                 {
                     // No: log that we're not permitted to create accounts automatically
-                    addAuditEvent(User.guest, request, "User " + email + " successfully authenticated via " + response.getConfiguration().getDescription() + ". Login failed because account creation is disabled.");
+                    addAuditEvent(User.guest, request, "User " + email + " successfully authenticated via " + response.getSuccessDetails() + ", but login failed because account creation is disabled.");
                     return new PrimaryAuthenticationResult(AuthenticationStatus.UserCreationNotAllowed);
                 }
             }
@@ -1077,7 +1077,7 @@ public class AuthenticationManager
             return new PrimaryAuthenticationResult(AuthenticationStatus.InactiveUser);
         }
 
-        addAuditEvent(user, request, email + " " + UserManager.UserAuditEvent.LOGGED_IN + " successfully via the \"" + response.getConfiguration().getDescription() + "\" configuration.");
+        addAuditEvent(user, request, email + " " + UserManager.UserAuditEvent.LOGGED_IN + " successfully via " + response.getSuccessDetails() + ".");
 
         return new PrimaryAuthenticationResult(user, response);
     }

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -862,7 +862,7 @@ public class AuthenticationManager
 
 
     /** avoid spamming the audit log **/
-    private static final Cache<String, String> AUTH_MESSAGES = CacheManager.getCache(100, TimeUnit.MINUTES.toMillis(10), "Authentication messages");
+    private static final Cache<String, String> AUTH_MESSAGES = CacheManager.getCache(1000, TimeUnit.MINUTES.toMillis(10), "Authentication messages");
 
     public static void addAuditEvent(@NotNull User user, HttpServletRequest request, String msg)
     {

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -969,7 +969,9 @@ public class AuthenticationManager
                     try
                     {
                         email = new ValidEmail(id);
-                        emailAddress = email.getEmailAddress();  // If this user doesn't exist we can still report the normalized email address
+                        // If this user doesn't exist we can still report the normalized email address.
+                        // FailureReason can determine whether to log the email address or not.
+                        emailAddress = firstFailure.getFailureReason().getEmailAddress(email);
                     }
                     catch (InvalidEmailException e)
                     {
@@ -998,7 +1000,7 @@ public class AuthenticationManager
                 else
                 {
                     // Funny audit case -- user doesn't exist, so there's no user to associate with the event. Use guest.
-                    addAuditEvent(User.guest, request, message);
+                    addAuditEvent(User.guest, request, "Unknown user" + message);
                     _log.warn("Unknown user" + message);
                 }
 

--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -278,8 +278,9 @@ public interface AuthenticationProvider
         private final @Nullable FailureReason _failureReason;
         private final @Nullable ActionURL _redirectURL;
         private final @NotNull Map<String, String> _attributeMap;
+        private final @Nullable String _successDetails;
 
-        private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap)
+        private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap, @Nullable String successDetails)
         {
             _configuration = configuration;
             _email = email;
@@ -287,6 +288,7 @@ public interface AuthenticationProvider
             _attributeMap = attributeMap;
             _failureReason = null;
             _redirectURL = null;
+            _successDetails = null != successDetails ? successDetails : "the \"" + configuration.getDescription() + "\" configuration";
         }
 
         private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull FailureReason failureReason, @Nullable ActionURL redirectURL)
@@ -297,6 +299,7 @@ public interface AuthenticationProvider
             _failureReason = failureReason;
             _redirectURL = redirectURL;
             _attributeMap = Collections.emptyMap();
+            _successDetails = null;
         }
 
         /**
@@ -306,20 +309,23 @@ public interface AuthenticationProvider
          */
         public static AuthenticationResponse createSuccessResponse(PrimaryAuthenticationConfiguration<?> configuration, ValidEmail email)
         {
-            return createSuccessResponse(configuration, email, null, Collections.emptyMap());
+            return createSuccessResponse(configuration, email, null, Collections.emptyMap(), null);
         }
 
         /**
          * Creates an authentication provider response that can include a validator to be called on every request and a
          * map of user attributes
+         * @param configuration The PrimaryAuthenticationConfiguration that was used in this authentication attempt
          * @param email Valid email address of the authenticated user
          * @param validator An authentication validator
          * @param attributeMap A <b>case-insensitive</b> map of attribute names and values associated with this authentication
+         * @param successDetails An optional string describing how successful authentication took place, which will appear in
+         *                       the audit log. If null, the configuration's description will be used.
          * @return A new successful authentication response containing the email address of the authenticated user and a validator
          */
-        public static AuthenticationResponse createSuccessResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap)
+        public static AuthenticationResponse createSuccessResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap, @Nullable String successDetails)
         {
-            return new AuthenticationResponse(configuration, email, validator, attributeMap);
+            return new AuthenticationResponse(configuration, email, validator, attributeMap, successDetails);
         }
 
         public static AuthenticationResponse createFailureResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, FailureReason failureReason)
@@ -372,6 +378,11 @@ public interface AuthenticationProvider
         public @NotNull Map<String, String> getAttributeMap()
         {
             return _attributeMap;
+        }
+
+        public String getSuccessDetails()
+        {
+            return _successDetails;
         }
     }
 

--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -396,7 +396,16 @@ public interface AuthenticationProvider
         complexity(ReportType.onFailure, "password does not meet the complexity requirements"),
         expired(ReportType.onFailure, "password has expired"),
         configurationError(ReportType.always, "configuration problem"),
-        notApplicable(ReportType.never, "not applicable");
+        notApplicable(ReportType.never, "not applicable"),
+        badApiKey(ReportType.onFailure, "invalid API key") {
+            @Override
+            public @Nullable String getEmailAddress(ValidEmail email) throws InvalidEmailException
+            {
+                // This override prevents logging a strange "apikey@domain.com"-type failure message. Invalid API key
+                // means email is unknown, so always return null.
+                return null;
+            }
+        };
 
         private final ReportType _type;
         private final String _message;
@@ -415,6 +424,11 @@ public interface AuthenticationProvider
         public String getMessage()
         {
             return _message;
+        }
+
+        public @Nullable String getEmailAddress(ValidEmail email) throws InvalidEmailException
+        {
+            return email.getEmailAddress();
         }
     }
 

--- a/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
+++ b/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.PropertyManager;
 import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.security.ApiKeyManager;
 import org.labkey.api.security.AuthenticationManager.AuthenticationValidator;
 import org.labkey.api.security.AuthenticationProvider.LoginFormAuthenticationProvider;
 import org.labkey.api.security.ConfigurationSettings;
@@ -47,13 +48,9 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.labkey.api.security.SecurityManager.API_KEY;
 import static org.labkey.core.login.DbLoginManager.DATABASE_AUTHENTICATION_CATEGORY_KEY;
 
-/**
- * User: adam
- * Date: Oct 12, 2007
- * Time: 1:31:18 PM
- */
 public class DbLoginAuthenticationProvider implements LoginFormAuthenticationProvider<DbLoginConfiguration>
 {
     @Override
@@ -100,36 +97,48 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
     // id and password will not be blank (not null, not empty, not whitespace only)
     public @NotNull AuthenticationResponse authenticate(DbLoginConfiguration configuration, @NotNull String id, @NotNull String password, URLHelper returnURL) throws ValidEmail.InvalidEmailException
     {
-        ValidEmail email = new ValidEmail(id);
-        String hash = SecurityManager.getPasswordHash(email);
-        User user = UserManager.getUser(email);
-
-        if (null == hash || null == user)
-            return AuthenticationResponse.createFailureResponse(configuration, FailureReason.userDoesNotExist);
-
-        if (!SecurityManager.matchPassword(password,hash))
-            return AuthenticationResponse.createFailureResponse(configuration, FailureReason.badPassword);
-
-        // Password is correct for this user; now check password rules and expiration.
-
-        PasswordRule rule = configuration.getPasswordRule();
-        Collection<String> messages = new LinkedList<>();
-
-        if (!rule.isValidForLogin(password, user, messages))
+        // Check for API key first
+        if (API_KEY.equals(id))
         {
-            return getChangePasswordResponse(configuration, user, returnURL, FailureReason.complexity);
+            User user = ApiKeyManager.get().authenticateFromApiKey(password);
+
+            return user != null ?
+                AuthenticationResponse.createSuccessResponse(configuration, new ValidEmail(user.getEmail()), null, Map.of(), "an API key") :
+                AuthenticationResponse.createFailureResponse(configuration, FailureReason.badCredentials);
         }
         else
         {
-            PasswordExpiration expiration = configuration.getExpiration();
+            ValidEmail email = new ValidEmail(id);
+            String hash = SecurityManager.getPasswordHash(email);
+            User user = UserManager.getUser(email);
 
-            if (expiration.hasExpired(() -> SecurityManager.getLastChanged(user)))
+            if (null == hash || null == user)
+                return AuthenticationResponse.createFailureResponse(configuration, FailureReason.userDoesNotExist);
+
+            if (!SecurityManager.matchPassword(password, hash))
+                return AuthenticationResponse.createFailureResponse(configuration, FailureReason.badPassword);
+
+            // Password is correct for this user; now check password rules and expiration.
+
+            PasswordRule rule = configuration.getPasswordRule();
+            Collection<String> messages = new LinkedList<>();
+
+            if (!rule.isValidForLogin(password, user, messages))
             {
-                return getChangePasswordResponse(configuration, user, returnURL, FailureReason.expired);
+                return getChangePasswordResponse(configuration, user, returnURL, FailureReason.complexity);
             }
-        }
+            else
+            {
+                PasswordExpiration expiration = configuration.getExpiration();
 
-        return AuthenticationResponse.createSuccessResponse(configuration, email);
+                if (expiration.hasExpired(() -> SecurityManager.getLastChanged(user)))
+                {
+                    return getChangePasswordResponse(configuration, user, returnURL, FailureReason.expired);
+                }
+            }
+
+            return AuthenticationResponse.createSuccessResponse(configuration, email);
+        }
     }
 
     @Override

--- a/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
+++ b/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
@@ -104,7 +104,7 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
 
             return user != null ?
                 AuthenticationResponse.createSuccessResponse(configuration, new ValidEmail(user.getEmail()), null, Map.of(), "an API key") :
-                AuthenticationResponse.createFailureResponse(configuration, FailureReason.badCredentials);
+                AuthenticationResponse.createFailureResponse(configuration, FailureReason.badApiKey);
         }
         else
         {

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -2150,7 +2150,7 @@ public class UserController extends SpringActionController
                 String defaultDomain = ValidEmail.getDefaultDomain();
                 StringBuilder sb = new StringBuilder();
                 sb.append("Please sign in using your full email address, for example: ");
-                if (defaultDomain.length() > 0)
+                if (!defaultDomain.isEmpty())
                 {
                     sb.append("employee@");
                     sb.append(defaultDomain);


### PR DESCRIPTION
#### Rationale
API key verification bypasses our standard authentication infrastructure, which means it skips success & failure logging, bad attempt throttling, secondary authentication checks, etc. See https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47683 and https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47658.

This PR moves API key verification into `DbLoginAuthenticationProvider`, treating it as a first-class authentication method. It also extends `AuthenticationResponse`, allowing an authentication to customize the details that are written to the audit log.

Note that scripts and tools might send an API key on every request and not track sessions, which could lead to a large number of authentications. However, the server already throttles the creation of user audit events, preventing duplicate messages from the same unique user + remote address unless ten minutes has passed.

#### Related Pull Requests
* https://github.com/LabKey/ldap/pull/67