### PR TITLE
PostgreSQL connections: set preparedStatementCacheQueries=0

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1768,7 +1768,7 @@ public class DbScope
                     // then set our default application name on the data source so it's set on every connection.
                     if (applicationName.equals(dialect.getDefaultApplicationName()))
                     {
-                        // Set LabKey's default application name ("LabKey Server") into the connectinon properties
+                        // Set LabKey's default application name ("LabKey Server") into the connection properties
                         applicationName = ds.setDefaultApplicationName();
                         LOG.info(message + " (the default name); all subsequent connections will use \"" + applicationName + "\" instead.");
                     }

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -762,6 +762,7 @@ public abstract class PostgreSql91Dialect extends SqlDialect
         if (dataSource.isPrimary())
         {
             dataSource.setConnectionProperty("preparedThreshold", "0");
+            dataSource.setConnectionProperty("preparedStatementCacheQueries", "0");
         }
     }
 


### PR DESCRIPTION
#### Rationale
There are [test failures](https://teamcity.labkey.org/buildConfiguration/LabKey_2311Release_Premium_ProductSuites_Biologics_BiologicsAPostgres/2786728?hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false&expandBuildChangesSection=true) in CI due to the server logging an exception:

![image](https://github.com/LabKey/platform/assets/3926239/05a40ccd-030d-4489-be79-7fd7355a29b7)

Originally, I'd thought that setting `preparedThreshold=0` should suffice in disabling the caching behavior, however, that doesn't appear to be correct. From the [PostgreSQL JDBC docs](https://jdbc.postgresql.org/documentation/use/#connection-parameters):

<p align="center">
<img width="650" alt="image" src="https://github.com/LabKey/platform/assets/3926239/ccd4014f-b298-4f6d-b3ed-2799c4a972fc">
</p>

I've elected to additionally add `preparedStatementCacheQueries=0`, however, it could be sufficient for [Issue 49216](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49216) that we only need to set this parameter and can remove `preparedThreshold=0`.

#### Related Pull Requests
* #5017

#### Changes
* Set `preparedStatementCacheQueries=0` for PostgreSQL connections
