### PR TITLE
Simplify upgrade/marketing check timer

### DIFF
--- a/api/src/org/labkey/api/util/DebugInfoDumper.java
+++ b/api/src/org/labkey/api/util/DebugInfoDumper.java
@@ -138,7 +138,7 @@ public class DebugInfoDumper
     }
 
 
-    record ThreadExtraContext(String context, StackTraceElement[] stack) {};
+    record ThreadExtraContext(String context, StackTraceElement[] stack) {}
 
     /* Can't use class ThreadLocal, which is frustrating */
     static final Map<Thread,List<ThreadExtraContext>> _threadDumpExtraContext = Collections.synchronizedMap(new WeakHashMap<>());

--- a/api/src/org/labkey/api/util/UsageReportingLevel.java
+++ b/api/src/org/labkey/api/util/UsageReportingLevel.java
@@ -65,17 +65,11 @@ public enum UsageReportingLevel implements SafeToRenderEnum
         {
             return false;
         }
-
-        @Override
-        public TimerTask createTimerTask()
-        {
-            return null;
-        }
     },
 
     /**
-     * Captures basic User info, container count information and Site Settings info to help identify the organization running the install,
-     * and more detailed stats about how many items exist or actions have been invoked.
+     * Captures basic User info, container count information and Site Settings info to help identify the organization
+     * running the installation, and more detailed stats about how many items exist or actions have been invoked.
      *
      * May capture site-wide usage information, including counts for certain data types, such as assay designs,
      * reports of a specific type, or lists. May also capture the number of times a certain feature was used in a
@@ -136,41 +130,37 @@ public enum UsageReportingLevel implements SafeToRenderEnum
     }
 
     private static final Logger LOG = LogHelper.getLogger(UsageReportingLevel.class, "Submits usage metrics to labkey.org");
-    private static Timer _timer;
+    private static final Timer _timer = new Timer("UpgradeCheck", true);
+    private static UsageTimerTask _task;
     private static HtmlString _upgradeMessage;
     private static HtmlString _marketingUpdate;
     private static String _marketingMessageDefault = "Do more with LabKey Server. <a href='https://www.labkey.com/products-services/labkey-server/'>Click here</a> to learn about our Premium Editions.";
 
-    public static void cancelUpgradeCheck()
+    public static void shutdown()
     {
-        if (_timer != null)
-        {
-            _timer.cancel();
-        }
-        _timer = null;
-        _upgradeMessage = null;
-        _marketingUpdate = null;
+        _timer.cancel();
     }
 
-    public void scheduleUpgradeCheck()
+    public static void init()
     {
-        cancelUpgradeCheck();
-        TimerTask task;
-        // override the configured reporting level if the self test experimental feature is on
-        if (MothershipReport.isSelfTestMarketingUpdates())
-            task = ON.createTimerTask();
-        else
-            task = createTimerTask();
-        if (task != null)
+        if (_task != null)
         {
-            _timer = new Timer("UpgradeCheck", true);
-            _timer.scheduleAtFixedRate(task, 0, DateUtils.MILLIS_PER_DAY);
+            throw new IllegalStateException("Already initialized");
         }
+        reportNow();
     }
 
-    protected TimerTask createTimerTask()
+    /** Reset the timer and immediately check in (or not) based on current configuration */
+    public static void reportNow()
     {
-        return new UsageTimerTask(this);
+        // Tasks can't be reused, so cancel any active task before creating a new one
+        if (_task != null)
+        {
+            _task.cancel();
+        }
+
+        _task = new UsageTimerTask();
+        _timer.scheduleAtFixedRate(_task, 0, DateUtils.MILLIS_PER_DAY);
     }
 
     public static @Nullable HtmlString getUpgradeMessage()
@@ -215,37 +205,54 @@ public enum UsageReportingLevel implements SafeToRenderEnum
 
     private static class UsageTimerTask extends TimerTask
     {
-        private final UsageReportingLevel _level;
-
-        UsageTimerTask(UsageReportingLevel level)
-        {
-            _level = level;
-        }
-
         @Override
         public void run()
         {
-            LOG.debug("Starting to generate metrics report for " + _level);
-            MothershipReport.Target target = MothershipReport.isSelfTestMarketingUpdates()
-                    ? MothershipReport.Target.local
-                    : MothershipReport.Target.remote;
-            MothershipReport report = generateReport(_level, target);
-            if (report != null)
+            try
             {
-                _upgradeMessage = null;
-                _marketingUpdate = null;
+                UsageReportingLevel level;
+                MothershipReport.Target target;
 
-                report.run();
-                if (!StringUtils.isEmpty(report.getUpgradeMessage()))
-                    _upgradeMessage = HtmlString.unsafe(report.getUpgradeMessage());
-
-                if (MothershipReport.shouldReceiveMarketingUpdates(MothershipReport.getDistributionName()))
+                if (MothershipReport.isSelfTestMarketingUpdates())
                 {
-                    if (!StringUtils.isEmpty(report.getMarketingUpdate()))
-                        _marketingUpdate = HtmlString.unsafe(report.getMarketingUpdate());
-                    else
-                        _marketingUpdate = HtmlString.unsafe(_marketingMessageDefault);
+                    target = MothershipReport.Target.local;
+                    level = UsageReportingLevel.ON;
                 }
+                else
+                {
+                    target = MothershipReport.Target.remote;
+                    level = AppProps.getInstance().getUsageReportingLevel();
+                }
+
+                LOG.debug("Checking whether to report metrics. Level: " + level);
+                MothershipReport report = generateReport(level, target);
+                if (report != null)
+                {
+                    report.run();
+
+                    _upgradeMessage = null;
+                    _marketingUpdate = null;
+
+                    report.run();
+                    if (!StringUtils.isEmpty(report.getUpgradeMessage()))
+                        _upgradeMessage = HtmlString.unsafe(report.getUpgradeMessage());
+
+                    if (MothershipReport.shouldReceiveMarketingUpdates(MothershipReport.getDistributionName()))
+                    {
+                        if (!StringUtils.isEmpty(report.getMarketingUpdate()))
+                            _marketingUpdate = HtmlString.unsafe(report.getMarketingUpdate());
+                        else
+                            _marketingUpdate = HtmlString.unsafe(_marketingMessageDefault);
+                    }
+                }
+                else
+                {
+                    _upgradeMessage = null;
+                }
+            }
+            catch (RuntimeException e)
+            {
+                LOG.error("Failed to report metrics", e);
             }
          }
     }
@@ -299,7 +306,7 @@ public enum UsageReportingLevel implements SafeToRenderEnum
         {
             MothershipReport report = UsageReportingLevel.generateReport(level, MothershipReport.Target.test);
             if (null == report && level.doGeneration())
-                throw new ApiUsageException("No report generated for level " + level.toString());
+                throw new ApiUsageException("No report generated for level " + level);
             else
                 return report;
         }

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -687,7 +687,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                 {
                     final CustomizeMenuForm form = AdminController.getCustomizeMenuForm(webPart);
                     String title = "My Menu";
-                    if (form.getTitle() != null && !form.getTitle().equals(""))
+                    if (form.getTitle() != null && !form.getTitle().isEmpty())
                         title = form.getTitle();
 
                     WebPartView<?> view;
@@ -794,10 +794,10 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         Container home = ContainerManager.bootstrapContainer(ContainerManager.HOME_PROJECT_PATH, readerRole, readerRole, null);
         home.setFolderType(collaborationType, null);
 
-        ContainerManager.createDefaultSupportContainer().setFolderType(collaborationType, (User)null);
+        ContainerManager.createDefaultSupportContainer().setFolderType(collaborationType, null);
 
         // Only users can read from /Shared
-        ContainerManager.bootstrapContainer(ContainerManager.SHARED_CONTAINER_PATH, readerRole, null, null).setFolderType(collaborationType, (User)null);
+        ContainerManager.bootstrapContainer(ContainerManager.SHARED_CONTAINER_PATH, readerRole, null, null).setFolderType(collaborationType, null);
 
         try
         {
@@ -833,7 +833,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     public void destroy()
     {
         super.destroy();
-        UsageReportingLevel.cancelUpgradeCheck();
+        UsageReportingLevel.shutdown();
     }
 
 
@@ -1055,7 +1055,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         ExperimentalFeatureService.get().addFeatureListener(EXPERIMENTAL_LOCAL_MARKETING_UPDATE, (feature, enabled) -> {
             // update the timer task when this setting changes
             MothershipReport.setSelfTestMarketingUpdates(enabled);
-            AppProps.getInstance().getUsageReportingLevel().scheduleUpgradeCheck();
+            UsageReportingLevel.reportNow();
         });
 
         if (null != PropertyService.get())
@@ -1171,7 +1171,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         // On bootstrap in production mode, this will send an initial ping with very little information, as the admin will
         // not have set up their account yet. On later startups, depending on the reporting level, this will send an immediate
         // ping, and then once every 24 hours.
-        AppProps.getInstance().getUsageReportingLevel().scheduleUpgradeCheck();
+        UsageReportingLevel.init();
         TempTableTracker.init();
     }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1255,9 +1255,7 @@ public class AdminController extends SpringActionController
             props.setXFrameOption(frameOption);
 
             props.save(getViewContext().getUser());
-
-            if (null != level)
-                level.scheduleUpgradeCheck();
+            UsageReportingLevel.reportNow();
 
             return true;
         }
@@ -2217,7 +2215,7 @@ public class AdminController extends SpringActionController
 
 
     @AdminConsoleAction
-    public class ShowThreadsAction extends SimpleViewAction
+    public class ShowThreadsAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -2236,13 +2234,13 @@ public class AdminController extends SpringActionController
     }
 
     @AdminConsoleAction
-    public class DumpHeapAction extends SimpleViewAction
+    public class DumpHeapAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
         {
             File destination = DebugInfoDumper.dumpHeap();
-            return new HtmlView(PageFlowUtil.filter("Heap dumped to " + destination.getAbsolutePath()));
+            return new HtmlView(HtmlString.of("Heap dumped to " + destination.getAbsolutePath()));
         }
 
         @Override
@@ -3816,7 +3814,7 @@ public class AdminController extends SpringActionController
                 lafProps.save();
 
                 // Send an immediate report now that they've set up their account and defaults, and then every 24 hours after.
-                AppProps.getInstance().getUsageReportingLevel().scheduleUpgradeCheck();
+                UsageReportingLevel.reportNow();
 
                 return true;
             }


### PR DESCRIPTION
#### Rationale
We've seen some instances that don't check regularly due to problems during startup/initialization

#### Changes
* Always start the background timer
* Conditionally submit when the timer fires, based on configuration