### PR TITLE
Issues 48991, 48994: Improve file root behavior

### DIFF
--- a/api/src/org/labkey/api/files/FileContentService.java
+++ b/api/src/org/labkey/api/files/FileContentService.java
@@ -122,6 +122,9 @@ public interface FileContentService
     @NotNull
     Path getSiteDefaultRootPath();
 
+    @Nullable
+    String getProblematicFileRootMessage();
+
     void setSiteDefaultRoot(File root, User user);
 
     public void setFileRootSetViaStartupProperty(boolean fileRootSetViaStartupProperty);

--- a/core/src/org/labkey/core/admin/admin.jsp
+++ b/core/src/org/labkey/core/admin/admin.jsp
@@ -36,6 +36,7 @@
 <%@ page import="java.util.Collection" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.TreeMap" %>
+<%@ page import="org.labkey.api.files.FileContentService" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -107,6 +108,7 @@
                 <tr class="<%=getShadeRowClass(row++)%>"><td>User Name</td><td><%=h(AdminBean.userName)%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>User Home Dir</td><td><%=h(AdminBean.userHomeDir)%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Webapp Dir</td><td><%=h(AdminBean.webappDir)%></td></tr>
+                <tr class="<%=getShadeRowClass(row++)%>"><td>Site-Wide File Root Dir</td><td><%=h(FileContentService.get() == null ? "" : FileContentService.get().getSiteDefaultRoot().getPath())%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Distribution</td><td><%=h(AdminBean.distribution)%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>Build Time</td><td><%=h(AdminBean.buildTime)%></td></tr>
                 <tr class="<%=getShadeRowClass(row++)%>"><td>OS</td><td><%=h(AdminBean.osName)%></td></tr>

--- a/core/src/org/labkey/core/admin/view/filesSiteSettings.jsp
+++ b/core/src/org/labkey/core/admin/view/filesSiteSettings.jsp
@@ -30,6 +30,7 @@
 <%@ page import="org.labkey.core.admin.FileSettingsForm" %>
 <%@ page import="org.labkey.core.admin.FilesSiteSettingsAction" %>
 <%@ page import="org.labkey.core.admin.UpdateFilePathsAction" %>
+<%@ page import="org.labkey.api.files.FileContentService" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -54,8 +55,8 @@
         <tr><td colspan="2">Set the site-level root for this server installation, or use the default provided. If the
             location does not exist, LabKey Server will create it for you.<br/><br/>
             When a site-level file root is set, each folder for every project has a corresponding subdirectory in the file system.
-            LabKey Server allows you to upload and process your data files, including flow, proteomics and
-            study-related files. By default, LabKey stores your files in a standard directory structure. You can
+            LabKey Server allows you to upload and process your data files, including assay and
+            study-related files. By default, LabKey Server stores your files in a standard directory structure. You can
             override this location for each project if you wish.
             </td></tr>
         <% } else { %>
@@ -64,7 +65,13 @@
             possible to <a href="<%= h(new ActionURL(UpdateFilePathsAction.class, getContainer())) %>">update paths stored in the database</a>.</td></tr>
         <% } %>
         <tr><td>&nbsp;</td></tr>
-        
+
+        <%
+            String problemMessage = FileContentService.get() == null ? null : FileContentService.get().getProblematicFileRootMessage();
+            if (problemMessage != null) { %>
+                <tr><td colspan="2"><span class="labkey-error"><%= h(problemMessage) %></span></td></tr>
+        <% } %>
+
         <tr><td class="labkey-form-label">Site-Level&nbsp;File&nbsp;Root&nbsp;<%=helpPopup("File Root", "Set a site-level file root. " +
                 "When a site-level file root is set, each folder for every project has a corresponding subdirectory in the file system." +
                 " A site-level file root may be overridden at the project level from 'Project Settings'.")%></td>

--- a/filecontent/src/org/labkey/filecontent/FileContentModule.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentModule.java
@@ -100,7 +100,7 @@ public class FileContentModule extends DefaultModule
     public Collection<String> getSummary(Container c)
     {
         List<String> result = new ArrayList<>();
-        FileContentService service = FileContentService.get();
+        FileContentServiceImpl service = FileContentServiceImpl.getInstance();
         Path file = service.getFileRootPath(c, FileContentService.ContentType.files);
         if (file != null && Files.isDirectory(file))
         {
@@ -149,10 +149,7 @@ public class FileContentModule extends DefaultModule
                     result.add(directoryCount + " directories in the file system, which may contain additional files, including: " + StringUtils.join(directoryNames, ", "));
                 }
             }
-            catch (IOException e)
-            {
-
-            }
+            catch (IOException ignored) {}
         }
 
         return result;
@@ -217,7 +214,7 @@ public class FileContentModule extends DefaultModule
                 {
                     succeeded = false;
                 }
-                results.put("invalidConfiguredFileRoot", FileContentServiceImpl.getInstance().hasInvalidConfiguredFileRoot());
+                results.put("invalidConfiguredFileRoot", FileContentServiceImpl.getInstance().getProblematicFileRootMessage() != null);
                 results.put("fileRootSize", totalSize.longValue());
                 results.put("fileRootFileCount", fileCount.longValue());
                 results.put("fileRootCrawlTimedOut", timedOut);

--- a/filecontent/src/org/labkey/filecontent/FileContentModule.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentModule.java
@@ -187,7 +187,7 @@ public class FileContentModule extends DefaultModule
 
         UsageMetricsService.get().registerUsageMetrics(getName(), () -> {
             Map<String, Object> results = new HashMap<>();
-            File root = FileContentService.get().getSiteDefaultRoot();
+            File root = FileContentServiceImpl.getInstance().getSiteDefaultRoot();
             if (root.isDirectory())
             {
                 long startTime = HeartBeat.currentTimeMillis();
@@ -217,6 +217,7 @@ public class FileContentModule extends DefaultModule
                 {
                     succeeded = false;
                 }
+                results.put("invalidConfiguredFileRoot", FileContentServiceImpl.getInstance().hasInvalidConfiguredFileRoot());
                 results.put("fileRootSize", totalSize.longValue());
                 results.put("fileRootFileCount", fileCount.longValue());
                 results.put("fileRootCrawlTimedOut", timedOut);

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -69,21 +69,27 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.security.User;
-import org.labkey.api.services.ServiceRegistry;
+import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.RandomSiteSettingsPropertyHandler;
 import org.labkey.api.settings.StartupPropertyEntry;
 import org.labkey.api.settings.WriteableAppProps;
 import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.ContainerUtil;
+import org.labkey.api.util.DOM;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewBackgroundInfo;
+import org.labkey.api.view.ViewContext;
+import org.labkey.api.view.template.WarningProvider;
+import org.labkey.api.view.template.WarningService;
+import org.labkey.api.view.template.Warnings;
 import org.labkey.api.webdav.WebdavResource;
 import org.labkey.api.webdav.WebdavService;
 
@@ -111,8 +117,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.labkey.api.settings.AppProps.SCOPE_SITE_SETTINGS;
+import static org.labkey.api.util.DOM.Attribute.href;
+import static org.labkey.api.util.DOM.at;
 
-public class FileContentServiceImpl implements FileContentService
+public class FileContentServiceImpl implements FileContentService, WarningProvider
 {
     private static final Logger _log = LogManager.getLogger(FileContentServiceImpl.class);
     private static final String UPLOAD_LOG = ".upload.log";
@@ -124,7 +132,7 @@ public class FileContentServiceImpl implements FileContentService
     private final List<DirectoryPattern> _ziploaderPattern = new CopyOnWriteArrayList<>();
 
     private volatile boolean _fileRootSetViaStartupProperty = false;
-    private File _lastLoggedProblematicFileRoot;
+    private String _problematicFileRootMessage;
 
     enum FileAction
     {
@@ -139,6 +147,7 @@ public class FileContentServiceImpl implements FileContentService
 
     private FileContentServiceImpl()
     {
+        WarningService.get().register(this);
     }
 
     @Override
@@ -594,15 +603,19 @@ public class FileContentServiceImpl implements FileContentService
             {
                 File configuredRoot = root;
                 root = getDefaultRoot();
-                if (configuredRoot != null && !configuredRoot.equals(root) && !configuredRoot.equals(_lastLoggedProblematicFileRoot))
+                if (configuredRoot != null && !configuredRoot.equals(root))
                 {
-                    _lastLoggedProblematicFileRoot = configuredRoot;
-                    _log.warn("Configured site-wide file root " + configuredRoot + " does not exist. Falling back to " + root);
+                    String message = "The configured site-wide file root " + configuredRoot + " does not exist. Falling back to " + root;
+                    if (!message.equals(_problematicFileRootMessage))
+                    {
+                        _problematicFileRootMessage = message;
+                        _log.error(_problematicFileRootMessage);
+                    }
                 }
             }
             else
             {
-                _lastLoggedProblematicFileRoot = null;
+                _problematicFileRootMessage = null;
             }
 
             if (!root.exists())
@@ -610,6 +623,10 @@ public class FileContentServiceImpl implements FileContentService
                 if (FileUtil.mkdirs(root))
                 {
                     _log.info("Created site-wide file root " + root);
+                }
+                else
+                {
+                    _log.error("Failed when attempting to create site-wide file root " + root);
                 }
             }
         }
@@ -621,11 +638,11 @@ public class FileContentServiceImpl implements FileContentService
         return root;
     }
 
-    public boolean hasInvalidConfiguredFileRoot()
+    @Override
+    public String getProblematicFileRootMessage()
     {
-        return _lastLoggedProblematicFileRoot != null;
+        return _problematicFileRootMessage;
     }
-
 
     @Override
     public @NotNull File getUserFilesRoot() throws IOException
@@ -1658,6 +1675,23 @@ public class FileContentServiceImpl implements FileContentService
         String targetPath = absoluteFilePath.replace(sourceRootPath, targetFileRoot.getAbsolutePath());
         File targetFile = new File(targetPath);
         return AssayFileWriter.findUniqueFileName(file.getName(), targetFile.getParentFile().toPath()).toFile();
+    }
+
+    @Override
+    public void addDynamicWarnings(@NotNull Warnings warnings, @Nullable ViewContext context, boolean showAllWarnings)
+    {
+        if (_problematicFileRootMessage != null && context != null && ContainerManager.getRoot().hasPermission(context.getUser(), AdminOperationsPermission.class))
+        {
+            warnings.add(DOM.createHtmlFragment(_problematicFileRootMessage, " ", DOM.A(at(href, PageFlowUtil.urlProvider(AdminUrls.class).getFilesSiteSettingsURL(false)), "Configure File System Access")));
+        }
+        else if (showAllWarnings)
+        {
+            try
+            {
+                warnings.add(HtmlString.of("Configured site-wide file root " + getDefaultRoot() + " does not exist. Falling back to " + getDefaultRoot()));
+            }
+            catch (IOException ignored) {}
+        }
     }
 
     // Cache with short-lived entries so that exp.files can perform reasonably


### PR DESCRIPTION
#### Rationale
Things can go badly if the server's configured file root isn't available and we fall back to the default location

#### Changes
* Log when the configured file root isn't available (exactly once per web app, at WARN level)
* Log when we create the file root directory
* Report a new metric if the configured file root isn't available
* Show file root in Admin Console->Server Information