### PR TITLE
Register all servlets via Java code

### DIFF
--- a/api/webapp/WEB-INF/web.xml
+++ b/api/webapp/WEB-INF/web.xml
@@ -5,28 +5,16 @@
      version="2.4">
     <display-name>LabKey Server</display-name>
 
+    <!-- Leave this here because it sets some important system properties that need to happen very early -->
     <listener>
         <listener-class>org.labkey.api.util.ContextListener</listener-class>
     </listener>
 
-    <listener>
-        <listener-class>org.labkey.api.security.UserManager$SessionListener</listener-class>
-    </listener>
-
-    <!-- Example filter to set character encoding on each request -->
+    <!-- Initialize the filters -->
     <filter>
         <filter-name>Set Character Encoding</filter-name>
         <filter-class>org.labkey.core.filters.SetCharacterEncodingFilter</filter-class>
-        <init-param>
-            <param-name>encoding</param-name>
-            <param-value>UTF-8</param-value>
-        </init-param>
-        <init-param>
-            <param-name>ignore</param-name>
-            <param-value>false</param-value>
-        </init-param>
     </filter>
-
     <filter>
         <filter-name>Form Authentication Filter</filter-name>
         <filter-class>org.labkey.api.security.AuthFilter</filter-class>
@@ -67,18 +55,6 @@
 
     <filter-mapping>
         <filter-name>Transaction Filter</filter-name>
-        <url-pattern>*.jsp</url-pattern>
-    </filter-mapping>
-    <filter-mapping>
-        <filter-name>Transaction Filter</filter-name>
-        <url-pattern>*.jpf</url-pattern>
-    </filter-mapping>
-    <filter-mapping>
-        <filter-name>Transaction Filter</filter-name>
-        <url-pattern>*.do</url-pattern>
-    </filter-mapping>
-    <filter-mapping>
-        <filter-name>Transaction Filter</filter-name>
         <url-pattern>*.view</url-pattern>
     </filter-mapping>
     <filter-mapping>
@@ -90,49 +66,6 @@
         <url-pattern>*.post</url-pattern>
     </filter-mapping>
 
-    <servlet>
-        <servlet-name>Kaptcha</servlet-name>
-        <servlet-class>com.google.code.kaptcha.servlet.KaptchaServlet</servlet-class>
-        <init-param>
-            <param-name>kaptcha.textproducer.char.length</param-name>
-            <param-value>6</param-value>
-        </init-param>
-    </servlet>
-    <servlet-mapping>
-        <servlet-name>Kaptcha</servlet-name>
-        <url-pattern>/kaptcha.jpg</url-pattern>
-    </servlet-mapping>
-
-    <!--
-    EXPERIMENTAL:
-    File Servlet. Maps standard requests for files onto the filecontent module.
-    Requests like http://host/labkey/files/home/test.pdf become
-    http://host/labkey/filecontent/home/sendFile.view?fileName=test.pdf
-    see http://host/labkey/filecontent/home/begin.view for description of how to
-    set up a static web parallel to the labkey folder hierarchy
-    -->
-    <servlet>
-        <servlet-name>FileServlet</servlet-name>
-        <servlet-class>org.labkey.api.view.FileServlet</servlet-class>
-    </servlet>
-
-    <servlet>
-        <servlet-name>ImageServlet</servlet-name>
-        <servlet-class>org.labkey.api.attachments.ImageServlet</servlet-class>
-    </servlet>
-
-    <servlet-mapping>
-        <servlet-name>ImageServlet</servlet-name>
-        <url-pattern>*.image</url-pattern>
-    </servlet-mapping>
-    <!--
-    maps http://host/labkey/files/proj/dir/test.html to
-    http://host/labkey/filecontent/proj/dir/sendFile.view?file=test.html
-    -->
-    <servlet-mapping>
-        <servlet-name>FileServlet</servlet-name>
-        <url-pattern>/files/*</url-pattern>
-    </servlet-mapping>
 
     <welcome-file-list>
         <welcome-file>/</welcome-file>

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1163,7 +1163,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     public void registerServlets(ServletContext servletCtx)
     {
 //        even though there is one webdav tree rooted at "/" we still use two servlet bindings.
-//        This is because we want /_webdav/* to be resolve BEFORE all other servlet-mappings
+//        This is because we want /_webdav/* to be resolved BEFORE all other servlet-mappings
 //        and /* to resolve AFTER all other servlet-mappings
         _webdavServletDynamic = servletCtx.addServlet("static", new WebdavServlet(true));
         _webdavServletDynamic.setMultipartConfig(new MultipartConfigElement(SpringActionController.getTempUploadDir().getPath()));

--- a/core/src/org/labkey/core/filters/SetCharacterEncodingFilter.java
+++ b/core/src/org/labkey/core/filters/SetCharacterEncodingFilter.java
@@ -61,7 +61,7 @@ public class SetCharacterEncodingFilter implements Filter
      * The default character encoding to set for requests that pass through
      * this filter.
      */
-    protected String encoding = null;
+    protected String encoding = "UTF-8";
 
 
     /**


### PR DESCRIPTION
#### Rationale
In preparation for Tomcat 10, I moved some servlet registrations out of web.xml and into Java code so that they can configure the multipart request files temp directory location. This moves the other servlets to Java-based registrations.

#### Changes
* Move other servlets to Java registration
* Clean up web.xml a bit