### PR TITLE
Validate values when saving/loading DB login properties

### DIFF
--- a/core/src/org/labkey/core/login/DbLoginConfiguration.java
+++ b/core/src/org/labkey/core/login/DbLoginConfiguration.java
@@ -10,14 +10,40 @@ import java.util.Map;
 
 public class DbLoginConfiguration extends BaseAuthenticationConfiguration<DbLoginAuthenticationProvider> implements AuthenticationConfiguration.LoginFormAuthenticationConfiguration<DbLoginAuthenticationProvider>
 {
+    private static final PasswordRule DEFAULT_RULE = PasswordRule.Strong;
+    private static final PasswordExpiration DEFAULT_EXPIRATION = PasswordExpiration.Never;
+
     private final PasswordRule _passwordRule;
     private final PasswordExpiration _expiration;
 
     protected DbLoginConfiguration(DbLoginAuthenticationProvider provider, Map<String, String> stringProperties, Map<String, Object> properties)
     {
         super(provider, properties);
-        _passwordRule = PasswordRule.valueOf(stringProperties.getOrDefault(DbLoginManager.Key.Strength.toString(), PasswordRule.Strong.toString()));
-        _expiration = PasswordExpiration.valueOf(stringProperties.getOrDefault(DbLoginManager.Key.Expiration.toString(), PasswordExpiration.Never.toString()));
+
+        String ruleProp = stringProperties.getOrDefault(DbLoginManager.Key.Strength.toString(), DEFAULT_RULE.toString());
+        String expProp = stringProperties.getOrDefault(DbLoginManager.Key.Expiration.toString(), DEFAULT_EXPIRATION.toString());
+
+        PasswordRule tempRule = DEFAULT_RULE;
+        try
+        {
+            tempRule = PasswordRule.valueOf(ruleProp);
+        }
+        catch (IllegalArgumentException ignore)
+        {
+            LOG.warn("%s: Unable to load saved password rule '%s'. Using default: %s".formatted(getDescription(), ruleProp, DEFAULT_RULE));
+        }
+        _passwordRule = tempRule;
+
+        PasswordExpiration tempExpiration = DEFAULT_EXPIRATION;
+        try
+        {
+            tempExpiration = PasswordExpiration.valueOf(expProp);
+        }
+        catch (IllegalArgumentException ignore)
+        {
+            LOG.warn("%s: Unable to load saved password expiration '%s'. Using default: %s".formatted(getDescription(), expProp, DEFAULT_EXPIRATION));
+        }
+        _expiration = tempExpiration;
     }
 
     @Override

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
+import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.action.FormHandlerAction;
 import org.labkey.api.action.FormViewAction;
 import org.labkey.api.action.MutatingApiAction;
@@ -2520,6 +2521,28 @@ public class LoginController extends SpringActionController
     @RequiresPermission(AdminOperationsPermission.class)
     public static class SaveDbLoginPropertiesAction extends MutatingApiAction<SaveDbLoginPropertiesForm>
     {
+        @Override
+        public void validateForm(SaveDbLoginPropertiesForm form, Errors errors)
+        {
+            try
+            {
+                PasswordRule.valueOf(form.getStrength());
+            }
+            catch (IllegalArgumentException ex)
+            {
+                throw new ApiUsageException("Invalid password strength: " + form.getStrength());
+            }
+
+            try
+            {
+                PasswordExpiration.valueOf(form.getExpiration());
+            }
+            catch (IllegalArgumentException ex)
+            {
+                throw new ApiUsageException("Invalid password expiration: " + form.getExpiration());
+            }
+        }
+
         @Override
         public Object execute(SaveDbLoginPropertiesForm form, BindException errors) throws Exception
         {


### PR DESCRIPTION
#### Rationale
I accidentally flipped the strength and expiration values when saving settings via API. This made my server unable to start up. Adding validation to save and falling back to `Strong`/`Never` if invalid values are found in the database.

#### Related Pull Requests
* N/A

#### Changes
* Implementing `SaveDbLoginPropertiesAction.validateForm` to prevent saving invalid values
* Use default rule (`Strong`) or expiration (`Never`) if invalid value(s) are found in database
