### PR TITLE
49253: unable to import samples with storage using auto link-to-study

### DIFF
--- a/study/src/org/labkey/study/assay/StudyPublishManager.java
+++ b/study/src/org/labkey/study/assay/StudyPublishManager.java
@@ -101,8 +101,10 @@ import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
+import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewBackgroundInfo;
+import org.labkey.api.view.ViewContext;
 import org.labkey.study.StudySchema;
 import org.labkey.study.StudyServiceImpl;
 import org.labkey.study.assay.query.PublishAuditProvider;
@@ -1680,15 +1682,16 @@ public class StudyPublishManager implements StudyPublishService
             // optionally add columns added through a view, useful for picking up any lineage fields
             if (qs != null)
             {
-                QueryView view = new QueryView(userSchema, qs, null);
-                // Issue 45238 - configure as API style invocation to skip setting up buttons and other items that
-                // rely on being invoked inside an HTTP request/ViewContext
-                view.setApiResponseView(true);
-                DataView dataView = view.createDataView();
-                for (Map.Entry<FieldKey, ColumnInfo> entry : dataView.getDataRegion().getSelectColumns().entrySet())
+                if (HttpView.hasCurrentView())
+                    getViewColumns(userSchema, qs, columns);
+                else
                 {
-                    if (!columns.containsKey(entry.getKey()))
-                        columns.put(entry.getKey(), entry.getValue());
+                    // Issue 49253 : the QueryView needs a view context to initialize properly. If we are running in a background job
+                    // push a fake view context onto the stack and remove it when we are done
+                    try (ViewContext.StackResetter ignored = ViewContext.pushMockViewContext(user, container, new ActionURL()))
+                    {
+                        getViewColumns(userSchema, qs, columns);
+                    }
                 }
             }
 
@@ -1722,5 +1725,19 @@ public class StudyPublishManager implements StudyPublishService
             }
         }
         return fieldKeyMap;
+    }
+
+    private void getViewColumns(UserSchema userSchema, QuerySettings qs, Map<FieldKey, ColumnInfo> columns)
+    {
+        QueryView view = new QueryView(userSchema, qs, null);
+        // Issue 45238 - configure as API style invocation to skip setting up buttons and other items that
+        // rely on being invoked inside an HTTP request/ViewContext
+        view.setApiResponseView(true);
+        DataView dataView = view.createDataView();
+        for (Map.Entry<FieldKey, ColumnInfo> entry : dataView.getDataRegion().getSelectColumns().entrySet())
+        {
+            if (!columns.containsKey(entry.getKey()))
+                columns.put(entry.getKey(), entry.getValue());
+        }
     }
 }


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49253)

When samples are imported in the background and there is an automatic link to study configured for that sample type, the import will succeed, but the link to study will fail. Part of the link to study process involves creating a `QueryView` to get the default columns, QV's need to be on the end of a request in order to initialize correctly, otherwise bad things happen. The pattern that is usually followed in this case is to push a `MockViewContext` onto the stack to keep the view happy.
