### PR TITLE
Build: remove glob pattern usages in clean commands

### DIFF
--- a/assay/package.json
+++ b/assay/package.json
@@ -9,7 +9,7 @@
     "start-link": "cross-env LINK=true npm run start",
     "build-dev": "npm run clean && cross-env NODE_ENV=development webpack --config node_modules/@labkey/build/webpack/dev.config.js --color",
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile",
-    "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen"
+    "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
     "@labkey/components": "2.370.0"

--- a/core/package.json
+++ b/core/package.json
@@ -7,7 +7,7 @@
     "build-analyze": "cross-env ANALYZE=true npm run build",
     "build-dev": "npm run copy-distributions && cross-env NODE_ENV=development webpack --config node_modules/@labkey/build/webpack/dev.config.js --color",
     "build-prod": "npm run copy-distributions && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile",
-    "clean": "rimraf resources/web/core/gen && rimraf resources/web/core/css && rimraf resources/web/clientapi && rimraf resources/views/gen && rimraf resources/views/authenticationConfiguration.* && rimraf resources/views/components.* && rimraf resources/web/gen",
+    "clean": "rimraf resources/web/core/gen && rimraf resources/web/core/css && rimraf resources/web/clientapi && rimraf resources/views/gen && rimraf resources/web/gen",
     "copy-distributions": "npm run clean && node copy-distributions.js",
     "start": "cross-env NODE_ENV=development webpack serve --config node_modules/@labkey/build/webpack/watch.config.js",
     "start-link": "cross-env LINK=true npm run start",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -9,7 +9,7 @@
     "start-link": "cross-env LINK=true npm run start",
     "build-dev": "npm run clean && cross-env NODE_ENV=development webpack --config node_modules/@labkey/build/webpack/dev.config.js --color",
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile",
-    "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen",
+    "clean": "rimraf resources/web/experiment/gen && rimraf resources/views/gen && rimraf resources/web/gen",
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "setup": "npm ci --legacy-peer-deps",
     "build": "npm run build-dev",
-    "clean": "rimraf resources/web/pipeline/gen && rimraf resources/views/gen && rimraf resources/views/*.* && rimraf resources/web/gen",
+    "clean": "rimraf resources/web/pipeline/gen && rimraf resources/views/gen && rimraf resources/web/gen",
     "lint": "eslint",
     "lint-fix": "eslint --fix",
     "start": "cross-env NODE_ENV=development webpack serve --config node_modules/@labkey/build/webpack/watch.config.js",


### PR DESCRIPTION
#### Rationale
After the recent package updates (see #4762) it was discovered that some of our usages of the `rimraf` file system utility were utilizing glob functionality which now, with `rimraf@4.2.0` requires the `--glob` flag to be specified in Windows build environments. That said, after inspecting our usages it turns out we don't need to be using glob patterns at all in our `clean` commands so I've removed them rather than specifying the flag.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4773
* https://github.com/LabKey/inventory/pull/1032
* https://github.com/LabKey/moduleEditor/pull/87
* https://github.com/LabKey/provenance/pull/151
* https://github.com/LabKey/puppeteer/pull/54

#### Changes
* Remove glob pattern from clean commands
