### PR TITLE
Issue 47898: Line chart not respecting dateTime format on X-axis

### DIFF
--- a/visualization/resources/web/vis/genericChart/genericChartHelper.js
+++ b/visualization/resources/web/vis/genericChart/genericChartHelper.js
@@ -475,6 +475,10 @@ LABKEY.vis.GenericChartHelper = new function(){
             else if (isMeasureXMatch && isNumericType(type)) {
                 scales.x.tickFormat = _getNumberFormatFn(fields[i], defaultFormatFn);
             }
+            else if (isMeasureXMatch && isDateType(type) && fields[i].extFormatFn && window.Ext4) {
+                // Issue 47898: use the Ext4 date format function if available
+                scales.x.tickFormat = fields[i].extFormatFn;
+            }
 
             var yMeasures = ensureMeasuresAsArray(measures.y);
             $.each(yMeasures, function(idx, yMeasure) {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=47898

BEFORE
<img width="1302" alt="Screenshot 2024-01-22 at 4 48 27 PM" src="https://github.com/LabKey/platform/assets/6411206/25199dc1-f7a5-457d-9441-316839c9e0e2">

AFTER
<img width="1305" alt="Screenshot 2024-01-22 at 4 48 38 PM" src="https://github.com/LabKey/platform/assets/6411206/5c6ac073-858d-46e5-8e39-48111fd3fa2c">

#### Changes
- use the Ext4 date format function if available for the selected measure/field
