### PR TITLE
Don't trigger duplicate file downloads

### DIFF
--- a/filecontent/webapp/File/system/Webdav.js
+++ b/filecontent/webapp/File/system/Webdav.js
@@ -627,8 +627,10 @@
                     {
                         url = url + "&file=" + encodeURIComponent(records[i].data.name);
                     }
-
-                    window.location = url;
+                }
+                else
+                {
+                    throw new Error("Nothing to download");
                 }
 
                 window.location = url;


### PR DESCRIPTION
#### Rationale
Automated tests occasionally see two files downloaded. Setting `window.location` twice seems to be the likely cause.
```
java.lang.AssertionError: Wrong number of files downloaded to D:\teamcity\work\769581da7f79098c\build\modules\testAutomation\test\logs\FileContentDownloadTest\downloads expected:<1> but was:<2>
  [...]
  at org.labkey.test.WebDriverWrapper.doAndWaitForDownload(WebDriverWrapper.java:2300)
  at org.labkey.test.WebDriverWrapper.doAndWaitForDownload(WebDriverWrapper.java:2272)
  at org.labkey.test.util.FileBrowserHelper.downloadSelectedFiles(FileBrowserHelper.java:351)
  at org.labkey.test.tests.filecontent.FileContentDownloadTest.testMultipleDownloadToZip(FileContentDownloadTest.java:87)
```

#### Related Pull Requests
* N/A

#### Changes
* Don't download files twice
