### PR TITLE
Replace deprecated buildDir with layout.buildDirectory

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -72,7 +72,7 @@ configurations {
 sourceSets {
   main {
     java {
-      srcDirs = ["src", "gwtsrc", "$project.buildDir/xb"]
+      srcDirs = ["src", "gwtsrc", "${BuildUtils.getBuildDirPath(project)}/xb"]
     }
     // TODO move resources files into resources directory to avoid this overlap
     resources {


### PR DESCRIPTION
#### Rationale
In Gradle 8.3, the use of `project.buildDir` was [deprecated](https://docs.gradle.org/current/userguide/upgrading_version_8.html#project_builddir) in favor of `project.layout.buildDirectory`.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/185

#### Changes
* Replace deprecated buildDir with layout.buildDirectory

