### PR TITLE
add a null check for the usageReportingLevel

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1213,12 +1213,13 @@ public class AdminController extends SpringActionController
             }
             catch (IllegalArgumentException ignored) {}
 
-            UsageReportingLevel level = null;
-
             try
             {
-                level = UsageReportingLevel.valueOf(form.getUsageReportingLevel());
-                props.setUsageReportingLevel(level);
+                if (form.getUsageReportingLevel() != null)
+                {
+                    UsageReportingLevel level = UsageReportingLevel.valueOf(form.getUsageReportingLevel());
+                    props.setUsageReportingLevel(level);
+                }
             }
             catch (IllegalArgumentException ignored) {}
 


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49166)

The usage reporting levels are no longer rendered for community edition instances. The POST handler now needs to check for `null` values on save.