### PR TITLE
Memory stress tester to help troubleshoot memory use/config problems

### DIFF
--- a/core/src/org/labkey/core/admin/memTracker.jsp
+++ b/core/src/org/labkey/core/admin/memTracker.jsp
@@ -25,6 +25,8 @@
 <%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.util.Tuple3" %>
 <%@ page import="java.text.DecimalFormat" %>
+<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.api.data.ContainerManager" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     JspView<MemBean> me = (JspView<MemBean>)HttpView.currentView();
@@ -46,6 +48,7 @@
     <%=link("Clear Caches, GC and Refresh", AdminController.getMemTrackerURL(true, true))%>
     <%=link("GC and Refresh", AdminController.getMemTrackerURL(false, true))%>
     <%=link("Refresh", AdminController.getMemTrackerURL(false, false))%>
+    <% if (getUser().hasSiteAdminPermission()) { %> <%=link("Memory Stress Test", new ActionURL(AdminController.MemoryStressTestAction.class, ContainerManager.getRoot()))%> <% } %>
 </p>
 <% } %>
 <table class="labkey-wp">


### PR DESCRIPTION
#### Rationale
It's hard to choose the right memory settings for the JVM and its host OS/container. This utility lets us easily allocate and churn through a lot of memory to test configurations. It can also be used to trigger an OutOfMemory error from the JVM to ensure that heap dumps are being captured.

Since this is effectively a built-in DOS tool, it's only available to full site admins.

Accessible via Admin Console->Memory Usage->Memory Stress Test

#### Changes
* New site admin-only action that allocates a lot of byte arrays