### PR TITLE
Issue 48667: Measurement.convertToAmount throws error for BigDecimal

### DIFF
--- a/api/src/org/labkey/api/data/measurement/Measurement.java
+++ b/api/src/org/labkey/api/data/measurement/Measurement.java
@@ -6,6 +6,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.data.ConversionExceptionWithMessage;
 
+import java.math.BigDecimal;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -305,6 +306,10 @@ public class Measurement
         else if (amountObj instanceof Double)
         {
             return (Double) amountObj;
+        }
+        else if (amountObj instanceof BigDecimal)
+        {
+            return ((BigDecimal) amountObj).doubleValue();
         }
         else if (amountObj instanceof String)
             try


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48667

#### Changes
* add Measurement.convertToAmount() conditional for handling BigDecimal
