### PR TITLE
Issue 48243: Period in Sample ID full of numbers expects an integer during Assay Import and is handled poorly during update

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -146,7 +146,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         // Issue 48243: For the assay import of lookup columns, we want to allow for the original value to be used when
         // attempting to resolve the lookup (for example, the SampleId column might be type int but the original value
         // could be a string or double and we want that original value to have a chance to resolve instead of giving a
-        // type conversion error.
+        // type conversion error).
         settings.setBestEffortConversion(true);
 
         Map<DataType, List<Map<String, Object>>> rawData = getValidationDataMap(data, dataFile, info, log, context, settings);

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -143,6 +143,12 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         DataLoaderSettings settings = new DataLoaderSettings();
         settings.setAllowLookupByAlternateKey(allowLookupByAlternateKey);
 
+        // Issue 48243: For the assay import of lookup columns, we want to allow for the original value to be used when
+        // attempting to resolve the lookup (for example, the SampleId column might be type int but the original value
+        // could be a string or double and we want that original value to have a chance to resolve instead of giving a
+        // type conversion error.
+        settings.setBestEffortConversion(true);
+
         Map<DataType, List<Map<String, Object>>> rawData = getValidationDataMap(data, dataFile, info, log, context, settings);
         assert(rawData.size() <= 1);
         try

--- a/study/test/src/org/labkey/test/tests/study/AssayTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AssayTest.java
@@ -384,7 +384,7 @@ public class AssayTest extends AbstractAssayTest
         setFormElement(Locator.id("TextAreaDataCollector.textArea"), TEST_RUN2_DATA2);
         clickButton("Save and Finish");
 
-        assertTextPresent("VisitID must be of type Number (Double)");
+        assertTextPresent("Could not convert value 'g' (String) for Double field 'VisitID'");
         assertTextPresent(PROTOCOL_DOC2.getName());
         assertFormElementEquals(Locator.name("name"), TEST_RUN2);
         assertFormElementEquals(Locator.name("comments"), TEST_RUN2_COMMENTS);

--- a/study/test/src/org/labkey/test/tests/study/LinkAssayToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/LinkAssayToStudyTest.java
@@ -209,7 +209,7 @@ public class LinkAssayToStudyTest extends AbstractAssayTest
         setFormElement(Locator.id("TextAreaDataCollector.textArea"), TEST_RUN2_DATA2);
         clickButton("Save and Finish");
 
-        assertTextPresent("VisitID must be of type Number (Double)");
+        assertTextPresent("Could not convert value 'g' (String) for Double field 'VisitID'");
         assertTextPresent(PROTOCOL_DOC2.getName());
         assertFormElementEquals(Locator.name("name"), TEST_RUN2);
         assertFormElementEquals(Locator.name("comments"), TEST_RUN2_COMMENTS);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48243

For the assay import of lookup columns, we want to allow for the original value to be used when attempting to resolve the lookup (for example, the SampleId column might be type int but the original value could be a string or double and we want that original value to have a chance to resolve instead of giving a type conversion error.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/1750

#### Changes
- AbstractAssayTsvDataHandler to setBsetEfforConversion(true) for DataLoaderSettings
- Fix tests to check for update to assay import data type conversion error message
