### PR TITLE
fixes for automated test failures

### DIFF
--- a/study/src/org/labkey/study/controllers/publish/PublishController.java
+++ b/study/src/org/labkey/study/controllers/publish/PublishController.java
@@ -374,6 +374,10 @@ public class PublishController extends SpringActionController
             {
                 error("Failure", t);
             }
+
+            if (getErrors() == 0)
+                setStatus(TaskStatus.complete);
+
             info("Auto link to study complete");
         }
     }

--- a/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
+++ b/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
@@ -275,6 +275,7 @@ public class CreateChildStudyPipelineJob extends AbstractStudyPipelineJob
                 // Save the snapshot RowId to the destination study
                 StudyImpl mutableStudy = StudyManager.getInstance().getStudy(getDstContainer()).createMutable();
                 mutableStudy.setStudySnapshot(snapshot.getRowId());
+                StudyManager.getInstance().updateStudy(user, mutableStudy);
 
                 // export objects from the parent study, then import them into the new study
                 getLogger().info("Exporting data from parent study.");
@@ -311,6 +312,7 @@ public class CreateChildStudyPipelineJob extends AbstractStudyPipelineJob
                 new TopLevelStudyPropertiesImporter().process(studyImportContext, studyDir, errors);
 
                 // after the data has been imported, configure the new study setting for undefined timepoints
+                mutableStudy = StudyManager.getInstance().getStudy(getDstContainer()).createMutable();
                 if (sourceStudy.isFailForUndefinedTimepoints())
                     mutableStudy.setFailForUndefinedTimepoints(true);
 

--- a/study/src/org/labkey/study/visitmanager/RelativeDateVisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/RelativeDateVisitManager.java
@@ -327,7 +327,7 @@ public class RelativeDateVisitManager extends VisitManager
         return errors;
     }
 
-    public @Nullable ValidationException recomputeDates(Date oldStartDate, User user)
+    public @NotNull ValidationException recomputeDates(Date oldStartDate, User user)
     {
         if (null != oldStartDate)
         {
@@ -351,7 +351,7 @@ public class RelativeDateVisitManager extends VisitManager
                 return updateParticipantVisits(user, getStudy().getDatasets());
             }
         }
-        return null;
+        return new ValidationException();
     }
 
     // Return sql for fetching all datasets and their visit sequence numbers, given a container


### PR DESCRIPTION
#### Rationale
This recent [PR](https://github.com/LabKey/platform/pull/5075) to prevent undefined visits from being automatically created during data import was causing failures in these tests:
- [DatasetPublishTest.testSteps](https://teamcity.labkey.org/buildConfiguration/bt20/2829099?buildTab=tests&status=failed&name=DatasetPublishTest.testSteps)
- [AncillaryStudyTest](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySuites_DailyEPostgres/2829103?buildTab=tests&status=failed&name=AncillaryStudyTest)
- [LinkAssayToStudyTest.verifyAsyncLinkToAssay](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySuites_DailyEPostgres/2829103?buildTab=tests&status=failed&name=LinkAssayToStudyTest.verifyAsyncLinkToAssay)
- [StudyDateAndContinuousTimepointTest.testPublishStudy](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySuites_DailyEPostgres/2829103?buildTab=tests&status=failed&name=StudyDateAndContinuousTimepointTest.testPublishStudy)

#### Changes
- `AutoLinkPipelineJob` - needs to set the status as complete if no errors were raised.
- `CreateChildStudyPipelineJob` - re-add the line of code to save the study prior to the folder export to allow study properties to be propagated to the dest study.
- `RelativeDateVisitManager.recomputDates` - always return a non-null `ValidationException` 