### PR TITLE
Capture metrics for all GWT endpoints

### DIFF
--- a/api/src/org/labkey/api/action/GWTServiceAction.java
+++ b/api/src/org/labkey/api/action/GWTServiceAction.java
@@ -17,6 +17,7 @@
 package org.labkey.api.action;
 
 import org.labkey.api.gwt.server.BaseRemoteService;
+import org.labkey.api.usageMetrics.SimpleMetricsService;
 import org.labkey.api.view.UnauthorizedException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
@@ -39,6 +40,9 @@ public abstract class GWTServiceAction extends BaseViewAction<Object>
     @Override
     public ModelAndView handleRequest(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse)
     {
+        // Use Core as the catch-all to consolidate reporting, even though GWT uses are distributed across modules
+        SimpleMetricsService.get().increment("Core", "GWTService", getClass().getSimpleName());
+
         BaseRemoteService service = createService();
         if (!isPost())
         {

--- a/api/src/org/labkey/api/view/GWTView.java
+++ b/api/src/org/labkey/api/view/GWTView.java
@@ -18,6 +18,7 @@ package org.labkey.api.view;
 
 import com.google.gwt.core.client.EntryPoint;
 import org.labkey.api.compliance.ComplianceService;
+import org.labkey.api.usageMetrics.SimpleMetricsService;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -46,6 +47,9 @@ public class GWTView extends JspView<GWTView.GWTViewBean>
 
         public void init(ViewContext context)
         {
+            // Use Core as the catch-all to consolidate reporting, even though GWT uses are distributed across modules
+            SimpleMetricsService.get().increment("Core", "GWTView", context.getActionURL().getController() + "-" + context.getActionURL().getAction());
+
             _properties.put("container", context.getContainer().getPath());
             _properties.put("controller", context.getActionURL().getController());
             _properties.put("action", context.getActionURL().getAction());


### PR DESCRIPTION
#### Rationale
To better prioritize migration or removal of GWT-based features, we want to know how often they're used.

#### Changes
* Capture metrics whenever a GWT UI loads or it makes a RPC service call