### PR TITLE
GetUsersWithPermissionsAction: Add includeInactive flag

### DIFF
--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2173,11 +2173,11 @@ public class SecurityManager
     /**
      * @return an immutable list of Users who have been assigned all the requested permissions in the given container
      */
-    public static List<User> getUsersWithPermissions(Container c, boolean includeDeactivated, Set<Class<? extends Permission>> perms)
+    public static List<User> getUsersWithPermissions(Container c, boolean includeInactive, Set<Class<? extends Permission>> perms)
     {
         // No cache right now, but performance seems fine. After the user list and policy are cached, no other queries occur.
         SecurityPolicy policy = c.getPolicy();
-        return UserManager.getUsers(includeDeactivated).stream()
+        return UserManager.getUsers(includeInactive).stream()
             .filter(user -> SecurityManager.hasAllPermissions(null, policy, user, perms, Set.of()))
             .toList();
     }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2173,13 +2173,21 @@ public class SecurityManager
     /**
      * @return an immutable list of Users who have been assigned all the requested permissions in the given container
      */
-    public static List<User> getUsersWithPermissions(Container c, Set<Class<? extends Permission>> perms)
+    public static List<User> getUsersWithPermissions(Container c, boolean includeDeactivated, Set<Class<? extends Permission>> perms)
     {
         // No cache right now, but performance seems fine. After the user list and policy are cached, no other queries occur.
         SecurityPolicy policy = c.getPolicy();
-        return UserManager.getActiveUsers().stream()
+        return UserManager.getUsers(includeDeactivated).stream()
             .filter(user -> SecurityManager.hasAllPermissions(null, policy, user, perms, Set.of()))
             .toList();
+    }
+
+    /**
+     * @return an immutable list of Users who have been assigned all the requested permissions in the given container
+     */
+    public static List<User> getUsersWithPermissions(Container c, Set<Class<? extends Permission>> perms)
+    {
+        return getUsersWithPermissions(c, false, perms);
     }
 
     /**

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2183,7 +2183,7 @@ public class SecurityManager
     }
 
     /**
-     * @return an immutable list of Users who have been assigned all the requested permissions in the given container
+     * @return an immutable list of active Users who have been assigned all the requested permissions in the given container
      */
     public static List<User> getUsersWithPermissions(Container c, Set<Class<? extends Permission>> perms)
     {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.385.0-fb-eln-issues.7",
+        "@labkey/components": "2.385.0-fb-eln-issues.8",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3297,6 +3297,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@labkey/api": {
+      "version": "1.26.1-fb-eln-issues.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1-fb-eln-issues.5.tgz",
+      "integrity": "sha512-WWTEe9Ws7WX31aEY1zKbn4NCPGuUM+yuSfxiInKVd5X/QxMRrM7KyspyPNs96lZ4KAoShSc4ja5gCkWTbs5feQ=="
+    },
     "node_modules/@labkey/build": {
       "version": "6.16.1",
       "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-6.16.1.tgz",
@@ -3333,11 +3338,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.385.0-fb-eln-issues.7",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.385.0-fb-eln-issues.7.tgz",
-      "integrity": "sha512-0GYN0N9daGcLWTHMmcacv8Euj407muTCuEmuR0NFcmWR4uB2Nl3ZHhDz/ZdtdlFO3n9MJ8wLkoT29of2QYi66w==",
+      "version": "2.385.0-fb-eln-issues.8",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.385.0-fb-eln-issues.8.tgz",
+      "integrity": "sha512-TF9GtMfEXGQWRKC1HpYHAsJ78pwXwSPye5zFVvhQvhJ1t0wZHdBmn5YdDsb67wW8GIhO0xz+9opz/c0Gr48vNw==",
       "dependencies": {
-        "@labkey/api": "1.26.1-fb-eln-issues.4",
+        "@labkey/api": "1.26.1-fb-eln-issues.5",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3372,11 +3377,6 @@
         "react-bootstrap": "^0.33.1",
         "react-dom": "^16.0"
       }
-    },
-    "node_modules/@labkey/components/node_modules/@labkey/api": {
-      "version": "1.26.1-fb-eln-issues.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1-fb-eln-issues.4.tgz",
-      "integrity": "sha512-dV0NbygLeZqw+VYbbJwOTYXdbk9RYNIukky929xTF9QKZxA3pSmXWTrkhcDHjcWRS+hfWSXzG5igDa15ouHeIQ=="
     },
     "node_modules/@labkey/eslint-config-base": {
       "version": "0.0.13",
@@ -19471,6 +19471,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@labkey/api": {
+      "version": "1.26.1-fb-eln-issues.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1-fb-eln-issues.5.tgz",
+      "integrity": "sha512-WWTEe9Ws7WX31aEY1zKbn4NCPGuUM+yuSfxiInKVd5X/QxMRrM7KyspyPNs96lZ4KAoShSc4ja5gCkWTbs5feQ=="
+    },
     "@labkey/build": {
       "version": "6.16.1",
       "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-6.16.1.tgz",
@@ -19507,11 +19512,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.385.0-fb-eln-issues.7",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.385.0-fb-eln-issues.7.tgz",
-      "integrity": "sha512-0GYN0N9daGcLWTHMmcacv8Euj407muTCuEmuR0NFcmWR4uB2Nl3ZHhDz/ZdtdlFO3n9MJ8wLkoT29of2QYi66w==",
+      "version": "2.385.0-fb-eln-issues.8",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.385.0-fb-eln-issues.8.tgz",
+      "integrity": "sha512-TF9GtMfEXGQWRKC1HpYHAsJ78pwXwSPye5zFVvhQvhJ1t0wZHdBmn5YdDsb67wW8GIhO0xz+9opz/c0Gr48vNw==",
       "requires": {
-        "@labkey/api": "1.26.1-fb-eln-issues.4",
+        "@labkey/api": "1.26.1-fb-eln-issues.5",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -19539,13 +19544,6 @@
         "react-select": "~5.7.0",
         "react-treebeard": "~3.2.4",
         "vis-network": "~6.5.2"
-      },
-      "dependencies": {
-        "@labkey/api": {
-          "version": "1.26.1-fb-eln-issues.4",
-          "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1-fb-eln-issues.4.tgz",
-          "integrity": "sha512-dV0NbygLeZqw+VYbbJwOTYXdbk9RYNIukky929xTF9QKZxA3pSmXWTrkhcDHjcWRS+hfWSXzG5igDa15ouHeIQ=="
-        }
       }
     },
     "@labkey/eslint-config-base": {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "1.82.0-fb-eln-issues.7",
+        "@labkey/components": "2.389.0",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3298,9 +3298,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.26.1-fb-eln-issues.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1-fb-eln-issues.5.tgz",
-      "integrity": "sha512-WWTEe9Ws7WX31aEY1zKbn4NCPGuUM+yuSfxiInKVd5X/QxMRrM7KyspyPNs96lZ4KAoShSc4ja5gCkWTbs5feQ=="
+      "version": "1.27.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.0.tgz",
+      "integrity": "sha512-Hs1TahaNp1K3JrvdpGCB0m8as1JidJImxyRD6NG5UK897z90tK1L3o3PihjyoU3oJ11nV/iePXJbG31c4C44gQ=="
     },
     "node_modules/@labkey/build": {
       "version": "6.16.1",
@@ -3338,11 +3338,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "1.82.0-fb-eln-issues.7",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.82.0-fb-eln-issues.7.tgz",
-      "integrity": "sha512-uHtyj70ZwPf3pffZ5mHdPGsCy4mjn597/jp8r/0kL9jnikxBTsUSvPeuUX/g3LosYg7BzNZbmrcjXONeax3bqw==",
+      "version": "2.389.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.389.0.tgz",
+      "integrity": "sha512-VjpumSZeqCxRQW0TY+W4bdyoVJE7wQaQSbUEHRFEpmSaM1XE+0fF2DkMFPhb+BrJQYUSCFi77xD44NypyvtCfg==",
       "dependencies": {
-        "@labkey/api": "1.26.1-fb-eln-issues.5",
+        "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -19453,9 +19453,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.26.1-fb-eln-issues.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1-fb-eln-issues.5.tgz",
-      "integrity": "sha512-WWTEe9Ws7WX31aEY1zKbn4NCPGuUM+yuSfxiInKVd5X/QxMRrM7KyspyPNs96lZ4KAoShSc4ja5gCkWTbs5feQ=="
+      "version": "1.27.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.0.tgz",
+      "integrity": "sha512-Hs1TahaNp1K3JrvdpGCB0m8as1JidJImxyRD6NG5UK897z90tK1L3o3PihjyoU3oJ11nV/iePXJbG31c4C44gQ=="
     },
     "@labkey/build": {
       "version": "6.16.1",
@@ -19493,11 +19493,11 @@
       }
     },
     "@labkey/components": {
-      "version": "1.82.0-fb-eln-issues.7",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.82.0-fb-eln-issues.7.tgz",
-      "integrity": "sha512-uHtyj70ZwPf3pffZ5mHdPGsCy4mjn597/jp8r/0kL9jnikxBTsUSvPeuUX/g3LosYg7BzNZbmrcjXONeax3bqw==",
+      "version": "2.389.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.389.0.tgz",
+      "integrity": "sha512-VjpumSZeqCxRQW0TY+W4bdyoVJE7wQaQSbUEHRFEpmSaM1XE+0fF2DkMFPhb+BrJQYUSCFi77xD44NypyvtCfg==",
       "requires": {
-        "@labkey/api": "1.26.1-fb-eln-issues.5",
+        "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,8 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/api": "1.26.1",
-        "@labkey/components": "2.385.0-fb-eln-issues.0",
+        "@labkey/components": "2.385.0-fb-eln-issues.7",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3298,11 +3297,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@labkey/api": {
-      "version": "1.26.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1.tgz",
-      "integrity": "sha512-3UTB+6TBN8W4Iz1RFGssKuloMm3Q1T74umgWjlrMk5wUvQJT1EIbwm/SgvkZ45QfwrzS0l4SIjciGnIR0+iUpA=="
-    },
     "node_modules/@labkey/build": {
       "version": "6.16.1",
       "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-6.16.1.tgz",
@@ -3339,11 +3333,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.385.0-fb-eln-issues.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.385.0-fb-eln-issues.0.tgz",
-      "integrity": "sha512-znMPZfaGPy4iBH7PHD0XH0lqw6a7VAxXxZ08CQa2uXPmeqODr+9FcHG2ZrTRJsxwqqqnSiL9Q0m+2o1ebrrltw==",
+      "version": "2.385.0-fb-eln-issues.7",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.385.0-fb-eln-issues.7.tgz",
+      "integrity": "sha512-0GYN0N9daGcLWTHMmcacv8Euj407muTCuEmuR0NFcmWR4uB2Nl3ZHhDz/ZdtdlFO3n9MJ8wLkoT29of2QYi66w==",
       "dependencies": {
-        "@labkey/api": "1.26.1-fb-eln-issues.0",
+        "@labkey/api": "1.26.1-fb-eln-issues.4",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3355,17 +3349,17 @@
         "formsy-react-components": "~1.1.0",
         "history": "~4.7.2",
         "immer": "~10.0.2",
-        "immutable": "^3.8.2",
+        "immutable": "~3.8.2",
         "moment": "~2.29.3",
         "moment-timezone": "~0.5.38",
         "normalizr": "~3.6.1",
         "numeral": "~2.0.6",
-        "react": "^16.0",
+        "react": "~16.14.0",
         "react-beautiful-dnd": "~13.1.1",
-        "react-bootstrap": "^0.33.1",
+        "react-bootstrap": "~0.33.1",
         "react-color": "~2.19.3",
         "react-datepicker": "~4.17.0",
-        "react-dom": "^16.0",
+        "react-dom": "~16.14.0",
         "react-redux": "~5.1.0",
         "react-router": "~3.2.6",
         "react-select": "~5.7.0",
@@ -3380,9 +3374,9 @@
       }
     },
     "node_modules/@labkey/components/node_modules/@labkey/api": {
-      "version": "1.26.1-fb-eln-issues.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1-fb-eln-issues.0.tgz",
-      "integrity": "sha512-P7jk9oSISHurWDYtVCd9YoXCtp/tCfFaHQqZi7KwwcNbvbH97g/502SK1qO5iy3G4xW+KFClvZzzQJJ4XFm7Vg=="
+      "version": "1.26.1-fb-eln-issues.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1-fb-eln-issues.4.tgz",
+      "integrity": "sha512-dV0NbygLeZqw+VYbbJwOTYXdbk9RYNIukky929xTF9QKZxA3pSmXWTrkhcDHjcWRS+hfWSXzG5igDa15ouHeIQ=="
     },
     "node_modules/@labkey/eslint-config-base": {
       "version": "0.0.13",
@@ -19477,11 +19471,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "@labkey/api": {
-      "version": "1.26.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1.tgz",
-      "integrity": "sha512-3UTB+6TBN8W4Iz1RFGssKuloMm3Q1T74umgWjlrMk5wUvQJT1EIbwm/SgvkZ45QfwrzS0l4SIjciGnIR0+iUpA=="
-    },
     "@labkey/build": {
       "version": "6.16.1",
       "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-6.16.1.tgz",
@@ -19518,11 +19507,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.385.0-fb-eln-issues.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.385.0-fb-eln-issues.0.tgz",
-      "integrity": "sha512-znMPZfaGPy4iBH7PHD0XH0lqw6a7VAxXxZ08CQa2uXPmeqODr+9FcHG2ZrTRJsxwqqqnSiL9Q0m+2o1ebrrltw==",
+      "version": "2.385.0-fb-eln-issues.7",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.385.0-fb-eln-issues.7.tgz",
+      "integrity": "sha512-0GYN0N9daGcLWTHMmcacv8Euj407muTCuEmuR0NFcmWR4uB2Nl3ZHhDz/ZdtdlFO3n9MJ8wLkoT29of2QYi66w==",
       "requires": {
-        "@labkey/api": "1.26.1-fb-eln-issues.0",
+        "@labkey/api": "1.26.1-fb-eln-issues.4",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -19534,17 +19523,17 @@
         "formsy-react-components": "~1.1.0",
         "history": "~4.7.2",
         "immer": "~10.0.2",
-        "immutable": "^3.8.2",
+        "immutable": "~3.8.2",
         "moment": "~2.29.3",
         "moment-timezone": "~0.5.38",
         "normalizr": "~3.6.1",
         "numeral": "~2.0.6",
-        "react": "^16.0",
+        "react": "~16.14.0",
         "react-beautiful-dnd": "~13.1.1",
-        "react-bootstrap": "^0.33.1",
+        "react-bootstrap": "~0.33.1",
         "react-color": "~2.19.3",
         "react-datepicker": "~4.17.0",
-        "react-dom": "^16.0",
+        "react-dom": "~16.14.0",
         "react-redux": "~5.1.0",
         "react-router": "~3.2.6",
         "react-select": "~5.7.0",
@@ -19553,9 +19542,9 @@
       },
       "dependencies": {
         "@labkey/api": {
-          "version": "1.26.1-fb-eln-issues.0",
-          "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1-fb-eln-issues.0.tgz",
-          "integrity": "sha512-P7jk9oSISHurWDYtVCd9YoXCtp/tCfFaHQqZi7KwwcNbvbH97g/502SK1qO5iy3G4xW+KFClvZzzQJJ4XFm7Vg=="
+          "version": "1.26.1-fb-eln-issues.4",
+          "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1-fb-eln-issues.4.tgz",
+          "integrity": "sha512-dV0NbygLeZqw+VYbbJwOTYXdbk9RYNIukky929xTF9QKZxA3pSmXWTrkhcDHjcWRS+hfWSXzG5igDa15ouHeIQ=="
         }
       }
     },

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.385.0-fb-eln-issues.8",
+        "@labkey/components": "1.82.0-fb-eln-issues.7",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3338,9 +3338,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.385.0-fb-eln-issues.8",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.385.0-fb-eln-issues.8.tgz",
-      "integrity": "sha512-TF9GtMfEXGQWRKC1HpYHAsJ78pwXwSPye5zFVvhQvhJ1t0wZHdBmn5YdDsb67wW8GIhO0xz+9opz/c0Gr48vNw==",
+      "version": "1.82.0-fb-eln-issues.7",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.82.0-fb-eln-issues.7.tgz",
+      "integrity": "sha512-uHtyj70ZwPf3pffZ5mHdPGsCy4mjn597/jp8r/0kL9jnikxBTsUSvPeuUX/g3LosYg7BzNZbmrcjXONeax3bqw==",
       "dependencies": {
         "@labkey/api": "1.26.1-fb-eln-issues.5",
         "@testing-library/jest-dom": "~5.17.0",
@@ -3365,7 +3365,6 @@
         "react-color": "~2.19.3",
         "react-datepicker": "~4.17.0",
         "react-dom": "~16.14.0",
-        "react-redux": "~5.1.0",
         "react-router": "~3.2.6",
         "react-select": "~5.7.0",
         "react-treebeard": "~3.2.4",
@@ -13921,24 +13920,6 @@
         "react": ">=0.14.0"
       }
     },
-    "node_modules/react-redux": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
-      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.6.0",
-        "react-lifecycles-compat": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",
-        "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
-      }
-    },
     "node_modules/react-router": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-3.2.6.tgz",
@@ -19512,9 +19493,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.385.0-fb-eln-issues.8",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.385.0-fb-eln-issues.8.tgz",
-      "integrity": "sha512-TF9GtMfEXGQWRKC1HpYHAsJ78pwXwSPye5zFVvhQvhJ1t0wZHdBmn5YdDsb67wW8GIhO0xz+9opz/c0Gr48vNw==",
+      "version": "1.82.0-fb-eln-issues.7",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-1.82.0-fb-eln-issues.7.tgz",
+      "integrity": "sha512-uHtyj70ZwPf3pffZ5mHdPGsCy4mjn597/jp8r/0kL9jnikxBTsUSvPeuUX/g3LosYg7BzNZbmrcjXONeax3bqw==",
       "requires": {
         "@labkey/api": "1.26.1-fb-eln-issues.5",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19539,7 +19520,6 @@
         "react-color": "~2.19.3",
         "react-datepicker": "~4.17.0",
         "react-dom": "~16.14.0",
-        "react-redux": "~5.1.0",
         "react-router": "~3.2.6",
         "react-select": "~5.7.0",
         "react-treebeard": "~3.2.4",
@@ -27371,20 +27351,6 @@
       "integrity": "sha512-IyjsJhDX9JkoOV9wlmLaS7z+oxYoIWhfzDcFy7inwoAKTu+VcVNrVpPmLeioJ94y6GeDRsnwarG1py5qofFQMg==",
       "requires": {
         "warning": "^3.0.0"
-      }
-    },
-    "react-redux": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
-      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-is": "^16.6.0",
-        "react-lifecycles-compat": "^3.0.0"
       }
     },
     "react-router": {

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@labkey/api": "1.26.1",
-        "@labkey/components": "2.388.1",
+        "@labkey/components": "2.385.0-fb-eln-issues.0",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3339,11 +3339,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.388.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.388.1.tgz",
-      "integrity": "sha512-HwHYQaYs3X3MnODdWGEJdNkjX1ca+H/tGnyVNwxXZ7vkR/fiEhBEedT5gGBrguvd2QxOl7ySE7RvB5jWD+NbGQ==",
+      "version": "2.385.0-fb-eln-issues.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.385.0-fb-eln-issues.0.tgz",
+      "integrity": "sha512-znMPZfaGPy4iBH7PHD0XH0lqw6a7VAxXxZ08CQa2uXPmeqODr+9FcHG2ZrTRJsxwqqqnSiL9Q0m+2o1ebrrltw==",
       "dependencies": {
-        "@labkey/api": "1.26.1",
+        "@labkey/api": "1.26.1-fb-eln-issues.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3355,17 +3355,18 @@
         "formsy-react-components": "~1.1.0",
         "history": "~4.7.2",
         "immer": "~10.0.2",
-        "immutable": "~3.8.2",
+        "immutable": "^3.8.2",
         "moment": "~2.29.3",
         "moment-timezone": "~0.5.38",
         "normalizr": "~3.6.1",
         "numeral": "~2.0.6",
-        "react": "~16.14.0",
+        "react": "^16.0",
         "react-beautiful-dnd": "~13.1.1",
-        "react-bootstrap": "~0.33.1",
+        "react-bootstrap": "^0.33.1",
         "react-color": "~2.19.3",
         "react-datepicker": "~4.17.0",
-        "react-dom": "~16.14.0",
+        "react-dom": "^16.0",
+        "react-redux": "~5.1.0",
         "react-router": "~3.2.6",
         "react-select": "~5.7.0",
         "react-treebeard": "~3.2.4",
@@ -3377,6 +3378,11 @@
         "react-bootstrap": "^0.33.1",
         "react-dom": "^16.0"
       }
+    },
+    "node_modules/@labkey/components/node_modules/@labkey/api": {
+      "version": "1.26.1-fb-eln-issues.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1-fb-eln-issues.0.tgz",
+      "integrity": "sha512-P7jk9oSISHurWDYtVCd9YoXCtp/tCfFaHQqZi7KwwcNbvbH97g/502SK1qO5iy3G4xW+KFClvZzzQJJ4XFm7Vg=="
     },
     "node_modules/@labkey/eslint-config-base": {
       "version": "0.0.13",
@@ -13921,6 +13927,24 @@
         "react": ">=0.14.0"
       }
     },
+    "node_modules/react-redux": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
+      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.1",
+        "react-is": "^16.6.0",
+        "react-lifecycles-compat": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",
+        "redux": "^2.0.0 || ^3.0.0 || ^4.0.0-0"
+      }
+    },
     "node_modules/react-router": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-3.2.6.tgz",
@@ -19494,11 +19518,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.388.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.388.1.tgz",
-      "integrity": "sha512-HwHYQaYs3X3MnODdWGEJdNkjX1ca+H/tGnyVNwxXZ7vkR/fiEhBEedT5gGBrguvd2QxOl7ySE7RvB5jWD+NbGQ==",
+      "version": "2.385.0-fb-eln-issues.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.385.0-fb-eln-issues.0.tgz",
+      "integrity": "sha512-znMPZfaGPy4iBH7PHD0XH0lqw6a7VAxXxZ08CQa2uXPmeqODr+9FcHG2ZrTRJsxwqqqnSiL9Q0m+2o1ebrrltw==",
       "requires": {
-        "@labkey/api": "1.26.1",
+        "@labkey/api": "1.26.1-fb-eln-issues.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -19510,21 +19534,29 @@
         "formsy-react-components": "~1.1.0",
         "history": "~4.7.2",
         "immer": "~10.0.2",
-        "immutable": "~3.8.2",
+        "immutable": "^3.8.2",
         "moment": "~2.29.3",
         "moment-timezone": "~0.5.38",
         "normalizr": "~3.6.1",
         "numeral": "~2.0.6",
-        "react": "~16.14.0",
+        "react": "^16.0",
         "react-beautiful-dnd": "~13.1.1",
-        "react-bootstrap": "~0.33.1",
+        "react-bootstrap": "^0.33.1",
         "react-color": "~2.19.3",
         "react-datepicker": "~4.17.0",
-        "react-dom": "~16.14.0",
+        "react-dom": "^16.0",
+        "react-redux": "~5.1.0",
         "react-router": "~3.2.6",
         "react-select": "~5.7.0",
         "react-treebeard": "~3.2.4",
         "vis-network": "~6.5.2"
+      },
+      "dependencies": {
+        "@labkey/api": {
+          "version": "1.26.1-fb-eln-issues.0",
+          "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.26.1-fb-eln-issues.0.tgz",
+          "integrity": "sha512-P7jk9oSISHurWDYtVCd9YoXCtp/tCfFaHQqZi7KwwcNbvbH97g/502SK1qO5iy3G4xW+KFClvZzzQJJ4XFm7Vg=="
+        }
       }
     },
     "@labkey/eslint-config-base": {
@@ -27352,6 +27384,20 @@
       "integrity": "sha512-IyjsJhDX9JkoOV9wlmLaS7z+oxYoIWhfzDcFy7inwoAKTu+VcVNrVpPmLeioJ94y6GeDRsnwarG1py5qofFQMg==",
       "requires": {
         "warning": "^3.0.0"
+      }
+    },
+    "react-redux": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.2.tgz",
+      "integrity": "sha512-Ns1G0XXc8hDyH/OcBHOxNgQx9ayH3SPxBnFCOidGKSle8pKihysQw2rG/PmciUQRoclhVBO8HMhiRmGXnDja9Q==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.1.0",
+        "prop-types": "^15.6.1",
+        "react-is": "^16.6.0",
+        "react-lifecycles-compat": "^3.0.0"
       }
     },
     "react-router": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.385.0-fb-eln-issues.8",
+    "@labkey/components": "1.82.0-fb-eln-issues.7",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,8 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/api": "1.26.1",
-    "@labkey/components": "2.385.0-fb-eln-issues.0",
+    "@labkey/components": "2.385.0-fb-eln-issues.7",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@labkey/api": "1.26.1",
-    "@labkey/components": "2.388.1",
+    "@labkey/components": "2.385.0-fb-eln-issues.0",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "1.82.0-fb-eln-issues.7",
+    "@labkey/components": "2.389.0",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.385.0-fb-eln-issues.7",
+    "@labkey/components": "2.385.0-fb-eln-issues.8",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -2501,6 +2501,7 @@ public class UserController extends SpringActionController
         private boolean _active; // should we get only active members (relevant only if permissions is empty)
         private Permission[] _permissions; // the  permissions each user must have (They must have all of these)
         private Set<Class<? extends Permission>> _permissionClasses = Collections.emptySet(); // the set of permission classes corresponding to the permissions array
+        private boolean _includeDeactivated; // Should we include inactive members (relevant if permissions is not empty)
 
         public String getGroup()
         {
@@ -2569,6 +2570,16 @@ public class UserController extends SpringActionController
         public void setActive(boolean active)
         {
             _active = active;
+        }
+
+        public boolean getIncludeDeactivated()
+        {
+            return _includeDeactivated;
+        }
+
+        public void setIncludeDeactivated(boolean includeDeactivated)
+        {
+            _includeDeactivated = includeDeactivated;
         }
     }
 
@@ -2752,7 +2763,7 @@ public class UserController extends SpringActionController
             }
             else
             {
-                users = SecurityManager.getUsersWithPermissions(container, form.getPermissionClasses());
+                users = SecurityManager.getUsersWithPermissions(container, form.getIncludeDeactivated(), form.getPermissionClasses());
             }
 
             this.setUsersList(form, users, response);

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
+import org.labkey.api.action.ApiVersion;
 import org.labkey.api.action.FormViewAction;
 import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.QueryViewAction;
@@ -2501,7 +2502,7 @@ public class UserController extends SpringActionController
         private boolean _active; // should we get only active members (relevant only if permissions is empty)
         private Permission[] _permissions; // the  permissions each user must have (They must have all of these)
         private Set<Class<? extends Permission>> _permissionClasses = Collections.emptySet(); // the set of permission classes corresponding to the permissions array
-        private boolean _includeDeactivated; // Should we include inactive members (relevant if permissions is not empty)
+        private boolean _includeDeactivated; // Should we include inactive members, only used in the 23.11 version of GetUsersWithPermissionsAction
 
         public String getGroup()
         {
@@ -2614,7 +2615,7 @@ public class UserController extends SpringActionController
             //if requesting users in a specific group...
             if (null != StringUtils.trimToNull(form.getGroup()) || null != form.getGroupId())
             {
-                users = getProjectGroupUsers(form, response);
+                users = getProjectGroupUsers(form, response, !form.getActive());
             }
             else
             {
@@ -2651,7 +2652,7 @@ public class UserController extends SpringActionController
         }
 
         @NotNull
-        protected Collection<User> getProjectGroupUsers(GetUsersForm form, ApiSimpleResponse response)
+        protected Collection<User> getProjectGroupUsers(GetUsersForm form, ApiSimpleResponse response, boolean includeDeactivated)
         {
             Container project = getContainer().getProject();
 
@@ -2675,10 +2676,10 @@ public class UserController extends SpringActionController
             response.put("groupCaption", SecurityManager.getDisambiguatedGroupName(group));
 
             MemberType<User> userMemberType;
-            if (form.getActive())
-                userMemberType = MemberType.ACTIVE_USERS;
-            else
+            if (includeDeactivated)
                 userMemberType = MemberType.ACTIVE_AND_INACTIVE_USERS;
+            else
+                userMemberType = MemberType.ACTIVE_USERS;
 
             // if the allMembers flag is set, then recurse and if group is site users group then return all site users
             Collection<User> users;
@@ -2727,6 +2728,7 @@ public class UserController extends SpringActionController
      */
     @RequiresLogin
     @RequiresPermission(ReadPermission.class)
+    @ApiVersion(23.10)
     public static class GetUsersWithPermissionsAction extends GetUsersAction
     {
         @Override
@@ -2742,6 +2744,55 @@ public class UserController extends SpringActionController
             }
         }
 
+        /**
+         * The older 23.10 response format does not honor the newer includeDeactivated flag. It only honors the active
+         * flag when requesting users of a group, and ignores the flag (only ever returning active users) when not
+         * requesting a group.
+         */
+        private ApiResponse response2310(ApiSimpleResponse response, GetUsersForm form)
+        {
+            Collection<User> users;
+
+            //if requesting users in a specific group...
+            if (null != StringUtils.trimToNull(form.getGroup()) || null != form.getGroupId())
+            {
+                users = filterForPermissions(form, getProjectGroupUsers(form, response, !form.getActive()));
+            }
+            else
+            {
+                users = SecurityManager.getUsersWithPermissions(getContainer(), form.getPermissionClasses());
+            }
+
+            this.setUsersList(form, users, response);
+
+            return response;
+        }
+
+        /**
+         * The 23.11 response format does not honor the active flag, instead it honors the includeDeactivated flag, and
+         * it honors it when requesting users or groups. The flag defaults to false, so by default only active users
+         * will be returned.
+         */
+        private ApiResponse response2311(ApiSimpleResponse response, GetUsersForm form)
+        {
+            boolean includeDeactivated = form.getIncludeDeactivated();
+            Collection<User> users;
+
+            //if requesting users in a specific group...
+            if (null != StringUtils.trimToNull(form.getGroup()) || null != form.getGroupId())
+            {
+                users = filterForPermissions(form, getProjectGroupUsers(form, response, includeDeactivated));
+            }
+            else
+            {
+                users = SecurityManager.getUsersWithPermissions(getContainer(), includeDeactivated, form.getPermissionClasses());
+            }
+
+            this.setUsersList(form, users, response);
+
+            return response;
+        }
+
         @Override
         public ApiResponse execute(GetUsersForm form, BindException errors)
         {
@@ -2754,20 +2805,10 @@ public class UserController extends SpringActionController
             ApiSimpleResponse response = new ApiSimpleResponse();
             response.put("container", container.getPath());
 
-            Collection<User> users;
+            if (getRequestedApiVersion() <= 23.10)
+                return response2310(response, form);
 
-            //if requesting users in a specific group...
-            if (null != StringUtils.trimToNull(form.getGroup()) || null != form.getGroupId())
-            {
-                users = filterForPermissions(form, getProjectGroupUsers(form, response));
-            }
-            else
-            {
-                users = SecurityManager.getUsersWithPermissions(container, form.getIncludeDeactivated(), form.getPermissionClasses());
-            }
-
-            this.setUsersList(form, users, response);
-            return response;
+            return response2311(response, form);
         }
     }
 

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -2502,7 +2502,7 @@ public class UserController extends SpringActionController
         private boolean _active; // should we get only active members (relevant only if permissions is empty)
         private Permission[] _permissions; // the  permissions each user must have (They must have all of these)
         private Set<Class<? extends Permission>> _permissionClasses = Collections.emptySet(); // the set of permission classes corresponding to the permissions array
-        private boolean _includeDeactivated; // Should we include inactive members, only used in the 23.11 version of GetUsersWithPermissionsAction
+        private boolean _includeInactive; // Should we include inactive members, only used in the 23.11 version of GetUsersWithPermissionsAction
 
         public String getGroup()
         {
@@ -2573,14 +2573,14 @@ public class UserController extends SpringActionController
             _active = active;
         }
 
-        public boolean getIncludeDeactivated()
+        public boolean getIncludeInactive()
         {
-            return _includeDeactivated;
+            return _includeInactive;
         }
 
-        public void setIncludeDeactivated(boolean includeDeactivated)
+        public void setIncludeInactive(boolean includeInactive)
         {
-            _includeDeactivated = includeDeactivated;
+            _includeInactive = includeInactive;
         }
     }
 
@@ -2775,17 +2775,17 @@ public class UserController extends SpringActionController
          */
         private ApiResponse response2311(ApiSimpleResponse response, GetUsersForm form)
         {
-            boolean includeDeactivated = form.getIncludeDeactivated();
+            boolean includeInactive = form.getIncludeInactive();
             Collection<User> users;
 
             //if requesting users in a specific group...
             if (null != StringUtils.trimToNull(form.getGroup()) || null != form.getGroupId())
             {
-                users = filterForPermissions(form, getProjectGroupUsers(form, response, includeDeactivated));
+                users = filterForPermissions(form, getProjectGroupUsers(form, response, includeInactive));
             }
             else
             {
-                users = SecurityManager.getUsersWithPermissions(getContainer(), includeDeactivated, form.getPermissionClasses());
+                users = SecurityManager.getUsersWithPermissions(getContainer(), includeInactive, form.getPermissionClasses());
             }
 
             this.setUsersList(form, users, response);


### PR DESCRIPTION
#### Rationale
Users want to be able to search for ELNs via author, even if the author is deactivated ([Issue 48250](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48250)).

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4870
* https://github.com/LabKey/labkey-api-js/pull/164
* https://github.com/LabKey/labkey-ui-components/pull/1328
* https://github.com/LabKey/labkey-ui-premium/pull/235
* https://github.com/LabKey/biologics/pull/2475
* https://github.com/LabKey/inventory/pull/1076
* https://github.com/LabKey/sampleManagement/pull/2191

#### Changes
* GetUsersWithPermissionsAction: version the API, add includeInactive flag
* SecurityManager: Add includeInactive flag to getUsersWithPermissions method


#### Additional Context
***Note:*** The below context has been addressed by versioning the API. I'm keeping it here since it's useful history.

I am really not sure that this is the correct way to go, but it seems like our best bet if we want to remain backwards compatible, and I'd really appreciate some feedback if there's maybe a better approach. Here are the current downsides as I see them:

1. We already have an `active` flag, so this new flag is kind of confusing since it's the opposite. However, even though we have the active flag, it's currently ignored if you're not requesting users of a group. This means that if we start to use it all existing consumers of this API will need to be updated to pass the flag as `true`, or they'll start getting inactive users returned. It also doesn't feel appropriate to use the `active` flag for this behavior, the behavior we want is to return all users, active or deactivated, or active users. So we'd be treating the `active` flag as meaning `activeUsersOnly`, which seems odd.
2. The active flag is used if you're trying to get users of a group (if the `group` attribute is passed), this means we cannot use the `includeDeactivated` flag for this usage of the GetUsersWithPermissionsAction without also breaking backwards compatibility (all consumers passing the active flag would have to be updated to use the `includeDeactivated` flag).

Here are the upsides:
1. It works
2. It's backwards compatible

Maybe we should version this API like we do for selectRows? We could make the default version `23.10`, and if `23.11` is passed we honor the `includeDeactivated` flag, but not the `active` flag.