### PR TITLE
Add moveRows to Query module in @labkey/api

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,8 +8,8 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.399.0",
-        "@labkey/themes": "1.3.2"
+        "@labkey/components": "2.399.0-fb-moveRowsJSAPI.2",
+        "@labkey/themes": "1.3.2-fb-moveRowsJSAPI.0"
       },
       "devDependencies": {
         "@labkey/build": "6.16.1",
@@ -3298,9 +3298,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.27.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.0.tgz",
-      "integrity": "sha512-Hs1TahaNp1K3JrvdpGCB0m8as1JidJImxyRD6NG5UK897z90tK1L3o3PihjyoU3oJ11nV/iePXJbG31c4C44gQ=="
+      "version": "1.27.1-fb-moveRowsJSAPI.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.3.tgz",
+      "integrity": "sha512-uqaVblaxE0OHdps44UjAtv8mWof3wBIa3JSDgvlZtN6Hg6t0Ph9Cof1fUC45mjowNkOvuMEJTNhzM4yi+n3g3Q=="
     },
     "node_modules/@labkey/build": {
       "version": "6.16.1",
@@ -3338,11 +3338,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.399.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.399.0.tgz",
-      "integrity": "sha512-21WPgUbBbSydk8+h0/1KNw3me9v3efFJtU1k/Tf5ZURCBYE3/lL/e2FVu/RufJSjCz59CddADIdWZuKxnrzGrQ==",
+      "version": "2.399.0-fb-moveRowsJSAPI.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.399.0-fb-moveRowsJSAPI.2.tgz",
+      "integrity": "sha512-Cc6QOPfvOS8eEJbw8ySEVMMDZabAfCOYk0E1pfK0aHhEcZPvtep6vnWwjyiq7wx5TYcfOoEZpcpwXxnfMx8ghA==",
       "dependencies": {
-        "@labkey/api": "1.27.0",
+        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.3",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3406,9 +3406,9 @@
       }
     },
     "node_modules/@labkey/themes": {
-      "version": "1.3.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2.tgz",
-      "integrity": "sha512-knJi2tZe4W6JCwebzhKYf/BeK3XY/NGfZPaEfrfs6l7MNnjMn90OzkVI59LQ9NW/gw9SRcnTjfSLuNBtSYWX1g=="
+      "version": "1.3.2-fb-moveRowsJSAPI.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2-fb-moveRowsJSAPI.0.tgz",
+      "integrity": "sha512-V/VJb7Axie0sQGTh2Hfp48gQm9DC8fDXn/ulguHT3IQ7NN4Hl02CYHvpHpGg6OkB3xFUHS18ZlxQysn+1jAiYQ=="
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
@@ -19439,9 +19439,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.27.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.0.tgz",
-      "integrity": "sha512-Hs1TahaNp1K3JrvdpGCB0m8as1JidJImxyRD6NG5UK897z90tK1L3o3PihjyoU3oJ11nV/iePXJbG31c4C44gQ=="
+      "version": "1.27.1-fb-moveRowsJSAPI.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.3.tgz",
+      "integrity": "sha512-uqaVblaxE0OHdps44UjAtv8mWof3wBIa3JSDgvlZtN6Hg6t0Ph9Cof1fUC45mjowNkOvuMEJTNhzM4yi+n3g3Q=="
     },
     "@labkey/build": {
       "version": "6.16.1",
@@ -19479,11 +19479,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.399.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.399.0.tgz",
-      "integrity": "sha512-21WPgUbBbSydk8+h0/1KNw3me9v3efFJtU1k/Tf5ZURCBYE3/lL/e2FVu/RufJSjCz59CddADIdWZuKxnrzGrQ==",
+      "version": "2.399.0-fb-moveRowsJSAPI.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.399.0-fb-moveRowsJSAPI.2.tgz",
+      "integrity": "sha512-Cc6QOPfvOS8eEJbw8ySEVMMDZabAfCOYk0E1pfK0aHhEcZPvtep6vnWwjyiq7wx5TYcfOoEZpcpwXxnfMx8ghA==",
       "requires": {
-        "@labkey/api": "1.27.0",
+        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.3",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -19541,9 +19541,9 @@
       }
     },
     "@labkey/themes": {
-      "version": "1.3.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2.tgz",
-      "integrity": "sha512-knJi2tZe4W6JCwebzhKYf/BeK3XY/NGfZPaEfrfs6l7MNnjMn90OzkVI59LQ9NW/gw9SRcnTjfSLuNBtSYWX1g=="
+      "version": "1.3.2-fb-moveRowsJSAPI.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2-fb-moveRowsJSAPI.0.tgz",
+      "integrity": "sha512-V/VJb7Axie0sQGTh2Hfp48gQm9DC8fDXn/ulguHT3IQ7NN4Hl02CYHvpHpGg6OkB3xFUHS18ZlxQysn+1jAiYQ=="
     },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,8 +8,8 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.399.0-fb-moveRowsJSAPI.2",
-        "@labkey/themes": "1.3.2-fb-moveRowsJSAPI.0"
+        "@labkey/components": "2.399.0-fb-moveRowsJSAPI.3",
+        "@labkey/themes": "1.3.2-fb-moveRowsJSAPI.1"
       },
       "devDependencies": {
         "@labkey/build": "6.16.1",
@@ -3298,9 +3298,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.27.1-fb-moveRowsJSAPI.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.3.tgz",
-      "integrity": "sha512-uqaVblaxE0OHdps44UjAtv8mWof3wBIa3JSDgvlZtN6Hg6t0Ph9Cof1fUC45mjowNkOvuMEJTNhzM4yi+n3g3Q=="
+      "version": "1.27.1-fb-moveRowsJSAPI.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.4.tgz",
+      "integrity": "sha512-hYdEYU4mQS4c6gDIowVURnKTMofGptrsBbqWuzdp/JSOOIvwllRsF/1U5oWXCA/CIaqbW2CByPC7orgJgIfcng=="
     },
     "node_modules/@labkey/build": {
       "version": "6.16.1",
@@ -3338,11 +3338,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.399.0-fb-moveRowsJSAPI.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.399.0-fb-moveRowsJSAPI.2.tgz",
-      "integrity": "sha512-Cc6QOPfvOS8eEJbw8ySEVMMDZabAfCOYk0E1pfK0aHhEcZPvtep6vnWwjyiq7wx5TYcfOoEZpcpwXxnfMx8ghA==",
+      "version": "2.399.0-fb-moveRowsJSAPI.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.399.0-fb-moveRowsJSAPI.3.tgz",
+      "integrity": "sha512-iovOAZ8TdM0bUU9R0GGx0cOgjHXRuzWy/tuk315s5nSZZiVRLrMPtPU8N27+IcQ16DiE/h9XEPubQosxHaP+og==",
       "dependencies": {
-        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.3",
+        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.4",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3406,9 +3406,9 @@
       }
     },
     "node_modules/@labkey/themes": {
-      "version": "1.3.2-fb-moveRowsJSAPI.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2-fb-moveRowsJSAPI.0.tgz",
-      "integrity": "sha512-V/VJb7Axie0sQGTh2Hfp48gQm9DC8fDXn/ulguHT3IQ7NN4Hl02CYHvpHpGg6OkB3xFUHS18ZlxQysn+1jAiYQ=="
+      "version": "1.3.2-fb-moveRowsJSAPI.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2-fb-moveRowsJSAPI.1.tgz",
+      "integrity": "sha512-d5cVGfjmMkmhhZzmoFsWNuQfSo5Kw71NgTllsu+OIN7tiiYWz1X3z3KeI8GAaQpKjOSU440JiT3rZs8Ovywpbw=="
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
@@ -19439,9 +19439,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.27.1-fb-moveRowsJSAPI.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.3.tgz",
-      "integrity": "sha512-uqaVblaxE0OHdps44UjAtv8mWof3wBIa3JSDgvlZtN6Hg6t0Ph9Cof1fUC45mjowNkOvuMEJTNhzM4yi+n3g3Q=="
+      "version": "1.27.1-fb-moveRowsJSAPI.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.4.tgz",
+      "integrity": "sha512-hYdEYU4mQS4c6gDIowVURnKTMofGptrsBbqWuzdp/JSOOIvwllRsF/1U5oWXCA/CIaqbW2CByPC7orgJgIfcng=="
     },
     "@labkey/build": {
       "version": "6.16.1",
@@ -19479,11 +19479,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.399.0-fb-moveRowsJSAPI.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.399.0-fb-moveRowsJSAPI.2.tgz",
-      "integrity": "sha512-Cc6QOPfvOS8eEJbw8ySEVMMDZabAfCOYk0E1pfK0aHhEcZPvtep6vnWwjyiq7wx5TYcfOoEZpcpwXxnfMx8ghA==",
+      "version": "2.399.0-fb-moveRowsJSAPI.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.399.0-fb-moveRowsJSAPI.3.tgz",
+      "integrity": "sha512-iovOAZ8TdM0bUU9R0GGx0cOgjHXRuzWy/tuk315s5nSZZiVRLrMPtPU8N27+IcQ16DiE/h9XEPubQosxHaP+og==",
       "requires": {
-        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.3",
+        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.4",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -19541,9 +19541,9 @@
       }
     },
     "@labkey/themes": {
-      "version": "1.3.2-fb-moveRowsJSAPI.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2-fb-moveRowsJSAPI.0.tgz",
-      "integrity": "sha512-V/VJb7Axie0sQGTh2Hfp48gQm9DC8fDXn/ulguHT3IQ7NN4Hl02CYHvpHpGg6OkB3xFUHS18ZlxQysn+1jAiYQ=="
+      "version": "1.3.2-fb-moveRowsJSAPI.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2-fb-moveRowsJSAPI.1.tgz",
+      "integrity": "sha512-d5cVGfjmMkmhhZzmoFsWNuQfSo5Kw71NgTllsu+OIN7tiiYWz1X3z3KeI8GAaQpKjOSU440JiT3rZs8Ovywpbw=="
     },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,8 +8,8 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "2.399.0-fb-moveRowsJSAPI.3",
-        "@labkey/themes": "1.3.2-fb-moveRowsJSAPI.1"
+        "@labkey/components": "2.399.1",
+        "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
         "@labkey/build": "6.16.1",
@@ -3298,9 +3298,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.27.1-fb-moveRowsJSAPI.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.4.tgz",
-      "integrity": "sha512-hYdEYU4mQS4c6gDIowVURnKTMofGptrsBbqWuzdp/JSOOIvwllRsF/1U5oWXCA/CIaqbW2CByPC7orgJgIfcng=="
+      "version": "1.28.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.28.0.tgz",
+      "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "node_modules/@labkey/build": {
       "version": "6.16.1",
@@ -3338,11 +3338,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "2.399.0-fb-moveRowsJSAPI.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.399.0-fb-moveRowsJSAPI.3.tgz",
-      "integrity": "sha512-iovOAZ8TdM0bUU9R0GGx0cOgjHXRuzWy/tuk315s5nSZZiVRLrMPtPU8N27+IcQ16DiE/h9XEPubQosxHaP+og==",
+      "version": "2.399.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.399.1.tgz",
+      "integrity": "sha512-nJ4QYwLmdLiwTk+xt2Kzi7WwmC+C0cHb09n+imzHwzg7mewzfsNgwUsDRbCC6GPge68AnpkGBTIDdOps5yWYgA==",
       "dependencies": {
-        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.4",
+        "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -3406,9 +3406,9 @@
       }
     },
     "node_modules/@labkey/themes": {
-      "version": "1.3.2-fb-moveRowsJSAPI.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2-fb-moveRowsJSAPI.1.tgz",
-      "integrity": "sha512-d5cVGfjmMkmhhZzmoFsWNuQfSo5Kw71NgTllsu+OIN7tiiYWz1X3z3KeI8GAaQpKjOSU440JiT3rZs8Ovywpbw=="
+      "version": "1.3.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.3.tgz",
+      "integrity": "sha512-vcJBtDGuE5KItBY59IXGGm/JBdSP5SQNHzhxm/VDHb5gGs3cuCkqTcVWKif0u3yXDBdKs0e02hQsKNqWPju0ww=="
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
@@ -19439,9 +19439,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.27.1-fb-moveRowsJSAPI.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.27.1-fb-moveRowsJSAPI.4.tgz",
-      "integrity": "sha512-hYdEYU4mQS4c6gDIowVURnKTMofGptrsBbqWuzdp/JSOOIvwllRsF/1U5oWXCA/CIaqbW2CByPC7orgJgIfcng=="
+      "version": "1.28.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.28.0.tgz",
+      "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "@labkey/build": {
       "version": "6.16.1",
@@ -19479,11 +19479,11 @@
       }
     },
     "@labkey/components": {
-      "version": "2.399.0-fb-moveRowsJSAPI.3",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.399.0-fb-moveRowsJSAPI.3.tgz",
-      "integrity": "sha512-iovOAZ8TdM0bUU9R0GGx0cOgjHXRuzWy/tuk315s5nSZZiVRLrMPtPU8N27+IcQ16DiE/h9XEPubQosxHaP+og==",
+      "version": "2.399.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-2.399.1.tgz",
+      "integrity": "sha512-nJ4QYwLmdLiwTk+xt2Kzi7WwmC+C0cHb09n+imzHwzg7mewzfsNgwUsDRbCC6GPge68AnpkGBTIDdOps5yWYgA==",
       "requires": {
-        "@labkey/api": "1.27.1-fb-moveRowsJSAPI.4",
+        "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -19541,9 +19541,9 @@
       }
     },
     "@labkey/themes": {
-      "version": "1.3.2-fb-moveRowsJSAPI.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.2-fb-moveRowsJSAPI.1.tgz",
-      "integrity": "sha512-d5cVGfjmMkmhhZzmoFsWNuQfSo5Kw71NgTllsu+OIN7tiiYWz1X3z3KeI8GAaQpKjOSU440JiT3rZs8Ovywpbw=="
+      "version": "1.3.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/themes/-/@labkey/themes-1.3.3.tgz",
+      "integrity": "sha512-vcJBtDGuE5KItBY59IXGGm/JBdSP5SQNHzhxm/VDHb5gGs3cuCkqTcVWKif0u3yXDBdKs0e02hQsKNqWPju0ww=="
     },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",

--- a/core/package.json
+++ b/core/package.json
@@ -54,8 +54,8 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.399.0-fb-moveRowsJSAPI.3",
-    "@labkey/themes": "1.3.2-fb-moveRowsJSAPI.1"
+    "@labkey/components": "2.399.1",
+    "@labkey/themes": "1.3.3"
   },
   "devDependencies": {
     "@labkey/build": "6.16.1",

--- a/core/package.json
+++ b/core/package.json
@@ -54,8 +54,8 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.399.0-fb-moveRowsJSAPI.2",
-    "@labkey/themes": "1.3.2-fb-moveRowsJSAPI.0"
+    "@labkey/components": "2.399.0-fb-moveRowsJSAPI.3",
+    "@labkey/themes": "1.3.2-fb-moveRowsJSAPI.1"
   },
   "devDependencies": {
     "@labkey/build": "6.16.1",

--- a/core/package.json
+++ b/core/package.json
@@ -54,8 +54,8 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "2.399.0",
-    "@labkey/themes": "1.3.2"
+    "@labkey/components": "2.399.0-fb-moveRowsJSAPI.2",
+    "@labkey/themes": "1.3.2-fb-moveRowsJSAPI.0"
   },
   "devDependencies": {
     "@labkey/build": "6.16.1",


### PR DESCRIPTION
#### Rationale
Related PR added a query-moveRows.api to the QueryController so that we could consolidate the various move entities actions to a single action. This PR bumps the @labkey package versions to use the Query.moveRows().

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1372

#### Changes
- update @labkey/components and @labkey/themes package versions
