### PR TITLE
Assay Transform Script UX update to allow file drop and file path entry

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -1292,12 +1292,12 @@ public abstract class AbstractAssayProvider implements AssayProvider
                 }
                 else
                 {
-                    validationErrors.addError(new SimpleValidationError("Script engine for the extension : " + ext + " has not been registered.", null, SEVERITY.ERROR, new HelpTopic("configureScripting")));
+                    validationErrors.addError(new SimpleValidationError("Script engine for the extension '" + ext + "' has not been registered.", null, SEVERITY.ERROR, new HelpTopic("configureScripting")));
                 }
             }
             else
             {
-                validationErrors.addError(new SimpleValidationError("The transform script '" + scriptFile.getPath() + "' is invalid or does not exist", null, SEVERITY.ERROR));
+                validationErrors.addError(new SimpleValidationError("The transform script '" + scriptFile.getPath() + "' is invalid or does not exist.", null, SEVERITY.ERROR));
             }
         }
 

--- a/api/src/org/labkey/api/assay/DefaultDataTransformer.java
+++ b/api/src/org/labkey/api/assay/DefaultDataTransformer.java
@@ -203,8 +203,8 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
             }
             else
             {
-                throw new ValidationException("The validation script: " + scriptFile.getAbsolutePath() + " configured for this Assay does not exist. Please check " +
-                        "the configuration for this Assay design.");
+                throw new ValidationException("The transform script, " + scriptFile.getAbsolutePath() + ", configured for this assay does not exist. Please check " +
+                        "the configuration for this assay design.");
             }
         }
         return result;

--- a/api/src/org/labkey/api/cloud/CloudStoreService.java
+++ b/api/src/org/labkey/api/cloud/CloudStoreService.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiConsumer;
 
 /**
  * User: kevink
@@ -37,9 +36,6 @@ import java.util.function.BiConsumer;
  */
 public interface CloudStoreService
 {
-    /** Root node for containers that are exposing cloud-backed storage in WebDAV */
-    String CLOUD_NAME = "@cloud";
-
     static @Nullable CloudStoreService get()
     {
         return ServiceRegistry.get().getService(CloudStoreService.class);

--- a/api/src/org/labkey/api/files/FileContentService.java
+++ b/api/src/org/labkey/api/files/FileContentService.java
@@ -51,6 +51,7 @@ public interface FileContentService
     String FILES_LINK = "@files";
     String FILE_SETS_LINK = "@filesets";
     String PIPELINE_LINK = "@pipeline";
+    String SCRIPTS_LINK = "@scripts";
     String CLOUD_LINK = "@cloud";
 
     String CLOUD_ROOT_PREFIX = "/@cloud";
@@ -166,6 +167,9 @@ public interface FileContentService
     @Nullable
     AttachmentDirectory getMappedAttachmentDirectory(Container c, boolean createDir) throws UnsetRootDirectoryException, MissingRootDirectoryException;
 
+    @Nullable
+    AttachmentDirectory getMappedAttachmentDirectory(Container c, ContentType contentType, boolean createDir) throws UnsetRootDirectoryException, MissingRootDirectoryException;
+
     /**
      * Return a named AttachmentParent for files in the directory mapped to this container
      *
@@ -202,6 +206,7 @@ public interface FileContentService
         files,
         pipeline,
         assay,
+        scripts
     }
 
     String getFolderName(ContentType type);

--- a/api/src/org/labkey/api/files/view/FilesWebPart.java
+++ b/api/src/org/labkey/api/files/view/FilesWebPart.java
@@ -116,7 +116,7 @@ public class FilesWebPart extends JspView<FilesWebPart.FilesForm>
                 _isPipelineFiles = true;
             }
             else if (fileRoot.startsWith(FileContentService.FILE_SETS_LINK)
-                    || fileRoot.startsWith(CloudStoreService.CLOUD_NAME) && !svc.isCloudRoot(c)
+                    || fileRoot.startsWith(FileContentService.CLOUD_LINK) && !svc.isCloudRoot(c)
                     || fileRoot.startsWith("@wiki"))
             {
                 _isRootNotFilesPipeline = true;
@@ -137,11 +137,11 @@ public class FilesWebPart extends JspView<FilesWebPart.FilesForm>
                 setTitleHref(PageFlowUtil.urlProvider(PipelineUrls.class).urlBrowse(c));
                 setTitle("Pipeline Files");
             }
-            else if (legacyFileRoot.startsWith(CloudStoreService.CLOUD_NAME))
+            else if (legacyFileRoot.startsWith(FileContentService.CLOUD_LINK))
             {
                 // UNDONE: Configure filebrowser to not expand by default since even listing store contents costs money.
-                String storeName = legacyFileRoot.substring((CloudStoreService.CLOUD_NAME + "/").length());
-                getModelBean().setRootPath(getRootPath(c, CloudStoreService.CLOUD_NAME, storeName));
+                String storeName = legacyFileRoot.substring((FileContentService.CLOUD_LINK + "/").length());
+                getModelBean().setRootPath(getRootPath(c, FileContentService.CLOUD_LINK, storeName));
                 setTitle(storeName);
                 setTitleHref(PageFlowUtil.urlProvider(FileUrls.class).urlBegin(c).addParameter("fileSetName", legacyFileRoot));
             }

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.393.2-fb-transformScriptUX.7",
+        "@labkey/components": "2.394.0",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3338,9 +3338,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.7",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.7.tgz",
-      "integrity": "sha512-AZST5CHXh7wPiYN9tg4SMFG2E9Nyg0EwgnbTeEPOcZYFO0aTqFMP8OGtKcY3ufCyQ/fc8fBrJs+MUutDkHH27g==",
+      "version": "2.394.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.394.0.tgz",
+      "integrity": "sha512-lxL3wC74/d9qxGCYLMyH5XhvEC1oR5EDSQa0ZwGEY26KxLAIM1tbqSFI8msfZd2S5mKgN/Xgc+0tWSqt4vkiPA==",
       "dependencies": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19493,9 +19493,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.7",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.7.tgz",
-      "integrity": "sha512-AZST5CHXh7wPiYN9tg4SMFG2E9Nyg0EwgnbTeEPOcZYFO0aTqFMP8OGtKcY3ufCyQ/fc8fBrJs+MUutDkHH27g==",
+      "version": "2.394.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.394.0.tgz",
+      "integrity": "sha512-lxL3wC74/d9qxGCYLMyH5XhvEC1oR5EDSQa0ZwGEY26KxLAIM1tbqSFI8msfZd2S5mKgN/Xgc+0tWSqt4vkiPA==",
       "requires": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.393.2-fb-transformScriptUX.6",
+        "@labkey/components": "2.393.2-fb-transformScriptUX.7",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3338,9 +3338,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.6",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.6.tgz",
-      "integrity": "sha512-6JE2coV+lDkxZoE5iDNwNcCqh6B/9r6spVnRSTH50vzhOP9acdAp8VDrBInW/O891GBctotX90W9vKrcQAs6kQ==",
+      "version": "2.393.2-fb-transformScriptUX.7",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.7.tgz",
+      "integrity": "sha512-AZST5CHXh7wPiYN9tg4SMFG2E9Nyg0EwgnbTeEPOcZYFO0aTqFMP8OGtKcY3ufCyQ/fc8fBrJs+MUutDkHH27g==",
       "dependencies": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19493,9 +19493,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.6",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.6.tgz",
-      "integrity": "sha512-6JE2coV+lDkxZoE5iDNwNcCqh6B/9r6spVnRSTH50vzhOP9acdAp8VDrBInW/O891GBctotX90W9vKrcQAs6kQ==",
+      "version": "2.393.2-fb-transformScriptUX.7",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.7.tgz",
+      "integrity": "sha512-AZST5CHXh7wPiYN9tg4SMFG2E9Nyg0EwgnbTeEPOcZYFO0aTqFMP8OGtKcY3ufCyQ/fc8fBrJs+MUutDkHH27g==",
       "requires": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.393.2-fb-transformScriptUX.1",
+        "@labkey/components": "2.393.2-fb-transformScriptUX.2",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3338,9 +3338,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.1.tgz",
-      "integrity": "sha512-kcxCc5mNWyA6gwjqFH7VviFWx9j7w4oLkQXLPipYTezHtu0tyQTnJqDqR+aThnNLbvjy/fuELdtcMeASkIFGfw==",
+      "version": "2.393.2-fb-transformScriptUX.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.2.tgz",
+      "integrity": "sha512-ZDWHBKyy8SWkRJZS7d2dv7V7P7prt76vw5xNYfDQUrGoP68R1969OBx/yeV+RGaTb1+UtWGw0C6yhluXENAuYg==",
       "dependencies": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19493,9 +19493,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.1.tgz",
-      "integrity": "sha512-kcxCc5mNWyA6gwjqFH7VviFWx9j7w4oLkQXLPipYTezHtu0tyQTnJqDqR+aThnNLbvjy/fuELdtcMeASkIFGfw==",
+      "version": "2.393.2-fb-transformScriptUX.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.2.tgz",
+      "integrity": "sha512-ZDWHBKyy8SWkRJZS7d2dv7V7P7prt76vw5xNYfDQUrGoP68R1969OBx/yeV+RGaTb1+UtWGw0C6yhluXENAuYg==",
       "requires": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.393.2-fb-transformScriptUX.0",
+        "@labkey/components": "2.393.2-fb-transformScriptUX.1",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3338,9 +3338,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.0.tgz",
-      "integrity": "sha512-hST1TwGk77ZE2tHVZgTSGhWw/wV6IiOLzMCxvx+Gr0dKErqf5o66gIvqHXT5Aswea/LG6vaEU6eLaGZBmcq4PA==",
+      "version": "2.393.2-fb-transformScriptUX.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.1.tgz",
+      "integrity": "sha512-kcxCc5mNWyA6gwjqFH7VviFWx9j7w4oLkQXLPipYTezHtu0tyQTnJqDqR+aThnNLbvjy/fuELdtcMeASkIFGfw==",
       "dependencies": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19493,9 +19493,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.0.tgz",
-      "integrity": "sha512-hST1TwGk77ZE2tHVZgTSGhWw/wV6IiOLzMCxvx+Gr0dKErqf5o66gIvqHXT5Aswea/LG6vaEU6eLaGZBmcq4PA==",
+      "version": "2.393.2-fb-transformScriptUX.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.1.tgz",
+      "integrity": "sha512-kcxCc5mNWyA6gwjqFH7VviFWx9j7w4oLkQXLPipYTezHtu0tyQTnJqDqR+aThnNLbvjy/fuELdtcMeASkIFGfw==",
       "requires": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.393.2-fb-transformScriptUX.3",
+        "@labkey/components": "2.393.2-fb-transformScriptUX.4",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3338,9 +3338,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.3.tgz",
-      "integrity": "sha512-oqfCHg7/1cZABLrgyl85aRk1PPY2vOWQ63vUTJoiyS85COouCZkwUa2b+8iyk5ATFjnpz5JhwXP7OGgllujpqg==",
+      "version": "2.393.2-fb-transformScriptUX.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.4.tgz",
+      "integrity": "sha512-2OlZHZYqJ5EKB0JdAU2v+YnR4ov10otl9RWz1cNAX4+ZLkOshwtmVDZNJkecZggk31rfHqt0Z1ox/UkTkmq49w==",
       "dependencies": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19493,9 +19493,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.3.tgz",
-      "integrity": "sha512-oqfCHg7/1cZABLrgyl85aRk1PPY2vOWQ63vUTJoiyS85COouCZkwUa2b+8iyk5ATFjnpz5JhwXP7OGgllujpqg==",
+      "version": "2.393.2-fb-transformScriptUX.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.4.tgz",
+      "integrity": "sha512-2OlZHZYqJ5EKB0JdAU2v+YnR4ov10otl9RWz1cNAX4+ZLkOshwtmVDZNJkecZggk31rfHqt0Z1ox/UkTkmq49w==",
       "requires": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.393.2-fb-transformScriptUX.2",
+        "@labkey/components": "2.393.2-fb-transformScriptUX.3",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3338,9 +3338,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.2.tgz",
-      "integrity": "sha512-ZDWHBKyy8SWkRJZS7d2dv7V7P7prt76vw5xNYfDQUrGoP68R1969OBx/yeV+RGaTb1+UtWGw0C6yhluXENAuYg==",
+      "version": "2.393.2-fb-transformScriptUX.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.3.tgz",
+      "integrity": "sha512-oqfCHg7/1cZABLrgyl85aRk1PPY2vOWQ63vUTJoiyS85COouCZkwUa2b+8iyk5ATFjnpz5JhwXP7OGgllujpqg==",
       "dependencies": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19493,9 +19493,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.2.tgz",
-      "integrity": "sha512-ZDWHBKyy8SWkRJZS7d2dv7V7P7prt76vw5xNYfDQUrGoP68R1969OBx/yeV+RGaTb1+UtWGw0C6yhluXENAuYg==",
+      "version": "2.393.2-fb-transformScriptUX.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.3.tgz",
+      "integrity": "sha512-oqfCHg7/1cZABLrgyl85aRk1PPY2vOWQ63vUTJoiyS85COouCZkwUa2b+8iyk5ATFjnpz5JhwXP7OGgllujpqg==",
       "requires": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.393.2",
+        "@labkey/components": "2.393.2-fb-transformScriptUX.0",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3338,9 +3338,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.393.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2.tgz",
-      "integrity": "sha512-qvN48IE4xL6x9qFzXHET2ECs08RZxzT7sVZSKzJkqJ3ntLRq+i2Pikib1Oyfk+ogG2v9mzO3SDIgM++k2Htxtw==",
+      "version": "2.393.2-fb-transformScriptUX.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.0.tgz",
+      "integrity": "sha512-hST1TwGk77ZE2tHVZgTSGhWw/wV6IiOLzMCxvx+Gr0dKErqf5o66gIvqHXT5Aswea/LG6vaEU6eLaGZBmcq4PA==",
       "dependencies": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19493,9 +19493,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.393.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2.tgz",
-      "integrity": "sha512-qvN48IE4xL6x9qFzXHET2ECs08RZxzT7sVZSKzJkqJ3ntLRq+i2Pikib1Oyfk+ogG2v9mzO3SDIgM++k2Htxtw==",
+      "version": "2.393.2-fb-transformScriptUX.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.0.tgz",
+      "integrity": "sha512-hST1TwGk77ZE2tHVZgTSGhWw/wV6IiOLzMCxvx+Gr0dKErqf5o66gIvqHXT5Aswea/LG6vaEU6eLaGZBmcq4PA==",
       "requires": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.393.2-fb-transformScriptUX.5",
+        "@labkey/components": "2.393.2-fb-transformScriptUX.6",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3338,9 +3338,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.5.tgz",
-      "integrity": "sha512-1tpSHFzq0LFFQp42BaZikq/TP/TgCqZMM7m0S8obpgqUhDzp5uMjcVE8k8y2QsLiTS+ooQtNbmAP8+LuOvJ0bw==",
+      "version": "2.393.2-fb-transformScriptUX.6",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.6.tgz",
+      "integrity": "sha512-6JE2coV+lDkxZoE5iDNwNcCqh6B/9r6spVnRSTH50vzhOP9acdAp8VDrBInW/O891GBctotX90W9vKrcQAs6kQ==",
       "dependencies": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19493,9 +19493,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.5.tgz",
-      "integrity": "sha512-1tpSHFzq0LFFQp42BaZikq/TP/TgCqZMM7m0S8obpgqUhDzp5uMjcVE8k8y2QsLiTS+ooQtNbmAP8+LuOvJ0bw==",
+      "version": "2.393.2-fb-transformScriptUX.6",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.6.tgz",
+      "integrity": "sha512-6JE2coV+lDkxZoE5iDNwNcCqh6B/9r6spVnRSTH50vzhOP9acdAp8VDrBInW/O891GBctotX90W9vKrcQAs6kQ==",
       "requires": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.393.2-fb-transformScriptUX.4",
+        "@labkey/components": "2.393.2-fb-transformScriptUX.5",
         "@labkey/themes": "1.3.2"
       },
       "devDependencies": {
@@ -3338,9 +3338,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.4.tgz",
-      "integrity": "sha512-2OlZHZYqJ5EKB0JdAU2v+YnR4ov10otl9RWz1cNAX4+ZLkOshwtmVDZNJkecZggk31rfHqt0Z1ox/UkTkmq49w==",
+      "version": "2.393.2-fb-transformScriptUX.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.5.tgz",
+      "integrity": "sha512-1tpSHFzq0LFFQp42BaZikq/TP/TgCqZMM7m0S8obpgqUhDzp5uMjcVE8k8y2QsLiTS+ooQtNbmAP8+LuOvJ0bw==",
       "dependencies": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19493,9 +19493,9 @@
       }
     },
     "@labkey/components": {
-      "version": "2.393.2-fb-transformScriptUX.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.4.tgz",
-      "integrity": "sha512-2OlZHZYqJ5EKB0JdAU2v+YnR4ov10otl9RWz1cNAX4+ZLkOshwtmVDZNJkecZggk31rfHqt0Z1ox/UkTkmq49w==",
+      "version": "2.393.2-fb-transformScriptUX.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.393.2-fb-transformScriptUX.5.tgz",
+      "integrity": "sha512-1tpSHFzq0LFFQp42BaZikq/TP/TgCqZMM7m0S8obpgqUhDzp5uMjcVE8k8y2QsLiTS+ooQtNbmAP8+LuOvJ0bw==",
       "requires": {
         "@labkey/api": "1.27.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.393.2-fb-transformScriptUX.6",
+    "@labkey/components": "2.393.2-fb-transformScriptUX.7",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.393.2-fb-transformScriptUX.1",
+    "@labkey/components": "2.393.2-fb-transformScriptUX.2",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.393.2-fb-transformScriptUX.7",
+    "@labkey/components": "2.394.0",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.393.2-fb-transformScriptUX.2",
+    "@labkey/components": "2.393.2-fb-transformScriptUX.3",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.393.2-fb-transformScriptUX.5",
+    "@labkey/components": "2.393.2-fb-transformScriptUX.6",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.393.2-fb-transformScriptUX.3",
+    "@labkey/components": "2.393.2-fb-transformScriptUX.4",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.393.2",
+    "@labkey/components": "2.393.2-fb-transformScriptUX.0",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.393.2-fb-transformScriptUX.0",
+    "@labkey/components": "2.393.2-fb-transformScriptUX.1",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.393.2-fb-transformScriptUX.4",
+    "@labkey/components": "2.393.2-fb-transformScriptUX.5",
     "@labkey/themes": "1.3.2"
   },
   "devDependencies": {

--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -44,6 +44,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.files.FileContentService;
 import org.labkey.api.files.FileUrls;
 import org.labkey.api.module.DefaultFolderType;
 import org.labkey.api.module.FolderType;
@@ -436,8 +437,8 @@ public class ProjectController extends SpringActionController
         }
     }
 
-    static final Path pipeline = new Path("@pipeline");
-    static final Path files = new Path("@files");
+    static final Path pipeline = new Path(FileContentService.PIPELINE_LINK);
+    static final Path files = new Path(FileContentService.FILES_LINK);
 
     @RequiresNoPermission
     public class FileBrowserAction extends org.labkey.api.action.SimpleRedirectAction

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -1582,7 +1582,7 @@ public class DavController extends SpringActionController
                             for (String listPath : listPaths)
                             {
                                 // Don't show @cloud if no configs are enabled
-                                if (CloudStoreService.CLOUD_NAME.equals(listPath))
+                                if (FileContentService.CLOUD_LINK.equals(listPath))
                                 {
                                     CloudStoreService cloudStoreService = CloudStoreService.get();
                                     Container resourceContainer = ContainerManager.getForId(resource.getContainerId());

--- a/core/src/org/labkey/core/webdav/WebFilesResolverImpl.java
+++ b/core/src/org/labkey/core/webdav/WebFilesResolverImpl.java
@@ -418,8 +418,8 @@ public class WebFilesResolverImpl extends AbstractWebdavResolver implements File
                 {
                     if (!FileUtil.hasCloudScheme(fileRootFile))
                     {
-                        FileSystemResource fileRootResource = new FileSystemResource(this, "@files", fileRootFile.toFile(), parentContainer.getPolicy());
-                        if (child.equals("@files"))
+                        FileSystemResource fileRootResource = new FileSystemResource(this, FileContentService.FILES_LINK, fileRootFile.toFile(), parentContainer.getPolicy());
+                        if (child.equals(FileContentService.FILES_LINK))
                             return fileRootResource;
                         return new FileSystemResource(fileRootResource, child);
                     }

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -552,6 +552,8 @@ public class ExperimentModule extends SpringModule
 
         AttachmentService.get().registerAttachmentType(ExpDataClassType.get());
 
+        WebdavService.get().addProvider(new ScriptsResourceProvider());
+
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -591,6 +591,7 @@ public class ExperimentModule extends SpringModule
                     }
                     assayMetrics.put("autoLinkedAssayCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.protocol EP JOIN exp.objectPropertiesView OP ON EP.lsid = OP.objecturi WHERE OP.propertyuri = 'terms.labkey.org#AutoCopyTargetContainer'").getObject(Long.class));
                     assayMetrics.put("standardAssayWithPlateSupportCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.protocol EP JOIN exp.objectPropertiesView OP ON EP.lsid = OP.objecturi WHERE OP.name = 'PlateMetadata' AND floatValue = 1").getObject(Long.class));
+                    assayMetrics.put("protocolsWithTransformScriptCount", new SqlSelector(ExperimentService.get().getSchema(), "SELECT COUNT(*) FROM exp.protocol EP JOIN exp.objectPropertiesView OP ON EP.lsid = OP.objecturi WHERE OP.name = 'TransformScript' AND status = 'Active'").getObject(Long.class));
 
                     Map<String, Object> sampleLookupCountMetrics = new HashMap<>();
                     SQLFragment baseAssaySampleLookupSQL = new SQLFragment("SELECT COUNT(*) FROM exp.propertydescriptor WHERE (lookupschema = 'samples' OR (lookupschema = 'exp' AND lookupquery =  'Materials')) AND propertyuri LIKE ?");

--- a/experiment/src/org/labkey/experiment/ScriptsResourceProvider.java
+++ b/experiment/src/org/labkey/experiment/ScriptsResourceProvider.java
@@ -62,20 +62,17 @@ public class ScriptsResourceProvider implements WebdavService.Provider
         if (service.isCloudRoot(c))
             return null;
 
-        if (FileContentService.SCRIPTS_LINK.equalsIgnoreCase(name))
+        try
         {
-            try
+            AttachmentDirectory dir = service.getMappedAttachmentDirectory(c, FileContentService.ContentType.scripts, false);
+            if (dir != null)
             {
-                AttachmentDirectory dir = service.getMappedAttachmentDirectory(c, FileContentService.ContentType.scripts, false);
-                if (dir != null)
-                {
-                    return new ScriptsResource(parent, name, dir.getFileSystemDirectory(), c.getPolicy());
-                }
+                return new ScriptsResource(parent, name, dir.getFileSystemDirectory(), c.getPolicy());
             }
-            catch (MissingRootDirectoryException e)
-            {
-                // Don't complain here, just hide the @files subfolder
-            }
+        }
+        catch (MissingRootDirectoryException e)
+        {
+            // Don't complain here, just hide the @scripts subfolder
         }
 
         return null;

--- a/experiment/src/org/labkey/experiment/ScriptsResourceProvider.java
+++ b/experiment/src/org/labkey/experiment/ScriptsResourceProvider.java
@@ -1,0 +1,150 @@
+package org.labkey.experiment;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.attachments.AttachmentDirectory;
+import org.labkey.api.data.Container;
+import org.labkey.api.files.FileContentService;
+import org.labkey.api.files.MissingRootDirectoryException;
+import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.User;
+import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.NetworkDrive;
+import org.labkey.api.webdav.FileSystemResource;
+import org.labkey.api.webdav.WebdavResolverImpl;
+import org.labkey.api.webdav.WebdavResource;
+import org.labkey.api.webdav.WebdavService;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ScriptsResourceProvider implements WebdavService.Provider
+{
+    @Override
+    public @Nullable Set<String> addChildren(@NotNull WebdavResource target, boolean isListing)
+    {
+        if (!(target instanceof WebdavResolverImpl.WebFolderResource folder))
+            return null;
+
+        FileContentService svc = FileContentService.get();
+        if (svc == null)
+            return null;
+
+        // Check for the default file location
+        Set<String> result = new HashSet<>();
+        Container c = folder.getContainer();
+        java.nio.file.Path root = svc.getFileRootPath(c);
+        if (root != null)
+        {
+            if (!FileUtil.hasCloudScheme(root) && NetworkDrive.exists(root.toFile()))
+            {
+                result.add(FileContentService.SCRIPTS_LINK);
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public WebdavResource resolve(@NotNull WebdavResource parent, @NotNull String name)
+    {
+        if (!FileContentService.SCRIPTS_LINK.equalsIgnoreCase(name))
+            return null;
+        if (!(parent instanceof WebdavResolverImpl.WebFolderResource folder))
+            return null;
+
+        Container c = folder.getContainer();
+        FileContentService service = FileContentService.get();
+        if (null == service)
+            return null;
+        if (service.isCloudRoot(c))
+            return null;
+
+        if (FileContentService.SCRIPTS_LINK.equalsIgnoreCase(name))
+        {
+            try
+            {
+                AttachmentDirectory dir = service.getMappedAttachmentDirectory(c, FileContentService.ContentType.scripts, false);
+                if (dir != null)
+                {
+                    return new ScriptsResource(parent, name, dir.getFileSystemDirectory(), c.getPolicy());
+                }
+            }
+            catch (MissingRootDirectoryException e)
+            {
+                // Don't complain here, just hide the @files subfolder
+            }
+        }
+
+        return null;
+    }
+
+    static class ScriptsResource extends FileSystemResource
+    {
+        public ScriptsResource(WebdavResource folder, String name, File file, SecurityPolicy policy)
+        {
+            super(folder, name, file, policy);
+        }
+
+        public ScriptsResource(FileSystemResource folder, String relativePath)
+        {
+            super(folder,relativePath);
+        }
+
+        @Override
+        public WebdavResource find(String name)
+        {
+            return new ScriptsResource(this, name);
+        }
+
+        @Override
+        protected boolean hasAccess(User user)
+        {
+            return user.isPlatformDeveloper();
+        }
+
+        @Override
+        public boolean canRead(User user, boolean forRead)
+        {
+            return hasAccess(user);
+        }
+
+        @Override
+        public boolean canWrite(User user, boolean forWrite)
+        {
+            return hasAccess(user);
+        }
+
+        @Override
+        public boolean canCreate(User user, boolean forCreate)
+        {
+            return hasAccess(user);
+        }
+
+        @Override
+        public boolean canDelete(User user, boolean forDelete, @Nullable List<String> message)
+        {
+            return hasAccess(user);
+        }
+
+        @Override
+        public boolean canRename(User user, boolean forRename)
+        {
+            return hasAccess(user);
+        }
+
+        @Override
+        public boolean canList(User user, boolean forRead)
+        {
+            return hasAccess(user);
+        }
+
+        @Override
+        public boolean shouldIndex()
+        {
+            return false;
+        }
+    }
+}

--- a/filecontent/src/org/labkey/filecontent/FileContentController.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentController.java
@@ -1104,7 +1104,7 @@ public class FileContentController extends SpringActionController
             {
                 for (String storeName : cloud.getEnabledCloudStores(getContainer()))
                 {
-                    ret.put(CloudStoreService.CLOUD_NAME + "/" + storeName, WebdavService.getPath().append(getContainer().getParsedPath()).append(CloudStoreService.CLOUD_NAME).append(storeName).toString());
+                    ret.put(FileContentService.CLOUD_LINK + "/" + storeName, WebdavService.getPath().append(getContainer().getParsedPath()).append(FileContentService.CLOUD_LINK).append(storeName).toString());
                 }
             }
 

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -764,8 +764,14 @@ public class FileContentServiceImpl implements FileContentService, WarningProvid
     }
 
     @Override
+    public @Nullable AttachmentDirectory getMappedAttachmentDirectory(Container c, boolean createDir) throws UnsetRootDirectoryException, MissingRootDirectoryException
+    {
+        return getMappedAttachmentDirectory(c, ContentType.files, createDir);
+    }
+
+    @Override
     @Nullable
-    public AttachmentDirectory getMappedAttachmentDirectory(Container c, boolean createDir) throws UnsetRootDirectoryException
+    public AttachmentDirectory getMappedAttachmentDirectory(Container c, ContentType contentType, boolean createDir) throws UnsetRootDirectoryException
     {
         try
         {
@@ -774,7 +780,7 @@ public class FileContentServiceImpl implements FileContentService, WarningProvid
             else if (null == getMappedDirectory(c, false))
                 return null;
 
-            return new FileSystemAttachmentParent(c, ContentType.files);
+            return new FileSystemAttachmentParent(c, contentType);
         }
         catch (IOException e)
         {

--- a/pipeline/src/org/labkey/pipeline/PipelineWebdavProvider.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineWebdavProvider.java
@@ -18,6 +18,7 @@ package org.labkey.pipeline;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.files.FileContentService;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.search.SearchService;
@@ -45,8 +46,6 @@ import java.util.Set;
  */
 public class PipelineWebdavProvider implements WebdavService.Provider
 {
-    public static final String PIPELINE_LINK = "@pipeline";
-
     // currently addChildren is called only for web folders
     @Override
     @Nullable
@@ -62,8 +61,8 @@ public class PipelineWebdavProvider implements WebdavService.Provider
             return null;
 
         String webdavURL = root.getWebdavURL();
-        if (null != webdavURL && webdavURL.contains(PIPELINE_LINK) && root.getContainer().equals(c))
-            return PageFlowUtil.set(PIPELINE_LINK);
+        if (null != webdavURL && webdavURL.contains(FileContentService.PIPELINE_LINK) && root.getContainer().equals(c))
+            return PageFlowUtil.set(FileContentService.PIPELINE_LINK);
 
         return null;
     }
@@ -72,7 +71,7 @@ public class PipelineWebdavProvider implements WebdavService.Provider
     @Override
     public WebdavResource resolve(@NotNull WebdavResource parent, @NotNull String name)
     {
-        if (!PIPELINE_LINK.equalsIgnoreCase(name))
+        if (!FileContentService.PIPELINE_LINK.equalsIgnoreCase(name))
             return null;
         if (!(parent instanceof WebdavResolverImpl.WebFolderResource))
             return null;
@@ -93,7 +92,7 @@ public class PipelineWebdavProvider implements WebdavService.Provider
 
         PipelineFolderResource(WebdavResource parent, Container c, PipeRootImpl root)
         {
-            super(parent.getPath(), PIPELINE_LINK);
+            super(parent.getPath(), FileContentService.PIPELINE_LINK);
 
             this.c = c;
             _containerId = c.getId();
@@ -130,7 +129,7 @@ public class PipelineWebdavProvider implements WebdavService.Provider
         @Override
         public String getName()
         {
-            return PIPELINE_LINK;
+            return FileContentService.PIPELINE_LINK;
         }
 
         @Override

--- a/pipeline/src/org/labkey/pipeline/api/PipelineManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineManager.java
@@ -40,6 +40,7 @@ import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.files.FileContentService;
 import org.labkey.api.pipeline.DirectoryNotDeletedException;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
@@ -76,7 +77,6 @@ import org.labkey.api.view.NotFoundException;
 import org.labkey.api.webdav.WebdavService;
 import org.labkey.api.writer.ZipUtil;
 import org.labkey.folder.xml.FolderDocument;
-import org.labkey.pipeline.PipelineWebdavProvider;
 import org.labkey.pipeline.status.StatusController;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
@@ -194,7 +194,7 @@ public class PipelineManager
                     Table.update(user, pipeline.getTableInfoPipelineRoots(), newValue, newValue.getPipelineRootId());
                 }
 
-                org.labkey.api.util.Path davPath = WebdavService.getPath().append(container.getParsedPath()).append(PipelineWebdavProvider.PIPELINE_LINK);
+                org.labkey.api.util.Path davPath = WebdavService.getPath().append(container.getParsedPath()).append(FileContentService.PIPELINE_LINK);
                 SearchService ss = SearchService.get();
                 if (null != ss)
                     ss.addPathToCrawl(davPath, null);

--- a/search/src/org/labkey/search/view/search.jsp
+++ b/search/src/org/labkey/search/view/search.jsp
@@ -21,6 +21,7 @@
 <%@ page import="org.json.JSONObject" %>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.ContainerManager" %>
+<%@ page import="org.labkey.api.files.FileContentService" %>
 <%@ page import="org.labkey.api.portal.ProjectUrls" %>
 <%@ page import="org.labkey.api.search.SearchMisconfiguredException" %>
 <%@ page import="org.labkey.api.search.SearchResultTemplate" %>
@@ -92,8 +93,8 @@
         return nav.isEmpty() ? null : nav;
     }
 
-    Path files = new Path("@files");
-    Path pipeline = new Path("@pipeline");
+    Path files = new Path(FileContentService.FILES_LINK);
+    Path pipeline = new Path(FileContentService.PIPELINE_LINK);
     Path dav = new Path("_webdav");
 
     NavTree getDocumentContext(Container c, SearchService.SearchHit hit)


### PR DESCRIPTION
#### Rationale
Traditionally, adding a new transform script to an assay design requires placing the transform script in a location accessible to the server and manually adding the file path to the assay design. This PR adds a new option to the field editor so that a platform developer can drop a file onto the field editor UI and have that added to a new @scripts secure directory for a given LK container. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1351

#### Changes
- update @labkey/components package version
- More consistent use of constants in FileContentService 
  - CloudStoreService.CLOUD_NAME -> FileContentService.CLOUD_LINK
  - PipelineWebdavProvider.PIPELINE_LINK -> FileContentService.PIPELINE_LINK
  - "@files" -> FileContentService.FILES_LINK
- ScriptsResourceProvider for `@scripts` dir with perm check for user.isPlatformDeveloper
- Add new endpoint to find out if a script engine is configured for a given file extension
