### PR TITLE
Handle different deploy directory structures

### DIFF
--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
@@ -99,7 +99,7 @@ public class MothershipReportTest extends BaseWebDriverTest implements PostgresO
 
     private String getDeployedDistributionName()
     {
-        File distFile = new File(TestFileUtils.getDefaultDeployDir(), "labkeyWebapp/WEB-INF/classes/distribution");
+        File distFile = new File(TestFileUtils.getDefaultWebAppRoot(), "WEB-INF/classes/distribution");
         if (distFile.exists())
         {
             // Deployed from distribution


### PR DESCRIPTION
#### Rationale
The webapp directory is in `build/deploy/embedded/server/labkeywebapp` instead of `build/deploy/labkeyWebapp` when the server was started from an embedded distribution (as on TeamCity).

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1798

#### Changes
* Use helper to locate labkeywebapp directory
