### PR TITLE
Update usage of OntologyManager.deleteOntologyObjects

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4584,7 +4584,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                         .append(" AND RowId ");
         table.getSqlDialect().appendInClauseSql(deleteSql, protocolInputRowIds);
 
-        OntologyManager.deleteOntologyObjects(getSchema(), ontologyLSIDSql, protocol.getContainer(), false);
+        OntologyManager.deleteOntologyObjects(getSchema(), ontologyLSIDSql, protocol.getContainer());
         new SqlExecutor(getSchema()).execute(deleteSql);
     }
 


### PR DESCRIPTION
#### Rationale
Fixes a build break caused by incongruent changes in #4904 and #4915.

#### Related Pull Requests
* #4904
* #4915

#### Changes
* Update call to `OntologyManager.deleteOntologyObjects()` to match new signature.
