### PR TITLE
Switch to Spring's StandardServletMultipartResolver

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -19,6 +19,7 @@ import org.apache.commons.collections4.Factory;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.labkey.api.action.ApiXmlWriter;
+import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.SubfolderWriter;
 import org.labkey.api.assay.ReplacedRunFilter;
 import org.labkey.api.attachments.AttachmentService;
@@ -102,11 +103,15 @@ import org.labkey.api.util.emailTemplate.EmailTemplate;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.JspTemplate;
 import org.labkey.api.view.Portal;
+import org.labkey.api.view.ViewServlet;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.api.webdav.WebdavResolverImpl;
 import org.labkey.api.writer.ContainerUser;
 
 import javax.management.StandardMBean;
+import javax.servlet.MultipartConfigElement;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRegistration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -153,6 +158,17 @@ public class ApiModule extends CodeOnlyModule
         // Handle experimental feature startup properties as late as possible; we want all experimental features to be registered first
         ContextListener.addStartupListener(new ExperimentalFeatureStartupListener());
         ContextListener.addStartupListener(new StartupPropertyStartupListener());
+    }
+
+    @Override
+    public void registerServlets(ServletContext servletCtx)
+    {
+        ServletRegistration.Dynamic d = servletCtx.addServlet("ViewServlet", new ViewServlet());
+        d.setLoadOnStartup(1);
+        d.setMultipartConfig(new MultipartConfigElement(SpringActionController.getTempUploadDir().getPath()));
+        d.addMapping("*.view");
+        d.addMapping("*.api");
+        d.addMapping("*.post");
     }
 
     @Override

--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -61,9 +61,8 @@ import org.labkey.api.view.template.PageConfig;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
-import org.springframework.web.multipart.commons.CommonsMultipartResolver;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
@@ -479,8 +478,7 @@ public abstract class SpringActionController implements Controller, HasViewConte
                 try
                 {
                     ViewBackgroundInfo info = new ViewBackgroundInfo(context.getContainer(), context.getUser(), context.getActionURL().clone());
-                    CommonsMultipartResolver resolver = AntiVirusProviderRegistry.get().getMultipartResolver(info);
-                    resolver.setUploadTempDir(new FileSystemResource(getTempUploadDir()));
+                    StandardServletMultipartResolver resolver = AntiVirusProviderRegistry.get().getMultipartResolver(info);
                     request = resolver.resolveMultipart(request);
                     context.setRequest(request);
                     // ViewServlet doesn't check validChars for parameters in a multipart request, so check again
@@ -546,7 +544,7 @@ public abstract class SpringActionController implements Controller, HasViewConte
     {
         if (TEMP_UPLOAD_DIR == null)
         {
-            TEMP_UPLOAD_DIR = new File(new File(System.getProperty("java.io.tmpdir")), "httpUploads");
+            TEMP_UPLOAD_DIR = new File(new File(System.getProperty("java.io.tmpdir")), "httpUploads").getAbsoluteFile();
             TEMP_UPLOAD_DIR.mkdirs();
         }
         return TEMP_UPLOAD_DIR;

--- a/api/src/org/labkey/api/module/Module.java
+++ b/api/src/org/labkey/api/module/Module.java
@@ -38,6 +38,7 @@ import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.writer.ContainerUser;
 import org.springframework.web.servlet.mvc.Controller;
 
+import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -60,6 +61,11 @@ import java.util.stream.Collectors;
  */
 public interface Module
 {
+    /** Register primary servlets and their mappings. */
+    default void registerServlets(ServletContext servletCtx) {}
+    /** Register any final servlet mappings after the main mappings are in place */
+    default void registerFinalServlets(ServletContext servletCtx) {}
+
     enum TabDisplayMode
     {
         DISPLAY_NEVER,

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -520,6 +520,15 @@ public class ModuleLoader implements Filter, MemTrackerListener
             throw new IllegalStateException("Core module was not first or could not find the Core module. Ensure that Tomcat user can create directories under the <LABKEY_HOME>/modules directory.");
         setProjectRoot(coreModule);
 
+        for (Module module : modules)
+        {
+            module.registerServlets(servletCtx);
+        }
+        for (Module module : modules)
+        {
+            module.registerFinalServlets(servletCtx);
+        }
+
         // Do this after we've checked to see if we can find the core module. See issue 22797.
         verifyProductionModeMatchesBuild();
 

--- a/api/src/org/labkey/api/premium/AntiVirusProvider.java
+++ b/api/src/org/labkey/api/premium/AntiVirusProvider.java
@@ -4,6 +4,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.view.ActionURL;
 
+import java.util.Collections;
+import java.util.Map;
+
 public interface AntiVirusProvider
 {
     @NotNull String getId();             // something unique e.g. className
@@ -18,4 +21,6 @@ public interface AntiVirusProvider
     {
         return getId().equals(id);
     }
+
+    default Map<String, Object> getUsageMetrics() { return Collections.emptyMap(); }
 }

--- a/api/src/org/labkey/api/premium/AntiVirusProviderRegistry.java
+++ b/api/src/org/labkey/api/premium/AntiVirusProviderRegistry.java
@@ -2,7 +2,7 @@ package org.labkey.api.premium;
 
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.view.ViewBackgroundInfo;
-import org.springframework.web.multipart.commons.CommonsMultipartResolver;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
 
 public interface AntiVirusProviderRegistry
 {
@@ -24,11 +24,8 @@ public interface AntiVirusProviderRegistry
 
     void registerAntiVirusProvider(AntiVirusProvider avp);
 
-    default CommonsMultipartResolver getMultipartResolver(ViewBackgroundInfo info)
+    default StandardServletMultipartResolver getMultipartResolver(ViewBackgroundInfo info)
     {
-        CommonsMultipartResolver result = new CommonsMultipartResolver();
-        // Issue 47362 - configure a limit for the number of files per request
-        result.getFileUpload().setFileCountMax(1_000);
-        return result;
+        return new StandardServletMultipartResolver();
     }
 }

--- a/api/src/org/labkey/api/security/DummyAntiVirusService.java
+++ b/api/src/org/labkey/api/security/DummyAntiVirusService.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.api.security;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -23,14 +22,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.premium.AntiVirusProvider;
 import org.labkey.api.premium.AntiVirusService;
-import org.labkey.api.reader.Readers;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
 
-import java.io.File;
 import java.io.IOException;
 
-import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.labkey.api.premium.AntiVirusService.Result.FAILED;
 import static org.labkey.api.premium.AntiVirusService.Result.OK;
 
@@ -39,17 +36,17 @@ public class DummyAntiVirusService implements AntiVirusService
     private static final Logger LOG = LogManager.getLogger(DummyAntiVirusService.class);
 
     @Override
-    public ScanResult scan(@NotNull File f, @Nullable String originalName, ViewBackgroundInfo info)
+    public ScanResult scan(@NotNull Scannable scannable, ViewBackgroundInfo info)
     {
-        originalName = defaultString(originalName, f.getName());
+        String originalName = scannable.getFileName();
 
         try
         {
-            long len = f.length();
+            long len = scannable.getSize();
             // editors really like to tack on new lines, so why fight it
             if (len >= TEST_VIRUS_CONTENT.length() && len <= TEST_VIRUS_CONTENT.length()+2)
             {
-                String s = IOUtils.toString(Readers.getReader(f));
+                String s = PageFlowUtil.getStreamContentsAsString(scannable.getInputStream());
                 if (StringUtils.equals(TEST_VIRUS_CONTENT, s.trim()))
                 {
                     String logmessage = "File failed virus scan: LABKEY test virus detected";

--- a/api/webapp/WEB-INF/web.xml
+++ b/api/webapp/WEB-INF/web.xml
@@ -91,12 +91,6 @@
     </filter-mapping>
 
     <servlet>
-        <servlet-name>ViewServlet</servlet-name>
-        <servlet-class>org.labkey.api.view.ViewServlet</servlet-class>
-        <load-on-startup>1</load-on-startup>
-    </servlet>
-
-    <servlet>
         <servlet-name>Kaptcha</servlet-name>
         <servlet-class>com.google.code.kaptcha.servlet.KaptchaServlet</servlet-class>
         <init-param>
@@ -127,38 +121,6 @@
         <servlet-class>org.labkey.api.attachments.ImageServlet</servlet-class>
     </servlet>
 
-    <servlet>
-        <servlet-name>static</servlet-name>
-        <servlet-class>org.labkey.core.webdav.WebdavServlet</servlet-class>
-        <init-param>
-          <param-name>resolver</param-name>
-          <param-value>org.labkey.core.webdav.ModuleStaticResolverImpl</param-value>
-        </init-param>
-    </servlet>
-
-    <!--
-        even though there is one webdav tree rooted at "/" we still use two servlet bindings.
-        This is because we want /_webdav/* to be resolve BEFORE all other servlet-mappings
-        and /* to resolve AFTER all other servlet-mappings
-    -->
-    <servlet-mapping>
-        <servlet-name>static</servlet-name>
-        <url-pattern>/_webdav/*</url-pattern>
-    </servlet-mapping>
-
-
-    <servlet-mapping>
-        <servlet-name>ViewServlet</servlet-name>
-        <url-pattern>*.view</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>ViewServlet</servlet-name>
-        <url-pattern>*.api</url-pattern>
-    </servlet-mapping>
-    <servlet-mapping>
-        <servlet-name>ViewServlet</servlet-name>
-        <url-pattern>*.post</url-pattern>
-    </servlet-mapping>
     <servlet-mapping>
         <servlet-name>ImageServlet</servlet-name>
         <url-pattern>*.image</url-pattern>
@@ -172,11 +134,6 @@
         <url-pattern>/files/*</url-pattern>
     </servlet-mapping>
 
-    <servlet-mapping>
-        <servlet-name>static</servlet-name>
-        <url-pattern>/</url-pattern>
-    </servlet-mapping>
-    
     <welcome-file-list>
         <welcome-file>/</welcome-file>
     </welcome-file-list>

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -256,6 +256,7 @@ import org.labkey.core.webdav.DavController;
 import org.labkey.core.webdav.ModuleStaticResolverImpl;
 import org.labkey.core.webdav.UserResolverImpl;
 import org.labkey.core.webdav.WebFilesResolverImpl;
+import org.labkey.core.webdav.WebdavServlet;
 import org.labkey.core.wiki.MarkdownServiceImpl;
 import org.labkey.core.wiki.RadeoxRenderer;
 import org.labkey.core.wiki.WikiRenderingServiceImpl;
@@ -266,7 +267,9 @@ import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.impl.StdSchedulerFactory;
 
+import javax.servlet.MultipartConfigElement;
 import javax.servlet.ServletContext;
+import javax.servlet.ServletRegistration;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -319,6 +322,8 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     }
 
     private CoreWarningProvider _warningProvider;
+    private ServletRegistration.Dynamic _webdavServletDynamic;
+
     @Override
     public boolean hasScripts()
     {
@@ -1150,6 +1155,23 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         {
             WebdavService.get().registerRootResolver(UserResolverImpl.get());
         }
+    }
+
+    @Override
+    public void registerServlets(ServletContext servletCtx)
+    {
+//        even though there is one webdav tree rooted at "/" we still use two servlet bindings.
+//        This is because we want /_webdav/* to be resolve BEFORE all other servlet-mappings
+//        and /* to resolve AFTER all other servlet-mappings
+        _webdavServletDynamic = servletCtx.addServlet("static", new WebdavServlet(true));
+        _webdavServletDynamic.setMultipartConfig(new MultipartConfigElement(SpringActionController.getTempUploadDir().getPath()));
+        _webdavServletDynamic.addMapping("/_webdav/*");
+    }
+
+    @Override
+    public void registerFinalServlets(ServletContext servletCtx)
+    {
+        _webdavServletDynamic.addMapping("/");
     }
 
     @Override

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -100,8 +100,7 @@ import org.springframework.validation.BindException;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
-import org.springframework.web.multipart.commons.CommonsMultipartFile;
-import org.springframework.web.multipart.commons.CommonsMultipartResolver;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.Controller;
 import org.w3c.dom.Document;
@@ -113,10 +112,12 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 import javax.servlet.http.HttpSession;
+import javax.servlet.http.Part;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -286,7 +287,7 @@ public class DavController extends SpringActionController
             {
                 try
                 {
-                    multipartRequest = (new CommonsMultipartResolver()).resolveMultipart(request);
+                    multipartRequest = new StandardServletMultipartResolver().resolveMultipart(request);
                     request = multipartRequest;
                 }
                 catch (MultipartException x)
@@ -360,16 +361,14 @@ public class DavController extends SpringActionController
                 // Be sure that temp files are deleted. This typically is handled via garbage collection
                 // but there is no guarantee that it will actually run in a timely fashion, or ever depending
                 // on how the server is shut down
-                for (List<MultipartFile> multipartFiles : multipartRequest.getMultiFileMap().values())
+                try
                 {
-                    for (MultipartFile multipartFile : multipartFiles)
+                    for (Part part : request.getParts())
                     {
-                        if (multipartFile instanceof CommonsMultipartFile)
-                        {
-                            ((CommonsMultipartFile)multipartFile).getFileItem().delete();
-                        }
+                        part.delete();
                     }
                 }
+                catch (IOException | ServletException ignored) {}
             }
         }
         for (Map.Entry<Closeable, Throwable> e : closables.entrySet())
@@ -413,7 +412,7 @@ public class DavController extends SpringActionController
         }
 
         @Override
-        public void sendError(int sc, String msg) throws IOException
+        public void sendError(int sc, String msg)
         {
             sendError(WebdavStatus.fromCode(sc), msg);
         }
@@ -468,7 +467,7 @@ public class DavController extends SpringActionController
                                 getRequest() instanceof MultipartHttpServletRequest)
                         {
                             super.setHeader("Content-Type", "text/html");
-                            super.getWriter().write("<html><body><textarea>" + o.toString() + "</textarea></body></html>");
+                            super.getWriter().write("<html><body><textarea>" + o + "</textarea></body></html>");
                         }
                         else
                         {
@@ -3110,7 +3109,7 @@ public class DavController extends SpringActionController
             fis.transferTo(tmp);
 
             ViewBackgroundInfo info = new ViewBackgroundInfo(getContainer(), getUser(), null);
-            AntiVirusService.ScanResult result = avs.scan(tmp, name, info);
+            AntiVirusService.ScanResult result = avs.scan(new AntiVirusService.FileScannable(tmp, name), info);
             if (result.result == AntiVirusService.Result.OK)
             {
                 _fis = new FileStream.FileFileStream(tmp, true);

--- a/core/src/org/labkey/core/webdav/WebdavServlet.java
+++ b/core/src/org/labkey/core/webdav/WebdavServlet.java
@@ -19,7 +19,6 @@ package org.labkey.core.webdav;
 /**
  * User: matthewb
  * Date: Apr 17, 2008
- * Time: 2:03:32 PM
  */
 
 import org.apache.commons.lang3.StringUtils;
@@ -51,6 +50,20 @@ import java.net.URISyntaxException;
 public class WebdavServlet extends HttpServlet
 {
     Logger _log = LogManager.getLogger(WebdavServlet.class);
+
+    final WebdavResolver _resolver;
+    String _serverHeader;
+
+    public WebdavServlet()
+    {
+        this(false);
+    }
+    
+    public WebdavServlet(boolean asStatic)
+    {
+        _resolver = asStatic ? ModuleStaticResolverImpl.get() : WebdavResolverImpl.get();
+    }
+
     @Override
     protected void service(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException
@@ -144,22 +157,4 @@ public class WebdavServlet extends HttpServlet
             dav.handleRequest(request, response);
         }
     }
-
-
-    @Override
-    public void init(ServletConfig config) throws ServletException
-    {
-        super.init(config);
-        String resolver = config.getInitParameter("resolver");
-        if (ModuleStaticResolverImpl.class.getName().equals(resolver))
-            _resolver = ModuleStaticResolverImpl.get();
-        else if (WebdavResolverImpl.class.getName().equals(resolver))
-            _resolver = WebdavResolverImpl.get();
-        else
-            throw new IllegalArgumentException("resolver");
-//        _serverHeader =  "Labkey/" + AppProps.getInstance().getLabkeyVersionString();
-    }
-
-    WebdavResolver _resolver;
-    String _serverHeader;
 }


### PR DESCRIPTION
#### Rationale
Spring 6 doesn't bundle CommonsMultipartResolver anymore. Switching to Spring's recommended replacement will make upgrading to Spring 6 and Tomcat 10 easier.

#### Changes
* Switch servlet registration to programmatic instead of through `web.xml` when we want to configure the temp upload directory
* Switch to virus scanning based on InputStreams instead of Files
* Delete a bit of dead code