### PR TITLE
Issue 49150: Fix sample type upgrade from 23.07 to 23.12

### DIFF
--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -357,12 +357,15 @@ public class ExperimentUpgradeCode implements UpgradeCode
         List<Integer> rootSamplesWithAvailableAliquotVolume = new ArrayList<>(s1);
 
         // Exposed as "public" only for upgrade. When removing this code make this signature "private".
+        // Issue 49150: Additionally, remove the "useRootMaterialLSID" flag and all of it's related logic as it
+        // is only necessary for this upgrade path.
         return SampleTypeServiceImpl.get().recomputeSamplesRollup(
             Collections.emptyList(),
             rootSamplesWithAvailableAliquot,
             rootSamplesWithAvailableAliquotVolume,
             sampleType.getMetricUnit(),
-            container
+            container,
+            true
         );
     }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1623,8 +1623,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         // have run yet.
         SQLFragment sql = new SQLFragment("SELECT m.RowId as SampleId, m.Units, (SELECT COUNT(*) FROM exp.material a WHERE ")
                 .append(useRootMaterialLSID ? "a.rootMaterialLsid = m.lsid" : "a.rootMaterialRowId = m.rowId")
-                .append(")-1 AS CreatedAliquotCount FROM exp.material AS m WHERE m.rowid")
-                .appendEOS().append("\n");
+                .append(")-1 AS CreatedAliquotCount FROM exp.material AS m WHERE m.rowid\s");
         dialect.appendInClauseSql(sql, sampleIds);
 
         Map<Integer, Pair<Integer, String>> sampleAliquotCounts = new HashMap<>();
@@ -1717,8 +1716,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 .append(useRootMaterialLSID ? "parent.lsid = aliquot.rootmateriallsid" : "parent.rowid = aliquot.rootmaterialrowid")
                 .append(" WHERE ")
                 .append(useRootMaterialLSID ? "aliquot.rootmateriallsid <> aliquot.lsid" : "aliquot.rootmaterialrowid <> aliquot.rowid")
-                .append(" AND parent.rowid")
-                .appendEOS().append("\n");
+                .append(" AND parent.rowid\s");
         dialect.appendInClauseSql(sql, sampleIds);
 
         Map<Integer, List<AliquotAmountUnitResult>> sampleAliquotAmounts = new HashMap<>();

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1289,11 +1289,18 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     /** This method updates exp.material, caller should call {@link SampleTypeServiceImpl#refreshSampleTypeMaterializedView} as appropriate. */
     private int recomputeSamplesRollup(Collection<Integer> parents, Collection<Integer> withAmountsParents, String sampleTypeUnit, Container container) throws IllegalStateException, SQLException
     {
-        return recomputeSamplesRollup(parents, null, withAmountsParents, sampleTypeUnit, container);
+        return recomputeSamplesRollup(parents, null, withAmountsParents, sampleTypeUnit, container, false);
     }
 
     /** This method updates exp.material, caller should call {@link SampleTypeServiceImpl#refreshSampleTypeMaterializedView} as appropriate. */
-    public int recomputeSamplesRollup(Collection<Integer> parents, @Nullable Collection<Integer> availableParents, Collection<Integer> withAmountsParents, String sampleTypeUnit, Container container) throws IllegalStateException, SQLException
+    public int recomputeSamplesRollup(
+        Collection<Integer> parents,
+        @Nullable Collection<Integer> availableParents,
+        Collection<Integer> withAmountsParents,
+        String sampleTypeUnit,
+        Container container,
+        boolean useRootMaterialLSID
+    ) throws IllegalStateException, SQLException
     {
         Map<Integer, String> sampleUnits = new HashMap<>();
         TableInfo materialTable = ExperimentService.get().getTinfoMaterial();
@@ -1312,7 +1319,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
         if (!parents.isEmpty())
         {
-            Map<Integer, Pair<Integer, String>> sampleAliquotCounts = getSampleAliquotCounts(parents);
+            Map<Integer, Pair<Integer, String>> sampleAliquotCounts = getSampleAliquotCounts(parents, useRootMaterialLSID);
             try (Connection c = scope.getConnection())
             {
                 Parameter rowid = new Parameter("rowid", JdbcType.INTEGER);
@@ -1347,7 +1354,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
         if (!parents.isEmpty() || (availableParents != null && !availableParents.isEmpty()))
         {
-            Map<Integer, Pair<Integer, String>> sampleAliquotCounts = getSampleAvailableAliquotCounts(availableParents == null ? parents : availableParents, availableSampleStates);
+            Map<Integer, Pair<Integer, String>> sampleAliquotCounts = getSampleAvailableAliquotCounts(availableParents == null ? parents : availableParents, availableSampleStates, useRootMaterialLSID);
             try (Connection c = scope.getConnection())
             {
                 Parameter rowid = new Parameter("rowid", JdbcType.INTEGER);
@@ -1382,7 +1389,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
         if (!withAmountsParents.isEmpty())
         {
-            Map<Integer, List<AliquotAmountUnitResult>> samplesAliquotAmounts = getSampleAliquotAmounts(withAmountsParents, availableSampleStates);
+            Map<Integer, List<AliquotAmountUnitResult>> samplesAliquotAmounts = getSampleAliquotAmounts(withAmountsParents, availableSampleStates, useRootMaterialLSID);
 
             try (Connection c = scope.getConnection())
             {
@@ -1606,15 +1613,18 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         return parentIds;
     }
 
-    private Map<Integer, Pair<Integer, String>> getSampleAliquotCounts(Collection<Integer> sampleIds) throws SQLException
+    private Map<Integer, Pair<Integer, String>> getSampleAliquotCounts(Collection<Integer> sampleIds, boolean useRootMaterialLSID) throws SQLException
     {
         DbSchema dbSchema = getExpSchema();
         SqlDialect dialect = dbSchema.getSqlDialect();
 
-        SQLFragment sql = new SQLFragment("""
-                        SELECT m.RowId as SampleId, m.Units, (SELECT COUNT(*) FROM exp.material a WHERE a.rootMaterialRowId = m.rowId)-1 AS CreatedAliquotCount
-                        FROM exp.material AS m
-                        WHERE m.rowid\s""");
+        // Issue 49150: In 23.12 we migrated from RootMaterialLSID to RootMaterialRowID, however, there is still an
+        // upgrade path that requires these queries be done with RootMaterialLSID since the 23.12 upgrade will not
+        // have run yet.
+        SQLFragment sql = new SQLFragment("SELECT m.RowId as SampleId, m.Units, (SELECT COUNT(*) FROM exp.material a WHERE ")
+                .append(useRootMaterialLSID ? "a.rootMaterialLsid = m.lsid" : "a.rootMaterialRowId = m.rowId")
+                .append(")-1 AS CreatedAliquotCount FROM exp.material AS m WHERE m.rowid")
+                .appendEOS().append("\n");
         dialect.appendInClauseSql(sql, sampleIds);
 
         Map<Integer, Pair<Integer, String>> sampleAliquotCounts = new HashMap<>();
@@ -1633,25 +1643,49 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         return sampleAliquotCounts;
     }
 
-    private Map<Integer, Pair<Integer, String>> getSampleAvailableAliquotCounts(Collection<Integer> sampleIds, Collection<Integer> availableSampleStates) throws SQLException
+    private Map<Integer, Pair<Integer, String>> getSampleAvailableAliquotCounts(Collection<Integer> sampleIds, Collection<Integer> availableSampleStates, boolean useRootMaterialLSID) throws SQLException
     {
         DbSchema dbSchema = getExpSchema();
         SqlDialect dialect = dbSchema.getSqlDialect();
 
-        SQLFragment sql = new SQLFragment(
-                """
-                        SELECT m.RowId as SampleId, m.Units,
-                        (CASE WHEN c.aliquotCount IS NULL THEN 0 ELSE c.aliquotCount END) as CreatedAliquotCount
-                        FROM exp.material AS m
-                            LEFT JOIN (
-                            SELECT RootMaterialRowId as rootRowId, COUNT(*) as aliquotCount
-                            FROM exp.material
-                            WHERE RootMaterialRowId <> RowId AND SampleState\s""")
+        // Issue 49150: In 23.12 we migrated from RootMaterialLSID to RootMaterialRowID, however, there is still an
+        // upgrade path that requires these queries be done with RootMaterialLSID since the 23.12 upgrade will not
+        // have run yet.
+        SQLFragment sql;
+        if (useRootMaterialLSID)
+        {
+            sql = new SQLFragment(
+            """
+                    SELECT m.RowId as SampleId, m.Units,
+                    (CASE WHEN c.aliquotCount IS NULL THEN 0 ELSE c.aliquotCount END) as CreatedAliquotCount
+                    FROM exp.material AS m
+                        LEFT JOIN (
+                        SELECT RootMaterialLSID as rootLsid, COUNT(*) as aliquotCount
+                        FROM exp.material
+                        WHERE RootMaterialLSID <> LSID AND SampleState\s""")
                 .appendInClause(availableSampleStates, dialect)
                 .append("""
-                            GROUP BY RootMaterialRowId
-                        ) AS c ON m.rowId = c.rootRowId
-                        WHERE m.rootmaterialrowid = m.rowid AND m.rowid\s""");
+                        GROUP BY RootMaterialLSID
+                    ) AS c ON m.lsid = c.rootLsid
+                    WHERE m.rootmateriallsid = m.LSID AND m.rowid\s""");
+        }
+        else
+        {
+            sql = new SQLFragment(
+            """
+                    SELECT m.RowId as SampleId, m.Units,
+                    (CASE WHEN c.aliquotCount IS NULL THEN 0 ELSE c.aliquotCount END) as CreatedAliquotCount
+                    FROM exp.material AS m
+                        LEFT JOIN (
+                        SELECT RootMaterialRowId as rootRowId, COUNT(*) as aliquotCount
+                        FROM exp.material
+                        WHERE RootMaterialRowId <> RowId AND SampleState\s""")
+                .appendInClause(availableSampleStates, dialect)
+                .append("""
+                        GROUP BY RootMaterialRowId
+                    ) AS c ON m.rowId = c.rootRowId
+                    WHERE m.rootmaterialrowid = m.rowid AND m.rowid\s""");
+        }
         dialect.appendInClauseSql(sql, sampleIds);
 
         Map<Integer, Pair<Integer, String>> sampleAliquotCounts = new HashMap<>();
@@ -1670,18 +1704,21 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         return sampleAliquotCounts;
     }
 
-    private Map<Integer, List<AliquotAmountUnitResult>> getSampleAliquotAmounts(Collection<Integer> sampleIds, List<Integer> availableSampleStates) throws SQLException
+    private Map<Integer, List<AliquotAmountUnitResult>> getSampleAliquotAmounts(Collection<Integer> sampleIds, List<Integer> availableSampleStates, boolean useRootMaterialLSID) throws SQLException
     {
         DbSchema exp = getExpSchema();
         SqlDialect dialect = exp.getSqlDialect();
 
-        SQLFragment sql = new SQLFragment(
-                """
-                    SELECT parent.rowid AS parentSampleId, aliquot.StoredAmount, aliquot.Units, aliquot.samplestate
-                    FROM exp.material AS aliquot
-                        JOIN exp.material AS parent ON parent.rowid = aliquot.rootmaterialrowid
-                    WHERE aliquot.rootmaterialrowid <> aliquot.rowid AND parent.rowid\s
-                    """);
+        // Issue 49150: In 23.12 we migrated from RootMaterialLSID to RootMaterialRowID, however, there is still an
+        // upgrade path that requires these queries be done with RootMaterialLSID since the 23.12 upgrade will not
+        // have run yet.
+        SQLFragment sql = new SQLFragment("SELECT parent.rowid AS parentSampleId, aliquot.StoredAmount, aliquot.Units, aliquot.samplestate\n")
+                .append("FROM exp.material AS aliquot JOIN exp.material AS parent ON ")
+                .append(useRootMaterialLSID ? "parent.lsid = aliquot.rootmateriallsid" : "parent.rowid = aliquot.rootmaterialrowid")
+                .append(" WHERE ")
+                .append(useRootMaterialLSID ? "aliquot.rootmateriallsid <> aliquot.lsid" : "aliquot.rootmaterialrowid <> aliquot.rowid")
+                .append(" AND parent.rowid")
+                .appendEOS().append("\n");
         dialect.appendInClauseSql(sql, sampleIds);
 
         Map<Integer, List<AliquotAmountUnitResult>> sampleAliquotAmounts = new HashMap<>();


### PR DESCRIPTION
#### Rationale
This seeks to address [Issue 49150](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49150) where an upgrade directly from a 23.07 (or earlier) instance to 23.12 can fail due to some shared code that generates queries using `RootMaterialLSID`/`RootMaterialRowId`. This updates the shared code to accept an additional argument to switch the target column for the joins. The intent is for this to be effectively reverted when the upgrade path goes defunct with the release of 25.2.0.

#### Related Pull Requests
* #4844 (upgrade that introduces `RootMaterialRowId`)

#### Changes
* Introduce `useRootMaterialLSID` and generate subsequent JOINs in queries based off this flag.
