### PR TITLE
Allow AppAdmin WaitForIndexerAction access

### DIFF
--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -48,6 +48,7 @@ import org.labkey.api.security.RequiresSiteAdmin;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.util.ConfigurationException;
@@ -854,7 +855,7 @@ public class SearchController extends SpringActionController
     // The tests can invoke this action to ensure that the indexer has executed all previous indexing tasks. It
     // does not guarantee that all indexed content has been committed... but that may not be required in practice.
 
-    @RequiresSiteAdmin
+    @RequiresPermission(ApplicationAdminPermission.class)
     public class WaitForIndexerAction extends ExportAction<PriorityForm>
     {
         @Override


### PR DESCRIPTION
#### Rationale
Recently, in https://github.com/LabKey/biologics/pull/2546 I tried adding a call to SearchAdminAPIHelper.waitForIndexer() in BiologicsBaseTest.insertAndVerifyRows because that seemed a way to avoid having tests fail because they didn't wait for the search indexer.

Unfortunately, [BiologicsAPITest.resolveInputsByAlternateKey](https://teamcity.labkey.org/viewLog.html?buildId=2778345&buildTypeId=LabKey_HostingAndEvaluationInfrastructure_AutomatedTest_AutomatedTestForTrunk_TrialBiologicsIntegrationTest&fromSakuraUI=true#testNameId-4342897430626213427) and several other tests recently failed in remote eval develop for reasons that appear to be that `SearchController.WaitForIndexerAction` requires SiteAdmin permissions (we run tests as AppAdmin on remote suites).

#### Related Pull Requests
https://github.com/LabKey/biologics/pull/2557

#### Changes
annotate `SearchController.WaitForIndexerAction` to allow AppAdmin to wait for search
