### PR TITLE
Don't attempt to include non-finite numbers in JSON

### DIFF
--- a/api/src/org/labkey/api/util/JsonUtil.java
+++ b/api/src/org/labkey/api/util/JsonUtil.java
@@ -238,7 +238,7 @@ public class JsonUtil
         json.put(key, translateNumber(value));
     }
 
-    private static Object translateNumber(Number value)
+    public static Object translateNumber(Number value)
     {
         if (value instanceof Double d)
         {

--- a/core/src/org/labkey/core/statistics/ParameterCurveFit.java
+++ b/core/src/org/labkey/core/statistics/ParameterCurveFit.java
@@ -214,7 +214,7 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
             {
                 double absoluteCutoff = min + (0.5 * (max - min));
                 double relativeEC50 = getInterpolatedCutoffXValue(absoluteCutoff);
-                if (relativeEC50 != Double.POSITIVE_INFINITY && relativeEC50 != Double.NEGATIVE_INFINITY)
+                if (!Double.isInfinite(relativeEC50) && !Double.isNaN(relativeEC50))
                 {
                     parameters.max = max;
                     parameters.inflection = relativeEC50;


### PR DESCRIPTION
#### Rationale
When constructing a `Map` that will be converted to a `JSONObject`, one might need to pre-emptively replace any non-finite numbers with something compatible with JSON

#### Related Pull Requests
* https://github.com/LabKey/server/pull/594

#### Changes
* Make `JsonUtil.translateNumber` public
