### PR TITLE
Issue 49328: Ensure RootMaterialRowId is set for all materials

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-23.011-23.012.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-23.011-23.012.sql
@@ -29,6 +29,9 @@ UPDATE exp.material AS mat SET RootMaterialRowId = (
     SELECT RootMaterialRowId FROM materialroottemp AS root WHERE mat.RowId = root.RowId
 );
 
+-- Issue 49328: Ensure RootMaterialRowId is set for all materials
+UPDATE exp.material as mat SET RootMaterialRowId = RowId WHERE RootMaterialRowId IS NULL;
+
 -- Drop the temporary table
 DROP TABLE materialroottemp;
 

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-23.011-23.012.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-23.011-23.012.sql
@@ -9,6 +9,10 @@ FROM exp.Material Material
 INNER JOIN exp.Material Parent ON Material.rootmateriallsid = Parent.lsid;
 GO
 
+-- Issue 49328: Ensure RootMaterialRowId is set for all materials
+UPDATE exp.Material SET rootmaterialrowid = rowid WHERE rootmaterialrowid IS NULL;
+GO
+
 -- Add NOT NULL constraint to "RootMaterialRowId"
 ALTER TABLE exp.Material ALTER COLUMN rootmaterialrowid INTEGER NOT NULL;
 GO


### PR DESCRIPTION
#### Rationale
This addresses [Issue 49328](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49328) by updating the upgrade script to repoint row's with invalid LSIDs, LSIDs of samples that do not exist in the system, to themselves for their `RootMaterialRowId` value. This can be done as an update to an existing script because upgrades will fail if there is `NULL` values for `RootMaterialRowId` which will mean this script will need to be re-run.

#### Related Pull Requests
* #4844

#### Changes
* Update upgrade script to account for `NULL` values in `RootMaterialRowId`
