### PR TITLE
Don't render bad link for mismatched DbSchema/UserSchema names

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1648,8 +1648,13 @@ public class QueryController extends SpringActionController
             {
                 VBox result = new VBox();
 
-                ActionURL url = new ActionURL(RawSchemaMetaDataAction.class, getContainer());
-                url.addParameter("schemaName", userSchemaName);
+                ActionURL url = null;
+                QuerySchema qs = DefaultSchema.get(getUser(), getContainer()).getSchema(userSchemaName);
+                if (qs != null)
+                {
+                    new ActionURL(RawSchemaMetaDataAction.class, getContainer());
+                    url.addParameter("schemaName", userSchemaName);
+                }
 
                 SqlDialect dialect = scope.getSqlDialect();
                 ScopeView scopeInfo = new ScopeView("Scope and Schema Information", scope, _dbSchemaName, url, _dbTableName);
@@ -1783,7 +1788,18 @@ public class QueryController extends SpringActionController
             StringBuilder sb = new StringBuilder("<table>\n");
 
             if (null != _schemaName)
-                sb.append("<tr><td class=\"labkey-form-label\">Schema</td><td><a href=\"").append(PageFlowUtil.filter(_url)).append("\">").append(PageFlowUtil.filter(_schemaName)).append("</a></td></tr>\n");
+            {
+                sb.append("<tr><td class=\"labkey-form-label\">Schema</td><td>");
+                if (_url == null)
+                {
+                    sb.append(PageFlowUtil.filter(_schemaName));
+                }
+                else
+                {
+                    sb.append("<a href=\"").append(PageFlowUtil.filter(_url)).append("\">").append(PageFlowUtil.filter(_schemaName)).append("</a>");
+                }
+                sb.append("</td></tr>\n");
+            }
             if (null != _tableName)
                 sb.append("<tr><td class=\"labkey-form-label\">Table</td><td>").append(PageFlowUtil.filter(_tableName)).append("</td></tr>\n");
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -1652,7 +1652,7 @@ public class QueryController extends SpringActionController
                 QuerySchema qs = DefaultSchema.get(getUser(), getContainer()).getSchema(userSchemaName);
                 if (qs != null)
                 {
-                    new ActionURL(RawSchemaMetaDataAction.class, getContainer());
+                    url = new ActionURL(RawSchemaMetaDataAction.class, getContainer());
                     url.addParameter("schemaName", userSchemaName);
                 }
 


### PR DESCRIPTION
#### Rationale
The crawler found a bad link for the raw schema metadata in a data class table. It's a mishmash of DbSchema and UserSchema metadata and naming.

Example: https://teamcity.labkey.org/buildConfiguration/LabKey_2311Release_Community_DailySuites_DailyAPostgres/2760149?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true

#### Changes
* Don't offer a link when the UserSchema isn't exposed under the same name.