### PR TITLE
Backport latest participant group related updates to 24.1

### DIFF
--- a/study/src/org/labkey/study/controllers/ParticipantGroupController.java
+++ b/study/src/org/labkey/study/controllers/ParticipantGroupController.java
@@ -1087,7 +1087,7 @@ public class ParticipantGroupController extends BaseStudyController
                     }
 
                     //if the label has changed, update the category label as well
-                    if (!form.getCategoryLabel().equalsIgnoreCase(category.getLabel()))
+                    if (null != form.getCategoryLabel() && !form.getCategoryLabel().equalsIgnoreCase(category.getLabel()))
                     {
                         category.setLabel(form.getCategoryLabel());
                         ParticipantGroupManager.getInstance().setParticipantCategory(getContainer(), getUser(), category);

--- a/study/src/org/labkey/study/controllers/ParticipantGroupController.java
+++ b/study/src/org/labkey/study/controllers/ParticipantGroupController.java
@@ -1086,6 +1086,13 @@ public class ParticipantGroupController extends BaseStudyController
                         ParticipantGroupManager.getInstance().setParticipantCategory(getContainer(), getUser(), category);
                     }
 
+                    //if the label has changed, update the category label as well
+                    if (!form.getCategoryLabel().equalsIgnoreCase(category.getLabel()))
+                    {
+                        category.setLabel(form.getCategoryLabel());
+                        ParticipantGroupManager.getInstance().setParticipantCategory(getContainer(), getUser(), category);
+                    }
+
                     deleteImplicitCategory(oldCategoryId, category);
                 }
                 transaction.commit();


### PR DESCRIPTION
#### Rationale
Backport below PRs to 24.1 so that production upgrade to 24.1 has the latest features and fixes.

#### Related Pull Requests
* https://github.com/LabKey/cds/pull/630

#### Changes
* Backport [Dataspace] - FR 48359: Active Filters - Update category label (https://github.com/LabKey/platform/pull/5087)
* Backport [Dataspace] - FR 48359: Curated groups and plots improvements - Active Filters - Add null check (https://github.com/LabKey/platform/pull/5115)
