### PR TITLE
Sample deletion test fix - stop deleting rows from other containers

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4671,6 +4671,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
      * null, the samples must have cpasType of {@link ExpMaterial#DEFAULT_CPAS_TYPE} unless
      * the <code>deleteFromAllSampleTypes</code> flag is true.
      * Deleting from multiple SampleTypes is only needed when cleaning an entire container.
+     * @param isTruncate delete all rows for this container. Not a real DB truncate because there may be rows in other containers.
      */
     public int deleteMaterialBySqlFilter(
         User user,
@@ -4850,17 +4851,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                     // NOTE: study specimens don't have a domain for their samples, so no table
                     if (null != dbTinfo)
                     {
-                        if (isTruncate)
-                        {
-                            executor.execute(new SQLFragment("TRUNCATE TABLE " + dbTinfo));
-                        }
-                        else
-                        {
-                            SQLFragment sampleTypeSQL = new SQLFragment("DELETE FROM " + dbTinfo + " WHERE lsid IN (SELECT lsid FROM exp.Material WHERE ");
-                            sampleTypeSQL.append(materialFilterSQL);
-                            sampleTypeSQL.append(")");
-                            executor.execute(sampleTypeSQL);
-                        }
+                        SQLFragment sampleTypeSQL = new SQLFragment("DELETE FROM " + dbTinfo + " WHERE lsid IN (SELECT lsid FROM exp.Material WHERE ");
+                        sampleTypeSQL.append(materialFilterSQL);
+                        sampleTypeSQL.append(")");
+                        executor.execute(sampleTypeSQL);
                     }
                 }
             }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4658,11 +4658,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                                       boolean deleteRunsUsingMaterials,
                                       @Nullable ExpSampleTypeImpl stDeleteFrom,
                                       boolean ignoreStatus,
-                                      boolean isTruncate)
+                                      boolean truncateContainer)
     {
         SQLFragment rowIdSQL = new SQLFragment("RowId ");
         rowIdSQL.appendInClause(selectedMaterialIds, getSchema().getSqlDialect());
-        return deleteMaterialBySqlFilter(user, container, rowIdSQL, deleteRunsUsingMaterials, false, stDeleteFrom, ignoreStatus, isTruncate);
+        return deleteMaterialBySqlFilter(user, container, rowIdSQL, deleteRunsUsingMaterials, false, stDeleteFrom, ignoreStatus, truncateContainer);
     }
 
     /**
@@ -4671,7 +4671,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
      * null, the samples must have cpasType of {@link ExpMaterial#DEFAULT_CPAS_TYPE} unless
      * the <code>deleteFromAllSampleTypes</code> flag is true.
      * Deleting from multiple SampleTypes is only needed when cleaning an entire container.
-     * @param isTruncate delete all rows for this container. Not a real DB truncate because there may be rows in other containers.
+     * @param truncateContainer delete all rows for this container. Not a real DB truncate because there may be rows in other containers.
      */
     public int deleteMaterialBySqlFilter(
         User user,
@@ -4681,7 +4681,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         boolean deleteFromAllSampleTypes,
         @Nullable ExpSampleTypeImpl stDeleteFrom,
         boolean ignoreStatus,
-        boolean isTruncate
+        boolean truncateContainer
     )
     {
         if (stDeleteFrom != null && deleteFromAllSampleTypes)
@@ -4745,7 +4745,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                                     throw new IllegalArgumentException("Error deleting '" + stDeleteFrom.getName() + "' sample: '" + material.getName() + "' is in the sample type '" + material.getCpasType() + "'");
                             }
 
-                            if (!isTruncate && !StringUtils.equals(material.getLSID(), material.getRootMaterialLSID()))
+                            if (!truncateContainer && !StringUtils.equals(material.getLSID(), material.getRootMaterialLSID()))
                             {
                                 ExpSampleType sampleType = material.getSampleType();
                                 sampleTypeAliquotRoots.computeIfAbsent(sampleType, (k) -> new HashSet<>())
@@ -4884,7 +4884,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             }
 
             // recalculate rollup
-            if (!isTruncate)
+            if (!truncateContainer)
             {
                 try (Timing ignored = MiniProfiler.step("recalculate aliquot rollup"))
                 {


### PR DESCRIPTION
#### Rationale
My commit last night to optimize sample deletion misinterpreted the `isTruncate` argument as indicating the whole sample type was being truncated. It's actually just being "truncated" for that single container. Thus, a DB-level `TRUNCATE` is not appropriate, as it will clear out rows from other containers too.

https://teamcity.labkey.org/buildConfiguration/LabKey_2311Release_Premium_ProductSuites_SampleManager_SampleManagerCPostgres/2733502?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true

#### Changes
* Revert the change to use `TRUNCATE`. It's faster, but not doing what we need