### PR TITLE
48973 : Don't overwrite existing target FK column

### DIFF
--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -425,12 +425,12 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
                                 // Issue 47495: respect lookup column provided by established foreign key
                                 if (rawLookupColumnName != null)
                                     fk.setFkColumnName(rawLookupColumnName);
-                                else
+                                // Issue 48973: don't overwrite existing target FK columns that were set via source
+                                else if (fk.getFkColumnName() == null)
                                     fk.setFkColumnName(pkCols.get(0));
+
                                 if (targetContainer != null)
-                                {
                                     fk.setFkFolderPath(targetContainer.getPath());
-                                }
                             }
                         }
                     }


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48973)

Don't assume the FK column is always the primary key, and in this case just respect the configured fkColumnName set in the metadata XML. The source editor would be the only way this could be setup since the UI metadata editor isn't expressive enough to set this configuration.

