### PR TITLE
Issue 49036: NAb PercentNeutralizationInitialDilution calculation incorrect for sample with method Concentration instead of Dilution

### DIFF
--- a/assay/api-src/org/labkey/api/assay/plate/PlateBasedRunCreator.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateBasedRunCreator.java
@@ -61,6 +61,7 @@ import java.util.Set;
 public class PlateBasedRunCreator<ProviderType extends AbstractPlateBasedAssayProvider> extends DefaultAssayRunCreator<ProviderType>
 {
     public static final AssayDataType SAMPLE_METADATA_FILE_TYPE = new AssayDataType("SampleMetadataFile", new FileType(Arrays.asList(".xls", ".xlsx"), ".xls"));
+    public static final String SAMPLE_TYPE_NAME_PREFIX = "Input Samples: ";
 
     public PlateBasedRunCreator(ProviderType provider)
     {
@@ -216,7 +217,7 @@ public class PlateBasedRunCreator<ProviderType extends AbstractPlateBasedAssayPr
                 {
                     sampleType = SampleTypeService.get().createSampleType();
                     sampleType.setContainer(context.getProtocol().getContainer());
-                    sampleType.setName("Input Samples: " + context.getProtocol().getName());
+                    sampleType.setName(SAMPLE_TYPE_NAME_PREFIX + context.getProtocol().getName());
                     sampleType.setLSID(domainURI);
 
                     Lsid.LsidBuilder sampleTypeLSID = new Lsid.LsidBuilder(domainURI);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49036

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4010
* https://github.com/LabKey/commonAssays/pull/674

#### Changes
- join from nab.NabSpecimen table to the sample type table to match on the InitialDilution value
