### PR TITLE
Resolve MenuBarTest Outage

### DIFF
--- a/core/src/org/labkey/core/view/template/bootstrap/navigation.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/navigation.jsp
@@ -261,6 +261,7 @@
 </nav>
 <% if (!model.getCustomMenus().isEmpty()) { %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    <%--  note __menus must be a var, not a let or const  --%>
     var __menus = {};
     LABKEY.Utils.onReady(function() {
         <%

--- a/core/src/org/labkey/core/view/template/bootstrap/navigation.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/navigation.jsp
@@ -261,7 +261,7 @@
 </nav>
 <% if (!model.getCustomMenus().isEmpty()) { %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
-    const __menus = {};
+    var __menus = {};
     LABKEY.Utils.onReady(function() {
         <%
             for (Portal.WebPart menu : model.getCustomMenus())


### PR DESCRIPTION
#### Rationale
Previously, a `var` was changed to a `const`. This `var` is updated in code below its declaration and also seems to be referenced in other .js files, meriting a `var` and not a `let`. This update should also fix MenuBarTest.testSteps.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5008

#### Changes
* Change const to var
* Add newline
