### PR TITLE
Issue 48705: LKSM: Long data class field names (>49 characters) causes error

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -698,7 +698,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             for (String pCol : pCols)
             {
                 sql.append(comma);
-                sql.append("p.").appendIdentifier(dialect.makeLegalIdentifier(pCol));
+                sql.append(provisioned.getColumn(pCol).getValueSql("p"));
             }
         }
         sql.append(" FROM ");


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48705

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/1639

#### Changes
- use the getValueSql() helper to get the correct alias for the column SQL select
