### PR TITLE
Metric to track invocations of old version of GetUsersWithPermissions

### DIFF
--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2075,7 +2075,7 @@ public class SecurityManager
        return getProjectUsers(c, includeGlobal, true);
     }
 
-    public static @NotNull List<User> getProjectUsers(Container c, boolean includeGlobal, boolean includeDeactivated)
+    public static @NotNull List<User> getProjectUsers(Container c, boolean includeGlobal, boolean includeInactive)
     {
         if (c != null && !c.isProject())
             c = c.getProject();
@@ -2093,7 +2093,7 @@ public class SecurityManager
                 continue;
 
             // TODO: currently only getting members that are users (no groups). should this be changed to get users of member groups?
-            members = getGroupMembers(g, includeDeactivated ? MemberType.ACTIVE_AND_INACTIVE_USERS : MemberType.ACTIVE_USERS);
+            members = getGroupMembers(g, includeInactive ? MemberType.ACTIVE_AND_INACTIVE_USERS : MemberType.ACTIVE_USERS);
 
             //add this group's members to hashset
             if (!members.isEmpty())

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -603,9 +603,9 @@ public class UserManager
     }
 
     @NotNull
-    public static Collection<User> getUsers(boolean includeDeactivated)
+    public static Collection<User> getUsers(boolean includeInactive)
     {
-        return includeDeactivated ? UserCache.getActiveAndInactiveUsers() : UserCache.getActiveUsers() ;
+        return includeInactive ? UserCache.getActiveAndInactiveUsers() : UserCache.getActiveUsers() ;
     }
 
     public static List<Integer> getUserIds()


### PR DESCRIPTION
#### Rationale
We want to track invocations of the old version of this API with an eye toward perhaps removing support for the old format

Also, switch `includeDeactivated` -> `includeInactive` in a few places

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4870