### PR TITLE
Issue 48301: LKSM: Show SourceID and Source Type on SourceEvents Audit Table

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2204,6 +2204,7 @@ public class ExpDataIterators
 
             CaseInsensitiveHashSet dontUpdate = new CaseInsensitiveHashSet();
             dontUpdate.addAll(NOT_FOR_UPDATE);
+            dontUpdate.add("rowid"); // rowid is added / not dropped for dataclass for QueryUpdateAuditEvent.rowpk audit purpose
             if (context.getInsertOption().updateOnly)
             {
                 dontUpdate.add("objectid");
@@ -2259,11 +2260,7 @@ public class ExpDataIterators
 
             // Since we support detailed audit logging add the ExistingRecordDataIterator here just before TableInsertDataIterator
             // this is a NOOP unless we are merging/updating and detailed logging is enabled
-            Set<String> existingRecordKey = isSample ? keyColumns : Set.of(ExpDataTable.Column.LSID.toString());
-            if (context.getInsertOption().updateOnly && !_isUpdateUsingLsid)
-                existingRecordKey = ((ExpRunItemTableImpl<?>) _expTable).getAltMergeKeys(context);
-
-            DataIteratorBuilder step2a = ExistingRecordDataIterator.createBuilder(step1, _expTable, existingRecordKey, true);
+            DataIteratorBuilder step2a = ExistingRecordDataIterator.createBuilder(step1, _expTable, keyColumns, true);
 
             // add "rootmateriallsid" if it does not exist
             DataIteratorBuilder step2b = new DataIteratorBuilder()

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -927,7 +927,11 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                     drop.add(name);
             }
             if (context.getConfigParameterBoolean(ExperimentService.QueryOptions.UseLsidForUpdate))
+            {
                 drop.remove("lsid");
+                drop.remove("rowid");// keep rowid for audit log
+            }
+
             if (!drop.isEmpty())
                 input = new DropColumnsDataIterator(input, drop);
 
@@ -1344,6 +1348,12 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         {
             if (context.getInsertOption().allowUpdate)
                 context.putConfigParameter(QueryUpdateService.ConfigParameters.CheckForCrossProjectData, true);
+            if (context.getInsertOption() == InsertOption.IMPORT || context.getInsertOption() == InsertOption.MERGE)
+            {
+                AuditBehaviorType auditType = (AuditBehaviorType) context.getConfigParameter(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior);
+                if (auditType != null && auditType != AuditBehaviorType.NONE)
+                    context.setSelectIds(true); // select rowId for QueryUpdateAuditEvent.rowPk
+            }
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
dataclass rowid is an auto interger, unlikey material rowid which is backed by DBSequence. This means that rowid needs to be reselected for newly inserted rows in order for it to be available for audit log generation. The statementutil already provides a way to efficiently reselect rowids, which can be utilized. For merge/update actions, this pr utilizes the rowids provided by user (update only) or attempts to get it from existingrecord.  

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1298
- https://github.com/LabKey/platform/pull/4796
- https://github.com/LabKey/sampleManagement/pull/2124
- https://github.com/LabKey/biologics/pull/2401

#### Changes
* fixed bug when oldRecord was not populated for dataclass merge action
* select rowId for newly created dataclass for QueryUpdateAuditEvent.rowPk, when audit is enabled
* try to get rowPK from existingRecord when absent from row record
