### PR TITLE
Issue 48703: Strange lineage result behavior when using UNION in queries containing ancestor columns

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -258,7 +258,7 @@ public class ClosureQueryHelper
     private static TableInfo getClosureTableInfo(UserSchema userSchema, TableType type, String sourceLSID)
     {
         var tx = userSchema.getDbSchema().getScope().getCurrentTransaction();
-        String key = ClosureQueryHelper.class.getName() + "/" + (null == tx ? "-" : tx.getId());
+        String key = ClosureQueryHelper.class.getName() + "/" + (null == tx ? "-" : tx.getId()) + "/" + sourceLSID;
         return userSchema.getCachedLookupTableInfo(key, () ->
         {
             MaterializedQueryHelper helper = Objects.requireNonNull(getClosureHelper(type, sourceLSID, true));


### PR DESCRIPTION
#### Rationale
Issue [48703](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48703): Strange lineage result behavior when using UNION in queries containing ancestor columns

ClosureQueryHelp switched to use getCachedLookupTableInfo to allow reusing temp table. The cache key consist only of transaction id. In the case when there are more than one sourcelsid for a query, the incorrect closure table would be used from cache.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4218

#### Changes
* use sourcelsid together with transaction id as cache key for closure tables
