### PR TITLE
Clear Daily E reports

### DIFF
--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -898,8 +898,9 @@ LABKEY.Utils = new function(impl, $) {
         const fn = function()
         {
             const list = document.querySelectorAll(selector);
-            for (let i in list)
-                list[i]['on' + eventName] = handler;
+            list.forEach(function(element) {
+                element['on' + eventName] = handler;
+            });
         };
         (immediate || document.readyState!=="loading") ? fn() : document.addEventListener('load', fn);
     };

--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -1226,7 +1226,7 @@ public class PipelineController extends SpringActionController
                 _archiveFile = PipelineManager.validateFolderImportFileNioPath(form.getFilePath(), currentPipelineRoot, errors);
 
                 // Be sure that the set of folder to apply the import to match the setting to enable/disable them
-                if (form.isApplyToMultipleFolders() && (form.getFolderRowIds() == null || form.getFolderRowIds().size() == 0))
+                if (form.isApplyToMultipleFolders() && (form.getFolderRowIds() == null || form.getFolderRowIds().isEmpty()))
                 {
                     errors.reject(ERROR_MSG, "At least one folder must be selected when 'apply to multiple folders' is enabled.");
                 }
@@ -1266,7 +1266,7 @@ public class PipelineController extends SpringActionController
                 }
 
                 // Be sure that the provided data types to import match the setting to enable/disable them
-                if (form.isSpecificImportOptions() && (form.getDataTypes() == null || form.getDataTypes().size() == 0))
+                if (form.isSpecificImportOptions() && (form.getDataTypes() == null || form.getDataTypes().isEmpty()))
                 {
                     errors.reject(ERROR_MSG, "At least one folder data type must be selected when 'select specific objects to import' is enabled.");
                 }

--- a/pipeline/src/org/labkey/pipeline/startPipelineImport.jsp
+++ b/pipeline/src/org/labkey/pipeline/startPipelineImport.jsp
@@ -62,7 +62,7 @@
 <labkey:errors/>
 <labkey:form id="<%=importFormId%>" action="<%=urlFor(StartFolderImportAction.class)%>" method="post">
     <input type="hidden" name="fromZip" value=<%=bean.isFromZip()%>>
-    <input type="hidden" name="filePath" value=<%=q(bean.getFilePath())%>>
+    <input type="hidden" name="filePath" value="<%=h(bean.getFilePath())%>">
     <div id="startPipelineImportForm"></div>
 </labkey:form>
 

--- a/study/src/org/labkey/study/view/customizeParticipantView.jsp
+++ b/study/src/org/labkey/study/view/customizeParticipantView.jsp
@@ -15,10 +15,13 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.labkey.api.reports.report.ReportUrls"%>
+<%@ page import="org.labkey.api.module.ModuleHtmlView"%>
+<%@ page import="org.labkey.api.module.ModuleLoader" %>
+<%@ page import="org.labkey.api.reports.report.ReportUrls" %>
 <%@ page import="org.labkey.api.study.StudyService" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.study.StudyModule" %>
 <%@ page import="org.labkey.study.controllers.StudyController.CustomizeParticipantViewAction" %>
 <%@ page import="org.labkey.study.controllers.StudyController.CustomizeParticipantViewForm" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -106,6 +109,7 @@
 <%
     if (bean.getParticipantId() != null)
     {
+        ModuleHtmlView view = new ModuleHtmlView(ModuleLoader.getInstance().getModule(StudyModule.MODULE_NAME), "Custom Participant View", unsafe(useCustomView ? bean.getCustomScript() : bean.getDefaultScript()));
 %>
 <table width="100%">
     <tr class="labkey-wp-header">
@@ -113,7 +117,7 @@
     </tr>
     <tr>
         <td>
-            <%= unsafe(useCustomView ? bean.getCustomScript() : bean.getDefaultScript()) %>
+            <%= view.getHtml() %>
         </td>
     </tr>
 </table>

--- a/wiki/resources/web/wiki/internal/wikiEdit.js
+++ b/wiki/resources/web/wiki/internal/wikiEdit.js
@@ -146,7 +146,9 @@ const TabNames = Object.freeze({
         row.id = "wiki-na-" + _newAttachmentIndex;
 
         var cell = row.insertCell(0);
-        cell.innerHTML = "<input type='file' name='formFiles[" + _newAttachmentIndex + "]' size='60' onChange='LABKEY._wiki.onAddAttachment(this," + _newAttachmentIndex + ")'>";
+        cell.innerHTML = "<input type='file' name='formFiles[" + _newAttachmentIndex + "]' size='60'>";
+        const nodeIndex = _newAttachmentIndex;
+        cell.childNodes[0]['onchange'] = function() { LABKEY._wiki.onAddAttachment(this, nodeIndex); };
 
         cell = row.insertCell(1);
         cell.id = "wiki-na-name-" + _newAttachmentIndex;
@@ -416,8 +418,10 @@ const TabNames = Object.freeze({
 
         getExistingAttachmentIconImg(index).src = LABKEY.ActionURL.getContextPath() + "/_icons/_deleted.gif";
         row.cells[1].style.textDecoration = "line-through";
-        row.cells[2].innerHTML = "<a onclick='LABKEY._wiki.onUndeleteAttachment(" + index + ")'><span>&nbsp; un-delete</span></a>"
+        row.cells[2].innerHTML = "<a><span>&nbsp; un-delete</span></a>"
                 + "<input type='hidden' name='toDelete' value=\"" + LABKEY.Utils.encodeHtml(_attachments[index].name) + "\"/>";
+        const nodeIndex = index;
+        row.cells[2].childNodes[0]['onclick'] = function() { LABKEY._wiki.onUndeleteAttachment(nodeIndex); };
 
         //add a prop so we know we need to save the attachments
         LABKEY.setDirty(true);
@@ -435,7 +439,9 @@ const TabNames = Object.freeze({
 
         getExistingAttachmentIconImg(index).src = _attachments[index].iconUrl;
         row.cells[1].style.textDecoration = "";
-        row.cells[2].innerHTML = "<a href='javascript:onDeleteAttachment("+ index +")'>&nbsp; delete</a>";
+        row.cells[2].innerHTML = "<a>&nbsp; delete</a>";
+        const nodeIndex = index;
+        row.cells[2].childNodes[0]['onclick'] = function(){ LABKEY._wiki.onDeleteAttachment(nodeIndex); };
     };
 
     var onDeletePage = function() {
@@ -613,7 +619,7 @@ const TabNames = Object.freeze({
         toSelect.children().remove();
 
         $.each(_formats, function(fmt, label) {
-            if (fmt != _wikiProps.rendererType) {
+            if (fmt !== _wikiProps.rendererType) {
                 toSelect.append('<option value=\"' + fmt + '\">' + label + '</option>');
             }
         });
@@ -754,7 +760,7 @@ const TabNames = Object.freeze({
             table.removeChild(table.childNodes[0]);
 
         var row, cell;
-        if (null == attachments || attachments.length == 0) {
+        if (attachments.length === 0) {
             row = table.insertRow(0);
             cell = row.insertCell(0);
             cell.innerHTML = "[none]";
@@ -775,7 +781,9 @@ const TabNames = Object.freeze({
 
                 cell = row.insertCell(2);
                 cell.id = "wiki-ea-del-" + idx;
-                cell.innerHTML = "<a href='javascript:LABKEY._wiki.onDeleteAttachment(" + idx + ")'>&nbsp; delete</a>";
+                cell.innerHTML = "<a>&nbsp; delete</a>";
+                const nodeIdx = idx;
+                cell.childNodes[0]['onclick'] = function() { LABKEY._wiki.onDeleteAttachment(nodeIdx); };
             }
         }
     };


### PR DESCRIPTION
#### Rationale
Should clear remaining Daily E complaints: https://teamcity.labkey.org/repository/download/LabkeyTrunk_DailySuites_DailyEPostgres/2802333:id/tomcatLogs.tar.gz!/csp-report.log

#### Changes
* Correct file path encoding on startup pipeline import page (crawler discovery)
* Route custom participant view preview rendering through `ModuleHtmlView` to populate nonce, etc.
* Correct `NodeList` iteration... we don't need to "attach events" to index, item, and other NodeList properties
* Fix wiki edit inline events
