### PR TITLE
document write

### DIFF
--- a/core/webapp/labkey.js
+++ b/core/webapp/labkey.js
@@ -741,34 +741,27 @@ if (typeof LABKEY == "undefined")
                 scriptCache.callbacksOnCache(file);
             };
 
-            if (configs.isDocumentClosed || callback)
-            {
-                //create a new script element and append it to the head element
-                var script = addElemToHead("script", {
-                    src: src,
-                    type: "text/javascript"
-                });
+            //create a new script element and append it to the head element
+            var script = addElemToHead("script", {
+                src: src,
+                type: "text/javascript"
+            });
 
-                // IE has a different way of handling <script> loads
-                if (script.readyState)
-                {
-                    script.onreadystatechange = function() {
-                        if (script.readyState == "loaded" || script.readyState == "complete") {
-                            script.onreadystatechange = null;
-                            cacheLoader();
-                        }
-                    };
-                }
-                else
-                {
-                    script.onload = cacheLoader;
-                }
+            // IE has a different way of handling <script> loads
+            if (script.readyState)
+            {
+                script.onreadystatechange = function() {
+                    if (script.readyState === "loaded" || script.readyState === "complete") {
+                        script.onreadystatechange = null;
+                        cacheLoader();
+                    }
+                };
             }
             else
             {
-                document.write('\n<script type="text/javascript" src="' + src + '"></script>\n');
-                cacheLoader();
+                script.onload = cacheLoader;
             }
+
         };
 
         var requiresVisualization = function(callback, scope)

--- a/core/webapp/labkey.js
+++ b/core/webapp/labkey.js
@@ -728,11 +728,6 @@ if (typeof LABKEY == "undefined")
                 scriptCache.loadCache(file, callback, scope);
             }
 
-            // although FireFox and Safari allow scripts to use the DOM
-            // during parse time, IE does not. So if the document is
-            // closed, use the DOM to create a script element and append it
-            // to the head element. Otherwise (still parsing), use document.write()
-
             // Support both LabKey and external JavaScript files
             var src = file.substr(0, 4) != "http" ? configs.contextPath + "/" + file + '?' + configs.hash : file;
 
@@ -741,27 +736,13 @@ if (typeof LABKEY == "undefined")
                 scriptCache.callbacksOnCache(file);
             };
 
-            //create a new script element and append it to the head element
-            var script = addElemToHead("script", {
+            // create a new script element and append it to the head element
+            var script = addElemToHead('script', {
                 src: src,
-                type: "text/javascript"
+                type: 'text/javascript',
             });
 
-            // IE has a different way of handling <script> loads
-            if (script.readyState)
-            {
-                script.onreadystatechange = function() {
-                    if (script.readyState === "loaded" || script.readyState === "complete") {
-                        script.onreadystatechange = null;
-                        cacheLoader();
-                    }
-                };
-            }
-            else
-            {
-                script.onload = cacheLoader;
-            }
-
+            script.onload = cacheLoader;
         };
 
         var requiresVisualization = function(callback, scope)

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -952,8 +952,7 @@ public class StudyController extends BaseStudyController
             if (status != null)
             {
                 // inject the dataset status marker class, but it is up to the client to style the page accordingly
-                String statusCls = "labkey-dataset-status-" + PageFlowUtil.filter(status.toLowerCase());
-                HtmlView scriptLock = new HtmlView("<script type=\"text/javascript\">(function($) { $(LABKEY.DataRegions['Dataset'].form).addClass(" + PageFlowUtil.jsString(statusCls) + "); })(jQuery);</script>");
+                HtmlView scriptLock = new HtmlView(HtmlString.unsafe("<script type=\"text/javascript\" nonce=\"" + PageFlowUtil.filter(HttpView.currentPageConfig().getScriptNonce()) + "\">(function($) { $(LABKEY.DataRegions['Dataset'].form).addClass(" + PageFlowUtil.jsString("labkey-dataset-status-" + status.toLowerCase()) + "); })(jQuery);</script>"));
                 view.addView(scriptLock);
             }
 


### PR DESCRIPTION
#### Rationale
The document.write() version of requiresScript() triggers "unsafe-inline".  Can we always use the addElemToHead() code path?

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
