### PR TITLE
Prevent multiple webapps pointed at the same database

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1757,7 +1757,7 @@ public class DbScope
         }
         catch (SQLException | ServletException e)
         {
-            LOG.warn("Attempt to detect other LabKey Server instances using this database failed: " + e.getMessage());
+            LOG.warn("Attempt to detect other LabKey Server instances using this database failed", e);
         }
     }
 
@@ -1776,6 +1776,7 @@ public class DbScope
                 if (rs.next())
                 {
                     applicationName = rs.getString(1);
+                    assert applicationName != null;
                     String message = "Application name detected on first database connection: \"" + applicationName + "\"";
 
                     // If connection shows the default application name (i.e., application name is not set on the JDBC URL)

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -334,6 +334,7 @@ public class DbScope
             _driverClassName = _dsPropertyReader.getDriverClassName();
             // Note: Dialect won't be versioned with the corresponding database
             _dialect = SqlDialectManager.getFromDriverClassname(_dsName, _driverClassName);
+            MemTracker.get().remove(_dialect);
             _driverClass = initializeDriver();
             _applicationName = ensureApplicationName();
             _url = _dsPropertyReader.getUrl();

--- a/api/src/org/labkey/api/data/DbScopeLoader.java
+++ b/api/src/org/labkey/api/data/DbScopeLoader.java
@@ -17,6 +17,9 @@ import java.util.concurrent.atomic.AtomicReference;
  * schema admin page or sending data source metrics to labkey.org). {@link #clearDbScope()} can be used to attempt a
  * re-connection to a data source that failed its previous connection attempt(s). This is used by the external schema
  * admin page, which provides a link to attempt re-connecting to all data sources that failed previous connection(s).
+ * Note that there's not always a 1:1 correspondence between DbScope/DbScopeLoader and LabKeyDataSource because module
+ * data sources that reference non-existent databases in dev mode will map to the primary data source. That's why
+ * dsName is passed into this constructor instead of delegating to the LabKeyDataSource.
  */
 class DbScopeLoader
 {

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -1916,4 +1916,10 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     {
         return "ApplicationName";
     }
+
+    @Override
+    public int getApplicationConnectionCount(Connection conn, String database, String applicationName)
+    {
+        return new SqlSelector(null, conn, new SQLFragment("SELECT COUNT(*) FROM pg_stat_activity WHERE datname = ? AND application_name = ?", database, applicationName)).getObject(Integer.class);
+    }
 }

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -1910,4 +1910,10 @@ public abstract class PostgreSql91Dialect extends SqlDialect
         // Don't test a LabKey data source
         return getServerType().shouldTest();
     }
+
+    @Override
+    public @Nullable String getApplicationNameParameter()
+    {
+        return "ApplicationName";
+    }
 }

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -1918,6 +1918,18 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     }
 
     @Override
+    public @Nullable String getApplicationNameSql()
+    {
+        return "SELECT current_setting('application_name')";
+    }
+
+    @Override
+    public @Nullable String getDefaultApplicationName()
+    {
+        return "PostgreSQL JDBC Driver";
+    }
+
+    @Override
     public @Nullable String getApplicationConnectionCountSql()
     {
         return "SELECT COUNT(*) FROM pg_stat_activity WHERE datname = ? AND application_name = ?";

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -1918,8 +1918,8 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     }
 
     @Override
-    public int getApplicationConnectionCount(Connection conn, String database, String applicationName)
+    public @Nullable String getApplicationConnectionCountSql()
     {
-        return new SqlSelector(null, conn, new SQLFragment("SELECT COUNT(*) FROM pg_stat_activity WHERE datname = ? AND application_name = ?", database, applicationName)).getObject(Integer.class);
+        return "SELECT COUNT(*) FROM pg_stat_activity WHERE datname = ? AND application_name = ?";
     }
 }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -44,6 +44,7 @@ import org.springframework.jdbc.BadSqlGrammarException;
 import javax.servlet.ServletException;
 import javax.sql.DataSource;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.CallableStatement;
 import java.sql.Connection;
@@ -62,6 +63,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
@@ -1106,7 +1108,7 @@ public abstract class SqlDialect
     //
     // Currently, JdbcHelper only finds the database name. It could be extended if we require querying other components or if
     // replacement/reassembly becomes necessary.
-    public String getDatabaseName(DataSourceProperties props) throws ServletException
+    public String getDatabaseName(DataSourcePropertyReader props) throws ServletException
     {
         try
         {
@@ -1184,14 +1186,14 @@ public abstract class SqlDialect
 
     // Trying to be DataSource-implementation agnostic here. DataSource interface doesn't provide access to any of
     // these properties, but we don't want to cast to a specific implementation class, so use reflection to get them.
-    public static class DataSourceProperties
+    public static class DataSourcePropertyReader
     {
         private final String _dsName;
         private final DataSource _ds;
 
-        public DataSourceProperties(String dsName, DataSource ds)
+        public DataSourcePropertyReader(String dsName, DataSource ds)
         {
-            _dsName = dsName;
+            _dsName = dsName; // Used only for error logging
             _ds = ds;
         }
 
@@ -1213,28 +1215,20 @@ public abstract class SqlDialect
             }
         }
 
-        public String getDataSourceName()
-        {
-            return _dsName;
-        }
-
         public String getUrl() throws ServletException
         {
             return getProperty("getUrl");
         }
-
 
         public String getDriverClassName() throws ServletException
         {
             return getProperty("getDriverClassName");
         }
 
-
         public String getUsername() throws ServletException
         {
             return getProperty("getUsername");
         }
-
 
         public String getPassword() throws ServletException
         {
@@ -1288,6 +1282,21 @@ public abstract class SqlDialect
             catch (ServletException e)
             {
                 LOG.error("Could not extract connection pool max wait (ms) from data source \"" + _dsName + "\"");
+                return null;
+            }
+        }
+
+        public Properties getConnectionProperties()
+        {
+            try
+            {
+                Method method = _ds.getClass().getDeclaredMethod("getConnectionProperties");
+                method.setAccessible(true);
+                return (Properties) method.invoke(_ds);
+            }
+            catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e)
+            {
+                LOG.error("Could not extract connection properties from data source \"" + _dsName + "\"");
                 return null;
             }
         }
@@ -1761,6 +1770,10 @@ public abstract class SqlDialect
         return true;
     }
 
+    public @Nullable String getApplicationNameParameter()
+    {
+        return null;
+    }
 
     public static class DialectTestCase
     {

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1775,6 +1775,12 @@ public abstract class SqlDialect
         return null;
     }
 
+    // Return count of connections with the specified application name that are using this database
+    public int getApplicationConnectionCount(Connection conn, String database, String applicationName)
+    {
+        return 0;
+    }
+
     public static class DialectTestCase
     {
         DbScope s;

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1286,7 +1286,7 @@ public abstract class SqlDialect
             }
         }
 
-        public Properties getConnectionProperties()
+        public @Nullable Properties getConnectionProperties()
         {
             try
             {
@@ -1775,10 +1775,11 @@ public abstract class SqlDialect
         return null;
     }
 
-    // Return count of connections with the specified application name that are using this database
-    public int getApplicationConnectionCount(Connection conn, String database, String applicationName)
+    // Returns SQL that counts connections that are using a specific database and are tagged with a specific application
+    // name. SQL must have two parameter placeholders for database name and application name (in that order).
+    public @Nullable String getApplicationConnectionCountSql()
     {
-        return 0;
+        return null;
     }
 
     public static class DialectTestCase

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1775,6 +1775,17 @@ public abstract class SqlDialect
         return null;
     }
 
+    // Returns SQL that queries the current connections application name
+    public @Nullable String getApplicationNameSql()
+    {
+        return null;
+    }
+
+    public @Nullable String getDefaultApplicationName()
+    {
+        return null;
+    }
+
     // Returns SQL that counts connections that are using a specific database and are tagged with a specific application
     // name. SQL must have two parameter placeholders for database name and application name (in that order).
     public @Nullable String getApplicationConnectionCountSql()

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -173,7 +173,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
                 DbScope scope = DbScope.getLabKeyScope();
 
                 _log.warn("Module \"" + getName() + "\" requires a data source called \"" + dsName + "\". It's not configured, so it will be created against the primary labkey database (\"" + scope.getDatabaseName() + "\") instead.");
-                DbScope.addScope(dsName, scope.getDataSource(), scope.getLabKeyProps());
+                DbScope.addScope(dsName, scope.getLabKeyDataSource());
                 if (null == DbScope.getDbScope(dsName)) // Force immediate connection to test
                     throw new ConfigurationException("Failed to connect to data source \"" + dsName + "\", created against the labkey database (\"" + scope.getDatabaseName() + "\").");
             }

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -156,8 +156,6 @@ public class ModuleLoader implements Filter, MemTrackerListener
 
     public static final String MODULE_NAME_REGEX = "\\w+";
     public static final String PRODUCTION_BUILD_TYPE = "Production";
-    public static final String LABKEY_DATA_SOURCE = "labkeyDataSource";
-    public static final String CPAS_DATA_SOURCE = "cpasDataSource";
     public static final Object SCRIPT_RUNNING_LOCK = new Object();
 
     private static ModuleLoader _instance = null;

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -2429,4 +2429,10 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     {
         return new MicrosoftSqlServerStringHandler();
     }
+
+    @Override
+    public @Nullable String getApplicationNameParameter()
+    {
+        return "applicationName";
+    }
 }

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -68,13 +68,6 @@ import java.util.Stack;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-
-/**
- * User: arauch
- * Date: Dec 28, 2004
- * Time: 8:58:25 AM
- */
-
 // Dialect specifics for Microsoft SQL Server
 abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
 {
@@ -2437,8 +2430,8 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     }
 
     @Override
-    public int getApplicationConnectionCount(Connection conn, String database, String applicationName)
+    public @Nullable String getApplicationConnectionCountSql()
     {
-        return new SqlSelector(null, conn, new SQLFragment("SELECT COUNT(*) FROM sys.sysprocesses WHERE DB_NAME(dbid) = ? AND program_name = ?", database, applicationName)).getObject(Integer.class);
+        return "SELECT COUNT(*) FROM sys.sysprocesses WHERE DB_NAME(dbid) = ? AND program_name = ?";
     }
 }

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -2435,4 +2435,10 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     {
         return "applicationName";
     }
+
+    @Override
+    public int getApplicationConnectionCount(Connection conn, String database, String applicationName)
+    {
+        return new SqlSelector(null, conn, new SQLFragment("SELECT COUNT(*) FROM sys.sysprocesses WHERE DB_NAME(dbid) = ? AND program_name = ?", database, applicationName)).getObject(Integer.class);
+    }
 }

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -2430,6 +2430,18 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     }
 
     @Override
+    public @Nullable String getApplicationNameSql()
+    {
+        return "SELECT APP_NAME()";
+    }
+
+    @Override
+    public @Nullable String getDefaultApplicationName()
+    {
+        return "Microsoft JDBC Driver for SQL Server";
+    }
+
+    @Override
     public @Nullable String getApplicationConnectionCountSql()
     {
         return "SELECT COUNT(*) FROM sys.sysprocesses WHERE DB_NAME(dbid) = ? AND program_name = ?";

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2008R2Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2008R2Dialect.java
@@ -19,9 +19,6 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.Table;
 
-/**
- * Created by adam on 12/4/2015.
- */
 public class MicrosoftSqlServer2008R2Dialect extends BaseMicrosoftSqlServerDialect
 {
     // Called only if offset is > 0, maxRows is not NO_ROWS, and order is non-blank

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2012Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2012Dialect.java
@@ -20,11 +20,6 @@ import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.dialect.LimitRowsSqlGenerator;
 
-/**
- * User: adam
- * Date: 2/9/12
- * Time: 8:34 AM
- */
 public class MicrosoftSqlServer2012Dialect extends MicrosoftSqlServer2008R2Dialect
 {
     // Called only if offset is > 0, maxRows is not NO_ROWS, and order is non-blank

--- a/bigiron/src/org/labkey/bigiron/mysql/MySqlDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySqlDialect.java
@@ -17,6 +17,7 @@ package org.labkey.bigiron.mysql;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CsvSet;
 import org.labkey.api.collections.Sets;
 import org.labkey.api.data.DatabaseTableType;
@@ -46,11 +47,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * User: adam
- * Date: Aug 17, 2010
- * Time: 3:53:40 PM
- */
 public class MySqlDialect extends SimpleSqlDialect
 {
     @Override
@@ -310,8 +306,14 @@ public class MySqlDialect extends SimpleSqlDialect
     protected String getExplainPrefix(ExecutionPlanType type)
     {
         // Note: This is not very useful because the query returns multiple columns, most of which we ignore. But
-        // MySQL 5.7 and before doesn't support FORMAT = TREE. We could concatenate the columns ourselves, but it's
+        // MySQL 5.7 and before don't support FORMAT = TREE. We could concatenate the columns ourselves, but it's
         // not worth the bother for unsupported versions of MySQL.
         return "EXPLAIN ";
+    }
+
+    @Override
+    public @Nullable String getApplicationNameParameter()
+    {
+        return "ApplicationName";
     }
 }

--- a/bigiron/src/org/labkey/bigiron/oracle/OracleDialect.java
+++ b/bigiron/src/org/labkey/bigiron/oracle/OracleDialect.java
@@ -20,6 +20,7 @@ import oracle.sql.TIMESTAMP;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ConnectionPool;
 import org.labkey.api.data.ConnectionWrapper;
 import org.labkey.api.data.DbScope;
@@ -56,12 +57,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-
-/**
- * User: trent
- * Date: 6/10/11
- * Time: 3:40 PM
- */
 abstract class OracleDialect extends SimpleSqlDialect
 {
     // To work around #33481, for each Oracle scope, create a special connection pool that invalidates connections before they hit the max usage limit
@@ -402,6 +397,12 @@ abstract class OracleDialect extends SimpleSqlDialect
     public @NotNull String getDefaultTablesToExcludeFromTesting()
     {
         return "SYS_IOT_OVER_*";
+    }
+
+    @Override
+    public @Nullable String getApplicationNameParameter()
+    {
+        return "v$session.program";
     }
 
     private static class OracleColumnMetaDataReader extends ColumnMetaDataReader

--- a/bigiron/src/org/labkey/bigiron/sas/SasDialect.java
+++ b/bigiron/src/org/labkey/bigiron/sas/SasDialect.java
@@ -160,7 +160,7 @@ public abstract class SasDialect extends SimpleSqlDialect
     // SAS has no database name, so override both getDatabaseName() methods and return null.
 
     @Override
-    public String getDatabaseName(DataSourceProperties props)
+    public String getDatabaseName(DataSourcePropertyReader props)
     {
         return null;
     }

--- a/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
@@ -34,10 +34,6 @@ import java.util.regex.Pattern;
 
 /*
  * PostgreSQL 9.2 is no longer supported, however, we keep this class to track changes we implemented specifically for this version.
- *
- * User: adam
- * Date: 5/21/12
- * Time: 8:52 AM
  */
 abstract class PostgreSql92Dialect extends PostgreSql91Dialect
 {

--- a/core/src/org/labkey/core/dialect/PostgreSql93Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql93Dialect.java
@@ -22,10 +22,6 @@ import java.util.Set;
 
 /*
  * PostgreSQL 9.3 is no longer supported, however, we keep this class to track changes we implemented specifically for this version.
- *
- * User: adam
- * Date: Jun 14, 2013
- * Time: 8:50:00 AM
  */
 abstract class PostgreSql93Dialect extends PostgreSql92Dialect
 {

--- a/core/src/org/labkey/core/dialect/PostgreSql94Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql94Dialect.java
@@ -21,10 +21,6 @@ import java.util.Set;
 
 /**
  * PostgreSQL 9.4 is no longer supported, however, we keep this class to track changes we implemented specifically for this version.
- *
- * User: adam
- * Date: 8/5/2014
- * Time: 10:49 PM
  */
 abstract class PostgreSql94Dialect extends PostgreSql93Dialect
 {

--- a/core/src/org/labkey/core/dialect/PostgreSql95Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql95Dialect.java
@@ -21,8 +21,6 @@ import java.util.Set;
 
 /**
  * PostgreSQL 9.5 is no longer supported, however, we keep this class to track changes we implemented specifically for this version.
- *
- * Created by adam on 7/24/2015.
  */
 abstract class PostgreSql95Dialect extends PostgreSql94Dialect
 {

--- a/core/src/org/labkey/core/dialect/PostgreSql96Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql96Dialect.java
@@ -15,9 +15,6 @@
  */
 package org.labkey.core.dialect;
 
-/**
- * Created by adam on 8/10/2016.
- */
 abstract class PostgreSql96Dialect extends PostgreSql95Dialect
 {
 }


### PR DESCRIPTION
#### Rationale
Our customers occasionally point multiple instances of LabKey Server at the same database; this never goes well and often results in problems that are difficult to diagnose.

This PR adds detection at server startup of any existing LabKey Server instance(s) operating on the same database; if found, the more recent server disables itself to prevent damage and alert administrators. Approach:

* On the very first connection to the primary database, query the application name.
* If the query returns the driver's default name then set "LabKey Server" as the application name on all subsequent connections, otherwise allow the custom name.
* On the next connection, query for other connections to the same database with this instance's application name.
* If any other connections exist, abort server startup. 

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=46149

```
org.labkey.api.util.ConfigurationException: There are 3 connections to database "labkey23.11" with the application name "LabKey Server"! This likely means another LabKey Server deployment is already using this database.
	org.labkey.api.data.DbScope.ensureDatabase(DbScope.java:1705)
	org.labkey.api.data.DbScope.initializeDataSources(DbScope.java:1581)
	org.labkey.api.module.ModuleLoader.doInit(ModuleLoader.java:527)
	org.labkey.api.module.ModuleLoader.init(ModuleLoader.java:254)
	org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:171)
	org.apache.catalina.startup.HostConfig.deployDescriptor(HostConfig.java:689)
```