### PR TITLE
Adjust password strength gauge and add guidance

### DIFF
--- a/api/src/org/labkey/api/security/DbLoginService.java
+++ b/api/src/org/labkey/api/security/DbLoginService.java
@@ -21,5 +21,11 @@ public interface DbLoginService
         return ServiceRegistry.get().getService(DbLoginService.class);
     }
 
-    AuthenticationResult attemptSetPassword(Container c, User currentUser, String rawPassword, String rawPassword2, HttpServletRequest request, ValidEmail email, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, BindException errors) throws InvalidEmailException;
+    @Deprecated // Call the variant that takes a changeOperation parameter
+    default AuthenticationResult attemptSetPassword(Container c, User currentUser, String rawPassword, String rawPassword2, HttpServletRequest request, ValidEmail email, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, BindException errors) throws InvalidEmailException
+    {
+        return attemptSetPassword(c, currentUser, rawPassword, rawPassword2, request, email, returnUrlHelper, auditMessage, clearVerification, false, errors);
+    }
+
+    AuthenticationResult attemptSetPassword(Container c, User currentUser, String rawPassword, String rawPassword2, HttpServletRequest request, ValidEmail email, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, boolean changeOperation, BindException errors) throws InvalidEmailException;
 }

--- a/api/src/org/labkey/api/security/EntropyPasswordValidator.java
+++ b/api/src/org/labkey/api/security/EntropyPasswordValidator.java
@@ -19,7 +19,7 @@ public abstract class EntropyPasswordValidator implements PasswordValidator
 
     protected int getCharacterCountEstimate()
     {
-        return (int)Math.ceil(getRequiredBitsOfEntropy() / (Math.log(26) / BASE2_LOG));
+        return (int)Math.ceil(getRequiredBitsOfEntropy() / (Math.log(52) / BASE2_LOG));
     }
 
     @Override

--- a/api/src/org/labkey/api/security/PasswordRule.java
+++ b/api/src/org/labkey/api/security/PasswordRule.java
@@ -70,21 +70,23 @@ public enum PasswordRule
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean isValidToStore(String password1, String password2, User user, @NotNull Collection<String> messages)
     {
-        if (StringUtils.isBlank(password1) || StringUtils.isBlank(password2))
+        if (StringUtils.isBlank(password1))
         {
-            messages.add("You must enter a password.");
-            return false;
-        }
-
-        if (StringUtils.isBlank(password1) || StringUtils.isBlank(password2))
-        {
-            messages.add("You must enter your password twice.");
+            messages.add("You must enter a new password.");
             return false;
         }
 
         if (!password1.equals(password2))
         {
-            messages.add("Your password entries didn't match.");
+            if (StringUtils.isBlank(password2))
+            {
+                messages.add("You must confirm your password.");
+            }
+            else
+            {
+                messages.add("Your password entries didn't match.");
+            }
+
             return false;
         }
 

--- a/api/src/org/labkey/api/security/PasswordRule.java
+++ b/api/src/org/labkey/api/security/PasswordRule.java
@@ -68,11 +68,11 @@ public enum PasswordRule
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    public boolean isValidToStore(String password1, String password2, User user, @NotNull Collection<String> messages)
+    public boolean isValidToStore(String password1, String password2, User user, boolean changeOperation, @NotNull Collection<String> messages)
     {
         if (StringUtils.isBlank(password1))
         {
-            messages.add("You must enter a new password.");
+            messages.add("You must enter a " + (changeOperation ? "new " : "") + "password.");
             return false;
         }
 

--- a/api/src/org/labkey/api/security/StrongPasswordValidator.java
+++ b/api/src/org/labkey/api/security/StrongPasswordValidator.java
@@ -3,11 +3,15 @@ package org.labkey.api.security;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.util.DOM;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
+import org.labkey.api.util.Link.LinkBuilder;
+
+import static org.labkey.api.util.DOM.DIV;
+import static org.labkey.api.util.DOM.id;
 
 public class StrongPasswordValidator extends EntropyPasswordValidator
 {
     private final HtmlString _fullRuleHtml;
-    private final HtmlString _summaryRuleHtml;
 
     public StrongPasswordValidator()
     {
@@ -16,16 +20,13 @@ public class StrongPasswordValidator extends EntropyPasswordValidator
                 DOM.LI("Evaluate passwords using a modern scoring approach based on entropy, a measure of the password's " +
                     "inherent randomness. Long passwords that use multiple character types (upper case, lower case, digits, " +
                     "symbols) result in higher scores. Repeated characters, repeated sequences, trivial sequences, and personal " +
-                    "information result in lower scores since they are easier to guess."),
-//                    "A visual gauge shows the strength of the " +
-//                    "characters entered so far, encouraging users to choose strong passwords."),
+                    "information result in lower scores since they are easier to guess. A visual gauge shows the strength of the " +
+                    "characters entered so far, encouraging users to choose strong passwords."),
                 DOM.LI("This option requires " + getRequiredBitsOfEntropy() + " bits of entropy, which typically requires " +
                     getCharacterCountEstimate() + " or more characters without any easy-to-guess sequences."),
                 PREVIOUS_PASSWORD_BULLET
             )
         ));
-
-        _summaryRuleHtml = HtmlString.of("Your password should be long and use multiple character types.");
     }
 
     @Override
@@ -40,9 +41,38 @@ public class StrongPasswordValidator extends EntropyPasswordValidator
         return _fullRuleHtml;
     }
 
+    private final HtmlString _intro = HtmlStringBuilder.of()
+        .append("Secure passwords are long and use multiple character types. The password strength gauge will turn green when your new password meets the complexity requirements.")
+        .append(HtmlString.BR)
+        .getHtmlString();
+
+    private final HtmlString _tips = DOM.createHtml(DOM.createHtmlFragment(
+        DIV(id("passwordTips").at(DOM.Attribute.style, "display:none;"),
+            DOM.UL(
+                DOM.LI("Use " + getCharacterCountEstimate() + " characters or more"),
+                DOM.LI("Include upper- and lower-case letters"),
+                DOM.LI("Include symbols and numbers"),
+                DOM.LI("Avoid repeated characters and sequences, personal information (email, name), and common sequences (\"abc\", \"123\")")
+            ),
+            "We recommend using a password manager to generate a unique password for every website."
+        )
+    ));
+
     @Override
     public @NotNull HtmlString getSummaryRuleHtml()
     {
-        return _summaryRuleHtml;
+        // We have to regenerate the link on every request because of per-page handling of the onClick event for CSP purposes
+        String onClick = """
+            const tips = document.getElementById('passwordTips');
+            if (tips) tips.style.display = (tips.style.display === 'none' ? 'block' : 'none');
+            const tipsLink = document.getElementById('tipsLink');
+            if (tipsLink) tipsLink.text = (tipsLink.text = (tipsLink.text.includes('show') ? 'Click to hide' : 'Click to show') + ' tips for creating a secure password');
+            """;
+
+        LinkBuilder builder = new LinkBuilder("Click to show tips for creating a secure password").id("tipsLink").onClick(onClick).clearClasses();
+        return HtmlStringBuilder.of(_intro)
+            .append(builder.getHtmlString())
+            .append(_tips)
+            .getHtmlString();
     }
 }

--- a/core/src/org/labkey/core/login/DbLoginManager.java
+++ b/core/src/org/labkey/core/login/DbLoginManager.java
@@ -76,7 +76,7 @@ public class DbLoginManager implements DbLoginService
     static final String DATABASE_AUTHENTICATION_CATEGORY_KEY = "DatabaseAuthentication";
 
     @Override
-    public AuthenticationResult attemptSetPassword(Container c, User currentUser, String rawPassword, String rawPassword2, HttpServletRequest request, ValidEmail email, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, BindException errors) throws InvalidEmailException
+    public AuthenticationResult attemptSetPassword(Container c, User currentUser, String rawPassword, String rawPassword2, HttpServletRequest request, ValidEmail email, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, boolean changeOperation, BindException errors) throws InvalidEmailException
     {
         String password = StringUtils.trimToEmpty(rawPassword);
         String password2 = StringUtils.trimToEmpty(rawPassword2);
@@ -84,7 +84,7 @@ public class DbLoginManager implements DbLoginService
         Collection<String> messages = new LinkedList<>();
         User user = UserManager.getUser(email);
 
-        if (!getPasswordRule().isValidToStore(password, password2, user, messages))
+        if (!getPasswordRule().isValidToStore(password, password2, user, changeOperation, messages))
         {
             for (String message : messages)
                 errors.reject("setPassword", message);

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1668,8 +1668,9 @@ public class LoginController extends SpringActionController
     private AuthenticationResult attemptSetPassword(ValidEmail email, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, BindException errors) throws InvalidEmailException
     {
         HttpServletRequest request = getViewContext().getRequest();
+        boolean changeOperation = StringUtils.startsWithIgnoreCase(auditMessage, "change");
 
-        return DbLoginService.get().attemptSetPassword(getContainer(), getUser(), request.getParameter("password"), request.getParameter("password2"), request, email, returnUrlHelper, auditMessage, clearVerification, errors);
+        return DbLoginService.get().attemptSetPassword(getContainer(), getUser(), request.getParameter("password"), request.getParameter("password2"), request, email, returnUrlHelper, auditMessage, clearVerification, changeOperation, errors);
     }
 
     @RequiresNoPermission

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -43,7 +43,7 @@
     SetPasswordBean bean = ((JspView<SetPasswordBean>)HttpView.currentView()).getModelBean();
     String errors = formatMissedErrorsStr("form");
     int gaugeWidth = 350;
-    int gaugeHeight = 40;
+    int gaugeHeight = 30;
     String firstPasswordId = null;
     PasswordRule rule = DbLoginManager.getPasswordRule();
 %>
@@ -82,10 +82,10 @@
 
             for (NamedObject input : bean.passwordInputs) {
                 boolean firstPassword = LoginController.PASSWORD1_TEXT_FIELD_NAME.equals(input.getObject());
-                HtmlString contextContent = firstPassword ? rule.getSummaryRuleHtml() : null;
+                HtmlString contextContent = firstPassword ? rule.getSummaryRuleHtml() : HtmlString.EMPTY_STRING;
         %>
             <p>
-                <%=h(contextContent)%>
+                <%=contextContent%>
             </p>
             <label for="<%=h(input.getObject().toString())%>">
                 <%=h(input.getName())%>
@@ -223,7 +223,7 @@
                     // Render text
                     ctx.fillStyle = 2 === colorIndex ? "white" : showPlaceholderText ? "gray" : "black";
                     const textIndex = Math.floor(percent * 6);
-                    const text = showPlaceholderText ?  "Password Guidance" : ["Very Weak", "Very Weak", "Weak", "Weak", "Strong", "Very Strong"][textIndex];
+                    const text = showPlaceholderText ?  "Password Strength Gauge" : ["Very Weak", "Very Weak", "Weak", "Weak", "Strong", "Very Strong"][textIndex];
                     ctx.fillText(text, centerX, centerY + textHeightFix);
                     canvas.text = "Password Strength: " + text;
                 })

--- a/core/src/org/labkey/core/wiki/HtmlRenderer.java
+++ b/core/src/org/labkey/core/wiki/HtmlRenderer.java
@@ -203,7 +203,7 @@ public class HtmlRenderer implements WikiRenderer
             String bodyHtml = PageFlowUtil.convertNodeToHtml(bodyNode);
 
             // Issue 12160: if there were any link decoding exceptions, replace the link with the error message
-            if (linkExceptions.size() > 0)
+            if (!linkExceptions.isEmpty())
             {
                 for (Map.Entry<Element, String> link : linkExceptions.entrySet())
                 {
@@ -212,7 +212,8 @@ public class HtmlRenderer implements WikiRenderer
                 }
             }
 
-            innerHtml.append(bodyHtml, "<body>".length(), bodyHtml.length()-"</body>".length());
+            assert bodyHtml.startsWith("<body") && bodyHtml.endsWith("</body>") : "bodyHtml did not start with \"<body\" and end with \"</body>\"";
+            innerHtml.append(bodyHtml, bodyHtml.indexOf('>') + 1, bodyHtml.length()-"</body>".length());
         }
         catch (Exception e)
         {


### PR DESCRIPTION
#### Rationale
Tweak styling and guidance on the set/change password page, per discussion in the spec. Reduce the height of the Password Strength Gauge and offer a pop-down panel with password tips.

![image](https://github.com/LabKey/platform/assets/5107383/b39fb7f9-cdd3-4279-b500-1f1b87f46ab0)

Separately, the latest jsoup upgrade (1.16.2) (https://github.com/LabKey/server/pull/611) began adding a namespace to the `<body>` element. We don't really care, because our wiki renderer strips off the body tag, but we need to generalize the stripping code to accommodate, otherwise HTML wikis will all look like this:

![image](https://github.com/LabKey/platform/assets/5107383/cbda62a0-4eac-4b0e-aece-153d2484e737)
