### PR TITLE
DownloadOutputView: render file names if not empty

### DIFF
--- a/api/src/org/labkey/api/reports/report/r/view/DownloadOutputView.java
+++ b/api/src/org/labkey/api/reports/report/r/view/DownloadOutputView.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.reports.report.r.view;
 
+import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.attachments.AttachmentParent;
 import org.labkey.api.reports.report.ReportUrls;
 import org.labkey.api.reports.report.r.ParamReplacement;
@@ -78,6 +79,7 @@ public abstract class DownloadOutputView extends ROutputView
         {
 
             String downloadUrl = renderInternalAsString(file);
+            String filename = file.getName();
 
             // if we "failed" because the file doesn't exist then no
             // exception is thrown; just return immediately.
@@ -96,8 +98,16 @@ public abstract class DownloadOutputView extends ROutputView
                 out.write("<a href=\"");
                 out.write(downloadUrl);
                 out.write("\">");
-                out.write(_fileType);
-                out.write(" output file (click to download)</a>");
+                if (StringUtils.stripToNull(filename) == null)
+                {
+                    out.write(_fileType);
+                    out.write(" output file (click to download)");
+                }
+                else
+                {
+                    out.write(filename);
+                }
+                out.write("</a>");
             }
 
             out.write("</td></tr>");


### PR DESCRIPTION
#### Rationale
We're adding R report rendering to Biologics as an experimental feature, and we'd like to handle file outputs, however as currently implemented, we don't render the filenames associated with the attachments, even if you give them nice names in your R Report. This PR updates DownloadOutputView to use the attachment's filename if it is not empty, which makes our R output much less confusing, especially if you are generating multiple output files.

Previous UI:
![Screenshot 2023-09-20 at 11 55 16 AM](https://github.com/LabKey/platform/assets/5341647/a4538e7e-f57e-4cd7-9747-faec53312cbc)

Updated UI:
![Screenshot 2023-09-20 at 11 53 32 AM](https://github.com/LabKey/platform/assets/5341647/51d835fe-f253-4932-af30-e9b9b646c1df)


#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1641

#### Changes
* DownloadOutputView: Use file name when rendering files
