### PR TITLE
Issue 48598: already saved query metadata XML is overridden / removed on a second save

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -250,7 +250,13 @@ public abstract class AssayProtocolSchema extends AssaySchema implements UserSch
     }
 
     @Override
-    public TableInfo createTable(String name, ContainerFilter cf)
+    public @Nullable TableInfo createTable(String name, ContainerFilter cf)
+    {
+        return createTable(name, cf, true);
+    }
+
+    @Override
+    public TableInfo createTable(String name, ContainerFilter cf, boolean includeExtraMetadata)
     {
         TableInfo table = createProviderTable(name, cf);
         if (table == null)
@@ -264,7 +270,8 @@ public abstract class AssayProtocolSchema extends AssaySchema implements UserSch
             }
         }
 
-        if (table != null)
+        // Issue 48598: when editing the assay table query metadata, don't overlayMetadata so that we can tell what changes the user is making
+        if (table != null && includeExtraMetadata)
             overlayMetadata(table, name);
 
         return table;

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -271,7 +271,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
                 return table;
         }
         if (null == table)
-            table = createTable(name, cf);
+            table = createTable(name, cf, includeExtraMetadata);
         Object torq;
 
         if (table != null)
@@ -323,8 +323,12 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         return createTable(name, null);
     }
 
-    public abstract @Nullable TableInfo createTable(String name, ContainerFilter cf);
+    public @Nullable TableInfo createTable(String name, ContainerFilter cf, boolean includeExtraMetadata)
+    {
+        return createTable(name, cf);
+    }
 
+    public abstract @Nullable TableInfo createTable(String name, ContainerFilter cf);
 
     @Override
     abstract public Set<String> getTableNames();

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -323,6 +323,11 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         return createTable(name, null);
     }
 
+    /**
+     * This is available for those subclasses that may need to apply metadata that comes from atypical locations. See
+     * example in AssayProtocolSchema.java which also looks to apply assay-provider-scoped metadata in addition to the
+     * standard query metadata. Issue 48598
+     */
     public @Nullable TableInfo createTable(String name, ContainerFilter cf, boolean includeExtraMetadata)
     {
         return createTable(name, cf);

--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -197,12 +197,10 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                 }
             }
 
-            boolean keepPreviousXml = false;
             if (xmlColumn != null)
             {
                 // Still valid, don't delete it from the metadata overrides
                 columnsToDelete.remove(metadataColumnJSON.getName());
-                keepPreviousXml = true;
             }
             else
             {
@@ -232,7 +230,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setFormatString(metadataColumnJSON.getFormat());
             }
-            else if (xmlColumn.isSetFormatString() && !keepPreviousXml)
+            else if (xmlColumn.isSetFormatString())
             {
                 xmlColumn.unsetFormatString();
             }
@@ -242,7 +240,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setIsHidden(metadataColumnJSON.isHidden());
             }
-            else if (xmlColumn.isSetIsHidden() && !keepPreviousXml)
+            else if (xmlColumn.isSetIsHidden())
             {
                 xmlColumn.unsetIsHidden();
             }
@@ -250,7 +248,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setShownInInsertView(metadataColumnJSON.isShownInInsertView());
             }
-            else if (xmlColumn.isSetShownInInsertView() && !keepPreviousXml)
+            else if (xmlColumn.isSetShownInInsertView())
             {
                 xmlColumn.unsetShownInInsertView();
             }
@@ -258,7 +256,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setShownInUpdateView(metadataColumnJSON.isShownInUpdateView());
             }
-            else if (xmlColumn.isSetShownInUpdateView() && !keepPreviousXml)
+            else if (xmlColumn.isSetShownInUpdateView())
             {
                 xmlColumn.unsetShownInUpdateView();
             }
@@ -266,7 +264,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setShownInDetailsView(metadataColumnJSON.isShownInDetailsView());
             }
-            else if (xmlColumn.isSetShownInDetailsView() && !keepPreviousXml)
+            else if (xmlColumn.isSetShownInDetailsView())
             {
                 xmlColumn.unsetShownInDetailsView();
             }
@@ -274,7 +272,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setMeasure(metadataColumnJSON.isMeasure());
             }
-            else if (xmlColumn.isSetMeasure() && !keepPreviousXml)
+            else if (xmlColumn.isSetMeasure())
             {
                 xmlColumn.unsetMeasure();
             }
@@ -283,7 +281,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setDimension(metadataColumnJSON.isDimension());
             }
-            else if (xmlColumn.isSetDimension() && !keepPreviousXml)
+            else if (xmlColumn.isSetDimension())
             {
                 xmlColumn.unsetDimension();
             }
@@ -292,7 +290,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setRecommendedVariable(metadataColumnJSON.isRecommendedVariable());
             }
-            else if (xmlColumn.isSetRecommendedVariable() && !keepPreviousXml)
+            else if (xmlColumn.isSetRecommendedVariable())
             {
                 xmlColumn.unsetRecommendedVariable();
             }
@@ -301,7 +299,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setDefaultScale(DefaultScaleType.Enum.forString(metadataColumnJSON.getDefaultScale()));
             }
-            else if (xmlColumn.isSetDefaultScale() && !keepPreviousXml)
+            else if (xmlColumn.isSetDefaultScale())
             {
                 xmlColumn.unsetDefaultScale();
             }
@@ -310,7 +308,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setDerivationDataScope(DerivationDataScopeTypes.Enum.forString(metadataColumnJSON.getDerivationDataScope()));
             }
-            else if (xmlColumn.isSetDerivationDataScope() && !keepPreviousXml)
+            else if (xmlColumn.isSetDerivationDataScope())
             {
                 xmlColumn.unsetDerivationDataScope();
             }
@@ -329,7 +327,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setExcludeFromShifting(metadataColumnJSON.isExcludeFromShifting());
             }
-            else if (xmlColumn.isSetExcludeFromShifting() && !keepPreviousXml)
+            else if (xmlColumn.isSetExcludeFromShifting())
             {
                 xmlColumn.unsetExcludeFromShifting();
             }
@@ -339,7 +337,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setColumnTitle(metadataColumnJSON.getLabel());
             }
-            else if (xmlColumn.isSetColumnTitle() && !keepPreviousXml)
+            else if (xmlColumn.isSetColumnTitle())
             {
                 xmlColumn.unsetColumnTitle();
             }
@@ -361,7 +359,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                     }
                 }
             }
-            else if (xmlColumn.isSetUrl() && !keepPreviousXml)
+            else if (xmlColumn.isSetUrl())
             {
                 xmlColumn.unsetUrl();
             }
@@ -386,7 +384,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                     }
                 }
                 // wipe off import aliases xml
-                else if (xmlColumn.isSetImportAliases() && !keepPreviousXml)
+                else if (xmlColumn.isSetImportAliases())
                 {
                     xmlColumn.unsetImportAliases();
                 }
@@ -437,18 +435,18 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                         }
                     }
                 }
-                else if (xmlColumn.isSetFk() && !keepPreviousXml)
+                else if (xmlColumn.isSetFk())
                 {
                     xmlColumn.unsetFk();
                 }
             }
-            else if (xmlColumn.isSetFk() && !keepPreviousXml)
+            else if (xmlColumn.isSetFk())
             {
                 xmlColumn.unsetFk();
             }
 
             // Always clear out the conditional formats if they've been set
-            if (xmlColumn.isSetConditionalFormats() && !keepPreviousXml)
+            if (xmlColumn.isSetConditionalFormats())
             {
                 xmlColumn.unsetConditionalFormats();
             }
@@ -463,7 +461,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setConceptURI(metadataColumnJSON.getConceptURI());
             }
-            else if (xmlColumn.isSetConceptURI() && !keepPreviousXml)
+            else if (xmlColumn.isSetConceptURI())
             {
                 xmlColumn.unsetConceptURI();
             }
@@ -489,7 +487,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setPrincipalConceptCode(metadataColumnJSON.getPrincipalConceptCode());
             }
-            else if (xmlColumn.isSetPrincipalConceptCode() && !keepPreviousXml)
+            else if (xmlColumn.isSetPrincipalConceptCode())
             {
                 xmlColumn.unsetPrincipalConceptCode();
             }

--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -197,10 +197,12 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                 }
             }
 
+            boolean keepPreviousXml = false;
             if (xmlColumn != null)
             {
                 // Still valid, don't delete it from the metadata overrides
                 columnsToDelete.remove(metadataColumnJSON.getName());
+                keepPreviousXml = true;
             }
             else
             {
@@ -230,7 +232,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setFormatString(metadataColumnJSON.getFormat());
             }
-            else if (xmlColumn.isSetFormatString())
+            else if (xmlColumn.isSetFormatString() && !keepPreviousXml)
             {
                 xmlColumn.unsetFormatString();
             }
@@ -240,7 +242,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setIsHidden(metadataColumnJSON.isHidden());
             }
-            else if (xmlColumn.isSetIsHidden())
+            else if (xmlColumn.isSetIsHidden() && !keepPreviousXml)
             {
                 xmlColumn.unsetIsHidden();
             }
@@ -248,7 +250,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setShownInInsertView(metadataColumnJSON.isShownInInsertView());
             }
-            else if (xmlColumn.isSetShownInInsertView())
+            else if (xmlColumn.isSetShownInInsertView() && !keepPreviousXml)
             {
                 xmlColumn.unsetShownInInsertView();
             }
@@ -256,7 +258,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setShownInUpdateView(metadataColumnJSON.isShownInUpdateView());
             }
-            else if (xmlColumn.isSetShownInUpdateView())
+            else if (xmlColumn.isSetShownInUpdateView() && !keepPreviousXml)
             {
                 xmlColumn.unsetShownInUpdateView();
             }
@@ -264,7 +266,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setShownInDetailsView(metadataColumnJSON.isShownInDetailsView());
             }
-            else if (xmlColumn.isSetShownInDetailsView())
+            else if (xmlColumn.isSetShownInDetailsView() && !keepPreviousXml)
             {
                 xmlColumn.unsetShownInDetailsView();
             }
@@ -272,7 +274,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setMeasure(metadataColumnJSON.isMeasure());
             }
-            else if (xmlColumn.isSetMeasure())
+            else if (xmlColumn.isSetMeasure() && !keepPreviousXml)
             {
                 xmlColumn.unsetMeasure();
             }
@@ -281,7 +283,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setDimension(metadataColumnJSON.isDimension());
             }
-            else if (xmlColumn.isSetDimension())
+            else if (xmlColumn.isSetDimension() && !keepPreviousXml)
             {
                 xmlColumn.unsetDimension();
             }
@@ -290,7 +292,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setRecommendedVariable(metadataColumnJSON.isRecommendedVariable());
             }
-            else if (xmlColumn.isSetRecommendedVariable())
+            else if (xmlColumn.isSetRecommendedVariable() && !keepPreviousXml)
             {
                 xmlColumn.unsetRecommendedVariable();
             }
@@ -299,7 +301,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setDefaultScale(DefaultScaleType.Enum.forString(metadataColumnJSON.getDefaultScale()));
             }
-            else if (xmlColumn.isSetDefaultScale())
+            else if (xmlColumn.isSetDefaultScale() && !keepPreviousXml)
             {
                 xmlColumn.unsetDefaultScale();
             }
@@ -308,7 +310,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setDerivationDataScope(DerivationDataScopeTypes.Enum.forString(metadataColumnJSON.getDerivationDataScope()));
             }
-            else if (xmlColumn.isSetDerivationDataScope())
+            else if (xmlColumn.isSetDerivationDataScope() && !keepPreviousXml)
             {
                 xmlColumn.unsetDerivationDataScope();
             }
@@ -327,7 +329,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setExcludeFromShifting(metadataColumnJSON.isExcludeFromShifting());
             }
-            else if (xmlColumn.isSetExcludeFromShifting())
+            else if (xmlColumn.isSetExcludeFromShifting() && !keepPreviousXml)
             {
                 xmlColumn.unsetExcludeFromShifting();
             }
@@ -337,7 +339,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setColumnTitle(metadataColumnJSON.getLabel());
             }
-            else if (xmlColumn.isSetColumnTitle())
+            else if (xmlColumn.isSetColumnTitle() && !keepPreviousXml)
             {
                 xmlColumn.unsetColumnTitle();
             }
@@ -359,7 +361,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                     }
                 }
             }
-            else if (xmlColumn.isSetUrl())
+            else if (xmlColumn.isSetUrl() && !keepPreviousXml)
             {
                 xmlColumn.unsetUrl();
             }
@@ -384,7 +386,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                     }
                 }
                 // wipe off import aliases xml
-                else if (xmlColumn.isSetImportAliases())
+                else if (xmlColumn.isSetImportAliases() && !keepPreviousXml)
                 {
                     xmlColumn.unsetImportAliases();
                 }
@@ -435,18 +437,18 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                         }
                     }
                 }
-                else if (xmlColumn.isSetFk())
+                else if (xmlColumn.isSetFk() && !keepPreviousXml)
                 {
                     xmlColumn.unsetFk();
                 }
             }
-            else if (xmlColumn.isSetFk())
+            else if (xmlColumn.isSetFk() && !keepPreviousXml)
             {
                 xmlColumn.unsetFk();
             }
 
-            // Always clear it out the conditional formats if they've been set
-            if (xmlColumn.isSetConditionalFormats())
+            // Always clear out the conditional formats if they've been set
+            if (xmlColumn.isSetConditionalFormats() && !keepPreviousXml)
             {
                 xmlColumn.unsetConditionalFormats();
             }
@@ -461,7 +463,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setConceptURI(metadataColumnJSON.getConceptURI());
             }
-            else if (xmlColumn.isSetConceptURI())
+            else if (xmlColumn.isSetConceptURI() && !keepPreviousXml)
             {
                 xmlColumn.unsetConceptURI();
             }
@@ -487,7 +489,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             {
                 xmlColumn.setPrincipalConceptCode(metadataColumnJSON.getPrincipalConceptCode());
             }
-            else if (xmlColumn.isSetPrincipalConceptCode())
+            else if (xmlColumn.isSetPrincipalConceptCode() && !keepPreviousXml)
             {
                 xmlColumn.unsetPrincipalConceptCode();
             }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48598

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4767
- https://github.com/LabKey/testAutomation/pull/1643

#### Changes
* AssayProtocolSchema.createTable() to take an includeExtraMetadata param and check it before calling overlayMetadata()
