### PR TITLE
Fix cross project sample import for sql server

### DIFF
--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -100,7 +100,7 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
             {
                 pkSuppliers.clear();
                 pkColumns.clear();
-                throw new IllegalStateException("Key column not found: " + name);
+                throw new IllegalArgumentException("Key column not found: " + name);
             }
             pkSuppliers.add(in.getSupplier(index));
             pkColumns.add(col);

--- a/api/src/org/labkey/api/dataiterator/SampleUpdateAliquotedFromDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/SampleUpdateAliquotedFromDataIterator.java
@@ -57,9 +57,7 @@ public class SampleUpdateAliquotedFromDataIterator extends WrapperDataIterator
         Integer index = map.get(keyCol);
         ColumnInfo col = target.getColumn(keyCol);
         if (null == index || null == col)
-        {
-            throw new IllegalStateException("Key column not found: " + keyCol);
-        }
+            throw new IllegalArgumentException("Key column not found: " + keyCol);
         pkSupplier = in.getSupplier(index);
         pkColumn = col;
     }

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -387,6 +387,14 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             }
             else
             {
+                if (pkCol.getJdbcType() == JdbcType.GUID)
+                {
+                    if (k == null)
+                        return null;
+                    if (k instanceof String strKey && !GUID.isGUID(strKey))
+                        return null;
+                }
+
                 try
                 {
                     if (_allowBulkLoads && _bulkLoads.add(Pair.of(pkCol, pkCol)))

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -387,16 +387,24 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             }
             else
             {
-                if (_allowBulkLoads && _bulkLoads.add(Pair.of(pkCol, pkCol)))
+                try
                 {
-                    TableSelector ts = createSelector(pkCol, pkCol);
-                    ts.forEach(pkCol.getJavaObjectClass(), (Object pk) -> map.put(pk, pk));
+                    if (_allowBulkLoads && _bulkLoads.add(Pair.of(pkCol, pkCol)))
+                    {
+                        TableSelector ts = createSelector(pkCol, pkCol);
+                        ts.forEach(pkCol.getJavaObjectClass(), (Object pk) -> map.put(pk, pk));
+                    }
+                    else
+                    {
+                        TableSelector ts = createSelector(pkCol, pkCol, k);
+                        ts.forEach(pkCol.getJavaObjectClass(), (Object pk) -> map.put(pk, pk));
+                    }
                 }
-                else
+                catch (Exception e)
                 {
-                    TableSelector ts = createSelector(pkCol, pkCol, k);
-                    ts.forEach(pkCol.getJavaObjectClass(), (Object pk) -> map.put(pk, pk));
+                    // ignore
                 }
+
 
                 if (map.containsKey(k))
                     return map.get(k);

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -389,10 +389,11 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             {
                 if (pkCol.getJdbcType() == JdbcType.GUID)
                 {
-                    if (k == null)
+                    if (k == null || (k instanceof String strKey && !GUID.isGUID(strKey)))
+                    {
+                        map.put(k, MISS);
                         return null;
-                    if (k instanceof String strKey && !GUID.isGUID(strKey))
-                        return null;
+                    }
                 }
 
                 try

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -396,24 +396,16 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                     }
                 }
 
-                try
+                if (_allowBulkLoads && _bulkLoads.add(Pair.of(pkCol, pkCol)))
                 {
-                    if (_allowBulkLoads && _bulkLoads.add(Pair.of(pkCol, pkCol)))
-                    {
-                        TableSelector ts = createSelector(pkCol, pkCol);
-                        ts.forEach(pkCol.getJavaObjectClass(), (Object pk) -> map.put(pk, pk));
-                    }
-                    else
-                    {
-                        TableSelector ts = createSelector(pkCol, pkCol, k);
-                        ts.forEach(pkCol.getJavaObjectClass(), (Object pk) -> map.put(pk, pk));
-                    }
+                    TableSelector ts = createSelector(pkCol, pkCol);
+                    ts.forEach(pkCol.getJavaObjectClass(), (Object pk) -> map.put(pk, pk));
                 }
-                catch (Exception e)
+                else
                 {
-                    // ignore
+                    TableSelector ts = createSelector(pkCol, pkCol, k);
+                    ts.forEach(pkCol.getJavaObjectClass(), (Object pk) -> map.put(pk, pk));
                 }
-
 
                 if (map.containsKey(k))
                     return map.get(k);


### PR DESCRIPTION
#### Rationale
Sample import now accepts "Container" column. For SQL server, GUID/uniqueidentifier datatype is incompatible with character string datatype. This PR adds the check if the _pkColumnLookupMap key is not GUID for GUID columns during remap cache fetch, in which case it should fetch based on _titleColumnLookupMap instead.

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_SampleManagerCSqlserver/2818132?buildTab=tests&status=failed&name=SMProSamplesCreateAndUpdateTest

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* skip fetch by _pkColumnLookupMap when pk is non-guid string for guid columns
* switch from IllegalStateException to IllegalArgumentException
