### PR TITLE
@labkey/build: Update to ES2019

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,10 +8,10 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.2.1-fb-ts-lib.1"
+        "@labkey/components": "3.2.2"
       },
       "devDependencies": {
-        "@labkey/build": "7.0.2-fb-ts-lib.0",
+        "@labkey/build": "7.0.2",
         "@types/jest": "29.5.4",
         "@types/react": "16.14.54",
         "@types/react-dom": "16.9.19"
@@ -2407,9 +2407,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "node_modules/@labkey/build": {
-      "version": "7.0.2-fb-ts-lib.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
-      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
+      "version": "7.0.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2.tgz",
+      "integrity": "sha512-TgHh2Q5YfXoZSbBuGpWQK8igxL9A5Jo2xcvInUZprVjx1iNhocqP6eIO/pHTKW9h/WUyF4+Yl6CTcEIT6y4A5g==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.22.20",
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.2.1-fb-ts-lib.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
-      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
+      "version": "3.2.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.2.tgz",
+      "integrity": "sha512-C/Gm7LbpFFFpmfD0D0RwnmPujDzasxoCPwqGuz4FFthj9+Ym0X0xgg3q99bw/wRHBxvsA+84w3SjiHH3xzwXsA==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -12883,9 +12883,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "@labkey/build": {
-      "version": "7.0.2-fb-ts-lib.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
-      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
+      "version": "7.0.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2.tgz",
+      "integrity": "sha512-TgHh2Q5YfXoZSbBuGpWQK8igxL9A5Jo2xcvInUZprVjx1iNhocqP6eIO/pHTKW9h/WUyF4+Yl6CTcEIT6y4A5g==",
       "dev": true,
       "requires": {
         "@babel/core": "~7.22.20",
@@ -12919,9 +12919,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.2.1-fb-ts-lib.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
-      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
+      "version": "3.2.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.2.tgz",
+      "integrity": "sha512-C/Gm7LbpFFFpmfD0D0RwnmPujDzasxoCPwqGuz4FFthj9+Ym0X0xgg3q99bw/wRHBxvsA+84w3SjiHH3xzwXsA==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,10 +8,10 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.1.2"
+        "@labkey/components": "3.2.1-fb-ts-lib.1"
       },
       "devDependencies": {
-        "@labkey/build": "7.0.1",
+        "@labkey/build": "7.0.2-fb-ts-lib.0",
         "@types/jest": "29.5.4",
         "@types/react": "16.14.54",
         "@types/react-dom": "16.9.19"
@@ -2407,9 +2407,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "node_modules/@labkey/build": {
-      "version": "7.0.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.1.tgz",
-      "integrity": "sha512-u8G+0HUgvfGoclRN1SsODbgEjyBELLdagUfX0esks+/cNLV/dn73Qcv+ETsXklp5OAjv1bfIMHS9R9UPUEnLwg==",
+      "version": "7.0.2-fb-ts-lib.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
+      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.22.20",
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
-      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
+      "version": "3.2.1-fb-ts-lib.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
+      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -12883,9 +12883,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "@labkey/build": {
-      "version": "7.0.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.1.tgz",
-      "integrity": "sha512-u8G+0HUgvfGoclRN1SsODbgEjyBELLdagUfX0esks+/cNLV/dn73Qcv+ETsXklp5OAjv1bfIMHS9R9UPUEnLwg==",
+      "version": "7.0.2-fb-ts-lib.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
+      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
       "dev": true,
       "requires": {
         "@babel/core": "~7.22.20",
@@ -12919,9 +12919,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
-      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
+      "version": "3.2.1-fb-ts-lib.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
+      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,10 +12,10 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.1.2"
+    "@labkey/components": "3.2.1-fb-ts-lib.1"
   },
   "devDependencies": {
-    "@labkey/build": "7.0.1",
+    "@labkey/build": "7.0.2-fb-ts-lib.0",
     "@types/jest": "29.5.4",
     "@types/react": "16.14.54",
     "@types/react-dom": "16.9.19"

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,10 +12,10 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.2.1-fb-ts-lib.1"
+    "@labkey/components": "3.2.2"
   },
   "devDependencies": {
-    "@labkey/build": "7.0.2-fb-ts-lib.0",
+    "@labkey/build": "7.0.2",
     "@types/jest": "29.5.4",
     "@types/react": "16.14.54",
     "@types/react-dom": "16.9.19"

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,11 +8,11 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.1.2",
+        "@labkey/components": "3.2.1-fb-ts-lib.1",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
-        "@labkey/build": "7.0.1",
+        "@labkey/build": "7.0.2-fb-ts-lib.0",
         "@labkey/eslint-config-react": "0.0.13",
         "@types/enzyme": "3.10.13",
         "@types/enzyme-adapter-react-16": "1.0.6",
@@ -3303,9 +3303,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "node_modules/@labkey/build": {
-      "version": "7.0.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.1.tgz",
-      "integrity": "sha512-u8G+0HUgvfGoclRN1SsODbgEjyBELLdagUfX0esks+/cNLV/dn73Qcv+ETsXklp5OAjv1bfIMHS9R9UPUEnLwg==",
+      "version": "7.0.2-fb-ts-lib.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
+      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.22.20",
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
-      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
+      "version": "3.2.1-fb-ts-lib.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
+      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19519,9 +19519,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "@labkey/build": {
-      "version": "7.0.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.1.tgz",
-      "integrity": "sha512-u8G+0HUgvfGoclRN1SsODbgEjyBELLdagUfX0esks+/cNLV/dn73Qcv+ETsXklp5OAjv1bfIMHS9R9UPUEnLwg==",
+      "version": "7.0.2-fb-ts-lib.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
+      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
       "dev": true,
       "requires": {
         "@babel/core": "~7.22.20",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
-      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
+      "version": "3.2.1-fb-ts-lib.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
+      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,11 +8,11 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.2.1-fb-ts-lib.1",
+        "@labkey/components": "3.2.2",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
-        "@labkey/build": "7.0.2-fb-ts-lib.0",
+        "@labkey/build": "7.0.2",
         "@labkey/eslint-config-react": "0.0.13",
         "@types/enzyme": "3.10.13",
         "@types/enzyme-adapter-react-16": "1.0.6",
@@ -3303,9 +3303,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "node_modules/@labkey/build": {
-      "version": "7.0.2-fb-ts-lib.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
-      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
+      "version": "7.0.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2.tgz",
+      "integrity": "sha512-TgHh2Q5YfXoZSbBuGpWQK8igxL9A5Jo2xcvInUZprVjx1iNhocqP6eIO/pHTKW9h/WUyF4+Yl6CTcEIT6y4A5g==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.22.20",
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.2.1-fb-ts-lib.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
-      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
+      "version": "3.2.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.2.tgz",
+      "integrity": "sha512-C/Gm7LbpFFFpmfD0D0RwnmPujDzasxoCPwqGuz4FFthj9+Ym0X0xgg3q99bw/wRHBxvsA+84w3SjiHH3xzwXsA==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19519,9 +19519,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "@labkey/build": {
-      "version": "7.0.2-fb-ts-lib.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
-      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
+      "version": "7.0.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2.tgz",
+      "integrity": "sha512-TgHh2Q5YfXoZSbBuGpWQK8igxL9A5Jo2xcvInUZprVjx1iNhocqP6eIO/pHTKW9h/WUyF4+Yl6CTcEIT6y4A5g==",
       "dev": true,
       "requires": {
         "@babel/core": "~7.22.20",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.2.1-fb-ts-lib.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
-      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
+      "version": "3.2.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.2.tgz",
+      "integrity": "sha512-C/Gm7LbpFFFpmfD0D0RwnmPujDzasxoCPwqGuz4FFthj9+Ym0X0xgg3q99bw/wRHBxvsA+84w3SjiHH3xzwXsA==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package.json
+++ b/core/package.json
@@ -54,11 +54,11 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.2.1-fb-ts-lib.1",
+    "@labkey/components": "3.2.2",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {
-    "@labkey/build": "7.0.2-fb-ts-lib.0",
+    "@labkey/build": "7.0.2",
     "@labkey/eslint-config-react": "0.0.13",
     "@types/enzyme": "3.10.13",
     "@types/enzyme-adapter-react-16": "1.0.6",

--- a/core/package.json
+++ b/core/package.json
@@ -54,11 +54,11 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.1.2",
+    "@labkey/components": "3.2.1-fb-ts-lib.1",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {
-    "@labkey/build": "7.0.1",
+    "@labkey/build": "7.0.2-fb-ts-lib.0",
     "@labkey/eslint-config-react": "0.0.13",
     "@types/enzyme": "3.10.13",
     "@types/enzyme-adapter-react-16": "1.0.6",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,10 +8,10 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.1.2"
+        "@labkey/components": "3.2.1-fb-ts-lib.1"
       },
       "devDependencies": {
-        "@labkey/build": "7.0.1",
+        "@labkey/build": "7.0.2-fb-ts-lib.0",
         "@labkey/test": "1.3.0",
         "@types/jest": "29.5.4",
         "@types/react": "16.14.54",
@@ -3188,9 +3188,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "node_modules/@labkey/build": {
-      "version": "7.0.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.1.tgz",
-      "integrity": "sha512-u8G+0HUgvfGoclRN1SsODbgEjyBELLdagUfX0esks+/cNLV/dn73Qcv+ETsXklp5OAjv1bfIMHS9R9UPUEnLwg==",
+      "version": "7.0.2-fb-ts-lib.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
+      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.22.20",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
-      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
+      "version": "3.2.1-fb-ts-lib.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
+      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17160,9 +17160,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "@labkey/build": {
-      "version": "7.0.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.1.tgz",
-      "integrity": "sha512-u8G+0HUgvfGoclRN1SsODbgEjyBELLdagUfX0esks+/cNLV/dn73Qcv+ETsXklp5OAjv1bfIMHS9R9UPUEnLwg==",
+      "version": "7.0.2-fb-ts-lib.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
+      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
       "dev": true,
       "requires": {
         "@babel/core": "~7.22.20",
@@ -17196,9 +17196,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
-      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
+      "version": "3.2.1-fb-ts-lib.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
+      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,10 +8,10 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.2.1-fb-ts-lib.1"
+        "@labkey/components": "3.2.2"
       },
       "devDependencies": {
-        "@labkey/build": "7.0.2-fb-ts-lib.0",
+        "@labkey/build": "7.0.2",
         "@labkey/test": "1.3.0",
         "@types/jest": "29.5.4",
         "@types/react": "16.14.54",
@@ -3188,9 +3188,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "node_modules/@labkey/build": {
-      "version": "7.0.2-fb-ts-lib.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
-      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
+      "version": "7.0.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2.tgz",
+      "integrity": "sha512-TgHh2Q5YfXoZSbBuGpWQK8igxL9A5Jo2xcvInUZprVjx1iNhocqP6eIO/pHTKW9h/WUyF4+Yl6CTcEIT6y4A5g==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.22.20",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.2.1-fb-ts-lib.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
-      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
+      "version": "3.2.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.2.tgz",
+      "integrity": "sha512-C/Gm7LbpFFFpmfD0D0RwnmPujDzasxoCPwqGuz4FFthj9+Ym0X0xgg3q99bw/wRHBxvsA+84w3SjiHH3xzwXsA==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17160,9 +17160,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "@labkey/build": {
-      "version": "7.0.2-fb-ts-lib.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
-      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
+      "version": "7.0.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2.tgz",
+      "integrity": "sha512-TgHh2Q5YfXoZSbBuGpWQK8igxL9A5Jo2xcvInUZprVjx1iNhocqP6eIO/pHTKW9h/WUyF4+Yl6CTcEIT6y4A5g==",
       "dev": true,
       "requires": {
         "@babel/core": "~7.22.20",
@@ -17196,9 +17196,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.2.1-fb-ts-lib.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
-      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
+      "version": "3.2.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.2.tgz",
+      "integrity": "sha512-C/Gm7LbpFFFpmfD0D0RwnmPujDzasxoCPwqGuz4FFthj9+Ym0X0xgg3q99bw/wRHBxvsA+84w3SjiHH3xzwXsA==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,10 +13,10 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.2.1-fb-ts-lib.1"
+    "@labkey/components": "3.2.2"
   },
   "devDependencies": {
-    "@labkey/build": "7.0.2-fb-ts-lib.0",
+    "@labkey/build": "7.0.2",
     "@labkey/test": "1.3.0",
     "@types/jest": "29.5.4",
     "@types/react": "16.14.54",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,10 +13,10 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.1.2"
+    "@labkey/components": "3.2.1-fb-ts-lib.1"
   },
   "devDependencies": {
-    "@labkey/build": "7.0.1",
+    "@labkey/build": "7.0.2-fb-ts-lib.0",
     "@labkey/test": "1.3.0",
     "@types/jest": "29.5.4",
     "@types/react": "16.14.54",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,10 +8,10 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.2.1-fb-ts-lib.1"
+        "@labkey/components": "3.2.2"
       },
       "devDependencies": {
-        "@labkey/build": "7.0.2-fb-ts-lib.0",
+        "@labkey/build": "7.0.2",
         "@labkey/eslint-config-react": "0.0.13",
         "@types/jest": "29.5.4",
         "@types/react": "16.14.54",
@@ -2603,9 +2603,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "node_modules/@labkey/build": {
-      "version": "7.0.2-fb-ts-lib.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
-      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
+      "version": "7.0.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2.tgz",
+      "integrity": "sha512-TgHh2Q5YfXoZSbBuGpWQK8igxL9A5Jo2xcvInUZprVjx1iNhocqP6eIO/pHTKW9h/WUyF4+Yl6CTcEIT6y4A5g==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.22.20",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.2.1-fb-ts-lib.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
-      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
+      "version": "3.2.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.2.tgz",
+      "integrity": "sha512-C/Gm7LbpFFFpmfD0D0RwnmPujDzasxoCPwqGuz4FFthj9+Ym0X0xgg3q99bw/wRHBxvsA+84w3SjiHH3xzwXsA==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -15360,9 +15360,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "@labkey/build": {
-      "version": "7.0.2-fb-ts-lib.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
-      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
+      "version": "7.0.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2.tgz",
+      "integrity": "sha512-TgHh2Q5YfXoZSbBuGpWQK8igxL9A5Jo2xcvInUZprVjx1iNhocqP6eIO/pHTKW9h/WUyF4+Yl6CTcEIT6y4A5g==",
       "dev": true,
       "requires": {
         "@babel/core": "~7.22.20",
@@ -15438,9 +15438,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.2.1-fb-ts-lib.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
-      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
+      "version": "3.2.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.2.tgz",
+      "integrity": "sha512-C/Gm7LbpFFFpmfD0D0RwnmPujDzasxoCPwqGuz4FFthj9+Ym0X0xgg3q99bw/wRHBxvsA+84w3SjiHH3xzwXsA==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,10 +8,10 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.1.2"
+        "@labkey/components": "3.2.1-fb-ts-lib.1"
       },
       "devDependencies": {
-        "@labkey/build": "7.0.1",
+        "@labkey/build": "7.0.2-fb-ts-lib.0",
         "@labkey/eslint-config-react": "0.0.13",
         "@types/jest": "29.5.4",
         "@types/react": "16.14.54",
@@ -2603,9 +2603,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "node_modules/@labkey/build": {
-      "version": "7.0.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.1.tgz",
-      "integrity": "sha512-u8G+0HUgvfGoclRN1SsODbgEjyBELLdagUfX0esks+/cNLV/dn73Qcv+ETsXklp5OAjv1bfIMHS9R9UPUEnLwg==",
+      "version": "7.0.2-fb-ts-lib.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
+      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
       "dev": true,
       "dependencies": {
         "@babel/core": "~7.22.20",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
-      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
+      "version": "3.2.1-fb-ts-lib.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
+      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
       "dependencies": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -15360,9 +15360,9 @@
       "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
     },
     "@labkey/build": {
-      "version": "7.0.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.1.tgz",
-      "integrity": "sha512-u8G+0HUgvfGoclRN1SsODbgEjyBELLdagUfX0esks+/cNLV/dn73Qcv+ETsXklp5OAjv1bfIMHS9R9UPUEnLwg==",
+      "version": "7.0.2-fb-ts-lib.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/build/-/@labkey/build-7.0.2-fb-ts-lib.0.tgz",
+      "integrity": "sha512-Z1+3bYvjWUY7omG2olhq5wS/EJ9so5rBeBOmMsQ/ALxS68M87yh3GWdpgFmzqyFNeb/fIvXnuTUZGD/EiREKow==",
       "dev": true,
       "requires": {
         "@babel/core": "~7.22.20",
@@ -15438,9 +15438,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.1.2.tgz",
-      "integrity": "sha512-O8JUh8GnYrf1e3igcBXByLBeydoJ21PDXkrqToib9qjfNvJENjQTq6GG9w6zbQapjRRNzs6DSUOkU8zfbW0Hfw==",
+      "version": "3.2.1-fb-ts-lib.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.1-fb-ts-lib.1.tgz",
+      "integrity": "sha512-NTMMHixrILMyiiVHmkuG0tFFx0y+vExVnSpfU4wEXj+7PaRSKKsTMet7IZ9iFI9jWaklLzXpgTp8M5ojIU0p5g==",
       "requires": {
         "@labkey/api": "1.28.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,10 +14,10 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.1.2"
+    "@labkey/components": "3.2.1-fb-ts-lib.1"
   },
   "devDependencies": {
-    "@labkey/build": "7.0.1",
+    "@labkey/build": "7.0.2-fb-ts-lib.0",
     "@labkey/eslint-config-react": "0.0.13",
     "@types/jest": "29.5.4",
     "@types/react": "16.14.54",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,10 +14,10 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.2.1-fb-ts-lib.1"
+    "@labkey/components": "3.2.2"
   },
   "devDependencies": {
-    "@labkey/build": "7.0.2-fb-ts-lib.0",
+    "@labkey/build": "7.0.2",
     "@labkey/eslint-config-react": "0.0.13",
     "@types/jest": "29.5.4",
     "@types/react": "16.14.54",


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-ui-components/pull/1379 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1379
- https://github.com/LabKey/labkey-ui-premium/pull/290
- https://github.com/LabKey/biologics/pull/2602
- https://github.com/LabKey/sampleManagement/pull/2330
- https://github.com/LabKey/inventory/pull/1141
- https://github.com/LabKey/platform/pull/5083

#### Changes
- Bump `@labkey` packages