### PR TITLE
Add nonce to tracking script template

### DIFF
--- a/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
@@ -205,7 +205,7 @@ public class AnalyticsServiceImpl implements AnalyticsService
     private static final String GA4_TRACKING_SCRIPT_TEMPLATE =
             """
                     <!-- Global site tag (gtag.js) - Google Analytics -->
-                    <script async src="${GA4_JS:htmlEncode}"></script>
+                    <script async src="${GA4_JS:htmlEncode}" nonce="${SCRIPT_NONCE:htmlEncode}"></script>
                     <script nonce="${SCRIPT_NONCE:htmlEncode}">
                       window.dataLayer = window.dataLayer || [];
                       function gtag(){dataLayer.push(arguments);}

--- a/core/src/org/labkey/core/analytics/analyticsSettings.jsp
+++ b/core/src/org/labkey/core/analytics/analyticsSettings.jsp
@@ -70,10 +70,10 @@
             <td style="padding-left: 1em;">
                 <strong><label for="customScript">Custom JavaScript Analytics</label></strong>
                 <p>
-                    Add <label for="ff_trackingScript">custom analytics script</label> to the <code>&lt;head&gt;</code> of every page.  Include required <code>&lt;script&gt;</code> tags.
+                    Add <label for="ff_trackingScript">custom analytics script</label> to the <code>&lt;head&gt;</code> of every page. Include required <code>&lt;script&gt;</code> tags. If the server enforces a Content Security Policy, script blocks may need a nonce to function: <code>&lt;script nonce="\${SCRIPT_NONCE:htmlEncode}"&gt;</code>.
                 </p>
                 <p>
-                    <strong>NOTE:</strong> You can mess up your site if you make a mistake here.  You may want to bookmark this page to aid in making corrections, just in case.
+                    <strong>NOTE:</strong> You can mess up your site if you make a mistake here. You may want to bookmark this page to aid in making corrections, just in case.
                 </p>
                 <textarea <%=unsafe(hasAdminOpsPerms?"":"disabled=\"disabled\"")%> style="width:100%; height:15em;" id="ff_trackingScript" name="ff_trackingScript"><%=h(settingsForm.ff_trackingScript)%></textarea>
             </td>


### PR DESCRIPTION
#### Rationale
Tracking scripts are triggering our new content security policy. They need the nonce.

#### Related Pull Requests
* Replaces #5121 

#### Changes
* Add nonce to Google analytics tracking script template
* Add instructions for adding nonce to custom tracking scripts
