### PR TITLE
Use lambdas for `Session.addMessageHandler`

### DIFF
--- a/api/src/org/labkey/api/websocket/BrowserEndpoint.java
+++ b/api/src/org/labkey/api/websocket/BrowserEndpoint.java
@@ -235,48 +235,38 @@ public abstract class BrowserEndpoint extends Endpoint
                     }
                 }
             });
-            from.addMessageHandler(new MessageHandler.Whole<ByteBuffer>()
-            {
-                @Override
-                public void onMessage(ByteBuffer byteBuffer)
+            from.addMessageHandler(ByteBuffer.class, byteBuffer -> {
+                try
                 {
-                    try
+                    synchronized (to)
                     {
-                        synchronized (to)
-                        {
-                            if (to.isOpen())
-                                to.getBasicRemote().sendBinary(byteBuffer);
-                        }
-                        LOG.trace(debugName + ".onMessage(<binary>)");
+                        if (to.isOpen())
+                            to.getBasicRemote().sendBinary(byteBuffer);
                     }
-                    catch (IOException x)
-                    {
-                        try { from.close(); } catch (IOException io) {/* */}
-                        try { to.close(); } catch (IOException io) {/* */}
-                        LOG.warn("websocket proxy exception", x);
-                    }
+                    LOG.trace(debugName + ".onMessage(<binary>)");
+                }
+                catch (IOException x)
+                {
+                    try { from.close(); } catch (IOException io) {/* */}
+                    try { to.close(); } catch (IOException io) {/* */}
+                    LOG.warn("websocket proxy exception", x);
                 }
             });
-            from.addMessageHandler(new MessageHandler.Whole<PongMessage>()
-            {
-                @Override
-                public void onMessage(PongMessage pongMessage)
+            from.addMessageHandler(PongMessage.class, pongMessage -> {
+                try
                 {
-                    try
+                    synchronized (to)
                     {
-                        synchronized (to)
-                        {
-                            if (to.isOpen())
-                                to.getBasicRemote().sendPong(pongMessage.getApplicationData());
-                        }
-                        LOG.trace(debugName + ".pong()");
+                        if (to.isOpen())
+                            to.getBasicRemote().sendPong(pongMessage.getApplicationData());
                     }
-                    catch (IOException x)
-                    {
-                        try { from.close(); } catch (IOException io) {/* */}
-                        try { to.close(); } catch (IOException io) {/* */}
-                        LOG.warn("websocket proxy exception", x);
-                    }
+                    LOG.trace(debugName + ".pong()");
+                }
+                catch (IOException x)
+                {
+                    try { from.close(); } catch (IOException io) {/* */}
+                    try { to.close(); } catch (IOException io) {/* */}
+                    LOG.warn("websocket proxy exception", x);
                 }
             });
         }


### PR DESCRIPTION
#### Rationale
IntelliJ recommends some lambda cleanup that break's tomcat's type inspection. Preemptively refactoring these in a way that works with Tomcat.

#### Related Pull Requests
* https://github.com/LabKey/connectors/pull/123

#### Changes
* Use lambdas for `Session.addMessageHandler`
