### PR TITLE
Disable privileged roles on permissions page

### DIFF
--- a/api/src/org/labkey/api/security/roles/RoleManager.java
+++ b/api/src/org/labkey/api/security/roles/RoleManager.java
@@ -99,10 +99,14 @@ public class RoleManager
     //register all core roles
     static
     {
-        // Privileged site roles first
+        // Privileged site roles first, so they appear at the top of the site permissions page
         registerAdminRole(siteAdminRole);
         registerRole(new PlatformDeveloperRole(), false);
         registerRole(new ImpersonatingTroubleshooterRole(), false);
+
+        // Now project and folder admin roles, so they pick up appropriate site roles
+        registerAdminRole(new ProjectAdminRole());
+        registerAdminRole(new FolderAdminRole());
 
         // Other site roles
         registerAdminRole(new ApplicationAdminRole());
@@ -116,8 +120,6 @@ public class RoleManager
         registerRole(new ProjectCreatorRole());
 
         // Project and folder roles
-        registerAdminRole(new ProjectAdminRole());
-        registerAdminRole(new FolderAdminRole());
         registerRole(new EditorRole());
         registerRole(new EditorWithoutDeleteRole());
         registerRole(new AuthorRole());

--- a/api/src/org/labkey/api/security/roles/RoleManager.java
+++ b/api/src/org/labkey/api/security/roles/RoleManager.java
@@ -99,8 +99,23 @@ public class RoleManager
     //register all core roles
     static
     {
+        // Privileged site roles first
         registerAdminRole(siteAdminRole);
+        registerRole(new PlatformDeveloperRole(), false);
+        registerRole(new ImpersonatingTroubleshooterRole(), false);
+
+        // Other site roles
         registerAdminRole(new ApplicationAdminRole());
+        registerRole(new TroubleshooterRole(), false);
+        registerRole(new SeeUserAndGroupDetailsRole());
+        registerRole(new CanSeeAuditLogRole());
+        registerRole(new SharedViewEditorRole());
+        registerRole(new EmailNonUsersRole(), false);
+        registerRole(new SeeFilePathsRole(), false);
+        registerRole(new CanUseSendMessageApi(), false);
+        registerRole(new ProjectCreatorRole());
+
+        // Project and folder roles
         registerAdminRole(new ProjectAdminRole());
         registerAdminRole(new FolderAdminRole());
         registerRole(new EditorRole());
@@ -111,16 +126,6 @@ public class RoleManager
         registerRole(new SubmitterRole());
         registerRole(new NoPermissionsRole());
         registerRole(new OwnerRole());
-        registerRole(new ImpersonatingTroubleshooterRole(), false);
-        registerRole(new TroubleshooterRole(), false);
-        registerRole(new PlatformDeveloperRole(), false);
-        registerRole(new SeeUserAndGroupDetailsRole());
-        registerRole(new CanSeeAuditLogRole());
-        registerRole(new SharedViewEditorRole());
-        registerRole(new EmailNonUsersRole(), false);
-        registerRole(new SeeFilePathsRole(), false);
-        registerRole(new CanUseSendMessageApi(), false);
-        registerRole(new ProjectCreatorRole());
     }
 
     public static void addAdminRoleListener(AdminRoleListener listener)

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -502,6 +502,7 @@ public class SecurityApiActions
                 excludedPrincipals.add(principal.getUserId());
             }
             props.put("excludedPrincipals", excludedPrincipals);
+            props.put("privileged", role.isPrivileged());
 
             return props;
         }

--- a/core/webapp/Security/panel/PolicyEditor.js
+++ b/core/webapp/Security/panel/PolicyEditor.js
@@ -265,6 +265,7 @@ Ext4.define('Security.panel.PolicyEditor', {
         var me = this;
         for (r=0; r < this.roles.length; r++){
             role = this.roles[r];
+            const disabled = this.canUserAlterRole(role);
             const isDeveloper = (-1 !== role.uniqueName.indexOf("Developer")) || ((-1 !== role.uniqueName.indexOf("Analyst")) && (-1 === role.uniqueName.indexOf("QCAnalyst")));
             roleRows.push({
                 layout: 'hbox',
@@ -295,6 +296,7 @@ Ext4.define('Security.panel.PolicyEditor', {
                         bodyStyle : 'background-color: transparent;'
                     },{
                         xtype  : 'labkey-principalcombo',
+                        disabled : disabled,
                         width  : 350,
                         cache  : this.cache,
                         itemId : ('$add$'+role.uniqueName),
@@ -308,7 +310,7 @@ Ext4.define('Security.panel.PolicyEditor', {
                     }],
                     scope : this
                 }],
-                listeners: {
+                listeners: disabled ? {} : {
                     render: this.initializeRoleDropZone,
                     scope: this
                 },
@@ -565,6 +567,7 @@ Ext4.define('Security.panel.PolicyEditor', {
         buttonArea = buttonArea.down('#buttonArea');
         var btnId = (ids.roleId + '$' + ids.groupId).replace(/\./g, "_");
         var button = buttonArea.down('button[itemId="'+btnId+'"]');
+        const disabled = this.canUserAlterRole(role);
 
         //button already exists...
         if (button){
@@ -576,6 +579,7 @@ Ext4.define('Security.panel.PolicyEditor', {
         var tooltip = (group.Type == 'u' ? 'User: ' : group.Container ? 'Group: ' : 'Site group: ') + group.Name;
         button = buttonArea.add({
             xtype : 'button',
+            disabled: disabled,
             cls: 'dragbutton',
             handleMouseEvents: false,
             iconCls   : 'closeicon',
@@ -588,7 +592,7 @@ Ext4.define('Security.panel.PolicyEditor', {
             tooltip : tooltip,
             hidden : hideButton || false,
             hideMode : hideButton ? 'visibility' : 'display',
-            listeners : {
+            listeners : disabled ? {} : {
                 afterrender : function(b) {
                     Ext4.DomQuery.select('span.closeicon', b.getEl().id)[0].onclick = Ext4.bind(this.Button_onClose, this, [b]);
                     this.initializeButtonDragZone(b);
@@ -599,6 +603,11 @@ Ext4.define('Security.panel.PolicyEditor', {
         });
 
         return button;
+    },
+
+    canUserAlterRole : function(role)
+    {
+        return role.privileged && !LABKEY.user.isSystemAdmin;
     },
 
     removeButton : function(groupId, roleId, animate)


### PR DESCRIPTION
#### Rationale
Application administrators aren't allowed to alter privileged roles, so let's disable them on the permissions page to signal what's allowed and what's not. Also moves all the privileged roles to the top of the list so they're grouped together.
