### PR TITLE
Stop using deprecated `GetDomainCommand`

### DIFF
--- a/experiment/test/src/org/labkey/test/tests/experiment/ProvenanceAssayHelper.java
+++ b/experiment/test/src/org/labkey/test/tests/experiment/ProvenanceAssayHelper.java
@@ -4,8 +4,9 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.domain.CreateDomainCommand;
+import org.labkey.remoteapi.domain.DomainDetailsResponse;
 import org.labkey.remoteapi.domain.DomainResponse;
-import org.labkey.remoteapi.domain.GetDomainCommand;
+import org.labkey.remoteapi.domain.GetDomainDetailsCommand;
 import org.labkey.remoteapi.domain.PropertyDescriptor;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
@@ -86,14 +87,14 @@ public abstract class ProvenanceAssayHelper extends BaseWebDriverTest
         clickAndWait(Locator.lkButton("Save and Finish"));
     }
 
-    protected DomainResponse createDomain(String domainKind, String domainName, String description, List<PropertyDescriptor> fields) throws IOException, CommandException
+    protected DomainDetailsResponse createDomain(String domainKind, String domainName, String description, List<PropertyDescriptor> fields) throws IOException, CommandException
     {
         CreateDomainCommand domainCommand = new CreateDomainCommand(domainKind, domainName);
         domainCommand.getDomainDesign().setFields(fields);
         domainCommand.getDomainDesign().setDescription(description);
 
         DomainResponse domainResponse = domainCommand.execute(createDefaultConnection(), getProjectName());
-        GetDomainCommand getDomainCommand = new GetDomainCommand(domainResponse.getDomain().getDomainId());
+        GetDomainDetailsCommand getDomainCommand = new GetDomainDetailsCommand(domainResponse.getDomain().getDomainId());
         return getDomainCommand.execute(createDefaultConnection(), getProjectName());
     }
 

--- a/experiment/test/src/org/labkey/test/tests/experiment/VocabularyViewSupportTest.java
+++ b/experiment/test/src/org/labkey/test/tests/experiment/VocabularyViewSupportTest.java
@@ -11,7 +11,7 @@ import org.labkey.remoteapi.assay.Run;
 import org.labkey.remoteapi.assay.SaveAssayBatchCommand;
 import org.labkey.remoteapi.assay.SaveAssayRunsCommand;
 import org.labkey.remoteapi.assay.SaveAssayRunsResponse;
-import org.labkey.remoteapi.domain.DomainResponse;
+import org.labkey.remoteapi.domain.DomainDetailsResponse;
 import org.labkey.remoteapi.domain.PropertyDescriptor;
 import org.labkey.remoteapi.query.InsertRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsCommand;
@@ -111,7 +111,7 @@ public class VocabularyViewSupportTest extends ProvenanceAssayHelper
         fields.add(pd2);
         fields.add(pd3);
 
-        DomainResponse domainResponse = createDomain(domainKind, domainName, description, fields);
+        DomainDetailsResponse domainResponse = createDomain(domainKind, domainName, description, fields);
         int domainId = domainResponse.getDomain().getDomainId().intValue();
 
         log("Create a sampleset");
@@ -224,7 +224,7 @@ public class VocabularyViewSupportTest extends ProvenanceAssayHelper
         fields.add(pd1);
         fields.add(pd2);
 
-        DomainResponse domainResponse = createDomain(domainKind, domainName, description, fields);
+        DomainDetailsResponse domainResponse = createDomain(domainKind, domainName, description, fields);
         int domainId = domainResponse.getDomain().getDomainId().intValue();
         String domainProperty = domainName + domainId;
 

--- a/study/test/src/org/labkey/test/tests/experiment/ExperimentAPITest.java
+++ b/study/test/src/org/labkey/test/tests/experiment/ExperimentAPITest.java
@@ -39,8 +39,9 @@ import org.labkey.remoteapi.assay.SaveAssayBatchResponse;
 import org.labkey.remoteapi.assay.SaveAssayRunsCommand;
 import org.labkey.remoteapi.assay.SaveAssayRunsResponse;
 import org.labkey.remoteapi.domain.CreateDomainCommand;
+import org.labkey.remoteapi.domain.DomainDetailsResponse;
 import org.labkey.remoteapi.domain.DomainResponse;
-import org.labkey.remoteapi.domain.GetDomainCommand;
+import org.labkey.remoteapi.domain.GetDomainDetailsCommand;
 import org.labkey.remoteapi.domain.ListDomainsCommand;
 import org.labkey.remoteapi.domain.ListDomainsResponse;
 import org.labkey.remoteapi.domain.PropertyDescriptor;
@@ -281,14 +282,14 @@ public class ExperimentAPITest extends BaseWebDriverTest
         return getResponse.getBatch();
     }
 
-    private DomainResponse createDomain(String domainKind, String domainName, String description, List<PropertyDescriptor> fields) throws IOException, CommandException
+    private DomainDetailsResponse createDomain(String domainKind, String domainName, String description, List<PropertyDescriptor> fields) throws IOException, CommandException
     {
         CreateDomainCommand domainCommand = new CreateDomainCommand(domainKind, domainName);
         domainCommand.getDomainDesign().setDescription(description);
         domainCommand.getDomainDesign().setFields(fields);
 
         DomainResponse domainResponse = domainCommand.execute(createDefaultConnection(), getProjectName());
-        GetDomainCommand getDomainCommand = new GetDomainCommand(domainResponse.getDomain().getDomainId());
+        GetDomainDetailsCommand getDomainCommand = new GetDomainDetailsCommand(domainResponse.getDomain().getDomainId());
         return getDomainCommand.execute(createDefaultConnection(), getProjectName());
     }
 
@@ -308,7 +309,7 @@ public class ExperimentAPITest extends BaseWebDriverTest
         fields.add(new PropertyDescriptor(prop1Name, prop1range));
         fields.add(new PropertyDescriptor(prop2Name, prop2range));
 
-        DomainResponse domainResponse = createDomain(domainKind, domainName, domainDescription,fields);
+        DomainDetailsResponse domainResponse = createDomain(domainKind, domainName, domainDescription,fields);
 
         //verifying properties got added in domainResponse
         assertEquals("First Adhoc property not found.", domainResponse.getDomain().getFields().get(0).getName(), prop1Name);
@@ -347,7 +348,7 @@ public class ExperimentAPITest extends BaseWebDriverTest
         List<PropertyDescriptor> fields = new ArrayList<>();
         fields.add(new PropertyDescriptor(propertyName, rangeURI));
 
-        DomainResponse domainResponse = createDomain(domainKind, domainName, domainDescription, fields);
+        DomainDetailsResponse domainResponse = createDomain(domainKind, domainName, domainDescription, fields);
 
         assertEquals("Property not added in Domain.", propertyName, domainResponse.getDomain().getFields().get(0).getName());
 
@@ -397,7 +398,7 @@ public class ExperimentAPITest extends BaseWebDriverTest
         String assayName = "ImportRunAssay";
 
         // 1. Create Vocabulary Domain with one adhoc property with CreateDomainApi
-        DomainResponse domainResponse = createDomain(domainKind, domainName, domainDescription, List.of(new PropertyDescriptor(propertyName,  rangeURI)));
+        DomainDetailsResponse domainResponse = createDomain(domainKind, domainName, domainDescription, List.of(new PropertyDescriptor(propertyName,  rangeURI)));
 
         assertEquals("Property not added in Vocabulary Domain.", propertyName, domainResponse.getDomain().getFields().get(0).getName());
 

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetDomainTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetDomainTest.java
@@ -9,8 +9,9 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.PostCommand;
 import org.labkey.remoteapi.domain.CreateDomainCommand;
 import org.labkey.remoteapi.domain.Domain;
+import org.labkey.remoteapi.domain.DomainDetailsResponse;
 import org.labkey.remoteapi.domain.DomainResponse;
-import org.labkey.remoteapi.domain.GetDomainCommand;
+import org.labkey.remoteapi.domain.GetDomainDetailsCommand;
 import org.labkey.remoteapi.domain.PropertyDescriptor;
 import org.labkey.remoteapi.domain.SaveDomainCommand;
 import org.labkey.test.BaseWebDriverTest;
@@ -135,8 +136,8 @@ public class StudyDatasetDomainTest extends BaseWebDriverTest
         renameColumnName();
 
         log("Test for an expected error when changing type from String to Int");
-        GetDomainCommand getCmd = new GetDomainCommand(STUDY_SCHEMA, STUDY_DATASET_NAME);
-        DomainResponse getDomainResponse = getCmd.execute(this.createDefaultConnection(), getContainerPath());
+        GetDomainDetailsCommand getCmd = new GetDomainDetailsCommand(STUDY_SCHEMA, STUDY_DATASET_NAME);
+        DomainDetailsResponse getDomainResponse = getCmd.execute(this.createDefaultConnection(), getContainerPath());
         List<PropertyDescriptor> getDomainCols = getDomainResponse.getDomain().getFields();
         PropertyDescriptor activityCodeCol = getDomainCols.get(3);
 
@@ -163,8 +164,8 @@ public class StudyDatasetDomainTest extends BaseWebDriverTest
 
     private void renameColumnName() throws IOException, CommandException
     {
-        GetDomainCommand getCmd = new GetDomainCommand(STUDY_SCHEMA, STUDY_DATASET_NAME);
-        DomainResponse getDomainResponse = getCmd.execute(this.createDefaultConnection(), getContainerPath());
+        GetDomainDetailsCommand getCmd = new GetDomainDetailsCommand(STUDY_SCHEMA, STUDY_DATASET_NAME);
+        DomainDetailsResponse getDomainResponse = getCmd.execute(this.createDefaultConnection(), getContainerPath());
         List<PropertyDescriptor> getDomainCols = getDomainResponse.getDomain().getFields();
         PropertyDescriptor activityCommentsCol = getDomainCols.get(3);
 


### PR DESCRIPTION
#### Rationale
In order to remove the deprecated `GetDomainCommand`, tests need to be updated to use `GetDomainDetailsCommand`.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/67

#### Changes
* Replace `GetDomainCommand` usages with `GetDomainDetailsCommand`
