### PR TITLE
Initial support for Plate Sets - server side

### DIFF
--- a/assay/api-src/org/labkey/api/assay/plate/Plate.java
+++ b/assay/api-src/org/labkey/api/assay/plate/Plate.java
@@ -40,7 +40,7 @@ public interface Plate extends PropertySet, Identifiable
 
     boolean isTemplate();
 
-    @NotNull PlateSet getPlateSetObject();
+    @Nullable PlateSet getPlateSetObject();
 
     /**
      * Returns an existing well, or creates a new well if one

--- a/assay/api-src/org/labkey/api/assay/plate/Plate.java
+++ b/assay/api-src/org/labkey/api/assay/plate/Plate.java
@@ -40,6 +40,8 @@ public interface Plate extends PropertySet, Identifiable
 
     boolean isTemplate();
 
+    @NotNull PlateSet getPlateSetObject();
+
     /**
      * Returns an existing well, or creates a new well if one
      * had not previously existed.

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -158,6 +158,13 @@ public interface PlateService
     List<Plate> getPlateTemplates(Container container);
 
     /**
+     * Gets the plate set by ID
+     *
+     * @return A plate set instance or null if it can't be located
+     */
+    @Nullable PlateSet getPlateSet(Container container, int plateSetId);
+
+    /**
      * Returns the number of assay runs that are linked to the specified plate. Currently, this only works
      * for the standard assay with plate support since other assays types do not store the plate ID with the
      * run.
@@ -251,6 +258,12 @@ public interface PlateService
      * Create the plate metadata domain for this container.
      */
     @NotNull Domain ensurePlateMetadataDomain(Container container, User user) throws ValidationException;
+
+    /**
+     * Name expressions for plate sets and plates.
+     */
+    @NotNull String getPlateSetNameExpression();
+    @NotNull String getPlateNameExpression();
 
     /**
      * A PlateDetailsResolver implementation provides a URL where a detailed, plate-type specific

--- a/assay/api-src/org/labkey/api/assay/plate/PlateSet.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateSet.java
@@ -1,0 +1,19 @@
+package org.labkey.api.assay.plate;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.security.User;
+
+import java.util.List;
+
+public interface PlateSet
+{
+    int getRowId();
+
+    Container getContainer();
+
+    String getName();
+
+    boolean isArchived();
+
+    List<Plate> getPlates(User user);
+}

--- a/assay/resources/schemas/assay.xml
+++ b/assay/resources/schemas/assay.xml
@@ -29,6 +29,14 @@
       <column columnName="Name">
         <description>The unique admin-provided name of each plate template (""NAb: 5 specimens in duplicate", for example).</description>
       </column>
+      <column columnName="PlateSet">
+        <description>The Plate Set that this plate is assigned to.</description>
+        <fk>
+          <fkColumnName>RowId</fkColumnName>
+          <fkTable>PlateSet</fkTable>
+          <fkDbSchema>assay</fkDbSchema>
+        </fk>
+      </column>
       <column columnName="CreatedBy">
         <datatype>int</datatype>
         <columnTitle>Created By</columnTitle>
@@ -163,6 +171,19 @@
       <column columnName="PlateId"/>
       <column columnName="PropertyURI"/>
       <column columnName="PropertyId"/>
+    </columns>
+  </table>
+  <table tableName="PlateSet" tableDbType="TABLE">
+    <description>Contains one row per plate set.</description>
+    <columns>
+      <column columnName="RowId"/>
+      <column columnName="Name"/>
+      <column columnName="Container"/>
+      <column columnName="CreatedBy"/>
+      <column columnName="Created"/>
+      <column columnName="ModifiedBy"/>
+      <column columnName="Modified"/>
+      <column columnName="Archived"/>
     </columns>
   </table>
 </tables>

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.000-24.001.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.000-24.001.sql
@@ -1,0 +1,32 @@
+CREATE TABLE assay.PlateSet
+(
+    RowId SERIAL,
+    Name VARCHAR(200) NOT NULL,
+    Container ENTITYID NOT NULL,
+    Created TIMESTAMP NOT NULL,
+    CreatedBy USERID NOT NULL,
+    Modified TIMESTAMP NOT NULL,
+    ModifiedBy USERID NOT NULL,
+    Archived BOOLEAN NOT NULL DEFAULT FALSE,
+    PlateId INT NOT NULL,                       -- temporary
+
+    CONSTRAINT PK_PlateSet PRIMARY KEY (RowId)
+);
+
+-- Insert a row into the plate set table for every plate in the system, store the plate row ID in the plate set table
+-- in order to create the FK from the plate to plate set table
+INSERT INTO assay.PlateSet (Name, Container, Created, CreatedBy, Modified, ModifiedBy, PlateId)
+    SELECT 'TempPlateSet', Container, now(), CreatedBy, now(), ModifiedBy, RowId FROM assay.Plate;
+
+-- Add the plate set field to the plate table and populate it with the plate set row ID
+ALTER TABLE assay.Plate ADD COLUMN PlateSet INTEGER;
+UPDATE assay.Plate SET PlateSet = (SELECT PS.RowID FROM assay.PlateSet PS WHERE Plate.RowId = PlateId);
+ALTER TABLE assay.plate ALTER PlateSet SET NOT NULL;
+
+-- Add the FK to the plate table
+ALTER TABLE assay.Plate ADD CONSTRAINT FK_Plate_PlateSet FOREIGN KEY (PlateSet) REFERENCES assay.PlateSet (RowId);
+
+-- Drop the temporary plate ID column in the plate set table
+ALTER TABLE assay.PlateSet DROP COLUMN PlateId;
+
+-- Run the java upgrade script to update plate set and plate tables to create the name expression based name values

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.000-24.001.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.000-24.001.sql
@@ -23,10 +23,10 @@ ALTER TABLE assay.Plate ADD COLUMN PlateSet INTEGER;
 UPDATE assay.Plate SET PlateSet = (SELECT PS.RowID FROM assay.PlateSet PS WHERE Plate.RowId = PlateId);
 ALTER TABLE assay.plate ALTER PlateSet SET NOT NULL;
 
--- Add the FK to the plate table
+-- Add the FK to the plate table and drop the temporary plate ID column in the plate set table
 ALTER TABLE assay.Plate ADD CONSTRAINT FK_Plate_PlateSet FOREIGN KEY (PlateSet) REFERENCES assay.PlateSet (RowId);
-
--- Drop the temporary plate ID column in the plate set table
 ALTER TABLE assay.PlateSet DROP COLUMN PlateId;
+CREATE INDEX IX_Plate_PlateSet ON assay.Plate (PlateSet);
 
 -- Run the java upgrade script to update plate set and plate tables to create the name expression based name values
+SELECT core.executeJavaUpgradeCode('updatePlateSetNames');

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.000-24.001.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.000-24.001.sql
@@ -1,6 +1,6 @@
 CREATE TABLE assay.PlateSet
 (
-    RowId SERIAL,
+    RowId INT NOT NULL,
     Name VARCHAR(200) NOT NULL,
     Container ENTITYID NOT NULL,
     Created TIMESTAMP NOT NULL,
@@ -8,24 +8,19 @@ CREATE TABLE assay.PlateSet
     Modified TIMESTAMP NOT NULL,
     ModifiedBy USERID NOT NULL,
     Archived BOOLEAN NOT NULL DEFAULT FALSE,
-    PlateId INT NOT NULL,                       -- temporary
 
     CONSTRAINT PK_PlateSet PRIMARY KEY (RowId)
 );
 
 -- Insert a row into the plate set table for every plate in the system, store the plate row ID in the plate set table
 -- in order to create the FK from the plate to plate set table
-INSERT INTO assay.PlateSet (Name, Container, Created, CreatedBy, Modified, ModifiedBy, PlateId)
-    SELECT 'TempPlateSet', Container, now(), CreatedBy, now(), ModifiedBy, RowId FROM assay.Plate;
+INSERT INTO assay.PlateSet (RowId, Name, Container, Created, CreatedBy, Modified, ModifiedBy)
+    SELECT RowId, 'TempPlateSet', Container, now(), CreatedBy, now(), ModifiedBy FROM assay.Plate;
 
 -- Add the plate set field to the plate table and populate it with the plate set row ID
 ALTER TABLE assay.Plate ADD COLUMN PlateSet INTEGER;
-UPDATE assay.Plate SET PlateSet = (SELECT PS.RowID FROM assay.PlateSet PS WHERE Plate.RowId = PlateId);
-ALTER TABLE assay.plate ALTER PlateSet SET NOT NULL;
-
--- Add the FK to the plate table and drop the temporary plate ID column in the plate set table
+UPDATE assay.Plate SET PlateSet = RowId;
 ALTER TABLE assay.Plate ADD CONSTRAINT FK_Plate_PlateSet FOREIGN KEY (PlateSet) REFERENCES assay.PlateSet (RowId);
-ALTER TABLE assay.PlateSet DROP COLUMN PlateId;
 CREATE INDEX IX_Plate_PlateSet ON assay.Plate (PlateSet);
 
 -- Run the java upgrade script to update plate set and plate tables to create the name expression based name values

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.000-24.001.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.000-24.001.sql
@@ -1,6 +1,6 @@
 CREATE TABLE assay.PlateSet
 (
-    RowId INT IDENTITY(1,1),
+    RowId INT NOT NULL,
     Name NVARCHAR(200) NOT NULL,
     Container ENTITYID NOT NULL,
     Created DATETIME NOT NULL,
@@ -8,26 +8,22 @@ CREATE TABLE assay.PlateSet
     Modified DATETIME NOT NULL,
     ModifiedBy USERID NOT NULL,
     Archived BIT NOT NULL DEFAULT 0,
-    PlateId INT NOT NULL,                       -- temporary
 
     CONSTRAINT PK_PlateSet PRIMARY KEY (RowId)
 );
 
 -- Insert a row into the plate set table for every plate in the system, store the plate row ID in the plate set table
 -- in order to create the FK from the plate to plate set table
-INSERT INTO assay.PlateSet (Name, Container, Created, CreatedBy, Modified, ModifiedBy, PlateId)
-SELECT 'TempPlateSet', Container, getdate(), CreatedBy, getdate(), ModifiedBy, RowId FROM assay.Plate;
+INSERT INTO assay.PlateSet (RowId, Name, Container, Created, CreatedBy, Modified, ModifiedBy)
+SELECT RowId, 'TempPlateSet', Container, getdate(), CreatedBy, getdate(), ModifiedBy FROM assay.Plate;
 
 -- Add the plate set field to the plate table and populate it with the plate set row ID
 ALTER TABLE assay.Plate ADD PlateSet INT;
 GO
 
-UPDATE assay.Plate SET PlateSet = (SELECT PS.RowID FROM assay.PlateSet PS WHERE Plate.RowId = PlateId);
+UPDATE assay.Plate SET PlateSet = Rowid;
 ALTER TABLE assay.plate ALTER COLUMN PlateSet INT NOT NULL;
-
--- Add the FK to the plate table and drop the temporary plate ID column in the plate set table
 ALTER TABLE assay.Plate ADD CONSTRAINT FK_Plate_PlateSet FOREIGN KEY (PlateSet) REFERENCES assay.PlateSet (RowId);
-ALTER TABLE assay.PlateSet DROP COLUMN PlateId;
 CREATE INDEX IX_Plate_PlateSet ON assay.Plate (PlateSet);
 
 -- Run the java upgrade script to update plate set and plate tables to create the name expression based name values

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.000-24.001.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.000-24.001.sql
@@ -1,0 +1,34 @@
+CREATE TABLE assay.PlateSet
+(
+    RowId INT IDENTITY(1,1),
+    Name NVARCHAR(200) NOT NULL,
+    Container ENTITYID NOT NULL,
+    Created DATETIME NOT NULL,
+    CreatedBy USERID NOT NULL,
+    Modified DATETIME NOT NULL,
+    ModifiedBy USERID NOT NULL,
+    Archived BIT NOT NULL DEFAULT 0,
+    PlateId INT NOT NULL,                       -- temporary
+
+    CONSTRAINT PK_PlateSet PRIMARY KEY (RowId)
+);
+
+-- Insert a row into the plate set table for every plate in the system, store the plate row ID in the plate set table
+-- in order to create the FK from the plate to plate set table
+INSERT INTO assay.PlateSet (Name, Container, Created, CreatedBy, Modified, ModifiedBy, PlateId)
+SELECT 'TempPlateSet', Container, getdate(), CreatedBy, getdate(), ModifiedBy, RowId FROM assay.Plate;
+
+-- Add the plate set field to the plate table and populate it with the plate set row ID
+ALTER TABLE assay.Plate ADD PlateSet INT;
+GO
+
+UPDATE assay.Plate SET PlateSet = (SELECT PS.RowID FROM assay.PlateSet PS WHERE Plate.RowId = PlateId);
+ALTER TABLE assay.plate ALTER COLUMN PlateSet INT NOT NULL;
+
+-- Add the FK to the plate table and drop the temporary plate ID column in the plate set table
+ALTER TABLE assay.Plate ADD CONSTRAINT FK_Plate_PlateSet FOREIGN KEY (PlateSet) REFERENCES assay.PlateSet (RowId);
+ALTER TABLE assay.PlateSet DROP COLUMN PlateId;
+CREATE INDEX IX_Plate_PlateSet ON assay.Plate (PlateSet);
+
+-- Run the java upgrade script to update plate set and plate tables to create the name expression based name values
+EXEC core.executeJavaUpgradeCode 'updatePlateSetNames';

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -107,7 +107,7 @@ public class AssayModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 24.000;
+        return 24.001;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -195,4 +195,24 @@ public class AssayUpgradeCode implements UpgradeCode
         ObjectProperty prop = protocol.getObjectProperties().get(protocol.getLSID() + AbstractPlateBasedAssayProvider.PLATE_TEMPLATE_SUFFIX);
         return prop != null ? PlateManager.get().getPlate(protocol.getContainer(), prop.getStringValue()) : null;
     }
+
+    /**
+     * Called from assay-24.000-24.001.sql
+     *
+     * The referenced upgrade script creates a new plate set for every plate in the system. We now
+     * want to iterate over each plate set to set the name using the configured name expression. We will
+     * also do the same for each plate but most likely there will be no plates in the system with a blank name
+     * since that was previously not allowed.
+     */
+    public static void updatePlateSetNames(ModuleContext ctx) throws Exception
+    {
+        if (ctx.isNewInstall())
+            return;
+
+        DbScope scope = AssayDbSchema.getInstance().getSchema().getScope();
+        try (DbScope.Transaction tx = scope.ensureTransaction())
+        {
+            tx.commit();
+        }
+    }
 }

--- a/assay/src/org/labkey/assay/plate/PlateImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateImpl.java
@@ -545,7 +545,7 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
 
     @Override
     @JsonIgnore
-    public @NotNull PlateSet getPlateSetObject()
+    public @Nullable PlateSet getPlateSetObject()
     {
         return PlateManager.get().getPlateSet(getContainer(), getPlateSet());
     }

--- a/assay/src/org/labkey/assay/plate/PlateImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateImpl.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateCustomField;
 import org.labkey.api.assay.plate.PlateService;
+import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.PositionImpl;
 import org.labkey.api.assay.plate.Well;
@@ -58,6 +59,7 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     private String _dataFileId;
     private String _type;
     private boolean _isTemplate;
+    private Integer _plateSetId;
 
     private Map<WellGroup.Type, Map<String, WellGroupImpl>> _groups;
     private List<WellGroupImpl> _deletedGroups;
@@ -529,6 +531,23 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     public void setTemplate(boolean template)
     {
         _isTemplate = template;
+    }
+
+    public void setPlateSet(Integer plateSetId)
+    {
+        _plateSetId = plateSetId;
+    }
+
+    public Integer getPlateSet()
+    {
+        return _plateSetId;
+    }
+
+    @Override
+    @JsonIgnore
+    public @NotNull PlateSet getPlateSetObject()
+    {
+        return PlateManager.get().getPlateSet(getContainer(), getPlateSet());
     }
 
     @JsonIgnore

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -97,6 +97,7 @@ import org.labkey.assay.TsvAssayProvider;
 import org.labkey.assay.plate.model.PlateType;
 import org.labkey.assay.plate.model.WellGroupBean;
 import org.labkey.assay.plate.query.PlateSchema;
+import org.labkey.assay.plate.query.PlateSetTable;
 import org.labkey.assay.plate.query.PlateTable;
 import org.labkey.assay.plate.query.WellGroupTable;
 import org.labkey.assay.plate.query.WellTable;
@@ -663,6 +664,13 @@ public class PlateManager implements PlateService
         {
             Integer plateId = plate.getRowId();
             String plateInstanceLsid = plate.getLSID();
+
+            if (!updateExisting && plate.getPlateSet() == null)
+            {
+                // ensure a plate set for each new plate
+                Integer plateSetId = ensureDefaultPlateSet(container, user);
+                plate.setPlateSet(plateSetId);
+            }
             Map<String, Object> plateRow = ObjectFactory.Registry.getFactory(PlateImpl.class).toMap(plate, new ArrayListMap<>());
             QueryUpdateService qus = getPlateUpdateService(container, user);
             BatchValidationException errors = new BatchValidationException();
@@ -802,6 +810,22 @@ public class PlateManager implements PlateService
 
             return plateId;
         }
+    }
+
+    // creates a default plate set in the specified container and returns its ID
+    private Integer ensureDefaultPlateSet(Container container, User user) throws Exception
+    {
+        BatchValidationException errors = new BatchValidationException();
+        QueryUpdateService qus = getPlateSetUpdateService(container, user);
+        PlateSetImpl plateSet = new PlateSetImpl();
+        plateSet.beforeInsert(user, container.getId());
+        Map<String, Object> plateSetRow = ObjectFactory.Registry.getFactory(PlateSetImpl.class).toMap(plateSet, new ArrayListMap<>());
+
+        List<Map<String, Object>> insertedRows = qus.insertRows(user, container, Collections.singletonList(plateSetRow), errors, null, null);
+        if (errors.hasErrors())
+            throw errors;
+
+        return (Integer)insertedRows.get(0).get("RowId");
     }
 
     // return a list of wellId and wellGroupId pairs
@@ -981,6 +1005,15 @@ public class PlateManager implements PlateService
         Table.delete(schema.getTableInfoWell(), filter);
         Table.delete(schema.getTableInfoWellGroup(), filter);
         Table.delete(schema.getTableInfoPlate(), filter);
+
+        // delete all empty plate sets in this container
+        SQLFragment sql3 = new SQLFragment("DELETE FROM ")
+                .append(AssayDbSchema.getInstance().getTableInfoPlateSet(), "PS")
+                .append(" WHERE RowId NOT IN (SELECT DISTINCT PlateSet FROM ").append(AssayDbSchema.getInstance().getTableInfoPlate(), "").append(")")
+                .append(" AND Container = ?")
+                .add(container);
+        new SqlExecutor(AssayDbSchema.getInstance().getSchema()).execute(sql3);
+
         clearCache(container);
     }
 
@@ -1031,6 +1064,17 @@ public class PlateManager implements PlateService
         QueryUpdateService qus = tableInfo.getUpdateService();
         if (qus == null)
             throw new IllegalStateException("Unable to resolve QueryUpdateService for Plates.");
+
+        return qus;
+    }
+
+    private @NotNull QueryUpdateService getPlateSetUpdateService(Container container, User user)
+    {
+        UserSchema schema = getPlateUserSchema(container, user);
+        TableInfo tableInfo = schema.getTable(PlateSetTable.NAME);
+        QueryUpdateService qus = tableInfo.getUpdateService();
+        if (qus == null)
+            throw new IllegalStateException("Unable to resolve QueryUpdateService for PlateSets.");
 
         return qus;
     }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1008,7 +1008,7 @@ public class PlateManager implements PlateService
 
         // delete all empty plate sets in this container
         SQLFragment sql3 = new SQLFragment("DELETE FROM ")
-                .append(AssayDbSchema.getInstance().getTableInfoPlateSet(), "PS")
+                .append(AssayDbSchema.getInstance().getTableInfoPlateSet(), "")
                 .append(" WHERE RowId NOT IN (SELECT DISTINCT PlateSet FROM ").append(AssayDbSchema.getInstance().getTableInfoPlate(), "").append(")")
                 .append(" AND Container = ?")
                 .add(container);

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -31,6 +31,7 @@ import org.labkey.api.assay.plate.AbstractPlateTypeHandler;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateCustomField;
 import org.labkey.api.assay.plate.PlateService;
+import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateTypeHandler;
 import org.labkey.api.assay.plate.PlateUtils;
 import org.labkey.api.assay.plate.Position;
@@ -135,6 +136,10 @@ public class PlateManager implements PlateService
     private final List<PlateService.PlateDetailsResolver> _detailsLinkResolvers = new ArrayList<>();
     private boolean _lsidHandlersRegistered = false;
     private final Map<String, PlateTypeHandler> _plateTypeHandlers = new HashMap<>();
+
+    // name expressions, currently not configurable
+    private static final String PLATE_SET_NAME_EXPRESSION = "PLS-${now:date('yyyyMMdd')}-${RowId}";
+    private static final String PLATE_NAME_EXPRESSION = "${${PlateSet/Name}-:withCounter}";
 
     public SearchService.SearchCategory PLATE_CATEGORY = new SearchService.SearchCategory("plate", "Plate") {
         @Override
@@ -317,6 +322,12 @@ public class PlateManager implements PlateService
     public List<Plate> getPlateTemplates(Container container)
     {
         return PlateCache.getPlateTemplates(container);
+    }
+
+    @Override
+    public @Nullable PlateSet getPlateSet(Container container, int plateSetId)
+    {
+        return new TableSelector(AssayDbSchema.getInstance().getTableInfoPlateSet()).getObject(container, plateSetId, PlateSetImpl.class);
     }
 
     @Override
@@ -1627,6 +1638,18 @@ public class PlateManager implements PlateService
         }
 
         return getFields(container, plateRowId);
+    }
+
+    @Override
+    public @NotNull String getPlateSetNameExpression()
+    {
+        return PLATE_SET_NAME_EXPRESSION;
+    }
+
+    @Override
+    public @NotNull String getPlateNameExpression()
+    {
+        return PLATE_NAME_EXPRESSION;
     }
 
     public static final class TestCase

--- a/assay/src/org/labkey/assay/plate/PlateSetImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetImpl.java
@@ -1,0 +1,81 @@
+package org.labkey.assay.plate;
+
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateSet;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.Entity;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.security.User;
+import org.labkey.assay.query.AssayDbSchema;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PlateSetImpl extends Entity implements PlateSet
+{
+    private int _rowId;
+    private String _name;
+    private boolean _archived;
+    private Container _container;
+
+    @Override
+    public int getRowId()
+    {
+        return _rowId;
+    }
+
+    public void setRowId(int rowId)
+    {
+        _rowId = rowId;
+    }
+
+    public void setContainer(Container container)
+    {
+        _container = container;
+    }
+
+    @Override
+    public Container getContainer()
+    {
+        return _container;
+    }
+
+    @Override
+    public String getName()
+    {
+        return _name;
+    }
+
+    public void setName(String name)
+    {
+        _name = name;
+    }
+
+    @Override
+    public boolean isArchived()
+    {
+        return _archived;
+    }
+
+    public void setArchived(boolean archived)
+    {
+        _archived = archived;
+    }
+
+    @Override
+    public List<Plate> getPlates(User user)
+    {
+        ContainerFilter cf = PlateManager.get().getPlateContainerFilter(null, getContainer(), user);
+        List<Plate> plates = new ArrayList<>();
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("PlateSet"), _rowId);
+        new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(), Collections.singleton("RowId"), filter, null).forEach(Integer.class, plateId -> {
+            plates.add(PlateCache.getPlate(cf, plateId));
+        });
+
+        return plates;
+    }
+}

--- a/assay/src/org/labkey/assay/plate/query/PlateSchema.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSchema.java
@@ -16,8 +16,6 @@
 
 package org.labkey.assay.plate.query;
 
-import org.jetbrains.annotations.NotNull;
-import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
@@ -45,7 +43,8 @@ public class PlateSchema extends SimpleUserSchema
     private static final Set<String> AVAILABLE_TABLES = new CaseInsensitiveTreeSet(List.of(
             PlateTable.NAME,
             WellGroupTable.NAME,
-            WellTable.NAME
+            WellTable.NAME,
+            PlateSetTable.NAME
     ));
 
     public PlateSchema(User user, Container container)
@@ -69,6 +68,8 @@ public class PlateSchema extends SimpleUserSchema
             return new WellGroupTable(this, cf).init();
         if (name.equalsIgnoreCase(WellTable.NAME))
             return new WellTable(this, cf).init();
+        if (name.equalsIgnoreCase(PlateSetTable.NAME))
+            return new PlateSetTable(this, cf).init();
 
         return null;
     }

--- a/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
@@ -1,0 +1,163 @@
+package org.labkey.assay.plate.query;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateService;
+import org.labkey.api.assay.plate.PlateSet;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.data.BaseColumnInfo;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.MutableColumnInfo;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.dataiterator.DataIterator;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.dataiterator.DetailedAuditLogDataIterator;
+import org.labkey.api.dataiterator.LoggingDataIterator;
+import org.labkey.api.dataiterator.NameExpressionDataIterator;
+import org.labkey.api.dataiterator.SimpleTranslator;
+import org.labkey.api.dataiterator.StandardDataIteratorBuilder;
+import org.labkey.api.dataiterator.TableInsertDataIteratorBuilder;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.DefaultQueryUpdateService;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.InvalidKeyException;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.QueryUpdateServiceException;
+import org.labkey.api.query.RowIdForeignKey;
+import org.labkey.api.query.SimpleUserSchema;
+import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.User;
+import org.labkey.assay.plate.PlateManager;
+import org.labkey.assay.query.AssayDbSchema;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class PlateSetTable extends SimpleUserSchema.SimpleTable<UserSchema>
+{
+    public static final String NAME = "PlateSet";
+    private static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
+
+    static
+    {
+        defaultVisibleColumns.add(FieldKey.fromParts("Name"));
+        defaultVisibleColumns.add(FieldKey.fromParts("Container"));
+        defaultVisibleColumns.add(FieldKey.fromParts("Created"));
+        defaultVisibleColumns.add(FieldKey.fromParts("CreatedBy"));
+        defaultVisibleColumns.add(FieldKey.fromParts("Archived"));
+    }
+
+    public PlateSetTable(PlateSchema schema, @Nullable ContainerFilter cf)
+    {
+        super(schema, AssayDbSchema.getInstance().getTableInfoPlateSet(), cf);
+        setTitleColumn("Name");
+    }
+
+    @Override
+    public MutableColumnInfo wrapColumn(ColumnInfo col)
+    {
+        var columnInfo = super.wrapColumn(col);
+
+        // the name field is always generated via name expression
+        if (columnInfo.getName().equalsIgnoreCase("Name"))
+        {
+            columnInfo.setUserEditable(false);
+        }
+        else if (columnInfo.getName().equalsIgnoreCase("RowId"))
+        {
+            // this is necessary in order to use rowId as a name expression token
+            columnInfo.setKeyField(true);
+            columnInfo.setUserEditable(false);
+            columnInfo.setHidden(true);
+            columnInfo.setShownInInsertView(false);
+            columnInfo.setShownInUpdateView(false);
+            columnInfo.setFk(new RowIdForeignKey(columnInfo));
+            columnInfo.setHasDbSequence(true);
+            columnInfo.setDbSequenceBatchSize(1);
+            columnInfo.setIsRootDbSequence(true);
+        }
+        return columnInfo;
+    }
+
+    @Override
+    public List<FieldKey> getDefaultVisibleColumns()
+    {
+        return defaultVisibleColumns;
+    }
+
+    @Override
+    public QueryUpdateService getUpdateService()
+    {
+        return new PlateSetUpdateService(this, AssayDbSchema.getInstance().getTableInfoPlateSet());
+    }
+
+    protected static class PlateSetUpdateService extends DefaultQueryUpdateService
+    {
+        public PlateSetUpdateService(TableInfo queryTable, TableInfo dbTable)
+        {
+            super(queryTable, dbTable);
+        }
+
+        @Override
+        public DataIteratorBuilder createImportDIB(User user, Container container, DataIteratorBuilder data, DataIteratorContext context)
+        {
+            SimpleTranslator nameExpressionTranslator = new SimpleTranslator(data.getDataIterator(context), context);
+            nameExpressionTranslator.setDebugName("nameExpressionTranslator");
+            nameExpressionTranslator.selectAll();
+            final Map<String, Integer> nameMap = nameExpressionTranslator.getColumnNameMap();
+            final TableInfo plateSetTable = getQueryTable();
+            if (!nameMap.containsKey("name"))
+            {
+                ColumnInfo nameCol = plateSetTable.getColumn("name");
+                nameExpressionTranslator.addColumn(nameCol, (Supplier) () -> null);
+            }
+            nameExpressionTranslator.addColumn(new BaseColumnInfo("nameExpression", JdbcType.VARCHAR),
+                    (Supplier) () -> PlateService.get().getPlateSetNameExpression());
+            DataIterator builtInColumnsTranslator = SimpleTranslator.wrapBuiltInColumns(nameExpressionTranslator, context, container, user, plateSetTable);
+            DataIterator di = LoggingDataIterator.wrap(new NameExpressionDataIterator(builtInColumnsTranslator, context, plateSetTable, container, null, null, null));
+
+            DataIteratorBuilder insertBuilder = LoggingDataIterator.wrap(StandardDataIteratorBuilder.forInsert(getDbTable(), di, container, user, context));
+            DataIteratorBuilder dib = new TableInsertDataIteratorBuilder(insertBuilder, plateSetTable, container)
+                    .setKeyColumns(new CaseInsensitiveHashSet("RowId"));
+            dib = DetailedAuditLogDataIterator.getDataIteratorBuilder(plateSetTable, dib, context.getInsertOption(), user, container);
+
+            return dib;
+        }
+
+        @Override
+        public List<Map<String, Object>> insertRows(User user, Container container, List<Map<String, Object>> rows, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
+        {
+            return super._insertRowsUsingDIB(user, container, rows, getDataIteratorContext(errors, InsertOption.INSERT, configParameters), extraScriptContext);
+        }
+
+        @Override
+        protected Map<String, Object> deleteRow(User user, Container container, Map<String, Object> oldRowMap) throws QueryUpdateServiceException, SQLException, InvalidKeyException
+        {
+            // ensure the plate set is empty
+            Integer plateSetId = (Integer)oldRowMap.get("RowId");
+            PlateSet plateSet = PlateManager.get().getPlateSet(container, plateSetId);
+            if (plateSet == null)
+                throw new QueryUpdateServiceException(String.format("Plate set could not be found for ID : %d", plateSetId));
+
+            List<Plate> plates = plateSet.getPlates(user);
+            if (!plates.isEmpty())
+                throw new QueryUpdateServiceException(String.format("Plate set has %d plates associated with it and cannot be deleted.", plates.size()));
+
+            try (DbScope.Transaction transaction = AssayDbSchema.getInstance().getScope().ensureTransaction())
+            {
+                Map<String, Object> returnMap = super.deleteRow(user, container, oldRowMap);
+
+                transaction.commit();
+                return returnMap;
+            }
+        }
+    }
+}

--- a/assay/src/org/labkey/assay/plate/query/PlateTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTable.java
@@ -110,20 +110,6 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
     }
 
     @Override
-    public MutableColumnInfo wrapColumn(ColumnInfo col)
-    {
-        var columnInfo = super.wrapColumn(col);
-
-        // require a plate name
-/*
-        if (columnInfo.getName().equalsIgnoreCase("Name"))
-            columnInfo.setRequired(true);
-*/
-
-        return columnInfo;
-    }
-
-    @Override
     public List<FieldKey> getDefaultVisibleColumns()
     {
         return defaultVisibleColumns;

--- a/assay/src/org/labkey/assay/query/AssayDbSchema.java
+++ b/assay/src/org/labkey/assay/query/AssayDbSchema.java
@@ -58,4 +58,9 @@ public class AssayDbSchema
     {
         return getSchema().getTable("PlateProperty");
     }
+
+    public TableInfo getTableInfoPlateSet()
+    {
+        return getSchema().getTable("PlateSet");
+    }
 }


### PR DESCRIPTION
#### Rationale
This change adds initial support for plate sets according to this [spec](https://docs.google.com/document/d/1i6qP3inaj5fFD6z0M-ZpaD4HLPmj1Z4wuj3BvmKRqFg/edit). Plate sets are intended to associate multiple plates together. This PR contains the following changes:
- Initial schema and changes for plate sets and plate support
- Expose schema changes to query
- `QueryUpdateService` implementation for the `PlateSet` table
- `NameExpression` support for both plate sets and plates. Generated names are site unique and non-configurable for this initial implementatation.
- Ensure that all plates must be assigned to a plate set. A default plate set is created if no existing plate set is specified
- Upgrade script to establish new plate sets for every plate in the system
