### PR TITLE
Exempt API Key authentications from 2FA

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -279,8 +279,9 @@ public interface AuthenticationProvider
         private final @Nullable ActionURL _redirectURL;
         private final @NotNull Map<String, String> _attributeMap;
         private final @Nullable String _successDetails;
+        private final boolean _requireSecondary;
 
-        private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap, @Nullable String successDetails)
+        private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap, @Nullable String successDetails, boolean requireSecondary)
         {
             _configuration = configuration;
             _email = email;
@@ -289,6 +290,7 @@ public interface AuthenticationProvider
             _failureReason = null;
             _redirectURL = null;
             _successDetails = null != successDetails ? successDetails : "the \"" + configuration.getDescription() + "\" configuration";
+            _requireSecondary = requireSecondary;
         }
 
         private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull FailureReason failureReason, @Nullable ActionURL redirectURL)
@@ -300,6 +302,7 @@ public interface AuthenticationProvider
             _redirectURL = redirectURL;
             _attributeMap = Collections.emptyMap();
             _successDetails = null;
+            _requireSecondary = true;
         }
 
         /**
@@ -309,23 +312,25 @@ public interface AuthenticationProvider
          */
         public static AuthenticationResponse createSuccessResponse(PrimaryAuthenticationConfiguration<?> configuration, ValidEmail email)
         {
-            return createSuccessResponse(configuration, email, null, Collections.emptyMap(), null);
+            return createSuccessResponse(configuration, email, null, Collections.emptyMap(), null, true);
         }
 
         /**
          * Creates an authentication provider response that can include a validator to be called on every request and a
          * map of user attributes
-         * @param configuration The PrimaryAuthenticationConfiguration that was used in this authentication attempt
-         * @param email Valid email address of the authenticated user
-         * @param validator An authentication validator
-         * @param attributeMap A <b>case-insensitive</b> map of attribute names and values associated with this authentication
-         * @param successDetails An optional string describing how successful authentication took place, which will appear in
-         *                       the audit log. If null, the configuration's description will be used.
+         *
+         * @param configuration     The PrimaryAuthenticationConfiguration that was used in this authentication attempt
+         * @param email             Valid email address of the authenticated user
+         * @param validator         An authentication validator
+         * @param attributeMap      A <b>case-insensitive</b> map of attribute names and values associated with this authentication
+         * @param successDetails    An optional string describing how successful authentication took place, which will appear in
+         *                          the audit log. If null, the configuration's description will be used.
+         * @param requireSecondary  Require secondary authentication
          * @return A new successful authentication response containing the email address of the authenticated user and a validator
          */
-        public static AuthenticationResponse createSuccessResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap, @Nullable String successDetails)
+        public static AuthenticationResponse createSuccessResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap, @Nullable String successDetails, boolean requireSecondary)
         {
-            return new AuthenticationResponse(configuration, email, validator, attributeMap, successDetails);
+            return new AuthenticationResponse(configuration, email, validator, attributeMap, successDetails, requireSecondary);
         }
 
         public static AuthenticationResponse createFailureResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, FailureReason failureReason)
@@ -383,6 +388,11 @@ public interface AuthenticationProvider
         public String getSuccessDetails()
         {
             return _successDetails;
+        }
+
+        public boolean requireSecondary()
+        {
+            return _requireSecondary;
         }
     }
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -17,7 +17,6 @@
 package org.labkey.api.security;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.collections4.bag.HashBag;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;

--- a/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
+++ b/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
@@ -102,8 +102,9 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
         {
             User user = ApiKeyManager.get().authenticateFromApiKey(password);
 
+            // API keys are exempt from secondary authentication, Issue 48764
             return user != null ?
-                AuthenticationResponse.createSuccessResponse(configuration, new ValidEmail(user.getEmail()), null, Map.of(), "an API key") :
+                AuthenticationResponse.createSuccessResponse(configuration, new ValidEmail(user.getEmail()), null, Map.of(), "an API key", false) :
                 AuthenticationResponse.createFailureResponse(configuration, FailureReason.badApiKey);
         }
         else

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -587,7 +587,7 @@ public class UserController extends SpringActionController
                         invalidUserIds.add(userId);
                 }
 
-                if (invalidUserIds.size() > 0)
+                if (!invalidUserIds.isEmpty())
                     errors.reject(ERROR_MSG, "Invalid user id(s) provided: " + StringUtils.join(invalidUserIds, ", ") + ".");
             }
         }


### PR DESCRIPTION
#### Rationale
Related PR made API key use a first class authentication mechanism which meant, among other things, they are subject to two-factor authentication mechanisms like TOTP and Duo. This PR removes the 2FA requirement when API keys are used to authenticate.

https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=48764

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4751
