### PR TITLE
Issue 48446: Add Test coverage for re-ordering authentication configs

### DIFF
--- a/devtools/test/src/org/labkey/test/params/devtools/TestSsoProvider.java
+++ b/devtools/test/src/org/labkey/test/params/devtools/TestSsoProvider.java
@@ -1,0 +1,53 @@
+package org.labkey.test.params.devtools;
+
+import org.labkey.test.pages.core.login.LoginConfigRow;
+import org.labkey.test.pages.core.login.SsoAuthDialogBase;
+import org.labkey.test.params.login.AuthenticationProvider;
+import org.openqa.selenium.WebDriver;
+
+public class TestSsoProvider extends AuthenticationProvider<TestSsoProvider.TestSsoConfigureDialog>
+{
+    @Override
+    public String getProviderName()
+    {
+        return "TestSSO";
+    }
+
+    @Override
+    public String getProviderDescription()
+    {
+        return "A trivial, insecure SSO authentication provider (for test purposes only)";
+    }
+
+    @Override
+    public TestSsoConfigureDialog getEditDialog(LoginConfigRow row)
+    {
+        return new TestSsoConfigureDialog(row);
+    }
+
+    @Override
+    public TestSsoConfigureDialog getNewDialog(WebDriver driver)
+    {
+        return new TestSsoConfigureDialog(driver);
+    }
+
+    public class TestSsoConfigureDialog extends SsoAuthDialogBase<TestSsoConfigureDialog>
+    {
+        public TestSsoConfigureDialog(LoginConfigRow row)
+        {
+            super(row);
+        }
+
+        public TestSsoConfigureDialog(WebDriver driver)
+        {
+            super(TestSsoProvider.this, driver);
+        }
+
+        @Override
+        protected TestSsoConfigureDialog getThis()
+        {
+            return this;
+        }
+
+    }
+}

--- a/devtools/test/src/org/labkey/test/tests/devtools/AuthenticationProviderReorderTest.java
+++ b/devtools/test/src/org/labkey/test/tests/devtools/AuthenticationProviderReorderTest.java
@@ -1,0 +1,90 @@
+package org.labkey.test.tests.devtools;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.BootstrapLocators;
+import org.labkey.test.Locator;
+import org.labkey.test.TestFileUtils;
+import org.labkey.test.categories.Git;
+import org.labkey.test.pages.core.login.LoginConfigurePage;
+import org.labkey.test.params.devtools.TestSsoProvider;
+import org.labkey.test.util.login.AuthenticationAPIUtils;
+import org.openqa.selenium.WebElement;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+@Category({Git.class})
+public class AuthenticationProviderReorderTest extends BaseWebDriverTest
+{
+    private static final TestSsoProvider PROVIDER = new TestSsoProvider();
+    private static final File THUMBNAIL_COOL = TestFileUtils.getSampleData("thumbnails/Super Cool R Report/Thumbnail.png");
+    private static final File THUMBNAIL_UNCOOL = TestFileUtils.getSampleData("thumbnails/Want To Be Cool/Thumbnail.png");
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        AuthenticationAPIUtils.deleteConfigurations(PROVIDER.getProviderName(), createDefaultConnection());
+    }
+
+    @Test
+    public void testReorderConfigurations()
+    {
+        String config_uncool = "TestSSO Uncool";
+        String config_cool = "TestSSO Cool";
+
+        log("Create SSO login configurations");
+        LoginConfigurePage configurePage = LoginConfigurePage.beginAt(this);
+        configurePage.addConfiguration(PROVIDER)
+                .setDescription(config_uncool)
+                .setLoginPageLogo(THUMBNAIL_UNCOOL)
+                .setPageHeaderLogo(THUMBNAIL_UNCOOL)
+                .clickApply();
+        configurePage.addConfiguration(PROVIDER)
+                .setDescription(config_cool)
+                .setLoginPageLogo(THUMBNAIL_COOL)
+                .setPageHeaderLogo(THUMBNAIL_COOL)
+                .clickApply();
+
+        signOut();
+        assertSsoLinkOrder(config_uncool, config_cool);
+        clickAndWait(Locator.linkWithText("Sign In"));
+        assertSsoLinkOrder(config_uncool, config_cool);
+        simpleSignIn();
+
+        configurePage = LoginConfigurePage.beginAt(this);
+        WebElement uncoolRow = Locator.byClass("domain-row-handle").findElement(configurePage.getPrimaryConfigurationRow(config_uncool));
+        WebElement coolRow = Locator.byClass("domain-row-handle").findElement(configurePage.getPrimaryConfigurationRow(config_cool));
+        dragAndDrop(uncoolRow, coolRow);
+        BootstrapLocators.infoBanner.waitForElement(getDriver(), 2_000);
+        configurePage.clickSaveAndFinish();
+
+        signOut();
+        assertSsoLinkOrder(config_cool, config_uncool);
+        clickAndWait(Locator.linkWithText("Sign In"));
+        assertSsoLinkOrder(config_cool, config_uncool);
+        simpleSignIn();
+    }
+
+    private void assertSsoLinkOrder(String firstConfig, String secondConfig)
+    {
+        List<WebElement> ssoIcons = Locator.tagWithAttributeContaining("a", "href", "ssoRedirect").childTag("img").waitForElements(getDriver(), 2_000);
+        List<String> ssoNames = ssoIcons.stream().map(el -> el.getAttribute("title")).map(s -> s.replace("Sign in using ", "")).toList();
+        Assertions.assertThat(ssoNames).as("SSO link order").endsWith(firstConfig, secondConfig);
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "AuthenticationProviderReorderTest Project";
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList();
+    }
+}

--- a/devtools/test/src/org/labkey/test/tests/devtools/SecondaryAuthenticationTest.java
+++ b/devtools/test/src/org/labkey/test/tests/devtools/SecondaryAuthenticationTest.java
@@ -16,8 +16,6 @@
 package org.labkey.test.tests.devtools;
 
 import org.apache.commons.lang3.time.DateUtils;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
@@ -33,6 +31,7 @@ import org.labkey.test.pages.core.login.LoginConfigRow;
 import org.labkey.test.pages.core.login.LoginConfigurePage;
 import org.labkey.test.params.devtools.SecondaryAuthenticationProvider;
 import org.labkey.test.util.PasswordUtil;
+import org.labkey.test.util.login.AuthenticationAPIUtils;
 
 import java.io.IOException;
 import java.text.DateFormat;
@@ -52,16 +51,10 @@ import static org.junit.Assert.assertTrue;
 @BaseWebDriverTest.ClassTimeout(minutes = 1)
 public class SecondaryAuthenticationTest extends BaseWebDriverTest
 {
-    @Before
-    public void preTest()
+    @Override
+    protected void doCleanup(boolean afterTest)
     {
-        clearSecondaryConfigs();
-    }
-
-    @After
-    public void afterTest()
-    {
-        clearSecondaryConfigs();
+        AuthenticationAPIUtils.deleteConfigurations(new SecondaryAuthenticationProvider().getProviderName(), createDefaultConnection());
     }
 
     private void clearSecondaryConfigs()


### PR DESCRIPTION
#### Rationale
[Issue 48446: Add Test coverage for re-ordering authentication configs](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=48446)

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1710

#### Changes
* Add test components for `TestSSO` authentication
* Add regression test for reordering authentication configs
