### PR TITLE
Add tsconfig.json

### DIFF
--- a/assay/tsconfig.json
+++ b/assay/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./node_modules/@labkey/build/webpack/tsconfig.json",
+  "include": ["src/client/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./node_modules/@labkey/build/webpack/tsconfig.json",
+  "include": ["src/client/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/experiment/tsconfig.json
+++ b/experiment/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./node_modules/@labkey/build/webpack/tsconfig.json",
+  "include": ["src/client/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/pipeline/tsconfig.json
+++ b/pipeline/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./node_modules/@labkey/build/webpack/tsconfig.json",
+  "include": ["src/client/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
#### Rationale
This adds a `tsconfig.json` file to modules with TypeScript usages so IntelliJ is able to recognize our TSC configuration provided via `@labkey/build`.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4977
- https://github.com/LabKey/inventory/pull/1107
- https://github.com/LabKey/sampleManagement/pull/2254

#### Changes
- Add `tsconfig.json` file.
