### PR TITLE
Move material query out from loop for nab views

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1355,7 +1355,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                     ListUtils.partition(lsids, 100).forEach(sublist ->
                         searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
                         {
-                            for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterialsByLSID(sublist))
+                            for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterialsByLsid(sublist))
                                 expMaterial.index(searchService.defaultTask());
                         })
                     );

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -707,25 +707,15 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return materials;
     }
 
-    private List<ExpMaterialImpl> _getExpMaterialsByLSID(Collection<String> lsids)
+    @Override
+    @NotNull
+    public List<ExpMaterialImpl> getExpMaterialsByLsid(Collection<String> lsids)
     {
         SimpleFilter filter = new SimpleFilter().addInClause(FieldKey.fromParts(ExpMaterialTable.Column.LSID.name()), lsids);
         TableSelector selector = new TableSelector(getTinfoMaterial(), filter, null);
 
         final List<ExpMaterialImpl> materials = new ArrayList<>(lsids.size());
         selector.forEach(Material.class, material -> materials.add(new ExpMaterialImpl(material)));
-
-        return materials;
-    }
-
-    @Override
-    @NotNull
-    public List<ExpMaterialImpl> getExpMaterialsByLsid(Collection<String> lsids)
-    {
-        List<ExpMaterialImpl> materials = new ArrayList<>();
-        Iterables.partition(lsids, 100).forEach(sublist ->
-                        materials.addAll(_getExpMaterialsByLSID(sublist))
-        );
 
         return materials;
     }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -707,9 +707,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return materials;
     }
 
-    @Override
-    @NotNull
-    public List<ExpMaterialImpl> getExpMaterialsByLsid(Collection<String> lsids)
+    private List<ExpMaterialImpl> _getExpMaterialsByLSID(Collection<String> lsids)
     {
         SimpleFilter filter = new SimpleFilter().addInClause(FieldKey.fromParts(ExpMaterialTable.Column.LSID.name()), lsids);
         TableSelector selector = new TableSelector(getTinfoMaterial(), filter, null);
@@ -720,14 +718,14 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return materials;
     }
 
+    @Override
     @NotNull
-    public List<ExpMaterialImpl> getExpMaterialsByLSID(Collection<String> lsids)
+    public List<ExpMaterialImpl> getExpMaterialsByLsid(Collection<String> lsids)
     {
-        SimpleFilter filter = new SimpleFilter().addInClause(FieldKey.fromParts(ExpMaterialTable.Column.LSID.name()), lsids);
-        TableSelector selector = new TableSelector(getTinfoMaterial(), filter, null);
-
-        final List<ExpMaterialImpl> materials = new ArrayList<>(lsids.size());
-        selector.forEach(Material.class, material -> materials.add(new ExpMaterialImpl(material)));
+        List<ExpMaterialImpl> materials = new ArrayList<>();
+        Iterables.partition(lsids, 100).forEach(sublist ->
+                        materials.addAll(_getExpMaterialsByLSID(sublist))
+        );
 
         return materials;
     }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -1123,7 +1123,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         if (!existingRowSelect.includeParent)
             return sampleRows;
 
-        List<ExpMaterialImpl> materials = ExperimentServiceImpl.get().getExpMaterialsByLSID(rowNumLsid.values());
+        List<ExpMaterialImpl> materials = ExperimentServiceImpl.get().getExpMaterialsByLsid(rowNumLsid.values());
 
         Map<String, Pair<Set<ExpMaterial>, Set<ExpData>>> parents = ExperimentServiceImpl.get().getParentMaterialAndDataMap(container, user, new HashSet<>(materials));
 


### PR DESCRIPTION
#### Rationale
Prefer getExpMaterialsByLsid in a batch way over getExpMaterialByLsid one by one. 

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/666
* https://github.com/LabKey/platform/pull/4875

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
