### PR TITLE
It's a bit too soon to be using NULLS NOT DISTINCT

### DIFF
--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 23.011
+SchemaVersion: 23.012
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-23.010-23.011.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-23.010-23.011.sql
@@ -1,4 +1,5 @@
 SELECT core.executeJavaUpgradeCode('uniquifyPrincipalsName');
 
-ALTER TABLE core.Principals DROP CONSTRAINT UQ_Principals_Container_Name_OwnerId;
-CREATE UNIQUE INDEX UQ_Principals_Container_Name_OwnerId ON core.Principals (Container, LOWER(Name), OwnerId) NULLS NOT DISTINCT;
+-- NULLS NOT DISTINCT syntax was introduced in PostgreSQL 15, so we can't use it. Next script adds the correct index.
+--ALTER TABLE core.Principals DROP CONSTRAINT UQ_Principals_Container_Name_OwnerId;
+--CREATE UNIQUE INDEX UQ_Principals_Container_Name_OwnerId ON core.Principals (Container, LOWER(Name), OwnerId) NULLS NOT DISTINCT;

--- a/core/resources/schemas/dbscripts/postgresql/core-23.011-23.012.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-23.011-23.012.sql
@@ -1,0 +1,10 @@
+-- Previous script attempted to create a unique index specifying NULLS NOT DISTINCT, but that syntax was just introduced
+-- in PostgreSQL 15. We want to fix servers that failed to create the new index; we also want to migrate servers that
+-- created it successfully, for consistency. Once PostgreSQL 15 is a minimum we could consider switching back to NULLS
+-- NOT DISTINCT.
+
+ALTER TABLE core.Principals DROP CONSTRAINT IF EXISTS UQ_Principals_Container_Name_OwnerId;
+DROP INDEX IF EXISTS core.UQ_Principals_Container_Name_OwnerId;
+-- COALESCE() works around PostgreSQL behavior that NULL values are not unique
+CREATE UNIQUE INDEX UQ_Principals_Container_Name_OwnerId ON core.Principals
+    (COALESCE(Container, '00000000-0000-0000-0000-000000000000'), LOWER(Name), COALESCE(OwnerId, '00000000-0000-0000-0000-000000000000'));


### PR DESCRIPTION
#### Rationale
`NULLS NOT DISTINCT` syntax was just added in PostgreSQL 15, so drop and recreate the unique index with the `COALESCE()` hack.