### PR TITLE
Issue 49216: Set JDBC preparedThreshold=0 for PostgreSQL

### DIFF
--- a/api/src/org/labkey/api/data/DbScopeLoader.java
+++ b/api/src/org/labkey/api/data/DbScopeLoader.java
@@ -80,7 +80,7 @@ class DbScopeLoader
                     try
                     {
                         scope = new DbScope(this);
-                        firstConnectionConsumer.accept(scope);
+                        firstConnectionConsumer.accept(scope); // Do this before prepare(), which could open connections
                         scope.getSqlDialect().prepare(scope);
                     }
                     catch (Throwable t)

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -27,13 +27,13 @@ import org.labkey.api.collections.CsvSet;
 import org.labkey.api.collections.Sets;
 import org.labkey.api.data.*;
 import org.labkey.api.data.ConnectionWrapper.Closer;
+import org.labkey.api.data.DbScope.LabKeyDataSource;
 import org.labkey.api.data.JdbcMetaDataSelector.JdbcMetaDataResultSetFactory;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.MemTracker;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.SystemMaintenance;
 import org.labkey.api.util.logging.LogHelper;
@@ -425,7 +425,14 @@ public abstract class SqlDialect
     {
     }
 
-    // Do scope-specific initialization work for this dialect. Note: this might be called multiple times, for example,
+    // Called once on each LabKeyDataSource before any connections are attempted. Do not create connections in this
+    // method otherwise the "other connections to this database" check will fail.
+    public void prepare(LabKeyDataSource dataSource)
+    {
+    }
+
+    // Do dialect-specific initialization work for this scope. This is called after prepare(LabKeyDataSource) and
+    // after the "other connections to this database" check. Note: this might be called multiple times, for example,
     // during bootstrap or upgrade.
     public void prepare(DbScope scope)
     {
@@ -1783,11 +1790,6 @@ public abstract class SqlDialect
     }
 
     public @Nullable String getDefaultApplicationName()
-    {
-        return null;
-    }
-
-    public @Nullable Pair<String, Object> getDisablePreparedStatementCachingEntry()
     {
         return null;
     }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -33,6 +33,7 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.MemTracker;
+import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.SystemMaintenance;
 import org.labkey.api.util.logging.LogHelper;
@@ -1782,6 +1783,11 @@ public abstract class SqlDialect
     }
 
     public @Nullable String getDefaultApplicationName()
+    {
+        return null;
+    }
+
+    public @Nullable Pair<String, Object> getDisablePreparedStatementCachingEntry()
     {
         return null;
     }


### PR DESCRIPTION
#### Rationale
This seeks to address [Issue 49216](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49216) by setting JDBC parameter `preparedThreshold=0` for all PostgreSQL primary database connections. Setting the parameter in this way [disables prepared statement caching](https://jdbc.postgresql.org/documentation/server-prepare/#deactivation) which is known to cause problems when schema changes occur.

#### Changes
- Expose setting of connection properties on `DbScope` and consolidate setting these properties.
- Introduce `prepare(LabKeyDataSource dataSource)` on `SqlDialect` to support dialect-specific preparation of the data source prior to connections being established.
- Set `preparedThreshold=0` for the primary data source on PostgreSQL to address [Issue 49216](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49216).
- Retrieve driver `Class` from data source rather than from connection.