### PR TITLE
include the (optional) data region name in DataViewInfo

### DIFF
--- a/api/src/org/labkey/api/data/views/DataViewInfo.java
+++ b/api/src/org/labkey/api/data/views/DataViewInfo.java
@@ -59,6 +59,7 @@ public interface DataViewInfo
     @Nullable String getSchemaName();
     @Nullable String getQueryName();
     @Nullable String getViewName();
+    @Nullable String getDataRegionName();
 
     boolean isVisible();                // specifies whether this view is hidden
     boolean showInDashboard();          // an optional visibility level

--- a/api/src/org/labkey/api/data/views/DataViewService.java
+++ b/api/src/org/labkey/api/data/views/DataViewService.java
@@ -197,6 +197,8 @@ public class DataViewService
             o.put("queryName", info.getQueryName());
         if (info.getViewName() != null)
             o.put("viewName", info.getViewName());
+        if (info.getDataRegionName() != null)
+            o.put("dataRegionName", info.getDataRegionName());
 
         if (info.getDefaultIconCls() != null)
             o.put("defaultIconCls", info.getDefaultIconCls());

--- a/api/src/org/labkey/api/data/views/DefaultViewInfo.java
+++ b/api/src/org/labkey/api/data/views/DefaultViewInfo.java
@@ -72,6 +72,7 @@ public class DefaultViewInfo implements DataViewInfo
     private String _schemaName;
     private String _queryName;
     private String _viewName;
+    private String _dataRegionName;
 
     private int _displayOrder;
 
@@ -435,6 +436,18 @@ public class DefaultViewInfo implements DataViewInfo
     public String getViewName() { return _viewName; }
 
     public void setViewName(String viewName) { _viewName = viewName; }
+
+    @Nullable
+    @Override
+    public String getDataRegionName()
+    {
+        return _dataRegionName;
+    }
+
+    public void setDataRegionName(String dataRegionName)
+    {
+        _dataRegionName = dataRegionName;
+    }
 
     @Override
     public int getDisplayOrder() {return _displayOrder; }

--- a/query/src/org/labkey/query/reports/ReportViewProvider.java
+++ b/query/src/org/labkey/query/reports/ReportViewProvider.java
@@ -162,10 +162,12 @@ public class ReportViewProvider implements DataViewProvider
                 String query = descriptor.getProperty(ReportDescriptor.Prop.queryName);
                 String schema = descriptor.getProperty(ReportDescriptor.Prop.schemaName);
                 String view = descriptor.getProperty(ReportDescriptor.Prop.viewName);
+                String dataRegionName = descriptor.getProperty(ReportDescriptor.Prop.dataRegionName);
 
                 info.setSchemaName(schema);
                 info.setQueryName(query);
                 info.setViewName(view);
+                info.setDataRegionName(dataRegionName);
 
                 ViewCategory category = descriptor.getCategory(c);
 


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49401)

Adds the data region name, when applicable, to the information that data views provide so that the `GetReportInfosAction` can serialize it for reports.