### PR TITLE
Regression test for password strength gauge

### DIFF
--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -225,7 +225,7 @@
                     const textIndex = Math.floor(percent * 6);
                     const text = showPlaceholderText ?  "Password Strength Gauge" : ["Very Weak", "Very Weak", "Weak", "Weak", "Strong", "Very Strong"][textIndex];
                     ctx.fillText(text, centerX, centerY + textHeightFix);
-                    canvas.innerText = showPlaceholderText ? text : ("Password Strength: " + text);
+                    canvas.innerText = text;
                 })
             });
         };

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -225,7 +225,7 @@
                     const textIndex = Math.floor(percent * 6);
                     const text = showPlaceholderText ?  "Password Strength Gauge" : ["Very Weak", "Very Weak", "Weak", "Weak", "Strong", "Very Strong"][textIndex];
                     ctx.fillText(text, centerX, centerY + textHeightFix);
-                    canvas.text = "Password Strength: " + text;
+                    canvas.innerText = showPlaceholderText ? text : ("Password Strength: " + text);
                 })
             });
         };


### PR DESCRIPTION
#### Rationale
I believe this was intended to set the placeholder text that shows up if canvas is disabled/unavailable. If so, `innerText` is the correct thing to set.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1736

#### Changes
* Use `innerText` to set canvas placeholder text
