### PR TITLE
Issue 48810: Field editor should check reserved field names based on the domain kind during create as it does during update

### DIFF
--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -255,7 +255,10 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         Set<String> reserved = new CaseInsensitiveHashSet(RESERVED_NAMES);
 
         if (domain == null)
+        {
+            reserved.remove("Name"); // Issue 48810: See SampleTypeService.createSampleType hasNameProperty
             return reserved;
+        }
 
         ExpSampleType st = getSampleType(domain);
         if (st == null)

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -252,11 +252,20 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
     @Override
     public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
+        return getReservedPropertyNames(domain, user, false);
+    }
+
+    @Override
+    public Set<String> getReservedPropertyNames(Domain domain, User user, boolean forCreate)
+    {
         Set<String> reserved = new CaseInsensitiveHashSet(RESERVED_NAMES);
 
         if (domain == null)
         {
-            reserved.remove("Name"); // Issue 48810: See SampleTypeService.createSampleType hasNameProperty
+            // Issue 48810: See SampleTypeService.createSampleType hasNameProperty
+            if (forCreate)
+                reserved.remove("Name");
+
             return reserved;
         }
 

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -110,6 +110,10 @@ abstract public class DomainKind<T>  implements Handler<String>
      * @return set of strings containing the names. This will be compared ignoring case
      */
     abstract public Set<String> getReservedPropertyNames(Domain domain, User user);
+    public Set<String> getReservedPropertyNames(Domain domain, User user, boolean forCreate)
+    {
+        return getReservedPropertyNames(domain, user);
+    }
 
     public Set<String> getReservedPropertyNamePrefixes()
     {

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -631,7 +631,10 @@ public class DomainUtil
         if (!kind.canCreateDefinition(user, container))
             throw new UnauthorizedException("You don't have permission to create a new domain");
 
-        ValidationException ve = DomainUtil.validateProperties(null, domain, kind, null, user);
+        // Issue 48810: if not creating from templateInfo, validate reserved field names based on domainKind
+        DomainKind validateDomainKind = templateInfo == null ? kind : null;
+
+        ValidationException ve = DomainUtil.validateProperties(null, domain, validateDomainKind, null, user);
         if (ve.hasErrors())
         {
             throw new ValidationException(ve);

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -631,7 +631,7 @@ public class DomainUtil
         if (!kind.canCreateDefinition(user, container))
             throw new UnauthorizedException("You don't have permission to create a new domain");
 
-        ValidationException ve = DomainUtil.validateProperties(null, domain, null, null, user);
+        ValidationException ve = DomainUtil.validateProperties(null, domain, kind, null, user);
         if (ve.hasErrors())
         {
             throw new ValidationException(ve);
@@ -1213,7 +1213,7 @@ public class DomainUtil
      */
     public static ValidationException validateProperties(@Nullable Domain domain, @NotNull GWTDomain updates, @Nullable DomainKind domainKind, @Nullable GWTDomain orig, @Nullable User user)
     {
-        Set<String> reservedNames = (null != domain && null != domainKind) ? new CaseInsensitiveHashSet(domainKind.getReservedPropertyNames(domain, user))
+        Set<String> reservedNames = null != domainKind ? new CaseInsensitiveHashSet(domainKind.getReservedPropertyNames(domain, user))
                 : new CaseInsensitiveHashSet(updates.getReservedFieldNames());
         Set<String> reservedPrefixes = (null != domain && null != domainKind) ? domainKind.getReservedPropertyNamePrefixes() : updates.getReservedFieldNamePrefixes();
         Map<String, Integer> namePropertyIdMap = new CaseInsensitiveHashMap<>();

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -1213,7 +1213,7 @@ public class DomainUtil
      */
     public static ValidationException validateProperties(@Nullable Domain domain, @NotNull GWTDomain updates, @Nullable DomainKind domainKind, @Nullable GWTDomain orig, @Nullable User user)
     {
-        Set<String> reservedNames = null != domainKind ? new CaseInsensitiveHashSet(domainKind.getReservedPropertyNames(domain, user))
+        Set<String> reservedNames = null != domainKind ? new CaseInsensitiveHashSet(domainKind.getReservedPropertyNames(domain, user, domain == null))
                 : new CaseInsensitiveHashSet(updates.getReservedFieldNames());
         Set<String> reservedPrefixes = (null != domain && null != domainKind) ? domainKind.getReservedPropertyNamePrefixes() : updates.getReservedFieldNamePrefixes();
         Map<String, Integer> namePropertyIdMap = new CaseInsensitiveHashMap<>();


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48810

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/1759

#### Changes
- DomainUtils.validateProperties update to pass in domain kind for the create case to better check reserved field names
