### PR TITLE
Issue 48810: Respect "strictFieldValidation" flag for domain creation check for reserved field names

### DIFF
--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -632,7 +632,7 @@ public class DomainUtil
             throw new UnauthorizedException("You don't have permission to create a new domain");
 
         // Issue 48810: if not creating from templateInfo, validate reserved field names based on domainKind
-        boolean strictFieldValidation = (Boolean) arguments.getOrDefault("strictFieldValidation", true);
+        boolean strictFieldValidation = arguments != null ? (Boolean) arguments.getOrDefault("strictFieldValidation", true) : true;
         DomainKind validateDomainKind = templateInfo == null && strictFieldValidation ? kind : null;
 
         ValidationException ve = DomainUtil.validateProperties(null, domain, validateDomainKind, null, user);

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -632,7 +632,8 @@ public class DomainUtil
             throw new UnauthorizedException("You don't have permission to create a new domain");
 
         // Issue 48810: if not creating from templateInfo, validate reserved field names based on domainKind
-        DomainKind validateDomainKind = templateInfo == null ? kind : null;
+        boolean strictFieldValidation = (Boolean) arguments.getOrDefault("strictFieldValidation", true);
+        DomainKind validateDomainKind = templateInfo == null && strictFieldValidation ? kind : null;
 
         ValidationException ve = DomainUtil.validateProperties(null, domain, validateDomainKind, null, user);
         if (ve.hasErrors())


### PR DESCRIPTION
#### Rationale
The related PRs added better reserved field name validation checking for the domain creation case (i.e. to make it more closely match the domain update case). However, the RlabkeyTest failures indicated that there are cases where a flag for strictFieldValidation (which defaults to true) is passed in as false. This PR updates the validation properties method to respect that flag and fall back to the original behavior if it is false.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5060
- https://github.com/LabKey/platform/pull/5072

#### Changes
- update createDomain() to fall back to passing in null for the domain kind when strictFieldValidation is false
