### PR TITLE
Query for other LabKey instances on a pooled connection

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1634,10 +1634,16 @@ public class DbScope
                 addScope(dsName, ds);
             }
 
-            _labkeyScope = getDbScope(labkeyDsName, dbScope -> detectOtherLabKeyInstances(dbScope));
+            _labkeyScope = getDbScope(labkeyDsName, DbScope::detectOtherLabKeyInstances);
 
             if (null == _labkeyScope)
-                throw new ConfigurationException("Cannot connect to DataSource \"" + labkeyDsName + "\" defined in " + AppProps.getInstance().getWebappConfigurationFilename() + ". Server cannot start.");
+            {
+                ConfigurationException ce = new ConfigurationException("Cannot connect to DataSource \"" + labkeyDsName + "\" defined in " + AppProps.getInstance().getWebappConfigurationFilename() + ". Server cannot start.");
+                Throwable cause = DbScope.getDataSourceFailure(labkeyDsName);
+                if (cause != null)
+                    ce.initCause(cause);
+                throw ce;
+            }
 
             _labkeyScope.getSqlDialect().prepareNewLabKeyDatabase(_labkeyScope);
         }

--- a/api/src/org/labkey/api/data/DbScopeLoader.java
+++ b/api/src/org/labkey/api/data/DbScopeLoader.java
@@ -9,6 +9,7 @@ import org.labkey.api.util.logging.LogHelper;
 
 import javax.sql.DataSource;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * Holds a data source's configuration information, attempts to connect to the corresponding database when requested,
@@ -56,7 +57,14 @@ class DbScopeLoader
 
     private final Object LOCK = new Object();
 
+    static final Consumer<DbScope> NO_OP_CONSUMER = dbScope -> {};
+
     @Nullable DbScope get()
+    {
+        return get(NO_OP_CONSUMER);
+    }
+
+    @Nullable DbScope get(Consumer<DbScope> firstConnectionConsumer)
     {
         DbScope scope = _dbScopeRef.get();
 
@@ -72,6 +80,7 @@ class DbScopeLoader
                     try
                     {
                         scope = new DbScope(this);
+                        firstConnectionConsumer.accept(scope);
                         scope.getSqlDialect().prepare(scope);
                     }
                     catch (Throwable t)


### PR DESCRIPTION
#### Rationale
During startup, there are very short windows when the server has no connections to the database. These windows could allow two servers starting in parallel to not detect each other. Moving the detection code to a pooled connection should eliminate these races. First server to create a pooled connection will likely succeed and leave that connection open (in the pool) for the second server to detect (and fail startup). It's possible the servers will create their initial pooled connections simultaneously, in which case both will fail to start up. That's certainly preferable to letting them both start up.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4937