### PR TITLE
Disallow plate size updates

### DIFF
--- a/assay/resources/schemas/assay.xml
+++ b/assay/resources/schemas/assay.xml
@@ -73,9 +73,11 @@
       </column>
       <column columnName="Rows">
         <description>The number of rows in each plate.</description>
+        <shownInUpdateView>false</shownInUpdateView>
       </column>
       <column columnName="Columns">
         <description>The number of columns in each plate.</description>
+        <shownInUpdateView>false</shownInUpdateView>
       </column>
       <column columnName="DataFileId">
         <isUserEditable>false</isUserEditable>

--- a/assay/src/org/labkey/assay/plate/query/PlateTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTable.java
@@ -16,6 +16,7 @@
 
 package org.labkey.assay.plate.query;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.plate.Plate;
@@ -231,6 +232,13 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
             int runsInUse = PlateManager.get().getRunCountUsingPlate(container, user, plate);
             if (runsInUse > 0)
                 throw new QueryUpdateServiceException(String.format("%s is used by %d runs and cannot be updated", plate.isTemplate() ? "Plate template" : "Plate", runsInUse));
+
+            // disallow plate size changes
+            if ((row.containsKey("rows") && ObjectUtils.notEqual(oldRow.get("rows"), row.get("rows"))) ||
+                    (row.containsKey("columns") && ObjectUtils.notEqual(oldRow.get("columns"), row.get("columns"))))
+            {
+                throw new QueryUpdateServiceException("Changing the plate size (rows or columns) is not allowed.");
+            }
 
             // if the name is changing, check for duplicates
             String oldName = (String) oldRow.get("Name");


### PR DESCRIPTION
#### Rationale
[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48943)

The plate size (row and column) should be considered immutable, at least we don't know of any scenarios where anyone would want to do so. At least for now we'll remove those fields from the update form and also check in the `QUS`.
