### PR TITLE
Fix EHR sql server error

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4436,6 +4436,11 @@ public class QueryController extends SpringActionController
 
         protected JSONObject executeJson(JSONObject json, CommandType commandType, boolean allowTransaction, Errors errors) throws Exception
         {
+            return executeJson(json, commandType, allowTransaction, errors, null);
+        }
+
+        protected JSONObject executeJson(JSONObject json, CommandType commandType, boolean allowTransaction, Errors errors, @Nullable TransactionAuditProvider.TransactionAuditEvent tAuditEvent) throws Exception
+        {
             JSONObject response = new JSONObject();
             Container container = getContainerForCommand(json);
             User user = getUser();
@@ -4550,6 +4555,8 @@ public class QueryController extends SpringActionController
                 {
                     if (transaction.getAuditEvent() != null)
                         auditEvent = transaction.getAuditEvent();
+                    else if (tAuditEvent != null)
+                        auditEvent = tAuditEvent;
                     else
                     {
                         auditEvent = AbstractQueryUpdateService.createTransactionAuditEvent(container, commandType.getAuditAction());
@@ -4976,7 +4983,7 @@ public class QueryController extends SpringActionController
                     }
                     commandObject.put("extraContext", commandExtraContext);
 
-                    JSONObject commandResponse = executeJson(commandObject, command, transacted, errors);
+                    JSONObject commandResponse = executeJson(commandObject, command, !transacted, errors, transaction.getAuditEvent());
                     // Bail out immediately if we're going to return a failure-type response message
                     if (commandResponse == null || (errors.hasErrors() && !isSuccessOnValidationError()))
                         return null;


### PR DESCRIPTION
#### Rationale
#5089 introduced a change to use the same transaction in a nested way. This turns out to be causing issues for sql server, see [related failures](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_EhrSqlserver/2840238?buildTab=overview&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true
)

This PR reverts the !transacted change to use NO_OP transaction for the inner transaction, and seek to handle transaction audit on an alternative current transaction. 
Good [run](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_EhrSqlserver/2848313?hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false&expandBuildChangesSection=true) 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* revert !transacted changes made in #5089 
* use alternative non NO_OP transaction for audit event, if available
