### PR TITLE
Stop reporting admin and developer group counts

### DIFF
--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -215,7 +215,7 @@ public class SecurityManager
             Map<String, Integer> roleCounts = mvm.keySet().stream()
                 .collect(Collectors.toMap(Role::getName, key -> mvm.get(key).size()));
 
-            return Map.of("SiteRoleUserCounts2", roleCounts);
+            return Map.of("SiteRoleUserCounts", roleCounts);
         };
     }
 


### PR DESCRIPTION
#### Rationale
Site Administrators and Developers groups are not so special anymore. Also, collect site role user memberships in a `HashSetValuedHashMap` to ensure unique user counts.