### PR TITLE
Fix render-as drop-down lists

### DIFF
--- a/announcements/src/org/labkey/announcements/insert.jsp
+++ b/announcements/src/org/labkey/announcements/insert.jsp
@@ -134,14 +134,7 @@
     if (settings.hasFormatPicker())
     {
         %><tr><td class="labkey-form-label">Render As</td><td colspan="2">
-        <%=select()
-            .name("rendererType")
-            .id("rendererType")
-            .addOptions(Arrays.stream(bean.renderers).map(WikiRendererType::getDisplayName))
-            .selected(bean.currentRendererType.getDisplayName())
-            .onChange("LABKEY.setDirty(true);")
-            .className(null)
-        %>
+        <%=bean.renderAsSelect%>
         </td></tr><%
     }
 

--- a/announcements/src/org/labkey/announcements/respond.jsp
+++ b/announcements/src/org/labkey/announcements/respond.jsp
@@ -145,14 +145,7 @@ if (settings.hasFormatPicker())
 %><tr>
     <td class="labkey-form-label">Render As</td>
     <td colspan="2">
-        <%=select()
-            .name("rendererType")
-            .id("rendererType")
-            .addOptions(Arrays.stream(bean.renderers).map(WikiRendererType::getDisplayName))
-            .selected(bean.currentRendererType.getDisplayName())
-            .onChange("LABKEY.setDirty(true);")
-            .className(null)
-        %>
+        <%=bean.renderAsSelect%>
      </td>
 </tr>
 <%}%>

--- a/announcements/src/org/labkey/announcements/update.jsp
+++ b/announcements/src/org/labkey/announcements/update.jsp
@@ -130,14 +130,7 @@ if (settings.hasExpires())
   <tr>
     <td class="labkey-form-label">Render As</td>
     <td colspan="2">
-        <%=select()
-            .name("rendererType")
-            .id("rendererType")
-            .addOptions(Arrays.stream(bean.renderers).map(WikiRendererType::getDisplayName))
-            .selected(bean.currentRendererType.getDisplayName())
-            .onChange("LABKEY.setDirty(true);")
-            .className(null)
-        %>
+        <%=bean.renderAsSelect%>
     </td>
   </tr>
 <%  } %>


### PR DESCRIPTION
#### Rationale
Related PR broke the render-as selects (key was accidentally switched from enum name to display name). Take the opportunity to render these selects in a single code path instead of three separate implementations.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4889