### PR TITLE
Issue 49131: Always calculate the values for the first N-1 samples, based on their sequence

### DIFF
--- a/api/src/org/labkey/api/visualization/Stats.java
+++ b/api/src/org/labkey/api/visualization/Stats.java
@@ -166,7 +166,7 @@ public class Stats
      */
     public static Double[] getTrailingMeans(Double[] values, int N)
     {
-        if (values == null || values.length <= 1 || values.length <= N)
+        if (values == null || values.length <= 1)
             return new Double[0];
 
         Double[] trailingMeans = new Double[values.length];
@@ -177,17 +177,12 @@ public class Stats
         {
             // Issue 49131: At the very beginning of the folder's date range, always calculate the values for the first N-1 samples,
             // based on their sequence. And so on until you hit N, when we start using the moving window.
-            if (i < N)
-            {
-                trailingMeans[i] = getMean(getValuesFromRange(values, start, end));
-                end++;
-            }
-            else
+            if (i >= N)
             {
                 start++;
-                trailingMeans[i] = getMean(getValuesFromRange(values, start, end));
-                end++;
             }
+            trailingMeans[i] = getMean(getValuesFromRange(values, start, end));
+            end++;
         }
 
         return trailingMeans;
@@ -213,40 +208,30 @@ public class Stats
         {
             // Issue 49131: At the very beginning of the folder's date range, always calculate the values for the first N-1 samples,
             // based on their sequence. And so on until you hit N, when we start using the moving window.
-            if (i < N)
-            {
-                Double[] vals = getValuesFromRange(values, start, end);
-                double sd = getStdDev(vals, false);
-                double mean = getMean(vals);
-                if (mean == 0)
-                {
-                    trailingCVs[i] = null;
-                }
-                else
-                {
-                    trailingCVs[i] = sd / mean * 100;
-                }
-                end++;
-            }
-            else
+            if (i >= N)
             {
                 start++;
-                Double[] vals = getValuesFromRange(values, start, end);
-                double sd = getStdDev(vals, false);
-                double mean = getMean(vals);
-                if (mean == 0)
-                {
-                    trailingCVs[i] = null;
-                }
-                else
-                {
-                    trailingCVs[i] = sd / mean * 100;
-                }
-                end++;
             }
+            calcCV(values, trailingCVs, start, end, i);
+            end++;
         }
 
         return trailingCVs;
+    }
+
+    private static void calcCV(Double[] values, Double[] trailingCVs, int start, int end, int i)
+    {
+        Double[] vals = getValuesFromRange(values, start, end);
+        double sd = getStdDev(vals, false);
+        double mean = getMean(vals);
+        if (mean == 0)
+        {
+            trailingCVs[i] = null;
+        }
+        else
+        {
+            trailingCVs[i] = sd / mean * 100;
+        }
     }
 
     private static Double[] getValuesFromRange(Double[] values, int start, int end)

--- a/api/src/org/labkey/api/visualization/Stats.java
+++ b/api/src/org/labkey/api/visualization/Stats.java
@@ -197,7 +197,7 @@ public class Stats
      */
     public static Double[] getTrailingCVs(Double[] values, int N)
     {
-        if (values == null || values.length <= 1 || values.length <= N)
+        if (values == null || values.length <= 1)
             return new Double[0];
 
         Double[] trailingCVs = new Double[values.length];


### PR DESCRIPTION
#### Rationale
This PR changes the trailing means and trailing cvs calculation helper to always calculate the values for the first N-1 samples, based on their sequence. For example, the first sample's data point for trailing mean should be the raw value of the first point, and the CV should be 0. The second sample's trailing mean should be the mean of the first and second point, and their CVs. And so on until you hit N, when we start using the moving window.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/798
