### PR TITLE
Issue 48538: Authentication provider list respects new "allowInsert" property

### DIFF
--- a/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
+++ b/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
@@ -271,7 +271,7 @@ export class App extends PureComponent<{}, Partial<State>> {
                 const dirtinessData = { ...state.dirtinessData, [configType]: newState };
                 return { [configType]: newState, dirtinessData };
             },
-            () => this.resetSecondaryProviders()
+            this.resetSecondaryProviders
         );
     };
 

--- a/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
+++ b/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
@@ -214,6 +214,27 @@ export class App extends PureComponent<{}, Partial<State>> {
         });
     };
 
+    resetSecondaryProviders = (): void => {
+        Ajax.request({
+            url: ActionURL.buildURL('login', 'initialMount.api'),
+            failure: Utils.getCallbackWrapper(
+                error => {
+                    console.error('Failed to load data', error);
+                    this.setState({
+                        loading: false,
+                        initError: resolveErrorMessage(error),
+                    });
+                },
+                undefined,
+                true
+            ),
+            success: Utils.getCallbackWrapper(response => {
+                const { secondaryProviders } = response;
+                this.setState({ secondaryProviders });
+            }),
+        });
+    };
+
     onDelete = (configuration: number, configType: string): void => {
         Ajax.request({
             url: ActionURL.buildURL('login', 'deleteConfiguration.api'),
@@ -230,22 +251,28 @@ export class App extends PureComponent<{}, Partial<State>> {
                 true
             ),
             success: Utils.getCallbackWrapper(() => {
-                this.setState(state => ({
-                    [configType]: state[configType].filter(auth => auth.configuration !== configuration),
-                }));
+                this.setState(
+                    state => ({
+                        [configType]: state[configType].filter(auth => auth.configuration !== configuration),
+                    }),
+                    () => this.resetSecondaryProviders()
+                );
             }),
         });
     };
 
     updateAuthRowsAfterSave = (config: string, configType: string): void => {
-        this.setState(state => {
-            const prevState = state[configType];
-            const newState = addOrUpdateAnAuthConfig(config, prevState, configType);
+        this.setState(
+            state => {
+                const prevState = state[configType];
+                const newState = addOrUpdateAnAuthConfig(config, prevState, configType);
 
-            // Update our dirtiness information with added modal, since dirtiness should only track reordering
-            const dirtinessData = { ...state.dirtinessData, [configType]: newState };
-            return { [configType]: newState, dirtinessData };
-        });
+                // Update our dirtiness information with added modal, since dirtiness should only track reordering
+                const dirtinessData = { ...state.dirtinessData, [configType]: newState };
+                return { [configType]: newState, dirtinessData };
+            },
+            () => this.resetSecondaryProviders()
+        );
     };
 
     render() {

--- a/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
+++ b/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
@@ -255,7 +255,7 @@ export class App extends PureComponent<{}, Partial<State>> {
                     state => ({
                         [configType]: state[configType].filter(auth => auth.configuration !== configuration),
                     }),
-                    () => this.resetSecondaryProviders()
+                    this.resetSecondaryProviders
                 );
             }),
         });

--- a/core/src/client/AuthenticationConfiguration/authenticationConfiguration.scss
+++ b/core/src/client/AuthenticationConfiguration/authenticationConfiguration.scss
@@ -209,3 +209,21 @@
 .global-settings__default-domain-field {
   margin-left: 30px;
 }
+
+.configurations__dropdown .dropdown .dropdown-menu .disabled::after {
+  content: "Only one configuration of this type is allowed";
+  display: none;
+  position: absolute;
+  top: -0px;
+  right: -30px;
+  width: 150px;
+  text-align: center;
+  background-color: #575858;
+  border: 1px solid #888888;
+  color: #eeeeee;
+  border-radius: 2px;
+  font-size: 0.8em;
+}
+.configurations__dropdown .dropdown .dropdown-menu .disabled:hover::after {
+  display: inline;
+}

--- a/core/src/client/components/AuthConfigMasterPanel.tsx
+++ b/core/src/client/components/AuthConfigMasterPanel.tsx
@@ -186,8 +186,10 @@ export default class AuthConfigMasterPanel extends PureComponent<Props, Partial<
             <MenuItem
                 key={authOption}
                 onClick={() => this.setState({ secondaryModalOpen: true, addModalType: authOption })}
+                disabled={!secondaryProviders[authOption].allowInsert}
             >
                 {authOption} : {secondaryProviders[authOption].description}
+                {!secondaryProviders[authOption].allowInsert && <i className="fa fa-question-circle" />}
             </MenuItem>
         ));
 

--- a/core/src/client/components/__snapshots__/AuthConfigMasterPanel.spec.tsx.snap
+++ b/core/src/client/components/__snapshots__/AuthConfigMasterPanel.spec.tsx.snap
@@ -594,7 +594,7 @@ exports[`<AuthConfigMasterPanel/> Editable mode 1`] = `
             [
               <MenuItem
                 bsClass="dropdown"
-                disabled={false}
+                disabled={true}
                 divider={false}
                 header={false}
                 onClick={[Function]}
@@ -602,10 +602,13 @@ exports[`<AuthConfigMasterPanel/> Editable mode 1`] = `
                 0
                  : 
                 Require two-factor authentication via Duo
+                <i
+                  className="fa fa-question-circle"
+                />
               </MenuItem>,
               <MenuItem
                 bsClass="dropdown"
-                disabled={false}
+                disabled={true}
                 divider={false}
                 header={false}
                 onClick={[Function]}
@@ -613,6 +616,9 @@ exports[`<AuthConfigMasterPanel/> Editable mode 1`] = `
                 1
                  : 
                 Adds a trivial, insecure secondary authentication requirement (for test purposes only)
+                <i
+                  className="fa fa-question-circle"
+                />
               </MenuItem>,
             ]
           }

--- a/core/src/client/components/models.ts
+++ b/core/src/client/components/models.ts
@@ -27,6 +27,7 @@ export interface AuthConfigProvider {
     settingsFields: AuthConfigField[];
     sso?: boolean;
     testLink?: string;
+    allowInsert?: boolean;
 }
 
 export interface GlobalSettingsOptions {


### PR DESCRIPTION
#### Rationale
See [issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48538) for more details.

#### Related Pull Requests
* N/A

#### Changes
* Reset secondary providers after addition or deletion of authconfig
* Disable menu item if allowInsert is false, add hacky css tooltip to avoid disabling-element-hover-element interaction
* Update snapshots
