### PR TITLE
Media: support updates for mixtures and batches

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpProtocol.java
+++ b/api/src/org/labkey/api/exp/api/ExpProtocol.java
@@ -156,6 +156,8 @@ public interface ExpProtocol extends ExpObject
     @Override
     void save(User user);
 
+    void save(User user, boolean saveProperties, @Nullable Collection<? extends ExpProtocolInput> protocolInputsToDeleteOnUpdate);
+
     default String getDocumentId()
     {
         return String.join(":",getContainer().getId(), "assay", String.valueOf(getRowId()));

--- a/experiment/src/org/labkey/experiment/api/ExpProtocolApplicationImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpProtocolApplicationImpl.java
@@ -491,6 +491,7 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
         OntologyManager.deleteOntologyObjects(getContainer(), lsid);
 
         removeInputs(ExperimentServiceImpl.get().getTinfoDataInput(), "DataId", List.of(data.getRowId()));
+        _inputDatas = null;
     }
 
     @Override
@@ -508,7 +509,7 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
         OntologyManager.deleteOntologyObjects(expSchema, lsidsSql, getContainer(), false);
 
         removeInputs(ExperimentServiceImpl.get().getTinfoDataInput(), "DataId", rowIds);
-
+        _inputDatas = null;
     }
 
     @Override
@@ -519,6 +520,7 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
         OntologyManager.deleteOntologyObjects(getContainer(), lsid);
 
         removeInputs(ExperimentServiceImpl.get().getTinfoMaterialInput(), "MaterialId", List.of(material.getRowId()));
+        _inputMaterials = null;
     }
 
     @Override
@@ -536,6 +538,7 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
         OntologyManager.deleteOntologyObjects(expSchema, lsidsSql, getContainer(), false);
 
         removeInputs(ExperimentServiceImpl.get().getTinfoMaterialInput(), "MaterialId", rowIds);
+        _inputMaterials = null;
     }
 
     public static List<ExpProtocolApplicationImpl> fromProtocolApplications(List<ProtocolApplication> apps)

--- a/experiment/src/org/labkey/experiment/api/ExpProtocolImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpProtocolImpl.java
@@ -232,6 +232,12 @@ public class ExpProtocolImpl extends ExpIdentifiableEntityImpl<Protocol> impleme
     }
 
     @Override
+    public void save(User user, boolean saveProperties, @Nullable Collection<? extends ExpProtocolInput> protocolInputsToDeleteOnUpdate)
+    {
+        _object = ExperimentServiceImpl.get().saveProtocol(user, _object, saveProperties, protocolInputsToDeleteOnUpdate);
+    }
+
+    @Override
     public void delete(User user)
     {
         delete(user, null);


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/recipe/pull/91 for rationale.

#### Related Pull Requests
* https://github.com/LabKey/recipe/pull/91

#### Changes
- Reset associated inputs for `ExpProtocolApplicationImpl` upon deletion. These are rehydrated upon a subsequent call to `getMaterialInputs()` or `getDataInputs()`.
- Introduce `protocolInputsToDeleteOnUpdate` to support more precise scenarios for altering protocol inputs. When `null` then all protocol inputs are deleted (default / backward compatible behavior). When a `Collection` is provided (even an empty one) then only those protocol inputs will be deleted.