### PR TITLE
Issue 48854: Trim spaces from names of domains

### DIFF
--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -1813,10 +1813,10 @@ public class OntologyManager
 
     public static DomainDescriptor ensureDomainDescriptor(String domainURI, String name, Container container)
     {
-        String trimmedName = StringUtils.trimToEmpty(name);
-        if (trimmedName.isEmpty())
+        String trimmedName = StringUtils.trimToNull(name);
+        if (trimmedName == null)
             throw new IllegalArgumentException("Non-blank name is required.");
-        DomainDescriptor dd = new DomainDescriptor.Builder(domainURI, container).setName(StringUtils.trimToNull(name)).build();
+        DomainDescriptor dd = new DomainDescriptor.Builder(domainURI, container).setName(trimmedName).build();
         return ensureDomainDescriptor(dd);
     }
 

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -17,6 +17,7 @@ package org.labkey.api.exp;
 
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -1812,7 +1813,10 @@ public class OntologyManager
 
     public static DomainDescriptor ensureDomainDescriptor(String domainURI, String name, Container container)
     {
-        DomainDescriptor dd = new DomainDescriptor.Builder(domainURI, container).setName(name).build();
+        String trimmedName = StringUtils.trimToEmpty(name);
+        if (trimmedName.isEmpty())
+            throw new IllegalArgumentException("Non-blank name is required.");
+        DomainDescriptor dd = new DomainDescriptor.Builder(domainURI, container).setName(StringUtils.trimToNull(name)).build();
         return ensureDomainDescriptor(dd);
     }
 

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -505,7 +505,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
     @Override
     public Domain createDomain(GWTDomain domain, @Nullable SampleTypeDomainKindProperties arguments, Container container, User user, @Nullable TemplateInfo templateInfo)
     {
-        String name = domain.getName();
+        String name = StringUtils.trimToNull(domain.getName());
         if (name == null)
             throw new IllegalArgumentException("SampleSet name required");
 

--- a/api/src/org/labkey/api/issues/AbstractIssuesListDefDomainKind.java
+++ b/api/src/org/labkey/api/issues/AbstractIssuesListDefDomainKind.java
@@ -308,13 +308,14 @@ public abstract class AbstractIssuesListDefDomainKind extends AbstractDomainKind
         int issueDefId;
         try (DbScope.Transaction transaction = ExperimentService.get().getSchema().getScope().ensureTransaction(_lock))
         {
-            String name = StringUtils.trimToEmpty(domain.getName());
+            String name = StringUtils.trimToNull(domain.getName());
+
+            if (null == name)
+                throw new IllegalArgumentException("Issue name must not be null.");
+
             String providerName = getKindName();
             String singularNoun = (arguments != null && arguments.getSingularItemName() != null) ? arguments.getSingularItemName() : getDefaultSingularName();
             String pluralNoun = (arguments != null && arguments.getPluralItemName() != null) ? arguments.getPluralItemName() : getDefaultPluralName();
-
-            if (StringUtils.isBlank(name))
-                throw new IllegalArgumentException("Issue name must not be null.");
 
             IssuesListDefService.get().saveIssueProperties(container, arguments,  IssuesListDefService.get().getNameFromDomain(domain));
 

--- a/api/src/org/labkey/api/issues/AbstractIssuesListDefDomainKind.java
+++ b/api/src/org/labkey/api/issues/AbstractIssuesListDefDomainKind.java
@@ -308,7 +308,7 @@ public abstract class AbstractIssuesListDefDomainKind extends AbstractDomainKind
         int issueDefId;
         try (DbScope.Transaction transaction = ExperimentService.get().getSchema().getScope().ensureTransaction(_lock))
         {
-            String name = domain.getName();
+            String name = StringUtils.trimToEmpty(domain.getName());
             String providerName = getKindName();
             String singularNoun = (arguments != null && arguments.getSingularItemName() != null) ? arguments.getSingularItemName() : getDefaultSingularName();
             String pluralNoun = (arguments != null && arguments.getPluralItemName() != null) ? arguments.getPluralItemName() : getDefaultPluralName();

--- a/api/src/org/labkey/api/query/ExtendedTableDomainKind.java
+++ b/api/src/org/labkey/api/query/ExtendedTableDomainKind.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.query;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.ChangePropertyDescriptorException;
@@ -70,7 +71,7 @@ public abstract class ExtendedTableDomainKind extends SimpleTableDomainKind
     @Override
     public Domain createDomain(GWTDomain<GWTPropertyDescriptor> gwtDomain, JSONObject arguments, Container container, User user, TemplateInfo templateInfo)
     {
-        if (gwtDomain.getName() == null)
+        if (StringUtils.trimToNull(gwtDomain.getName()) == null)
             throw new IllegalArgumentException("table name is required");
 
         String domainURI = generateDomainURI(getSchemaName(), gwtDomain.getName(), container, user);

--- a/api/src/org/labkey/api/query/SimpleTableDomainKind.java
+++ b/api/src/org/labkey/api/query/SimpleTableDomainKind.java
@@ -18,6 +18,7 @@ package org.labkey.api.query;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.data.ColumnInfo;
@@ -267,9 +268,11 @@ public class SimpleTableDomainKind extends BaseAbstractDomainKind
         String tableName = (String)arguments.get("tableName");
         if (schemaName == null || tableName == null)
             throw new IllegalArgumentException("schemaName and tableName are required");
-
+        String trimmedName = StringUtils.trimToNull(domain.getName());
+        if (trimmedName == null)
+            throw new IllegalArgumentException("Non-blank domain name is required.");
         String domainURI = generateDomainURI(schemaName, tableName, container, user);
-        return PropertyService.get().createDomain(container, domainURI, domain.getName(), templateInfo);
+        return PropertyService.get().createDomain(container, domainURI, trimmedName, templateInfo);
     }
 }
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.25.0",
-        "@labkey/components": "2.380.2-nameTrimming.0",
+        "@labkey/components": "2.381.2-nameTrimming.2",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.380.2-nameTrimming.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.380.2-nameTrimming.0.tgz",
-      "integrity": "sha512-nXt6rpW/L6rmgE8NPUFNDzAw7xoXY+fAn5Nvx+Z2Dagr5pZXCTnKeNjM5MBVdYYOLBMtaNcKBXhZilJQ2kJfNA==",
+      "version": "2.381.2-nameTrimming.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.381.2-nameTrimming.2.tgz",
+      "integrity": "sha512-J6rMcBHO5q6NGXNHzvLWZFPEwEIzXuy97bAhvS3ULSXxuG8I122PQWiBwEQlZDT2dvaCE7KNxK5+jEt8fOcBNA==",
       "dependencies": {
         "@labkey/api": "1.25.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19533,9 +19533,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.380.2-nameTrimming.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.380.2-nameTrimming.0.tgz",
-      "integrity": "sha512-nXt6rpW/L6rmgE8NPUFNDzAw7xoXY+fAn5Nvx+Z2Dagr5pZXCTnKeNjM5MBVdYYOLBMtaNcKBXhZilJQ2kJfNA==",
+      "version": "2.381.2-nameTrimming.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.381.2-nameTrimming.2.tgz",
+      "integrity": "sha512-J6rMcBHO5q6NGXNHzvLWZFPEwEIzXuy97bAhvS3ULSXxuG8I122PQWiBwEQlZDT2dvaCE7KNxK5+jEt8fOcBNA==",
       "requires": {
         "@labkey/api": "1.25.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.25.0",
-        "@labkey/components": "2.380.1",
+        "@labkey/components": "2.380.2-nameTrimming.0",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.380.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.380.1.tgz",
-      "integrity": "sha512-5y5mYnTRoquJp6bf8nazWPzRo7ELr0q8iVFIiufYAe++WfRg2bTr4+ajvdv3zhGgyowMNp7LOfaWcq4Z2COO5A==",
+      "version": "2.380.2-nameTrimming.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.380.2-nameTrimming.0.tgz",
+      "integrity": "sha512-nXt6rpW/L6rmgE8NPUFNDzAw7xoXY+fAn5Nvx+Z2Dagr5pZXCTnKeNjM5MBVdYYOLBMtaNcKBXhZilJQ2kJfNA==",
       "dependencies": {
         "@labkey/api": "1.25.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19533,9 +19533,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.380.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.380.1.tgz",
-      "integrity": "sha512-5y5mYnTRoquJp6bf8nazWPzRo7ELr0q8iVFIiufYAe++WfRg2bTr4+ajvdv3zhGgyowMNp7LOfaWcq4Z2COO5A==",
+      "version": "2.380.2-nameTrimming.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.380.2-nameTrimming.0.tgz",
+      "integrity": "sha512-nXt6rpW/L6rmgE8NPUFNDzAw7xoXY+fAn5Nvx+Z2Dagr5pZXCTnKeNjM5MBVdYYOLBMtaNcKBXhZilJQ2kJfNA==",
       "requires": {
         "@labkey/api": "1.25.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.25.0",
-    "@labkey/components": "2.380.1",
+    "@labkey/components": "2.380.2-nameTrimming.0",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.25.0",
-    "@labkey/components": "2.380.2-nameTrimming.0",
+    "@labkey/components": "2.381.2-nameTrimming.2",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/experiment/src/org/labkey/experiment/api/VocabularyDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/VocabularyDomainKind.java
@@ -1,5 +1,6 @@
 package org.labkey.experiment.api;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.data.Container;
@@ -145,7 +146,7 @@ public class VocabularyDomainKind extends BaseAbstractDomainKind
     @Override
     public Domain createDomain(GWTDomain domain, JSONObject arguments, Container container, User user, @Nullable TemplateInfo templateInfo)
     {
-        String name = domain.getName();
+        String name = StringUtils.trimToNull(domain.getName());
         if (name == null)
             throw new IllegalArgumentException("Vocabulary name required");
 

--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -262,7 +262,7 @@ public class PropertyController extends SpringActionController
 
             String kindName = form.getKind() == null ? form.getDomainKind() : form.getKind();
             String domainGroup = form.getDomainGroup();
-            String domainName = form.getDomainName();
+            String domainName = StringUtils.trimToNull(form.getDomainName());
 
             if (domainGroup != null)
             {

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -358,7 +358,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
     @Override
     public Domain createDomain(GWTDomain domain, ListDomainKindProperties listProperties, Container container, User user, @Nullable TemplateInfo templateInfo)
     {
-        String name = domain.getName();
+        String name = StringUtils.trimToEmpty(domain.getName());
         String keyName = listProperties.getKeyName();
 
         if (StringUtils.isEmpty(name))

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -401,7 +401,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
         arguments.setName(StringUtils.trimToNull(domain.getName()));
         String name = arguments.getName();
         if (name == null)
-            throw new IllegalArgumentException("Non-blank name is required.");
+            throw new IllegalArgumentException("Dataset name cannot be empty.");
         String description = arguments.getDescription() != null ? arguments.getDescription() : domain.getDescription();
         String label = (arguments.getLabel() == null || arguments.getLabel().length() == 0) ? arguments.getName() : arguments.getLabel();
         Integer cohortId = arguments.getCohortId();

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -17,6 +17,7 @@
 package org.labkey.study.model;
 
 import org.apache.commons.beanutils.BeanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.data.BaseColumnInfo;
@@ -397,8 +398,10 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
     public Domain createDomain(GWTDomain domain, DatasetDomainKindProperties arguments, Container container, User user,
                                @Nullable TemplateInfo templateInfo)
     {
-        arguments.setName(domain.getName());
+        arguments.setName(StringUtils.trimToNull(domain.getName()));
         String name = arguments.getName();
+        if (name == null)
+            throw new IllegalArgumentException("Non-blank name is required.");
         String description = arguments.getDescription() != null ? arguments.getDescription() : domain.getDescription();
         String label = (arguments.getLabel() == null || arguments.getLabel().length() == 0) ? arguments.getName() : arguments.getLabel();
         Integer cohortId = arguments.getCohortId();


### PR DESCRIPTION
#### Rationale
[Issue 48854](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48854): Leading and trailing spaces in the names of domains are problematic.

#### Related Pull Requests
- https://github.com/LabKey/inventory/pull/1061
- https://github.com/LabKey/sampleManagement/pull/2170
- https://github.com/LabKey/biologics/pull/2448
- https://github.com/LabKey/testAutomation/pull/1679
- https://github.com/LabKey/labkey-ui-premium/pull/225
- https://github.com/LabKey/labkey-ui-components/pull/1317

#### Changes
* Update various places where we create domains to trim off leading and trailing spaces and throw exceptions as appropriate.
