### PR TITLE
Eliminate some inline handlers and fix some URLs

### DIFF
--- a/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
+++ b/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
@@ -121,11 +121,6 @@ import static org.labkey.api.util.DOM.FONT;
 import static org.labkey.api.util.DOM.cl;
 import static org.labkey.api.util.DOM.createHtml;
 
-/**
- * User: brittp
- * Date: Jul 26, 2007
- * Time: 7:01:17 PM
- */
 @RequiresPermission(InsertPermission.class)
 public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType>, ProviderType extends AssayProvider> extends FormViewAction<FormType>
 {
@@ -1206,7 +1201,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
                     }
                     uniqueErrorStrs.add(errStr);
                 }
-                if (sb.toString().length() > 0)
+                if (!sb.isEmpty())
                     sb.append(HtmlString.unsafe("</font>"));
 
                 if (uniqueErrorStrs.size() > MAX_ERRORS)
@@ -1280,7 +1275,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
                 }
                 catch (Exception e)
                 {
-                    throw (IOException) new IOException(e);
+                    throw new IOException(e);
                 }
             }
         }

--- a/api/src/org/labkey/api/data/PanelButton.java
+++ b/api/src/org/labkey/api/data/PanelButton.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.api.data;
 
-import org.labkey.api.util.HttpUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.HttpView;
@@ -29,8 +28,6 @@ import java.util.Map;
 /**
  * Shows a button with a drop-down arrow. When clicked, the button renders a subpanel
  * with a tabbed UI, similar to a ribbon bar in Office.
- * User: jeckels
- * Date: Dec 11, 2009
  */
 public class PanelButton extends ActionButton
 {

--- a/api/src/org/labkey/api/util/DOM.java
+++ b/api/src/org/labkey/api/util/DOM.java
@@ -269,7 +269,7 @@ public class DOM
             _selfClosing = b;
         }
 
-        protected Appendable _render(Appendable builder, Iterable<Map.Entry<Object,Object>> attrs, Object...body) throws IOException
+        private Appendable _render(Appendable builder, Iterable<Map.Entry<Object, Object>> attrs, Object... body) throws IOException
         {
             return appendElement(builder, name(), _selfClosing, attrs, body);
         }
@@ -448,8 +448,7 @@ public class DOM
         ondrop,
         ondurationchange,
         onemptied,
-        onended, */
-        onerror, /*
+        onended,
         onfocus,
         onhashchange,
         oninput,

--- a/api/src/org/labkey/api/util/Link.java
+++ b/api/src/org/labkey/api/util/Link.java
@@ -29,8 +29,8 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.labkey.api.util.DOM.A;
-import static org.labkey.api.util.DOM.Attribute.name;
 import static org.labkey.api.util.DOM.Attribute.href;
+import static org.labkey.api.util.DOM.Attribute.name;
 import static org.labkey.api.util.DOM.Attribute.rel;
 import static org.labkey.api.util.DOM.Attribute.style;
 import static org.labkey.api.util.DOM.Attribute.target;
@@ -68,17 +68,20 @@ public class Link extends DisplayElement implements HasHtmlString
                  clickEvent = lb.onClick;
         }
 
+        String id = lb.id;
+
         // Allow generation of HTML outside an active request, where JavaScript event handlers are unlikely to be important
         if (HttpView.hasCurrentView())
         {
             var page = HttpView.currentPageConfig();
-            if (isBlank(lb.id))
-                lb.id = page.makeId("a_");
-            page.addHandler(lb.id, "click", clickEvent);
+            if (isBlank(id))
+                id = page.makeId("a_");
+            page.addHandler(id, "click", clickEvent);
         }
+
         return A(at(lb.attributes==null ? Collections.emptyMap() : lb.attributes)
                 .cl(lb.iconCls != null, lb.iconCls, lb.cssClass)
-                .id(lb.id)
+                .id(id)
                 .at(!lb.usePost, href,  defaultIfBlank(lb.href, "#"), "#")
                 .data(lb.usePost, "href", lb.href)
                 .data(lb.usePost, "confirmmessage", trimToNull(lb.confirmMessage))
@@ -90,7 +93,7 @@ public class Link extends DisplayElement implements HasHtmlString
                 .data(null != lb.tooltip, "tt", "tooltip")
                 .data(null != lb.tooltip, "placement","top")
                 .data(null != lb.tooltip, "original-title", lb.tooltip),
-                (lb.iconCls!=null ? null : lb.html)
+                (lb.iconCls != null ? null : lb.html)
         ).appendTo(out);
     }
 

--- a/api/src/org/labkey/api/util/element/Input.java
+++ b/api/src/org/labkey/api/util/element/Input.java
@@ -601,7 +601,7 @@ public class Input extends DisplayElement implements HasHtmlString, SafeToRender
         }
     }
 
-    protected void doInputEvents(String id) throws IOException
+    protected void doInputEvents(String id)
     {
         var pageConfig = HttpView.currentPageConfig();
         if (StringUtils.isNotEmpty(getOnClick()))

--- a/api/src/org/labkey/api/view/GWTView.java
+++ b/api/src/org/labkey/api/view/GWTView.java
@@ -27,8 +27,6 @@ import java.util.Set;
 
 /**
  * Wrapper around a GWT (Google Web Toolkit) module that knows how to render into the overall HTML of the page.
- * User: Mark Igra
- * Date: Jan 30, 2007
  */
 public class GWTView extends JspView<GWTView.GWTViewBean>
 {

--- a/api/webapp/clientapi/dom/WebSocket.js
+++ b/api/webapp/clientapi/dom/WebSocket.js
@@ -173,7 +173,7 @@ LABKEY.WebSocket = new function ()
 
         if (showReloadMessage) {
             message += ' Please reload the page or '
-                + '<a href="login-login.view?" target="_blank" rel="noopener noreferrer">'
+                + '<a href="login-login.view" target="_blank" rel="noopener noreferrer">'
                 + 'log in via another browser tab</a> to continue.'
         }
 

--- a/core/resources/views/login.html
+++ b/core/resources/views/login.html
@@ -6,7 +6,7 @@
         <input id="email" name="email" type="text" class="input-block" tabindex="1" autocomplete="off">
         <label for="password">Password</label>
         <div class="forgot-password-link">
-            <a href="login-resetPassword.view?">Forgot password</a>
+            <a href="login-resetPassword.view">Forgot password</a>
         </div>
         <input id="password" name="password" type="password" class="input-block" tabindex="2" autocomplete="off">
         <input tabindex="3" type="checkbox" name="remember" id="remember"  checked> Remember my email address
@@ -23,7 +23,7 @@
             <input type="submit" tabindex="-1" class="loginSubmitButton"/>
             <a tabindex="5" class="labkey-button primary signin-btn"><span>Sign In</span></a>
             <span class="registrationSection" hidden>
-                <a class="labkey-button" id="registerButton" href="login-register.view?">Register</a>
+                <a class="labkey-button" id="registerButton" href="login-register.view">Register</a>
             </span>
         </div>
         <div class="signing-in-msg" hidden>
@@ -40,7 +40,7 @@
     <div class="otherLoginMechanismsContent"></div>
 </div>
 
-<script type="application/javascript" nonce="<%= scriptNonce %>">
+<script type="text/javascript" nonce="<%= scriptNonce %>">
     if (LABKEY.ActionURL.getParameter('returnUrl')) {
         document.getElementById('registerButton').href += 'returnUrl=' + encodeURIComponent(LABKEY.ActionURL.getParameter('returnUrl'));
     }

--- a/core/resources/views/login.html
+++ b/core/resources/views/login.html
@@ -40,8 +40,10 @@
     <div class="otherLoginMechanismsContent"></div>
 </div>
 
-<script type="text/javascript" nonce="<%= scriptNonce %>">
-    if (LABKEY.ActionURL.getParameter('returnUrl')) {
-        document.getElementById('registerButton').href += 'returnUrl=' + encodeURIComponent(LABKEY.ActionURL.getParameter('returnUrl'));
-    }
+<script type="text/javascript" nonce="<%=scriptNonce%>">
+    LABKEY.Utils.onReady(function() {
+        if (LABKEY.ActionURL.getParameter('returnUrl')) {
+            document.getElementById('registerButton').href += '?returnUrl=' + encodeURIComponent(LABKEY.ActionURL.getParameter('returnUrl'));
+        }
+    });
 </script>

--- a/core/resources/views/register.html
+++ b/core/resources/views/register.html
@@ -2,7 +2,7 @@
     <div id="registration-header" class="auth-header">Register for a New Account</div>
     <div class="labkey-error" id="errors"></div>
     <div id="registration-content" class="auth-form-body">
-        <p>Already have an account? <a id="signInLink" href="login-login.view?">Sign In</a></p>
+        <p>Already have an account? <a id="signInLink" href="login-login.view">Sign In</a></p>
         <label for="email">Email</label>
         <input id="email" name="email" type="text" class="input-block" tabindex="1" autofocus>
 

--- a/core/resources/views/register.html
+++ b/core/resources/views/register.html
@@ -12,7 +12,7 @@
         <label for="kaptchaText">Verification</label>
         <p>
             <div>Please enter the six characters shown below (case-insensitive).</div>
-            <div><a href="javascript: window.location.reload()">Reload the page to get a new image.</a></div>
+            <div><a id="reload" href="#">Reload the page to get a new image.</a></div>
             <div><img src="<%= contextPath %>/kaptcha.jpg" alt="Verification text" title="Verification text" height="50" width="200"/></div>
         </p>
         <input id="kaptchaText" name="kaptchaText" type="text" class="input-block" tabindex="3" autofocus>
@@ -24,7 +24,10 @@
 </form>
 
 <script type="text/javascript" nonce="<%=scriptNonce%>">
-    if (LABKEY.ActionURL.getParameter('returnUrl')) {
-        document.getElementById('signInLink').href += 'returnUrl=' + encodeURIComponent(LABKEY.ActionURL.getParameter('returnUrl'));
-    }
+    LABKEY.Utils.onReady(function() {
+        if (LABKEY.ActionURL.getParameter('returnUrl')) {
+            document.getElementById('signInLink').href += '?returnUrl=' + encodeURIComponent(LABKEY.ActionURL.getParameter('returnUrl'));
+        }
+        document.getElementById("reload")['onclick'] = function() { window.location.reload(); };
+    });
 </script>

--- a/core/src/org/labkey/core/view/template/bootstrap/navigation.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/navigation.jsp
@@ -1,4 +1,4 @@
-<%--
+<%
 /*
  * Copyright (c) 2017-2019 LabKey Corporation
  *
@@ -14,11 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
---%>
+%>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.module.FolderType" %>
 <%@ page import="org.labkey.api.settings.LookAndFeelProperties" %>
 <%@ page import="org.labkey.api.settings.TemplateResourceHandler" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.util.Pair" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
@@ -28,7 +29,6 @@
 <%@ page import="org.labkey.api.view.ViewContext" %>
 <%@ page import="org.labkey.api.view.WebPartFactory" %>
 <%@ page import="org.labkey.api.view.WebPartView" %>
-<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.core.view.template.bootstrap.PageTemplate.NavigationModel" %>
 <%@ page import="java.util.LinkedHashSet" %>
 <%@ page import="java.util.List" %>
@@ -143,7 +143,7 @@
                 <% } if (context.isShowFolders()) { %>
                 <li class="dropdown dropdown-folder-nav" data-webpart="FolderNav" data-name="FolderNav">
                     <a data-target="#" class="dropdown-toggle" data-toggle="dropdown">
-                        <%=h(model.getProjectTitle().equals("") ? "Site Navigation" : model.getProjectTitle())%><i style="margin-left: 5px" class="fa fa-chevron-down"></i>
+                        <%=h(model.getProjectTitle().isEmpty() ? "Site Navigation" : model.getProjectTitle())%><i style="margin-left: 5px" class="fa fa-chevron-down"></i>
                     </a>
                     <ul class="dropdown-menu"></ul>
                 </li>
@@ -164,7 +164,7 @@
                         {
                             boolean show = isPageAdminMode || !tab.isDisabled();
 
-                            if (show && null != tab.getText() && tab.getText().length() > 0)
+                            if (show && null != tab.getText() && !tab.getText().isEmpty())
                             {
                 %>
                 <li role="presentation" class="<%= text(tab.isSelected() ? "active" : "") %>">
@@ -192,11 +192,10 @@
 
                     if (isPageAdminMode && c.getFolderType() != FolderType.NONE)
                     {
+                        HtmlString plus = HtmlString.unsafe("<i class=\"fa fa-plus\" style=\"font-size: 12px;\"></i>");
                 %>
                 <li role="presentation">
-                    <a href="javascript:LABKEY.Portal.addTab();" id="addTab" title="Add New Tab">
-                        <i class="fa fa-plus" style="font-size: 12px;"></i>
-                    </a>
+                    <%=link(plus).id("addTab").title("Add New Tab").onClick("LABKEY.Portal.addTab();").clearClasses()%>
                 </li>
                 <%
                     }
@@ -209,7 +208,7 @@
                     {
                         for (NavTree tab : tabs)
                         {
-                            if (null != tab.getText() && tab.getText().length() > 0)
+                            if (null != tab.getText() && !tab.getText().isEmpty())
                             {
                                 if (tab.isSelected())
                                 {
@@ -231,7 +230,7 @@
                             {
                                 boolean show = isPageAdminMode || !tab.isDisabled();
 
-                                if (show && null != tab.getText() && tab.getText().length() > 0)
+                                if (show && null != tab.getText() && !tab.getText().isEmpty())
                                 {
                         %>
                         <li>
@@ -260,9 +259,9 @@
         </div>
     </div>
 </nav>
-<% if (model.getCustomMenus().size() > 0) { %>
+<% if (!model.getCustomMenus().isEmpty()) { %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
-    var __menus = {};
+    const __menus = {};
     LABKEY.Utils.onReady(function() {
         <%
             for (Portal.WebPart menu : model.getCustomMenus())

--- a/mothership/src/org/labkey/mothership/CreateIssueDisplayColumn.java
+++ b/mothership/src/org/labkey/mothership/CreateIssueDisplayColumn.java
@@ -25,10 +25,6 @@ import org.labkey.api.util.PageFlowUtil;
 import java.io.IOException;
 import java.io.Writer;
 
-/**
- * User: jeckels
- * Date: Jun 29, 2006
- */
 public class CreateIssueDisplayColumn extends DataColumn
 {
     private final ActionButton _saveButton;
@@ -45,6 +41,11 @@ public class CreateIssueDisplayColumn extends DataColumn
     public void renderDetailsCellContents(RenderContext ctx, Writer out) throws IOException
     {
         _saveButton.render(ctx, out);
-        out.write("\t" + PageFlowUtil.button("Create Issue").href("javascript:document.forms.CreateIssue.elements['assignedTo'].value = document.forms[" + PageFlowUtil.jsString(ctx.getCurrentRegion().getFormId()) + "].elements['assignedTo'].value; document.forms.CreateIssue.submit();"));
+        out.write("\t");
+        PageFlowUtil.button("Create Issue")
+            .onClick("document.forms.CreateIssue.elements['assignedTo'].value = document.forms[" +
+                PageFlowUtil.jsString(ctx.getCurrentRegion().getFormId()) +
+                "].elements['assignedTo'].value; document.forms.CreateIssue.submit();")
+            .appendTo(out);
     }
 }

--- a/study/gwtsrc/gwt/client/org/labkey/study/designer/client/Designer.java
+++ b/study/gwtsrc/gwt/client/org/labkey/study/designer/client/Designer.java
@@ -229,7 +229,7 @@ public class Designer implements EntryPoint
                     if (null != PropertyUtil.getServerProperty("finishURL"))
                         WindowUtil.setLocation(PropertyUtil.getServerProperty("finishURL"));
                     else if (definition.getCavdStudyId() == 0)
-                        WindowUtil.setLocation(PropertyUtil.getContextPath() + "/Project" + PropertyUtil.getContainerPath() + "/start.view?");
+                        WindowUtil.setLocation(PropertyUtil.getContextPath() + PropertyUtil.getContainerPath() + "/project-start.view");
                     else
                         WindowUtil.setLocation(PropertyUtil.getRelativeURL("designer.view") + "?studyId=" + definition.getCavdStudyId());
                 }

--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -181,7 +181,7 @@ public class SharedStudyTest extends BaseWebDriverTest
     public void testStudyOverview()
     {
         log("Verify sub-folder study PV_One dataset has 2 participants at 'Visit 1'");
-        beginAt("/study/" + getProjectName() + "/" + STUDY1 + "/overview.view?");
+        beginAt("/" + getProjectName() + "/" + STUDY1 + "/study-overview.view");
         assertEquals("PV_One?", getTableCellText(Locator.id("studyOverview"), 6, 0));
         String visitLabel = getTableCellText(Locator.id("studyOverview"), 0, 4);
         Assert.assertTrue("Expected 'Visit 1', got: " + visitLabel, visitLabel.contains("Visit 1"));
@@ -281,7 +281,7 @@ public class SharedStudyTest extends BaseWebDriverTest
         waitForPipelineJobsToComplete(1, "Publish Study", false);
 
         // verify that published study description has correct number visits, and number participants
-        beginAt("/" + nonDataspaceProject + "/" + studyPublishedFromDataspace + "/project-begin.view?");
+        beginAt("/" + nonDataspaceProject + "/" + studyPublishedFromDataspace + "/project-begin.view");
         assertTextPresent("over 6 visits. Data is present for 6 Pandas.");
 
         // verify that published study description has correct dataset

--- a/wiki/src/org/labkey/wiki/view/customizeWiki.jsp
+++ b/wiki/src/org/labkey/wiki/view/customizeWiki.jsp
@@ -181,12 +181,12 @@ function restoreDefaultPage()
                 }
                 return new OptionBuilder(c.getPath(), c.getId()).selected(selected);
             }))%>
-    <span class="help-block">You can also <a href="javascript:restoreDefaultPage();">restore to this folder's default page.</a></span><br>
+    <span class="help-block">You can also <%=link("restore to this folder's default page.").onClick("restoreDefaultPage();").clearClasses()%></span><br>
     <%
         final Stream<OptionBuilder> builders;
 
         //if current container has no pages
-        if (null == me.getContainerNameTitleMap() || me.getContainerNameTitleMap().size() == 0)
+        if (null == me.getContainerNameTitleMap() || me.getContainerNameTitleMap().isEmpty())
         {
             builders = Stream.of(new OptionBuilder().value("").label("no pages"));
         }


### PR DESCRIPTION
#### Rationale
Clean up CSP reports

@labkey-matthewb the only remotely interesting change is in `Link.java`. By no longer pushing the generated ID back into the LinkBuilder we can reuse builders to generate multiple links with different event handlers. I used this here: https://github.com/LabKey/harvest/pull/251/files#diff-8e1ec8921d92ab38d7e1e65982f13f65fef4ab13b9959aedcb77dade34875658