### PR TITLE
When creating entities, check name requirements against current container only

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -264,7 +264,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 c.setNullable(nameExpression != null);
 
                 // shut off this field in insert and update views if user-specified names are not allowed
-                if (!NameExpressionOptionService.get().allowUserSpecifiedNames(getContainer()))
+                if (!NameExpressionOptionService.get().getAllowUserSpecificNamesValue(getContainer()))
                 {
                     c.setShownInInsertView(false);
                     c.setShownInUpdateView(false);
@@ -1022,7 +1022,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 }
                 Map<String, String> finalImportAliasMap = importAliasMap;
                 di = LoggingDataIterator.wrap(new NameExpressionDataIterator(di, context, dataClassTInfo, getContainer(), _dataClass.getMaxDataCounterFunction(), DATA_COUNTER_SEQ_PREFIX + _dataClass.getRowId() + "-", importAliasMap)
-                        .setAllowUserSpecifiedNames(NameExpressionOptionService.get().allowUserSpecifiedNames(getContainer()))
+                        .setAllowUserSpecifiedNames(NameExpressionOptionService.get().getAllowUserSpecificNamesValue(getContainer()))
                         .addExtraPropsFn(() -> {
                             Map<String, Object> props = new HashMap<>();
                             props.put(PARENT_IMPORT_ALIAS_MAP_PROP, finalImportAliasMap);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -257,7 +257,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             {
                 var nameCol = wrapColumn(alias, _rootTable.getColumn(column.toString()));
                 // shut off this field in insert and update views if user specified names are not allowed
-                if (!NameExpressionOptionService.get().allowUserSpecifiedNames(getContainer()))
+                if (!NameExpressionOptionService.get().getAllowUserSpecificNamesValue(getContainer()))
                 {
                     nameCol.setShownInInsertView(false);
                     nameCol.setShownInUpdateView(false);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -624,7 +624,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         String oldName = (String) oldRow.get(Name.name());
         boolean hasNameChange = !StringUtils.isEmpty(newName) && !newName.equals(oldName);
-        if (hasNameChange && !NameExpressionOptionService.get().allowUserSpecifiedNames(c))
+        if (hasNameChange && !NameExpressionOptionService.get().getAllowUserSpecificNamesValue(c))
             throw new ValidationException("User-specified sample name not allowed");
 
         String oldAliquotedFromLSID = (String) oldRow.get(AliquotedFromLSID.name());
@@ -1450,7 +1450,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             // sampleset.createSampleNames() + generate lsid
             // TODO: does not handle insertIgnore
             DataIterator names = new _GenerateNamesDataIterator(sampleType, container, user, DataIteratorUtil.wrapMap(dataIterator, false), context, batchSize)
-                    .setAllowUserSpecifiedNames(NameExpressionOptionService.get().allowUserSpecifiedNames(container))
+                    .setAllowUserSpecifiedNames(NameExpressionOptionService.get().getAllowUserSpecificNamesValue(container))
                     .addExtraPropsFn(() -> {
                         if (container != null)
                             return Map.of(NameExpressionOptionService.FOLDER_PREFIX_TOKEN, StringUtils.trimToEmpty(NameExpressionOptionService.get().getExpressionPrefix(container)));


### PR DESCRIPTION
#### Rationale
The setting for whether to allow users to supply names for entities is folder-specific. When creating new entity types, we need to check all containers in context to determine if any do not allow users to supply names and thus require a naming pattern for all entity types, but when creating the entities themselves, we should always be checking the current container's setting to determine if user-supplied names are allowed.

#### Related Pull Requests
* #5036
* https://github.com/LabKey/biologics/pull/2609

#### Changes
* Update checks on whether to allow names to be provided during insert and update
