### PR TITLE
Fork two Mule classes to prep for javax->jakarta rename

### DIFF
--- a/pipeline/src/org/labkey/pipeline/mule/LabKeyMuleXmlBuilderContextListener.java
+++ b/pipeline/src/org/labkey/pipeline/mule/LabKeyMuleXmlBuilderContextListener.java
@@ -1,0 +1,72 @@
+package org.labkey.pipeline.mule;
+
+import org.labkey.api.util.UnexpectedException;
+import org.mule.MuleManager;
+import org.mule.config.ConfigurationException;
+import org.mule.util.StringUtils;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+/** Forked into our codebase to support transition from javax.servlet to jakarta.servlet */
+public class LabKeyMuleXmlBuilderContextListener implements ServletContextListener
+{
+    public static final String INIT_PARAMETER_MULE_CONFIG = "org.mule.config";
+    public static final String INIT_PARAMETER_WEBAPP_CLASSPATH = "org.mule.webapp.classpath";
+
+    @Override
+    public void contextInitialized(ServletContextEvent event)
+    {
+        try
+        {
+            initialize(event.getServletContext());
+        }
+        catch (ConfigurationException e)
+        {
+            throw UnexpectedException.wrap(e);
+        }
+    }
+
+    public void initialize(ServletContext context) throws ConfigurationException
+    {
+        String config = context.getInitParameter(INIT_PARAMETER_MULE_CONFIG);
+        if (config == null)
+        {
+            config = getDefaultConfigResource();
+        }
+
+        String webappClasspath = context.getInitParameter(INIT_PARAMETER_WEBAPP_CLASSPATH);
+        if (StringUtils.isBlank(webappClasspath))
+        {
+            webappClasspath = null;
+        }
+
+        createManager(config, webappClasspath, context);
+    }
+
+    protected void createManager(String configResource, String webappClasspath, ServletContext context) throws ConfigurationException
+    {
+        LabKeyWebappMuleXmlConfigurationBuilder builder = new LabKeyWebappMuleXmlConfigurationBuilder(context, webappClasspath);
+        builder.configure(configResource, null);
+    }
+
+    protected String getDefaultConfigResource()
+    {
+        return "mule-config.xml";
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event)
+    {
+        destroy();
+    }
+
+    public void destroy()
+    {
+        if (MuleManager.isInstanciated())
+        {
+            MuleManager.getInstance().dispose();
+        }
+    }
+}

--- a/pipeline/src/org/labkey/pipeline/mule/LabKeyWebappMuleXmlConfigurationBuilder.java
+++ b/pipeline/src/org/labkey/pipeline/mule/LabKeyWebappMuleXmlConfigurationBuilder.java
@@ -1,0 +1,73 @@
+package org.labkey.pipeline.mule;
+
+import org.apache.logging.log4j.Logger;
+import org.labkey.api.util.logging.LogHelper;
+import org.mule.config.ConfigurationException;
+import org.mule.config.builders.MuleXmlConfigurationBuilder;
+import org.mule.util.FileUtils;
+
+import javax.servlet.ServletContext;
+import java.io.File;
+import java.io.InputStream;
+
+/** Forked into our codebase to support transition from javax.servlet to jakarta.servlet */
+public class LabKeyWebappMuleXmlConfigurationBuilder extends MuleXmlConfigurationBuilder
+{
+    private static final Logger LOG = LogHelper.getLogger(MuleListenerHelper.class, "Initializes and configures Mule for pipelines");
+    private final ServletContext context;
+    private final String webappClasspath;
+
+    public LabKeyWebappMuleXmlConfigurationBuilder(ServletContext context, String webappClasspath) throws ConfigurationException
+    {
+        super();
+        this.context = context;
+        this.webappClasspath = webappClasspath;
+    }
+
+    @Override
+    protected InputStream loadResource(String resource) throws ConfigurationException
+    {
+        String resourcePath = resource;
+        InputStream is = null;
+        if (webappClasspath != null)
+        {
+            resourcePath = (new File(webappClasspath, resource)).getPath();
+            is = context.getResourceAsStream(resourcePath);
+        }
+
+        if (is == null)
+        {
+            is = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
+        }
+
+        if (is != null)
+        {
+            LOG.debug("Resource " + resource + " is found in Servlet Context.");
+        }
+        else
+        {
+            LOG.debug("Resource " + resourcePath + " is not found in Servlet Context, loading from classpath or as external file");
+        }
+
+        if (is == null && webappClasspath != null)
+        {
+            resourcePath = FileUtils.newFile(webappClasspath, resource).getPath();
+
+            try
+            {
+                is = super.loadResource(resourcePath);
+            }
+            catch (ConfigurationException e)
+            {
+                LOG.debug("Resource " + resourcePath + " is not found in filesystem");
+            }
+        }
+
+        if (is == null)
+        {
+            is = super.loadResource(resource);
+        }
+
+        return is;
+    }
+}


### PR DESCRIPTION
#### Rationale
Prepping for the upcoming Tomcat 10 upgrade that also migrates from `javax.servlet` to `jakarta.servlet`

#### Changes
* Fork two small classes so that we can control their imports