### PR TITLE
Issue 48501: MultiValuedDisplayColumn doesn't handle rows with mismatched null/non-nulls

### DIFF
--- a/api/src/org/labkey/api/data/MultiValuedDisplayColumn.java
+++ b/api/src/org/labkey/api/data/MultiValuedDisplayColumn.java
@@ -135,9 +135,13 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
 
             while (mvCtx.next())
             {
-                out.append(sep);
-                super.renderGridCellContents(mvCtx, out);
-                sep = ", ";
+                Object o = getValue(mvCtx);
+                if (o != null)
+                {
+                    out.append(sep);
+                    super.renderGridCellContents(mvCtx, out);
+                    sep = ", ";
+                }
             }
         }
         finally
@@ -176,7 +180,7 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
     @Override
     public String getTsvFormattedValue(RenderContext ctx)
     {
-        return getTsvFormattedValues(ctx).stream().collect(Collectors.joining(", "));
+        return String.join(", ", getTsvFormattedValues(ctx));
     }
 
     @Override

--- a/api/src/org/labkey/api/data/MultiValuedLookupColumn.java
+++ b/api/src/org/labkey/api/data/MultiValuedLookupColumn.java
@@ -167,7 +167,7 @@ public class MultiValuedLookupColumn extends LookupColumn
 
                 // TODO: Always order by value
 
-                strJoin.append(dialect.getSelectConcat(select, ","));
+                strJoin.append(dialect.getSelectConcat(select, MultiValuedRenderContext.VALUE_DELIMITER));
             }
 
             strJoin.append(" AS ");

--- a/api/src/org/labkey/api/data/MultiValuedRenderContext.java
+++ b/api/src/org/labkey/api/data/MultiValuedRenderContext.java
@@ -59,6 +59,8 @@ public class MultiValuedRenderContext extends RenderContextDecorator
             }
             else
             {
+                // Use -1 as the limit so that we pick up back-to-back delimiters as empty strings in the returned array,
+                // which lets us understand there were rows with nulls.
                 String[] values = value.toString().split(VALUE_DELIMITER_REGEX, -1);
                 if (length != -1 && values.length != length)
                 {

--- a/api/src/org/labkey/api/data/MultiValuedRenderContext.java
+++ b/api/src/org/labkey/api/data/MultiValuedRenderContext.java
@@ -59,7 +59,7 @@ public class MultiValuedRenderContext extends RenderContextDecorator
             }
             else
             {
-                String[] values = value.toString().split(VALUE_DELIMITER_REGEX);
+                String[] values = value.toString().split(VALUE_DELIMITER_REGEX, -1);
                 if (length != -1 && values.length != length)
                 {
                     throw new IllegalStateException("Expected all columns to have the same number of values, but '" + fieldKey + "' has " + values.length + " and " + _iterators.keySet() + " had " + length);
@@ -104,16 +104,16 @@ public class MultiValuedRenderContext extends RenderContextDecorator
 
         if (null != value)
         {
+            // empty string values map to null
+            if ("".equals(value))
+                value = null;
+
             ColumnInfo columnInfo = getFieldMap().get(key);
             // The value was concatenated with others, so it's become a string.
             // Do conversion to switch it back to the expected type.
-            if (columnInfo != null && !columnInfo.getJavaClass().isInstance(value))
+            if (value != null && columnInfo != null && !columnInfo.getJavaClass().isInstance(value))
             {
-                // empty string values map to null
-                if ("".equals(value))
-                    value = null;
-                else
-                    value = ConvertUtils.convert(value.toString(), columnInfo.getJavaClass());
+                value = ConvertUtils.convert(value.toString(), columnInfo.getJavaClass());
             }
         }
         else

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -493,8 +493,9 @@ public abstract class PostgreSql91Dialect extends SqlDialect
         {
             result.append("DISTINCT ");
         }
+        result.append("COALESCE(CAST(");
         result.append(sql);
-        result.append(")");
+        result.append(" AS VARCHAR), ''))");
         if (useSortFunction)
         {
             result.append(")");

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -687,7 +687,7 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     @Override
     public SQLFragment getSelectConcat(SQLFragment selectSql, String delimiter)
     {
-        String sql = selectSql.getSQL().toUpperCase();
+        String sql = selectSql.getRawSQL().toUpperCase();
 
         // Use SQLServer's FOR XML syntax to concat multiple values together
         // We want them separated by commas, so prefix each value with a comma and then use SUBSTRING to strip
@@ -728,9 +728,9 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         {
             throw new IllegalArgumentException("Can't handle SQL: " + sql);
         }
-        ret.insert(fromIndex, "AS NVARCHAR) AS [text()] ");
+        ret.insert(fromIndex, "AS NVARCHAR), '') AS [text()] ");
         int selectIndex = sql.indexOf("SELECT");
-        ret.insert(selectIndex + "SELECT".length(), "'" + delimiter + "' + CAST(");
+        ret.insert(selectIndex + "SELECT".length(), "'" + delimiter + "' + COALESCE(CAST(");
         ret.insert(0, "SUBSTRING ((");
         ret.append(" FOR XML PATH ('')), ");
         // Trim off the first delimiter

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -728,6 +728,8 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         {
             throw new IllegalArgumentException("Can't handle SQL: " + sql);
         }
+        // This closes the COALESCE that's injected a couple of lines down, and starts the SQL Server-specific
+        // syntax that concludes later with FOR XML PATH
         ret.insert(fromIndex, "AS NVARCHAR), '') AS [text()] ");
         int selectIndex = sql.indexOf("SELECT");
         ret.insert(selectIndex + "SELECT".length(), "'" + delimiter + "' + COALESCE(CAST(");


### PR DESCRIPTION
#### Rationale
Multi valued lookups get very confused when the child rows have columns with different numbers of nulls. Separately but relatedly, our SQL Server implementation didn't handle CTEs in the underlying SQL

#### Changes
* Handle nulls for child rows in the SQL we generate and how we parse the flattened string with all the values
* Use expected delimiter for SQL Server
* Be CTE-aware in SQL Server query generation
