### PR TITLE
Simplify generated SQL

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpLineageOptions.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineageOptions.java
@@ -34,15 +34,13 @@ public class ExpLineageOptions extends ResolveLsidsForm
 
         public static @Nullable LineageExpType fromValue(String value)
         {
-            for (LineageExpType type : LineageExpType.values()) {
-                if (type.name().equals(value)) {
+            for (LineageExpType type : LineageExpType.values())
+            {
+                if (type.name().equals(value))
                     return type;
-                }
             }
-
             return null;
         }
-
     }
 
     private int _depth;
@@ -65,6 +63,11 @@ public class ExpLineageOptions extends ResolveLsidsForm
         _parents = parents;
         _children = children;
         _depth = depth;
+    }
+
+    public String getExpEdge()
+    {
+        return "exp.Edge";
     }
 
     public int getDepth()

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -812,6 +812,7 @@ public class ExperimentModule extends SpringModule
             DomainPropertyImpl.TestCase.class,
             ExpDataTableImpl.TestCase.class,
             ExperimentServiceImpl.TestCase.class,
+            ExperimentServiceImpl.LineageQueryTestCase.class,
             ExperimentStressTest.class,
             LineagePerfTest.class,
             LineageTest.class,

--- a/experiment/src/org/labkey/experiment/api/ExperimentRunGraph2.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRunGraph2.jsp
@@ -59,7 +59,7 @@
       _Graph.depth - 1                                           AS depth,
       _Edges.fromObjectId,
       _Edges.toObjectId,
-      CAST(SUBSTRING(_Graph.path,1+{fn LENGTH(_Graph.path)}+21-8000,8000) <%=CONCAT%> CAST(_Edges.toObjectId AS VARCHAR(20)) <%=CONCAT%> '/' AS VARCHAR(8000)) AS path
+      CAST('/' <%=CONCAT%> CAST(_Edges.toObjectId AS VARCHAR(20)) <%=CONCAT%> _Graph.path AS VARCHAR(8000)) AS path
     FROM exp.Edge _Edges
       INNER JOIN $SELF$ _Graph ON _Edges.toObjectId = _Graph.fromObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.fromObjectId as VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}
@@ -158,7 +158,7 @@
       _Graph.depth + 1                               AS depth,
       _Edges.fromObjectId,
       _Edges.toObjectId,
-      CAST(SUBSTRING(_Graph.path,1+{fn LENGTH(_Graph.path)}+21-8000,8000) <%=CONCAT%> CAST(_Edges.fromObjectId AS VARCHAR(20)) <%=CONCAT%> '/' AS VARCHAR(8000)) AS path
+      CAST('/' <%=CONCAT%> CAST(_Edges.fromObjectId AS VARCHAR(20)) <%=CONCAT%> _Graph.path AS VARCHAR(8000)) AS path
     FROM exp.Edge _Edges
       INNER JOIN $SELF$ _Graph ON _Edges.fromObjectId = _Graph.toObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.toObjectId AS VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}

--- a/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
@@ -67,7 +67,7 @@
       objectid                      AS self,
       objectid                      AS fromObjectId,
       CAST(NULL AS INT)             AS toObjectId,
-      CAST('/' AS VARCHAR(8000)) AS path
+      CAST('/' <%=CONCAT%> CAST(objectid AS VARCHAR(20)) <%=CONCAT%> '/' AS VARCHAR(8000)) AS path
 <% if (bean.isUseObjectIds()) { %>
     FROM ($LSIDS$) as _seed_(objectid)
 <% } else { %>
@@ -82,8 +82,8 @@
       _Graph.self,
       _Edges.fromObjectId,
       _Edges.toObjectId,
-      CAST(SUBSTRING(_Graph.path,1+{fn LENGTH(_Graph.path)}+21-8000,8000) <%=CONCAT%> CAST(_Edges.toObjectId AS VARCHAR(20)) <%=CONCAT%> '/' AS VARCHAR(8000)) AS path
-    FROM exp.Edge _Edges
+      CAST('/' <%=CONCAT%> CAST(_Edges.fromObjectId AS VARCHAR(20)) <%=CONCAT%> _Graph.path AS VARCHAR(8000)) AS path
+    FROM <%=bean.getExpEdge()%> _Edges
       INNER JOIN $SELF$ _Graph ON _Edges.toObjectId = _Graph.fromObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.fromObjectId as VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}
       AND _Graph.depth >= <%= (-1 * Math.abs(depth)) + 1 %>
@@ -162,7 +162,7 @@ if (bean.isOnlySelectObjectId()) {
       objectid                      AS self,
       CAST(NULL AS INT)             AS fromObjectId,
       objectid                      AS toObjectId,
-      CAST('/' AS VARCHAR(8000)) AS path
+      CAST('/' <%=CONCAT%> CAST(objectid AS VARCHAR(20)) <%=CONCAT%> '/' AS VARCHAR(8000)) AS path
 <% if (bean.isUseObjectIds()) { %>
     FROM ($LSIDS$) as _seed_(objectid)
 <% } else { %>
@@ -177,8 +177,8 @@ if (bean.isOnlySelectObjectId()) {
       _Graph.self,
       _Edges.fromObjectId           AS fromObjectId,
       _Edges.toObjectId             AS toObjectId,
-      CAST(SUBSTRING(_Graph.path,1+{fn LENGTH(_Graph.path)}+21-8000,8000) <%=CONCAT%> CAST(_Edges.fromObjectId AS VARCHAR(20)) <%=CONCAT%> '/' AS VARCHAR(8000)) AS path
-    FROM exp.Edge _Edges
+      CAST('/' <%=CONCAT%> CAST(_Edges.toObjectId AS VARCHAR(20)) <%=CONCAT%> _Graph.path AS VARCHAR(8000)) AS path
+    FROM <%=unsafe(bean.getExpEdge())%> _Edges
       INNER JOIN $SELF$ _Graph ON _Edges.fromObjectId = _Graph.toObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.toObjectId as VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}
       AND _Graph.depth <= <%= depth - 1 %>

--- a/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
@@ -88,7 +88,7 @@
       _Edges.fromObjectId,
       _Edges.toObjectId,
       CAST('/' <%=CONCAT%> CAST(_Edges.fromObjectId AS VARCHAR(20)) <%=CONCAT%> _Graph.path AS VARCHAR(8000)) AS path
-    FROM <%=bean.getExpEdge()%> _Edges
+    FROM <%=unsafe(bean.getExpEdge())%> _Edges
       INNER JOIN $SELF$ _Graph ON _Edges.toObjectId = _Graph.fromObjectId
     WHERE 0 = {fn LOCATE('/' <%=CONCAT%> CAST(_Edges.fromObjectId as VARCHAR(20)) <%=CONCAT%> '/', _Graph.path)}
       AND _Graph.depth >= <%= (-1 * Math.abs(depth)) + 1 %>

--- a/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
@@ -77,6 +77,11 @@
 
     UNION ALL
 
+<%--
+    NOTE this query (for lookup) stops short of including the node that would complete a cycle.  This node is already in the set
+    and won't add any information once the lookup SQL enforces uniqueness (GROUP BY self, objectid)
+    This is different than ExperimentRunGraph2.jsp.
+--%>
     SELECT
       _Graph.depth - 1              AS depth,
       _Graph.self,


### PR DESCRIPTION
#### Rationale
Simplify generated SQL
 - prepend new path part
 - rely on implicit truncation of CAST( AS VARCHAR(8000)) 

LineageQueryTest
 - test expected behavior of recursive query

TODO consider updating ExperimentRunGraph2.jsp as well

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
