### PR TITLE
Issue 49035: DELETE from exp.edges during sample type deletion never completes

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -438,7 +438,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 // delete provenance for assay result rows
                 ProvenanceService.get().deleteProvenanceByLsids(run.getContainer(), user, new SQLFragment(" IN (").append(assayResultLsidSql).append(")"), true, Set.of(StudyPublishService.STUDY_PUBLISH_PROTOCOL_LSID));
 
-                int count = OntologyManager.deleteOntologyObjects(ExperimentService.get().getSchema(), assayResultLsidSql, run.getContainer(), false);
+                int count = OntologyManager.deleteOntologyObjects(ExperimentService.get().getSchema(), assayResultLsidSql, run.getContainer());
                 LOG.debug("AbstractAssayTsvDataHandler.beforeDeleteData: deleted " + count + " ontology objects for assay result lsids");
             }
 

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -975,8 +975,6 @@ public class OntologyManager
 
     public static int deleteOntologyObjectsByObjectIdSql(DbSchema schema, SQLFragment objectIdSql)
     {
-        // we have different levels of optimization possible here deleteOwned=true/false, scope=/<>exp
-
         if (!schema.getScope().equals(getExpSchema().getScope()))
             throw new UnsupportedOperationException("can only use with same DbScope");
 

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -16,7 +16,6 @@
 package org.labkey.api.exp;
 
 import org.apache.commons.beanutils.ConversionException;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -958,50 +957,41 @@ public class OntologyManager
         }
     }
 
-    public static int deleteOntologyObjects(DbSchema schema, SQLFragment sub, @Nullable Container c, boolean deleteOwnedObjects)
+    public static int deleteOntologyObjects(DbSchema schema, SQLFragment objectUriSql, @Nullable Container c)
+    {
+        SQLFragment objectIdSQL = new SQLFragment("SELECT ObjectId FROM ")
+            .append(getTinfoObject()).append("\n")
+            .append(" WHERE ");
+        if (c != null)
+        {
+            objectIdSQL.append(" Container = ?").add(c.getId());
+            objectIdSQL.append(" AND ");
+        }
+        objectIdSQL.append("ObjectUri IN (");
+        objectIdSQL.append(objectUriSql);
+        objectIdSQL.append(")");
+        return deleteOntologyObjectsByObjectIdSql(schema, objectIdSQL);
+    }
+
+    public static int deleteOntologyObjectsByObjectIdSql(DbSchema schema, SQLFragment objectIdSql)
     {
         // we have different levels of optimization possible here deleteOwned=true/false, scope=/<>exp
 
-        // let's handle one case
         if (!schema.getScope().equals(getExpSchema().getScope()))
             throw new UnsupportedOperationException("can only use with same DbScope");
 
-        // CONSIDER: use temp table for objectids?
+        SQLFragment sqlDeleteProperties = new SQLFragment();
+        sqlDeleteProperties.append("DELETE FROM ").append(getTinfoObjectProperty())
+                .append(" WHERE ObjectId IN (\n");
+        sqlDeleteProperties.append(objectIdSql);
+        sqlDeleteProperties.append(")");
+        new SqlExecutor(getExpSchema()).execute(sqlDeleteProperties);
 
-        if (deleteOwnedObjects)
-        {
-            throw new UnsupportedOperationException("Don't do this yet either");
-        }
-        else
-        {
-            SQLFragment sqlDeleteProperties = new SQLFragment();
-            sqlDeleteProperties.append("DELETE FROM ").append(getTinfoObjectProperty())
-                    .append(" WHERE ObjectId IN\n")
-                    .append("(SELECT ObjectId FROM ")
-                    .append(getTinfoObject()).append("\n")
-                    .append(" WHERE ");
-            if (c != null)
-            {
-                sqlDeleteProperties.append(" Container = ?").add(c.getId());
-                sqlDeleteProperties.append(" AND ");
-            }
-            sqlDeleteProperties.append("ObjectUri IN (");
-            sqlDeleteProperties.append(sub);
-            sqlDeleteProperties.append("))");
-            new SqlExecutor(getExpSchema()).execute(sqlDeleteProperties);
-
-            SQLFragment sqlDeleteObjects = new SQLFragment();
-            sqlDeleteObjects.append("DELETE FROM ").append(getTinfoObject()).append(" WHERE ");
-            if (c != null)
-            {
-                sqlDeleteObjects.append(" Container = ?").add(c.getId());
-                sqlDeleteObjects.append(" AND ");
-            }
-            sqlDeleteObjects.append("ObjectURI IN (");
-            sqlDeleteObjects.append(sub);
-            sqlDeleteObjects.append(")");
-            return new SqlExecutor(getExpSchema()).execute(sqlDeleteObjects);
-        }
+        SQLFragment sqlDeleteObjects = new SQLFragment();
+        sqlDeleteObjects.append("DELETE FROM ").append(getTinfoObject()).append(" WHERE ObjectId IN (");
+        sqlDeleteObjects.append(objectIdSql);
+        sqlDeleteObjects.append(")");
+        return new SqlExecutor(getExpSchema()).execute(sqlDeleteObjects);
     }
 
 

--- a/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
@@ -670,7 +670,7 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
                 lsids.add(container.getId());
             }
 
-            OntologyManager.deleteOntologyObjects(ExperimentService.get().getSchema(), lsids, container, false);
+            OntologyManager.deleteOntologyObjects(ExperimentService.get().getSchema(), lsids, container);
         }
 
         // delete all the rows in this table, scoping to the container if the column

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -896,7 +896,7 @@ public class PlateManager implements PlateService
                 .append(AssayDbSchema.getInstance().getTableInfoWell(), "")
                 .append(" WHERE PlateId = ?")
                 .add(plateId);
-        OntologyManager.deleteOntologyObjects(AssayDbSchema.getInstance().getSchema(), sql, container, false);
+        OntologyManager.deleteOntologyObjects(AssayDbSchema.getInstance().getSchema(), sql, container);
 
         // delete PlateProperty mappings
         SQLFragment sql2 = new SQLFragment("DELETE FROM ")
@@ -956,7 +956,7 @@ public class PlateManager implements PlateService
                 .append(AssayDbSchema.getInstance().getTableInfoWell(), "AW")
                 .append(" WHERE Container = ?")
                 .add(container);
-        OntologyManager.deleteOntologyObjects(AssayDbSchema.getInstance().getSchema(), sql, container, false);
+        OntologyManager.deleteOntologyObjects(AssayDbSchema.getInstance().getSchema(), sql, container);
 
         // delete PlateProperty mappings
         SQLFragment sql2 = new SQLFragment("DELETE FROM ")

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -149,13 +149,13 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
     }
 
     @Nullable @Override
-    public ExpSampleType getSampleType()
+    public ExpSampleTypeImpl getSampleType()
     {
         String type = _object.getCpasType();
         if (!ExpMaterialImpl.DEFAULT_CPAS_TYPE.equals(type) && !"Sample".equals(type))
         {
             // try current container first (uses cache)
-            return SampleTypeService.get().getSampleTypeByType(type, getContainer());
+            return SampleTypeServiceImpl.get().getSampleTypeByType(type, getContainer());
         }
         else
         {

--- a/experiment/src/org/labkey/experiment/api/ExpProtocolApplicationImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpProtocolApplicationImpl.java
@@ -365,12 +365,12 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
             OntologyManager.deleteOntologyObjects(svc.getSchema(), new SQLFragment("SELECT " +
                     dialect.concatenate("'" + DataInput.lsidPrefix() + "'",
                             "CAST(dataId AS VARCHAR)", "'.'", "CAST(targetApplicationId AS VARCHAR)") +
-                    " FROM " + svc.getTinfoDataInput() + " WHERE TargetApplicationId IN (SELECT RowId FROM exp.ProtocolApplication WHERE RunId = " + getRowId() + ")"), getContainer(), false);
+                    " FROM " + svc.getTinfoDataInput() + " WHERE TargetApplicationId IN (SELECT RowId FROM exp.ProtocolApplication WHERE RunId = " + getRowId() + ")"), getContainer());
 
             OntologyManager.deleteOntologyObjects(svc.getSchema(), new SQLFragment("SELECT " +
                     dialect.concatenate("'" + MaterialInput.lsidPrefix() + "'",
                             "CAST(materialId AS VARCHAR)", "'.'", "CAST(targetApplicationId AS VARCHAR)") +
-                    " FROM " + svc.getTinfoMaterialInput() + " WHERE TargetApplicationId IN (SELECT RowId FROM exp.ProtocolApplication WHERE RunId = " + getRowId() + ")"), getContainer(), false);
+                    " FROM " + svc.getTinfoMaterialInput() + " WHERE TargetApplicationId IN (SELECT RowId FROM exp.ProtocolApplication WHERE RunId = " + getRowId() + ")"), getContainer());
 
             long countInputs = 0;
             countInputs += Table.delete(ExperimentServiceImpl.get().getTinfoDataInput(), new SimpleFilter(FieldKey.fromParts("TargetApplicationId"), getRowId()));
@@ -505,7 +505,7 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
         SQLFragment lsidsSql = new SQLFragment().append("SELECT ObjectUri FROM exp.Object WHERE Container = ").appendValue(getContainer())
                 .append(" AND ObjectURI ");
         expSchema.getSqlDialect().appendInClauseSql(lsidsSql, inputLsids);
-        OntologyManager.deleteOntologyObjects(expSchema, lsidsSql, getContainer(), false);
+        OntologyManager.deleteOntologyObjects(expSchema, lsidsSql, getContainer());
 
         removeInputs(ExperimentServiceImpl.get().getTinfoDataInput(), "DataId", rowIds);
 
@@ -533,7 +533,7 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
         SQLFragment lsidsSql = new SQLFragment().append("SELECT ObjectUri FROM exp.Object WHERE Container = ").appendValue(getContainer())
                 .append(" AND ObjectURI ");
         expSchema.getSqlDialect().appendInClauseSql(lsidsSql, inputLsids);
-        OntologyManager.deleteOntologyObjects(expSchema, lsidsSql, getContainer(), false);
+        OntologyManager.deleteOntologyObjects(expSchema, lsidsSql, getContainer());
 
         removeInputs(ExperimentServiceImpl.get().getTinfoMaterialInput(), "MaterialId", rowIds);
     }

--- a/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
@@ -611,7 +611,7 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
                 .append(dataInputSQL)
                 .append(")");
 
-        OntologyManager.deleteOntologyObjects(svc.getSchema(), unionSQL, getContainer(), false);
+        OntologyManager.deleteOntologyObjects(svc.getSchema(), unionSQL, getContainer());
     }
 
     private void deleteProtocolApplicationProvenance()

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4852,7 +4852,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                     {
                         if (isTruncate)
                         {
-                            executor.execute(new SQLFragment("TRUNCATE " + dbTinfo));
+                            executor.execute(new SQLFragment("TRUNCATE TABLE " + dbTinfo));
                         }
                         else
                         {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -537,7 +537,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
      * Delete all exp.Material from the SampleType. If container is not provided,
      * all rows from the SampleType will be deleted regardless of container.
      */
-    public int truncateSampleType(ExpSampleType source, User user, @Nullable Container c)
+    public int truncateSampleType(ExpSampleTypeImpl source, User user, @Nullable Container c)
     {
         assert getExpSchema().getScope().isTransactionActive();
 

--- a/experiment/src/org/labkey/experiment/defaults/DefaultValueServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/defaults/DefaultValueServiceImpl.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 /*
  * User: brittp
@@ -297,7 +296,7 @@ public class DefaultValueServiceImpl implements DefaultValueService
         // Do a single call with both LIKE filters since it's faster than two separate calls
         SQLFragment sql = new SQLFragment("SELECT ObjectURI FROM " + OntologyManager.getTinfoObject() + " WHERE ObjectURI LIKE ? OR ObjectURI LIKE ?",
                 userParentLsid, userScopesLsid);
-        OntologyManager.deleteOntologyObjects(ExperimentService.get().getSchema(), sql, container, false);
+        OntologyManager.deleteOntologyObjects(ExperimentService.get().getSchema(), sql, container);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Deleting from a 1.5 million row sample type took more than 24 hours to delete from `exp.edge` with the current code (and was still cranking). Switching to use `ObjectId` in the temp table instead of `ObjectURI` and using three separate `DELETE` statements is *way* faster in local testing with a restore of the DB in question.

#### Changes
* Use `ObjectId` in temp table. It's 3x faster to create the temp table, and for most uses, faster in queries that reference it
* Support deleting directly by `ObjectId` SQL in `OntologyManager`
* Improve generics a bit to avoid a cast