### PR TITLE
Issue 49141: Don't assume files have extensions when looking at R outputs

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -1264,9 +1264,9 @@ public abstract class AbstractAssayProvider implements AssayProvider
         String separator = "";
         for (File scriptFile : scripts)
         {
-            if (scriptFile.isFile())
+            String ext = FileUtil.getExtension(scriptFile);
+            if (scriptFile.isFile() && ext != null)
             {
-                String ext = FileUtil.getExtension(scriptFile);
                 ScriptEngine engine = LabKeyScriptEngineManager.get().getEngineByExtension(protocol.getContainer(), ext, LabKeyScriptEngineManager.EngineContext.pipeline);
                 if (engine != null)
                 {

--- a/api/src/org/labkey/api/assay/DefaultDataTransformer.java
+++ b/api/src/org/labkey/api/assay/DefaultDataTransformer.java
@@ -109,9 +109,13 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
                 {
                     throw new ValidationException(e.getMessage());
                 }
-
-                ScriptEngine engine = LabKeyScriptEngineManager.get()
-                        .getEngineByExtension(context.getContainer(), FileUtil.getExtension(scriptFile), LabKeyScriptEngineManager.EngineContext.pipeline);
+                ScriptEngine engine = null;
+                String ext = FileUtil.getExtension(scriptFile);
+                if (ext != null)
+                {
+                    engine = LabKeyScriptEngineManager.get()
+                        .getEngineByExtension(context.getContainer(), ext, LabKeyScriptEngineManager.EngineContext.pipeline);
+                }
                 if (engine != null)
                 {
                     // issue : 46838 remote scripting engines don't support transform scripts yet

--- a/api/src/org/labkey/api/reports/report/r/RReportJob.java
+++ b/api/src/org/labkey/api/reports/report/r/RReportJob.java
@@ -286,7 +286,7 @@ public class RReportJob extends PipelineJob implements Serializable
                     // clean up the destination folder
                     for (File file : parentDir.listFiles())
                     {
-                        if (!file.isDirectory() && !FileUtil.getExtension(file).equalsIgnoreCase("log"))
+                        if (!file.isDirectory() && !"log".equalsIgnoreCase(FileUtil.getExtension(file)))
                             file.delete();
                     }
 

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -429,6 +429,7 @@ public class FileUtil
      * Returns the file name extension without the dot, null if there
      * isn't one.
      */
+    @Nullable
     public static String getExtension(File file)
     {
         return getExtension(file.getName());
@@ -1387,9 +1388,9 @@ quickScan:
      * @param prefix the start of the file name to generate, to be appended with a timestamp suffix
      * @param extension the extension (not including the dot) for the desired file name
      */
-    public static String makeFileNameWithTimestamp(String prefix, String extension)
+    public static String makeFileNameWithTimestamp(String prefix, @Nullable String extension)
     {
-        return makeLegalName(prefix + "_" + getTimestamp() + "." + extension);
+        return makeLegalName(prefix + "_" + getTimestamp() + (extension == null ? "" : ("." + extension)));
     }
 
     public static String makeFileNameWithTimestamp(String prefix)

--- a/assay/src/org/labkey/assay/pipeline/AssayImportRunTask.java
+++ b/assay/src/org/labkey/assay/pipeline/AssayImportRunTask.java
@@ -283,7 +283,7 @@ public class AssayImportRunTask extends PipelineJob.Task<AssayImportRunTask.Fact
                         }
                     }
                 }
-                else if (FileUtil.getExtension(dataFile).equals("zip"))
+                else if ("zip".equalsIgnoreCase(FileUtil.getExtension(dataFile)))
                 {
                     ensureExplodedZip(job, dataFile);
                     File dir = getExplodedZipDir(job, dataFile);
@@ -317,7 +317,7 @@ public class AssayImportRunTask extends PipelineJob.Task<AssayImportRunTask.Fact
                 {
                     return loadProperties(dataFile, BATCH_PROPS_NAME, job.getLogger());
                 }
-                else if (FileUtil.getExtension(dataFile).equals("zip"))
+                else if ("zip".equalsIgnoreCase(FileUtil.getExtension(dataFile)))
                 {
                     ensureExplodedZip(job, dataFile);
                     File dir = getExplodedZipDir(job, dataFile);
@@ -350,7 +350,7 @@ public class AssayImportRunTask extends PipelineJob.Task<AssayImportRunTask.Fact
                 {
                     return loadProperties(dataFile, RUN_PROPS_NAME, job.getLogger());
                 }
-                else if (FileUtil.getExtension(dataFile).equals("zip"))
+                else if ("zip".equalsIgnoreCase(FileUtil.getExtension(dataFile)))
                 {
                     ensureExplodedZip(job, dataFile);
                     File dir = getExplodedZipDir(job, dataFile);
@@ -384,7 +384,7 @@ public class AssayImportRunTask extends PipelineJob.Task<AssayImportRunTask.Fact
                 try
                 {
                     // plate metadata is only supported for zip archives because on JSON formats are currently supported
-                    if (FileUtil.getExtension(dataFile).equals("zip"))
+                    if ("zip".equalsIgnoreCase(FileUtil.getExtension(dataFile)))
                     {
                         ensureExplodedZip(job, dataFile);
                         File dir = getExplodedZipDir(job, dataFile);
@@ -409,7 +409,7 @@ public class AssayImportRunTask extends PipelineJob.Task<AssayImportRunTask.Fact
         void cleanUp(PipelineJob job) throws PipelineJobException
         {
             File dataFile = getDataFile(job);
-            if (FileUtil.getExtension(dataFile).equals("zip"))
+            if ("zip".equalsIgnoreCase(FileUtil.getExtension(dataFile)))
             {
                 File dir = getExplodedZipDir(job, dataFile);
                 FileUtil.deleteDir(dir, job.getLogger());

--- a/assay/src/org/labkey/assay/view/PlateMetadataDataCollector.java
+++ b/assay/src/org/labkey/assay/view/PlateMetadataDataCollector.java
@@ -48,7 +48,7 @@ public class PlateMetadataDataCollector<ContextType extends AssayRunUploadContex
         Map<String, File> createdData = super.createData(context);
         for (File file : createdData.values())
         {
-            if (!FileUtil.getExtension(file).equalsIgnoreCase("json"))
+            if (!"json".equalsIgnoreCase(FileUtil.getExtension(file)))
             {
                 ExperimentException x = new ExperimentException("Plate metadata must be of type : JSON.");
                 ExceptionUtil.decorateException(x, ExceptionUtil.ExceptionInfo.SkipMothershipLogging, "true", true);


### PR DESCRIPTION
#### Rationale
Not all files have extensions, even those created by R scripts.

#### Changes
* Annotate method as nullable
* Flip the check to avoid NPE