### PR TITLE
Exempt inactive users from password changes

### DIFF
--- a/api/src/org/labkey/api/security/StrongPasswordValidator.java
+++ b/api/src/org/labkey/api/security/StrongPasswordValidator.java
@@ -7,6 +7,8 @@ import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.Link.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 
+import java.util.Map;
+
 import static org.labkey.api.util.DOM.DIV;
 import static org.labkey.api.util.DOM.id;
 
@@ -53,7 +55,11 @@ public class StrongPasswordValidator extends EntropyPasswordValidator
         if (tips) tips.style.display = (tips.style.display === 'none' ? 'block' : 'none');
         this.text = (this.text.includes('show') ?
         """ + PageFlowUtil.jsString(_tipsLinkText.replace("show", "hide")) + " : " + PageFlowUtil.jsString(_tipsLinkText) + ");";
-    private final LinkBuilder _tipsLink = new LinkBuilder(_tipsLinkText).id("tipsLink").onClick(_tipsLinkOnClick).clearClasses();
+    private final LinkBuilder _tipsLink = new LinkBuilder(_tipsLinkText)
+        .id("tipsLink")
+        .attributes(Map.of(DOM.Attribute.tabindex.name(), "5"))
+        .onClick(_tipsLinkOnClick)
+        .clearClasses();
 
     private final HtmlString _tips = DOM.createHtml(DOM.createHtmlFragment(
         DIV(id("passwordTips").at(DOM.Attribute.style, "display:none;"),

--- a/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
+++ b/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
@@ -119,22 +119,24 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
             if (!SecurityManager.matchPassword(password, hash))
                 return AuthenticationResponse.createFailureResponse(configuration, FailureReason.badPassword);
 
-            // Password is correct for this user; now check password rules and expiration.
-
-            PasswordRule rule = configuration.getPasswordRule();
-            Collection<String> messages = new LinkedList<>();
-
-            if (!rule.isValidForLogin(password, user, messages))
+            if (user.isActive())
             {
-                return getChangePasswordResponse(configuration, user, returnURL, FailureReason.complexity);
-            }
-            else
-            {
-                PasswordExpiration expiration = configuration.getExpiration();
+                // Password is correct and user is active; now check password rules and expiration
+                PasswordRule rule = configuration.getPasswordRule();
+                Collection<String> messages = new LinkedList<>();
 
-                if (expiration.hasExpired(() -> SecurityManager.getLastChanged(user)))
+                if (!rule.isValidForLogin(password, user, messages))
                 {
-                    return getChangePasswordResponse(configuration, user, returnURL, FailureReason.expired);
+                    return getChangePasswordResponse(configuration, user, returnURL, FailureReason.complexity);
+                }
+                else
+                {
+                    PasswordExpiration expiration = configuration.getExpiration();
+
+                    if (expiration.hasExpired(() -> SecurityManager.getLastChanged(user)))
+                    {
+                        return getChangePasswordResponse(configuration, user, returnURL, FailureReason.expired);
+                    }
                 }
             }
 

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -140,8 +140,8 @@
     <% }
        else
        {
-           Container c = getContainer().isRoot() ? ContainerManager.getHomeContainer() : getContainer();
-           URLHelper homeURL = bean.form.getReturnURLHelper() != null ? bean.form.getReturnURLHelper() : new ActionURL(StartAction.class, c);
+            Container c = getContainer().isRoot() ? ContainerManager.getHomeContainer() : getContainer();
+            URLHelper homeURL = bean.form.getReturnURLHelper() != null ? bean.form.getReturnURLHelper() : new ActionURL(StartAction.class, c);
     %>
             <div class="auth-item">
                 <%= unsafe(button("Home").href(homeURL).toString()) %>


### PR DESCRIPTION
#### Rationale
Currently, we force inactive users with an expired or insufficiently complex password through the change password process, and then dump them on the home page without logging them in or informing them of their unfortunate status. That's kind of mean. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48765
