### PR TITLE
Issue 48908: Fix moving assays between project from filtered grid

### DIFF
--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -121,6 +121,7 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.ResponseHelper;
 import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.DataViewSnapshotSelectionForm;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
@@ -1698,11 +1699,11 @@ public class AssayController extends SpringActionController
 
     @Marshal(Marshaller.Jackson)
     @RequiresPermission(ReadPermission.class)
-    public static class GetAssayRunDeletionConfirmationDataAction extends ReadOnlyApiAction<OperationConfirmationForm>
+    public static class GetAssayRunDeletionConfirmationDataAction extends ReadOnlyApiAction<DataViewSnapshotSelectionForm>
     {
 
         @Override
-        public Object execute(OperationConfirmationForm form, BindException errors) throws Exception
+        public Object execute(DataViewSnapshotSelectionForm form, BindException errors) throws Exception
         {
             Collection<Integer> permittedIds = form.getIds(false);
 
@@ -1713,37 +1714,6 @@ public class AssayController extends SpringActionController
             permittedIds.removeAll(notPermittedIds);
             return success(Map.of("allowed", permittedIds, "notAllowed", notPermittedIds));
 
-        }
-    }
-
-    public static class OperationConfirmationForm extends ViewForm
-    {
-        private String _dataRegionSelectionKey;
-        private Set<Integer> _rowIds;
-
-        public String getDataRegionSelectionKey()
-        {
-            return _dataRegionSelectionKey;
-        }
-
-        public void setDataRegionSelectionKey(String dataRegionSelectionKey)
-        {
-            _dataRegionSelectionKey = dataRegionSelectionKey;
-        }
-
-        public Set<Integer> getRowIds()
-        {
-            return _rowIds;
-        }
-
-        public void setRowIds(Set<Integer> rowIds)
-        {
-            _rowIds = rowIds;
-        }
-
-        public Set<Integer> getIds(boolean clear)
-        {
-            return (_rowIds != null) ? _rowIds : DataRegionSelection.getSelectedIntegers(getViewContext(), getDataRegionSelectionKey(), clear);
         }
     }
 }


### PR DESCRIPTION
#### Rationale
Issue [48908](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48908)

#### Related Pull Requests

- https://github.com/LabKey/sampleManagement/pull/2202


#### Changes
* Use `DataViewSnapshotSelectionForm` for `GetAssayRunDeletionConfirmationDataAction`, which supports `useSnapshotSelection`.
