### PR TITLE
Issue 48715: Limit Data Region "Show all" to a maximum number of rows

### DIFF
--- a/api/src/org/labkey/api/view/DefaultWebPartFactory.java
+++ b/api/src/org/labkey/api/view/DefaultWebPartFactory.java
@@ -18,6 +18,7 @@ package org.labkey.api.view;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.UnexpectedException;
 
 /**
@@ -45,7 +46,7 @@ public class DefaultWebPartFactory extends BaseWebPartFactory
     public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         if (!portalCtx.hasPermission(ReadPermission.class))
-            return new HtmlView("Not Authorized", portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data");
+            return new HtmlView("Not Authorized", HtmlString.of(portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data"));
 
         try
         {

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3539,7 +3539,7 @@ if (!LABKEY.DataRegions) {
 
             msg += "&nbsp;" + "<span class='labkey-button select-none'>Select None</span>";
             var showOpts = [];
-            if (region.showRows !== 'all')
+            if (region.showRows !== 'all' && region.maxRows !== ALL_ROWS_MAX)
                 showOpts.push("<span class='labkey-button show-all'>Show All</span>");
             if (region.showRows !== 'selected')
                 showOpts.push("<span class='labkey-button show-selected'>Show Selected</span>");

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -12,8 +12,10 @@ if (!LABKEY.DataRegions) {
     //
     // CONSTANTS
     //
+    // Issue 48715: Limit the number of rows that can be displayed in a data region
+    var ALL_ROWS_MAX = 1_000;
     var CUSTOM_VIEW_PANELID = '~~customizeView~~';
-    var DEFAULT_TIMEOUT = 30000;
+    var DEFAULT_TIMEOUT = 30_000;
     var PARAM_PREFIX = '.param.';
     var SORT_ASC = '+';
     var SORT_DESC = '-';
@@ -31,7 +33,7 @@ if (!LABKEY.DataRegions) {
     var SHOW_ROWS_PREFIX = '.showRows';
     var VIEWNAME_PREFIX = '.viewName';
 
-    // 33536: These prefixes should match the URL parameter key exactly
+    // Issue 33536: These prefixes should match the URL parameter key exactly
     var EXACT_MATCH_PREFIXES = [
         COLUMNS_PREFIX,
         CONTAINER_FILTER_NAME,
@@ -213,7 +215,7 @@ if (!LABKEY.DataRegions) {
 
         if (config.buttonBar && config.buttonBar.items && LABKEY.Utils.isArray(config.buttonBar.items)) {
             // Be tolerant of the caller passing in undefined items, as pageSize has been removed as an option. Strip
-            // them out so they don't cause problems downstream. See issue 34562
+            // them out so they don't cause problems downstream. See Issue 34562.
             config.buttonBar.items = config.buttonBar.items.filter(function (value, index, arr) {
                 return value;
             });
@@ -854,7 +856,7 @@ if (!LABKEY.DataRegions) {
     var _selClickLock; // lock to prevent removing a row highlight that was just applied
     var _selDocClick; // global (shared across all Data Region instances) click event handler instance
 
-    // 32898: Clear row highlights on document click
+    // Issue 32898: Clear row highlights on document click
     var _onDocumentClick = function() {
         if (_selClickLock) {
             var form = _getFormSelector(_selClickLock);
@@ -1349,7 +1351,7 @@ if (!LABKEY.DataRegions) {
      * Clear the message box contents.
      */
     LABKEY.DataRegion.prototype.clearMessage = function() {
-        if (this.msgbox) this.msgbox.clear();
+        if (this.msgbox) this.msgbox.removeAll();
     };
 
     /**
@@ -1636,7 +1638,9 @@ if (!LABKEY.DataRegions) {
 
                     var offsets = [20, 40, 100, 250];
                     if (this.maxRows > 0 && offsets.indexOf(this.maxRows) === -1) {
-                        offsets.push(this.maxRows);
+                        if (this.maxRows !== ALL_ROWS_MAX) {
+                            offsets.push(this.maxRows);
+                        }
                         offsets = offsets.sort(function(a, b) { return a - b; });
                     }
 
@@ -1659,7 +1663,11 @@ if (!LABKEY.DataRegions) {
                     //bind functions to menu items
                     _getShowFirstSelector(this).click(_firstPage.bind(this));
                     _getShowLastSelector(this).click(_lastPage.bind(this));
-                    _getShowAllSelector(this).click(_showRows.bind(this, this, 'all'));
+                    _getShowAllSelector(this).click(this.showAllRows.bind(this));
+
+                    if (this.maxRows === ALL_ROWS_MAX && this.totalRows > this.maxRows) {
+                        this.addMessage('<span><b>Show all:</b> Displaying the first ' + ALL_ROWS_MAX.toLocaleString() + ' rows. Use paging to see more results.</span>');
+                    }
 
                     for (var key in offsetIds) {
                         if (offsetIds.hasOwnProperty(key)) {
@@ -1715,7 +1723,7 @@ if (!LABKEY.DataRegions) {
     };
 
     var _showAllEnabled = function(region) {
-        return _showFirstEnabled(region) || _showLastEnabled(region);
+        return (_showFirstEnabled(region) || _showLastEnabled(region)) && region.maxRows !== ALL_ROWS_MAX;
     };
 
     var _getPaginationText = function(region) {
@@ -1768,7 +1776,7 @@ if (!LABKEY.DataRegions) {
      * Forces the grid to show all rows, without any paging
      */
     LABKEY.DataRegion.prototype.showAllRows = function() {
-        _showRows(this, 'all');
+        _setMaxRows.bind(this, ALL_ROWS_MAX)();
     };
 
     /**
@@ -1912,7 +1920,7 @@ if (!LABKEY.DataRegions) {
             ctxBar.find('.ctx-clear-all').off('click').on('click', $.proxy(this.clearAllFilters, this));
         }
 
-        // 35396: Support ButtonBarOptions <onRender>
+        // Issue 35396: Support ButtonBarOptions <onRender>
         if (LABKEY.Utils.isArray(this.buttonBarOnRenders)) {
             for (var i=0; i < this.buttonBarOnRenders.length; i++) {
                 var scriptFnName = this.buttonBarOnRenders[i];
@@ -3212,7 +3220,7 @@ if (!LABKEY.DataRegions) {
                             return;
                         }
                         else if (REQUIRE_NAME_PREFIX.hasOwnProperty(key)) {
-                            // 26686: Block known parameters, should be prefixed by region name
+                            // Issue 26686: Block known parameters, should be prefixed by region name
                             return;
                         }
 
@@ -3759,7 +3767,7 @@ if (!LABKEY.DataRegions) {
 
         _processButtonBar(region, json);
 
-        // 10505: add non-removable sorts and filters to json (not url params).
+        // Issue 10505: add non-removable sorts and filters to json (not url params).
         if (region.sort || region.filters || region.aggregates) {
             json.filters = {};
 
@@ -3927,9 +3935,7 @@ if (!LABKEY.DataRegions) {
 
         if (newParams) {
             newParams.forEach(function(pair) {
-                //
-                // Filters may repeat themselves #25337
-                //
+                // Issue 25337: Filters may repeat themselves
                 if (_isFilter(region, pair[0])) {
                     if (params[pair[0]] == undefined) {
                         params[pair[0]] = [];
@@ -3955,10 +3961,7 @@ if (!LABKEY.DataRegions) {
             });
         }
 
-        //
-        // 40226: Don't include parameters that are being logically excluded
-        //
-
+        // Issue 40226: Don't include parameters that are being logically excluded
         if (skipPrefixes) {
             skipPrefixes.forEach(function(skipKey) {
                 if (params.hasOwnProperty(skipKey) && !newParamPrefixes.hasOwnProperty(skipKey)) {
@@ -4029,7 +4032,7 @@ if (!LABKEY.DataRegions) {
             _showSelectMessage(region, msg);
         }
 
-        // 10566: for javascript perf on IE stash the requires selection buttons
+        // Issue 10566: for javascript perf on IE stash the requires selection buttons
         if (!region._requiresSelectionButtons) {
             // escape ', ", and \
             var escaped = region.name.replace(/('|"|\\)/g, "\\$1");
@@ -4294,7 +4297,7 @@ if (!LABKEY.DataRegions) {
                 .on('resize', resizeTask)
                 .on('scroll', onScroll);
         $(document)
-                .on('DOMNodeInserted', domTask); // 13121
+                .on('DOMNodeInserted', domTask); // Issue 13121
 
         // ensure that resize/scroll fire at the end of initialization
         domTask();

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -13,7 +13,7 @@ if (!LABKEY.DataRegions) {
     // CONSTANTS
     //
     // Issue 48715: Limit the number of rows that can be displayed in a data region
-    var ALL_ROWS_MAX = 1_000;
+    var ALL_ROWS_MAX = 5_000;
     var CUSTOM_VIEW_PANELID = '~~customizeView~~';
     var DEFAULT_TIMEOUT = 30_000;
     var PARAM_PREFIX = '.param.';
@@ -1638,7 +1638,7 @@ if (!LABKEY.DataRegions) {
 
                     var offsets = [20, 40, 100, 250];
                     if (this.maxRows > 0 && offsets.indexOf(this.maxRows) === -1) {
-                        if (this.maxRows !== ALL_ROWS_MAX) {
+                        if (!_isMaxRowsAllRows(this)) {
                             offsets.push(this.maxRows);
                         }
                         offsets = offsets.sort(function(a, b) { return a - b; });
@@ -1665,7 +1665,7 @@ if (!LABKEY.DataRegions) {
                     _getShowLastSelector(this).click(_lastPage.bind(this));
                     _getShowAllSelector(this).click(this.showAllRows.bind(this));
 
-                    if (this.maxRows === ALL_ROWS_MAX && this.totalRows > this.maxRows) {
+                    if (_isMaxRowsAllRows(this) && this.totalRows > this.maxRows) {
                         this.addMessage('<span><b>Show all:</b> Displaying the first ' + ALL_ROWS_MAX.toLocaleString() + ' rows. Use paging to see more results.</span>');
                     }
 
@@ -1723,7 +1723,7 @@ if (!LABKEY.DataRegions) {
     };
 
     var _showAllEnabled = function(region) {
-        return (_showFirstEnabled(region) || _showLastEnabled(region)) && region.maxRows !== ALL_ROWS_MAX;
+        return (_showFirstEnabled(region) || _showLastEnabled(region)) && !_isMaxRowsAllRows(region);
     };
 
     var _getPaginationText = function(region) {
@@ -1772,8 +1772,12 @@ if (!LABKEY.DataRegions) {
         return false;
     };
 
+    var _isMaxRowsAllRows = function(region) {
+        return region.maxRows === ALL_ROWS_MAX;
+    };
+
     /**
-     * Forces the grid to show all rows, without any paging
+     * Forces the grid to show all rows, up to ALL_ROWS_MAX, without any paging
      */
     LABKEY.DataRegion.prototype.showAllRows = function() {
         _setMaxRows.bind(this, ALL_ROWS_MAX)();
@@ -3539,7 +3543,7 @@ if (!LABKEY.DataRegions) {
 
             msg += "&nbsp;" + "<span class='labkey-button select-none'>Select None</span>";
             var showOpts = [];
-            if (region.showRows !== 'all' && region.maxRows !== ALL_ROWS_MAX)
+            if (region.showRows !== 'all' && !_isMaxRowsAllRows(region))
                 showOpts.push("<span class='labkey-button show-all'>Show All</span>");
             if (region.showRows !== 'selected')
                 showOpts.push("<span class='labkey-button show-selected'>Show Selected</span>");

--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -898,8 +898,9 @@ LABKEY.Utils = new function(impl, $) {
         const fn = function()
         {
             const list = document.querySelectorAll(selector);
-            for (let i in list)
-                list[i]['on' + eventName] = handler;
+            list.forEach(function(element) {
+                element['on' + eventName] = handler;
+            });
         };
         (immediate || document.readyState!=="loading") ? fn() : document.addEventListener('load', fn);
     };

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1032,16 +1032,16 @@ public class LoginController extends SpringActionController
 
         if (ModuleLoader.getInstance().isUpgradeRequired() || ModuleLoader.getInstance().isUpgradeInProgress())
         {
-            HtmlView updateMessageView = new HtmlView("Server upgrade in progress",
+            HtmlView updateMessageView = new HtmlView("Server upgrade in progress", HtmlString.unsafe(
                     "This server is being upgraded to a new version of LabKey Server.<br/>" +
-                    "Only Site Administrators are permitted to log in during the upgrade process.");
+                    "Only Site Administrators are permitted to log in during the upgrade process."));
             vBox.addView(updateMessageView);
         }
         else if (!ModuleLoader.getInstance().isStartupComplete())
         {
-            HtmlView startupMessageView = new HtmlView("Server startup in progress",
+            HtmlView startupMessageView = new HtmlView("Server startup in progress", HtmlString.unsafe(
                     "This server is starting up.<br/>" +
-                    "Only Site Administrators are permitted to log in during the startup process.");
+                    "Only Site Administrators are permitted to log in during the startup process."));
             vBox.addView(startupMessageView);
         }
         else if (isAdminOnlyMode())

--- a/devtools/src/org/labkey/devtools/TestController.java
+++ b/devtools/src/org/labkey/devtools/TestController.java
@@ -788,7 +788,7 @@ public class TestController extends SpringActionController
         public ModelAndView getView(Object o, BindException errors)
         {
             String title = getViewContext().getActionURL().getParameter("title");
-            return new HtmlView(title, "This is my HTML");
+            return new HtmlView(title, HtmlString.of("This is my HTML"));
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4899,10 +4899,11 @@ public class ExperimentController extends SpringActionController
                 message = "Could not map lsid to URL";
             }
 
-            String html = message + "<form action=\"" + getViewContext().cloneActionURL().setAction(ResolveLSIDAction.class) + "\">" +
-                    " Lsid <input type=text name=lsid size=\"80\" value=\"" +
-                    (form.getLsid() == null ? "" : PageFlowUtil.filter(form.getLsid())) + "\">" +
-                    PageFlowUtil.button("Go").submit(true) + "</form>";
+            HtmlStringBuilder html = HtmlStringBuilder.of();
+            html.append(message).unsafeAppend("<form action=\"").append(getViewContext().cloneActionURL().setAction(ResolveLSIDAction.class).toString()).unsafeAppend("\">")
+                    .unsafeAppend(" Lsid <input type=text name=lsid size=\"80\" value=\"")
+                    .append(form.getLsid() == null ? "" : form.getLsid()).unsafeAppend("\">")
+                    .append(PageFlowUtil.button("Go").submit(true)).unsafeAppend("</form>");
 
             return new HtmlView("Enter LSID", html);
         }
@@ -7696,8 +7697,8 @@ public class ExperimentController extends SpringActionController
                 List<? extends ExpSampleType> sampleTypes = SampleTypeService.get()
                         .getSampleTypes(container, user, true);
 
-                StringBuilder builder = new StringBuilder();
-                builder.append("<table class=\"DataRegion\"><tr><th>Sample Type</th><th>#Recomputed</th></tr>");
+                HtmlStringBuilder builder = HtmlStringBuilder.of();
+                builder.unsafeAppend("<table class=\"DataRegion\"><tr><th>Sample Type</th><th>#Recomputed</th></tr>");
 
                 SampleTypeService service = SampleTypeService.get();
                 for (ExpSampleType sampleType : sampleTypes)
@@ -7705,15 +7706,15 @@ public class ExperimentController extends SpringActionController
                     int updatedCount;
                     updatedCount = service.recomputeSampleTypeRollup(sampleType, container);
                     SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(sampleType, false);
-                    builder.append("<tr><td>")
+                    builder.unsafeAppend("<tr><td>")
                             .append(sampleType.getName())
-                            .append("</td><td>")
+                            .unsafeAppend("</td><td>")
                             .append(updatedCount)
-                            .append("</td></tr>");
+                            .unsafeAppend("</td></tr>");
                 }
 
-                builder.append("</table>");
-                return new HtmlView("Aliquot Rollup Recalculation Result", builder.toString());
+                builder.unsafeAppend("</table>");
+                return new HtmlView("Aliquot Rollup Recalculation Result", builder);
             }
         }
     }

--- a/list/src/org/labkey/list/view/SingleListWebPartFactory.java
+++ b/list/src/org/labkey/list/view/SingleListWebPartFactory.java
@@ -22,6 +22,7 @@ import org.labkey.api.admin.FolderImportContext;
 import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListService;
 import org.labkey.api.query.QuerySettings;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.view.AlwaysAvailableWebPartFactory;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
@@ -57,7 +58,7 @@ public class SingleListWebPartFactory extends AlwaysAvailableWebPartFactory
         String title = (null == props.get("title") ? "List" : props.get("title"));
 
         if (null == listNameParam && null == listIdParam)
-            return new HtmlView(title, "There is no list selected to be displayed in this webpart");
+            return new HtmlView(title, HtmlString.of("There is no list selected to be displayed in this webpart"));
 
         ListQueryForm form;
 
@@ -73,7 +74,7 @@ public class SingleListWebPartFactory extends AlwaysAvailableWebPartFactory
             }
             catch (NumberFormatException e)
             {
-                return new HtmlView(title, "List id is invalid");
+                return new HtmlView(title, HtmlString.of("List id is invalid"));
             }
         }
 
@@ -81,7 +82,7 @@ public class SingleListWebPartFactory extends AlwaysAvailableWebPartFactory
         form.bindParameters(portalCtx.getBindPropertyValues());
 
         if (null == form.getList())
-            return new HtmlView(title, "List does not exist");
+            return new HtmlView(title, HtmlString.of("List does not exist"));
 
         form.setViewName(viewName);
         return new SingleListWebPart(form, props);

--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -1226,7 +1226,7 @@ public class PipelineController extends SpringActionController
                 _archiveFile = PipelineManager.validateFolderImportFileNioPath(form.getFilePath(), currentPipelineRoot, errors);
 
                 // Be sure that the set of folder to apply the import to match the setting to enable/disable them
-                if (form.isApplyToMultipleFolders() && (form.getFolderRowIds() == null || form.getFolderRowIds().size() == 0))
+                if (form.isApplyToMultipleFolders() && (form.getFolderRowIds() == null || form.getFolderRowIds().isEmpty()))
                 {
                     errors.reject(ERROR_MSG, "At least one folder must be selected when 'apply to multiple folders' is enabled.");
                 }
@@ -1266,7 +1266,7 @@ public class PipelineController extends SpringActionController
                 }
 
                 // Be sure that the provided data types to import match the setting to enable/disable them
-                if (form.isSpecificImportOptions() && (form.getDataTypes() == null || form.getDataTypes().size() == 0))
+                if (form.isSpecificImportOptions() && (form.getDataTypes() == null || form.getDataTypes().isEmpty()))
                 {
                     errors.reject(ERROR_MSG, "At least one folder data type must be selected when 'select specific objects to import' is enabled.");
                 }

--- a/pipeline/src/org/labkey/pipeline/startPipelineImport.jsp
+++ b/pipeline/src/org/labkey/pipeline/startPipelineImport.jsp
@@ -62,7 +62,7 @@
 <labkey:errors/>
 <labkey:form id="<%=importFormId%>" action="<%=urlFor(StartFolderImportAction.class)%>" method="post">
     <input type="hidden" name="fromZip" value=<%=bean.isFromZip()%>>
-    <input type="hidden" name="filePath" value=<%=q(bean.getFilePath())%>>
+    <input type="hidden" name="filePath" value="<%=h(bean.getFilePath())%>">
     <div id="startPipelineImportForm"></div>
 </labkey:form>
 

--- a/specimen/src/org/labkey/specimen/view/SpecimenSearchWebPartFactory.java
+++ b/specimen/src/org/labkey/specimen/view/SpecimenSearchWebPartFactory.java
@@ -3,6 +3,7 @@ package org.labkey.specimen.view;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.study.StudyService;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.view.DefaultWebPartFactory;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.Portal;
@@ -21,10 +22,10 @@ public class SpecimenSearchWebPartFactory extends DefaultWebPartFactory
     public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         if (!portalCtx.hasPermission(ReadPermission.class))
-            return new HtmlView("Specimens", portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data");
+            return new HtmlView("Specimens", HtmlString.of(portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data"));
 
         if (null == StudyService.get().getStudy(portalCtx.getContainer()))
-            return new HtmlView("Specimens", "This folder does not contain a study.");
+            return new HtmlView("Specimens", HtmlString.of("This folder does not contain a study."));
         return new SpecimenSearchWebPart(true);
     }
 }

--- a/specimen/src/org/labkey/specimen/view/SpecimenWebPartFactory.java
+++ b/specimen/src/org/labkey/specimen/view/SpecimenWebPartFactory.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.view.DefaultWebPartFactory;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
@@ -24,11 +25,11 @@ public class SpecimenWebPartFactory extends DefaultWebPartFactory
     public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         if (!portalCtx.hasPermission(ReadPermission.class))
-            return new HtmlView("Specimens", portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data");
+            return new HtmlView("Specimens", HtmlString.of(portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data"));
 
         Study study = StudyService.get().getStudy(portalCtx.getContainer());
         if (null == study)
-            return new HtmlView("Specimens", "This folder does not contain a study.");
+            return new HtmlView("Specimens", HtmlString.of("This folder does not contain a study."));
         return new SpecimenWebPart(webPart.getLocation().equals(HttpView.BODY), study);
     }
 }

--- a/study/src/org/labkey/study/StudyMacroProvider.java
+++ b/study/src/org/labkey/study/StudyMacroProvider.java
@@ -17,6 +17,7 @@
 package org.labkey.study;
 
 import org.labkey.api.reports.Report;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
@@ -73,6 +74,6 @@ public class StudyMacroProvider implements MacroProvider
             }
         }
         else
-            return new HtmlView(null, "No such macro, study:" + PageFlowUtil.filter(name) + "<br>");
+            return HtmlView.of("No such macro, study:" + name);
     }
 }

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -93,6 +93,7 @@ import org.labkey.api.study.reports.CrosstabReportDescriptor;
 import org.labkey.api.study.security.StudySecurityEscalationAuditProvider;
 import org.labkey.api.study.security.permissions.ManageStudyPermission;
 import org.labkey.api.usageMetrics.UsageMetricsService;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.JspTestCase;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.SystemMaintenance;
@@ -561,10 +562,10 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
         public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
         {
             if (!portalCtx.hasPermission(ReadPermission.class))
-                return new HtmlView("Views", portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data");
+                return new HtmlView("Views", HtmlString.of(portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data"));
 
             if (null == StudyManager.getInstance().getStudy(portalCtx.getContainer()))
-                return new HtmlView("Views", "This folder does not contain a study");
+                return new HtmlView("Views", HtmlString.of("This folder does not contain a study"));
             return new ReportsController.ReportsWebPart(!WebPartFactory.LOCATION_RIGHT.equalsIgnoreCase(webPart.getLocation()));
         }
     }
@@ -631,10 +632,10 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
         public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
         {
             if (!portalCtx.hasPermission(ReadPermission.class))
-                return new HtmlView(getDisplayName(portalCtx.getContainer(),  webPart.getLocation()), portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data");
+                return new HtmlView(getDisplayName(portalCtx.getContainer(),  webPart.getLocation()), HtmlString.of(portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data"));
 
             if (null == StudyManager.getInstance().getStudy(portalCtx.getContainer()))
-                return new HtmlView("Subject List", "This folder does not contain a study.");
+                return new HtmlView("Subject List", HtmlString.of("This folder does not contain a study."));
             return new SubjectsWebPart(portalCtx, HttpView.BODY.equals(webPart.getLocation()), webPart.getIndex());
         }
     }
@@ -660,10 +661,10 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
         public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
         {
             if (!portalCtx.hasPermission(ReadPermission.class))
-                return new HtmlView("Datasets", portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data");
+                return new HtmlView("Datasets", HtmlString.of(portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data"));
 
             if (null == StudyManager.getInstance().getStudy(portalCtx.getContainer()))
-                return new HtmlView("Datasets", "This folder does not contain a study.");
+                return new HtmlView("Datasets", HtmlString.of("This folder does not contain a study."));
 
             return new DatasetsWebPartView();
         }

--- a/study/src/org/labkey/study/view/StudySummaryWebPartFactory.java
+++ b/study/src/org/labkey/study/view/StudySummaryWebPartFactory.java
@@ -138,7 +138,7 @@ public class StudySummaryWebPartFactory extends BaseWebPartFactory
     public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         if (!portalCtx.hasPermission(ReadPermission.class))
-            return new HtmlView(NAME, portalCtx.getUser().isGuest() ? "Please log in to see this data" : "You do not have permission to see this data");
+            return new HtmlView(NAME, HtmlString.of(portalCtx.getUser().isGuest() ? "Please log in to see this data" : "You do not have permission to see this data"));
 
         BindException errors = (BindException) portalCtx.getRequest().getAttribute("errors");
         WebPartView v = new JspView<>("/org/labkey/study/view/studySummary.jsp", new StudySummaryBean(portalCtx), errors);

--- a/study/src/org/labkey/study/view/customizeParticipantView.jsp
+++ b/study/src/org/labkey/study/view/customizeParticipantView.jsp
@@ -15,10 +15,13 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.labkey.api.reports.report.ReportUrls"%>
+<%@ page import="org.labkey.api.module.ModuleHtmlView"%>
+<%@ page import="org.labkey.api.module.ModuleLoader" %>
+<%@ page import="org.labkey.api.reports.report.ReportUrls" %>
 <%@ page import="org.labkey.api.study.StudyService" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.study.StudyModule" %>
 <%@ page import="org.labkey.study.controllers.StudyController.CustomizeParticipantViewAction" %>
 <%@ page import="org.labkey.study.controllers.StudyController.CustomizeParticipantViewForm" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -106,6 +109,7 @@
 <%
     if (bean.getParticipantId() != null)
     {
+        ModuleHtmlView view = new ModuleHtmlView(ModuleLoader.getInstance().getModule(StudyModule.MODULE_NAME), "Custom Participant View", unsafe(useCustomView ? bean.getCustomScript() : bean.getDefaultScript()));
 %>
 <table width="100%">
     <tr class="labkey-wp-header">
@@ -113,7 +117,7 @@
     </tr>
     <tr>
         <td>
-            <%= unsafe(useCustomView ? bean.getCustomScript() : bean.getDefaultScript()) %>
+            <%= view.getHtml() %>
         </td>
     </tr>
 </table>

--- a/survey/src/org/labkey/survey/SurveyModule.java
+++ b/survey/src/org/labkey/survey/SurveyModule.java
@@ -42,6 +42,7 @@ import org.labkey.api.survey.SurveyService;
 import org.labkey.api.survey.model.Survey;
 import org.labkey.api.survey.model.SurveyDesign;
 import org.labkey.api.usageMetrics.UsageMetricsService;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.ReturnURLString;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.UsageReportingLevel;
@@ -178,7 +179,7 @@ public class SurveyModule extends DefaultModule
         public WebPartView getWebPartView(@NotNull ViewContext context, @NotNull Portal.WebPart webPart)
         {
             if (!context.hasPermission(AdminPermission.class))
-                return new HtmlView("Survey Designs", "You do not have permission to see this data");
+                return new HtmlView("Survey Designs", HtmlString.of("You do not have permission to see this data"));
 
             VBox view = new VBox();
             view.setTitle("Survey Designs");
@@ -187,7 +188,7 @@ public class SurveyModule extends DefaultModule
             BindException errors = new NullSafeBindException(this, "form");
             UserSchema schema = QueryService.get().getUserSchema(context.getUser(), context.getContainer(), SurveyQuerySchema.SCHEMA_NAME);
             if (schema == null)
-                return new HtmlView("Survey Designs", "The 'survey' schema is not enabled for this folder.");
+                return new HtmlView("Survey Designs", HtmlString.of("The 'survey' schema is not enabled for this folder."));
 
             QuerySettings settings = schema.getSettings(context, QueryView.DATAREGIONNAME_DEFAULT, SurveyQuerySchema.SURVEY_DESIGN_TABLE_NAME);
             settings.setReturnUrl(new ReturnURLString(context.getActionURL().clone()));
@@ -216,20 +217,20 @@ public class SurveyModule extends DefaultModule
         public WebPartView getWebPartView(@NotNull ViewContext context, @NotNull Portal.WebPart webPart)
         {
             if (!context.hasPermission(ReadPermission.class) || context.getUser().isGuest())
-                return new HtmlView("Surveys", "You do not have permission to see this data");
+                return new HtmlView("Surveys", HtmlString.of("You do not have permission to see this data"));
 
             Map<String, String> props = webPart.getPropertyMap();
 
             String designIdStr = props.get("surveyDesignId");
             SurveyDesign surveyDesign;
             if (null == designIdStr)
-                return new HtmlView("Surveys", "There is no survey design selected to be displayed in this webpart.");
+                return new HtmlView("Surveys", HtmlString.of("There is no survey design selected to be displayed in this webpart."));
             else
             {
                 surveyDesign = SurveyManager.get().getSurveyDesign(context.getContainer(), context.getUser(), Integer.parseInt(designIdStr));
 
                 if (surveyDesign == null)
-                    return new HtmlView("Surveys", "The survey design configured for this webpart cannot be found and may have been deleted.");
+                    return new HtmlView("Surveys", HtmlString.of("The survey design configured for this webpart cannot be found and may have been deleted."));
             }
 
             try
@@ -256,7 +257,7 @@ public class SurveyModule extends DefaultModule
             }
             catch (NumberFormatException e)
             {
-                return new HtmlView("Surveys", "Survey Design id is invalid");
+                return new HtmlView("Surveys", HtmlString.of("Survey Design id is invalid"));
             }
         }
     }

--- a/wiki/resources/web/wiki/internal/wikiEdit.js
+++ b/wiki/resources/web/wiki/internal/wikiEdit.js
@@ -146,7 +146,9 @@ const TabNames = Object.freeze({
         row.id = "wiki-na-" + _newAttachmentIndex;
 
         var cell = row.insertCell(0);
-        cell.innerHTML = "<input type='file' name='formFiles[" + _newAttachmentIndex + "]' size='60' onChange='LABKEY._wiki.onAddAttachment(this," + _newAttachmentIndex + ")'>";
+        cell.innerHTML = "<input type='file' name='formFiles[" + _newAttachmentIndex + "]' size='60'>";
+        const nodeIndex = _newAttachmentIndex;
+        cell.childNodes[0]['onchange'] = function() { LABKEY._wiki.onAddAttachment(this, nodeIndex); };
 
         cell = row.insertCell(1);
         cell.id = "wiki-na-name-" + _newAttachmentIndex;
@@ -416,8 +418,10 @@ const TabNames = Object.freeze({
 
         getExistingAttachmentIconImg(index).src = LABKEY.ActionURL.getContextPath() + "/_icons/_deleted.gif";
         row.cells[1].style.textDecoration = "line-through";
-        row.cells[2].innerHTML = "<a onclick='LABKEY._wiki.onUndeleteAttachment(" + index + ")'><span>&nbsp; un-delete</span></a>"
+        row.cells[2].innerHTML = "<a><span>&nbsp; un-delete</span></a>"
                 + "<input type='hidden' name='toDelete' value=\"" + LABKEY.Utils.encodeHtml(_attachments[index].name) + "\"/>";
+        const nodeIndex = index;
+        row.cells[2].childNodes[0]['onclick'] = function() { LABKEY._wiki.onUndeleteAttachment(nodeIndex); };
 
         //add a prop so we know we need to save the attachments
         LABKEY.setDirty(true);
@@ -435,7 +439,9 @@ const TabNames = Object.freeze({
 
         getExistingAttachmentIconImg(index).src = _attachments[index].iconUrl;
         row.cells[1].style.textDecoration = "";
-        row.cells[2].innerHTML = "<a href='javascript:onDeleteAttachment("+ index +")'>&nbsp; delete</a>";
+        row.cells[2].innerHTML = "<a>&nbsp; delete</a>";
+        const nodeIndex = index;
+        row.cells[2].childNodes[0]['onclick'] = function(){ LABKEY._wiki.onDeleteAttachment(nodeIndex); };
     };
 
     var onDeletePage = function() {
@@ -613,7 +619,7 @@ const TabNames = Object.freeze({
         toSelect.children().remove();
 
         $.each(_formats, function(fmt, label) {
-            if (fmt != _wikiProps.rendererType) {
+            if (fmt !== _wikiProps.rendererType) {
                 toSelect.append('<option value=\"' + fmt + '\">' + label + '</option>');
             }
         });
@@ -754,7 +760,7 @@ const TabNames = Object.freeze({
             table.removeChild(table.childNodes[0]);
 
         var row, cell;
-        if (null == attachments || attachments.length == 0) {
+        if (attachments.length === 0) {
             row = table.insertRow(0);
             cell = row.insertCell(0);
             cell.innerHTML = "[none]";
@@ -775,7 +781,9 @@ const TabNames = Object.freeze({
 
                 cell = row.insertCell(2);
                 cell.id = "wiki-ea-del-" + idx;
-                cell.innerHTML = "<a href='javascript:LABKEY._wiki.onDeleteAttachment(" + idx + ")'>&nbsp; delete</a>";
+                cell.innerHTML = "<a>&nbsp; delete</a>";
+                const nodeIdx = idx;
+                cell.childNodes[0]['onclick'] = function() { LABKEY._wiki.onDeleteAttachment(nodeIdx); };
             }
         }
     };


### PR DESCRIPTION
#### Rationale
This addresses [Issue 48715](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48715) by switching "Show all" functionality in Data Regions to set a `maxRows=1000` parameter instead of setting `showRows=all`. The intention is to a) avoid unwieldy large requests generated by our UI that can consume significant server resources and b) avoid crashing the user's browser attempting to render too many results. This is a client-side change only (so `showRows=all` is still supported but just not generated by our UI).

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/1760

#### Changes
- Switch selecting "Show all" or calling `DataRegion.showAllRows()` to setting the URL parameter `maxRows=1000` instead of `showRows=all`
- Display a message to the user iff the "Show all" max rows boundary is selected and has been reached.