### PR TITLE
Issue 48773: diagnostic export too slow for clients with giant file roots

### DIFF
--- a/api/src/org/labkey/api/data/StopIteratingRuntimeException.java
+++ b/api/src/org/labkey/api/data/StopIteratingRuntimeException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2016 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.api.data;
+
+/**
+ * Can be thrown from stream operations, iterators, etc to signal that we reached our limit.
+ */
+public class StopIteratingRuntimeException extends RuntimeException
+{
+}

--- a/filecontent/src/org/labkey/filecontent/FileContentModule.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentModule.java
@@ -195,9 +195,9 @@ public class FileContentModule extends DefaultModule
                 MutableLong fileCount = new MutableLong(0);
                 boolean timedOut = false;
                 boolean succeeded = true;
-                try
+                try (Stream<File> s = FileUtils.streamFiles(root, true, (String[])null))
                 {
-                    FileUtils.streamFiles(root, true, (String[])null).forEach(f ->
+                    s.forEach(f ->
                     {
                         totalSize.add(f.length());
                         fileCount.increment();

--- a/filecontent/src/org/labkey/filecontent/FileContentModule.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentModule.java
@@ -18,12 +18,14 @@ package org.labkey.filecontent;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableLong;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.admin.FolderSerializationRegistry;
 import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.StopIteratingRuntimeException;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.files.view.FilesWebPart;
@@ -33,6 +35,7 @@ import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.usageMetrics.UsageMetricsService;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.HeartBeat;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.api.webdav.WebdavService;
@@ -155,6 +158,9 @@ public class FileContentModule extends DefaultModule
         return result;
     }
 
+    /** Maximum time to spend crawling the file root to get its size */
+    private static final long FILE_CRAWL_TIMEOUT_MILLIS = 20_000;
+
     @Override
     public void doStartup(ModuleContext moduleContext)
     {
@@ -184,9 +190,38 @@ public class FileContentModule extends DefaultModule
             File root = FileContentService.get().getSiteDefaultRoot();
             if (root.isDirectory())
             {
-                long currentTime = System.currentTimeMillis();
-                results.put("fileRootSize", FileUtils.sizeOfDirectory(root));
-                results.put("fileRootMillisecondsToCalculateSize", System.currentTimeMillis() - currentTime);
+                long startTime = HeartBeat.currentTimeMillis();
+                MutableLong totalSize = new MutableLong(0);
+                MutableLong fileCount = new MutableLong(0);
+                boolean timedOut = false;
+                boolean succeeded = true;
+                try
+                {
+                    FileUtils.streamFiles(root, true, (String[])null).forEach(f ->
+                    {
+                        totalSize.add(f.length());
+                        fileCount.increment();
+
+                        if (HeartBeat.currentTimeMillis() - startTime > FILE_CRAWL_TIMEOUT_MILLIS)
+                        {
+                            throw new StopIteratingRuntimeException();
+                        }
+                    });
+                }
+                catch (StopIteratingRuntimeException e)
+                {
+                    timedOut = true;
+                    succeeded = false;
+                }
+                catch (IOException ignored)
+                {
+                    succeeded = false;
+                }
+                results.put("fileRootSize", totalSize.longValue());
+                results.put("fileRootFileCount", fileCount.longValue());
+                results.put("fileRootCrawlTimedOut", timedOut);
+                results.put("fileRootCrawlSucceeded", succeeded);
+                results.put("fileRootMillisecondsToCalculateSize", System.currentTimeMillis() - startTime);
             }
             return results;
         });


### PR DESCRIPTION
#### Rationale
Servers with large or high-latency file systems as their file root can take many minutes to recursively call them to get the total file size. This is packaged into the diagnostics export, and when submitting usage metrics.

#### Changes
* Time out after 20 seconds of crawling
* Count the files visited
* Track whether we completed or not