### PR TITLE
Capture JMS queue type metric. Remove defunct enterprise pipeline metric

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineService.java
+++ b/api/src/org/labkey/api/pipeline/PipelineService.java
@@ -131,6 +131,11 @@ public interface PipelineService extends PipelineStatusFile.StatusReader, Pipeli
 
     boolean isEnterprisePipeline();
 
+    enum JmsType { none, inProcess, external, unknown }
+    @NotNull
+    JmsType getJmsType();
+
+
     @NotNull
     PipelineQueue getPipelineQueue();
 

--- a/api/src/org/labkey/api/util/MothershipReport.java
+++ b/api/src/org/labkey/api/util/MothershipReport.java
@@ -440,7 +440,6 @@ public class MothershipReport implements Runnable
     {
         addParam("runtimeOS", System.getProperty("os.name"));
         addParam("javaVersion", System.getProperty("java.version"));
-        addParam("enterprisePipelineEnabled", PipelineService.get() != null && PipelineService.get().isEnterprisePipeline());
 
         addParam("heapSize", ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax() / 1024 / 1024);
 

--- a/mothership/resources/schemas/dbscripts/postgresql/mothership-23.001-23.002.sql
+++ b/mothership/resources/schemas/dbscripts/postgresql/mothership-23.001-23.002.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE mothership.ServerSession DROP COLUMN EnterprisePipelineEnabled;

--- a/mothership/resources/schemas/mothership.xml
+++ b/mothership/resources/schemas/mothership.xml
@@ -135,7 +135,6 @@
             </column>
             <column columnName="RuntimeOS"/>
             <column columnName="JavaVersion"/>
-            <column columnName="EnterprisePipelineEnabled"/>
             <column columnName="UserCount"/>
             <column columnName="RecentUserCount"/>
             <column columnName="ProjectCount"/>

--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -934,7 +934,6 @@ public class MothershipController extends SpringActionController
         private Integer _containerCount;
         private Integer _heapSize;
         private String _administratorEmail;
-        private boolean _enterprisePipelineEnabled;
         private String _servletContainer;
         private String _description;
         private String _distribution;
@@ -1284,7 +1283,6 @@ public class MothershipController extends SpringActionController
             session.setProjectCount(getProjectCount());
             session.setContainerCount(getContainerCount());
             session.setAdministratorEmail(getAdministratorEmail());
-            session.setEnterprisePipelineEnabled(isEnterprisePipelineEnabled());
             session.setHeapSize(getHeapSize());
             session.setServletContainer(getServletContainer());
             session.setDistribution(getDistribution());
@@ -1293,16 +1291,6 @@ public class MothershipController extends SpringActionController
             session.setJsonMetrics(getJsonMetrics());
 
             return new Pair<>(session, release);
-        }
-
-        public boolean isEnterprisePipelineEnabled()
-        {
-            return _enterprisePipelineEnabled;
-        }
-
-        public void setEnterprisePipelineEnabled(boolean enterprisePipelineEnabled)
-        {
-            _enterprisePipelineEnabled = enterprisePipelineEnabled;
         }
 
         public String getServletContainer()
@@ -1650,7 +1638,7 @@ public class MothershipController extends SpringActionController
         {
             super(new DataRegion(), form);
             getDataRegion().setTable(MothershipManager.get().getTableInfoServerSession());
-            getDataRegion().addColumns(MothershipManager.get().getTableInfoServerSession(), "ServerSessionId,ServerSessionGUID,ServerInstallationId,EarliestKnownTime,LastKnownTime,DatabaseProductName,DatabaseProductVersion,DatabaseDriverName,DatabaseDriverVersion,RuntimeOS,JavaVersion,SoftwareReleaseId,UserCount,ActiveUserCount,ProjectCount,ContainerCount,AdministratorEmail,EnterprisePipelineEnabled,Distribution,ServerIP,ServerHostName,ServletContainer,BuildTime");
+            getDataRegion().addColumns(MothershipManager.get().getTableInfoServerSession(), "ServerSessionId,ServerSessionGUID,ServerInstallationId,EarliestKnownTime,LastKnownTime,DatabaseProductName,DatabaseProductVersion,DatabaseDriverName,DatabaseDriverVersion,RuntimeOS,JavaVersion,SoftwareReleaseId,UserCount,ActiveUserCount,ProjectCount,ContainerCount,AdministratorEmail,Distribution,ServerIP,ServerHostName,ServletContainer,BuildTime");
             final DisplayColumn defaultServerInstallationColumn = getDataRegion().getDisplayColumn("ServerInstallationId");
             defaultServerInstallationColumn.setVisible(false);
             DataColumn replacementServerInstallationColumn = new DataColumn(defaultServerInstallationColumn.getColumnInfo())

--- a/mothership/src/org/labkey/mothership/MothershipManager.java
+++ b/mothership/src/org/labkey/mothership/MothershipManager.java
@@ -332,7 +332,6 @@ public class MothershipManager
         session.setRecentUserCount(getBestInteger(session.getRecentUserCount(), form.getRecentUserCount()));
         session.setUserCount(getBestInteger(session.getUserCount(), form.getUserCount()));
         session.setAdministratorEmail(getBestString(session.getAdministratorEmail(), form.getAdministratorEmail()));
-        session.setEnterprisePipelineEnabled(getBestBoolean(session.isEnterprisePipelineEnabled(), form.isEnterprisePipelineEnabled()));
         session.setDistribution(getBestString(session.getDistribution(), form.getDistribution()));
         session.setUsageReportingLevel(getBestString(session.getUsageReportingLevel(), form.getUsageReportingLevel()));
         session.setExceptionReportingLevel(getBestString(session.getExceptionReportingLevel(), form.getExceptionReportingLevel()));

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -62,7 +62,7 @@ public class MothershipModule extends DefaultModule
     @Override
     public Double getSchemaVersion()
     {
-        return 23.001;
+        return 23.002;
     }
 
     @Override

--- a/mothership/src/org/labkey/mothership/ServerSession.java
+++ b/mothership/src/org/labkey/mothership/ServerSession.java
@@ -40,8 +40,6 @@ public class ServerSession
     private String _runtimeOS;
     private String _javaVersion;
 
-    private Boolean _enterprisePipelineEnabled;
-
     private Integer _userCount;
     private Integer _recentUserCount;
     private Integer _projectCount;
@@ -250,16 +248,6 @@ public class ServerSession
     public void setAdministratorEmail(String administratorEmail)
     {
         _administratorEmail = administratorEmail;
-    }
-
-    public Boolean isEnterprisePipelineEnabled()
-    {
-        return _enterprisePipelineEnabled;
-    }
-
-    public void setEnterprisePipelineEnabled(Boolean enterprisePipelineEnabled)
-    {
-        _enterprisePipelineEnabled = enterprisePipelineEnabled;
     }
 
     public Integer getHeapSize()

--- a/pipeline/src/org/labkey/pipeline/PipelineModule.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineModule.java
@@ -254,6 +254,7 @@ public class PipelineModule extends SpringModule implements ContainerManager.Con
                     m.put("Jobs", rs.getLong("Jobs"));
                 });
             result.put("triggerCounts", triggerCounts);
+            result.put("jmsType", PipelineService.get().getJmsType().toString());
 
             return result;
         });

--- a/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
@@ -18,6 +18,7 @@ package org.labkey.pipeline.api;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -136,6 +137,7 @@ public class PipelineServiceImpl implements PipelineService, PipelineMXBean
 
     private final List<PipelineProviderSupplier> _suppliers = new CopyOnWriteArrayList<>();
     private final PipelineQueue _queue;
+    private final JmsType _jmsType;
 
     public static PipelineServiceImpl get()
     {
@@ -170,11 +172,20 @@ public class PipelineServiceImpl implements PipelineService, PipelineMXBean
         if (factory == null)
         {
             _queue = new PipelineQueueImpl();
+            _jmsType = JmsType.none;
         }
         else
         {
-            LOG.info("Found JMS queue; running Enterprise Pipeline.");
             _queue = new EPipelineQueueImpl(factory);
+            if (factory instanceof ActiveMQConnectionFactory a && a.getBrokerURL() != null)
+            {
+                _jmsType = a.getBrokerURL().startsWith("vm:") ? JmsType.inProcess : JmsType.external;
+            }
+            else
+            {
+                _jmsType = JmsType.unknown;
+            }
+            LOG.info("Found " + _jmsType + " JMS queue.");
         }
     }
 
@@ -432,6 +443,12 @@ public class PipelineServiceImpl implements PipelineService, PipelineMXBean
     public boolean isEnterprisePipeline()
     {
         return (getPipelineQueue() instanceof EPipelineQueueImpl);
+    }
+
+    @Override
+    public @NotNull JmsType getJmsType()
+    {
+        return _jmsType;
     }
 
     @NotNull


### PR DESCRIPTION
#### Rationale
It's useful to know what JMS queues deployments are using. Something's been going wrong with the old enterprise pipeline-tracking metric for many years, so remove it completely.

#### Changes
* New JSON-based metric
* Yank old-style HTTP parameter metric
