### PR TITLE
Remove investigative logging from FileContentServiceImpl

### DIFF
--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -331,10 +331,8 @@ public class FileContentServiceImpl implements FileContentService, WarningProvid
             }
             else
             {
-                File fileRootFile = new File(parentRoot.toFile(), getRelativePath(c, firstOverride));
-                _log.info("File root for '%s': '%s'".formatted(c.getPath(), fileRootFile.toString()));
                 // For local, the path may be several directories deep (since it matches the LK folder path), so we should create the directories for that path
-                fileRootPath = fileRootFile.toPath();
+                fileRootPath = new File(parentRoot.toFile(), getRelativePath(c, firstOverride)).toPath();
 
                 try
                 {


### PR DESCRIPTION
#### Rationale
I was troubleshooting some path problems on TeamCity and forgot to remove this code.

#### Related Pull Requests
* #5088 

#### Changes
* Remove investigative logging from FileContentServiceImpl
