### PR TITLE
Allow updating the CSP to allow the configured BarTender url

### DIFF
--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -220,9 +220,16 @@ public class SecurityManager
         };
     }
 
-    public static void registerAllowedConnectionSource(String serviceURL)
+    public static void registerAllowedConnectionSource(String key, String serviceURL)
     {
-        ContentSecurityPolicyFilter.registerAllowedConnectionSource(serviceURL);
+        if (StringUtils.trimToNull(serviceURL) == null)
+        {
+            ContentSecurityPolicyFilter.unregisterAllowedConnectionSource(key);
+            _log.trace(String.format("Unregistered [%1$s] as an allowed connection source", key));
+            return;
+        }
+
+        ContentSecurityPolicyFilter.registerAllowedConnectionSource(key, serviceURL);
         _log.trace(String.format("Registered [%1$s] as an allowed connection source", serviceURL));
     }
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -113,6 +113,7 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.ViewServlet;
 import org.labkey.api.webdav.permissions.SeeFilePathsPermission;
 import org.labkey.api.writer.ContainerUser;
+import org.labkey.filters.ContentSecurityPolicyFilter;
 import org.labkey.security.xml.GroupEnumType;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.validation.BindException;
@@ -217,6 +218,12 @@ public class SecurityManager
 
             return Map.of("SiteRoleUserCounts", roleCounts);
         };
+    }
+
+    public static void registerAllowedConnectionSource(String serviceURL)
+    {
+        ContentSecurityPolicyFilter.registerAllowedConnectionSource(serviceURL);
+        _log.trace(String.format("Registered [%1$s] as an allowed connection source", serviceURL));
     }
 
     public enum PermissionSet


### PR DESCRIPTION
#### Rationale
Need to allow the BT print service URL through the CSP

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/2272
* https://github.com/LabKey/server/pull/633

#### Changes
* Added method to support registering URL to be included in the CSP