### PR TITLE
Issue 49227: Default lineage maximum depth

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpLineageOptions.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineageOptions.java
@@ -17,13 +17,17 @@ package org.labkey.api.exp.api;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.module.ModuleLoader;
 
 /**
  * Captures options for doing a lineage search
- * Created by Nick Arnold on 2/12/2016.
  */
 public class ExpLineageOptions extends ResolveLsidsForm
 {
+    // Issue 37332: SQL Server can hit max recursion depth over 100 generations.
+    // Note: If this is adjusted higher, then consider separate default values for SQL Server and PostgreSQL.
+    public static final int LINEAGE_DEFAULT_MAXIMUM_DEPTH = 100;
+
     public enum LineageExpType
     {
         ALL,
@@ -177,5 +181,22 @@ public class ExpLineageOptions extends ResolveLsidsForm
     public void setSourceKey(String sourceKey)
     {
         _sourceKey = sourceKey;
+    }
+
+    public int getConfiguredDepth()
+    {
+        if (_depth != 0)
+            return _depth;
+
+        var module = ModuleLoader.getInstance().getModule(ExperimentService.MODULE_NAME);
+        var property = module.getModuleProperties().get(ExperimentService.LINEAGE_DEFAULT_MAXIMUM_DEPTH_PROPERTY_NAME);
+        if (property != null)
+        {
+            String sDepth = property.getEffectiveValue(null);
+            if (!StringUtils.isEmpty(sDepth))
+                return Integer.parseInt(sDepth);
+        }
+
+        return LINEAGE_DEFAULT_MAXIMUM_DEPTH;
     }
 }

--- a/api/src/org/labkey/api/exp/api/ExpLineageOptions.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineageOptions.java
@@ -186,7 +186,7 @@ public class ExpLineageOptions extends ResolveLsidsForm
     public int getConfiguredDepth()
     {
         if (_depth != 0)
-            return _depth;
+            return Math.abs(_depth);
 
         var module = ModuleLoader.getInstance().getModule(ExperimentService.MODULE_NAME);
         var property = module.getModuleProperties().get(ExperimentService.LINEAGE_DEFAULT_MAXIMUM_DEPTH_PROPERTY_NAME);

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -114,6 +114,8 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     String LSID_COUNTER_DB_SEQUENCE_PREFIX = "LsidCounter-";
 
+    String LINEAGE_DEFAULT_MAXIMUM_DEPTH_PROPERTY_NAME = "lineageDefaultMaximumDepth";
+
     int SIMPLE_PROTOCOL_FIRST_STEP_SEQUENCE = 1;
     int SIMPLE_PROTOCOL_CORE_STEP_SEQUENCE = 10;
     int SIMPLE_PROTOCOL_EXTRA_STEP_SEQUENCE = 15;

--- a/api/src/org/labkey/api/module/ModuleProperty.java
+++ b/api/src/org/labkey/api/module/ModuleProperty.java
@@ -290,6 +290,8 @@ public class ModuleProperty
             }
         }
 
+        validate(user, c, value);
+
         PropertyManager.PropertyMap props = PropertyManager.getWritableProperties(PropertyManager.SHARED_USER, c, getCategory(), true);
 
         if (!StringUtils.isEmpty(value))
@@ -298,6 +300,10 @@ public class ModuleProperty
             props.remove(getName());
 
         props.save();
+    }
+
+    public void validate(@Nullable User user, Container c, @Nullable String value)
+    {
     }
 
     /**

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -43,6 +43,7 @@ import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.DefaultExperimentDataHandler;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpDataClass;
+import org.labkey.api.exp.api.ExpLineageOptions;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpProtocolAttachmentType;
@@ -68,6 +69,7 @@ import org.labkey.api.exp.xar.LsidUtils;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.files.TableUpdaterFileListener;
 import org.labkey.api.module.ModuleContext;
+import org.labkey.api.module.ModuleProperty;
 import org.labkey.api.module.SpringModule;
 import org.labkey.api.module.Summary;
 import org.labkey.api.ontology.OntologyService;
@@ -231,7 +233,6 @@ public class ExperimentModule extends SpringModule
         AdminConsole.addExperimentalFeatureFlag(ExpMaterialTable.USE_MATERIALIZED_SAMPLETYPE, "Use materialized views for sample type tables",
                 "PROTOTYPE: possible approach for improving query performance.", false);
 
-
         RoleManager.registerPermission(new DesignVocabularyPermission(), true);
 
         AttachmentService.get().registerAttachmentType(ExpRunAttachmentType.get());
@@ -239,6 +240,8 @@ public class ExperimentModule extends SpringModule
 
         WebdavService.get().addExpDataProvider((path, container) -> ExperimentService.get().getAllExpDataByURL(path, container));
         ExperimentService.get().registerObjectReferencer(ExperimentServiceImpl.get());
+
+        addModuleProperty(new LineageMaximumDepthModuleProperty(this));
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/LineageMaximumDepthModuleProperty.java
+++ b/experiment/src/org/labkey/experiment/LineageMaximumDepthModuleProperty.java
@@ -3,6 +3,7 @@ package org.labkey.experiment;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.CoreSchema;
 import org.labkey.api.exp.api.ExpLineageOptions;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.module.Module;
@@ -12,14 +13,13 @@ import org.labkey.api.security.User;
 public class LineageMaximumDepthModuleProperty extends ModuleProperty
 {
     private final int MINIMUM_DEPTH = 1;
-    private final int MAXIMUM_DEPTH = 1_000;
 
     public LineageMaximumDepthModuleProperty(Module module)
     {
         super(module, ExperimentService.LINEAGE_DEFAULT_MAXIMUM_DEPTH_PROPERTY_NAME);
 
         setLabel("Lineage Default Maximum Depth");
-        setDescription(String.format("Default maximum depth lineage queries will recurse (%d-%d). Defaults to %d.", MINIMUM_DEPTH, MAXIMUM_DEPTH, ExpLineageOptions.LINEAGE_DEFAULT_MAXIMUM_DEPTH));
+        setDescription(String.format("Default maximum depth lineage queries will recurse (%d-%d). Defaults to %d.", MINIMUM_DEPTH, getMaximumDepth(), ExpLineageOptions.LINEAGE_DEFAULT_MAXIMUM_DEPTH));
         setShowDescriptionInline(true);
     }
 
@@ -34,12 +34,20 @@ public class LineageMaximumDepthModuleProperty extends ModuleProperty
             var depth = Integer.parseInt(value);
             if (depth < MINIMUM_DEPTH)
                 throw new IllegalArgumentException(String.format("Invalid value for \"%s\". Minimum value is %d.", getLabel(), MINIMUM_DEPTH));
-            else if (depth > MAXIMUM_DEPTH)
-                throw new IllegalArgumentException(String.format("Invalid value for \"%s\". Maximum value is %d.", getLabel(), MAXIMUM_DEPTH));
+
+            var maxDepth = getMaximumDepth();
+            if (depth > maxDepth)
+                throw new IllegalArgumentException(String.format("Invalid value for \"%s\". Maximum value is %d.", getLabel(), maxDepth));
         }
         catch (NumberFormatException e)
         {
             throw new IllegalArgumentException(String.format("Invalid value for \"%s\". Must be a number.", getLabel()));
         }
+    }
+
+    private static int getMaximumDepth()
+    {
+        // Issue 37332: SQL Server can hit max recursion depth over 100 generations.
+        return CoreSchema.getInstance().getSqlDialect().isSqlServer() ? 100 : 1_000;
     }
 }

--- a/experiment/src/org/labkey/experiment/LineageMaximumDepthModuleProperty.java
+++ b/experiment/src/org/labkey/experiment/LineageMaximumDepthModuleProperty.java
@@ -1,0 +1,45 @@
+package org.labkey.experiment;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
+import org.labkey.api.exp.api.ExpLineageOptions;
+import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.module.Module;
+import org.labkey.api.module.ModuleProperty;
+import org.labkey.api.security.User;
+
+public class LineageMaximumDepthModuleProperty extends ModuleProperty
+{
+    private final int MINIMUM_DEPTH = 1;
+    private final int MAXIMUM_DEPTH = 1_000;
+
+    public LineageMaximumDepthModuleProperty(Module module)
+    {
+        super(module, ExperimentService.LINEAGE_DEFAULT_MAXIMUM_DEPTH_PROPERTY_NAME);
+
+        setLabel("Lineage Default Maximum Depth");
+        setDescription(String.format("Default maximum depth lineage queries will recurse (%d-%d). Defaults to %d.", MINIMUM_DEPTH, MAXIMUM_DEPTH, ExpLineageOptions.LINEAGE_DEFAULT_MAXIMUM_DEPTH));
+        setShowDescriptionInline(true);
+    }
+
+    @Override
+    public void validate(@Nullable User user, Container c, @Nullable String value)
+    {
+        if (StringUtils.isEmpty(value))
+            return;
+
+        try
+        {
+            var depth = Integer.parseInt(value);
+            if (depth < MINIMUM_DEPTH)
+                throw new IllegalArgumentException(String.format("Invalid value for \"%s\". Minimum value is %d.", getLabel(), MINIMUM_DEPTH));
+            else if (depth > MAXIMUM_DEPTH)
+                throw new IllegalArgumentException(String.format("Invalid value for \"%s\". Maximum value is %d.", getLabel(), MAXIMUM_DEPTH));
+        }
+        catch (NumberFormatException e)
+        {
+            throw new IllegalArgumentException(String.format("Invalid value for \"%s\". Must be a number.", getLabel()));
+        }
+    }
+}

--- a/experiment/src/org/labkey/experiment/api/ExperimentRunGraph2.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRunGraph2.jsp
@@ -29,10 +29,8 @@
     SqlDialect dialect = CoreSchema.getInstance().getSqlDialect();
     var bean = (ExpLineageOptions) HttpView.currentModel();
     String expType = StringUtils.defaultString(bean.getExpTypeValue(), "ALL");
-  // see bug 37332, better (but more complicated) fix for sql server would be to use "option (maxrecursion 1000)"
-    int depth = bean.getDepth();
-    if (depth == 0)
-      depth = dialect.isSqlServer() ? 100 : 1000;
+    // See Issue 37332, better (but more complicated) fix for sql server would be to use "option (maxrecursion 1000)"
+    int depth = bean.getConfiguredDepth();
     var CONCAT = HtmlString.unsafe(dialect.isPostgreSQL() ? "||" : "+");
 
     assert ExpLineageOptions.LineageExpType.fromValue(expType) != null;

--- a/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExperimentRunGraphForLookup2.jsp
@@ -31,10 +31,8 @@
     SqlDialect dialect = CoreSchema.getInstance().getSqlDialect();
     var bean = (ExpLineageOptions) HttpView.currentModel();
     String expType = StringUtils.defaultString(bean.getExpTypeValue(), "ALL");
-    // see bug 37332, better (but more complicated) fix for sql server would be to use "option (maxrecursion 1000)"
-    int depth = bean.getDepth();
-    if (depth == 0)
-        depth = dialect.isSqlServer() ? 100 : 1000;
+    // See Issue 37332, better (but more complicated) fix for sql server would be to use "option (maxrecursion 1000)"
+    int depth = bean.getConfiguredDepth();
     var CONCAT = unsafe(dialect.isPostgreSQL() ? "||" : "+");
 
     String varcharType = dialect.getSqlTypeName(JdbcType.VARCHAR);


### PR DESCRIPTION
#### Rationale
This seeks to address [Issue 49227](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49227) by a) lowering the default maximum lineage depth to 100 (from 1,000 on PostgreSQL) and b) introducing a new site-wide Experiment module ModuleProperty that allows for users to override this setting.

![image](https://github.com/LabKey/platform/assets/3926239/21d3a5a6-9bf9-4aaa-bce9-dffd56af912f)

#### Changes
- Set default maximum depth to 100.
- Introduce Experiment module ModuleProperty `LineageMaximumDepthModuleProperty` to support user override of the default depth.
- Add validation of module properties prior to save save.
- Maximum allowed depth is 100 for SQL Server and 1,000 for PostgreSQL.
