### PR TITLE
Avoid unneeded map copying

### DIFF
--- a/api/src/org/labkey/api/collections/CaseInsensitiveArrayListValuedMap.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveArrayListValuedMap.java
@@ -27,7 +27,7 @@ import java.util.List;
  *
  * Created by Nick on 10/1/2016.
  */
-public class CaseInsensitiveArrayListValuedMap<V> extends AbstractListValuedMap<String, V>
+public class CaseInsensitiveArrayListValuedMap<V> extends AbstractListValuedMap<String, V> implements CaseInsensitiveCollection
 {
     public CaseInsensitiveArrayListValuedMap()
     {

--- a/api/src/org/labkey/api/collections/CaseInsensitiveCollection.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveCollection.java
@@ -1,0 +1,6 @@
+package org.labkey.api.collections;
+
+/** Marker interface for collection implementations that operate on strings in a case-insensitive way */
+public interface CaseInsensitiveCollection
+{
+}

--- a/api/src/org/labkey/api/collections/CaseInsensitiveHashMap.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveHashMap.java
@@ -33,7 +33,7 @@ import java.util.Random;
  * User: arauch
  * Date: Dec 25, 2004
  */
-public class CaseInsensitiveHashMap<V> extends CaseInsensitiveMapWrapper<V> implements Serializable
+public class CaseInsensitiveHashMap<V> extends CaseInsensitiveMapWrapper<V> implements Serializable, CaseInsensitiveCollection
 {
     public CaseInsensitiveHashMap()
     {

--- a/api/src/org/labkey/api/collections/CaseInsensitiveHashSet.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveHashSet.java
@@ -29,7 +29,7 @@ import java.util.Set;
  * or searching. Could easily extend this to preserve the case... just add a lowercase version to uppercase version map.
  */
 // TODO: Merge CaseInsensitiveHashSet and CaseInsensitiveHashMap implementations
-public class CaseInsensitiveHashSet extends HashSet<String>
+public class CaseInsensitiveHashSet extends HashSet<String> implements CaseInsensitiveCollection
 {
     public CaseInsensitiveHashSet()
     {

--- a/api/src/org/labkey/api/collections/CaseInsensitiveHashSetValuedMap.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveHashSetValuedMap.java
@@ -23,7 +23,7 @@ import java.util.Set;
 /**
  * A case-insensitive version of org.apache.commons.collections4.multimap.HashSetValuedHashMap
  */
-public class CaseInsensitiveHashSetValuedMap<V> extends AbstractSetValuedMap<String, V>
+public class CaseInsensitiveHashSetValuedMap<V> extends AbstractSetValuedMap<String, V> implements CaseInsensitiveCollection
 {
     public CaseInsensitiveHashSetValuedMap()
     {

--- a/api/src/org/labkey/api/collections/CaseInsensitiveLinkedHashMap.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveLinkedHashMap.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * User: daveb  
  * Date: 5/17/2018
  */
-public class CaseInsensitiveLinkedHashMap<V> extends CaseInsensitiveMapWrapper<V> implements Serializable
+public class CaseInsensitiveLinkedHashMap<V> extends CaseInsensitiveMapWrapper<V> implements Serializable, CaseInsensitiveCollection
 {
     public CaseInsensitiveLinkedHashMap()
     {

--- a/api/src/org/labkey/api/collections/CaseInsensitiveMapWrapper.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveMapWrapper.java
@@ -29,7 +29,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-public class CaseInsensitiveMapWrapper<V> extends MapWrapper<String, V> implements Serializable
+public class CaseInsensitiveMapWrapper<V> extends MapWrapper<String, V> implements Serializable, CaseInsensitiveCollection
 {
     private final Map<String, String> _correctCaseMap;
 

--- a/api/src/org/labkey/api/collections/CaseInsensitiveTreeMap.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveTreeMap.java
@@ -23,7 +23,7 @@ import java.util.TreeMap;
 * Date: Nov 12, 2010
 * Time: 4:13:31 PM
 */
-public class CaseInsensitiveTreeMap<V> extends TreeMap<String, V>
+public class CaseInsensitiveTreeMap<V> extends TreeMap<String, V> implements CaseInsensitiveCollection
 {
     public CaseInsensitiveTreeMap()
     {

--- a/api/src/org/labkey/api/collections/CaseInsensitiveTreeSet.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveTreeSet.java
@@ -24,7 +24,7 @@ import java.util.TreeSet;
 * Date: Nov 30, 2010
 * Time: 8:32:21 AM
 */
-public class CaseInsensitiveTreeSet extends TreeSet<String>
+public class CaseInsensitiveTreeSet extends TreeSet<String> implements CaseInsensitiveCollection
 {
     public CaseInsensitiveTreeSet()
     {

--- a/api/src/org/labkey/api/collections/ConcurrentCaseInsensitiveSortedMap.java
+++ b/api/src/org/labkey/api/collections/ConcurrentCaseInsensitiveSortedMap.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
  * User: adam
  * Date: Nov 30, 2010
  */
-public class ConcurrentCaseInsensitiveSortedMap<V> extends ConcurrentSkipListMap<String, V>
+public class ConcurrentCaseInsensitiveSortedMap<V> extends ConcurrentSkipListMap<String, V> implements CaseInsensitiveCollection
 {
     public ConcurrentCaseInsensitiveSortedMap()
     {

--- a/api/src/org/labkey/api/collections/CopyOnWriteCaseInsensitiveHashMap.java
+++ b/api/src/org/labkey/api/collections/CopyOnWriteCaseInsensitiveHashMap.java
@@ -6,7 +6,7 @@ import java.util.Map;
  * A thread-safe version of {@link CaseInsensitiveHashMap} in which all operations that change the Map are implemented
  * by making a new copy of the underlying Map. This is appropriate for scenarios where reads vastly outnumber writes.
  */
-public class CopyOnWriteCaseInsensitiveHashMap<V> extends CopyOnWriteMap<String, V, CaseInsensitiveHashMap<V>>
+public class CopyOnWriteCaseInsensitiveHashMap<V> extends CopyOnWriteMap<String, V, CaseInsensitiveHashMap<V>> implements CaseInsensitiveCollection
 {
     public CopyOnWriteCaseInsensitiveHashMap()
     {

--- a/api/src/org/labkey/api/collections/RowMap.java
+++ b/api/src/org/labkey/api/collections/RowMap.java
@@ -23,7 +23,7 @@ import java.util.List;
  * Time: 11:48:46 PM
  */
 
-public class RowMap<V> extends ArrayListMap<String, V>
+public class RowMap<V> extends ArrayListMap<String, V> implements CaseInsensitiveCollection
 {
     protected RowMap()
     {

--- a/api/src/org/labkey/api/data/BeanObjectFactory.java
+++ b/api/src/org/labkey/api/data/BeanObjectFactory.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
+import org.labkey.api.collections.CaseInsensitiveCollection;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.RowMap;
 import org.labkey.api.module.ModuleLoader;
@@ -131,7 +132,7 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
     @Override
     public K fromMap(K bean, Map<String, ?> m)
     {
-        if (!(m instanceof CaseInsensitiveHashMap || m instanceof RowMap))
+        if (!(m instanceof CaseInsensitiveCollection))
             m = new CaseInsensitiveHashMap<>(m);
 
         for (var prop : _writeableProperties)

--- a/api/src/org/labkey/api/data/BeanObjectFactory.java
+++ b/api/src/org/labkey/api/data/BeanObjectFactory.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.RowMap;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.util.UnexpectedException;
@@ -130,7 +131,7 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
     @Override
     public K fromMap(K bean, Map<String, ?> m)
     {
-        if (!(m instanceof CaseInsensitiveHashMap))
+        if (!(m instanceof CaseInsensitiveHashMap || m instanceof RowMap))
             m = new CaseInsensitiveHashMap<>(m);
 
         for (var prop : _writeableProperties)
@@ -169,7 +170,7 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
                 }
                 catch (IllegalAccessException | InvocationTargetException x)
                 {
-                    throw new UnexpectedException(x);
+                    throw UnexpectedException.wrap(x);
                 }
                 catch (IllegalArgumentException | ConversionException x)
                 {
@@ -192,7 +193,7 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
 
     public @NotNull Map<String, String> toStringMap(K bean, @Nullable Map<String, String> m)
     {
-        //noinspection unchecked
+        //noinspection unchecked,rawtypes
         return (Map)_toMap(bean, (Map)m, true);
     }
 
@@ -312,7 +313,7 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
     public K[] handleArray(ResultSet rs) throws SQLException
     {
         ArrayList<K> list = handleArrayList(rs);
-        K[] array = (K[]) Array.newInstance(_class, list.size());
+        @SuppressWarnings("unchecked") K[] array = (K[]) Array.newInstance(_class, list.size());
         return list.toArray(array);
     }
 

--- a/api/src/org/labkey/api/data/BuilderObjectFactory.java
+++ b/api/src/org/labkey/api/data/BuilderObjectFactory.java
@@ -26,9 +26,11 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.RowMap;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.ResultSetUtil;
+import org.labkey.api.util.UnexpectedException;
 
 import java.beans.Introspector;
 import java.lang.reflect.Array;
@@ -162,7 +164,7 @@ public class BuilderObjectFactory<K> implements ObjectFactory<K>
     public K fromMap(Map<String, ?> m)
     {
         Builder<K> builder = (Builder<K>)newInstance();
-        if (!(m instanceof CaseInsensitiveHashMap))
+        if (!(m instanceof CaseInsensitiveHashMap || m instanceof RowMap))
             m = new CaseInsensitiveHashMap<>(m);
 
         for (Map.Entry<String,MethodAndConverter> e : _writeableProperties.entrySet())
@@ -182,11 +184,11 @@ public class BuilderObjectFactory<K> implements ObjectFactory<K>
             }
             catch (IllegalAccessException | InvocationTargetException x)
             {
-                assert null == "unexpected exception";
+                throw UnexpectedException.wrap(x);
             }
             catch (IllegalArgumentException x)
             {
-                _log.error("could not set property: " + name + "=" + String.valueOf(value), x);
+                _log.error("could not set property: " + name + "=" + value, x);
             }
         }
 
@@ -403,7 +405,7 @@ public class BuilderObjectFactory<K> implements ObjectFactory<K>
         {
             Foo foo = new Foo("ONE", 1, 1.0);
             ObjectFactory<Foo> f = new BuilderObjectFactory<>(Foo.class, FooBuilder.class);
-            Map<String, Object> m = f.toMap(foo, new CaseInsensitiveHashMap<Object>());
+            Map<String, Object> m = f.toMap(foo, new CaseInsensitiveHashMap<>());
             assertEquals("ONE", m.get("s"));
             assertEquals(1, m.get("I"));
             assertEquals(String.valueOf(1.0), String.valueOf(m.get("F")));

--- a/api/src/org/labkey/api/data/BuilderObjectFactory.java
+++ b/api/src/org/labkey/api/data/BuilderObjectFactory.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.collections.CaseInsensitiveCollection;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.RowMap;
 import org.labkey.api.module.ModuleLoader;
@@ -164,7 +165,7 @@ public class BuilderObjectFactory<K> implements ObjectFactory<K>
     public K fromMap(Map<String, ?> m)
     {
         Builder<K> builder = (Builder<K>)newInstance();
-        if (!(m instanceof CaseInsensitiveHashMap || m instanceof RowMap))
+        if (!(m instanceof CaseInsensitiveCollection))
             m = new CaseInsensitiveHashMap<>(m);
 
         for (Map.Entry<String,MethodAndConverter> e : _writeableProperties.entrySet())


### PR DESCRIPTION
#### Rationale
Profiling shows that iterating through large result sets and converting rows to strongly typed beans churns a lot of memory copying into CaseInsensitiveHashMap. RowMap is already case insensitive, so that's a waste

#### Changes
* Introduce marker interface instead of checking for specific implementations
* Don't bother copying RowMap
* Misc code cleanup