### PR TITLE
ElevatedUser

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -88,6 +88,7 @@ import org.labkey.api.security.AvatarType;
 import org.labkey.api.security.Encryption;
 import org.labkey.api.security.EntropyPasswordValidator;
 import org.labkey.api.security.GroupManager;
+import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.NestedGroupsTest;
 import org.labkey.api.security.PasswordExpiration;
 import org.labkey.api.security.SecurityManager;
@@ -198,6 +199,7 @@ public class ApiModule extends CodeOnlyModule
             JavaVersion.TestCase.class,
             JsonTest.class,
             JsonUtil.TestCase.class,
+            LimitedUser.TestCase.class,
             MarkableIterator.TestCase.class,
             MaterializedQueryHelper.TestCase.class,
             Measurement.TestCase.class,

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -70,7 +70,7 @@ import org.labkey.api.query.QueryView;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.reports.report.view.ReportUtil;
-import org.labkey.api.security.LimitedUser;
+import org.labkey.api.security.ElevatedUser;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AssayReadPermission;
 import org.labkey.api.security.permissions.QCAnalystPermission;
@@ -698,7 +698,7 @@ public abstract class AssayProtocolSchema extends AssaySchema implements UserSch
                     {
                         try
                         {
-                            User elevatedUser = LimitedUser.getElevatedUser(user, Set.of(qcRole.getClass(), readerRole.getClass()));
+                            User elevatedUser = ElevatedUser.getElevatedUser(user, Set.of(qcRole.getClass(), readerRole.getClass()));
 
                             ViewContext viewContext = new ViewContext(context);
                             viewContext.setUser(elevatedUser);

--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -698,7 +698,7 @@ public abstract class AssayProtocolSchema extends AssaySchema implements UserSch
                     {
                         try
                         {
-                            User elevatedUser = ElevatedUser.getElevatedUser(user, Set.of(qcRole.getClass(), readerRole.getClass()));
+                            User elevatedUser = ElevatedUser.getElevatedUser(user, qcRole.getClass(), readerRole.getClass());
 
                             ViewContext viewContext = new ViewContext(context);
                             viewContext.setUser(elevatedUser);

--- a/api/src/org/labkey/api/security/ClonedUser.java
+++ b/api/src/org/labkey/api/security/ClonedUser.java
@@ -1,0 +1,36 @@
+package org.labkey.api.security;
+
+import org.labkey.api.security.impersonation.ImpersonationContext;
+import org.labkey.api.security.roles.Role;
+import org.labkey.api.security.roles.RoleManager;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public abstract class ClonedUser extends User
+{
+    protected ClonedUser(User user, ImpersonationContext ctx)
+    {
+        super(user.getEmail(), user.getUserId());
+        setFirstName(user.getFirstName());
+        setLastName(user.getLastName());
+        setActive(user.isActive());
+        setDisplayName(user.getFriendlyName());
+        setLastLogin(user.getLastLogin());
+        setPhone(user.getPhone());
+        setLastLogin(user.getLastLogin());
+        setLastActivity(user.getLastActivity());
+
+        setImpersonationContext(ctx);
+    }
+
+    protected static Set<Role> getRoles(Collection<Class<? extends Role>> rolesToAdd)
+    {
+        return rolesToAdd.stream()
+            .map(RoleManager::getRole)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    }
+}

--- a/api/src/org/labkey/api/security/ElevatedUser.java
+++ b/api/src/org/labkey/api/security/ElevatedUser.java
@@ -14,9 +14,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * A wrapped user that possesses all the security aspects (groups, roles, impersonation status, etc.) of the underlying
- * user and adds one or more contextual roles. Use this class as a last resort; preference is to use contextual roles
- * in individual permissions checks or LimitedUser.
+ * A wrapped user that possesses all the security properties (groups, roles, impersonation status, etc.) of the
+ * underlying user and adds one or more contextual roles. Use this class as a last resort; preference is to use
+ * contextual roles in individual permission checks or LimitedUser.
  */
 public class ElevatedUser extends ClonedUser
 {

--- a/api/src/org/labkey/api/security/ElevatedUser.java
+++ b/api/src/org/labkey/api/security/ElevatedUser.java
@@ -1,0 +1,50 @@
+package org.labkey.api.security;
+
+import org.labkey.api.audit.permissions.CanSeeAuditLogPermission;
+import org.labkey.api.data.Container;
+import org.labkey.api.security.impersonation.WrappedImpersonationContext;
+import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.roles.CanSeeAuditLogRole;
+import org.labkey.api.security.roles.Role;
+import org.labkey.api.util.Pair;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A wrapped user that possesses all the permissions associated with that user plus one or more contextual roles
+ */
+public class ElevatedUser extends ClonedUser
+{
+    private ElevatedUser(User user, Collection<Class<? extends Role>> rolesToAdd)
+    {
+        super(user, new WrappedImpersonationContext(user.getImpersonationContext(), getRoles(rolesToAdd)));
+    }
+
+    /**
+     * Conditionally add roles to the supplied user. For each permission + role pair, add the role if the user doesn't
+     * have the corresponding permission in the supplied container.
+     */
+    @SafeVarargs
+    public static User getElevatedUser(Container container, User user, Pair<Class<? extends Permission>, Class<? extends Role>>... pairs)
+    {
+        Set<Class<? extends Role>> rolesToAdd = Arrays.stream(pairs)
+            .filter(pair -> !container.hasPermission(user, pair.first))
+            .map(pair -> pair.second)
+            .collect(Collectors.toSet());
+
+        return !rolesToAdd.isEmpty() ? getElevatedUser(user, rolesToAdd) : user;
+    }
+
+    public static User getElevatedUser(User user, Collection<Class<? extends Role>> rolesToAdd)
+    {
+        return new ElevatedUser(user, rolesToAdd);
+    }
+
+    public static User getCanSeeAuditLogUser(Container container, User user)
+    {
+        return getElevatedUser(container, user, Pair.of(CanSeeAuditLogPermission.class, CanSeeAuditLogRole.class));
+    }
+}

--- a/api/src/org/labkey/api/security/ElevatedUser.java
+++ b/api/src/org/labkey/api/security/ElevatedUser.java
@@ -10,19 +10,30 @@ import org.labkey.api.util.Pair;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
  * A wrapped user that possesses all the security properties (groups, roles, impersonation status, etc.) of the
- * underlying user and adds one or more contextual roles. Use this class as a last resort; preference is to use
- * contextual roles in individual permission checks or LimitedUser.
+ * underlying user and adds one or more roles. WARNING: The additional roles apply UNCONDITIONALLY, in all containers
+ * and resources. You must ensure that the scope of use is constrained appropriately. Use this class as a last resort;
+ * preference is to use contextual roles in individual permission checks or LimitedUser.
  */
 public class ElevatedUser extends ClonedUser
 {
     private ElevatedUser(User user, Collection<Class<? extends Role>> rolesToAdd)
     {
         super(user, new WrappedImpersonationContext(user.getImpersonationContext(), getRoles(rolesToAdd)));
+    }
+
+    /**
+     * Wrap the supplied user and unconditionally add the supplied role(s). Always returns an ElevatedUser.
+     */
+    @SafeVarargs
+    public static ElevatedUser getElevatedUser(User user, Class<? extends Role>... rolesToAdd)
+    {
+        return new ElevatedUser(user, Arrays.stream(rolesToAdd).filter(Objects::nonNull).collect(Collectors.toSet()));
     }
 
     /**

--- a/api/src/org/labkey/api/security/LimitedUser.java
+++ b/api/src/org/labkey/api/security/LimitedUser.java
@@ -72,7 +72,7 @@ public class LimitedUser extends ClonedUser
     @SafeVarargs
     public static User getElevatedUser(Container container, User user, Pair<Class<? extends Permission>, Class<? extends Role>>... pairs)
     {
-        return ElevatedUser.getElevatedUser(container, user, pairs);
+        return ElevatedUser.ensureContextualRoles(container, user, pairs);
     }
 
     @Deprecated // Call ElevatedUser!
@@ -84,7 +84,7 @@ public class LimitedUser extends ClonedUser
     @Deprecated // Call ElevatedUser!
     public static User getCanSeeAuditLogUser(Container container, User user)
     {
-        return ElevatedUser.getCanSeeAuditLogUser(container, user);
+        return ElevatedUser.ensureCanSeeAuditLogRole(container, user);
     }
 
     public static class TestCase extends Assert
@@ -101,9 +101,9 @@ public class LimitedUser extends ClonedUser
             testPermissions(new LimitedUser(new LimitedUser(user, FolderAdminRole.class), ReaderRole.class), 1, true, false, false, false, false);
 
             Container c = JunitUtil.getTestContainer();
-            testPermissions(ElevatedUser.getCanSeeAuditLogUser(c, new LimitedUser(user)), 1, false, false, false, false, true);
-            testPermissions(ElevatedUser.getCanSeeAuditLogUser(c, new LimitedUser(user, ReaderRole.class)), 2, true, false, false, false, true);
-            testPermissions(ElevatedUser.getCanSeeAuditLogUser(c, ElevatedUser.getElevatedUser(new LimitedUser(user, ReaderRole.class), Set.of(EditorRole.class))), 3, true, true, true, false, true);
+            testPermissions(ElevatedUser.ensureCanSeeAuditLogRole(c, new LimitedUser(user)), 1, false, false, false, false, true);
+            testPermissions(ElevatedUser.ensureCanSeeAuditLogRole(c, new LimitedUser(user, ReaderRole.class)), 2, true, false, false, false, true);
+            testPermissions(ElevatedUser.ensureCanSeeAuditLogRole(c, ElevatedUser.getElevatedUser(new LimitedUser(user, ReaderRole.class), Set.of(EditorRole.class))), 3, true, true, true, false, true);
 
             int groupCount = (int)user.getGroups().stream().count();
             int roleCount = user.getAssignedRoles(c.getPolicy()).size();

--- a/api/src/org/labkey/api/security/LimitedUser.java
+++ b/api/src/org/labkey/api/security/LimitedUser.java
@@ -81,13 +81,6 @@ public class LimitedUser extends ClonedUser
         return ElevatedUser.getElevatedUser(user, rolesToAdd);
     }
 
-    /** Unconditionally add roles to the supplied user */
-    @Deprecated // Call ElevatedUser!
-    public static User getElevatedUser(User user, Collection<Class<? extends Role>> rolesToAdd)
-    {
-        return ElevatedUser.getElevatedUser(user, rolesToAdd);
-    }
-
     @Deprecated // Call ElevatedUser!
     public static User getCanSeeAuditLogUser(Container container, User user)
     {

--- a/api/src/org/labkey/api/security/LimitedUser.java
+++ b/api/src/org/labkey/api/security/LimitedUser.java
@@ -16,98 +16,131 @@
 
 package org.labkey.api.security;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.labkey.api.audit.permissions.CanSeeAuditLogPermission;
 import org.labkey.api.data.Container;
+import org.labkey.api.security.impersonation.NotImpersonatingContext;
+import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.roles.CanSeeAuditLogRole;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.security.roles.EditorRole;
+import org.labkey.api.security.roles.FolderAdminRole;
+import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.security.roles.Role;
-import org.labkey.api.security.roles.RoleManager;
+import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.TestContext;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
- * A wrapper around another user that limits the permissions associated that that user, and thus
- * the operations that the user is allowed to perform.
+ * A cloned user that limits the permissions associated with that user to only the passed in roles
  */
-public class LimitedUser extends User
+public class LimitedUser extends ClonedUser
 {
-    private final PrincipalArray _groups;
-    private final Set<Role> _roles;
-
-    // LimitedUser that's granted one or more roles (no groups)
     @SafeVarargs
     public LimitedUser(User user, Class<? extends Role>... roleClasses)
     {
-        this(user, PrincipalArray.getEmptyPrincipalArray(), Set.of(roleClasses));
+        this(user, Set.of(roleClasses));
     }
 
-    private LimitedUser(User user, PrincipalArray groups, Collection<Class<? extends Role>> rolesToAdd)
+    private LimitedUser(User user, Collection<Class<? extends Role>> rolesToAdd)
     {
-        super(user.getEmail(), user.getUserId());
-        setFirstName(user.getFirstName());
-        setLastName(user.getLastName());
-        setActive(user.isActive());
-        setDisplayName(user.getFriendlyName());
-        setLastLogin(user.getLastLogin());
-        setPhone(user.getPhone());
-        _groups = groups;
-        _roles = rolesToAdd.stream()
-            .map(RoleManager::getRole)
-            .filter(Objects::nonNull)
-            .collect(Collectors.toSet());
+        super(user, new NotImpersonatingContext()
+        {
+            private final Set<Role> _roles = getRoles(rolesToAdd);
+
+            @Override
+            public PrincipalArray getGroups(User user)
+            {
+                return PrincipalArray.getEmptyPrincipalArray(); // No groups!
+            }
+
+            @Override
+            public Set<Role> getAssignedRoles(User user, SecurityPolicy policy)
+            {
+                return _roles;
+            }
+        });
     }
 
-    @Override
-    public PrincipalArray getGroups()
-    {
-        return _groups;
-    }
-
-    @Override
-    public Set<Role> getAssignedRoles(SecurityPolicy policy)
-    {
-        // Get all the roles in the root and this policy based on the supplied groups (often empty)
-        Set<Role> roles = super.getAssignedRoles(policy);
-        roles.addAll(_roles);
-
-        return roles;
-    }
-
-    /**
-     * Conditionally add roles to the supplied user. For each permission + role pair, add the role if the user doesn't
-     * have the corresponding permission in the supplied container. I don't love using LimitedUser, but at least we're
-     * no longer implementing this (incorrectly) in a ton of modules.
-     */
+    @Deprecated // Call ElevatedUser!
     @SafeVarargs
     public static User getElevatedUser(Container container, User user, Pair<Class<? extends Permission>, Class<? extends Role>>... pairs)
     {
-        Set<Class<? extends Role>> rolesToAdd = Arrays.stream(pairs)
-            .filter(pair -> !container.hasPermission(user, pair.first))
-            .map(pair -> pair.second)
-            .collect(Collectors.toSet());
-
-        return !rolesToAdd.isEmpty() ? getElevatedUser(user, rolesToAdd) : user;
+        return ElevatedUser.getElevatedUser(container, user, pairs);
     }
 
-    @Deprecated // Call the other variant!
+    @Deprecated // Call ElevatedUser!
     public static User getElevatedUser(Container container, User user, Collection<Class<? extends Role>> rolesToAdd)
     {
-        return getElevatedUser(user, rolesToAdd);
+        return ElevatedUser.getElevatedUser(user, rolesToAdd);
     }
 
     /** Unconditionally add roles to the supplied user */
+    @Deprecated // Call ElevatedUser!
     public static User getElevatedUser(User user, Collection<Class<? extends Role>> rolesToAdd)
     {
-        return new LimitedUser(user, user.getGroups(), rolesToAdd);
+        return ElevatedUser.getElevatedUser(user, rolesToAdd);
     }
 
+    @Deprecated // Call ElevatedUser!
     public static User getCanSeeAuditLogUser(Container container, User user)
     {
-        return getElevatedUser(container, user, Pair.of(CanSeeAuditLogPermission.class, CanSeeAuditLogRole.class));
+        return ElevatedUser.getCanSeeAuditLogUser(container, user);
+    }
+
+    public static class TestCase extends Assert
+    {
+        @Test
+        public void testLimitedUser()
+        {
+            User user = TestContext.get().getUser();
+
+            testPermissions(new LimitedUser(user),0, false, false, false, false, false);
+            testPermissions(new LimitedUser(user, ReaderRole.class), 1, true, false, false, false, false);
+            testPermissions(new LimitedUser(user, EditorRole.class), 1, true, true, true, false, false);
+            testPermissions(new LimitedUser(user, FolderAdminRole.class), 1, true, true, true, true, true);
+            testPermissions(new LimitedUser(new LimitedUser(user, FolderAdminRole.class), ReaderRole.class), 1, true, false, false, false, false);
+
+            Container c = JunitUtil.getTestContainer();
+            testPermissions(ElevatedUser.getCanSeeAuditLogUser(c, new LimitedUser(user)), 1, false, false, false, false, true);
+            testPermissions(ElevatedUser.getCanSeeAuditLogUser(c, new LimitedUser(user, ReaderRole.class)), 2, true, false, false, false, true);
+            testPermissions(ElevatedUser.getCanSeeAuditLogUser(c, ElevatedUser.getElevatedUser(new LimitedUser(user, ReaderRole.class), Set.of(EditorRole.class))), 3, true, true, true, false, true);
+
+            int groupCount = (int)user.getGroups().stream().count();
+            int roleCount = user.getAssignedRoles(c.getPolicy()).size();
+            int siteRolesCount = user.getSiteRoles().size();
+            User elevated = ElevatedUser.getElevatedUser(user, Set.of());
+            assertEquals(groupCount, elevated.getGroups().stream().count());
+            assertEquals(roleCount, elevated.getAssignedRoles(c.getPolicy()).size());
+            assertEquals(siteRolesCount, elevated.getSiteRoles().size());
+        }
+
+        private void testPermissions(User user, int roleCount, boolean hasRead, boolean hasInsert, boolean hasUpdate, boolean hasAdmin, boolean hasCanSeeAuditLog)
+        {
+            Container c = JunitUtil.getTestContainer();
+            assertEquals(roleCount, user.getAssignedRoles(c.getPolicy()).size());
+            assertTrue(user.getSiteRoles().isEmpty());
+            assertFalse(user.hasSiteAdminPermission());
+            assertEquals(0, user.getGroups().stream().count());
+            assertFalse(user.hasPrivilegedRole());
+            assertFalse(user.isPlatformDeveloper());
+            assertFalse(user.isInGroup(Group.groupAdministrators));
+            assertFalse(user.isImpersonated());
+            assertNull(user.getImpersonatingUser());
+            assertNull(user.getImpersonationProject());
+            assertFalse(user.isGuest());
+
+            assertEquals(hasRead, c.hasPermission(user, ReadPermission.class));
+            assertEquals(hasInsert, c.hasPermission(user, InsertPermission.class));
+            assertEquals(hasUpdate, c.hasPermission(user, UpdatePermission.class));
+            assertEquals(hasAdmin, c.hasPermission(user, AdminPermission.class));
+            assertEquals(hasCanSeeAuditLog, c.hasPermission(user, CanSeeAuditLogPermission.class));
+        }
     }
 }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3239,7 +3239,7 @@ public class SecurityManager
         Stream<Role> roles = principal.getAssignedRoles(policy).stream()
             .filter(Objects::nonNull);
 
-        if (null != contextualRoles)
+        if (null != contextualRoles && !contextualRoles.isEmpty())
             roles = Stream.concat(roles, contextualRoles.stream());
 
         Stream<Class<? extends Permission>> permissions = roles.flatMap(role -> role.getPermissions().stream());

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -365,12 +365,6 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
         return User.getUserProps(this);
     }
 
-    @Deprecated // Delete
-    public Set<Role> getStandardContextualRoles()
-    {
-        return getSiteRoles();
-    }
-
     public Set<Role> getSiteRoles()
     {
         return _impersonationContext.getSiteRoles(this);

--- a/api/src/org/labkey/api/security/impersonation/WrappedImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/WrappedImpersonationContext.java
@@ -30,10 +30,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 /**
- * Used for when a user is not impersonating another user. That is, they are logged in normally, and operating as
- * themselves. This class can be used to grant a user a contextual role for the duration of a request. This should not
- * be first tool to reach for. It is usually better to find a way to provide the additional contextual roles in a more
- * limited scope.
+ * Do not use this class directly; use ElevatedUser instead.
  */
 public class WrappedImpersonationContext implements ImpersonationContext
 {

--- a/api/src/org/labkey/api/security/impersonation/WrappedImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/WrappedImpersonationContext.java
@@ -37,81 +37,80 @@ import java.util.stream.Stream;
  */
 public class WrappedImpersonationContext implements ImpersonationContext
 {
-    final ImpersonationContext delegate;
-    final Set<Role> additionalRoles;
+    private final ImpersonationContext _delegate;
+    private final Set<Role> _additionalRoles;
 
-    public WrappedImpersonationContext(ImpersonationContext delegate)
+    public WrappedImpersonationContext(ImpersonationContext delegate, Set<Role> additionalRoles)
     {
-        this.delegate = delegate;
-        additionalRoles = Set.of();
+        _delegate = delegate;
+        _additionalRoles = additionalRoles;
     }
 
     public WrappedImpersonationContext(ImpersonationContext delegate, Role additionalRole)
     {
-        this.delegate = delegate;
-        additionalRoles = Set.of(additionalRole);
+        this(delegate, Set.of(additionalRole));
     }
 
     @Override
     public boolean isImpersonating()
     {
-        return delegate.isImpersonating();
+        return _delegate.isImpersonating();
     }
 
     @Override
     @Nullable
     public Container getImpersonationProject()
     {
-        return delegate.getImpersonationProject();
+        return _delegate.getImpersonationProject();
     }
 
     @Override
     public User getAdminUser()
     {
-        return delegate.getAdminUser();
+        return _delegate.getAdminUser();
     }
 
     @Override
     public String getCacheKey()
     {
-        return delegate.getCacheKey();
+        return _delegate.getCacheKey();
     }
 
     @Override
     public ActionURL getReturnURL()
     {
-        return delegate.getReturnURL();
+        return _delegate.getReturnURL();
     }
 
     @Override
     public PrincipalArray getGroups(User user)
     {
-        return delegate.getGroups(user);
+        return _delegate.getGroups(user);
     }
 
     @Override
     public Set<Role> getAssignedRoles(User user, SecurityPolicy policy)
     {
-        Set<Role> ret = new HashSet<>(additionalRoles);
-        ret.addAll(delegate.getAssignedRoles(user, policy));
+        Set<Role> ret = new HashSet<>(_additionalRoles);
+        ret.addAll(_delegate.getAssignedRoles(user, policy));
         return ret;
     }
 
     @Override
     public ImpersonationContextFactory getFactory()
     {
-        return delegate.getFactory();
+        return _delegate.getFactory();
     }
 
     @Override
     public void addMenu(NavTree menu, Container c, User user, ActionURL currentURL)
     {
-        delegate.addMenu(menu, c, user, currentURL);
+        _delegate.addMenu(menu, c, user, currentURL);
     }
 
     @Override
     public Stream<Class<? extends Permission>> filterPermissions(Stream<Class<? extends Permission>> perms)
     {
-        return delegate.filterPermissions(perms);
+        return _delegate.filterPermissions(perms);
     }
 }

--- a/assay/api-src/org/labkey/api/assay/nab/view/RunDetailsAction.java
+++ b/assay/api-src/org/labkey/api/assay/nab/view/RunDetailsAction.java
@@ -47,8 +47,6 @@ import org.labkey.api.view.VBox;
 import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 
-import java.util.Set;
-
 public abstract class RunDetailsAction<FormType extends RenderAssayBean> extends SimpleViewAction<FormType>
 {
     protected int _runRowId;
@@ -87,11 +85,11 @@ public abstract class RunDetailsAction<FormType extends RenderAssayBean> extends
         User elevatedUser = getUser();
         if (!getContainer().hasPermission(getUser(), ReadPermission.class))
         {
-            elevatedUser = ElevatedUser.getElevatedUser(getUser(), Set.of(ReaderRole.class));
+            elevatedUser = ElevatedUser.getElevatedUser(getUser(), ReaderRole.class);
         }
         else if (getUser().equals(run.getCreatedBy()) && !getContainer().hasPermission(getUser(), DeletePermission.class))
         {
-            elevatedUser = ElevatedUser.getElevatedUser(getUser(), Set.of(EditorRole.class));
+            elevatedUser = ElevatedUser.getElevatedUser(getUser(), EditorRole.class);
         }
 
         try

--- a/assay/api-src/org/labkey/api/assay/nab/view/RunDetailsAction.java
+++ b/assay/api-src/org/labkey/api/assay/nab/view/RunDetailsAction.java
@@ -30,7 +30,7 @@ import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
-import org.labkey.api.security.LimitedUser;
+import org.labkey.api.security.ElevatedUser;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.ReadPermission;
@@ -87,11 +87,11 @@ public abstract class RunDetailsAction<FormType extends RenderAssayBean> extends
         User elevatedUser = getUser();
         if (!getContainer().hasPermission(getUser(), ReadPermission.class))
         {
-            elevatedUser = LimitedUser.getElevatedUser(getUser(), Set.of(ReaderRole.class));
+            elevatedUser = ElevatedUser.getElevatedUser(getUser(), Set.of(ReaderRole.class));
         }
         else if (getUser().equals(run.getCreatedBy()) && !getContainer().hasPermission(getUser(), DeletePermission.class))
         {
-            elevatedUser = LimitedUser.getElevatedUser(getUser(), Set.of(EditorRole.class));
+            elevatedUser = ElevatedUser.getElevatedUser(getUser(), Set.of(EditorRole.class));
         }
 
         try

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -101,7 +101,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.security.LimitedUser;
+import org.labkey.api.security.ElevatedUser;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AssayReadPermission;
@@ -1549,7 +1549,7 @@ public class AssayController extends SpringActionController
                 if (form.getRuns().size() == 1)
                 {
                     // construct the audit log query view
-                    User user = LimitedUser.getCanSeeAuditLogUser(getContainer(), getUser());
+                    User user = ElevatedUser.getCanSeeAuditLogUser(getContainer(), getUser());
                     UserSchema schema = AuditLogService.getAuditLogSchema(user, getContainer());
                     ExpRun run = ExperimentService.get().getExpRun(form.getRuns().stream().findFirst().get());
                     if (run != null && schema != null)

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1549,7 +1549,7 @@ public class AssayController extends SpringActionController
                 if (form.getRuns().size() == 1)
                 {
                     // construct the audit log query view
-                    User user = ElevatedUser.getCanSeeAuditLogUser(getContainer(), getUser());
+                    User user = ElevatedUser.ensureCanSeeAuditLogRole(getContainer(), getUser());
                     UserSchema schema = AuditLogService.getAuditLogSchema(user, getContainer());
                     ExpRun run = ExperimentService.get().getExpRun(form.getRuns().stream().findFirst().get());
                     if (run != null && schema != null)

--- a/audit/src/org/labkey/audit/AuditController.java
+++ b/audit/src/org/labkey/audit/AuditController.java
@@ -42,7 +42,7 @@ import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryUrls;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.security.LimitedUser;
+import org.labkey.api.security.ElevatedUser;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
@@ -381,7 +381,7 @@ public class AuditController extends SpringActionController
         {
             List<Integer> rowIds;
             if (form.isSampleType())
-                rowIds = AuditLogImpl.get().getTransactionSampleIds(form.getTransactionAuditId(), LimitedUser.getCanSeeAuditLogUser(getContainer(), getUser()), getContainer());
+                rowIds = AuditLogImpl.get().getTransactionSampleIds(form.getTransactionAuditId(), ElevatedUser.getCanSeeAuditLogUser(getContainer(), getUser()), getContainer());
             else
                 rowIds = AuditLogImpl.get().getTransactionSourceIds(form.getTransactionAuditId(), getUser(), getContainer());
 

--- a/audit/src/org/labkey/audit/AuditController.java
+++ b/audit/src/org/labkey/audit/AuditController.java
@@ -381,7 +381,7 @@ public class AuditController extends SpringActionController
         {
             List<Integer> rowIds;
             if (form.isSampleType())
-                rowIds = AuditLogImpl.get().getTransactionSampleIds(form.getTransactionAuditId(), ElevatedUser.getCanSeeAuditLogUser(getContainer(), getUser()), getContainer());
+                rowIds = AuditLogImpl.get().getTransactionSampleIds(form.getTransactionAuditId(), ElevatedUser.ensureCanSeeAuditLogRole(getContainer(), getUser()), getContainer());
             else
                 rowIds = AuditLogImpl.get().getTransactionSourceIds(form.getTransactionAuditId(), getUser(), getContainer());
 

--- a/issues/src/org/labkey/issue/IssueServiceImpl.java
+++ b/issues/src/org/labkey/issue/IssueServiceImpl.java
@@ -301,7 +301,7 @@ public class IssueServiceImpl implements IssueService
         if (relatedContainer == null)
             relatedContainer = container;
 
-        return ElevatedUser.getElevatedUser(relatedContainer, user, Pair.of(UpdatePermission.class, EditorRole.class));
+        return ElevatedUser.ensureContextualRoles(relatedContainer, user, Pair.of(UpdatePermission.class, EditorRole.class));
     }
 
     @Nullable

--- a/issues/src/org/labkey/issue/IssueServiceImpl.java
+++ b/issues/src/org/labkey/issue/IssueServiceImpl.java
@@ -10,7 +10,7 @@ import org.labkey.api.data.ObjectFactory;
 import org.labkey.api.issues.Issue;
 import org.labkey.api.issues.IssueService;
 import org.labkey.api.issues.IssuesSchema;
-import org.labkey.api.security.LimitedUser;
+import org.labkey.api.security.ElevatedUser;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.ReadPermission;
@@ -301,7 +301,7 @@ public class IssueServiceImpl implements IssueService
         if (relatedContainer == null)
             relatedContainer = container;
 
-        return LimitedUser.getElevatedUser(relatedContainer, user, Pair.of(UpdatePermission.class, EditorRole.class));
+        return ElevatedUser.getElevatedUser(relatedContainer, user, Pair.of(UpdatePermission.class, EditorRole.class));
     }
 
     @Nullable

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -51,7 +51,7 @@ import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.DataLoader;
-import org.labkey.api.security.LimitedUser;
+import org.labkey.api.security.ElevatedUser;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.UpdatePermission;
@@ -178,7 +178,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         {
             // if the list is a picklist and you have permission to manage picklists, that equates
             // to having editor permission.
-            return LimitedUser.getElevatedUser(container, user, Pair.of(DeletePermission.class, EditorRole.class));
+            return ElevatedUser.getElevatedUser(container, user, Pair.of(DeletePermission.class, EditorRole.class));
         }
         return user;
     }

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -178,7 +178,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
         {
             // if the list is a picklist and you have permission to manage picklists, that equates
             // to having editor permission.
-            return ElevatedUser.getElevatedUser(container, user, Pair.of(DeletePermission.class, EditorRole.class));
+            return ElevatedUser.ensureContextualRoles(container, user, Pair.of(DeletePermission.class, EditorRole.class));
         }
         return user;
     }

--- a/pipeline/src/org/labkey/pipeline/PipelineWebdavProvider.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineWebdavProvider.java
@@ -118,7 +118,7 @@ public class PipelineWebdavProvider implements WebdavService.Provider
         @Override
         protected boolean hasAccess(User user)
         {
-            return user.hasRootPermission(AdminOperationsPermission.class) || SecurityManager.getPermissions(c.getPolicy(), user, Set.of()).size() > 0;
+            return user.hasRootPermission(AdminOperationsPermission.class) || !SecurityManager.getPermissions(c.getPolicy(), user, Set.of()).isEmpty();
         }
 
         @Override

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -73,7 +73,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reports.model.ViewCategoryManager;
-import org.labkey.api.security.LimitedUser;
+import org.labkey.api.security.ElevatedUser;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.InsertPermission;
@@ -439,7 +439,7 @@ public class StudyPublishManager implements StudyPublishService
             {
                 // we allow linking data to a study even if the study security is set to read-only datasets, since the
                 // underlying insert uses the QUS, we add a contextual role to allow the insert to succeed
-                user = LimitedUser.getElevatedUser(user, Set.of(FolderAdminRole.class));
+                user = ElevatedUser.getElevatedUser(user, Set.of(FolderAdminRole.class));
             }
             datasetLsids = StudyManager.getInstance().importDatasetData(user, dataset, convertedDataMaps, validationException, DatasetDefinition.CheckForDuplicates.sourceAndDestination, defaultQCState, null, false, false);
             StudyManager.getInstance().batchValidateExceptionToList(validationException, errors);

--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -439,7 +439,7 @@ public class StudyPublishManager implements StudyPublishService
             {
                 // we allow linking data to a study even if the study security is set to read-only datasets, since the
                 // underlying insert uses the QUS, we add a contextual role to allow the insert to succeed
-                user = ElevatedUser.getElevatedUser(user, Set.of(FolderAdminRole.class));
+                user = ElevatedUser.getElevatedUser(user, FolderAdminRole.class);
             }
             datasetLsids = StudyManager.getInstance().importDatasetData(user, dataset, convertedDataMaps, validationException, DatasetDefinition.CheckForDuplicates.sourceAndDestination, defaultQCState, null, false, false);
             StudyManager.getInstance().batchValidateExceptionToList(validationException, errors);


### PR DESCRIPTION
#### Rationale
Creating a fake user with strictly limited permissions and augmenting a real user's permissions with contextual roles are very different actions that deserve separate (but related) classes. They also deserve junit tests. New class `ElevatedUser` effectively wraps a user to correctly convey its underlying groups, impersonation status, roles, etc. Both classes now dictate the new user's security properties by setting `ImpersonationContext`, which is preferred vs. overriding `User` methods. ElevatedUser leverages existing class `WrappedImpersonationContext`, reconciling what were two separate approaches to escalating permissions.

This fixes `BiologicsManagerTest`, which was failing because SeqPart cache loading expected wrapping one `LimitedUser` with another to work.

Note: Deprecated "elevate user" methods in `LimitedUser` are left temporarily to decouple PRs in multiple repos. These will be removed shortly.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4865