### PR TITLE
Issues 49027 and 49085: Attachment field visibility and don't log to mothership for input data errors

### DIFF
--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -2402,6 +2402,9 @@ public class OntologyManager
     @Nullable
     public static DomainDescriptor getDomainDescriptor(String domainURI, Container c)
     {
+        if (c == null)
+            return null;
+
         // cache lookup by project. if not found at project level, check to see if global
         DomainDescriptor dd = DOMAIN_DESCRIPTORS_BY_URI_CACHE.get(getCacheKey(domainURI, c));
         if (null != dd)

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -800,14 +800,14 @@ public interface ExperimentService extends ExperimentRunTypeSource
      */
     ExpProtocolApplication createSimpleRunExtraProtocolApplication(ExpRun expRun, String name);
 
-    ExpRun deriveSamples(Map<ExpMaterial, String> inputMaterials, Map<ExpMaterial, String> outputMaterials, ViewBackgroundInfo info, Logger log) throws ExperimentException;
+    ExpRun deriveSamples(Map<ExpMaterial, String> inputMaterials, Map<ExpMaterial, String> outputMaterials, ViewBackgroundInfo info, Logger log) throws ExperimentException, ValidationException;
 
     ExpRun derive(Map<? extends ExpMaterial, String> inputMaterials, Map<? extends ExpData, String> inputDatas,
                   Map<ExpMaterial, String> outputMaterials, Map<ExpData, String> outputDatas,
                   ViewBackgroundInfo info, Logger log)
-            throws ExperimentException;
+            throws ExperimentException, ValidationException;
 
-    void deriveSamplesBulk(List<? extends SimpleRunRecord> runRecords, ViewBackgroundInfo info, Logger log) throws ExperimentException;
+    void deriveSamplesBulk(List<? extends SimpleRunRecord> runRecords, ViewBackgroundInfo info, Logger log) throws ExperimentException, ValidationException;
 
     void registerExperimentDataHandler(ExperimentDataHandler handler);
 

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -1420,6 +1420,7 @@ public class ExpDataIterators
                 catch (ValidationException e)
                 {
                     getErrors().addRowError(e);
+                    throw getErrors();
                 }
             }
             return hasNext;

--- a/experiment/src/org/labkey/experiment/api/LineagePerfTest.java
+++ b/experiment/src/org/labkey/experiment/api/LineagePerfTest.java
@@ -48,6 +48,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.test.TestTimeout;
@@ -414,7 +415,7 @@ public class LineagePerfTest extends Assert
         return Pair.of(st, data);
     }
 
-    private void lineageQueries(String prefix, CPUTimer lineageQuery, CPUTimer lineageGraph, CPUTimer insertMoreTimer, ExpSampleType st, ExpData firstData) throws ExperimentException
+    private void lineageQueries(String prefix, CPUTimer lineageQuery, CPUTimer lineageGraph, CPUTimer insertMoreTimer, ExpSampleType st, ExpData firstData) throws ExperimentException, ValidationException
     {
         // parse the query once
         final StringBuilder sql = new StringBuilder()

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -1505,7 +1505,10 @@ public class ExperimentController extends SpringActionController
                 throw new NotFoundException("Error: missing required param 'lsid' or 'name'.");
 
             Lsid lsid = new Lsid(form.getLsid());
-            AttachmentParent parent = new ExpDataClassAttachmentParent(getContainer(), lsid);
+            ExpData data = ExperimentServiceImpl.get().getExpData(lsid.toString());
+            if (data == null)
+                throw new NotFoundException("Error: Data object not found for the given LSID: " + lsid);
+            AttachmentParent parent = new ExpDataClassAttachmentParent(data.getContainer(), lsid);
 
             return new Pair<>(parent, form.getName());
         }


### PR DESCRIPTION
#### Rationale
* [Issue 49027: Files attached to a source in the parent project are not visible in child projects.](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49027)

* [Issue 49085: Don't log to mothership when the data for derivations is incorrect](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49085) - we were throwing ExperimentExceptions when we detected invalid input data. These exceptions get caught and turned into RuntimeExceptions, which are logged to mothership. We need to report the invalid data to the user, but no need to alert mothership about them.  The changes here may cause us to throw the validation exception earlier than we did before, but since our current error handling generally throws after the first error (or at least consumers don't expect reporting beyond the first error), this seems like consistent behavior.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/2238

#### Changes
* Protect against containers having been deleted (by a test, say) while in the process of retrieving the domain (for search indexing, say)
* Update methods for creating runs to throw `ValidationExceptions` for cases related to input error or local configuration
* Update `DataClassAttachmentDownloadAction` to use the container of the data class object when retrieving the attachments of the object.
* 
