### PR TITLE
Issue 48925: Indexing pulls all samples in a container in a single list

### DIFF
--- a/api/src/org/labkey/api/data/BaseSelector.java
+++ b/api/src/org/labkey/api/data/BaseSelector.java
@@ -17,6 +17,7 @@ package org.labkey.api.data;
 
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.RowMap;
@@ -189,6 +190,7 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
             {
                 Iterator<ResultSet> iter = new SimpleResultSetIterator(rs);
 
+                //noinspection Convert2Diamond
                 return new Iterator<T>()
                 {
                     @Override
@@ -217,6 +219,7 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
                 Iterator<Map<String, Object>> iter = new ResultSetIterator(rs);
                 ObjectFactory<T> factory = getObjectFactory(clazz);
 
+                //noinspection Convert2Diamond
                 return new Iterator<T>()
                 {
                     @Override
@@ -397,15 +400,20 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
         forEachMap(getStandardResultSetFactory(), block);
     }
 
-    private void forEachMap(ResultSetFactory factory, final ForEachBlock<Map<String, Object>> block)
+    private int forEachMap(ResultSetFactory factory, final ForEachBlock<Map<String, Object>> block)
     {
+        MutableInt rowCount = new MutableInt();
+
         factory.handleResultSet((rs, conn) -> {
             ResultSetIterator iter = new ResultSetIterator(rs);
 
             try
             {
                 while (iter.hasNext())
+                {
                     block.exec(iter.next());
+                    rowCount.increment();
+                }
             }
             catch (StopIteratingException ignored)
             {
@@ -413,6 +421,8 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
 
             return null;
         });
+
+        return rowCount.intValue();
     }
 
     public interface ResultSetHandler<T>
@@ -421,25 +431,28 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
     }
 
     @Override
-    public <T> void forEach(Class<T> clazz, final ForEachBlock<T> block)
+    public <T> int forEach(Class<T> clazz, final ForEachBlock<T> block)
     {
-        forEach(clazz, getStandardResultSetFactory(), block);
+        return forEach(clazz, getStandardResultSetFactory(), block);
     }
 
-    public <T> void forEach2(Class<T> clazz, final ForEachBlock<T> block)
+    public <T> int forEach2(Class<T> clazz, final ForEachBlock<T> block)
     {
-        forEach2(() -> uncachedStream(clazz), getStandardResultSetFactory(), block);
+        return forEach2(() -> uncachedStream(clazz), getStandardResultSetFactory(), block);
     }
 
     // Prototype general purpose forEach() built on an uncached stream (not used)
-    private <T> void forEach2(Supplier<Stream<T>> streamFactory, ResultSetFactory resultSetFactory, ForEachBlock<T> block)
+    private <T> int forEach2(Supplier<Stream<T>> streamFactory, ResultSetFactory resultSetFactory, ForEachBlock<T> block)
     {
+        MutableInt rowCount = new MutableInt();
+
         try (Stream<T> stream = streamFactory.get())
         {
             stream.forEach(t-> {
                 try
                 {
                     block.exec(t);
+                    rowCount.increment();
                 }
                 catch (SQLException | StopIteratingException e)
                 {
@@ -467,19 +480,23 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
                 throw e;
             }
         }
+        return rowCount.intValue();
     }
 
-    private <T> void forEach(Class<T> clazz, ResultSetFactory resultSetFactory, final ForEachBlock<T> block)
+    private <T> int forEach(Class<T> clazz, ResultSetFactory resultSetFactory, final ForEachBlock<T> block)
     {
         final Getter getter = Getter.forClass(clazz);
 
         // This is a simple object (Number, String, Date, etc.)
         if (null != getter)
         {
+            MutableInt rowCount = new MutableInt();
             forEach(resultSetFactory, rs -> {
                 //noinspection unchecked
                 block.exec((T)getter.getObject(rs));
+                rowCount.increment();
             });
+            return rowCount.intValue();
         }
         else
         {
@@ -487,7 +504,7 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
 
             ForEachBlock<Map<String, Object>> mapBlock = map -> block.exec(factory.fromMap(map));
 
-            forEachMap(resultSetFactory, mapBlock);
+            return forEachMap(resultSetFactory, mapBlock);
         }
     }
 
@@ -508,18 +525,19 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
     }
 
     @Override
-    public <T> void forEachBatch(Class<T> clazz, int batchSize, ForEachBatchBlock<T> batchBlock)
+    public <T> int forEachBatch(Class<T> clazz, int batchSize, ForEachBatchBlock<T> batchBlock)
     {
         ResultSetFactory factory = getStandardResultSetFactory();
 
         // Try-with-resources ensures that the final batch gets processed (on close())
         try (BatchForEachBlock<T> bfeb = new BatchForEachBlock<>(batchSize, batchBlock))
         {
-            forEach(clazz, factory, bfeb);
+            return forEach(clazz, factory, bfeb);
         }
         catch (SQLException e)
         {
             factory.handleSqlException(e, null);
+            return -1;
         }
     }
 

--- a/api/src/org/labkey/api/data/Selector.java
+++ b/api/src/org/labkey/api/data/Selector.java
@@ -132,14 +132,14 @@ public interface Selector
     void forEachMapBatch(int batchSize, ForEachBatchBlock<Map<String, Object>> batchBlock);
 
     /** Stream objects from the database. Convert each result row into an object specified by clazz and invoke block.exec() on it. */
-    <T> void forEach(Class<T> clazz, ForEachBlock<T> block);
+    <T> int forEach(Class<T> clazz, ForEachBlock<T> block);
 
     /**
      *  Stream objects from the database in batches. Convert rows to objects and pass them to batchBlock.exec() in batches
      *  no larger than batchSize. This is convenient for cases where streaming is desired, but processing in batches is more
      *  efficient than one-by-one. All batches are of size batchSize, except the last batch which is typically smaller.
      */
-    <T> void forEachBatch(Class<T> clazz, int batchSize, ForEachBatchBlock<T> batchBlock);
+    <T> int forEachBatch(Class<T> clazz, int batchSize, ForEachBatchBlock<T> batchBlock);
 
     /**
      * Return a new value map. If the query selects a single column, return an identity map. If the query selects

--- a/api/src/org/labkey/api/data/Selector.java
+++ b/api/src/org/labkey/api/data/Selector.java
@@ -131,13 +131,18 @@ public interface Selector
      */
     void forEachMapBatch(int batchSize, ForEachBatchBlock<Map<String, Object>> batchBlock);
 
-    /** Stream objects from the database. Convert each result row into an object specified by clazz and invoke block.exec() on it. */
+    /**
+     * Stream objects from the database.
+     * Convert each result row into an object specified by clazz and invoke block.exec() on it.
+     * @return the number of rows processed
+     */
     <T> int forEach(Class<T> clazz, ForEachBlock<T> block);
 
     /**
      *  Stream objects from the database in batches. Convert rows to objects and pass them to batchBlock.exec() in batches
      *  no larger than batchSize. This is convenient for cases where streaming is desired, but processing in batches is more
      *  efficient than one-by-one. All batches are of size batchSize, except the last batch which is typically smaller.
+     *  @return the number of rows processed
      */
     <T> int forEachBatch(Class<T> clazz, int batchSize, ForEachBatchBlock<T> batchBlock);
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -899,9 +899,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
      */
     Lock getProtocolImportLock();
 
-    HttpView createRunExportView(Container container, String defaultFilenamePrefix);
+    HttpView<?> createRunExportView(Container container, String defaultFilenamePrefix);
 
-    HttpView createFileExportView(Container container, String defaultFilenamePrefix);
+    HttpView<?> createFileExportView(Container container, String defaultFilenamePrefix);
 
     void auditRunEvent(User user, ExpProtocol protocol, ExpRun run, @Nullable ExpExperiment runGroup, String message);
     void auditRunEvent(User user, ExpProtocol protocol, ExpRun run, @Nullable ExpExperiment runGroup, String message, String userComment);
@@ -940,11 +940,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
      * Get the set of runs that can be deleted based on the materials supplied.
      * INCLUDES: Derivative runs, and if only remaining output/derivative the immediate precursor run
      * @param materials Set of materials to get runs for
-     * @return Set of runs that can be deleted based on the materials
+     * @return runs that can be deleted based on the materials
      */
     List<ExpRun> getDeletableRunsFromMaterials(Collection<? extends ExpMaterial> materials);
-
-    boolean useUXDomainDesigner();
 
     List<String> collectRunsToInvestigate(ExpRunItem start, ExpLineageOptions options);
 

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -863,9 +863,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
         }, SearchService.PRIORITY.bulk);
 
         task.addRunnable(() -> {
-            // batch by the 100's
-            List<ExpMaterialImpl> materials = ExperimentServiceImpl.get().getIndexableMaterials(c, modifiedSince);
-            task.addResourceList(materials, 100, ExpMaterialImpl::createIndexDocument);
+            ExperimentServiceImpl.get().indexMaterials(task, c, modifiedSince);
         }, SearchService.PRIORITY.bulk);
 
         task.addRunnable(() -> {
@@ -876,8 +874,7 @@ public class ExperimentModule extends SpringModule implements SearchService.Docu
         }, SearchService.PRIORITY.bulk);
 
         task.addRunnable(() -> {
-            List<ExpDataImpl> dataObjects = ExperimentServiceImpl.get().getIndexableData(c, modifiedSince);
-            task.addResourceList(dataObjects, 100, ExpDataImpl::createDocument);
+            ExperimentServiceImpl.get().indexData(task, c, modifiedSince);
         }, SearchService.PRIORITY.bulk);
     }
 

--- a/experiment/src/org/labkey/experiment/api/AbstractRunItemImpl.java
+++ b/experiment/src/org/labkey/experiment/api/AbstractRunItemImpl.java
@@ -139,7 +139,7 @@ public abstract class AbstractRunItemImpl<Type extends RunItem> extends ExpIdent
 
     @Override
     @Nullable
-    public ExpProtocolApplication getSourceApplication()
+    public ExpProtocolApplicationImpl getSourceApplication()
     {
         if (null != _sourceApp)
         {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -216,8 +216,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return Collections.unmodifiableSortedSet(new TreeSet<>(new TableSelector(getTinfoDataClass(), filter, null).getCollection(DataClass.class)));
     });
 
-    public static final String EXPERIMENTAL_DOMAIN_DESIGNER = "experimental-uxdomaindesigner";
-
     private static final List<ExperimentListener> _listeners = new CopyOnWriteArrayList<>();
     private static final ReentrantLock XAR_IMPORT_LOCK = new ReentrantLockWithName(ExperimentServiceImpl.class, "XAR_IMPORT_LOCK");
 


### PR DESCRIPTION
#### Rationale
Some servers have more samples in a single container than we can comfortably fit into memory at once for indexing purposes.

#### Changes
* Break samples and datas into blocks of 10,000 for indexing purposes
* Make selector methods return the number of rows processed
* Shift all responsibility for search indexing from ExperimentModule to ExperimentServiceImpl
