### PR TITLE
AbDisc: Cross folder Plate Import

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -409,7 +409,6 @@ public abstract class AbstractAssayProvider implements AssayProvider
     @Override
     public void changeDomain(User user, ExpProtocol protocol, GWTDomain<GWTPropertyDescriptor> orig, GWTDomain<GWTPropertyDescriptor> update)
     {
-        // NOTE: this will only be needed in HaplotypeAssayProvider; thus this is no-op.
     }
 
     @Override

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -162,9 +162,9 @@ public interface PlateService
      * for the standard assay with plate support since other assays types do not store the plate ID with the
      * run.
      */
-    int getRunCountUsingPlate(@NotNull Container c, @NotNull Plate plate);
+    int getRunCountUsingPlate(@NotNull Container c, @NotNull User user, @NotNull Plate plate);
 
-    List<? extends ExpRun> getRunsUsingPlate(@NotNull Container c, @NotNull Plate plate);
+    List<? extends ExpRun> getRunsUsingPlate(@NotNull Container c, @NotNull User user, @NotNull Plate plate);
 
     /**
      * Creates a new plate template.

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -645,7 +645,7 @@ public class PlateController extends SpringActionController
         @Override
         public Object execute(DataViewSnapshotSelectionForm form, BindException errors) throws Exception
         {
-            var results = PlateManager.get().getPlateOperationConfirmationData(getContainer(), form.getIds(false));
+            var results = PlateManager.get().getPlateOperationConfirmationData(getContainer(), getUser(), form.getIds(false));
             return success(results);
         }
     }
@@ -849,7 +849,7 @@ public class PlateController extends SpringActionController
             Plate plate = PlateManager.get().getPlate(cf, form.getRowId());
 
             if (plate != null && Boolean.TRUE.equals(form.getIncludeRunCount()))
-                ((PlateImpl) plate).setRunCount(PlateManager.get().getRunCountUsingPlate(plate.getContainer(), plate));
+                ((PlateImpl) plate).setRunCount(PlateManager.get().getRunCountUsingPlate(plate.getContainer(), getUser(), plate));
 
             return plate;
         }

--- a/assay/src/org/labkey/assay/TsvAssayProvider.java
+++ b/assay/src/org/labkey/assay/TsvAssayProvider.java
@@ -349,7 +349,7 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
                 Optional<GWTPropertyDescriptor> plateTemplateColumn = update.getFields().stream().filter(field -> field.getName().equals(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME)).findFirst();
                 if (plateTemplateColumn.isPresent())
                 {
-                    // Ensure the lookup container is null so it defaults to "Current Folder" to more easily support
+                    // Ensure the lookup container is null, so it defaults to "Current Folder" to more easily support
                     // cross-folder support.
                     GWTPropertyDescriptor plateTemplate = plateTemplateColumn.get();
                     plateTemplate.setLookupContainer(null);

--- a/assay/src/org/labkey/assay/TsvAssayProvider.java
+++ b/assay/src/org/labkey/assay/TsvAssayProvider.java
@@ -84,6 +84,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -345,12 +346,20 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
             Domain runDomain = getRunDomain(protocol);
             if (runDomain != null && runDomain.getTypeURI().equals(update.getDomainURI()))
             {
-                if (update.getFields().stream().noneMatch(field -> field.getName().equals(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME)))
+                Optional<GWTPropertyDescriptor> plateTemplateColumn = update.getFields().stream().filter(field -> field.getName().equals(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME)).findFirst();
+                if (plateTemplateColumn.isPresent())
+                {
+                    // Ensure the lookup container is null so it defaults to "Current Folder" to more easily support
+                    // cross-folder support.
+                    GWTPropertyDescriptor plateTemplate = plateTemplateColumn.get();
+                    plateTemplate.setLookupContainer(null);
+                }
+                else
                 {
                     GWTPropertyDescriptor plateTemplate = new GWTPropertyDescriptor(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME, PropertyType.STRING.getTypeUri());
                     plateTemplate.setLookupSchema(AssaySchema.NAME + "." + getResourceName());
                     plateTemplate.setLookupQuery(TsvProviderSchema.PLATE_TEMPLATE_TABLE);
-                    plateTemplate.setLookupContainer(protocol.getContainer().getId());
+                    plateTemplate.setLookupContainer(null);
                     plateTemplate.setRequired(!AssayPlateMetadataService.isExperimentalAppPlateEnabled());
                     plateTemplate.setShownInUpdateView(false);
 

--- a/assay/src/org/labkey/assay/plate/query/PlateTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTable.java
@@ -228,7 +228,7 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
             if (plate == null)
                 return Collections.emptyMap();
 
-            int runsInUse = PlateManager.get().getRunCountUsingPlate(container, plate);
+            int runsInUse = PlateManager.get().getRunCountUsingPlate(container, user, plate);
             if (runsInUse > 0)
                 throw new QueryUpdateServiceException(String.format("%s is used by %d runs and cannot be updated", plate.isTemplate() ? "Plate template" : "Plate", runsInUse));
 
@@ -254,7 +254,7 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
             if (plate == null)
                 return Collections.emptyMap();
 
-            int runsInUse = PlateManager.get().getRunCountUsingPlate(container, plate);
+            int runsInUse = PlateManager.get().getRunCountUsingPlate(container, user, plate);
             if (runsInUse > 0)
                 throw new QueryUpdateServiceException(String.format("%s is used by %d runs and cannot be deleted", plate.isTemplate() ? "Plate template" : "Plate", runsInUse));
 

--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -262,7 +262,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<UserSchema>
                 Plate plate = PlateManager.get().getPlate(container, (Integer)oldRow.get("plateId"));
                 if (plate != null)
                 {
-                    int runsInUse = PlateManager.get().getRunCountUsingPlate(container, plate);
+                    int runsInUse = PlateManager.get().getRunCountUsingPlate(container, user, plate);
                     if (runsInUse > 0)
                         throw new QueryUpdateServiceException(String.format("This %s is used by %d runs and its wells cannot be modified.", plate.isTemplate() ? "Plate template" : "Plate", runsInUse));
                 }

--- a/assay/src/org/labkey/assay/plate/view/plateTemplateList.jsp
+++ b/assay/src/org/labkey/assay/plate/view/plateTemplateList.jsp
@@ -47,7 +47,7 @@
     Map<Plate, Integer> plateTemplateRunCount = new HashMap<>();
     for (Plate template : plateTemplates)
     {
-        int count = PlateService.get().getRunCountUsingPlate(c, template);
+        int count = PlateService.get().getRunCountUsingPlate(c, getUser(), template);
         plateTemplateRunCount.put(template, count);
     }
 %>


### PR DESCRIPTION
#### Rationale
There is a current limitation on what plates are available for an assay to import and as of now, it is limited to the container that the assay definition exists in. For the phase 1 demos, the team would like to be able to define plates at the project and subfolder levels and make them available for any assay within the project. Additionally some valid scenarios were not working in the cross folder case:
- Assay and plate defined in the project, but importing data from a subfolder failed with a `resolve plate failed` error.
- Transform scripts were not able to merge in metadata when importing from a subfolder

This PR makes it so plate availability during assay import follows the expected application behavior. Server side changes were made so that plates could be resolved during the integration of plate metadata and assay data. Similar work had to be done to support transformation scripts. Most of the work centered around the construction and usage of container filters that matched the client side filters.