### PR TITLE
CopyOnWriteMap

### DIFF
--- a/announcements/src/org/labkey/announcements/api/AnnouncementServiceImpl.java
+++ b/announcements/src/org/labkey/announcements/api/AnnouncementServiceImpl.java
@@ -28,6 +28,7 @@ import org.labkey.api.announcements.api.Announcement;
 import org.labkey.api.announcements.api.AnnouncementService;
 import org.labkey.api.announcements.api.DiscussionSrcTypeProvider;
 import org.labkey.api.attachments.AttachmentFile;
+import org.labkey.api.collections.CopyOnWriteHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
@@ -42,17 +43,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-/**
- * User: Nick
- * Date: Jun 30, 2010
- * Time: 5:39:12 PM
- */
 public class AnnouncementServiceImpl implements AnnouncementService
 {
-    private final Map<String, DiscussionSrcTypeProvider> _discussionSrcTypeProviders = new ConcurrentHashMap<>();
+    private final Map<String, DiscussionSrcTypeProvider> _discussionSrcTypeProviders = new CopyOnWriteHashMap<>();
 
     @Override
     public Announcement insertAnnouncement(Container c, User u, String title, String body, boolean sendEmailNotification)

--- a/api/src/org/labkey/api/attachments/Attachment.java
+++ b/api/src/org/labkey/api/attachments/Attachment.java
@@ -183,7 +183,7 @@ public class Attachment implements Serializable
     {
         synchronized (icons)
         {
-            if (icons.size() == 0)
+            if (icons.isEmpty())
             {
                 WebdavResolver staticFiles = ServiceRegistry.get().getService(WebdavResolver.class);
                 if (staticFiles != null)
@@ -204,7 +204,7 @@ public class Attachment implements Serializable
                         }
                     }
                 }
-                if (icons.size() == 0)
+                if (icons.isEmpty())
                 {
                     ServletContext context = ViewServlet.getViewServletContext();
                     if (null != context)

--- a/api/src/org/labkey/api/collections/CopyOnWriteCaseInsensitiveHashMap.java
+++ b/api/src/org/labkey/api/collections/CopyOnWriteCaseInsensitiveHashMap.java
@@ -1,0 +1,42 @@
+package org.labkey.api.collections;
+
+import java.util.Map;
+
+/**
+ * A thread-safe version of {@link CaseInsensitiveHashMap} in which all operations that change the Map are implemented
+ * by making a new copy of the underlying Map. This is appropriate for scenarios where reads far outnumber writes.
+ */
+public class CopyOnWriteCaseInsensitiveHashMap<V> extends CopyOnWriteMap<String, V, CaseInsensitiveHashMap<V>>
+{
+    public CopyOnWriteCaseInsensitiveHashMap()
+    {
+    }
+
+    public CopyOnWriteCaseInsensitiveHashMap(int initialCapacity)
+    {
+        super(initialCapacity);
+    }
+
+    public CopyOnWriteCaseInsensitiveHashMap(Map<String, V> data)
+    {
+        super(data);
+    }
+
+    @Override
+    protected CaseInsensitiveHashMap<V> newMap()
+    {
+        return new CaseInsensitiveHashMap<>();
+    }
+
+    @Override
+    protected CaseInsensitiveHashMap<V> newMap(int initialCapacity)
+    {
+        return new CaseInsensitiveHashMap<>(initialCapacity);
+    }
+
+    @Override
+    protected CaseInsensitiveHashMap<V> newMap(Map<String, V> data)
+    {
+        return new CaseInsensitiveHashMap<>(data);
+    }
+}

--- a/api/src/org/labkey/api/collections/CopyOnWriteCaseInsensitiveHashMap.java
+++ b/api/src/org/labkey/api/collections/CopyOnWriteCaseInsensitiveHashMap.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 /**
  * A thread-safe version of {@link CaseInsensitiveHashMap} in which all operations that change the Map are implemented
- * by making a new copy of the underlying Map. This is appropriate for scenarios where reads far outnumber writes.
+ * by making a new copy of the underlying Map. This is appropriate for scenarios where reads vastly outnumber writes.
  */
 public class CopyOnWriteCaseInsensitiveHashMap<V> extends CopyOnWriteMap<String, V, CaseInsensitiveHashMap<V>>
 {

--- a/api/src/org/labkey/api/collections/CopyOnWriteHashMap.java
+++ b/api/src/org/labkey/api/collections/CopyOnWriteHashMap.java
@@ -1,0 +1,43 @@
+package org.labkey.api.collections;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A thread-safe version of {@link HashMap} in which all operations that change the Map are implemented by making
+ * a new copy of the underlying Map. This is appropriate for scenarios where reads far outnumber writes.
+ */
+public class CopyOnWriteHashMap<K, V> extends CopyOnWriteMap<K, V, HashMap<K, V>>
+{
+    public CopyOnWriteHashMap()
+    {
+    }
+
+    public CopyOnWriteHashMap(int initialCapacity)
+    {
+        super(initialCapacity);
+    }
+
+    public CopyOnWriteHashMap(Map<K, V> data)
+    {
+        super(data);
+    }
+
+    @Override
+    protected HashMap<K, V> newMap()
+    {
+        return new HashMap<>();
+    }
+
+    @Override
+    protected HashMap<K, V> newMap(int initialCapacity)
+    {
+        return new HashMap<>(initialCapacity);
+    }
+
+    @Override
+    protected HashMap<K, V> newMap(Map<K, V> data)
+    {
+        return new HashMap<>(data);
+    }
+}

--- a/api/src/org/labkey/api/collections/CopyOnWriteHashMap.java
+++ b/api/src/org/labkey/api/collections/CopyOnWriteHashMap.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 /**
  * A thread-safe version of {@link HashMap} in which all operations that change the Map are implemented by making
- * a new copy of the underlying Map. This is appropriate for scenarios where reads far outnumber writes.
+ * a new copy of the underlying Map. This is appropriate for scenarios where reads vastly outnumber writes.
  */
 public class CopyOnWriteHashMap<K, V> extends CopyOnWriteMap<K, V, HashMap<K, V>>
 {

--- a/api/src/org/labkey/api/collections/CopyOnWriteMap.java
+++ b/api/src/org/labkey/api/collections/CopyOnWriteMap.java
@@ -1,0 +1,227 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+package org.labkey.api.collections;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A thread-safe version of {@link Map} in which all operations that change the
+ * Map are implemented by making a new copy of the underlying Map.
+ * While the creation of a new Map can be expensive, this class is designed for
+ * cases in which the primary function is to read data from the Map, not to
+ * modify the Map. Therefore, the operations that do not cause a change to the
+ * Map happen quickly and concurrently.
+ *
+ * @param <K> The key type
+ * @param <V> The value type
+ *
+ * @author <a href="http://mina.apache.org">Apache MINA Project</a>
+ * <a href="https://github.com/apache/mina/blob/2.2.X/mina-core/src/main/java/org/apache/mina/util/CopyOnWriteMap.java">Original Source</a>
+ * Original Mina source was modified to allow for different internal map implementations (e.g., HashMap, CaseInsensitiveHashMap, etc.).
+ */
+abstract class CopyOnWriteMap<K, V, MAP extends Map<K, V>> implements Map<K, V>, Cloneable {
+    private volatile MAP internalMap;
+
+    /**
+     * Creates a new instance of CopyOnWriteMap.
+     */
+    public CopyOnWriteMap() {
+        internalMap = newMap();
+    }
+
+    /**
+     * Creates a new instance of CopyOnWriteMap with the specified initial size
+     *
+     * @param initialCapacity The initial size of the Map.
+     */
+    public CopyOnWriteMap(int initialCapacity) {
+        internalMap = newMap(initialCapacity);
+    }
+
+    /**
+     * Creates a new instance of CopyOnWriteMap in which the
+     * initial data being held by this map is contained in
+     * the supplied map.
+     *
+     * @param data A Map containing the initial contents to be placed into
+     *  this class.
+     */
+    public CopyOnWriteMap(Map<K, V> data) {
+        internalMap = newMap(data);
+    }
+
+    protected abstract MAP newMap();
+    protected abstract MAP newMap(int initialCapacity);
+    protected abstract MAP newMap(Map<K, V> data);
+
+    /**
+     * Adds the provided key and value to this map.
+     *
+     * @see java.util.Map#put(java.lang.Object, java.lang.Object)
+     */
+    @Override
+    public V put(K key, V value) {
+        synchronized (this) {
+            MAP newMap = newMap(internalMap);
+            V val = newMap.put(key, value);
+            internalMap = newMap;
+
+            return val;
+        }
+    }
+
+    /**
+     * Removes the value and key from this map based on the
+     * provided key.
+     *
+     * @see java.util.Map#remove(java.lang.Object)
+     */
+    @Override
+    public V remove(Object key) {
+        synchronized (this) {
+            MAP newMap = newMap(internalMap);
+            V val = newMap.remove(key);
+            internalMap = newMap;
+
+            return val;
+        }
+    }
+
+    /**
+     * Inserts all the keys and values contained in the
+     * provided map to this map.
+     *
+     * @see java.util.Map#putAll(java.util.Map)
+     */
+    @Override
+    public void putAll(@NotNull Map<? extends K, ? extends V> newData) {
+        synchronized (this) {
+            MAP newMap = newMap(internalMap);
+            newMap.putAll(newData);
+            internalMap = newMap;
+        }
+    }
+
+    /**
+     * Removes all entries in this map.
+     *
+     * @see java.util.Map#clear()
+     */
+    @Override
+    public void clear() {
+        synchronized (this) {
+            internalMap = newMap();
+        }
+    }
+
+    // ==============================================
+    // ==== Below are methods that do not modify ====
+    // ====         the internal Maps            ====
+    // ==============================================
+    /**
+     * @return the number of key/value pairs in this map.
+     *
+     * @see java.util.Map#size()
+     */
+    @Override
+    public int size() {
+        return internalMap.size();
+    }
+
+    /**
+     * @return true if this map is empty, otherwise false.
+     *
+     * @see java.util.Map#isEmpty()
+     */
+    @Override
+    public boolean isEmpty() {
+        return internalMap.isEmpty();
+    }
+
+    /**
+     * @return true if this map contains the provided key, otherwise
+     * this method return false.
+     *
+     * @see java.util.Map#containsKey(java.lang.Object)
+     */
+    @Override
+    public boolean containsKey(Object key) {
+        return internalMap.containsKey(key);
+    }
+
+    /**
+     * @return true if this map contains the provided value, otherwise
+     * this method returns false.
+     *
+     * @see java.util.Map#containsValue(java.lang.Object)
+     */
+    @Override
+    public boolean containsValue(Object value) {
+        return internalMap.containsValue(value);
+    }
+
+    /**
+     * @return the value associated with the provided key from this
+     * map.
+     *
+     * @see java.util.Map#get(java.lang.Object)
+     */
+    @Override
+    public V get(Object key) {
+        return internalMap.get(key);
+    }
+
+    /**
+     * This method will return a read-only {@link Set}.
+     */
+    @Override
+    public @NotNull Set<K> keySet() {
+        return internalMap.keySet();
+    }
+
+    /**
+     * This method will return a read-only {@link Collection}.
+     */
+    @Override
+    public @NotNull Collection<V> values() {
+        return internalMap.values();
+    }
+
+    /**
+     * This method will return a read-only {@link Set}.
+     */
+    @Override
+    public @NotNull Set<Entry<K, V>> entrySet() {
+        return internalMap.entrySet();
+    }
+
+    @Override
+    public Object clone() {
+        try {
+            return super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+}

--- a/api/src/org/labkey/api/data/ContainerTypeRegistry.java
+++ b/api/src/org/labkey/api/data/ContainerTypeRegistry.java
@@ -15,18 +15,19 @@
  */
 package org.labkey.api.data;
 
+import org.labkey.api.collections.CopyOnWriteHashMap;
+
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
- * Registry for different types of container.  The name provided when registering is the value
+ * Registry for different types of containers. The name provided when registering is the value
  * stored in the "type" field of the container table.
  */
 public class ContainerTypeRegistry
 {
-    private ConcurrentMap<String, ContainerType> types = new ConcurrentHashMap<>();
-    private static ContainerTypeRegistry instance = new ContainerTypeRegistry();
+    private final Map<String, ContainerType> types = new CopyOnWriteHashMap<>();
+    private static final ContainerTypeRegistry instance = new ContainerTypeRegistry();
 
     private ContainerTypeRegistry()
     {

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
+import org.labkey.api.collections.CopyOnWriteHashMap;
 import org.labkey.api.collections.CsvSet;
 import org.labkey.api.collections.Sets;
 import org.labkey.api.data.*;
@@ -58,7 +59,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
@@ -74,7 +74,7 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     public static final String PRODUCT_NAME = "PostgreSQL";
     public static final String RECOMMENDED = PRODUCT_NAME + " 16.x is the recommended version.";
 
-    private final Map<String, Integer> _domainScaleMap = new ConcurrentHashMap<>();
+    private final Map<String, Integer> _domainScaleMap = new CopyOnWriteHashMap<>();
     private final AtomicBoolean _arraySortFunctionExists = new AtomicBoolean(false);
     private final InClauseGenerator _tempTableInClauseGenerator = new TempTableInClauseGenerator();
 
@@ -1884,7 +1884,7 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     {
         if (null != _adminWarning)
             warnings.add(_adminWarning);
-        else if (showAllWarnings) // PostgreSqlDialectFactory.getStandardWarningMessage() is not accessible from here, so hard-code a sample warning
+        else if (showAllWarnings) // PostgreSqlDialectFactory.getStandardWarningMessage() is not accessible from here, so hard-code a generic warning
             warnings.add(HtmlString.of("LabKey Server has not been tested against this version. " + RECOMMENDED));
     }
 

--- a/api/src/org/labkey/api/module/actionAndFormTest.jsp
+++ b/api/src/org/labkey/api/module/actionAndFormTest.jsp
@@ -68,23 +68,6 @@
             }
         }
 
-        // Identify all form getter methods that return an old JSONObject (or an array or list of them). This is useful
-        // for the JSONObject migration process.
-//        for (Class<?> formClass : formClasses)
-//        {
-//            for (Method method : formClass.getDeclaredMethods())
-//            {
-//                String name = method.getName();
-//                if (name.startsWith("get"))
-//                {
-//                    String typeName = method.getGenericReturnType().toString();
-//
-//                    if (typeName.contains("org.json.old.JSONObject"))
-//                        System.out.println(typeName + ": " + formClass + "." + name + " -> " + typeName);
-//                }
-//            }
-//        }
-
         assertTrue(errorMessages.toString(), errorMessages.isEmpty());
     }
 %>

--- a/api/src/org/labkey/api/usageMetrics/UsageMetricsService.java
+++ b/api/src/org/labkey/api/usageMetrics/UsageMetricsService.java
@@ -21,8 +21,6 @@ import org.labkey.api.services.ServiceRegistry;
 import java.util.Map;
 
 /**
- * Created by Tony on 2/14/2017.
- *
  * Service for modules to register their own set of metrics to include in mothership usage reports
  * Example usage from DataIntegrationModule.doStartup():
  *         UsageMetricsService svc = UsageMetricsService.get();

--- a/core/src/org/labkey/core/admin/usageMetrics/UsageMetricsServiceImpl.java
+++ b/core/src/org/labkey/core/admin/usageMetrics/UsageMetricsServiceImpl.java
@@ -18,6 +18,7 @@ package org.labkey.core.admin.usageMetrics;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.ConcurrentHashSet;
+import org.labkey.api.collections.CopyOnWriteHashMap;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.usageMetrics.UsageMetricsProvider;
@@ -29,17 +30,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-/**
- * Created by Tony on 2/14/2017.
- */
 public class UsageMetricsServiceImpl implements UsageMetricsService
 {
     private static final Logger LOG = LogHelper.getLogger(UsageMetricsServiceImpl.class, "Usage metrics errors");
 
-    private final Map<String, Set<UsageMetricsProvider>> moduleUsageReports = new ConcurrentHashMap<>();
+    private final Map<String, Set<UsageMetricsProvider>> moduleUsageReports = new CopyOnWriteHashMap<>();
 
     @Override
     public void registerUsageMetrics(String moduleName, UsageMetricsProvider metrics)

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -195,7 +195,7 @@ public class CoreWarningProvider implements WarningProvider
     private void getPasswordRuleWarnings(Warnings warnings, boolean showAllWarnings)
     {
         if (showAllWarnings || (!AppProps.getInstance().isDevMode() && DbLoginManager.getPasswordRule().isDeprecated()))
-            warnings.add(HtmlString.of("Database authentication is configured with \"" + DbLoginManager.getPasswordRule().name() + "\" strength, which is not appropriate for a production deployment. This option will be removed shortly."));
+            warnings.add(HtmlString.of("Database authentication is configured with \"" + DbLoginManager.getPasswordRule().name() + "\" strength, which is not appropriate for a production deployment. This option will be removed in the next production release."));
     }
 
     private void getHeapSizeWarnings(Warnings warnings, boolean showAllWarnings)

--- a/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/CoreWarningProvider.java
@@ -195,7 +195,7 @@ public class CoreWarningProvider implements WarningProvider
     private void getPasswordRuleWarnings(Warnings warnings, boolean showAllWarnings)
     {
         if (showAllWarnings || (!AppProps.getInstance().isDevMode() && DbLoginManager.getPasswordRule().isDeprecated()))
-            warnings.add(HtmlString.of("Database authentication is configured with \"" + DbLoginManager.getPasswordRule().name() + "\" strength, which is not appropriate for a production deployment. This option will be removed in the next production release."));
+            warnings.add(HtmlString.of("Database authentication is configured with \"" + DbLoginManager.getPasswordRule().name() + "\" strength, which is not appropriate for a production deployments. This option will be removed in the next major release."));
     }
 
     private void getHeapSizeWarnings(Warnings warnings, boolean showAllWarnings)

--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -1472,7 +1472,7 @@ public class PropertyController extends SpringActionController
         if (!kind.canEditDefinition(user, domain))
             throw new UnauthorizedException("You don't have permission to edit this domain.");
 
-        if (JSONObject.class == kind.getTypeClass()) // Old JSONObject. TODO: Remove this once all DomainKinds use new JSONObject
+        if (JSONObject.class == kind.getTypeClass())
         {
             return kind.updateDomain(original, update, options, container, user, includeWarnings);
         }

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CopyOnWriteHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
@@ -71,7 +72,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -640,15 +640,13 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         }
     }
 
-
-    private final Map<String, ResourceResolver> _resolvers = new ConcurrentHashMap<>();
+    private final Map<String, ResourceResolver> _resolvers = new CopyOnWriteHashMap<>();
 
     @Override
     public void addResourceResolver(@NotNull String prefix, @NotNull ResourceResolver resolver)
     {
         _resolvers.put(prefix, resolver);
     }
-
 
     // CONSIDER Iterable<Resource>
     @Override
@@ -664,7 +662,6 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             return null;
         return res.resolve(resourceIdentifier.substring(i+1));
     }
-
 
     @Override
     public HttpView<?> getCustomSearchResult(User user, @NotNull String resourceIdentifier)


### PR DESCRIPTION
#### Rationale
We use the concurrent collection classes `CopyOnWriteArrayList` and `CopyOnWriteArraySet` for registries and other scenarios where we expect reads to vastly outnumber writes. Adding `CopyOnWriteMap` implementations provides concurrent Maps with similar properties.