### PR TITLE
Issue 49170: Postgres JDBC caches all sample rows during delete

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1107,10 +1107,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             filter.addCondition(FieldKey.fromParts("Container"), container);
         }
         List<Protocol> protocols = new TableSelector(getTinfoProtocol(), filter, null).getArrayList(Protocol.class);
-        
+
         if (protocols.isEmpty())
             return null;
-        
+
         // should only find one protocol per container+name
         return toExpProtocol(protocols.get(0));
     }
@@ -4715,9 +4715,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         try (DbScope.Transaction transaction = ensureTransaction();
             Timing timing = MiniProfiler.step("delete materials"))
         {
-            SQLFragment sql = new SQLFragment("SELECT * FROM exp.Material WHERE ");
-            sql.append(materialFilterSQL);
-
             Map<ExpSampleType, Set<String>> sampleTypeAliquotRoots = new HashMap<>();
 
             Map<String, ExpSampleTypeImpl> sampleTypes = new HashMap<>();
@@ -4728,70 +4725,80 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             // will be successful
             final List<String> docids = new ArrayList<>();
 
-            // Do this work in batches to avoid holding all materials in memory at once
-            int count = new SqlSelector(getExpSchema(), sql).setJdbcCaching(false).forEachBatch(Material.class, 10_000, rawMaterials ->
+            int count = 0;
+            // Fetch in batches so that Postgres doesn't cache all rows in memory. Disabling caching doesn't work
+            // because we're inside a transaction
+            final int maxBatch = 10_000;
+            boolean moreBatches = true;
+            while (moreBatches)
+            {
+                SQLFragment sql = dialect.limitRows(new SQLFragment("SELECT *"), new SQLFragment("FROM exp.Material"), new SQLFragment("WHERE ").append(materialFilterSQL), "ORDER BY RowId", null, maxBatch, count);
+                List<Material> rawMaterials = new SqlSelector(getExpSchema(), sql).getArrayList(Material.class);
+
+                moreBatches = rawMaterials.size() == maxBatch;
+                count += rawMaterials.size();
+
+                List<ExpMaterialImpl> materials = ExpMaterialImpl.fromMaterials(rawMaterials);
+                for (ExpMaterialImpl material : materials)
+                {
+                    if (!material.getContainer().hasPermission(user, DeletePermission.class))
+                        throw new UnauthorizedException();
+
+                    if (!ignoreStatus && !material.isOperationPermitted(SampleTypeService.SampleOperations.Delete))
+                        throw new IllegalArgumentException(String.format("Sample %s with status %s cannot be deleted", material.getName(), material.getStateLabel()));
+
+                    docids.add(material.getDocumentId());
+
+                    if (null == stDeleteFrom)
                     {
-                        List<ExpMaterialImpl> materials = ExpMaterialImpl.fromMaterials(rawMaterials);
-                        for (ExpMaterialImpl material : materials)
+                        if (deleteFromAllSampleTypes)
                         {
-                            if (!material.getContainer().hasPermission(user, DeletePermission.class))
-                                throw new UnauthorizedException();
-
-                            if (!ignoreStatus && !material.isOperationPermitted(SampleTypeService.SampleOperations.Delete))
-                                throw new IllegalArgumentException(String.format("Sample %s with status %s cannot be deleted", material.getName(), material.getStateLabel()));
-
-                            docids.add(material.getDocumentId());
-
-                            if (null == stDeleteFrom)
+                            String cpasType = material.getCpasType();
+                            if (!sampleTypes.containsKey(cpasType))
                             {
-                                if (deleteFromAllSampleTypes)
-                                {
-                                    String cpasType = material.getCpasType();
-                                    if (!sampleTypes.containsKey(cpasType))
-                                    {
-                                        ExpSampleTypeImpl st = material.getSampleType();
-                                        if (st == null && !ExpMaterial.DEFAULT_CPAS_TYPE.equals(material.getCpasType()))
-                                            LOG.warn("SampleType '" + material.getCpasType() + "' not found while deleting sample '" + material.getName() + "'");
-                                        sampleTypes.put(cpasType, st);
-                                    }
-                                }
-                                else
-                                {
-                                    // verify the material doesn't belong to a SampleType
-                                    if (!ExpMaterial.DEFAULT_CPAS_TYPE.equals(material.getCpasType()))
-                                        throw new IllegalArgumentException("Error deleting sample of default '" + ExpMaterialImpl.DEFAULT_CPAS_TYPE + "' type: '" + material.getName() + "' is in the sample type '" + material.getCpasType() + "'");
-                                }
-                            }
-                            else
-                            {
-                                // verify the material doesn't belong to a SampleType
-                                if (!stDeleteFrom.getLSID().equals(material.getCpasType()))
-                                    throw new IllegalArgumentException("Error deleting '" + stDeleteFrom.getName() + "' sample: '" + material.getName() + "' is in the sample type '" + material.getCpasType() + "'");
-                            }
-
-                            if (!truncateContainer && !StringUtils.equals(material.getLSID(), material.getRootMaterialLSID()))
-                            {
-                                ExpSampleType sampleType = material.getSampleType();
-                                sampleTypeAliquotRoots.computeIfAbsent(sampleType, (k) -> new HashSet<>())
-                                        .add(material.getRootMaterialLSID());
+                                ExpSampleTypeImpl st = material.getSampleType();
+                                if (st == null && !ExpMaterial.DEFAULT_CPAS_TYPE.equals(material.getCpasType()))
+                                    LOG.warn("SampleType '" + material.getCpasType() + "' not found while deleting sample '" + material.getName() + "'");
+                                sampleTypes.put(cpasType, st);
                             }
                         }
-
-                        try (Timing ignored = MiniProfiler.step("beforeDelete"))
+                        else
                         {
-                            beforeDeleteMaterials(user, container, materials);
+                            // verify the material doesn't belong to a SampleType
+                            if (!ExpMaterial.DEFAULT_CPAS_TYPE.equals(material.getCpasType()))
+                                throw new IllegalArgumentException("Error deleting sample of default '" + ExpMaterialImpl.DEFAULT_CPAS_TYPE + "' type: '" + material.getName() + "' is in the sample type '" + material.getCpasType() + "'");
                         }
+                    }
+                    else
+                    {
+                        // verify the material doesn't belong to a SampleType
+                        if (!stDeleteFrom.getLSID().equals(material.getCpasType()))
+                            throw new IllegalArgumentException("Error deleting '" + stDeleteFrom.getName() + "' sample: '" + material.getName() + "' is in the sample type '" + material.getCpasType() + "'");
+                    }
 
-                        try (Timing ignored = MiniProfiler.step("deleteRunsUsingInput"))
-                        {
-                            // Delete any runs using the material if the ProtocolImplementation allows deleting the run when an input is deleted.
-                            if (deleteRunsUsingMaterials)
-                            {
-                                deleteRunsUsingInputs(user, null, rawMaterials);
-                            }
-                        }
-                        LOG.debug("Completed batch of sample deletion");
-                    });
+                    if (!truncateContainer && !StringUtils.equals(material.getLSID(), material.getRootMaterialLSID()))
+                    {
+                        ExpSampleType sampleType = material.getSampleType();
+                        sampleTypeAliquotRoots.computeIfAbsent(sampleType, (k) -> new HashSet<>())
+                                .add(material.getRootMaterialLSID());
+                    }
+                }
+
+                try (Timing ignored = MiniProfiler.step("beforeDelete"))
+                {
+                    beforeDeleteMaterials(user, container, materials);
+                }
+
+                try (Timing ignored = MiniProfiler.step("deleteRunsUsingInput"))
+                {
+                    // Delete any runs using the material if the ProtocolImplementation allows deleting the run when an input is deleted.
+                    if (deleteRunsUsingMaterials)
+                    {
+                        deleteRunsUsingInputs(user, null, rawMaterials);
+                    }
+                }
+                LOG.debug("Completed batch of sample deletion. " + count + " rows processed so far");
+            }
 
             // generate in clause for the Material LSIDs
             SQLFragment lsidInFrag = new SQLFragment(" IN (SELECT Lsid FROM ");


### PR DESCRIPTION
#### Rationale
We're intending to disable JDBC driver caching of the very large results, but it's not happening because we're in a transaction. We need to separately batch into more manageable chunks.

#### Changes
* Use limit/offset in the SQL to separate into batches of 10,000
* Don't bother turning off caching since it'll be ignored