### PR TITLE
@labkey/components package.json update to pin devDependencies versions

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0"
+        "@labkey/components": "3.1.2"
       },
       "devDependencies": {
         "@labkey/build": "7.0.0",
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.1.1-fb-reactBootstrapConverts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
-      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
+      "version": "3.1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
+      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -12919,9 +12919,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.1.1-fb-reactBootstrapConverts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
-      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
+      "version": "3.1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
+      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,12 +8,12 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.1.1"
+        "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.0",
         "@types/jest": "29.5.4",
-        "@types/react": "16.14.46",
+        "@types/react": "16.14.54",
         "@types/react-dom": "16.9.19"
       }
     },
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.1.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1.tgz",
-      "integrity": "sha512-by3HrKxmnZixyiwgDVCq0t0Ca0OV5RzRxP9ZYrHYdeRF7RN0pgJXzMc6Nfs1mdk8Ba8MRmdsq7pvbC0kadj4Tg==",
+      "version": "3.1.1-fb-reactBootstrapConverts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
+      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -3167,9 +3167,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "16.14.46",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.46.tgz",
-      "integrity": "sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==",
+      "version": "16.14.54",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.54.tgz",
+      "integrity": "sha512-54MOeVbxTlC8U6XBy2sLhLaHg/QGP0gPEWIpl1E5tNTJDz/SdFktT3OuvAfKxpSXATUmKXDozHvxbT3XohJgDQ==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -12919,9 +12919,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.1.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1.tgz",
-      "integrity": "sha512-by3HrKxmnZixyiwgDVCq0t0Ca0OV5RzRxP9ZYrHYdeRF7RN0pgJXzMc6Nfs1mdk8Ba8MRmdsq7pvbC0kadj4Tg==",
+      "version": "3.1.1-fb-reactBootstrapConverts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
+      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -13473,9 +13473,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.14.46",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.46.tgz",
-      "integrity": "sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==",
+      "version": "16.14.54",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.54.tgz",
+      "integrity": "sha512-54MOeVbxTlC8U6XBy2sLhLaHg/QGP0gPEWIpl1E5tNTJDz/SdFktT3OuvAfKxpSXATUmKXDozHvxbT3XohJgDQ==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0"
+    "@labkey/components": "3.1.2"
   },
   "devDependencies": {
     "@labkey/build": "7.0.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,12 +12,12 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.1.1"
+    "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.0",
     "@types/jest": "29.5.4",
-    "@types/react": "16.14.46",
+    "@types/react": "16.14.54",
     "@types/react-dom": "16.9.19"
   }
 }

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0",
+        "@labkey/components": "3.1.2",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.1.1-fb-reactBootstrapConverts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
-      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
+      "version": "3.1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
+      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.1.1-fb-reactBootstrapConverts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
-      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
+      "version": "3.1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
+      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.1.1",
+        "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -17,7 +17,7 @@
         "@types/enzyme": "3.10.13",
         "@types/enzyme-adapter-react-16": "1.0.6",
         "@types/jest": "29.5.4",
-        "@types/react": "16.14.46",
+        "@types/react": "16.14.54",
         "@types/react-dom": "16.9.19",
         "enzyme": "3.11.0",
         "enzyme-adapter-react-16": "1.15.7",
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.1.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1.tgz",
-      "integrity": "sha512-by3HrKxmnZixyiwgDVCq0t0Ca0OV5RzRxP9ZYrHYdeRF7RN0pgJXzMc6Nfs1mdk8Ba8MRmdsq7pvbC0kadj4Tg==",
+      "version": "3.1.1-fb-reactBootstrapConverts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
+      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -4203,9 +4203,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "16.14.46",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.46.tgz",
-      "integrity": "sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==",
+      "version": "16.14.54",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.54.tgz",
+      "integrity": "sha512-54MOeVbxTlC8U6XBy2sLhLaHg/QGP0gPEWIpl1E5tNTJDz/SdFktT3OuvAfKxpSXATUmKXDozHvxbT3XohJgDQ==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.1.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1.tgz",
-      "integrity": "sha512-by3HrKxmnZixyiwgDVCq0t0Ca0OV5RzRxP9ZYrHYdeRF7RN0pgJXzMc6Nfs1mdk8Ba8MRmdsq7pvbC0kadj4Tg==",
+      "version": "3.1.1-fb-reactBootstrapConverts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
+      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -20255,9 +20255,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.14.46",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.46.tgz",
-      "integrity": "sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==",
+      "version": "16.14.54",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.54.tgz",
+      "integrity": "sha512-54MOeVbxTlC8U6XBy2sLhLaHg/QGP0gPEWIpl1E5tNTJDz/SdFktT3OuvAfKxpSXATUmKXDozHvxbT3XohJgDQ==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0",
+    "@labkey/components": "3.1.2",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.1.1",
+    "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {
@@ -63,7 +63,7 @@
     "@types/enzyme": "3.10.13",
     "@types/enzyme-adapter-react-16": "1.0.6",
     "@types/jest": "29.5.4",
-    "@types/react": "16.14.46",
+    "@types/react": "16.14.54",
     "@types/react-dom": "16.9.19",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.7",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0"
+        "@labkey/components": "3.1.2"
       },
       "devDependencies": {
         "@labkey/build": "7.0.0",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.1.1-fb-reactBootstrapConverts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
-      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
+      "version": "3.1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
+      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17196,9 +17196,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.1.1-fb-reactBootstrapConverts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
-      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
+      "version": "3.1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
+      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,13 +8,13 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.1.1"
+        "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.0",
         "@labkey/test": "1.3.0",
         "@types/jest": "29.5.4",
-        "@types/react": "16.14.46",
+        "@types/react": "16.14.54",
         "@types/react-dom": "16.9.19",
         "jest": "29.7.0",
         "jest-cli": "29.7.0",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.1.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1.tgz",
-      "integrity": "sha512-by3HrKxmnZixyiwgDVCq0t0Ca0OV5RzRxP9ZYrHYdeRF7RN0pgJXzMc6Nfs1mdk8Ba8MRmdsq7pvbC0kadj4Tg==",
+      "version": "3.1.1-fb-reactBootstrapConverts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
+      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -4028,9 +4028,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "16.14.46",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.46.tgz",
-      "integrity": "sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==",
+      "version": "16.14.54",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.54.tgz",
+      "integrity": "sha512-54MOeVbxTlC8U6XBy2sLhLaHg/QGP0gPEWIpl1E5tNTJDz/SdFktT3OuvAfKxpSXATUmKXDozHvxbT3XohJgDQ==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -17196,9 +17196,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.1.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1.tgz",
-      "integrity": "sha512-by3HrKxmnZixyiwgDVCq0t0Ca0OV5RzRxP9ZYrHYdeRF7RN0pgJXzMc6Nfs1mdk8Ba8MRmdsq7pvbC0kadj4Tg==",
+      "version": "3.1.1-fb-reactBootstrapConverts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
+      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17833,9 +17833,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.14.46",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.46.tgz",
-      "integrity": "sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==",
+      "version": "16.14.54",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.54.tgz",
+      "integrity": "sha512-54MOeVbxTlC8U6XBy2sLhLaHg/QGP0gPEWIpl1E5tNTJDz/SdFktT3OuvAfKxpSXATUmKXDozHvxbT3XohJgDQ==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0"
+    "@labkey/components": "3.1.2"
   },
   "devDependencies": {
     "@labkey/build": "7.0.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,13 +13,13 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.1.1"
+    "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.0",
     "@labkey/test": "1.3.0",
     "@types/jest": "29.5.4",
-    "@types/react": "16.14.46",
+    "@types/react": "16.14.54",
     "@types/react-dom": "16.9.19",
     "jest": "29.7.0",
     "jest-cli": "29.7.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,13 +8,13 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.1.1"
+        "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.0",
         "@labkey/eslint-config-react": "0.0.13",
         "@types/jest": "29.5.4",
-        "@types/react": "16.14.46",
+        "@types/react": "16.14.54",
         "@types/react-dom": "16.9.19"
       }
     },
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.1.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1.tgz",
-      "integrity": "sha512-by3HrKxmnZixyiwgDVCq0t0Ca0OV5RzRxP9ZYrHYdeRF7RN0pgJXzMc6Nfs1mdk8Ba8MRmdsq7pvbC0kadj4Tg==",
+      "version": "3.1.1-fb-reactBootstrapConverts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
+      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -3512,9 +3512,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "16.14.46",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.46.tgz",
-      "integrity": "sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==",
+      "version": "16.14.54",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.54.tgz",
+      "integrity": "sha512-54MOeVbxTlC8U6XBy2sLhLaHg/QGP0gPEWIpl1E5tNTJDz/SdFktT3OuvAfKxpSXATUmKXDozHvxbT3XohJgDQ==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -15438,9 +15438,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.1.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1.tgz",
-      "integrity": "sha512-by3HrKxmnZixyiwgDVCq0t0Ca0OV5RzRxP9ZYrHYdeRF7RN0pgJXzMc6Nfs1mdk8Ba8MRmdsq7pvbC0kadj4Tg==",
+      "version": "3.1.1-fb-reactBootstrapConverts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
+      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -16061,9 +16061,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.14.46",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.46.tgz",
-      "integrity": "sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==",
+      "version": "16.14.54",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.54.tgz",
+      "integrity": "sha512-54MOeVbxTlC8U6XBy2sLhLaHg/QGP0gPEWIpl1E5tNTJDz/SdFktT3OuvAfKxpSXATUmKXDozHvxbT3XohJgDQ==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0"
+        "@labkey/components": "3.1.2"
       },
       "devDependencies": {
         "@labkey/build": "7.0.0",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.1.1-fb-reactBootstrapConverts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
-      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
+      "version": "3.1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
+      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -15438,9 +15438,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.1.1-fb-reactBootstrapConverts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.1-fb-reactBootstrapConverts.0.tgz",
-      "integrity": "sha512-Ih1GPgaI43dsK5CUUmC2sngKIP5YExOyOiZyRMHDxf6obuhqDq92iGRTRvHSJh7HWMDQNcFYeuiP5p5TdMLqAg==",
+      "version": "3.1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
+      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,13 +14,13 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.1.1"
+    "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.0",
     "@labkey/eslint-config-react": "0.0.13",
     "@types/jest": "29.5.4",
-    "@types/react": "16.14.46",
+    "@types/react": "16.14.54",
     "@types/react-dom": "16.9.19"
   }
 }

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.1.1-fb-reactBootstrapConverts.0"
+    "@labkey/components": "3.1.2"
   },
   "devDependencies": {
     "@labkey/build": "7.0.0",


### PR DESCRIPTION
#### Rationale
After recent rehydration of package-lock files, the npm run start-link stated getting react typing errors for the app modules. This was because of a mismatch in the types for @types/react. This PR updates the package.json to drop the tilde from the devDependencies to pin the version matches across packages/apps.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1377

#### Changes
- update @labkey/components and @types/react to match versions to fix stat-link errors
