### PR TITLE
Allow sites to have just app admins

### DIFF
--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1459,7 +1459,7 @@ public class SecurityManager
             Table.delete(core.getTableInfoPrincipals(), principalsFilter);
             Container c = ContainerManager.getForId(group.getContainer());
 
-            // Clear caches immediately (before the last site admin check) and again after commit/rollback
+            // Clear caches immediately (before the last root admin check) and again after commit/rollback
             transaction.addCommitTask(() -> {
                 GroupCache.uncache(groupId);
                 ProjectAndSiteGroupsCache.uncache(c);
@@ -1520,7 +1520,7 @@ public class SecurityManager
             {
                 new SqlExecutor(core.getSchema()).execute(sql);
 
-                // Clear caches immediately (before the last site admin check) and again after commit/rollback
+                // Clear caches immediately (before the last root admin check) and again after commit/rollback
                 transaction.addCommitTask( () -> {
                     for (UserPrincipal member : membersToDelete)
                         GroupMembershipCache.handleGroupChange(group, member);

--- a/api/src/org/labkey/api/security/SecurityPolicyManager.java
+++ b/api/src/org/labkey/api/security/SecurityPolicyManager.java
@@ -236,12 +236,12 @@ public class SecurityPolicyManager
                 Table.insert(null, table, assignment);
             }
 
-            // Remove policy from cache immediately (before the last site admin check) and again after commit/rollback
+            // Remove policy from cache immediately (before the last root admin check) and again after commit/rollback
             transaction.addCommitTask(() -> remove(policy), CommitTaskOption.IMMEDIATE, CommitTaskOption.POSTCOMMIT, CommitTaskOption.POSTROLLBACK);
             // Notify on commit
             transaction.addCommitTask(() -> notifyPolicyChange(policy.getResourceId()), CommitTaskOption.POSTCOMMIT);
 
-            // Ensure at least one site admin will remain if attempting to modify the root container's policy
+            // Ensure at least one root admin will remain if attempting to modify the root container's policy
             if (policy.getResourceId().equals(ContainerManager.getRoot().getResourceId()))
                 SecurityManager.ensureAtLeastOneRootAdminExists();
 

--- a/api/src/org/labkey/api/security/SecurityPolicyManager.java
+++ b/api/src/org/labkey/api/security/SecurityPolicyManager.java
@@ -243,11 +243,7 @@ public class SecurityPolicyManager
 
             // Ensure at least one site admin will remain if attempting to modify the root container's policy
             if (policy.getResourceId().equals(ContainerManager.getRoot().getResourceId()))
-            {
-                // Remove the resource-oriented policy from cache BEFORE checking for the last site admin
-                remove(policy);
-                SecurityManager.ensureAtLeastOneSiteAdminExists();
-            }
+                SecurityManager.ensureAtLeastOneRootAdminExists();
 
             transaction.commit();
         }

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -965,7 +965,7 @@ public class UserManager
 
             OntologyManager.deleteOntologyObject(user.getEntityId(), ContainerManager.getSharedContainer(), true);
 
-            // Clear user list immediately (before the last site admin check) and again after commit/rollback
+            // Clear user list immediately (before the last root admin check) and again after commit/rollback
             transaction.addCommitTask(UserManager::clearUserList, CommitTaskOption.IMMEDIATE, CommitTaskOption.POSTCOMMIT, CommitTaskOption.POSTROLLBACK);
 
             if (needToEnsureRootAdmins)
@@ -1034,10 +1034,10 @@ public class UserManager
             // Call update unconditionally to ensure Modified & ModifiedBy are always updated
             Table.update(currentUser, CoreSchema.getInstance().getTableInfoUsers(), map, userId);
 
-            // Clear user list immediately (before the last site admin check) and again after commit/rollback
+            // Clear user list immediately (before the last root admin check) and again after commit/rollback
             transaction.addCommitTask(UserManager::clearUserList, CommitTaskOption.IMMEDIATE, CommitTaskOption.POSTCOMMIT, CommitTaskOption.POSTROLLBACK);
 
-            // If deactivating a site admin or impersonating troubleshooter, ensure at least one site admin remains
+            // If deactivating a root admin, ensure at least one root admin remains
             if (!active && SecurityManager.isRootAdmin(userToAdjust))
                 SecurityManager.ensureAtLeastOneRootAdminExists();
 

--- a/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
@@ -22,6 +22,7 @@ import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.security.permissions.CanImpersonateSiteRolesPermission;
 import org.labkey.api.security.permissions.DeleteUserPermission;
 import org.labkey.api.security.permissions.EnableRestrictedModules;
+import org.labkey.api.security.permissions.ExemptFromAccountDisablingPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.security.permissions.UpdateUserPermission;
@@ -41,6 +42,7 @@ public class ApplicationAdminRole extends AbstractRootContainerRole implements A
         CanImpersonateSiteRolesPermission.class,
         DeleteUserPermission.class,
         EnableRestrictedModules.class,
+        ExemptFromAccountDisablingPermission.class,
         TroubleshooterPermission.class,
         UpdateUserPermission.class,
         UserManagementPermission.class

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -1853,10 +1853,6 @@ public class SecurityApiActions
             if (group != null && group.isSystemGroup() && !getUser().hasSiteAdminPermission())
                 throw new UnauthorizedException("Can not update members of system group: " + group.getName());
 
-            //ensure there will still be someone in the admin group
-            if (group.isAdministrators() && SecurityManager.getGroupMembers(group, MemberType.ACTIVE_AND_INACTIVE_USERS).size() == 1)
-                throw new IllegalArgumentException("The system administrators group must have at least one member!");
-
             for (int id : form.getPrincipalIds())
             {
                 UserPrincipal principal = getPrincipal(id);

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1538,7 +1538,7 @@ public class SecurityController extends SpringActionController
     }
 
     // Delete all container permissions. Note: savePolicy() and deleteMember() throw on some unauthorized actions
-    // (e.g., App Admin attempting to delete Site Admin perms, deleting the last site admin)
+    // (e.g., App Admin attempting to delete Site Admin perms, deleting the last root admin)
     private void deletePermissions(User user)
     {
         if (user != null)

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -826,7 +826,7 @@ public class SecurityController extends SpringActionController
                 //check for users to delete
                 if (removeNames != null)
                 {
-                    // Note: deleteMembers() will throw if removing this member will result in no Site Admins
+                    // Note: deleteMembers() will throw if removing this member will result in no root admins
                     SecurityManager.deleteMembers(_group, removeIds);
                 }
 


### PR DESCRIPTION
#### Rationale
Trial instances are created with no site admins, only app admins. Related PR didn't get that memo, causing trial instance tests to fail on security-related actions. This relaxes our rules to ensure at least one site admin, impersonating troubleshooter, or app admin remains after key updates. Various checks are genericized to centralize the code that implements the rules.

Also fix `deleteMembers()` to clear caches immediately so `ensure()` doesn't see a stale admin count.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4811