### PR TITLE
Remove deprecated ContainerFilter.getSQLFragment

### DIFF
--- a/announcements/src/org/labkey/announcements/query/AnnouncementSubscriptionTable.java
+++ b/announcements/src/org/labkey/announcements/query/AnnouncementSubscriptionTable.java
@@ -82,7 +82,7 @@ public class AnnouncementSubscriptionTable extends AbstractSubscriptionTable
         SQLFragment sql = new SQLFragment("MessageId IN (SELECT RowId FROM ");
         sql.append(CommSchema.getInstance().getTableInfoAnnouncements(), "a");
         sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("a.Container"), getContainer()));
+        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("a.Container")));
         sql.append(")");
 
         addCondition(sql, FieldKey.fromParts("Container"));

--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -55,8 +55,6 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
  * Represents which set of containers should be included when querying for data. In general, the code will
  * default to showing data from just the current container, but alternative ContainerFilters can resolve items
  * in the /Shared project, in parent containers, or a variety of other scoping locations.
- * User: jeckels
- * Date: Nov 3, 2008
  */
 public abstract class ContainerFilter
 {

--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -183,7 +183,7 @@ public abstract class ContainerFilter
         SQLFragment sql;
         if (columnInfo != null)
         {
-            // NOTE: we really should know the tableAlias here, but we don't, so caller has to guarantee that the columninfo is unambigious
+            // NOTE: we really should know the tableAlias here, but we don't, so caller has to guarantee that the columninfo is unambiguous
             SQLFragment value = columnInfo.getValueSql(ExprColumn.STR_TABLE_ALIAS);
             sql = new SQLFragment(value.getSQL().replace(ExprColumn.STR_TABLE_ALIAS+".", ""), value.getParams());
         }

--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -197,13 +197,6 @@ public abstract class ContainerFilter
     }
 
     /** Create an expression for a WHERE clause */
-    @Deprecated
-    public final SQLFragment getSQLFragment(DbSchema schema, SQLFragment containerColumnSQL, Container container)
-    {
-        assert null==_container || null==container || _container.equals(container);
-        return getSQLFragment(schema, containerColumnSQL, true);
-    }
-
     public SQLFragment getSQLFragment(DbSchema schema, SQLFragment containerColumnSQL)
     {
         return getSQLFragment(schema, containerColumnSQL, true);
@@ -716,7 +709,7 @@ public abstract class ContainerFilter
         {
             super(current, user);
 
-            //Note: dont force upstream code to consider this
+            // Note: don't force upstream code to consider this
             _extraContainers = new ArrayList<>(extraContainers);
             _extraContainers.removeIf(c -> c.getContainerType().isDuplicatedInContainerFilter());
         }

--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -402,12 +402,9 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
     protected void applyContainerFilter(ContainerFilter filter)
     {
         // There isn't a container column directly on this table so do a special filter
-        if (getContainer() != null)
-        {
-            FieldKey containerColumn = FieldKey.fromParts("Container");
-            clearConditions(containerColumn);
-            addCondition(filter.getSQLFragment(getSchema(), new SQLFragment("Container"), getContainer()), containerColumn);
-        }
+        FieldKey containerColumn = FieldKey.fromParts("Container");
+        clearConditions(containerColumn);
+        addCondition(filter.getSQLFragment(getSchema(), new SQLFragment("Container")), containerColumn);
     }
 
     @NotNull

--- a/assay/api-src/org/labkey/api/assay/nab/query/CutoffValueTable.java
+++ b/assay/api-src/org/labkey/api/assay/nab/query/CutoffValueTable.java
@@ -114,7 +114,7 @@ public class CutoffValueTable extends FilteredTable<AssayProtocolSchema>
             sql.append(", ");
             sql.append(DilutionManager.getTableInfoNAbSpecimen(), "ns");
             sql.append(" WHERE r.RowId = ns.RunId AND ");
-            sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container"), _userSchema.getContainer()));
+            sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container")));
             sql.append(")");
             addCondition(sql, CONTAINER_FIELD_KEY);
         }

--- a/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
+++ b/assay/api-src/org/labkey/api/assay/nab/query/NAbSpecimenTable.java
@@ -88,7 +88,7 @@ public class NAbSpecimenTable extends FilteredTable<AssayProtocolSchema>
         SQLFragment sql = new SQLFragment("RunId IN (SELECT RowId FROM ");
         sql.append(ExperimentService.get().getTinfoExperimentRun(), "r");
         sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("r.Container"), _userSchema.getContainer()));
+        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("r.Container")));
         sql.append(")");
         addCondition(sql, CONTAINER_FIELD_KEY);
     }

--- a/experiment/src/org/labkey/experiment/api/ExpQCFlagTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpQCFlagTableImpl.java
@@ -187,7 +187,7 @@ public class ExpQCFlagTableImpl extends ExpTableImpl<ExpQCFlagTable.Column> impl
         SQLFragment sql = new SQLFragment("RunId IN (SELECT er.RowId FROM ");
         sql.append(ExperimentService.get().getTinfoExperimentRun(), "er");
         sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("er.Container"), getContainer()));
+        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("er.Container")));
         sql.append(")");
 
         addCondition(sql, containerFieldKey);

--- a/experiment/src/org/labkey/experiment/api/ExpRunGroupMapTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunGroupMapTableImpl.java
@@ -118,7 +118,7 @@ public class ExpRunGroupMapTableImpl extends ExpTableImpl<ExpRunGroupMapTable.Co
         // Filter out hidden run groups
         ret.append(" WHERE e.Hidden = ? AND rl.ExperimentId = e.RowId AND rl.ExperimentRunId = er.RowId AND ");
         ret.add(false);
-        ret.append(getContainerFilter().getSQLFragment(ExperimentServiceImpl.get().getSchema(), new SQLFragment("er.Container"), getExpSchema().getContainer()));
+        ret.append(getContainerFilter().getSQLFragment(ExperimentServiceImpl.get().getSchema(), new SQLFragment("er.Container")));
         ret.append(") X ");
         SQLFragment filterFrag = getFilter().getSQLFragment(_rootTable, null);
         ret.append("\n").append(filterFrag).append(") ").append(alias);

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -338,7 +338,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         SQLFragment sql = new SQLFragment("SELECT DISTINCT er.ProtocolLSID FROM ");
         sql.append(getTinfoExperimentRun(), "er");
         sql.append(" WHERE ");
-        sql.append(containerFilter.getSQLFragment(getSchema(), new SQLFragment("er.Container"), c));
+        sql.append(containerFilter.getSQLFragment(getSchema(), new SQLFragment("er.Container")));
 
         // Translate the LSIDs into protocol objects
         List<ExpProtocolImpl> result = new ArrayList<>();
@@ -2021,7 +2021,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         sql.append(" pa.runid IN (SELECT rowid FROM ");
         sql.append(getTinfoExperimentRun(), "er");
         sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container"), container));
+        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("Container")));
         sql.append("))");
         return new TreeSet<>(new SqlSelector(getSchema(), sql).getCollection(String.class));
     }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -321,7 +321,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
         sql.append(" m.RowId = mi.MaterialId AND mi.TargetApplicationId = pa.RowId AND " +
                 "pa.RunId = r.RowId AND ");
-        sql.append(filter.getSQLFragment(getExpSchema(), new SQLFragment("r.Container"), container));
+        sql.append(filter.getSQLFragment(getExpSchema(), new SQLFragment("r.Container")));
         sql.append(" GROUP BY mi.Role ORDER BY mi.Role");
 
         Map<String, ExpSampleType> result = new LinkedHashMap<>();

--- a/issues/src/org/labkey/issue/query/CommentsTable.java
+++ b/issues/src/org/labkey/issue/query/CommentsTable.java
@@ -119,7 +119,7 @@ public class CommentsTable extends FilteredTable<IssuesQuerySchema>
         SQLFragment sql = new SQLFragment("IssueId IN (SELECT i.IssueId FROM ");
         sql.append(IssuesSchema.getInstance().getTableInfoIssues(), "i");
         sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("i.Container"), getContainer()));
+        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("i.Container")));
         sql.append(")");
         addCondition(sql, containerFieldKey);
     }

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -3110,7 +3110,7 @@ public class StudyManager
                 throw new IllegalStateException("provide a user to query the participants table");
             if (null == cf)
                 cf = new DataspaceContainerFilter(user, study);
-            filter = cf.getSQLFragment(SCHEMA.getSchema(), new SQLFragment("Container"), study.getContainer());
+            filter = cf.getSQLFragment(SCHEMA.getSchema(), new SQLFragment("Container"));
         }
         return filter;
     }

--- a/survey/src/org/labkey/survey/SurveyManager.java
+++ b/survey/src/org/labkey/survey/SurveyManager.java
@@ -298,7 +298,7 @@ public class SurveyManager
         DbSchema schema = SurveySchema.getInstance().getSchema();
         SQLFragment sql = new SQLFragment("SELECT * FROM ").append(SurveySchema.getInstance().getSurveyDesignsTable(), "sd");
         sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(schema, new SQLFragment("sd.container"), container));
+        sql.append(filter.getSQLFragment(schema, new SQLFragment("sd.container")));
         return new SqlSelector(schema, sql).getArray(SurveyDesign.class);
     }
 


### PR DESCRIPTION
#### Rationale
This removes the deprecated variant of `ContainerFilter.getSQLFragment(DbSchema, SQLFragment, Container)` in favor of using `ContainerFilter.getSQLFragment(DbSchema, SQLFragment)`. Container filters were converted to persisting their own containers awhile back and this variant contained assertion checks on unused parameters.

#### Related Pull Requests
* https://github.com/LabKey/labbook/pull/590

#### Changes
* Remove `ContainerFilter.getSQLFragment(DbSchema, SQLFragment, Container)` and replace usages with calls to `ContainerFilter.getSQLFragment(DbSchema, SQLFragment)`.
