### PR TITLE
Issue 48810: SimpleTableDomainKind.getReservedPropertyNames null check for domain object

### DIFF
--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -262,7 +262,9 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
 
         if (domain == null)
         {
-            // Issue 48810: See SampleTypeService.createSampleType hasNameProperty
+            // Issue 48810: See SampleTypeService.createSampleType hasNameProperty. We are adding in a "name" col on the
+            // client side right before calling the saveDomain API, so we need to "exclude" it from the reserved set in
+            // this case.
             if (forCreate)
                 reserved.remove("Name");
 

--- a/api/src/org/labkey/api/query/SimpleTableDomainKind.java
+++ b/api/src/org/labkey/api/query/SimpleTableDomainKind.java
@@ -244,7 +244,7 @@ public class SimpleTableDomainKind extends BaseAbstractDomainKind
     @Override
     public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        SimpleUserSchema.SimpleTable table = getTable(domain, user);
+        SimpleUserSchema.SimpleTable table = domain != null ? getTable(domain, user) : null;
         if (table != null)
         {
             // return the set of built-in column names.


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48810

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5060

#### Changes
- SimpleTableDomainKind.getReservedPropertyNames null check for domain object
