### PR TITLE
Make the button builder css respect the Primary setting

### DIFF
--- a/api/src/org/labkey/api/util/Button.java
+++ b/api/src/org/labkey/api/util/Button.java
@@ -255,7 +255,6 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
             .data("placement", "top")
             .cl(CLS, typeCls, getCssClass())
             .cl(!isEnabled(), DISABLEDCLS)
-            .cl(isSubmit(), PRIMARY_CLS)
             .cl(isDropdown(), "labkey-down-arrow")
             .cl(isDropdown(), "dropdown-toggle")
             .cl(iconOnly, "icon-only");
@@ -327,6 +326,7 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
         public ButtonBuilder submit(boolean submit)
         {
             this.submit = submit;
+            this.primary(true);
             return this;
         }
 


### PR DESCRIPTION
#### Rationale
[Issue 48203: Flow import analysis workflow: Selecting BACK button results in "Confirm Form Resubmission" page error](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48203)

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/644

#### Changes
* Adjust the Button builder to respect the primary property when using a submit button
