### PR TITLE
Set Weak password rule on existing servers that never changed the def…

### DIFF
--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 23.008
+SchemaVersion: 23.009
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/prop-23.008-23.009.sql
+++ b/core/resources/schemas/dbscripts/postgresql/prop-23.008-23.009.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('saveNullStrengthAsWeak');

--- a/core/resources/schemas/dbscripts/sqlserver/prop-23.008-23.009.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/prop-23.008-23.009.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'saveNullStrengthAsWeak';

--- a/core/src/org/labkey/core/login/DbLoginManager.java
+++ b/core/src/org/labkey/core/login/DbLoginManager.java
@@ -170,7 +170,7 @@ public class DbLoginManager implements DbLoginService
         }
     }
 
-    static @NotNull Map<String, String> getProperties()
+    public static @NotNull Map<String, String> getProperties()
     {
         return PropertyManager.getProperties(DATABASE_AUTHENTICATION_CATEGORY_KEY);
     }


### PR DESCRIPTION
…ault

#### Rationale
We intended to switch the database authentication default strength to "Strong" for new installations and leave existing installations with whatever value was set before. However, we didn't anticipate the case of existing servers that had never saved a strength setting; these servers would see their strength switched to "Strong" as well, which was not the intent. This upgrade code explicitly saves "Weak" strength on existing servers that don't have a saved setting. It also logs what it's doing during this upgrade process.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4707