### PR TITLE
Add password complexity gauge to set-password page

### DIFF
--- a/api/src/org/labkey/api/data/JdbcMetaDataSelector.java
+++ b/api/src/org/labkey/api/data/JdbcMetaDataSelector.java
@@ -60,7 +60,7 @@ public class JdbcMetaDataSelector
 
     public void forEach(final ForEachBlock<ResultSet> block) throws SQLException
     {
-        handleResultSet(new ResultSetHandler<Object>()
+        handleResultSet(new ResultSetHandler<>()
         {
             @Override
             public Object handle(ResultSet rs) throws SQLException

--- a/api/src/org/labkey/api/security/EntropyPasswordValidator.java
+++ b/api/src/org/labkey/api/security/EntropyPasswordValidator.java
@@ -102,7 +102,8 @@ public abstract class EntropyPasswordValidator implements PasswordValidator
             "abcdefghijklmnopqrstuvwxyz"
         )
             .flatMap(s -> Stream.of(s, new StringBuilder(s).reverse().toString())) // Forward and reverse
-            .sorted(Comparator.comparingInt(String::length)) // Shortest to longest
+            // Sort longest to shortest - we want the full alphabet before the keyboard rows (which contain "fgh" and "jkl")
+            .sorted(Comparator.comparingInt(String::length).reversed())
             .map(String::toCharArray)
             .toArray(char[][]::new);
     }

--- a/api/src/org/labkey/api/security/EntropyPasswordValidator.java
+++ b/api/src/org/labkey/api/security/EntropyPasswordValidator.java
@@ -44,6 +44,12 @@ public abstract class EntropyPasswordValidator implements PasswordValidator
         return false;
     }
 
+    @Override
+    public boolean shouldShowPasswordGuidance()
+    {
+        return true;
+    }
+
     private static final double BASE2_LOG = Math.log(2);
 
     public static double score(String password, User user)

--- a/api/src/org/labkey/api/security/EntropyPasswordValidator.java
+++ b/api/src/org/labkey/api/security/EntropyPasswordValidator.java
@@ -371,7 +371,7 @@ public abstract class EntropyPasswordValidator implements PasswordValidator
         }
 
         // Convenience method that works with strings
-        private String filter(String password, User user)
+        private String filter(@NotNull String password, @NotNull User user)
         {
             return new String(concatenate(EntropyPasswordValidator.filter(password.toCharArray(), user)));
         }

--- a/api/src/org/labkey/api/security/PasswordRule.java
+++ b/api/src/org/labkey/api/security/PasswordRule.java
@@ -101,4 +101,9 @@ public enum PasswordRule
     {
         return _validator.isDeprecated();
     }
+
+    public boolean shouldShowPasswordGuidance()
+    {
+        return _validator.shouldShowPasswordGuidance();
+    }
 }

--- a/api/src/org/labkey/api/security/PasswordValidator.java
+++ b/api/src/org/labkey/api/security/PasswordValidator.java
@@ -16,4 +16,5 @@ public interface PasswordValidator
     boolean isValidForLogin(@NotNull String password, @NotNull User user, @Nullable Collection<String> messages);
     boolean isPreviousPasswordForbidden();
     boolean isDeprecated();
+    boolean shouldShowPasswordGuidance();
 }

--- a/api/src/org/labkey/api/security/RuleBasedPasswordValidator.java
+++ b/api/src/org/labkey/api/security/RuleBasedPasswordValidator.java
@@ -188,4 +188,10 @@ abstract class RuleBasedPasswordValidator implements PasswordValidator
     {
         return _summaryRuleHtml;
     }
+
+    @Override
+    public boolean shouldShowPasswordGuidance()
+    {
+        return false;
+    }
 }

--- a/api/src/org/labkey/api/security/ValidEmail.java
+++ b/api/src/org/labkey/api/security/ValidEmail.java
@@ -42,9 +42,6 @@ import java.util.Map;
 /**
  * Represents an email address that is known to be valid according to RFC 822. Will automatically append
  * the default email domain from {@link AppProps} and do other normalization if needed.
- *
- * User: adam
- * Date: Aug 24, 2006
  */
 public class ValidEmail
 {
@@ -148,7 +145,7 @@ public class ValidEmail
             LOG.debug("Resolving user name '" + rawEmail + "' using default domain '" + getDefaultDomain() + "'");
             String domain = getDefaultDomain();
 
-            if (domain.length() > 0)
+            if (!domain.isEmpty())
                 return trimmed + "@" + domain;
         }
 
@@ -160,7 +157,7 @@ public class ValidEmail
     {
         String[] tokens = getEmailAddress().split("@");
 
-        return tokens.length == 2 && tokens[0].length() > 0 && tokens[1].length() > 0;
+        return tokens.length == 2 && !tokens[0].isEmpty() && !tokens[1].isEmpty();
     }
 
 

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -2748,7 +2748,24 @@ public class LoginController extends SpringActionController
         public Object execute(PasswordForm form, BindException errors) throws Exception
         {
             String email = form.getEmail();
-            User user = email != null ? UserManager.getUser(new ValidEmail(form.getEmail())) : User.guest;
+            User user = null;
+
+            if (email != null)
+            {
+                try
+                {
+                    user = UserManager.getUser(new ValidEmail(email));
+                }
+                catch (InvalidEmailException e)
+                {
+                    // Ignore
+                }
+            }
+
+            // If user doesn't exist (initial user case) or email is invalid pass in a fake user to filter the email address
+            if (null == user)
+                user = new User(form.getEmail(), -9999);
+
             return Map.of("score", EntropyPasswordValidator.score(StringUtils.trimToEmpty(form.getPassword()), user));
         }
     }

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -2738,8 +2738,10 @@ public class LoginController extends SpringActionController
         }
     }
 
+    @SuppressWarnings("unused") // Called from setPassword.jsp
     @RequiresNoPermission
     @AllowedDuringUpgrade
+    @AllowedBeforeInitialUserIsSet
     public static class GetPasswordScoreAction extends ReadOnlyApiAction<PasswordForm>
     {
         @Override

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1541,7 +1541,7 @@ public class LoginController extends SpringActionController
     public static final String PASSWORD1_TEXT_FIELD_NAME = "password";
     public static final String PASSWORD2_TEXT_FIELD_NAME = "password2";
 
-    private abstract class AbstractSetPasswordAction extends FormViewAction<SetPasswordForm>
+    public abstract class AbstractSetPasswordAction extends FormViewAction<SetPasswordForm>
     {
         protected ValidEmail _email = null;
         protected boolean _unrecoverableError = false;
@@ -2041,7 +2041,7 @@ public class LoginController extends SpringActionController
         public final String message;
         public final NamedObjectList nonPasswordInputs;
         public final NamedObjectList passwordInputs;
-        public final Class action;
+        public final Class<? extends AbstractSetPasswordAction> action;
         public final boolean cancellable;
         public final String buttonText;
         public final String title;
@@ -2715,6 +2715,7 @@ public class LoginController extends SpringActionController
     public static class PasswordForm
     {
         private String _password;
+        private String _email;
 
         public String getPassword()
         {
@@ -2725,6 +2726,16 @@ public class LoginController extends SpringActionController
         {
             _password = password;
         }
+
+        public String getEmail()
+        {
+            return _email;
+        }
+
+        public void setEmail(String email)
+        {
+            _email = email;
+        }
     }
 
     @RequiresNoPermission
@@ -2734,7 +2745,9 @@ public class LoginController extends SpringActionController
         @Override
         public Object execute(PasswordForm form, BindException errors) throws Exception
         {
-            return Map.of("score", EntropyPasswordValidator.score(StringUtils.trimToEmpty(form.getPassword()), getUser()));
+            String email = form.getEmail();
+            User user = email != null ? UserManager.getUser(new ValidEmail(form.getEmail())) : User.guest;
+            return Map.of("score", EntropyPasswordValidator.score(StringUtils.trimToEmpty(form.getPassword()), user));
         }
     }
 

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -80,11 +80,9 @@
             />
         <%  }
 
-            boolean firstPassword = true;
-
             for (NamedObject input : bean.passwordInputs) {
-                HtmlString contextContent = LoginController.PASSWORD1_TEXT_FIELD_NAME.equals(input.getObject())
-                    ? rule.getSummaryRuleHtml() : null;
+                boolean firstPassword = LoginController.PASSWORD1_TEXT_FIELD_NAME.equals(input.getObject());
+                HtmlString contextContent = firstPassword ? rule.getSummaryRuleHtml() : null;
         %>
             <p>
                 <%=h(contextContent)%>
@@ -103,7 +101,6 @@
                 if (rule.shouldShowPasswordGuidance() && firstPassword)
                 {
                     firstPasswordId = input.getObject().toString();
-                    firstPassword = false;
 
         %>
             <canvas id="strengthGuidance" width="<%=gaugeWidth%>" height="<%=gaugeHeight%>">

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -195,6 +195,7 @@
                 firstPassword.removeEventListener('input', renderBarFunction);
 
             renderBarFunction = function() {
+                const showPlaceholderText = !firstPassword.value;
                 LABKEY.Ajax.request({
                     url: LABKEY.ActionURL.buildURL("login", "getPasswordScore.api"),
                     method: 'POST',
@@ -202,7 +203,7 @@
                         password: firstPassword.value,
                         email: email || emailField?.value
                     },
-                    success: function (response)
+                    success: function(response)
                     {
                         const responseText = LABKEY.Utils.decode(response.responseText);
                         if (responseText)
@@ -218,9 +219,9 @@
                             ctx.fillRect(borderWidth, borderWidth, barWidth, barHeight);
 
                             // Render text
-                            ctx.fillStyle = 2 === colorIndex ? "white" : "black";
+                            ctx.fillStyle = 2 === colorIndex ? "white" : showPlaceholderText ? "gray" : "black";
                             const textIndex = Math.floor(percent * 6);
-                            const text = ["Very Weak", "Very Weak", "Weak", "Weak", "Strong", "Very Strong"][textIndex];
+                            const text = showPlaceholderText ?  "Password Guidance" : ["Very Weak", "Very Weak", "Weak", "Weak", "Strong", "Very Strong"][textIndex];
                             ctx.fillText(text, centerX, centerY + textHeightFix);
                             canvas.text = "Password Strength: " + text;
                         }

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -19,6 +19,7 @@
 <%@ page import="org.labkey.api.collections.NamedObject" %>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.ContainerManager" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.util.URLHelper" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
@@ -29,7 +30,6 @@
 <%@ page import="org.labkey.core.login.LoginController.SetPasswordBean" %>
 <%@ page import="org.labkey.core.portal.ProjectController.HomeAction" %>
 <%@ page import="org.labkey.core.portal.ProjectController.StartAction" %>
-<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
     @Override
@@ -158,11 +158,11 @@
             const ctx = canvas.getContext("2d");
 
             if (ctx) {
+                drawOutline(canvas, ctx);
                 const ratio = increaseResolution(canvas, ctx);
                 const gaugeWidth = canvas.width;
                 const gaugeHeight = canvas.height;
 
-                drawOutline(canvas, ctx, ratio);
                 ctx.lineWidth = 1;
                 ctx.font = 12 * ratio + "pt Sans-Serif"
                 ctx.textAlign = "center";
@@ -209,7 +209,7 @@
         }
     });
 
-    function drawOutline(canvas, ctx, ratio) {
+    function drawOutline(canvas, ctx) {
         ctx.lineWidth = 3;
         ctx.strokeRect(0, 0, canvas.width, canvas.height);
     }
@@ -234,7 +234,7 @@
         canvas.style.width = width + "px";
         canvas.style.height = height + "px";
 
-        // Uncomment if you want your coordinate system to be the original width and height instead of the new dimensions
+        // Uncomment if you want to draw using the original width + height resolution instead of the new high resolution
         //ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
 
         return ratio;

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -187,6 +187,8 @@
             const textHeightFix = (metrics.fontBoundingBoxAscent - metrics.fontBoundingBoxDescent) / 2 - 1;
 
             const firstPassword = document.getElementById(<%=q(firstPasswordId)%>);
+            const email = <%=q(bean.email)%>;
+            const emailField = document.getElementById("email");
 
             // Remove existing event, if present (resize case)
             if (renderBarFunction)
@@ -198,7 +200,7 @@
                     method: 'POST',
                     params: {
                         password: firstPassword.value,
-                        email: <%=q(bean.email)%>
+                        email: email || emailField?.value
                     },
                     success: function (response)
                     {

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -174,18 +174,18 @@
     function render(canvas, ctx, originalWidth, originalHeight)
     {
         const ratio = increaseResolution(canvas, ctx, originalWidth, originalHeight);
-        const borderWidth = drawOutline(canvas, ctx, ratio);
+        const borderWidth = drawOutline(canvas, ctx, ratio) + ratio; // leave one css pixel between border and bar
         const maxBarWidth = canvas.width - 2 * borderWidth;
         const barHeight = canvas.height - 2 * borderWidth;
         const centerX = canvas.width / 2;
         const centerY = canvas.height / 2;
 
-        ctx.lineWidth = 1;
+        ctx.lineWidth = ratio;
         ctx.font = 12 * ratio + "pt Sans-Serif"
         ctx.textAlign = "center";
         ctx.textBaseLine = "middle";
 
-        // testBaseLine = middle sets the text too high, IMO. Adjust by half the size of the vertical bound.
+        // textBaseLine = middle sets the text too high, IMO. Adjust by half the size of the vertical bound.
         const metrics = ctx.measureText("H");
         const textHeightFix = (metrics.fontBoundingBoxAscent - metrics.fontBoundingBoxDescent) / 2 - 1;
 
@@ -208,8 +208,10 @@
                 },
                 success: LABKEY.Utils.getCallbackWrapper(function(responseText)
                 {
-                    // Clear everything inside the outline
-                    ctx.clearRect(borderWidth, borderWidth, maxBarWidth, barHeight);
+                    // Clear everything inside the border. You might think I could clear using the same coordinates as
+                    // I fill below (that's what I thought, anyway), but this tended to leave single-pixel trails of
+                    // color behind. I clear a larger rectangle than what I filled to erase these trails.
+                    ctx.clearRect(borderWidth - ratio, borderWidth - ratio, maxBarWidth + 2 * ratio, barHeight + 2 * ratio);
 
                     // Render bar
                     const percent = Math.min(responseText.score / 90, 0.99999);

--- a/core/src/org/labkey/core/search/NoopSearchService.java
+++ b/core/src/org/labkey/core/search/NoopSearchService.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.search.SearchResultTemplate;
-import org.labkey.api.search.SearchScope;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
@@ -31,7 +30,6 @@ import org.labkey.api.view.HttpView;
 import org.labkey.api.view.WebPartView;
 import org.labkey.api.webdav.WebdavResource;
 
-import java.io.IOException;
 import java.io.Reader;
 import java.util.Collection;
 import java.util.Collections;
@@ -40,11 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-/**
- * User: matthewb
- * Date: Nov 18, 2009
- * Time: 1:10:55 PM
- */
 public class NoopSearchService implements SearchService
 {
     IndexTask _dummyTask = new IndexTask()


### PR DESCRIPTION
#### Rationale
We want a visual indicator of password strength to guide users toward picking strong passwords that LabKey will accept

https://docs.google.com/document/d/1Kv_aA7vEv-uYY00rNcYu_fx3qVUxaMCeN8qJVBPj9f0/edit#heading=h.x18uari75hjx

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4707

![image](https://github.com/LabKey/platform/assets/5107383/940f67ff-2d84-4c87-a15a-44bc5985252d)
