### PR TITLE
Move &nbsp; to after redundant member asterisk

### DIFF
--- a/core/src/org/labkey/core/security/group.jsp
+++ b/core/src/org/labkey/core/security/group.jsp
@@ -245,7 +245,7 @@ else
             {
                 %>
                 <%= h(memberName) %>&nbsp;
-                <%= h(!memberName.equalsIgnoreCase(displayName) && StringUtils.isNotBlank(displayName) ? "(" + displayName + ")" : "") %>&nbsp;&nbsp;
+                <%= h(!memberName.equalsIgnoreCase(displayName) && StringUtils.isNotBlank(displayName) ? "(" + displayName + ")" : "") %>
                 <%
             }
         }
@@ -255,7 +255,7 @@ else
             %><a data-qtitle="Redundant Member" data-qtip="<%=text(bean.displayRedundancyReasonHTML(member))%>">*</a><%
         }
         %>
-            </td>
+            &nbsp;&nbsp;</td>
             <td>
                 <% if (!isGroup)
                    {


### PR DESCRIPTION
#### Rationale
`GroupTest` is unhappy with spaces I added to separate member names from permissions links on the manage group page. They need to go after the "redundant member" asterisk.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4978