### PR TITLE
Remove references to Group.groupAdministrators

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -92,6 +92,7 @@ import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.NestedGroupsTest;
 import org.labkey.api.security.PasswordExpiration;
 import org.labkey.api.security.SecurityManager;
+import org.labkey.api.security.UserManager;
 import org.labkey.api.security.ValidEmail;
 import org.labkey.api.settings.AppPropsTestCase;
 import org.labkey.api.settings.ExperimentalFeatureStartupListener;
@@ -310,6 +311,7 @@ public class ApiModule extends CodeOnlyModule
             TempTableInClauseGenerator.TestCase.class,
             TomcatVersion.TestCase.class,
             URLHelper.TestCase.class,
+            UserManager.TestCase.class,
             ViewCategoryManager.TestCase.class,
             WebdavResolverImpl.TestCase.class,
             WorkbookContainerType.TestCase.class,
@@ -342,5 +344,4 @@ public class ApiModule extends CodeOnlyModule
     {
         Encryption.initEncryptionKeyTest();
     }
-
 }

--- a/api/src/org/labkey/api/action/LabKeyErrorWithLink.java
+++ b/api/src/org/labkey/api/action/LabKeyErrorWithLink.java
@@ -1,5 +1,6 @@
 package org.labkey.api.action;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.Link.LinkBuilder;
@@ -8,9 +9,9 @@ import org.labkey.api.view.ViewContext;
 public class LabKeyErrorWithLink extends LabKeyError
 {
     private final String _adviceText;
-    private final String _adviceHref;
+    private final @Nullable String _adviceHref;
 
-    public LabKeyErrorWithLink(String message, String adviceText, String adviceHref)
+    public LabKeyErrorWithLink(String message, String adviceText, @Nullable String adviceHref)
     {
         super(message);
         _adviceText = adviceText;
@@ -21,8 +22,14 @@ public class LabKeyErrorWithLink extends LabKeyError
     public HtmlString renderToHTML(ViewContext context)
     {
         HtmlStringBuilder builder = HtmlStringBuilder.of(super.renderToHTML(context));
-        builder.append(" ");
-        builder.append(new LinkBuilder(getAdviceText()).href(getAdviceHref()).clearClasses());
+
+        String adviceHref = getAdviceHref();
+
+        if (adviceHref != null)
+        {
+            builder.append(" ");
+            builder.append(new LinkBuilder(getAdviceText()).href(getAdviceHref()).clearClasses());
+        }
 
         return builder.getHtmlString();
     }
@@ -32,7 +39,7 @@ public class LabKeyErrorWithLink extends LabKeyError
         return _adviceText;
     }
 
-    public String getAdviceHref()
+    public @Nullable String getAdviceHref()
     {
         return _adviceHref;
     }

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -2487,7 +2487,7 @@ public class ContainerManager
         return bootstrapContainer(DEFAULT_SUPPORT_PROJECT_PATH,
                 RoleManager.getRole(AuthorRole.class),
                 RoleManager.getRole(ReaderRole.class),
-                null);
+                null, null);
     }
 
     public static void removeDefaultSupportContainer(User user)
@@ -2644,14 +2644,12 @@ public class ContainerManager
     }
 
     /**
-     * If a container at the given path does not exist create one
-     * and set permissions. If the container does exist, permissions
-     * are only set if there is no explicit ACL for the container.
-     * This prevents us from resetting permissions if all users
-     * are dropped. Implicitly done as an admin-level service user.
+     * If a container at the given path does not exist create one and set permissions. If the container does exist,
+     * permissions are only set if there is no explicit ACL for the container. This prevents us from resetting
+     * permissions if all users are dropped. Implicitly done as an admin-level service user.
      */
     @NotNull
-    public static Container bootstrapContainer(String path, Role userRole, @Nullable Role guestRole, @Nullable Role devRole)
+    public static Container bootstrapContainer(String path, @NotNull Role userRole, @Nullable Role guestRole, @Nullable Role devRole, @Nullable Role adminRole)
     {
         Container c = null;
         User user = User.getAdminServiceUser();
@@ -2697,6 +2695,8 @@ public class ContainerManager
                 policy.addRoleAssignment(SecurityManager.getGroup(Group.groupGuests), guestRole);
             if (devRole != null)
                 policy.addRoleAssignment(SecurityManager.getGroup(Group.groupDevelopers), devRole);
+            if (adminRole != null)
+                policy.addRoleAssignment(SecurityManager.getGroup(Group.groupAdministrators), adminRole);
             SecurityPolicyManager.savePolicy(policy, user);
         }
 

--- a/api/src/org/labkey/api/reports/report/view/ReportUtil.java
+++ b/api/src/org/labkey/api/reports/report/view/ReportUtil.java
@@ -809,7 +809,7 @@ public class ReportUtil
         if (null != principal)
         {
             MutableSecurityPolicy policy = new MutableSecurityPolicy(report.getDescriptor(), SecurityPolicyManager.getPolicy(report.getDescriptor(), false));
-            // make sure the Administrators remains readers of this report
+            // make sure the Administrators remain readers of this report
             policy.addRoleAssignment(SecurityManager.getGroup(Group.groupAdministrators), ReaderRole.class);
 
             List<Role> principalAssignedRoles = policy.getAssignedRoles(principal);

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -779,7 +779,13 @@ public class AuthenticationManager
     {
         public ContactAnAdministratorError(String message, String adviceTextSuffix)
         {
-            super(message, "Please contact a system administrator " + adviceTextSuffix, "mailto:" + AppProps.getInstance().getAdministratorContactEmail(true));
+            super(message, "Please contact a system administrator " + adviceTextSuffix, getHref());
+        }
+
+        private static String getHref()
+        {
+            String adminEmail = AppProps.getInstance().getAdministratorContactEmail(true);
+            return adminEmail != null ? "mailto:" + adminEmail : null;
         }
     }
 

--- a/api/src/org/labkey/api/security/GroupMembershipCache.java
+++ b/api/src/org/labkey/api/security/GroupMembershipCache.java
@@ -140,10 +140,6 @@ public class GroupMembershipCache
                 .forEach(principals::addLast);
         }
 
-        // Site administrators always get developer role as well
-        if (groupSet.contains(Group.groupAdministrators))
-            groupSet.add(Group.groupDevelopers);
-
         return new PrincipalArray(groupSet);
     }
 

--- a/api/src/org/labkey/api/security/LimitedUser.java
+++ b/api/src/org/labkey/api/security/LimitedUser.java
@@ -125,7 +125,6 @@ public class LimitedUser extends ClonedUser
             assertEquals(0, user.getGroups().stream().count());
             assertFalse(user.hasPrivilegedRole());
             assertFalse(user.isPlatformDeveloper());
-            assertFalse(user.isInGroup(Group.groupAdministrators));
             assertFalse(user.isImpersonated());
             assertNull(user.getImpersonatingUser());
             assertNull(user.getImpersonationProject());

--- a/api/src/org/labkey/api/security/PrincipalType.java
+++ b/api/src/org/labkey/api/security/PrincipalType.java
@@ -17,8 +17,6 @@ package org.labkey.api.security;
 
 /**
  * Different types of entities that can interact with the system, such as users and groups.
- * User: adam
- * Date: 1/14/12
  */
 public enum PrincipalType
 {

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1413,18 +1413,15 @@ public class SecurityManager
 
     static void deleteGroup(int groupId)
     {
-        if (groupId == Group.groupAdministrators ||
-                groupId == Group.groupGuests ||
-                groupId == Group.groupUsers ||
-                groupId == Group.groupDevelopers)
-            throw new IllegalArgumentException("The global groups cannot be deleted.");
+        Group group = getGroup(groupId);
+        if (null == group)
+            return;
+
+        if (group.isSystemGroup())
+            throw new IllegalArgumentException("The system groups cannot be deleted.");
 
         try (Transaction transaction = core.getScope().beginTransaction())
         {
-            Group group = getGroup(groupId);
-            if (null == group)
-                return;
-
             // Need to invalidate all computed group lists. This isn't quite right, but it gets the job done.
             GroupMembershipCache.handleGroupChange(group, group);
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1555,7 +1555,7 @@ public class SecurityManager
     }
 
     // A permission class that uniquely identifies the root admins, of which we insist there must be at least one
-    public static final Class<? extends Permission> ROOT_ADMIN_PERMISSION =  CanImpersonateSiteRolesPermission.class;
+    public static final Class<? extends Permission> ROOT_ADMIN_PERMISSION = CanImpersonateSiteRolesPermission.class;
 
     public static boolean isRootAdmin(User user)
     {

--- a/api/src/org/labkey/api/security/UserPrincipal.java
+++ b/api/src/org/labkey/api/security/UserPrincipal.java
@@ -146,6 +146,6 @@ public abstract class UserPrincipal implements Principal, Parameter.JdbcParamete
     public boolean hasPrivilegedRole()
     {
         // Check for any privileged role assigned to this principal at the root
-        return isInGroup(Group.groupAdministrators) || ContainerManager.getRoot().getPolicy().getRoles(getGroups()).stream().anyMatch(Role::isPrivileged);
+        return ContainerManager.getRoot().getPolicy().getRoles(getGroups()).stream().anyMatch(Role::isPrivileged);
     }
 }

--- a/api/src/org/labkey/api/security/impersonation/ImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/ImpersonationContext.java
@@ -18,7 +18,6 @@ package org.labkey.api.security.impersonation;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.security.Group;
 import org.labkey.api.security.PrincipalArray;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
@@ -73,11 +72,7 @@ public interface ImpersonationContext extends Serializable
         roles.remove(RoleManager.getRole(NoPermissionsRole.class));
         for (Role role : roles)
             assert role.isApplicable(policy, root);
-        // This is the magic that gives those in the Site Admin group the Site Admin role. Consider removing this and
-        // simply assigning the role to the group (like Platform Developers). This is special to the Site Admin group;
-        // no other role or group should follow this pattern.
-        if (user.isInGroup(Group.groupAdministrators))
-            roles.add(RoleManager.siteAdminRole);
+
         return roles;
     }
 

--- a/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
+++ b/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
@@ -59,8 +59,8 @@ import java.util.Map;
 
 public abstract class AbstractActionPermissionTest extends Assert
 {
-    private static final String SITE_ADMIN_EMAIL = "sadmin@actionpermission.test";
-    private static final String APPLICATION_ADMIN_EMAIL = "aadmin@actionpermission.test";
+    public static final String SITE_ADMIN_EMAIL = "sadmin@actionpermission.test";
+    public static final String APPLICATION_ADMIN_EMAIL = "aadmin@actionpermission.test";
     private static final String PROJECT_ADMIN_EMAIL = "padmin@actionpermission.test";
     private static final String FOLDER_ADMIN_EMAIL = "fadmin@actionpermission.test";
     private static final String EDITOR_EMAIL = "editor@actionpermission.test";
@@ -149,7 +149,7 @@ public abstract class AbstractActionPermissionTest extends Assert
     @Test
     public abstract void testActionPermissions();
 
-    protected static void cleanupUsers(String[] userEmails)
+    public static void cleanupUsers(String[] userEmails)
     {
         //clean up users in case this failed part way through
         try
@@ -165,7 +165,7 @@ public abstract class AbstractActionPermissionTest extends Assert
         {}
     }
 
-    protected static Map<String, User> createUsers(String[] userEmails)
+    public static Map<String, User> createUsers(String[] userEmails)
     {
         Map<String, User> users = new HashMap<>();
 

--- a/api/src/org/labkey/api/security/roles/PlatformDeveloperRole.java
+++ b/api/src/org/labkey/api/security/roles/PlatformDeveloperRole.java
@@ -20,20 +20,29 @@ import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.AnalystPermission;
 import org.labkey.api.security.permissions.BrowserDeveloperPermission;
 import org.labkey.api.security.permissions.EditModuleResourcesPermission;
+import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.PlatformDeveloperPermission;
 import org.labkey.api.security.permissions.TrustedPermission;
 import org.labkey.api.settings.AppProps;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 public class PlatformDeveloperRole extends AbstractRootContainerRole
 {
+    static Collection<Class<? extends Permission>> PERMISSIONS = Arrays.asList(
+        AnalystPermission.class,
+        BrowserDeveloperPermission.class,
+        AppProps.getInstance().isDevMode() ? EditModuleResourcesPermission.class : null,
+        PlatformDeveloperPermission.class,
+        TrustedPermission.class,
+        null
+    );
+
     public PlatformDeveloperRole()
     {
         super("Platform Developer", "Allows developers to write and deploy code outside the LabKey security framework.",
-            AnalystPermission.class,
-            BrowserDeveloperPermission.class,
-            AppProps.getInstance().isDevMode() ? EditModuleResourcesPermission.class : null,
-            PlatformDeveloperPermission.class,
-            TrustedPermission.class
+            PERMISSIONS
         );
 
         addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));

--- a/api/src/org/labkey/api/security/roles/PlatformDeveloperRole.java
+++ b/api/src/org/labkey/api/security/roles/PlatformDeveloperRole.java
@@ -35,8 +35,7 @@ public class PlatformDeveloperRole extends AbstractRootContainerRole
         BrowserDeveloperPermission.class,
         AppProps.getInstance().isDevMode() ? EditModuleResourcesPermission.class : null,
         PlatformDeveloperPermission.class,
-        TrustedPermission.class,
-        null
+        TrustedPermission.class
     );
 
     public PlatformDeveloperRole()

--- a/api/src/org/labkey/api/security/roles/SiteAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/SiteAdminRole.java
@@ -16,17 +16,13 @@
 package org.labkey.api.security.roles;
 
 import org.labkey.api.security.permissions.AdminOperationsPermission;
-import org.labkey.api.security.permissions.AnalystPermission;
-import org.labkey.api.security.permissions.BrowserDeveloperPermission;
 import org.labkey.api.security.permissions.CanImpersonatePrivilegedSiteRolesPermission;
 import org.labkey.api.security.permissions.CanImpersonateSiteRolesPermission;
 import org.labkey.api.security.permissions.CanUseSendMessageApiPermission;
 import org.labkey.api.security.permissions.EditModuleResourcesPermission;
 import org.labkey.api.security.permissions.ExemptFromAccountDisablingPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.permissions.PlatformDeveloperPermission;
 import org.labkey.api.security.permissions.SiteAdminPermission;
-import org.labkey.api.security.permissions.TrustedPermission;
 import org.labkey.api.security.permissions.UploadFileBasedModulePermission;
 import org.labkey.api.settings.AppProps;
 
@@ -41,16 +37,12 @@ public class SiteAdminRole extends AbstractRootContainerRole implements AdminRol
 {
     private static final Collection<Class<? extends Permission>> PERMISSIONS = Arrays.asList(
         AdminOperationsPermission.class,
-        AnalystPermission.class,
-        BrowserDeveloperPermission.class,
         CanImpersonatePrivilegedSiteRolesPermission.class,
         CanImpersonateSiteRolesPermission.class,
         CanUseSendMessageApiPermission.class,
         EmailNonUsersPermission.class,
         ExemptFromAccountDisablingPermission.class,
-        PlatformDeveloperPermission.class,
         SiteAdminPermission.class,
-        TrustedPermission.class,
         UploadFileBasedModulePermission.class
     );
 
@@ -59,6 +51,7 @@ public class SiteAdminRole extends AbstractRootContainerRole implements AdminRol
         super("Site Administrator", "Site Administrators have full control over the entire system.",
             FolderAdminRole.PERMISSIONS,
             ApplicationAdminRole.PERMISSIONS,
+            PlatformDeveloperRole.PERMISSIONS,
             PERMISSIONS,
             AppProps.getInstance().isDevMode() ? Collections.singleton(EditModuleResourcesPermission.class) : Collections.emptyList()
         );

--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -198,11 +198,13 @@ public interface AppProps
     String getWebappConfigurationFilename();
 
     /**
-     * Email address of the primary site or application administrator, set on the site settings page. Useful in error messages when only an administrator can help.
+     * Email address of the primary site or application administrator, set on the site settings page. Useful in error
+     * messages when only an administrator can help. Returns null if there are no site or application admins (i.e.,
+     * only impersonating troubleshooters).
      *
      * @return Email address of the primary site or application administrator
      */
-    String getAdministratorContactEmail(boolean includeAppAdmins);
+    @Nullable String getAdministratorContactEmail(boolean includeAppAdmins);
 
     /**
      * Whether to use the newer, and preferred, container-relative style of URLs of the form

--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -815,7 +815,7 @@ public class ExceptionUtil
             // useful for when the page wants to handle 401s itself
             String headerHint = request.getHeader("X-ONUNAUTHORIZED");
 
-            boolean isGuest = user.isGuest();
+            boolean isGuest = user != null && user.isGuest();
             UnauthorizedException.Type type = uae.getType();
             boolean overrideBasicAuth = "UNAUTHORIZED".equals(headerHint);
             boolean isCSRFViolation = uae instanceof CSRFException;

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -303,7 +303,7 @@ public class FileUtil
         String msg = isAllowedFileName(s);
         if (null == msg)
             return;
-        throw new IOException(msg);
+        throw new IOException(s + ": " + msg);
     }
 
     public static boolean mkdir(File file) throws IOException
@@ -1198,7 +1198,7 @@ quickScan:
             return "__null__";
         }
 
-        if (name.length() == 0)
+        if (name.isEmpty())
         {
             return "__empty__";
         }

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 23.009
+SchemaVersion: 23.010
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-23.009-23.010.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-23.009-23.010.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('assignSiteAdminRole');

--- a/core/resources/schemas/dbscripts/sqlserver/core-23.009-23.010.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-23.009-23.010.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'assignSiteAdminRole';

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -16,12 +16,12 @@
  */
 %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
-<%@ page import="org.labkey.api.data.ContainerManager" %>
-<%@ page import="org.labkey.api.security.User"%>
+<%@ page import="org.labkey.api.security.User" %>
+<%@ page import="org.labkey.api.security.UserManager"%>
 <%@ page import="org.labkey.api.security.permissions.AdminOperationsPermission" %>
-<%@ page import="org.labkey.api.security.permissions.SiteAdminPermission" %>
 <%@ page import="org.labkey.api.settings.AppProps" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
+<%@ page import="org.labkey.api.util.MothershipReport" %>
 <%@ page import="org.labkey.api.util.UsageReportingLevel" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
@@ -29,11 +29,9 @@
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Objects" %>
-<%@ page import="java.util.Set" %>
 <%@ page import="static org.labkey.api.security.SecurityManager.SECONDS_PER_DAY" %>
 <%@ page import="static org.labkey.api.util.ExceptionReportingLevel.*" %>
 <%@ page import="static org.labkey.api.settings.SiteSettingsProperties.*" %>
-<%@ page import="org.labkey.api.util.MothershipReport" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%=formatMissedErrors("form")%>
@@ -139,7 +137,7 @@ Click the Save button at any time to accept the current settings and continue.</
     <td>
         <select name="<%=administratorContactEmail%>" id="<%=administratorContactEmail%>">
             <%
-                List<User> siteAdmins = org.labkey.api.security.SecurityManager.getUsersWithPermissions(ContainerManager.getRoot(), Set.of(SiteAdminPermission.class));
+                List<User> siteAdmins = UserManager.getSiteAdmins();
                 String selectedAdminEmail = appProps.getAdministratorContactEmail(false);
                 for (User siteAdmin : siteAdmins) { %>
                     <option value="<%=h(siteAdmin.getEmail())%>"<%=selected(Objects.equals(siteAdmin.getEmail(), selectedAdminEmail))%>><%=h(siteAdmin.getEmail())%></option>

--- a/core/src/org/labkey/core/query/CoreQuerySchema.java
+++ b/core/src/org/labkey/core/query/CoreQuerySchema.java
@@ -40,8 +40,10 @@ import org.labkey.api.security.SecurityLogger;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserManager;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.security.permissions.SeeGroupDetailsPermission;
 import org.labkey.api.security.permissions.SeeUserDetailsPermission;
 import org.labkey.api.security.permissions.TroubleshooterPermission;
@@ -62,6 +64,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -480,6 +483,17 @@ public class CoreQuerySchema extends UserSchema
                         _projectUserIds.add(assignment.getUserId());
                     });
                 }
+
+                Set<Integer> projectUserIds = new HashSet<>(SecurityManager.getFolderUserids(getContainer()));
+                // Add app admins and site admins (site admins have this permission as well)
+                SecurityManager.getUsersWithPermissions(ContainerManager.getRoot(), true, Set.of(ApplicationAdminPermission.class)).stream()
+                    .map(User::getUserId)
+                    .forEach(projectUserIds::add);
+
+                assert _projectUserIds.containsAll(projectUserIds) : "Expected old user id list to contain all ids in the new list";
+                Set<Integer> copy = new HashSet<>(_projectUserIds);
+                copy.removeAll(projectUserIds);
+                assert copy.stream().map(UserManager::getUser).allMatch(Objects::nonNull) : "Expected additional ids in the old list to all be group ids";
             }
             ColumnInfo userid = users.getRealTable().getColumn("userid");
             users.addInClause(userid, _projectUserIds);

--- a/core/src/org/labkey/core/query/CoreQuerySchema.java
+++ b/core/src/org/labkey/core/query/CoreQuerySchema.java
@@ -420,7 +420,6 @@ public class CoreQuerySchema extends UserSchema
         return members;
     }
 
-
     private SQLFragment getRootPlusProjectCondition()
     {
         SQLFragment sql = new SQLFragment("Container IS NULL");
@@ -455,6 +454,7 @@ public class CoreQuerySchema extends UserSchema
             {
                 _projectUserIds = new HashSet<>(SecurityManager.getFolderUserids(getContainer()));
 
+                // TODO: Please remove this old, tortured way of finding app admins
                 // add all Site Admin group members
                 Group siteAdminGroup = SecurityManager.getGroup(Group.groupAdministrators);
                 _projectUserIds.addAll(
@@ -484,8 +484,9 @@ public class CoreQuerySchema extends UserSchema
                     });
                 }
 
+                // TODO: New shiny way
                 Set<Integer> projectUserIds = new HashSet<>(SecurityManager.getFolderUserids(getContainer()));
-                // Add app admins and site admins (site admins have this permission as well)
+                // Add app admins and site admins (they both have ApplicationAdminPermission)
                 SecurityManager.getUsersWithPermissions(ContainerManager.getRoot(), true, Set.of(ApplicationAdminPermission.class)).stream()
                     .map(User::getUserId)
                     .forEach(projectUserIds::add);
@@ -493,7 +494,7 @@ public class CoreQuerySchema extends UserSchema
                 assert _projectUserIds.containsAll(projectUserIds) : "Expected old user id list to contain all ids in the new list";
                 Set<Integer> copy = new HashSet<>(_projectUserIds);
                 copy.removeAll(projectUserIds);
-                assert copy.stream().map(UserManager::getUser).allMatch(Objects::nonNull) : "Expected additional ids in the old list to all be group ids";
+                assert copy.stream().map(UserManager::getUser).allMatch(Objects::isNull) : "Expected additional ids in the old list to all be group ids";
             }
             ColumnInfo userid = users.getRealTable().getColumn("userid");
             users.addInClause(userid, _projectUserIds);

--- a/core/src/org/labkey/core/script/RhinoCompiledScript.java
+++ b/core/src/org/labkey/core/script/RhinoCompiledScript.java
@@ -52,9 +52,8 @@ final class RhinoCompiledScript extends CompiledScript
 {
     private final Logger _log = LogManager.getLogger(RhinoCompiledScript.class);
 
-    private RhinoScriptEngine engine;
-    private Script script;
-    private final static boolean DEBUG = RhinoScriptEngine.DEBUG;
+    private final RhinoScriptEngine engine;
+    private final Script script;
 
     RhinoCompiledScript(RhinoScriptEngine engine, Script script) {
         this.engine = engine;
@@ -79,14 +78,14 @@ final class RhinoCompiledScript extends CompiledScript
             String str = (value != null && value.getClass().getName().equals("org.mozilla.javascript.NativeError") ?
                           value.toString() :
                           jse.toString());
-            // kevink: supress mothership logging.
+            // kevink: suppress mothership logging.
             ScriptException ex = new ExtendedScriptException(jse, str, jse.sourceName(), line);
             ExceptionUtil.decorateException(ex, ExceptionUtil.ExceptionInfo.SkipMothershipLogging, "true", true);
             throw ex;
         } catch (RhinoException re) {
             _log.debug(re);
             int line = (line = re.lineNumber()) == 0 ? -1 : line;
-            // kevink: supress mothership logging.
+            // kevink: suppress mothership logging.
             ScriptException ex = new ExtendedScriptException(re, re.toString(), re.sourceName(), line);
             ExceptionUtil.decorateException(ex, ExceptionUtil.ExceptionInfo.SkipMothershipLogging, "true", true);
             throw ex;
@@ -101,5 +100,4 @@ final class RhinoCompiledScript extends CompiledScript
     public ScriptEngine getEngine() {
         return engine;
     }
-
 }

--- a/core/src/org/labkey/core/script/RhinoScriptEngine.java
+++ b/core/src/org/labkey/core/script/RhinoScriptEngine.java
@@ -228,14 +228,14 @@ public class RhinoScriptEngine extends AbstractScriptEngine implements LabKeyScr
             String str = (value != null && value.getClass().getName().equals("org.mozilla.javascript.NativeError") ?
                           value.toString() :
                           jse.toString());
-            // kevink: supress mothership logging.
+            // kevink: suppress mothership logging.
             ScriptException ex = new ExtendedScriptException(jse, str, jse.sourceName(), line);
             ExceptionUtil.decorateException(ex, ExceptionUtil.ExceptionInfo.SkipMothershipLogging, "true", true);
             throw ex;
         } catch (RhinoException re) {
             _log.debug(re);
             int line = (line = re.lineNumber()) == 0 ? -1 : line;
-            // kevink: supress mothership logging.
+            // kevink: suppress mothership logging.
             ScriptException ex = new ExtendedScriptException(re, re.toString(), re.sourceName(), line);
             ExceptionUtil.decorateException(ex, ExceptionUtil.ExceptionInfo.SkipMothershipLogging, "true", true);
             throw ex;
@@ -313,14 +313,14 @@ public class RhinoScriptEngine extends AbstractScriptEngine implements LabKeyScr
             String str = (value != null && value.getClass().getName().equals("org.mozilla.javascript.NativeError") ?
                           value.toString() :
                           jse.toString());
-            // kevink: supress mothership logging.
+            // kevink: suppress mothership logging.
             ScriptException ex = new ExtendedScriptException(jse, str, jse.sourceName(), line);
             ExceptionUtil.decorateException(ex, ExceptionUtil.ExceptionInfo.SkipMothershipLogging, "true", true);
             throw ex;
         } catch (RhinoException re) {
             _log.debug(re);
             int line = (line = re.lineNumber()) == 0 ? -1 : line;
-            // kevink: Throw our exception class to supress mothership logging.
+            // kevink: Throw our exception class to suppress mothership logging.
             ScriptException ex = new ExtendedScriptException(re, re.toString(), re.sourceName(), line);
             ExceptionUtil.decorateException(ex, ExceptionUtil.ExceptionInfo.SkipMothershipLogging, "true", true);
             throw ex;

--- a/core/src/org/labkey/core/security/GroupView.java
+++ b/core/src/org/labkey/core/security/GroupView.java
@@ -28,10 +28,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-/**
- * User: jeckels
-* Date: May 1, 2008
-*/
 public class GroupView extends JspView<GroupView.GroupBean>
 {
     public GroupView(Group group, Collection<UserPrincipal> members, Map<UserPrincipal, List<UserPrincipal>> redundantMembers, List<HtmlString> messages, boolean systemGroup, BindException errors)

--- a/core/src/org/labkey/core/security/group.jsp
+++ b/core/src/org/labkey/core/security/group.jsp
@@ -63,24 +63,24 @@
     }
 </style>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
-    var form;
+    let form;
     
     function selectAllCheckboxes(form, value)
     {
-        var elems = form.elements;
-        var l = elems.length;
-        for (var i = 0; i < l; i++)
+        const elems = form.elements;
+        const l = elems.length;
+        for (let i = 0; i < l; i++)
         {
-            var e = elems[i];
-            if (e.type == 'checkbox' && !e.disabled && e.name == 'delete') e.checked = value;
+            const e = elems[i];
+            if (e.type === 'checkbox' && !e.disabled && e.name === 'delete') e.checked = value;
         }
         return false;
     }
 
     function selectForRemoval(id, name, value)
     {
-        var el = document.getElementById(id);
-        if (el && el.type == 'checkbox' && !el.disabled && el.name == 'delete' && el.value == name)
+        const el = document.getElementById(id);
+        if (el && el.type === 'checkbox' && !el.disabled && el.name === 'delete' && el.value === name)
         {
             el.checked = value;
         }
@@ -97,11 +97,11 @@
 
     function confirmRemoveUsers()
     {
-        var elems = document.getElementsByName("delete");
-        var l = elems.length;
-        var selected = 0;
-        var deletingSelf = false;
-        for (var i = 0; i < l; i++)
+        const elems = document.getElementsByName("delete");
+        const l = elems.length;
+        let selected = 0;
+        let deletingSelf = false;
+        for (let i = 0; i < l; i++)
         {
             if (elems[i].checked)
             {
@@ -110,10 +110,10 @@
                     deletingSelf = true;
             }
         }
-        var ok = true;
+        let ok = true;
         if (selected > 0)
         {
-            var msg = "Are";
+            let msg = "Are";
             if (deletingSelf)
             {
                 msg = "Are you sure you want to delete yourself from this group? You will likely lose all permissions granted to this group.";
@@ -126,7 +126,7 @@
             // Deleting other users case
             if (selected > 0)
             {
-                var who = deletingSelf ? "other user" : "selected user";
+                let who = deletingSelf ? "other user" : "selected user";
 
                 if (selected > 1)
                     who = who + "s";
@@ -245,7 +245,7 @@ else
             {
                 %>
                 <%= h(memberName) %>&nbsp;
-                <%= h(!memberName.equalsIgnoreCase(displayName) && StringUtils.isNotBlank(displayName) ? "(" + displayName + ")" : "") %>
+                <%= h(!memberName.equalsIgnoreCase(displayName) && StringUtils.isNotBlank(displayName) ? "(" + displayName + ")" : "") %>&nbsp;&nbsp;
                 <%
             }
         }

--- a/core/src/org/labkey/core/security/permissions.jsp
+++ b/core/src/org/labkey/core/security/permissions.jsp
@@ -95,12 +95,12 @@
 <% } %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
 
-var viewTabs = [];
+const viewTabs = [];
 
 Ext4.onReady(function(){
     Ext4.QuickTips.init();
 
-    var editor = Ext4.create('Security.panel.PermissionEditor', {
+    const editor = Ext4.create('Security.panel.PermissionEditor', {
         renderTo: 'tabBoxDiv',
         minHeight: 450,
         isSiteRoot: <%= JavaScriptFragment.bool(c.isRoot()) %>,

--- a/core/src/org/labkey/core/view/TableViewFormTestCase.java
+++ b/core/src/org/labkey/core/view/TableViewFormTestCase.java
@@ -22,11 +22,6 @@ import org.labkey.api.action.NullSafeBindException;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableViewForm;
 import org.labkey.api.data.TestSchema;
-import org.labkey.api.security.Group;
-import org.labkey.api.security.MutableSecurityPolicy;
-import org.labkey.api.security.SecurityManager;
-import org.labkey.api.security.SecurityPolicyManager;
-import org.labkey.api.security.roles.FolderAdminRole;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.TestContext;
@@ -101,9 +96,6 @@ public class TableViewFormTestCase extends Assert
     public void testDbOperations() throws SQLException
     {
         Container test = JunitUtil.getTestContainer();
-        MutableSecurityPolicy policy = new MutableSecurityPolicy(test);
-        policy.addRoleAssignment(SecurityManager.getGroup(Group.groupAdministrators), FolderAdminRole.class);
-        SecurityPolicyManager.savePolicy(policy, TestContext.get().getUser());
 
         ViewContext ctx = new ViewContext(HttpView.currentContext());
         ctx.setContainer(test);

--- a/issues/src/org/labkey/issue/model/IssueListDef.java
+++ b/issues/src/org/labkey/issue/model/IssueListDef.java
@@ -44,14 +44,9 @@ import org.labkey.api.util.UnexpectedException;
 import org.labkey.issue.query.IssueDefDomainKind;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-/**
- * Created by klum on 4/5/2016.
- */
 public class IssueListDef extends Entity
 {
     public final static String DEFAULT_ISSUE_LIST_NAME = "issues";
@@ -197,16 +192,9 @@ public class IssueListDef extends Entity
                     }
                 }
                 Container container = ContainerManager.getForId(def.getContainerId());
-                // issue 29493 : set the default assigned to group to site administrators
-                List<Group> siteAdminGroups = SecurityManager.getGroups(container.getProject(), true)
-                        .stream()
-                        .filter(group -> !group.isProjectGroup() && group.isAdministrators() && group.getName().equalsIgnoreCase("Administrators"))
-                        .collect(Collectors.toList());
 
-                if (siteAdminGroups.size() == 1)
-                {
-                    IssueManager.saveAssignedToGroup(container, def.getName(), siteAdminGroups.get(0));
-                }
+                // issue 29493 : set the default assigned-to group to site administrators
+                IssueManager.saveAssignedToGroup(container, def.getName(), SecurityManager.getGroup(Group.groupAdministrators));
 
                 IssueListDefCache.uncache(container);
                 transaction.commit();


### PR DESCRIPTION
#### Rationale
Most code that directly references the "Site Admin" group is wrong; typically, it should be checking for `SiteAdminPermission` or assigning the `SiteAdminRole` instead.

In the process, remove pointless code, simplify some overly complex handling, add and use a standard method for enumerating site admins, fix null handling for "primary admin," and add a test to confirm some assumptions.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48879