### PR TITLE
Fix issues with displaying delete summary for SQLServer

### DIFF
--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -779,7 +779,7 @@ public class ExperimentModule extends SpringModule
         Map<String, Object> tsSamplesResults = new TableSelector(sampleTypeTable, sampleTypeTable.getColumns("Name,SampleCount"), null, null).getValueMap();
         for (String k : tsSamplesResults.keySet())
         {
-            int count = ((Long) tsSamplesResults.get(k)).intValue();
+            int count = ((Number) tsSamplesResults.get(k)).intValue();
             if (count != 0)
             {
                 Summary s = k.equals("MixtureBatches")


### PR DESCRIPTION
#### Rationale
SQLServer apparently returns an integer instead of a long for this query, so we'll cast to a Number before converting to the intValue


#### Changes
* Cast to a Number; don't assume a Long
