### PR TITLE
Add standard method for elevating a user's permissions

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -692,16 +692,13 @@ public abstract class AssayProtocolSchema extends AssaySchema implements UserSch
                 // if the user does not have the QCAnalyst permission, they may not be seeing unapproved data
                 if (!context.getContainer().hasPermission(user, QCAnalystPermission.class))
                 {
-                    Set<Role> contextualRoles = new HashSet<>(user.getSiteRoles());
                     Role qcRole = RoleManager.getRole("org.labkey.api.security.roles.QCAnalystRole");
                     Role readerRole = RoleManager.getRole("org.labkey.api.security.roles.ReaderRole");
                     if (qcRole != null && readerRole != null)
                     {
                         try
                         {
-                            contextualRoles.add(RoleManager.getRole(qcRole.getClass()));
-                            contextualRoles.add(RoleManager.getRole(readerRole.getClass()));
-                            User elevatedUser = new LimitedUser(user, user.getGroups(), contextualRoles);
+                            User elevatedUser = LimitedUser.getElevatedUser(context.getContainer(), user, Set.of(qcRole.getClass(), readerRole.getClass()));
 
                             ViewContext viewContext = new ViewContext(context);
                             viewContext.setUser(elevatedUser);

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -365,7 +365,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
         return User.getUserProps(this);
     }
 
-    @Deprecated // Confusing name... use getSiteRoles() instead
+    @Deprecated // Delete
     public Set<Role> getStandardContextualRoles()
     {
         return getSiteRoles();

--- a/api/src/org/labkey/api/security/roles/RestrictedReaderRole.java
+++ b/api/src/org/labkey/api/security/roles/RestrictedReaderRole.java
@@ -23,9 +23,6 @@ import org.labkey.api.study.Study;
 /**
  * Used exclusively in dataset security, as a marker in the study policy to indicate a group has per-dataset permissions.
  * As a result, we don't directly surface this role anywhere in the product. See #42682.
- *
- * User: Dave
- * Date: Apr 30, 2009
  */
 public class RestrictedReaderRole extends AbstractRole
 {

--- a/assay/api-src/org/labkey/api/assay/nab/view/RunDetailsAction.java
+++ b/assay/api-src/org/labkey/api/assay/nab/view/RunDetailsAction.java
@@ -36,8 +36,6 @@ import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.roles.EditorRole;
 import org.labkey.api.security.roles.ReaderRole;
-import org.labkey.api.security.roles.Role;
-import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HtmlView;
@@ -49,13 +47,8 @@ import org.labkey.api.view.VBox;
 import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 
-import java.util.HashSet;
 import java.util.Set;
 
-/**
- * User: klum
- * Date: 5/15/13
- */
 public abstract class RunDetailsAction<FormType extends RenderAssayBean> extends SimpleViewAction<FormType>
 {
     protected int _runRowId;
@@ -94,17 +87,11 @@ public abstract class RunDetailsAction<FormType extends RenderAssayBean> extends
         User elevatedUser = getUser();
         if (!getContainer().hasPermission(getUser(), ReadPermission.class))
         {
-            User currentUser = getUser();
-            Set<Role> contextualRoles = new HashSet<>(currentUser.getSiteRoles());
-            contextualRoles.add(RoleManager.getRole(ReaderRole.class));
-            elevatedUser = new LimitedUser(currentUser, currentUser.getGroups(), contextualRoles, false);
+            elevatedUser = LimitedUser.getElevatedUser(getContainer(), getUser(), Set.of(ReaderRole.class));
         }
         else if (getUser().equals(run.getCreatedBy()) && !getContainer().hasPermission(getUser(), DeletePermission.class))
         {
-            User currentUser = getUser();
-            Set<Role> contextualRoles = new HashSet<>(currentUser.getSiteRoles());
-            contextualRoles.add(RoleManager.getRole(EditorRole.class));
-            elevatedUser = new LimitedUser(currentUser, currentUser.getGroups(), contextualRoles, false);
+            elevatedUser = LimitedUser.getElevatedUser(getContainer(), getUser(), Set.of(EditorRole.class));
         }
 
         try

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -61,7 +61,6 @@ import org.labkey.api.assay.actions.UploadWizardAction;
 import org.labkey.api.assay.plate.PlateBasedAssayProvider;
 import org.labkey.api.assay.security.DesignAssayPermission;
 import org.labkey.api.audit.AuditLogService;
-import org.labkey.api.audit.permissions.CanSeeAuditLogPermission;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -110,9 +109,6 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.QCAnalystPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.security.roles.CanSeeAuditLogRole;
-import org.labkey.api.security.roles.Role;
-import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.actions.TransformResultsAction;
 import org.labkey.api.study.publish.StudyPublishService;
@@ -1553,14 +1549,7 @@ public class AssayController extends SpringActionController
                 if (form.getRuns().size() == 1)
                 {
                     // construct the audit log query view
-                    User user = getUser();
-                    if (!getContainer().hasPermission(user, CanSeeAuditLogPermission.class))
-                    {
-                        Set<Role> contextualRoles = new HashSet<>(user.getSiteRoles());
-                        contextualRoles.add(RoleManager.getRole(CanSeeAuditLogRole.class));
-                        user = new LimitedUser(user, user.getGroups(), contextualRoles, false);
-                    }
-
+                    User user = LimitedUser.getCanSeeAuditLogUser(getContainer(), getUser());
                     UserSchema schema = AuditLogService.getAuditLogSchema(user, getContainer());
                     ExpRun run = ExperimentService.get().getExpRun(form.getRuns().stream().findFirst().get());
                     if (run != null && schema != null)

--- a/audit/src/org/labkey/audit/AuditController.java
+++ b/audit/src/org/labkey/audit/AuditController.java
@@ -71,11 +71,6 @@ import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
 
-/**
- * User: adam
- * Date: Jul 24, 2008
- * Time: 4:07:39 PM
- */
 public class AuditController extends SpringActionController
 {
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(AuditController.class);

--- a/audit/src/org/labkey/audit/AuditController.java
+++ b/audit/src/org/labkey/audit/AuditController.java
@@ -48,10 +48,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.TroubleshooterPermission;
-import org.labkey.api.security.roles.CanSeeAuditLogRole;
 import org.labkey.api.security.roles.ReaderRole;
-import org.labkey.api.security.roles.Role;
-import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.util.DateUtil;
@@ -71,10 +68,8 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * User: adam
@@ -387,11 +382,11 @@ public class AuditController extends SpringActionController
         }
 
         @Override
-        public Object execute(AuditTransactionForm form, BindException errors) throws Exception
+        public Object execute(AuditTransactionForm form, BindException errors)
         {
             List<Integer> rowIds;
             if (form.isSampleType())
-                rowIds = AuditLogImpl.get().getTransactionSampleIds(form.getTransactionAuditId(), getCanSeeAuditLogUser(getUser()), getContainer());
+                rowIds = AuditLogImpl.get().getTransactionSampleIds(form.getTransactionAuditId(), LimitedUser.getCanSeeAuditLogUser(getContainer(), getUser()), getContainer());
             else
                 rowIds = AuditLogImpl.get().getTransactionSourceIds(form.getTransactionAuditId(), getUser(), getContainer());
 
@@ -400,19 +395,6 @@ public class AuditController extends SpringActionController
             response.put("rowIds", rowIds);
 
             return response;
-        }
-
-        private User getCanSeeAuditLogUser(User user)
-        {
-            User elevatedUser = user;
-            if (!getContainer().hasPermission(getUser(), CanSeeAuditLogPermission.class))
-            {
-                Set<Role> contextualRoles = new HashSet<>(user.getSiteRoles());
-                contextualRoles.add(RoleManager.getRole(CanSeeAuditLogRole.class));
-                elevatedUser = new LimitedUser(user, user.getGroups(), contextualRoles, false);
-            }
-
-            return elevatedUser;
         }
     }
 

--- a/issues/src/org/labkey/issue/IssueServiceImpl.java
+++ b/issues/src/org/labkey/issue/IssueServiceImpl.java
@@ -16,9 +16,8 @@ import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.EditorRole;
-import org.labkey.api.security.roles.Role;
-import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
 import org.labkey.issue.actions.ChangeSummary;
@@ -302,13 +301,7 @@ public class IssueServiceImpl implements IssueService
         if (relatedContainer == null)
             relatedContainer = container;
 
-        if (!relatedContainer.hasPermission(user, UpdatePermission.class))
-        {
-            Set<Role> contextualRoles = new HashSet<>(user.getSiteRoles());
-            contextualRoles.add(RoleManager.getRole(EditorRole.class));
-            return new LimitedUser(user, user.getGroups(), contextualRoles, false);
-        }
-        return user;
+        return LimitedUser.getElevatedUser(relatedContainer, user, Pair.of(UpdatePermission.class, EditorRole.class));
     }
 
     @Nullable

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -53,10 +53,10 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.EditorRole;
-import org.labkey.api.security.roles.Role;
-import org.labkey.api.security.roles.RoleManager;
+import org.labkey.api.util.Pair;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.writer.VirtualFile;
@@ -67,10 +67,8 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /*
 * User: Nick Arnold
@@ -186,15 +184,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         {
             // if the list is a picklist and you have permission to manage picklists, that equates
             // to having editor permission.
-            Set<Role> contextualRoles = new HashSet<>(user.getSiteRoles());
-            contextualRoles.addAll(user.getAssignedRoles(container.getPolicy()));
-            Role editorRole = RoleManager.getRole(EditorRole.class);
-            if (!contextualRoles.contains(editorRole))
-            {
-                contextualRoles.add(RoleManager.getRole(EditorRole.class));
-                return new LimitedUser(user, user.getGroups(), contextualRoles, false);
-            }
-            return user;
+            return LimitedUser.getElevatedUser(container, user, Pair.of(DeletePermission.class, EditorRole.class));
         }
         return user;
     }

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -70,12 +70,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/*
-* User: Nick Arnold
-* Date: June 5, 2012
-* Time: 10:27:30 AM
-*/
-
 /**
  * Implementation of QueryUpdateService for Lists
  */


### PR DESCRIPTION
#### Rationale
Many code paths attempt to elevate users' permissions by essentially tacking contextual roles onto the `User` object by wrapping it with `LimitedUser`. These code paths are duplicative and broken. This PR introduces a standard method that correctly ensures a user has the requested permissions. Or at least provides a single place to fix if it's not correct.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4811
