### PR TITLE
Issue 47919: exp.DataClass.DataCount should respect container filter

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
@@ -145,8 +145,9 @@ public class ExpDataClassTableImpl extends ExpTableImpl<ExpDataClassTable.Column
             {
                 SQLFragment sql = new SQLFragment("(SELECT COUNT(*) FROM ").append(ExperimentServiceImpl.get().getTinfoData(), "d")
                     .append(" WHERE d.classId = ").append(ExprColumn.STR_TABLE_ALIAS + ".rowid")
-                    .append(" AND d.container = ?)")
-                    .add(_userSchema.getContainer().getEntityId());
+                    .append(" AND ")
+                    .append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("d.container")))
+                    .append(")");
                 ExprColumn sampleCountColumnInfo = new ExprColumn(this, "DataCount", sql, JdbcType.INTEGER);
                 sampleCountColumnInfo.setDescription("Contains the number of data currently stored in this data class");
                 return sampleCountColumnInfo;


### PR DESCRIPTION
#### Rationale
This addresses [Issue 47919](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47919) by updating the `ExprColumn` for `DataCount` to source the containers from the provided container filter.

#### Related Pull Requests
* https://github.com/LabKey/biologics/pull/2496

#### Changes
- Respect table-level container filter when calculating `DataCount` for `exp.DataClass` table.
