### PR TITLE
Remove unused elevation methods from LimitedUser

### DIFF
--- a/api/src/org/labkey/api/security/ClonedUser.java
+++ b/api/src/org/labkey/api/security/ClonedUser.java
@@ -4,10 +4,12 @@ import org.labkey.api.security.impersonation.ImpersonationContext;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public abstract class ClonedUser extends User
 {
@@ -26,11 +28,25 @@ public abstract class ClonedUser extends User
         setImpersonationContext(ctx);
     }
 
-    protected static Set<Role> getRoles(Collection<Class<? extends Role>> rolesToAdd)
+    // Map a stream of role classes to a set of roles
+    protected static Set<Role> getRoles(Stream<Class<? extends Role>> roleClassStream)
     {
-        return rolesToAdd.stream()
+        return roleClassStream
+            .filter(Objects::nonNull)
             .map(RoleManager::getRole)
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
+    }
+
+    // Map a collection of role classes to a set of roles
+    protected static Set<Role> getRoles(Collection<Class<? extends Role>> roleClassCollection)
+    {
+        return getRoles(roleClassCollection.stream());
+    }
+
+    // Map an array of role classes to a set of roles
+    protected static Set<Role> getRoles(Class<? extends Role>[] roleClassArray)
+    {
+        return getRoles(Arrays.stream(roleClassArray));
     }
 }

--- a/api/src/org/labkey/api/security/ElevatedUser.java
+++ b/api/src/org/labkey/api/security/ElevatedUser.java
@@ -10,7 +10,6 @@ import org.labkey.api.util.Pair;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -22,26 +21,26 @@ import java.util.stream.Collectors;
  */
 public class ElevatedUser extends ClonedUser
 {
-    private ElevatedUser(User user, Collection<Class<? extends Role>> rolesToAdd)
+    private ElevatedUser(User user, Set<Role> rolesToAdd)
     {
-        super(user, new WrappedImpersonationContext(user.getImpersonationContext(), getRoles(rolesToAdd)));
+        super(user, new WrappedImpersonationContext(user.getImpersonationContext(), rolesToAdd));
     }
 
     /**
      * Wrap the supplied user and unconditionally add the supplied role(s). Always returns an ElevatedUser.
      */
     @SafeVarargs
-    public static ElevatedUser getElevatedUser(User user, Class<? extends Role>... rolesToAdd)
+    public static ElevatedUser getElevatedUser(User user, Class<? extends Role>... roleClassesToAdd)
     {
-        return new ElevatedUser(user, Arrays.stream(rolesToAdd).filter(Objects::nonNull).collect(Collectors.toSet()));
+        return new ElevatedUser(user, getRoles(roleClassesToAdd));
     }
 
     /**
      * Wrap the supplied user and unconditionally add the supplied role(s). Always returns an ElevatedUser.
      */
-    public static ElevatedUser getElevatedUser(User user, Collection<Class<? extends Role>> rolesToAdd)
+    public static ElevatedUser getElevatedUser(User user, Collection<Class<? extends Role>> roleClassesToAdd)
     {
-        return new ElevatedUser(user, rolesToAdd);
+        return new ElevatedUser(user, getRoles(roleClassesToAdd));
     }
 
     /**
@@ -61,7 +60,7 @@ public class ElevatedUser extends ClonedUser
     }
 
     /**
-     * Ensure the supplied user can read the audit log
+     * Ensure the supplied user can read the audit log in all containers
      */
     public static User ensureCanSeeAuditLogRole(Container container, User user)
     {


### PR DESCRIPTION
#### Rationale
We can remove these unused methods. Also a good time to reconcile two code paths that were mapping role classes to roles. And add another test case.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4876