### PR TITLE
Support finding samples with multiple parent matches

### DIFF
--- a/api/schemas/queryCustomView.xsd
+++ b/api/schemas/queryCustomView.xsd
@@ -133,6 +133,8 @@
             <xsd:enumeration value="where"/>
             <xsd:enumeration value="inexpancestorsof"/>
             <xsd:enumeration value="inexpdescendantsof"/>
+            <xsd:enumeration value="notinexpancestorsof"/>
+            <xsd:enumeration value="notinexpdescendantsof"/>
         </xsd:restriction>
     </xsd:simpleType>
 


### PR DESCRIPTION
#### Rationale
We are adding a new "Equals all of" filter type for sample finder's parent cards to allow finding samples with multiple ancestors. The values in "Equals all of" filter is used to generate an array of inexpdescendantsof filters to find the matched results. We additionally allow a second (AND) filter for each field. When a negative (neq, not in) type filter is used in combination with "Equals all of" filter, we would want to make sure "notinexpdescendantsof" instead of "inexpdescendantsof" for the second filter to correctly further filter the multi-value field. 

The scenario would be:
Patient Equals All Of ("Mouse-1", "Mouse-2)
AND Patient <> "Mouse-3"

The expected filter array should be
- inexpdescendantsof " ... = Mouse-1"
- inexpdescendantsof " ... = Mouse-2"
- notinexpdescendantsof "... = Mouse-3"

Instead of 
- inexpdescendantsof "... = Mouse-1"
- inexpdescendantsof "...  =Mouse-2"
- inexpdescendantsof  " ... <> Mouse-3"

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1391
- https://github.com/LabKey/labkey-ui-premium/pull/303
- https://github.com/LabKey/platform/pull/5120
- https://github.com/LabKey/biologics/pull/2638
- https://github.com/LabKey/sampleManagement/pull/2379
- https://github.com/LabKey/testAutomation/pull/1790

#### Changes
* add support for notinexpdescendantsof operator type
