### PR TITLE
Issue 49036: Include containerFilter in sample table info for NAb PercentNeutralizationInitialDilution calculation

### DIFF
--- a/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
+++ b/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
@@ -138,7 +138,7 @@ public class NAbSpecimenTable extends FilteredTable<AssayProtocolSchema>
         // Issue 49036: InitialDilution does not always equal MinDilution (i.e. method Dilution vs Concentration)
         // so we need to join to the sample type table to get the InitialDilution value
         SamplesSchema schema = new SamplesSchema(_userSchema);
-        TableInfo samplesTable = schema.getTable(SAMPLE_TYPE_NAME_PREFIX + _protocol.getName(), null);
+        TableInfo samplesTable = schema.getTable(SAMPLE_TYPE_NAME_PREFIX + _protocol.getName(), getContainerFilter());
         if (samplesTable != null && samplesTable.getColumn("InitialDilution") != null)
         {
             List<ColumnInfo> columns = Arrays.asList(samplesTable.getColumn("LSID"), samplesTable.getColumn("InitialDilution"));


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49036

The related PR fixed the issue for the NAb PercentNeutralizationInitialDilution calculation by joining to the NAb samples table to get the initial dilution for the calc where clause. However, the container filter was not passed through to the TableInfo for the samples table, so this resulted in blank value in the NAb Link to Study dataset when the NAb run was in a subfolder of the assay design container.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4936

#### Changes
* Include containerFilter in sample table info for NAb PercentNeutralizationInitialDilution calculation
