### PR TITLE
Restore UTF-8 as default character encoding

### DIFF
--- a/core/src/org/labkey/core/filters/SetCharacterEncodingFilter.java
+++ b/core/src/org/labkey/core/filters/SetCharacterEncodingFilter.java
@@ -20,6 +20,7 @@ package org.labkey.core.filters;
 
 import javax.servlet.*;
 import java.io.IOException;
+import java.util.Objects;
 
 
 /**
@@ -132,7 +133,7 @@ public class SetCharacterEncodingFilter implements Filter
     {
 
         this.filterConfig = filterConfig;
-        this.encoding = filterConfig.getInitParameter("encoding");
+        this.encoding = Objects.toString(filterConfig.getInitParameter("encoding"), this.encoding);
         String value = filterConfig.getInitParameter("ignore");
         if (value == null)
             this.ignore = true;


### PR DESCRIPTION
#### Rationale
My change in https://github.com/LabKey/platform/pull/4987 to simplify configuration of `SetCharacterEncodingFilter` failed to correctly initialize the intended default, `UTF-8`

#### Changes
* Use `UTF-8` if there's no configured value provided