### PR TITLE
Cap the total number of JS handlers we're tracking per page

### DIFF
--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -601,7 +601,7 @@ public class PageConfig
         {
             if (_eventHandlers.size() == MAX_EVENT_HANDLERS)
             {
-                LOG.warn("Limit of " + MAX_EVENT_HANDLERS + " JavaScript event handlers reached. Subsequent handlers will be dropped. Current handler for " + eh.event + ": " + eh.handler);
+                LOG.error("Limit of " + MAX_EVENT_HANDLERS + " JavaScript event handlers reached. Subsequent handlers will be dropped. Current handler for " + eh.event + ": " + eh.handler);
             }
             var prev = _eventHandlers.put(eh.getKey(), eh);
             assert null == prev || prev.handler.equals(eh.handler) : "Duplicate handler registered. event:" + eh.getKey() + " handler:" + eh.handler();


### PR DESCRIPTION
#### Rationale
We store and later render all inline JavaScript handlers to support stronger Content Security Policy directives. Some page renders, especially huge grids, may produce enough of them to overwhelm the heap. See issue 48714

#### Changes
* Don't track more than 100,000 handlers
* Clarify reason for not preloading fonts