### PR TITLE
Issues 49200 (standardized sample unit) and 49246 (remove redundant index)

### DIFF
--- a/api/src/org/labkey/api/data/PropertyStorageSpec.java
+++ b/api/src/org/labkey/api/data/PropertyStorageSpec.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -464,6 +465,24 @@ public class PropertyStorageSpec
             return piColumns.isEmpty();
         }
 
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+
+            Index otherIndex = (Index) obj;
+            if (!isSameIndex(this, otherIndex))
+                return false;
+
+            return this.isClustered == otherIndex.isClustered;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(Arrays.hashCode(columnNames), isClustered, isClustered);
+        }
     }
 
     public enum Special

--- a/core/src/org/labkey/core/query/UserAuditProvider.java
+++ b/core/src/org/labkey/core/query/UserAuditProvider.java
@@ -143,13 +143,12 @@ public class UserAuditProvider extends AbstractAuditTypeProvider implements Audi
         @Override
         public Set<PropertyStorageSpec.Index> getPropertyIndices(Domain domain)
         {
-            Set<PropertyStorageSpec.Index> indexes = super.getPropertyIndices(domain)
-                    .stream()
-                    .filter(index -> index.columnNames.length != 1 || !index.columnNames[0].equalsIgnoreCase(COLUMN_NAME_CREATED))
-                    .collect(Collectors.toSet());
-           indexes.add(new PropertyStorageSpec.Index(false, COLUMN_NAME_USER));
-           indexes.add(new PropertyStorageSpec.Index(false, COLUMN_NAME_CREATED, COLUMN_NAME_USER));
-           return indexes;
+            PropertyStorageSpec.Index createdIndex = new PropertyStorageSpec.Index(false,  "Created");
+            Set<PropertyStorageSpec.Index> indexes = super.getPropertyIndices(domain);
+            indexes.remove(createdIndex);
+            indexes.add(new PropertyStorageSpec.Index(false, COLUMN_NAME_USER));
+            indexes.add(new PropertyStorageSpec.Index(false, COLUMN_NAME_CREATED, COLUMN_NAME_USER));
+            return indexes;
         }
 
         @Override

--- a/core/src/org/labkey/core/query/UserAuditProvider.java
+++ b/core/src/org/labkey/core/query/UserAuditProvider.java
@@ -142,9 +142,11 @@ public class UserAuditProvider extends AbstractAuditTypeProvider implements Audi
         @Override
         public Set<PropertyStorageSpec.Index> getPropertyIndices(Domain domain)
         {
-            Set<PropertyStorageSpec.Index> indexes = super.getPropertyIndices(domain);
-            indexes.add(new PropertyStorageSpec.Index(false, COLUMN_NAME_USER));
-            indexes.add(new PropertyStorageSpec.Index(false, COLUMN_NAME_CREATED, COLUMN_NAME_USER));
+            Set<PropertyStorageSpec.Index> indexes = PageFlowUtil.set(
+                new PropertyStorageSpec.Index(false, "Container"),
+                new PropertyStorageSpec.Index(false, COLUMN_NAME_USER),
+                new PropertyStorageSpec.Index(false, COLUMN_NAME_CREATED, COLUMN_NAME_USER)
+            );
             return indexes;
         }
 

--- a/core/src/org/labkey/core/query/UserAuditProvider.java
+++ b/core/src/org/labkey/core/query/UserAuditProvider.java
@@ -39,6 +39,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * User: klum
@@ -142,12 +143,13 @@ public class UserAuditProvider extends AbstractAuditTypeProvider implements Audi
         @Override
         public Set<PropertyStorageSpec.Index> getPropertyIndices(Domain domain)
         {
-            Set<PropertyStorageSpec.Index> indexes = PageFlowUtil.set(
-                new PropertyStorageSpec.Index(false, "Container"),
-                new PropertyStorageSpec.Index(false, COLUMN_NAME_USER),
-                new PropertyStorageSpec.Index(false, COLUMN_NAME_CREATED, COLUMN_NAME_USER)
-            );
-            return indexes;
+            Set<PropertyStorageSpec.Index> indexes = super.getPropertyIndices(domain)
+                    .stream()
+                    .filter(index -> index.columnNames.length != 1 || !index.columnNames[0].equalsIgnoreCase(COLUMN_NAME_CREATED))
+                    .collect(Collectors.toSet());
+           indexes.add(new PropertyStorageSpec.Index(false, COLUMN_NAME_USER));
+           indexes.add(new PropertyStorageSpec.Index(false, COLUMN_NAME_CREATED, COLUMN_NAME_USER));
+           return indexes;
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -1817,7 +1817,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             protected Object convert(Object o)
             {
                 Measurement.validateUnits((String) o, _metricUnit);
-                return o;
+                return Measurement.Unit.getUnit((String) o);
             }
         }
 


### PR DESCRIPTION
#### Rationale
Issue [49200:](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49200) - When importing with units that do not match the standard, we were matching properly, but leaving the non-standard casing in the data. This PR updates the conversion to always return a Units value.
Issue [49246](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49246) - inadvertently created a redundant index for the User Audit Domain when adding the `Created` index in the base class

#### Related Pull Requests
* #4830 

#### Changes
* In `UserAuditProvider`, don't call the base class method that creates the redundant index
* Update `SampleUnitsConvertColumn` to have the `convert` method return the standardized measurement unit.
