### PR TITLE
Automated test fix - faulty logic for undefined visits

### DIFF
--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -1148,14 +1148,17 @@ public class StudyManager
         for (BigDecimal sequencenum : sequencenums)
         {
             VisitImpl result = ensureVisitWithoutSaving(study, sequencenum, type, visits);
-            if (result.getRowId() == 0 && !failForUndefinedVisits)
+            if (result.getRowId() == 0)
             {
-                createVisit(study, user, result, visits);
-                // Refresh existing visits to avoid constraint violation, see #44425
-                visits = getVisits(study, Visit.Order.SEQUENCE_NUM);
+                if (!failForUndefinedVisits)
+                {
+                    createVisit(study, user, result, visits);
+                    // Refresh existing visits to avoid constraint violation, see #44425
+                    visits = getVisits(study, Visit.Order.SEQUENCE_NUM);
+                }
+                else
+                    seqNumFailures.add(String.valueOf(sequencenum));
             }
-            else
-                seqNumFailures.add(String.valueOf(sequencenum));
         }
 
         if (!seqNumFailures.isEmpty())


### PR DESCRIPTION
#### Rationale
One last [test failure](https://teamcity.labkey.org/buildConfiguration/LabKey_241RElease_Community_DailySuites_DailyAPostgres/2831423?buildTab=tests&status=failed&name=DatasetPublishTest.testSteps)...

I'm surprised this didn't get exposed earlier because the logic wasn't correct in determining when a new visit would be created (the rowId would be zero if the visit already existed).