### PR TITLE
Issue 48999: Unable to "Select them in the grid" when created trigger script runs after samples are added

### DIFF
--- a/api/src/org/labkey/api/audit/TransactionAuditProvider.java
+++ b/api/src/org/labkey/api/audit/TransactionAuditProvider.java
@@ -143,8 +143,7 @@ public class TransactionAuditProvider extends AbstractAuditTypeProvider implemen
         @Override
         public void setComment(String comment)
         {
-            if (!StringUtils.isEmpty(comment))
-                _commentCount++;
+            _commentCount++;
             super.setComment(comment);
         }
 

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.data.ConnectionWrapper.Closer;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -2087,7 +2088,10 @@ public class DbScope
         @Nullable
         Long getAuditId();
 
-        void setAuditId(Long auditId);
+        @Nullable
+        TransactionAuditProvider.TransactionAuditEvent getAuditEvent();
+
+        void setAuditEvent(TransactionAuditProvider.TransactionAuditEvent event);
     }
 
     /** A dummy object for swap-in usage when no transaction is actually desired */
@@ -2141,8 +2145,14 @@ public class DbScope
             return null;
         }
 
+        @Override @Nullable
+        public TransactionAuditProvider.TransactionAuditEvent getAuditEvent()
+        {
+            return null;
+        }
+
         @Override
-        public void setAuditId(Long auditId)
+        public void setAuditEvent(TransactionAuditProvider.TransactionAuditEvent event)
         {
 
         }
@@ -2204,7 +2214,7 @@ public class DbScope
 
         private boolean _aborted = false;
         private int _closesToIgnore = 0;
-        private Long _auditId;
+        private TransactionAuditProvider.TransactionAuditEvent _auditEvent = null;
 
         private int _lockTimeout = 5;
         private TimeUnit _lockTimeoutUnit = TimeUnit.MINUTES;
@@ -2225,13 +2235,19 @@ public class DbScope
         @Override @Nullable
         public Long getAuditId()
         {
-            return _auditId;
+            return _auditEvent == null ? null : _auditEvent.getRowId();
+        }
+
+        @Override @Nullable
+        public TransactionAuditProvider.TransactionAuditEvent getAuditEvent()
+        {
+            return _auditEvent;
         }
 
         @Override
-        public void setAuditId(Long auditId)
+        public void setAuditEvent(TransactionAuditProvider.TransactionAuditEvent event)
         {
-            _auditId = auditId;
+            _auditEvent = event;
         }
 
         <K, V> Cache<K, V> getCache(DatabaseCache<K, V> cache)

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -227,7 +227,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
 
             transaction.addCommitTask(() -> AuditLogService.get().addEvent(user, auditEvent), DbScope.CommitTaskOption.PRECOMMIT);
 
-            transaction.setAuditId(auditEvent.getRowId());
+            transaction.setAuditEvent(auditEvent);
         }
     }
 

--- a/api/src/org/labkey/api/query/QueryImportPipelineJob.java
+++ b/api/src/org/labkey/api/query/QueryImportPipelineJob.java
@@ -282,7 +282,12 @@ public class QueryImportPipelineJob extends PipelineJob
                 Map<String, Object> results = new HashMap<>();
                 results.put("rowCount", importedCount);
                 if (_transactionAuditId > 0)
+                {
                     results.put("transactionAuditId", _transactionAuditId);
+                    if (auditEvent != null)
+                        results.put("reselectRowCount", auditEvent.hasMultiActions());
+                }
+
                 if (!diContext.getResponseInfo().isEmpty())
                     results.putAll(diContext.getResponseInfo());
                 notificationProvider.onJobSuccess(this, results);

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -445,6 +445,11 @@ public interface QueryService
             return _verbPastTense;
         }
 
+        public String getDefaultCommentSummary()
+        {
+            return String.format(getCommentSummary(), "Some");
+        }
+
     }
 
     /**

--- a/bigiron/src/org/labkey/bigiron/sas/SasDialect.java
+++ b/bigiron/src/org/labkey/bigiron/sas/SasDialect.java
@@ -18,6 +18,7 @@ package org.labkey.bigiron.sas;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.data.ConnectionWrapper;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcMetaDataSelector.JdbcMetaDataResultSetFactory;
@@ -403,8 +404,14 @@ public abstract class SasDialect extends SimpleSqlDialect
             return null;
         }
 
+        @Override @Nullable
+        public TransactionAuditProvider.TransactionAuditEvent getAuditEvent()
+        {
+            return null;
+        }
+
         @Override
-        public void setAuditId(Long auditId)
+        public void setAuditEvent(TransactionAuditProvider.TransactionAuditEvent event)
         {
         }
     }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8915,7 +8915,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (AuditBehaviorType.NONE != auditBehavior)
             {
                 TransactionAuditProvider.TransactionAuditEvent auditEvent = AbstractQueryUpdateService.createTransactionAuditEvent(targetContainer, QueryService.AuditAction.UPDATE);
-                auditEvent.setRowCount(dataObjects.size());
+                auditEvent.updateCommentRowCount(dataObjects.size());
                 AbstractQueryUpdateService.addTransactionAuditEvent(transaction, user, auditEvent);
             }
 
@@ -9156,7 +9156,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (auditBehavior != null && AuditBehaviorType.NONE != auditBehavior)
             {
                 TransactionAuditProvider.TransactionAuditEvent auditEvent = AbstractQueryUpdateService.createTransactionAuditEvent(targetContainer, QueryService.AuditAction.UPDATE);
-                auditEvent.setRowCount(assayRuns.size());
+                auditEvent.updateCommentRowCount(assayRuns.size());
                 AbstractQueryUpdateService.addTransactionAuditEvent(transaction, user, auditEvent);
             }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -17,8 +17,6 @@
 package org.labkey.experiment.api;
 
 import org.apache.commons.collections4.ListUtils;
-import org.apache.commons.collections4.MultiValuedMap;
-import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -32,7 +30,6 @@ import org.labkey.api.audit.SampleTimelineAuditEvent;
 import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
-import org.labkey.api.collections.Sets;
 import org.labkey.api.data.*;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.measurement.Measurement;
@@ -1806,7 +1803,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             if (AuditBehaviorType.NONE != auditBehavior)
             {
                 TransactionAuditProvider.TransactionAuditEvent auditEvent = AbstractQueryUpdateService.createTransactionAuditEvent(targetContainer, QueryService.AuditAction.UPDATE);
-                auditEvent.setRowCount(samples.size());
+                auditEvent.updateCommentRowCount(samples.size());
                 AbstractQueryUpdateService.addTransactionAuditEvent(transaction, user, auditEvent);
             }
 


### PR DESCRIPTION
#### Rationale
Trigger script can call [labkey/api/Query](https://labkey.github.io/labkey-api-js/modules/Query.html) to additionally do insert/update/delete at any of the before/after calls. Those nested actions do belong to the same transaction and shouldn't trigger separate creation of TransactionAuditEvents. Changes made in this PR to attach the transactionAuditEvent on Transaction, so it can be reused. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1340
- https://github.com/LabKey/labkey-ui-premium/pull/246
- https://github.com/LabKey/platform/pull/4913
- https://github.com/LabKey/biologics/pull/2501
- https://github.com/LabKey/sampleManagement/pull/2220

#### Changes
* add get/setAuditEvent to Transaction
* add addComment function to allow appending of comment per action
* check existing auditEvent for query actions and import actions
* add reselectRowCount flag in response to indicate the returned rowCount might not reflect the total rows affected
