### PR TITLE
Handle multi-CTE WITH clauses

### DIFF
--- a/api/src/org/labkey/api/data/SqlScanner.java
+++ b/api/src/org/labkey/api/data/SqlScanner.java
@@ -11,11 +11,8 @@ import java.util.Collection;
  * A simple scanner for SQL text that understands block & single-line comments, double-quoted identifiers, single-quoted strings,
  * and quote escaping. It is not a SQL tokenizer or parser... it merely enables simple text operations that are aware of comments
  * and strings. It currently supports finding characters and substrings outside of comments and quoted strings, as well as
- * stripping comments. It could be extended to support search & replace and other useful text operations.
- *
+ * stripping comments and quoted strings. It could be extended to support search & replace and other useful text operations.
  * Consider: Use in SQLFragment.getFilterText() replacements
- *
- * Created by adam on 6/29/2017.
  */
 public class SqlScanner extends BaseScanner
 {
@@ -75,6 +72,7 @@ public class SqlScanner extends BaseScanner
             else if ('\'' == c || '"' == c)
             {
                 String escape = "" + c + c;
+                int startIndex = i;
 
                 while (++i < _text.length())
                 {
@@ -85,9 +83,15 @@ public class SqlScanner extends BaseScanner
                         twoChars = _text.substring(i, i + 2);
 
                     if (escape.equals(twoChars))
+                    {
                         i++;
+                    }
                     else if (c == c2)
+                    {
+                        if (!handler.string(startIndex, i + 1))
+                            return;
                         break next;
+                    }
                 }
 
                 throw new NotFoundException("Expected ending quote (" + c + ") was not found");

--- a/api/src/org/labkey/api/util/BaseScanner.java
+++ b/api/src/org/labkey/api/util/BaseScanner.java
@@ -150,7 +150,7 @@ public abstract class BaseScanner
 
     /**
      * Returns the text stripped of all comments (while correctly handling comment characters in quoted strings).
-     * @return StringBuilder containing the stripped text
+     * @return StringBuilder containing the text stripped of comments
      */
     public StringBuilder stripComments()
     {
@@ -161,6 +161,32 @@ public abstract class BaseScanner
         {
             @Override
             public boolean comment(int startIndex, int endIndex)
+            {
+                ret.append(_text, previous.getValue(), startIndex);
+                previous.setValue(endIndex);
+
+                return true;
+            }
+        });
+
+        ret.append(_text.substring(previous.getValue()));
+
+        return ret;
+    }
+
+    /**
+     * Returns the text stripped of all quoted strings (while correctly handling quote characters in comments).
+     * @return StringBuilder containing the text stripped of quoted strings
+     */
+    public StringBuilder stripQuotedStrings()
+    {
+        StringBuilder ret = new StringBuilder();
+        MutableInt previous = new MutableInt(0);
+
+        scan(0, new Handler()
+        {
+            @Override
+            public boolean string(int startIndex, int endIndex)
             {
                 ret.append(_text, previous.getValue(), startIndex);
                 previous.setValue(endIndex);


### PR DESCRIPTION
#### Rationale
Parser didn't understand the case where a WITH clause had multiple CTEs. It also could get tripped up by keywords in quoted strings; addressing that required wiring up the `strings()` handler method in `SqlScanner`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4772