### PR TITLE
refresh materialized sampletype table after sample move

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1881,10 +1881,14 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             updateCounts.putAll(moveDerivationRuns(samples, targetContainer, user));
 
             transaction.addCommitTask(() -> {
-                // update search index for moved samples via indexSampleType() helper, it filters for samples to index
-                // based on the modified date
                 for (ExpSampleType sampleType : sampleTypesMap.keySet())
+                {
+                    // force refresh of materialized view
+                    SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(sampleType, false);
+                    // update search index for moved samples via indexSampleType() helper, it filters for samples to index
+                    // based on the modified date
                     SampleTypeServiceImpl.get().indexSampleType(sampleType);
+                }
             }, DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
 
             transaction.addCommitTask(() -> {


### PR DESCRIPTION
#### Rationale
This path does not go through exp.material or QUS, so it did not invalidate the materialized table.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
