### PR TITLE
Uniquify principal names and add case-insensitive unique index

### DIFF
--- a/api/src/org/labkey/api/data/Filter.java
+++ b/api/src/org/labkey/api/data/Filter.java
@@ -25,8 +25,6 @@ import java.util.Set;
 /**
  * Knows how to generate a WHERE clause to filter a query based on some set of criteria. Used extensively, often
  * via {@link SimpleFilter} when selecting from database tables.
- * User: arauch
- * Date: Jan 11, 2005
  */
 public interface Filter
 {

--- a/api/src/org/labkey/api/data/SimpleFilter.java
+++ b/api/src/org/labkey/api/data/SimpleFilter.java
@@ -58,8 +58,6 @@ import static org.labkey.api.data.CompareType.NOT_IN;
 
 /**
  * Representation of zero or more filters to be used with a database query after being translated to a WHERE clause.
- * User: arauch
- * Date: Jan 11, 2005
  */
 public class SimpleFilter implements Filter
 {
@@ -1305,7 +1303,7 @@ public class SimpleFilter implements Filter
      */
     public SQLFragment getSQLFragment(TableInfo t, @Nullable String tableAlias)
     {
-        if (null == _clauses || 0 == _clauses.size())
+        if (null == _clauses || _clauses.isEmpty())
             return new SQLFragment();
 
         return getSQLFragment(t.getSqlDialect(), tableAlias, Table.createColumnMap(t, t.getColumns()));

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1378,7 +1378,7 @@ public class SecurityManager
     // Case-insensitive existence check -- disallows groups that differ only by case
     private static boolean groupExists(Container c, String groupName, String ownerId)
     {
-        return null != getGroupId(c, groupName, ownerId, false, true);
+        return null != getGroupId(c, groupName, ownerId, false);
     }
 
     public static Group renameGroup(Group group, String newName, User currentUser)
@@ -2287,17 +2287,8 @@ public class SecurityManager
 
     public static Integer getGroupId(@Nullable Container c, String groupName, @Nullable String ownerId, boolean throwOnFailure)
     {
-        return getGroupId(c, groupName, ownerId, throwOnFailure, false);
-    }
-
-    // This is temporary... in CPAS 1.5 on PostgreSQL it was possible to create two groups in the same container that differed only
-    // by case (this was not possible on SQL Server). In CPAS 1.6 we disallow this on PostgreSQL... but we still need to be able to
-    // retrieve group IDs in a case-sensitive manner.
-    // TODO: For CPAS 1.7: this should always be case-insensitive (we will clean up the database by renaming duplicate groups)
-    private static Integer getGroupId(@Nullable Container c, String groupName, @Nullable String ownerId, boolean throwOnFailure, boolean caseInsensitive)
-    {
-        SQLFragment sql = new SQLFragment("SELECT UserId FROM " + core.getTableInfoPrincipals() + " WHERE Type!='u' AND " + (caseInsensitive ? "LOWER(Name)" : "Name") + " = ? AND Container ");
-        sql.add(caseInsensitive ? groupName.toLowerCase() : groupName);
+        SQLFragment sql = new SQLFragment("SELECT UserId FROM " + core.getTableInfoPrincipals() + " WHERE Type != 'u' AND LOWER(Name) = ? AND Container ");
+        sql.add(groupName.toLowerCase());
 
         if (c == null || c.isRoot())
         {

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 23.010
+SchemaVersion: 23.011
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-23.010-23.011.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-23.010-23.011.sql
@@ -1,0 +1,4 @@
+SELECT core.executeJavaUpgradeCode('uniquifyPrincipalsName');
+
+ALTER TABLE core.Principals DROP CONSTRAINT UQ_Principals_Container_Name_OwnerId;
+CREATE UNIQUE INDEX UQ_Principals_Container_Name_OwnerId ON core.Principals (Container, LOWER(Name), OwnerId) NULLS NOT DISTINCT;


### PR DESCRIPTION
#### Rationale
Better late than never

`SecurityManager` has had a TODO about case-insensitive group name comparisons for 17 years. Back then, we began blocking the creation of names that differed by case only, but never created a case-insensitive unique constraint/index. This uniquifies all group, user, and module group names within their containers and then adds a unique index.

It also fixes up `UpgradeUtils.uniquifyValues()` to handle more scenarios, null containers, etc.
