### PR TITLE
Issue 49168: Update sizes of audit domain fields

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
@@ -166,13 +166,13 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
             super(SampleTimelineAuditEvent.EVENT_TYPE);
 
             Set<PropertyDescriptor> fields = new LinkedHashSet<>();
-            fields.add(createPropertyDescriptor(SAMPLE_TYPE_COLUMN_NAME, PropertyType.STRING));
+            fields.add(createPropertyDescriptor(SAMPLE_TYPE_COLUMN_NAME, PropertyType.STRING, 100));
             fields.add(createPropertyDescriptor(SAMPLE_TYPE_ID_COLUMN_NAME, PropertyType.INTEGER));
-            fields.add(createPropertyDescriptor(SAMPLE_NAME_COLUMN_NAME, PropertyType.STRING));
+            fields.add(createPropertyDescriptor(SAMPLE_NAME_COLUMN_NAME, PropertyType.STRING, 200));
             fields.add(createPropertyDescriptor(SAMPLE_ID_COLUMN_NAME, PropertyType.INTEGER));
-            fields.add(createPropertyDescriptor(SAMPLE_LSID_COLUMN_NAME, PropertyType.STRING));
+            fields.add(createPropertyDescriptor(SAMPLE_LSID_COLUMN_NAME, PropertyType.STRING, 300));
             fields.add(createPropertyDescriptor(IS_LINEAGE_UPDATE_COLUMN_NAME, PropertyType.BOOLEAN));
-            fields.add(createPropertyDescriptor(INVENTORY_UPDATE_TYPE_COLUMN_NAME, PropertyType.STRING));
+            fields.add(createPropertyDescriptor(INVENTORY_UPDATE_TYPE_COLUMN_NAME, PropertyType.STRING, 25));
             fields.add(createPropertyDescriptor(METADATA_COLUMN_NAME, PropertyType.STRING, -1));        // varchar max
             fields.add(createPropertyDescriptor(COLUMN_NAME_USER_COMMENT, PropertyType.STRING, -1));
             fields.add(createOldDataMapPropertyDescriptor());

--- a/study/src/org/labkey/study/dataset/DatasetAuditProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetAuditProvider.java
@@ -260,7 +260,7 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
             Set<PropertyDescriptor> fields = new LinkedHashSet<>();
             fields.add(createPropertyDescriptor(COLUMN_NAME_DATASET_ID, PropertyType.INTEGER));
             fields.add(createPropertyDescriptor(COLUMN_NAME_HAS_DETAILS, PropertyType.BOOLEAN));
-            fields.add(createPropertyDescriptor(COLUMN_NAME_LSID, PropertyType.STRING));
+            fields.add(createPropertyDescriptor(COLUMN_NAME_LSID, PropertyType.STRING, 300));
             fields.add(createOldDataMapPropertyDescriptor());
             fields.add(createNewDataMapPropertyDescriptor());
             _fields = Collections.unmodifiableSet(fields);


### PR DESCRIPTION
#### Rationale
Issue [49168](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49168): When no field size is provided for audit domain fields, we use the default size of 4000 for strings. Aside from being just way too big for most of our string fields, this prevents creation of the indexes over these fields in SQLServer.  This PR updates the domain sizes for the two audit domains mentioned in the issue. A spot check of other audit domains suggests we have lots of fields that are too big, but that's likely not a problem unless attempting to create indexes over the fields. I will leave a full audit of the audit fields to a different branch.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Update field sizes for some audit domains to match the corresponding field sizes in the domains being audited.
