### PR TITLE
Issue 49002: Fixing up file paths fails SQLFragment validation w/ provisioned table File column

### DIFF
--- a/experiment/src/org/labkey/experiment/FileLinkFileListener.java
+++ b/experiment/src/org/labkey/experiment/FileLinkFileListener.java
@@ -268,7 +268,7 @@ public class FileLinkFileListener implements FileListener
         frag.append("  )\n");
 
         hardTableFileLinkColumns((schema, table, pathColumn, containerId) -> {
-            SQLFragment containerFrag = new SQLFragment("'").append(containerId).append("'");
+            SQLFragment containerFrag = new SQLFragment("?", containerId);
             TableUpdaterFileListener updater = new TableUpdaterFileListener(table, pathColumn.getColumnName(), TableUpdaterFileListener.Type.filePath, null, containerFrag);
             frag.append("UNION\n");
             frag.append(updater.listFilesQuery());


### PR DESCRIPTION
#### Rationale
This codepath safely generates SQL, but is failing the new stricter SQLFragment validation.

#### Changes
* Use a JDBC parameter instead of quoting value ourself