### PR TITLE
Fix nested data region expandos

### DIFF
--- a/api/src/org/labkey/api/query/AbstractNestableDataRegion.java
+++ b/api/src/org/labkey/api/query/AbstractNestableDataRegion.java
@@ -24,7 +24,6 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.ResultsImpl;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SimpleDisplayColumn;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
@@ -88,7 +87,7 @@ public abstract class AbstractNestableDataRegion extends DataRegion
         out.write("/_images/");
         out.write(_expanded ? "minus" : "plus");
         out.write(".gif\"/></a>");
-        page.addHandler(id, "click", "return toggleNestedGrid(" + jsString(getName()) + "," + (_ajaxNestedGridURL == null ? "null" : jsString(PageFlowUtil.filter(_ajaxNestedGridURL + value))) + ", " + jsString(value) + ")");
+        page.addHandler(id, "click", "return toggleNestedGrid(" + jsString(getName()) + "," + (_ajaxNestedGridURL == null ? "null" : jsString(_ajaxNestedGridURL + value)) + ", " + jsString(value) + ")");
     }
 
     private String getUniqueColumnValue(RenderContext ctx)


### PR DESCRIPTION
#### Rationale
Nested data region expandos (e.g., on the protein grouping grid) AJAX to get their inner grid HTML; these AJAX requests are returning 404 because the URLs are double encoded. Related PR refactored the expando JavaScript, moving it from inline to a `<script>` block. As such, I believe the URL parameter should be `jsString()` encoded but NOT HTML encoded.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4620/files#diff-de7165261b9c8e2cc66c2f542db26e406d9fb772b5b93d8c4f21728aaf09c91fR91