### PR TITLE
Remove exp.material.rootMaterialRowId foreign key constraint

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-23.011-23.012.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-23.011-23.012.sql
@@ -36,8 +36,9 @@ DROP TABLE materialroottemp;
 ALTER TABLE exp.material ALTER COLUMN RootMaterialRowId SET NOT NULL;
 
 -- Add FK on "RootMaterialRowId"
-ALTER TABLE exp.material ADD CONSTRAINT FK_Material_RootMaterialRowId
-    FOREIGN KEY (RootMaterialRowId) REFERENCES exp.material (RowId);
+-- See exp-23.012-23.013.sql
+-- ALTER TABLE exp.material ADD CONSTRAINT FK_Material_RootMaterialRowId
+--     FOREIGN KEY (RootMaterialRowId) REFERENCES exp.material (RowId);
 
 -- Remove the "RootMaterialLSID" column
 ALTER TABLE exp.material DROP COLUMN RootMaterialLSID;

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-23.012-23.013.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-23.012-23.013.sql
@@ -1,0 +1,3 @@
+-- It is possible for parent samples of aliquots to be moved to a subfolder where upon deletion
+-- of the subfolder we need to delete the parent sample but the aliquot still exists.
+ALTER TABLE exp.material DROP CONSTRAINT IF EXISTS FK_Material_RootMaterialRowId;

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-23.011-23.012.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-23.011-23.012.sql
@@ -14,9 +14,10 @@ ALTER TABLE exp.Material ALTER COLUMN rootmaterialrowid INTEGER NOT NULL;
 GO
 
 -- Add FK on "RootMaterialRowId"
-ALTER TABLE exp.Material ADD CONSTRAINT FK_Material_RootMaterialRowId
-    FOREIGN KEY (RootMaterialRowId) REFERENCES exp.Material (RowId);
-GO
+-- See exp-23.012-23.013.sql
+-- ALTER TABLE exp.Material ADD CONSTRAINT FK_Material_RootMaterialRowId
+--     FOREIGN KEY (RootMaterialRowId) REFERENCES exp.Material (RowId);
+-- GO
 
 CREATE INDEX ix_material_rootmaterialrowid ON exp.Material (rootmaterialrowid);
 GO

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-23.012-23.013.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-23.012-23.013.sql
@@ -1,0 +1,3 @@
+-- It is possible for parent samples of aliquots to be moved to a subfolder where upon deletion
+-- of the subfolder we need to delete the parent sample but the aliquot still exists.
+SELECT core.fn_dropifexists('material', 'exp', 'constraint', 'FK_Material_RootMaterialRowId');

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-23.012-23.013.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-23.012-23.013.sql
@@ -1,3 +1,3 @@
 -- It is possible for parent samples of aliquots to be moved to a subfolder where upon deletion
 -- of the subfolder we need to delete the parent sample but the aliquot still exists.
-SELECT core.fn_dropifexists('material', 'exp', 'constraint', 'FK_Material_RootMaterialRowId');
+EXEC core.fn_dropifexists 'material', 'exp', 'constraint', 'FK_Material_RootMaterialRowId';

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -176,7 +176,7 @@ public class ExperimentModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 23.012;
+        return 23.013;
     }
 
     @Nullable


### PR DESCRIPTION
#### Rationale
In #4844 a foreign key constraint was added on the newly migrated `RootMaterialRowId` column. It is possible for parent samples of aliquots to be moved to a subfolder where upon deletion of the subfolder we need to delete the parent sample but the aliquot still exists. This causes the folder deletion to fail on the constraint. In light of this I recommend we remove this constraint.

There may be further debate on if this is indeed a viable scenario that we want to continue to support but I think this is the most straight-forward thing to do at the moment. If/when we decide we do want this foreign key then we can consider how we'll handle these scenarios and subsequent application changes will be needed to allow for this foreign key constraint.

#### Related Pull Requests
* #4844

#### Changes
* Remove `FK_Material_RootMaterialRowId` from previous upgrade script.
* Add preventative upgrade script to ensure instances that have run the previous script drop this FK.
