### PR TITLE
Migrate Ext3 -> Ext4 to eliminate inline handlers

### DIFF
--- a/specimen/src/org/labkey/specimen/view/configRequestabilityRules.jsp
+++ b/specimen/src/org/labkey/specimen/view/configRequestabilityRules.jsp
@@ -50,7 +50,7 @@
                 {
                     store.removeAt(index);
                     store.insert(index - 1, record);
-                    selectionModel.selectRow(index - 1);
+                    selectionModel.select(index - 1);
                     grid.getView().refresh();
                 }
             }
@@ -60,7 +60,7 @@
                 {
                     store.removeAt(index);
                     store.insert(index + 1, record);
-                    selectionModel.selectRow(index + 1);
+                    selectionModel.select(index + 1);
                     grid.getView().refresh();
                 }
             }
@@ -86,17 +86,16 @@
 
     function populateSchemas(schemaCombo, queryCombo, viewCombo, schemasInfo)
     {
-        console.log("populateSchemas", schemasInfo);
         if (schemaCombo.store)
         {
             schemaCombo.store.removeAll();
-            schemaCombo.store.loadData(getArrayArray(schemasInfo.schemas)); // TODO: Fix this!
-            schemaCombo.on("select", function(combo, record)
+            schemaCombo.store.loadData(getArrayArray(schemasInfo.schemas));
+            schemaCombo.on("select", function(combo, records)
             {
                 queryCombo.clearValue();
                 viewCombo.clearValue();
                 LABKEY.Query.getQueries({
-                    schemaName: record.data[record.fields.first().name],
+                    schemaName: records[0].get(dataFieldName),
                     success: function(queriesInfo) { populateQueries(queryCombo, viewCombo, queriesInfo); }
                 })
             });
@@ -116,12 +115,12 @@
 
             queryCombo.store.removeAll();
             queryCombo.store.loadData(records);
-            queryCombo.on("select", function(combo, record)
+            queryCombo.on("select", function(combo, records)
             {
                 viewCombo.clearValue();
                 LABKEY.Query.getQueryViews({
                     schemaName: queriesInfo.schemaName,
-                    queryName: record.data[record.fields.first().name],
+                    queryName: records[0].get(dataFieldName),
                     success: function(queriesInfo) { populateViews(viewCombo, queriesInfo); }
                 })
             });
@@ -180,7 +179,7 @@
                 allowBlank:false,
                 readOnly:false,
                 editable:false,
-                mode:'local',
+                queryMode :'local',
                 triggerAction: 'all'
             });
 
@@ -203,7 +202,7 @@
                 allowBlank:false,
                 readOnly:false,
                 editable:false,
-                mode:'local',
+                queryMode :'local',
                 triggerAction: 'all'
             });
 
@@ -226,7 +225,7 @@
                 allowBlank:true,
                 readOnly:false,
                 editable:false,
-                mode:'local',
+                queryMode :'local',
                 triggerAction: 'all'
             });
 
@@ -248,7 +247,7 @@
                 allowBlank:false,
                 readOnly:false,
                 editable:false,
-                mode:'local',
+                queryMode :'local',
                 triggerAction: 'all'
             });
 
@@ -268,16 +267,17 @@
         });
 
         const formPanel = new Ext4.form.FormPanel({
-            padding: 5,
+            padding: 10,
+            border: false,
             items: [queryLabel, schemaCombo, queryCombo, viewCombo, actionLabel, actionCombo]});
 
         const win = new Ext4.Window({
             title: 'Add Custom Query Rule',
-            layout:'fit',
+            layout:'form',
             border: false,
             width: 475,
-            height: 330,
-            closeAction:'close',
+            autoHeight : true,
+            closeAction:'destroy',
             modal: true,
             items: formPanel,
             resizable: false,

--- a/specimen/src/org/labkey/specimen/view/configRequestabilityRules.jsp
+++ b/specimen/src/org/labkey/specimen/view/configRequestabilityRules.jsp
@@ -139,7 +139,7 @@
                 const viewInfo = queryViews.views[i];
                 if (!viewInfo.hidden)
                 {
-                    const name =  viewInfo.name != null ? viewInfo.name : defaultViewLabel;
+                    const name = viewInfo.name != null ? viewInfo.name : defaultViewLabel;
                     records[records.length] = [name, viewInfo.viewDataUrl];
                 }
             }
@@ -295,7 +295,7 @@
                     }
 
                     let viewName = viewCombo.getValue();
-                    if (viewName === defaultViewLabel)
+                    if (!viewName || viewName === defaultViewLabel)
                         viewName = "";
                     let ruleName = "<%= h(RequestabilityManager.RuleType.CUSTOM_QUERY.getName()) %>: " + schemaCombo.getValue() + "." + queryCombo.getValue();
                     if (viewName)

--- a/specimen/src/org/labkey/specimen/view/configRequestabilityRules.jsp
+++ b/specimen/src/org/labkey/specimen/view/configRequestabilityRules.jsp
@@ -26,7 +26,7 @@
     @Override
     public void addClientDependencies(ClientDependencies dependencies)
     {
-        dependencies.add("Ext3");
+        dependencies.add("Ext4");
     }
 %>
 <%
@@ -34,17 +34,16 @@
     Container c = getContainer();
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
-    Ext.QuickTips.init();
     window.onbeforeunload = LABKEY.beforeunload();
 
     function reorder(grid, moveUp)
     {
-        var store = grid.store;
-        var selectionModel = grid.getSelectionModel();
-        var record = selectionModel.getSelected();
+        const store = grid.store;
+        const selectionModel = grid.getSelectionModel();
+        const record = selectionModel.getLastSelected();
         if (record)
         {
-            var index = store.indexOf(record);
+            const index = store.indexOf(record);
             if (moveUp)
             {
                 if (index > 0)
@@ -70,9 +69,9 @@
 
     function removeRule(grid)
     {
-        var store = grid.store;
-        var selectionModel = grid.getSelectionModel();
-        var record = selectionModel.getSelected();
+        const store = grid.store;
+        const selectionModel = grid.getSelectionModel();
+        const record = selectionModel.getLastSelected();
         if (record)
         {
             // Move the selection to the next item without preserving the current selection:
@@ -82,16 +81,17 @@
         }
     }
 
-    var dataFieldName = 'name';
-    var dataUrlFieldName = 'viewDataUrl';
+    const dataFieldName = 'name';
+    const dataUrlFieldName = 'viewDataUrl';
 
     function populateSchemas(schemaCombo, queryCombo, viewCombo, schemasInfo)
     {
+        console.log("populateSchemas", schemasInfo);
         if (schemaCombo.store)
         {
             schemaCombo.store.removeAll();
-            schemaCombo.store.loadData(getArrayArray(schemasInfo.schemas));
-            schemaCombo.on("select", function(combo, record, index)
+            schemaCombo.store.loadData(getArrayArray(schemasInfo.schemas)); // TODO: Fix this!
+            schemaCombo.on("select", function(combo, record)
             {
                 queryCombo.clearValue();
                 viewCombo.clearValue();
@@ -107,16 +107,16 @@
     {
         if (queryCombo.store)
         {
-            var records = [];
-            for (var i = 0; i < queriesInfo.queries.length; i++)
+            const records = [];
+            for (let i = 0; i < queriesInfo.queries.length; i++)
             {
-                var queryInfo = queriesInfo.queries[i];
+                let queryInfo = queriesInfo.queries[i];
                 records[i] = [queryInfo.name, queryInfo.viewDataUrl];
             }
 
             queryCombo.store.removeAll();
             queryCombo.store.loadData(records);
-            queryCombo.on("select", function(combo, record, index)
+            queryCombo.on("select", function(combo, record)
             {
                 viewCombo.clearValue();
                 LABKEY.Query.getQueryViews({
@@ -128,19 +128,19 @@
         }
     }
 
-    var defaultViewLabel = "[default view]";
+    const defaultViewLabel = "[default view]";
 
     function populateViews(viewCombo, queryViews)
     {
         if (viewCombo.store)
         {
-            var records = [[defaultViewLabel]];
-            for (var i = 0; i < queryViews.views.length; i++)
+            const records = [[defaultViewLabel]];
+            for (let i = 0; i < queryViews.views.length; i++)
             {
-                var viewInfo = queryViews.views[i];
+                const viewInfo = queryViews.views[i];
                 if (!viewInfo.hidden)
                 {
-                    var name =  viewInfo.name != null ? viewInfo.name : defaultViewLabel;
+                    const name =  viewInfo.name != null ? viewInfo.name : defaultViewLabel;
                     records[records.length] = [name, viewInfo.viewDataUrl];
                 }
             }
@@ -152,8 +152,8 @@
 
     function getArrayArray(simpleArray)
     {
-        var arrayArray = [];
-        for (var i = 0; i < simpleArray.length; i++)
+        const arrayArray = [];
+        for (let i = 0; i < simpleArray.length; i++)
         {
             arrayArray[i] = [];
             arrayArray[i][0] = simpleArray[i];
@@ -163,9 +163,9 @@
 
     function setupUserQuery(grid, type)
     {
-        var schemaCombo = new Ext.form.ComboBox({
+        const schemaCombo = new Ext4.form.ComboBox({
                 typeAhead: false,
-                store: new Ext.data.ArrayStore({
+                store: new Ext4.data.ArrayStore({
                     fields: [{
                         name: dataFieldName,
                         sortType: function(value) { return value.toLowerCase(); }
@@ -184,9 +184,9 @@
                 triggerAction: 'all'
             });
 
-        var queryCombo = new Ext.form.ComboBox({
+        const queryCombo = new Ext4.form.ComboBox({
                 typeAhead: false,
-                store: new Ext.data.ArrayStore({
+                store: new Ext4.data.ArrayStore({
                     fields: [{
                         name: dataFieldName,
                         sortType: function(value) { return value.toLowerCase(); }
@@ -207,9 +207,9 @@
                 triggerAction: 'all'
             });
 
-        var viewCombo = new Ext.form.ComboBox({
+        const viewCombo = new Ext4.form.ComboBox({
                 typeAhead: false,
-                store: new Ext.data.ArrayStore({
+                store: new Ext4.data.ArrayStore({
                     fields: [{
                         name: dataFieldName,
                         sortType: function(value) { return value.toLowerCase(); }
@@ -230,9 +230,9 @@
                 triggerAction: 'all'
             });
 
-        var actionCombo = new Ext.form.ComboBox({
+        const actionCombo = new Ext4.form.ComboBox({
                 typeAhead: false,
-                store: new Ext.data.ArrayStore(
+                store: new Ext4.data.ArrayStore(
                 {
                     fields: ['option'],
                     data: [
@@ -256,22 +256,22 @@
             success: function(schemasInfo) { populateSchemas(schemaCombo, queryCombo, viewCombo, schemasInfo); }
         });
 
-        var labelStyle = 'padding-bottom: 5px; font-weight: normal;';
+        const labelStyle = 'padding-bottom: 5px; font-weight: normal;';
 
-        var queryHelpText = 'Select the query and view that identify vials affected by this rule.  The returned list must include a "GlobalUniqueId" column.';
-        var queryLabel = new Ext.form.Label({
+        const queryHelpText = 'Select the query and view that identify vials affected by this rule.  The returned list must include a "GlobalUniqueId" column.';
+        const queryLabel = new Ext4.form.Label({
             html: '<div style="' + labelStyle +'">' + queryHelpText + '</div>'
         });
 
-        var actionLabel = new Ext.form.Label({
+        const actionLabel = new Ext4.form.Label({
             html: '<br><div style="' + labelStyle +'">Select whether vials identified by the query should be marked as available or unavailable.</div>'
         });
 
-        var formPanel = new Ext.form.FormPanel({
+        const formPanel = new Ext4.form.FormPanel({
             padding: 5,
             items: [queryLabel, schemaCombo, queryCombo, viewCombo, actionLabel, actionCombo]});
-        
-        var win = new Ext.Window({
+
+        const win = new Ext4.Window({
             title: 'Add Custom Query Rule',
             layout:'fit',
             border: false,
@@ -287,22 +287,22 @@
             },{
                 text: 'Submit',
                 handler: function(){
-                    var form = formPanel.getForm();
+                    const form = formPanel.getForm();
                     if (form && !form.isValid())
                     {
-                        Ext.Msg.alert('Add Custon Query Rule', 'Please complete all required fields.');
+                        Ext4.Msg.alert('Add Custom Query Rule', 'Please complete all required fields.');
                         return false;
                     }
 
-                    var viewName = viewCombo.getValue();
-                    if (viewName == defaultViewLabel)
+                    let viewName = viewCombo.getValue();
+                    if (viewName === defaultViewLabel)
                         viewName = "";
-                    var ruleName = "<%= h(RequestabilityManager.RuleType.CUSTOM_QUERY.getName()) %>: " + schemaCombo.getValue() + "." + queryCombo.getValue();
+                    let ruleName = "<%= h(RequestabilityManager.RuleType.CUSTOM_QUERY.getName()) %>: " + schemaCombo.getValue() + "." + queryCombo.getValue();
                     if (viewName)
                         ruleName += ", view " + viewName;
-                    var testUrl = getSelectedURL(viewName ? viewCombo : queryCombo);
-                    var markRequestable = actionCombo.getValue() == '<%= h(RequestabilityManager.MarkType.AVAILABLE.getLabel()) %>';
-                    var ruleData = schemaCombo.getValue() + "<%= text(RequestabilityManager.CUSTOM_QUERY_DATA_SEPARATOR) %>" +
+                    const testUrl = getSelectedURL(viewName ? viewCombo : queryCombo);
+                    const markRequestable = actionCombo.getValue() == '<%= h(RequestabilityManager.MarkType.AVAILABLE.getLabel()) %>';
+                    const ruleData = schemaCombo.getValue() + "<%= text(RequestabilityManager.CUSTOM_QUERY_DATA_SEPARATOR) %>" +
                                    queryCombo.getValue() + "<%= text(RequestabilityManager.CUSTOM_QUERY_DATA_SEPARATOR) %>" +
                                    viewName + "<%= text(RequestabilityManager.CUSTOM_QUERY_DATA_SEPARATOR) %>" +
                                    markRequestable;
@@ -317,27 +317,26 @@
 
     function getSelectedURL(comboBox)
     {
-        var value = comboBox.getValue();
-        var record = comboBox.findRecord(comboBox.valueField, value);
+        const value = comboBox.getValue();
+        const record = comboBox.findRecord(comboBox.valueField, value);
         return record.data[dataUrlFieldName];
     }
 
-
     function addRule(grid, type, name, action, testURL, ruleData)
     {
-        var store = grid.store;
+        const store = grid.store;
 
-        if (type == 'CUSTOM_QUERY' && !ruleData)
+        if (type === 'CUSTOM_QUERY' && !ruleData)
         {
             setupUserQuery(grid, type);
             return false;
         }
 
         // Don't add more than 1 of any rules except CUSTOM QUERY
-        if (type != 'CUSTOM_QUERY' && ruleTypeAlreadyPresent(grid, type))
+        if (type !== 'CUSTOM_QUERY' && ruleTypeAlreadyPresent(grid, type))
             return true;
 
-        var ruleProperties = {
+        const ruleProperties = {
             type: type,
             ruleData: ruleData,
             name: name,
@@ -346,14 +345,13 @@
         };
 
         // insert after current selection or last if none
-        var insertIndex = store.getCount();
-        var selectionModel = grid.getSelectionModel();
-        var record = selectionModel.getSelected();
+        let insertIndex = store.getCount();
+        const selectionModel = grid.getSelectionModel();
+        const record = selectionModel.getLastSelected();
         if (record)
             insertIndex = Math.min(insertIndex, store.indexOf(record) + 1);
 
-        var newRule = new store.recordType(ruleProperties); // create new record
-        store.insert(insertIndex, newRule); // insert a new record into the store
+        store.insert(insertIndex, [ruleProperties]); // insert a new record into the store
         grid.getView().refresh();
         
         return true;
@@ -361,11 +359,11 @@
 
     function ruleTypeAlreadyPresent(grid, type)
     {
-        var store = grid.store;
-        for (var i = 0; i < store.getCount(); i++)
+        const store = grid.store;
+        for (let i = 0; i < store.getCount(); i++)
         {
-            var record = store.getAt(i);
-            if (type == record.data.type)
+            let record = store.getAt(i);
+            if (type === record.data.type)
                 return true;
         }
         return false;
@@ -378,7 +376,7 @@
 
     function testColumnRenderer(value, p, record)
     {
-        var txt = '';
+        let txt = '';
 
         if (record.data.testURL){
             txt = LABKEY.Utils.textLink({
@@ -393,14 +391,14 @@
 
     function saveComplete()
     {
-        Ext.Msg.hide();
+        Ext4.Msg.hide();
         LABKEY.setDirty(false);
         document.location = <%=q(urlProvider(StudyUrls.class).getManageStudyURL(c))%>;
     }
 
     function saveFailed(response, options)
     {
-        Ext.Msg.hide();
+        Ext4.Msg.hide();
         LABKEY.Utils.displayAjaxErrorResponse(response, options);
     }
 
@@ -412,18 +410,18 @@
             return;
         }
 
-        var store = rulesGrid.store;
-        var ruleTypes = [];
-        var ruleDatas = [];
-        for (var i = 0; i < store.getCount(); i++)
+        const store = rulesGrid.store;
+        const ruleTypes = [];
+        const ruleDatas = [];
+        for (let i = 0; i < store.getCount(); i++)
         {
-            var record = store.getAt(i);
+            let record = store.getAt(i);
             ruleTypes[i] = record.data.type;
             ruleDatas[i] = record.data.ruleData ? record.data.ruleData : "";
         }
 
-        Ext.Msg.wait("Saving...");
-        Ext.Ajax.request({
+        Ext4.Msg.wait("Saving...");
+        Ext4.Ajax.request({
             url : LABKEY.ActionURL.buildURL("specimen", "updateRequestabilityRules"),
             method : 'POST',
             success: saveComplete,
@@ -440,11 +438,11 @@
 
     function showRules()
     {
-        Ext.QuickTips.init();
+        Ext4.QuickTips.init();
 
-        var rulesGrid;
+        let rulesGrid;
 
-        var addMenuItems = [
+        const addMenuItems = [
             <%
                 boolean first = true;
                 for (RequestabilityManager.RuleType type : RequestabilityManager.RuleType.values())
@@ -452,33 +450,33 @@
                     ActionURL defaultTestURL = type.getDefaultTestURL(c);
                     RequestabilityManager.MarkType defaultMarkType = type.getDefaultMarkType();
                 %>
-                    <%= text(!first ? "," : "") %>new Ext.menu.Item({
-                                id: 'add_<%= h(type.name()) %>',
-                                text:'<%= h(type.getName()) %>',
-                                listeners:{
-                                    click:function(button, event) {
-                                        LABKEY.setDirty(true);
-                                        addRule(rulesGrid,
-                                           '<%= h(type.name()) %>', // type enum
-                                           '<%= h(type.getName()) %>', // friendly name
-                                           '<%= h(defaultMarkType != null ? defaultMarkType.getLabel() : "") %>', // default mark type
-                                           '<%= h(defaultTestURL != null ? defaultTestURL.getLocalURIString() : "") %>'); // default mark type
-                                    }
-                                }
-                            })
+                    <%= text(!first ? "," : "") %>new Ext4.menu.Item({
+                        id: 'add_<%= h(type.name()) %>',
+                        text:'<%= h(type.getName()) %>',
+                        listeners:{
+                            click:function(button, event) {
+                                LABKEY.setDirty(true);
+                                addRule(rulesGrid,
+                                   '<%= h(type.name()) %>', // type enum
+                                   '<%= h(type.getName()) %>', // friendly name
+                                   '<%= h(defaultMarkType != null ? defaultMarkType.getLabel() : "") %>', // default mark type
+                                   '<%= h(defaultTestURL != null ? defaultTestURL.getLocalURIString() : "") %>'); // default mark type
+                            }
+                        }
+                    })
                 <%
                     first = false;
                 }
             %>
         ];
 
-        var addMenu = new Ext.menu.Menu({
+        const addMenu = new Ext4.menu.Menu({
             id: 'mainMenu',
             cls:'extContainer',
             items:addMenuItems
         });
 
-        var removeButton = new Ext.Button({
+        const removeButton = new Ext4.Button({
             text:'Remove Rule',
             id: 'btn_deleteEngine',
             tooltip: {
@@ -490,7 +488,7 @@
             }
         });
 
-        var moveUpButton = new Ext.Button({
+        const moveUpButton = new Ext4.Button({
             text:'Move Up',
             id: 'btn_moveUp',
             tooltip: {
@@ -502,7 +500,7 @@
             }
         });
 
-        var moveDownButton = new Ext.Button({
+        const moveDownButton = new Ext4.Button({
             text:'Move Down',
             id: 'btn_moveDown',
             tooltip: {
@@ -514,17 +512,7 @@
             }
         });
         
-        // shared reader
-        var reader = new Ext.data.ArrayReader({}, [
-            {name: 'type'},
-            {name: 'ruleData'},
-            {name: 'name'},
-            {name: 'action'},
-            {name: 'testURL'}
-        ]);
-
-
-        var initialData = [
+        const initialData = [
         <%
         first = true;
         for (RequestabilityManager.RequestableRule rule : RequestabilityManager.getInstance().getRules(c))
@@ -541,16 +529,16 @@
         %>
         ];
 
-        var rowSelectionModel = new Ext.grid.RowSelectionModel({singleSelect: true});
-        rowSelectionModel.on("rowselect", function(model, rowIndex, record)
+        const rowSelectionModel = new Ext4.selection.RowModel({singleSelect: true});
+        rowSelectionModel.on("select", function(model, record, rowIndex)
         {
-            if (rowIndex == rulesGrid.getStore().getCount() - 1)
+            if (rowIndex === rulesGrid.getStore().getCount() - 1)
             {
                 moveUpButton.enable();
                 moveDownButton.disable();
                 removeButton.enable();
             }
-            else if (rowIndex == 0)
+            else if (rowIndex === 0)
             {
                 moveUpButton.disable();
                 moveDownButton.enable();
@@ -564,7 +552,7 @@
             }
         });
 
-        rowSelectionModel.on("rowdeselect", function()
+        rowSelectionModel.on("deselect", function()
         {
             moveUpButton.disable();
             moveDownButton.disable();
@@ -576,34 +564,36 @@
         moveDownButton.disable();
         removeButton.disable();
 
-        rulesGrid = new Ext.grid.GridPanel({
-            store: new Ext.data.Store({
-                reader: reader,
+        rulesGrid = new Ext4.grid.Panel({
+            store: new Ext4.data.ArrayStore({
+                fields: [
+                    {name: 'type'},
+                    {name: 'ruleData'},
+                    {name: 'name'},
+                    {name: 'action'},
+                    {name: 'testURL'}
+                ],
                 data: initialData
             }),
-            cm: new Ext.grid.ColumnModel({
-                columns: [
-                    new Ext.grid.RowNumberer({ header: 'Order', width: 50}),
-                    {header:'Type', dataIndex:'type', hidden: true},
-                    {header:'RuleData', dataIndex:'ruleData', hidden: true},
-                    {header:'Rule', dataIndex:'name'},
-                    {header:'Action', dataIndex:'action', renderer: actionColumnRenderer, width: 60},
-                    {header:'Test Link', dataIndex:'testURL', renderer: testColumnRenderer, width: 55}
-                ],
-                sortable: false
-            }),
-            viewConfig: {
-                forceFit:true
-            },
+            columns: [
+                new Ext4.grid.RowNumberer({ header: 'Order', width: 50}),
+                {header:'Type', dataIndex:'type', hidden: true},
+                {header:'RuleData', dataIndex:'ruleData', hidden: true},
+                {header:'Rule', dataIndex:'name'},
+                {header:'Action', dataIndex:'action', renderer: actionColumnRenderer, width: 60},
+                {header:'Test Link', dataIndex:'testURL', renderer: testColumnRenderer, width: 55}
+            ],
+            sortableColumns: false,
+            forceFit: true,
             columnLines: true,
-            enableDragDrop: true,
+            draggable: true,
             width:700,
             height:300,
             title:'Active Rules',
             iconCls:'icon-grid',
             renderTo: 'rulesGrid',
             buttonAlign:'center',
-            sm: rowSelectionModel,
+            selModel: rowSelectionModel,
             buttons: [{
                 text: 'Add Rule',
                 menu: addMenu,
@@ -625,7 +615,7 @@
         });
     }
 
-    Ext.onReady(showRules);
+    Ext4.onReady(showRules);
 </script>
 
 <labkey:errors/>
@@ -664,7 +654,7 @@
 %>
     <tr>
         <td><b><%= h(type.getName())%></b></td>
-        <td><%= h(type.getDescription())%></td>
+        <td>&nbsp;&nbsp;<%= h(type.getDescription())%></td>
     </tr>
 <%
     }

--- a/study/api-src/org/labkey/api/specimen/importer/RequestabilityManager.java
+++ b/study/api-src/org/labkey/api/specimen/importer/RequestabilityManager.java
@@ -421,7 +421,7 @@ public class RequestabilityManager
         protected SQLFragment getGlobalUniqueIdInSQL(List<Vial> vials)
         {
             SQLFragment sql = new SQLFragment();
-            if (vials != null && vials.size() > 0)
+            if (vials != null && !vials.isEmpty())
             {
                 sql.append("GlobalUniqueId ");
                 sql.append(getSpecimenGlobalUniqueIdSet(vials));
@@ -699,7 +699,7 @@ public class RequestabilityManager
                 throw new IllegalStateException("Expected Vial table to exist.");
 
             SQLFragment sql = new SQLFragment();
-            if (vials != null && vials.size() > 0)
+            if (vials != null && !vials.isEmpty())
                 sql.append(getGlobalUniqueIdInSQL(vials)).append(" AND ");
 
             sql.append(" RowId IN (SELECT SV.RowId FROM ").append(tableInfoVial).append(" SV")
@@ -715,7 +715,7 @@ public class RequestabilityManager
                 .append(" WHERE SRS.Container = ? AND SRST.FinalState = ?");
             sql.add(container.getId());
             sql.add(false);
-            if (vials != null && vials.size() > 0)
+            if (vials != null && !vials.isEmpty())
                 sql.append(" AND SpecimenGlobalUniqueId ").append(getSpecimenGlobalUniqueIdSet(vials));
 
             sql.append(")");

--- a/study/api-src/org/labkey/api/specimen/importer/RequestabilityManager.java
+++ b/study/api-src/org/labkey/api/specimen/importer/RequestabilityManager.java
@@ -545,7 +545,7 @@ public class RequestabilityManager
                     throw new InvalidRuleException("Could not find view " + _viewName + " on query " + _queryName + " in schema " + _schemaName + ".");
             }
 
-            if (vials != null && vials.size() > 0)
+            if (vials != null && !vials.isEmpty())
             {
                 Set<String> globalUniqueIds = new HashSet<>();
                 for (Vial vial : vials)

--- a/study/src/org/labkey/study/view/manageStudyPropertiesExt.jsp
+++ b/study/src/org/labkey/study/view/manageStudyPropertiesExt.jsp
@@ -58,10 +58,11 @@
 
 Ext4.QuickTips.init();
 
-var canEdit = <%=canEdit%>;
-var editableFormPanel = canEdit;
-var studyPropertiesFormPanel = null;
-var timepointType = "<%=timepointType%>";
+const canEdit = <%=canEdit%>;
+const timepointType = "<%=timepointType%>";
+
+let editableFormPanel = canEdit;
+let studyPropertiesFormPanel = null;
 
 function removeProtocolDocument(name, xid)
 {
@@ -71,12 +72,12 @@ function removeProtocolDocument(name, xid)
         buttons: Ext4.Msg.OKCANCEL,
         icon: Ext4.MessageBox.QUESTION,
         fn  : function(b) {
-            if (b == 'ok') {
+            if (b === 'ok') {
                 Ext4.Ajax.request({
                     url    : LABKEY.ActionURL.buildURL('study', 'removeProtocolDocument'),
                     method : 'POST',
                     success: function() {
-                        var el = document.getElementById(xid);
+                        const el = document.getElementById(xid);
                         if (el) {
                             el.parentNode.removeChild(el);
                         }
@@ -94,13 +95,13 @@ function removeProtocolDocument(name, xid)
 
 function addExtFilePickerHandler()
 {
-    var fibasic = Ext4.create('Ext.form.field.File', {
+    const fibasic = Ext4.create('Ext.form.field.File', {
         width  : 300,
         height : 30,
         style  : 'float: left;'
     });
 
-    var removeBtn = Ext4.create('Ext.Button', {
+    const removeBtn = Ext4.create('Ext.Button', {
         text: "remove",
         name: "remove",
         uploadId: fibasic.id,
@@ -108,14 +109,14 @@ function addExtFilePickerHandler()
         handler: removeNewAttachment
     });
 
-    var uploadField = Ext4.create('Ext.Panel', {
+    const uploadField = Ext4.create('Ext.Panel', {
         border : false, frame : false,
         bodyStyle : 'background-color: transparent;',
         height : 35,
         items:[fibasic, removeBtn]
     });
 
-    var protocolPanel = studyPropertiesFormPanel.getComponent('protocolPanel');
+    const protocolPanel = studyPropertiesFormPanel.getComponent('protocolPanel');
     if (protocolPanel) {
         protocolPanel.add(uploadField);
         protocolPanel.enlarge();
@@ -145,10 +146,10 @@ function unmask()
     Ext4.getBody().unmask();
 }
 
-function showSuccessMessage(message, after)
+function showSuccessMessage(message)
 {
     Ext4.get("formError").update("");
-    var el = Ext4.get("formSuccess");
+    const el = Ext4.get("formSuccess");
     el.update(message);
     el.pause(3).fadeOut({callback:function(){el.update("");}});
 }
@@ -156,12 +157,12 @@ function showSuccessMessage(message, after)
 function onSaveSuccess_updateRows()
 {
     // if you want to stay on page, you need to refresh anyway to update attachments
-    var msgbox = Ext4.Msg.show({
+    const msgbox = Ext4.Msg.show({
         title:'Status',
         msg: '<span class="labkey-message">Changes saved successfully.</span>',
         buttons: false
     });
-    var el = msgbox.getDialog().el;
+    const el = msgbox.getDialog().el;
     el.pause(1).fadeOut({callback:cancelButtonHandler});
 }
 
@@ -169,13 +170,13 @@ function onSaveSuccess_formSubmit()
 {
     // if you want to stay on page, you need to refresh anyway to update attachments
     LABKEY.setSubmit(true);
-    var msgbox = Ext4.Msg.show({
+    const msgbox = Ext4.Msg.show({
         title:'Status',
         msg: '<span class="labkey-message">Changes saved successfully.</span>',
         buttons: false
     });
     window.location = <%=q(cancelLink)%>;
-    var el = msgbox.getEl();
+    const el = msgbox.getEl();
     el.pause(1).fadeOut({callback:cancelButtonHandler});
 }
 
@@ -199,10 +200,10 @@ function onSaveFailure_formSubmit(form, action)
             break;
         case Ext4.form.Action.SERVER_INVALID:
         {
-            var msg = action.result.msg || action.result.exception || "";
+            let msg = action.result.msg || action.result.exception || "";
             if (action.result.errors)
             {
-                for (var prop in action.result.errors)
+                for (let prop in action.result.errors)
 
                     // Don't double print form and general exception if the same
                     if (action.result.errors[prop] !== msg)
@@ -216,16 +217,16 @@ function onSaveFailure_formSubmit(form, action)
 
 function submitButtonHandler()
 {
-    var form = studyPropertiesFormPanel.getForm();
+    const form = studyPropertiesFormPanel.getForm();
     if (form.isValid())
     {
         form.fileUpload = true;
         form.submit(
-                {
-                    url     : LABKEY.ActionURL.buildURL('study', 'manageStudyProperties.view'),
-                    success : onSaveSuccess_formSubmit,
-                    failure : onSaveFailure_formSubmit
-                });
+        {
+            url     : LABKEY.ActionURL.buildURL('study', 'manageStudyProperties.view'),
+            success : onSaveSuccess_formSubmit,
+            failure : onSaveFailure_formSubmit
+        });
         mask();
     }
     else
@@ -262,17 +263,8 @@ function destroyFormPanel()
     }
 }
 
-var renderTypes = {<%
-String comma = "";
-for (WikiRendererType type : getRendererTypes())
-{
-    %><%=text(comma)%><%=q(type.name())%>:<%=q(type.getDisplayName())%><%
-    comma = ",";
-}
-%>}
-
 function renderFormPanel(data, editable){
-    var protocolDocs = [];
+    const protocolDocs = [];
 <%
     int x = 0;
     for (Attachment att : getStudy().getProtocolDocuments())
@@ -288,7 +280,7 @@ function renderFormPanel(data, editable){
         x++;
     }
 %>
-    var initHeight = <%=x%>;
+    const initHeight = <%=x%>;
     Ext4.define('ProtocolDoc', {
         extend : 'Ext.data.Model',
         fields : [
@@ -299,7 +291,7 @@ function renderFormPanel(data, editable){
         ]
     });
 
-    var protoTemplate = new Ext4.XTemplate(
+    const protoTemplate = new Ext4.XTemplate(
         '<tpl for=".">',
             '<div class="protoDoc" id="attach-{atId}">',
                 '<td>&nbsp;<img src="{logo}" talt="logo"/></td>',
@@ -312,7 +304,7 @@ function renderFormPanel(data, editable){
         '</div>'
     );
 
-    var buttons = [];
+    const buttons = [];
 
     if (editable)
     {
@@ -332,14 +324,14 @@ function renderFormPanel(data, editable){
         buttons.push({text:"Done", handler: doneButtonHandler});
     }
 
-    var getConfig = function(searchString)
+    const getConfig = function(searchString)
     {
-        var fields = data.metaData.fields;
-        for (var i = 0; i < fields.length; i++)
+        const fields = data.metaData.fields;
+        for (let i = 0; i < fields.length; i++)
         {
             if (fields[i].caption === searchString)
             {
-                var config = LABKEY.ext4.Util.getFormEditorConfig(data.metaData.fields[i]);
+                const config = LABKEY.ext4.Util.getFormEditorConfig(data.metaData.fields[i]);
 
                 // textarea size doesn't reflect the form defaults
                 if (config.xtype === 'textarea')
@@ -352,7 +344,7 @@ function renderFormPanel(data, editable){
         }
         return undefined;
     };
-    var items = [
+    const items = [
         getConfig('Label'),
         getConfig('Investigator'),
         getConfig('Grant'),
@@ -360,7 +352,7 @@ function renderFormPanel(data, editable){
         getConfig('Description')
     ];
 
-    var handledFields = {
+    const handledFields = {
         Label: true,
         Investigator: true,
         Grant: true,
@@ -400,7 +392,7 @@ function renderFormPanel(data, editable){
                 fields : ['renderType', 'displayText'],
                 data : [
 <%
-                    comma = "";
+                    String comma = "";
                     for (WikiRendererType type : getRendererTypes())
                     {
                         %><%=text(comma)%>[<%=q(type.name())%>,<%=q(type.getDisplayName())%>]<%
@@ -418,6 +410,7 @@ function renderFormPanel(data, editable){
         style : 'float: left; text-align: right; padding-right: 0;',
         width : 160
     });
+
     items.push({
         xtype: 'panel',
         bodyStyle : 'background-color: transparent;',
@@ -464,7 +457,7 @@ function renderFormPanel(data, editable){
             inputValue: 'VISIT',
             value: 'VISIT',
             name: 'TimepointType',
-            checked: timepointType == 'VISIT'
+            checked: timepointType === 'VISIT'
         },{
             xtype: 'radio',
             id : 'dateRadio',
@@ -473,7 +466,7 @@ function renderFormPanel(data, editable){
             boxLabel: 'DATE',
             inputValue: 'DATE',
             name: 'TimepointType',
-            checked: timepointType == 'DATE'
+            checked: timepointType === 'DATE'
         },{
             xtype: 'radio',
             id : 'continuousRadio',
@@ -482,11 +475,11 @@ function renderFormPanel(data, editable){
             boxLabel: 'CONTINUOUS',
             inputValue: 'CONTINUOUS',
             name: 'TimepointType',
-            checked: timepointType == 'CONTINUOUS'
+            checked: timepointType === 'CONTINUOUS'
         }]
     });
 
-    var info = data.rows[0];
+    const info = data.rows[0];
 
     items[0].value = info.Label.value;
     items[1].value = info.Investigator.value;
@@ -494,30 +487,30 @@ function renderFormPanel(data, editable){
     items[3].value = info.Species.value;
     items[4].value = info.Description.value;
 
-    var cm = data.columnModel,
-        col,
-        hold;
+    const cm = data.columnModel;
+    let col;
+    let hold;
 
-    for(var i = 0; i < cm.length; i++){
+    for (let i = 0; i < cm.length; i++){
         col = cm[i];
-        if(col.hidden) continue;
-        if(handledFields[col.dataIndex]) continue;
+        if (col.hidden) continue;
+        if (handledFields[col.dataIndex]) continue;
         hold = getConfig(col.header);
-        if(hold != undefined){
+        if (hold !== undefined){
             items.push(hold);
         }
     }
 
-    for(i = 9; i < items.length; i++){
+    for (let i = 9; i < items.length; i++){
 
         // initialize the form elements
-        var value = data.rows[0][items[i].name].value;
+        const value = data.rows[0][items[i].name].value;
 
         // stupid date conversion...
-        if (items[i].xtype == 'datefield')
+        if (items[i].xtype === 'datefield')
         {
             items[i].format = LABKEY.extDateInputFormat;
-            items[i].value = (value != null && value != '') ? new Date(value) : '';
+            items[i].value = (value != null && value !== '') ? new Date(value) : '';
             items[i].listeners = {
                 render : {
                     fn : function(cmp){
@@ -529,7 +522,7 @@ function renderFormPanel(data, editable){
                 }
             }
         }
-        else if (items[i].xtype == 'checkbox')    // Checkbox doesn't respect "value"
+        else if (items[i].xtype === 'checkbox')    // Checkbox doesn't respect "value"
             items[i].checked = value;
         else
             items[i].value = value;
@@ -600,5 +593,5 @@ Ext4.onReady(createPage);
 
 </script>
 
-<span id=formSuccess class=labkey-message-strong></span><span id=formError class=labkey-error></span>&nbsp;</br>
+<span id=formSuccess class=labkey-message-strong></span><span id=formError class=labkey-error></span>&nbsp;<br>
 <div id='formDiv'></div>

--- a/study/test/src/org/labkey/test/tests/study/TargetStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/TargetStudyTest.java
@@ -48,20 +48,20 @@ public class TargetStudyTest extends AbstractAssayTest
 
     protected static final String TEST_RUN1 = "FirstRun";
     protected static final String TEST_RUN1_DATA1 =
-            "specimenID\tparticipantID\tvisitID\tTargetStudy\n" +
-            // study 1: full container path
-            "AAA07XK5-05\t\t\t" + ("/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY1) + "\n" +
-            // study 1: container id
-            "AAA07XMC-02\t\t\t${Study1ContainerID}\n" +
-            // study 1: study label
-            "AAA07XMC-04\t\t\t${Study1Label}" + "\n" +
-            // fake study / no study
-            "AAA07XSF-02\t\t\tStudyNotExist\n" +
-            // study 2
-            "AAA07YGN-01\t\t\t" +("/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY2) + "\n" +
-            // study 3
-            "AAA07YGN-02\t\t\t" +("/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY3) + "\n"
-            ;
+        "specimenID\tparticipantID\tvisitID\tTargetStudy\n" +
+        // study 1: full container path
+        "AAA07XK5-05\t\t\t" + ("/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY1) + "\n" +
+        // study 1: container id
+        "AAA07XMC-02\t\t\t${Study1ContainerID}\n" +
+        // study 1: study label
+        "AAA07XMC-04\t\t\t${Study1Label}" + "\n" +
+        // fake study / no study
+        "AAA07XSF-02\t\t\tStudyNotExist\n" +
+        // study 2
+        "AAA07YGN-01\t\t\t" +("/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY2) + "\n" +
+        // study 3
+        "AAA07YGN-02\t\t\t" +("/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY3) + "\n"
+        ;
 
     private String _study1ContainerId = null;
     private String _study1Label = null;
@@ -73,7 +73,6 @@ public class TargetStudyTest extends AbstractAssayTest
     {
         return TEST_ASSAY_PRJ_SECURITY;
     }
-
 
     @Test
     public void runUITests() throws Exception
@@ -96,7 +95,6 @@ public class TargetStudyTest extends AbstractAssayTest
         linkToStudy();
     }
 
-
     @LogMethod
     protected void setupSpecimens() throws Exception
     {
@@ -110,32 +108,31 @@ public class TargetStudyTest extends AbstractAssayTest
 
         importer1.waitForComplete();
         importer2.waitForComplete();
-
     }
 
     @LogMethod
     protected void setupLabels()
     {
-        // Using a random label helps uniqueify the study when there is another "AwesomeStudy3" from a previous test run.
+        // Using a random label helps uniquify the study when there is another "AwesomeStudy3" from a previous test run.
         int r = new Random().nextInt();
         _study1Label = STUDY1_LABEL + " " + r;
         _study2Label = STUDY2_LABEL + " " + r;
         _study3Label = STUDY3_LABEL + " " + r;
 
         log("** Set some awesome study labels");
-        beginAt("/study/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY1 + "/manageStudyProperties.view");
+        beginAt("/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY1 + "/study-manageStudyProperties.view");
         waitForElement(Locator.name("Label"), WAIT_FOR_JAVASCRIPT);
         setFormElement(Locator.name("Label"), _study1Label);
         clickButton("Submit");
 
-        beginAt("/study/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY2 + "/manageStudyProperties.view");
+        beginAt("/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY2 + "/study-manageStudyProperties.view");
         waitForElement(Locator.name("Label"), WAIT_FOR_JAVASCRIPT);
         setFormElement(Locator.name("Label"), _study2Label);
         clickButton("Submit", 0);
         // Save is via AJAX, but redirects to the general study settings page when it's done
         waitForText("General Study Settings");
 
-        beginAt("/study/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY3 + "/manageStudyProperties.view");
+        beginAt("/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY3 + "/study-manageStudyProperties.view");
         waitForElement(Locator.name("Label"), WAIT_FOR_JAVASCRIPT);
         setFormElement(Locator.name("Label"), _study3Label);
         clickButton("Submit", 0);
@@ -174,8 +171,8 @@ public class TargetStudyTest extends AbstractAssayTest
         setFormElement(Locator.name("name"), TEST_RUN1);
         click(Locator.xpath("//input[@value='textAreaDataProvider']"));
         String data1 = TEST_RUN1_DATA1
-                .replace("${Study1ContainerID}", _study1ContainerId)
-                .replace("${Study1Label}", _study1Label);
+            .replace("${Study1ContainerID}", _study1ContainerId)
+            .replace("${Study1Label}", _study1Label);
         setFormElement(Locator.name("TextAreaDataCollector.textArea"), data1);
         clickButton("Save and Finish");
         assertTextPresent("Couldn't resolve TargetStudy 'StudyNotExist' to a study folder.");
@@ -190,9 +187,10 @@ public class TargetStudyTest extends AbstractAssayTest
         clickAndWait(Locator.linkWithText(TEST_RUN1));
         // all target study values should render as either [None] or the name of the study
         assertTextNotPresent(
-                "/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY1,
-                "/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY2,
-                "/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY3);
+            "/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY1,
+            "/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY2,
+            "/" + TEST_ASSAY_PRJ_SECURITY + "/" + TEST_ASSAY_FLDR_STUDIES + "/" + TEST_ASSAY_FLDR_STUDY3
+        );
 
         DataRegionTable table = new DataRegionTable("Data", this);
         assertEquals(_study1Label, table.getDataAsText(0, "Target Study"));


### PR DESCRIPTION
#### Rationale
ExtJS 3 drop-down menu buttons inject HTML with JavaScript handlers into the page, which trips up our Content Security Policy. ExtJS 4 doesn't seem to do this.