### PR TITLE
Plate Set: Listing, Create, & Details

### DIFF
--- a/assay/api-src/org/labkey/api/assay/plate/PlateSet.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateSet.java
@@ -7,7 +7,9 @@ import java.util.List;
 
 public interface PlateSet
 {
-    int getRowId();
+    int MAX_PLATES = 60;
+
+    Integer getRowId();
 
     Container getContainer();
 

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -64,6 +64,7 @@ import org.labkey.api.vocabulary.security.DesignVocabularyPermission;
 import org.labkey.assay.plate.PlateDataServiceImpl;
 import org.labkey.assay.plate.PlateImpl;
 import org.labkey.assay.plate.PlateManager;
+import org.labkey.assay.plate.PlateSetImpl;
 import org.labkey.assay.plate.PlateUrls;
 import org.labkey.assay.plate.model.PlateType;
 import org.labkey.assay.view.AssayGWTView;
@@ -545,12 +546,18 @@ public class PlateController extends SpringActionController
     public static class CreatePlateForm implements ApiJsonForm
     {
         private String _name;
+        private Integer _plateSetId;
         private PlateType _plateType;
         private List<Map<String, Object>> _data = new ArrayList<>();
 
         public String getName()
         {
             return _name;
+        }
+
+        public Integer getPlateSetId()
+        {
+            return _plateSetId;
         }
 
         public PlateType getPlateType()
@@ -570,6 +577,9 @@ public class PlateController extends SpringActionController
 
             if (json.has("name"))
                 _name = json.getString("name");
+
+            if (json.has("plateSetId"))
+                _plateSetId = json.getInt("plateSetId");
 
             if (json.has("plateType"))
                 _plateType = objectMapper.convertValue(json.getJSONObject("plateType"), PlateType.class);
@@ -599,8 +609,6 @@ public class PlateController extends SpringActionController
         @Override
         public void validateForm(CreatePlateForm form, Errors errors)
         {
-            if (StringUtils.trimToNull(form.getName()) == null)
-                errors.reject(ERROR_REQUIRED, "Plate \"name\" is required.");
             if (form.getPlateType() == null)
                 errors.reject(ERROR_REQUIRED, "Plate \"plateType\" is required.");
         }
@@ -610,7 +618,7 @@ public class PlateController extends SpringActionController
         {
             try
             {
-                Plate plate = PlateManager.get().createAndSavePlate(getContainer(), getUser(), form.getPlateType(), form.getName(), form.getData());
+                Plate plate = PlateManager.get().createAndSavePlate(getContainer(), getUser(), form.getPlateType(), form.getName(), form.getPlateSetId(), form.getData());
                 return success(plate);
             }
             catch (Exception e)
@@ -852,6 +860,70 @@ public class PlateController extends SpringActionController
                 ((PlateImpl) plate).setRunCount(PlateManager.get().getRunCountUsingPlate(plate.getContainer(), getUser(), plate));
 
             return plate;
+        }
+    }
+
+    // TODO: It'd be nice if we could not have to implement ApiJsonForm here and just bind via Jackson
+    public static class CreatePlateSetForm implements ApiJsonForm
+    {
+        private String _name;
+        private List<PlateType> _plateTypes = new ArrayList<>();
+
+        public String getName()
+        {
+            return _name;
+        }
+
+        // TODO: Would be really nice to be able to reference plate types by a single identifier. Maybe we just give
+        // them hard-coded names that can act as a "PK" which we can specify.
+        public List<PlateType> getPlateTypes()
+        {
+            return _plateTypes;
+        }
+
+        @Override
+        public void bindJson(JSONObject json)
+        {
+            ObjectMapper objectMapper = JsonUtil.DEFAULT_MAPPER;
+
+            if (json.has("name"))
+                _name = json.getString("name");
+
+            if (json.has("plateTypes"))
+            {
+                JSONArray plateTypes = json.getJSONArray("plateTypes");
+
+                for (int i = 0; i < plateTypes.length(); i++)
+                {
+                    JSONObject jsonObj = plateTypes.getJSONObject(i);
+                    if (jsonObj != null)
+                        _plateTypes.add(objectMapper.convertValue(jsonObj, PlateType.class));
+                }
+            }
+        }
+    }
+
+    @Marshal(Marshaller.JSONObject)
+    @RequiresPermission(InsertPermission.class)
+    public static class CreatePlateSetAction extends MutatingApiAction<CreatePlateSetForm>
+    {
+        @Override
+        public Object execute(CreatePlateSetForm form, BindException errors) throws Exception
+        {
+            try
+            {
+                PlateSetImpl plateSet = new PlateSetImpl();
+                plateSet.setName(form.getName());
+
+                plateSet = PlateManager.get().createPlateSet(getContainer(), getUser(), plateSet, form.getPlateTypes());
+                return success(plateSet);
+            }
+            catch (Exception e)
+            {
+                errors.reject(ERROR_GENERIC, e.getMessage() != null ? e.getMessage() : "Failed to create plate set. An error has occurred.");
+            }
+
+            return null;
         }
     }
 }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -85,6 +85,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.GUID;
@@ -92,6 +93,7 @@ import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.webdav.WebdavResource;
 import org.labkey.assay.TsvAssayProvider;
 import org.labkey.assay.plate.model.PlateType;
@@ -127,6 +129,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.api.assay.plate.PlateSet.MAX_PLATES;
 
 public class PlateManager implements PlateService
 {
@@ -215,6 +218,7 @@ public class PlateManager implements PlateService
         @NotNull User user,
         @NotNull PlateType plateType,
         @Nullable String plateName,
+        @Nullable Integer plateSetId,
         @Nullable List<Map<String, Object>> data
     ) throws Exception
     {
@@ -225,6 +229,14 @@ public class PlateManager implements PlateService
             Plate plateTemplate = plateTypeHandler.createTemplate(plateType.getType(), container, plateType.getRows(), plateType.getCols());
 
             plate = createPlate(plateTemplate, null, null);
+            if (plateSetId != null)
+            {
+                PlateSet plateSet = getPlateSet(container, plateSetId);
+                if (plateSet == null)
+                    throw new IllegalArgumentException("Failed to create plate. Plate set with rowId (" + plateSetId + ") is not available in " + container.getPath());
+                ((PlateImpl) plate).setPlateSet(plateSetId);
+            }
+
             if (StringUtils.trimToNull(plateName) != null)
                 plate.setName(plateName.trim());
 
@@ -663,7 +675,6 @@ public class PlateManager implements PlateService
         try (DbScope.Transaction transaction = ensureTransaction())
         {
             Integer plateId = plate.getRowId();
-            String plateInstanceLsid = plate.getLSID();
 
             if (!updateExisting && plate.getPlateSet() == null)
             {
@@ -691,12 +702,13 @@ public class PlateManager implements PlateService
                 List<Map<String, Object>> insertedRows = qus.insertRows(user, container, Collections.singletonList(plateRow), errors, null, null);
                 if (errors.hasErrors())
                     throw errors;
-                plateId = (Integer)insertedRows.get(0).get("RowId");
-                plateInstanceLsid = (String)insertedRows.get(0).get("Lsid");
+                Map<String, Object> row = insertedRows.get(0);
+                plateId = (Integer) row.get("RowId");
                 plate.setRowId(plateId);
-                plate.setLsid(plateInstanceLsid);
+                plate.setLsid((String) row.get("Lsid"));
+                plate.setName((String) row.get("Name"));
             }
-            savePropertyBag(container, plateInstanceLsid, plate.getProperties(), updateExisting);
+            savePropertyBag(container, plate.getLSID(), plate.getProperties(), updateExisting);
 
             // delete well groups first
             List<WellGroupImpl> deletedWellGroups = plate.getDeletedWellGroups();
@@ -1696,6 +1708,46 @@ public class PlateManager implements PlateService
         return PLATE_NAME_EXPRESSION;
     }
 
+    public PlateSetImpl createPlateSet(Container container, User user, @NotNull PlateSetImpl plateSet, @Nullable List<PlateType> plateTypes) throws Exception
+    {
+        if (!container.hasPermission(user, InsertPermission.class))
+            throw new UnauthorizedException("Failed to create plate set. Insufficient permissions.");
+
+        if (plateSet.getRowId() != null)
+            throw new ValidationException("Failed to create plate set. Cannot create plate set with rowId (" + plateSet.getRowId() + ").");
+
+        if (plateTypes != null && plateTypes.size() > MAX_PLATES)
+            throw new ValidationException(String.format("Failed to create plate set. Plate sets can have a maximum of %d plates.", MAX_PLATES));
+
+        try (DbScope.Transaction tx = ensureTransaction())
+        {
+            BatchValidationException errors = new BatchValidationException();
+            QueryUpdateService qus = getPlateSetUpdateService(container, user);
+
+            Map<String, Object> plateSetRow = ObjectFactory.Registry.getFactory(PlateSetImpl.class).toMap(plateSet, new ArrayListMap<>());
+            List<Map<String, Object>> rows = qus.insertRows(user, container, Collections.singletonList(plateSetRow), errors, null, null);
+            if (errors.hasErrors())
+                throw errors;
+
+            Integer plateSetId = (Integer) rows.get(0).get("RowId");
+
+            if (plateTypes != null)
+            {
+                for (PlateType plateType : plateTypes)
+                {
+                    // TODO: Write a cheaper plate create/save for multiple plates
+                    if (plateType != null)
+                        createAndSavePlate(container, user, plateType, null, plateSetId, null);
+                }
+            }
+
+            plateSet = (PlateSetImpl) getPlateSet(container, plateSetId);
+            tx.commit();
+        }
+
+        return plateSet;
+    }
+
     public static final class TestCase
     {
         private static Container container;
@@ -1846,7 +1898,7 @@ public class PlateManager implements PlateService
             PlateType plateType = new PlateType(TsvPlateTypeHandler.TYPE, TsvPlateTypeHandler.BLANK_PLATE, "Test plate type", 8, 12);
 
             // Act
-            Plate plate = PlateManager.get().createAndSavePlate(container, user, plateType, "testCreateAndSavePlate plate", null);
+            Plate plate = PlateManager.get().createAndSavePlate(container, user, plateType, "testCreateAndSavePlate plate", null, null);
 
             // Assert
             assertTrue("Expected plate to have been persisted and provided with a rowId", plate.getRowId() > 0);
@@ -2008,7 +2060,7 @@ public class PlateManager implements PlateService
                             "properties/barcode", "B5678"
                     )
             );
-            Plate plate = PlateManager.get().createAndSavePlate(container, user, plateType, "hit selection plate", rows);
+            Plate plate = PlateManager.get().createAndSavePlate(container, user, plateType, "hit selection plate", null, rows);
             assertEquals("Expected 2 plate custom fields", 2, plate.getCustomFields().size());
 
             TableInfo wellTable = QueryService.get().getUserSchema(user, container, PlateSchema.SCHEMA_NAME).getTable(WellTable.NAME);

--- a/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
@@ -54,10 +54,11 @@ public class PlateSetTable extends SimpleUserSchema.SimpleTable<UserSchema>
     {
         defaultVisibleColumns.add(FieldKey.fromParts("Name"));
         defaultVisibleColumns.add(FieldKey.fromParts("Container"));
+        defaultVisibleColumns.add(FieldKey.fromParts("PlateCount"));
         defaultVisibleColumns.add(FieldKey.fromParts("Created"));
         defaultVisibleColumns.add(FieldKey.fromParts("CreatedBy"));
-        defaultVisibleColumns.add(FieldKey.fromParts("PlateCount"));
-        defaultVisibleColumns.add(FieldKey.fromParts("Archived"));
+        defaultVisibleColumns.add(FieldKey.fromParts("Modified"));
+        defaultVisibleColumns.add(FieldKey.fromParts("ModifiedBy"));
     }
 
     public PlateSetTable(PlateSchema schema, @Nullable ContainerFilter cf)

--- a/assay/src/org/labkey/assay/plate/query/PlateTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTable.java
@@ -73,11 +73,6 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Supplier;
 
-/**
- * User: brittp
- * Date: Nov 1, 2006
- * Time: 4:37:02 PM
- */
 public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
 {
     public static final String NAME = "Plate";
@@ -86,14 +81,13 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
     static
     {
         defaultVisibleColumns.add(FieldKey.fromParts("Name"));
+        defaultVisibleColumns.add(FieldKey.fromParts("Rows"));
+        defaultVisibleColumns.add(FieldKey.fromParts("Columns"));
+        defaultVisibleColumns.add(FieldKey.fromParts("Type"));
         defaultVisibleColumns.add(FieldKey.fromParts("Created"));
         defaultVisibleColumns.add(FieldKey.fromParts("CreatedBy"));
         defaultVisibleColumns.add(FieldKey.fromParts("Modified"));
         defaultVisibleColumns.add(FieldKey.fromParts("ModifiedBy"));
-        defaultVisibleColumns.add(FieldKey.fromParts("Template"));
-        defaultVisibleColumns.add(FieldKey.fromParts("Rows"));
-        defaultVisibleColumns.add(FieldKey.fromParts("Columns"));
-        defaultVisibleColumns.add(FieldKey.fromParts("Type"));
     }
 
     public PlateTable(PlateSchema schema, @Nullable ContainerFilter cf)


### PR DESCRIPTION
#### Rationale
Introduces UX for creation, listing, and details for Plate Sets.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1390
- https://github.com/LabKey/labkey-ui-premium/pull/302
- https://github.com/LabKey/platform/pull/5118
- https://github.com/LabKey/biologics/pull/2636
- https://github.com/LabKey/sampleManagement/pull/2374
- https://github.com/LabKey/inventory/pull/1162

#### Changes
- Add `plate-createPlateSet.api` which supports creating a plate set with multiple plates within one transaction
- Make `PlateSetImpl` serializable via Jackson
- Introduce `plateCount` on `PlateSetImpl`
- Update plate creation API to accept an optional `plateSetId`.
- Update `PlateManager.getPlateOperationConfirmationData` to return "ContainerPath" for each plate