### PR TITLE
@labkey/themes switch to npm

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@labkey/api": "1.24.2",
         "@labkey/components": "2.370.0",
-        "@labkey/themes": "1.3.2-fb-npm-themes.0"
+        "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
         "@labkey/build": "6.15.0",
@@ -3410,9 +3410,9 @@
       }
     },
     "node_modules/@labkey/themes": {
-      "version": "1.3.2-fb-npm-themes.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2-fb-npm-themes.0.tgz",
-      "integrity": "sha512-gxKe81Iw7zy84ltxIfJQ8rmojcc+2Y/ZTS0Ly6Sl6p7E86m/gDF34IK3XfJ7pruXQhfjycVKLnxq1gY/8wcO2g=="
+      "version": "1.3.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2.tgz",
+      "integrity": "sha512-knJi2tZe4W6JCwebzhKYf/BeK3XY/NGfZPaEfrfs6l7MNnjMn90OzkVI59LQ9NW/gw9SRcnTjfSLuNBtSYWX1g=="
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
@@ -19598,9 +19598,9 @@
       }
     },
     "@labkey/themes": {
-      "version": "1.3.2-fb-npm-themes.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2-fb-npm-themes.0.tgz",
-      "integrity": "sha512-gxKe81Iw7zy84ltxIfJQ8rmojcc+2Y/ZTS0Ly6Sl6p7E86m/gDF34IK3XfJ7pruXQhfjycVKLnxq1gY/8wcO2g=="
+      "version": "1.3.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2.tgz",
+      "integrity": "sha512-knJi2tZe4W6JCwebzhKYf/BeK3XY/NGfZPaEfrfs6l7MNnjMn90OzkVI59LQ9NW/gw9SRcnTjfSLuNBtSYWX1g=="
     },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@labkey/api": "1.24.2",
         "@labkey/components": "2.370.0",
-        "@labkey/themes": "1.3.1"
+        "@labkey/themes": "1.3.2-fb-npm-themes.0"
       },
       "devDependencies": {
         "@labkey/build": "6.15.0",
@@ -3410,9 +3410,9 @@
       }
     },
     "node_modules/@labkey/themes": {
-      "version": "1.3.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.1.tgz",
-      "integrity": "sha512-USeKNUyggu9RDqyjuSBPoOYkD2vepx6V57LKf5XVN1vHS+sjlQ06Cer9DM1YF+giwWnVneVupmYOHckdALR1FQ=="
+      "version": "1.3.2-fb-npm-themes.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2-fb-npm-themes.0.tgz",
+      "integrity": "sha512-gxKe81Iw7zy84ltxIfJQ8rmojcc+2Y/ZTS0Ly6Sl6p7E86m/gDF34IK3XfJ7pruXQhfjycVKLnxq1gY/8wcO2g=="
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
@@ -19598,9 +19598,9 @@
       }
     },
     "@labkey/themes": {
-      "version": "1.3.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.1.tgz",
-      "integrity": "sha512-USeKNUyggu9RDqyjuSBPoOYkD2vepx6V57LKf5XVN1vHS+sjlQ06Cer9DM1YF+giwWnVneVupmYOHckdALR1FQ=="
+      "version": "1.3.2-fb-npm-themes.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2-fb-npm-themes.0.tgz",
+      "integrity": "sha512-gxKe81Iw7zy84ltxIfJQ8rmojcc+2Y/ZTS0Ly6Sl6p7E86m/gDF34IK3XfJ7pruXQhfjycVKLnxq1gY/8wcO2g=="
     },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",

--- a/core/package.json
+++ b/core/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@labkey/api": "1.24.2",
     "@labkey/components": "2.370.0",
-    "@labkey/themes": "1.3.2-fb-npm-themes.0"
+    "@labkey/themes": "1.3.2"
   },
   "devDependencies": {
     "@labkey/build": "6.15.0",

--- a/core/package.json
+++ b/core/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@labkey/api": "1.24.2",
     "@labkey/components": "2.370.0",
-    "@labkey/themes": "1.3.1"
+    "@labkey/themes": "1.3.2-fb-npm-themes.0"
   },
   "devDependencies": {
     "@labkey/build": "6.15.0",


### PR DESCRIPTION
#### Rationale
Updates the `@labkey/themes` package to utilize `npm` instead of `yarn`.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1293
- https://github.com/LabKey/platform/pull/4770

#### Changes
* Bump `@labkey/themes` package
