### PR TITLE
Issue 49233: Use proper container for checking name requirements for samples

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -1375,7 +1375,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             // sampleset.createSampleNames() + generate lsid
             // TODO: does not handle insertIgnore
             DataIterator names = new _GenerateNamesDataIterator(sampleType, container, user, DataIteratorUtil.wrapMap(dataIterator, false), context, batchSize)
-                    .setAllowUserSpecifiedNames(NameExpressionOptionService.get().allowUserSpecifiedNames(sampleType.getContainer()))
+                    .setAllowUserSpecifiedNames(NameExpressionOptionService.get().allowUserSpecifiedNames(container))
                     .addExtraPropsFn(() -> {
                         if (container != null)
                             return Map.of(NameExpressionOptionService.FOLDER_PREFIX_TOKEN, StringUtils.trimToEmpty(NameExpressionOptionService.get().getExpressionPrefix(container)));


### PR DESCRIPTION
#### Rationale
Issue [49233](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49233) since the setting for whether user-provided ids are allowed is specified on the container, we need to use that container rather than the sample type's container for checking what's allowed.

#### Related Pull Requests
* https://github.com/LabKey/sampleManagement/pull/2283

#### Changes
* Update container used for checking id settings.
