### PR TITLE
Issue 48118: Always display an aliquot naming pattern

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-23.010-23.011.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-23.010-23.011.sql
@@ -1,0 +1,3 @@
+UPDATE exp.materialsource
+    SET aliquotnameexpression = '${${AliquotedFrom}-:withCounter}'
+    WHERE aliquotnameexpression IS NULL;

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-23.010-23.011.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-23.010-23.011.sql
@@ -1,0 +1,3 @@
+UPDATE exp.materialsource
+    SET aliquotnameexpression = '${${AliquotedFrom}-:withCounter}'
+    WHERE aliquotnameexpression IS NULL;

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -175,7 +175,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
     @Override
     public Double getSchemaVersion()
     {
-        return 23.010;
+        return 23.011;
     }
 
     @Nullable


### PR DESCRIPTION
#### Rationale
[Issue 48118](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48118): There's always a naming pattern for aliquots, so we want to always display one. New sample types now save the default naming pattern value in the database. The upgrade script here sets the naming pattern for sample types created before this change was made.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-premium/pull/138

#### Changes
* Upgrade script to populate the aliquotNameExpression for all sample types that don't have it set.
