### PR TITLE
Fix LoggingTestCase for embedded distributions

### DIFF
--- a/core/src/org/labkey/core/admin/logger/LoggingTestCase.java
+++ b/core/src/org/labkey/core/admin/logger/LoggingTestCase.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.test.TestWhen;
-import org.labkey.api.util.PageFlowUtil;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -29,12 +28,13 @@ public class LoggingTestCase extends Assert
         // log4j2.xml file is found first.
         String filename = "log4j2.xml";
         String substring = "labkeyWebapp/WEB-INF/classes/log4j2.xml"; // Our standard log4j2.xml file
+        String substring2 = "labkeywebapp/WEB-INF/classes/log4j2.xml"; // From an embedded distribution
 
         List<URL> list = Collections.list(getClass().getClassLoader().getResources(filename));
         assertFalse("Didn't find expected file: " + filename, list.isEmpty());
         String first = list.get(0).toString();
         assertTrue("Did not find substring \"" + substring + "\" in file path of the first " + filename + " file on the class path. Here's what was found: "
-            + list.stream().map(URL::toString).collect(Collectors.joining(", ")), first.contains(substring));
+            + list.stream().map(URL::toString).collect(Collectors.joining(", ")), first.contains(substring) || first.contains(substring2));
     }
 
     @Test

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -331,8 +331,10 @@ public class FileContentServiceImpl implements FileContentService, WarningProvid
             }
             else
             {
+                File fileRootFile = new File(parentRoot.toFile(), getRelativePath(c, firstOverride));
+                _log.info("File root for '%s': '%s'".formatted(c.getPath(), fileRootFile.toString()));
                 // For local, the path may be several directories deep (since it matches the LK folder path), so we should create the directories for that path
-                fileRootPath = new File(parentRoot.toFile(), getRelativePath(c, firstOverride)).toPath();
+                fileRootPath = fileRootFile.toPath();
 
                 try
                 {


### PR DESCRIPTION
#### Rationale
Casing for the `labkeyWebapp` directory varies between embedded and non-embedded deployments. To run tests against embedded distributions, the tests need to account for slight deployment differences.
[[Validating Fix](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Internal_Embedded_TestEmbeddedPostgres/2819955)]

#### Related Pull Requests
* N/A

#### Changes
* Update `LoggingTestCase.testXmlFiles` to permit `labkeyWebapp` or `labkeywebapp`
