### PR TITLE
Upgrade to latest GraalJS version

### DIFF
--- a/api/src/org/labkey/api/util/ContextListener.java
+++ b/api/src/org/labkey/api/util/ContextListener.java
@@ -39,8 +39,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class ContextListener implements ServletContextListener
 {
-    public static final String POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY = "polyglot.engine.WarnInterpreterOnly";
-
     // this is among the earliest classes loaded (except for classes loaded via annotations @ClientEndpoint @ServerEndpoint etc)
 
     // IMPORTANT see also LabKeyBootstrapClassLoader/PipelineBootstrapConfig which duplicates this code, keep them consistent
@@ -61,13 +59,6 @@ public class ContextListener implements ServletContextListener
         }
         // As of log4j2 2.17.2, we must declare languages referenced in log4j2.xml. Our DefaultRolloverStrategy uses rhino.
         System.setProperty("log4j2.Script.enableLanguages", "rhino");
-
-        // Issue 47679 - suppress stdout logging from GraalJS about compilation mode, due to significant difficulties
-        // in getting the VM configured to use compilation mode
-        if (System.getProperty(POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY) == null)
-        {
-            System.setProperty(POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY, "false");
-        }
     }
 
     // NOTE: this line of code with LogManager.getLogger() has to happen after System.setProperty(LOG_HOME_PROPERTY_NAME)

--- a/api/src/org/labkey/api/util/ContextListener.java
+++ b/api/src/org/labkey/api/util/ContextListener.java
@@ -39,6 +39,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class ContextListener implements ServletContextListener
 {
+    public static final String POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY = "polyglot.engine.WarnInterpreterOnly";
+
     // this is among the earliest classes loaded (except for classes loaded via annotations @ClientEndpoint @ServerEndpoint etc)
 
     // IMPORTANT see also LabKeyBootstrapClassLoader/PipelineBootstrapConfig which duplicates this code, keep them consistent
@@ -59,6 +61,13 @@ public class ContextListener implements ServletContextListener
         }
         // As of log4j2 2.17.2, we must declare languages referenced in log4j2.xml. Our DefaultRolloverStrategy uses rhino.
         System.setProperty("log4j2.Script.enableLanguages", "rhino");
+
+        // Issue 47679 - suppress stdout logging from GraalJS about compilation mode, due to significant difficulties
+        // in getting the VM configured to use compilation mode
+        if (System.getProperty(POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY) == null)
+        {
+            System.setProperty(POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY, "false");
+        }
     }
 
     // NOTE: this line of code with LogManager.getLogger() has to happen after System.setProperty(LOG_HOME_PROPERTY_NAME)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -47,20 +47,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "org.graalvm.sdk:graal-sdk:${graalVersion}",
-            "GraalJS",
-            "GraalJS",
-            "https://github.com/graalvm/graaljs",
-            "Universal Permissive License",
-            "https://github.com/graalvm/graaljs/blob/master/LICENSE",
-            "Server-side JavaScript evaluation"
-        )
-    )
-
-    BuildUtils.addExternalDependency(
-        project,
-        new ExternalDependency(
-            "org.graalvm.js:js:${graalVersion}",
+            "org.graalvm.polyglot:js-community:${graalVersion}",
             "GraalJS",
             "GraalJS",
             "https://github.com/graalvm/graaljs",

--- a/core/src/org/labkey/core/wiki/MarkdownServiceImpl.java
+++ b/core/src/org/labkey/core/wiki/MarkdownServiceImpl.java
@@ -50,6 +50,18 @@ public class MarkdownServiceImpl implements MarkdownService
 
     private static class PoolFactory implements KeyedPoolableObjectFactory<Map<Options, Boolean>, MarkdownInvocable>
     {
+        public static final String POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY = "polyglot.engine.WarnInterpreterOnly";
+
+        static
+        {
+            // Issue 47679 - suppress stdout logging from GraalJS about compilation mode, due to significant difficulties
+            // in getting the VM configured to use compilation mode
+            if (System.getProperty(POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY) == null)
+            {
+                System.setProperty(POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY, "false");
+            }
+        }
+
         @Override
         public MarkdownInvocable makeObject(Map<Options, Boolean> options) throws Exception
         {

--- a/core/src/org/labkey/core/wiki/MarkdownServiceImpl.java
+++ b/core/src/org/labkey/core/wiki/MarkdownServiceImpl.java
@@ -50,9 +50,6 @@ public class MarkdownServiceImpl implements MarkdownService
 
     private static class PoolFactory implements KeyedPoolableObjectFactory<Map<Options, Boolean>, MarkdownInvocable>
     {
-
-        public static final String POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY = "polyglot.engine.WarnInterpreterOnly";
-
         @Override
         public MarkdownInvocable makeObject(Map<Options, Boolean> options) throws Exception
         {
@@ -60,13 +57,6 @@ public class MarkdownServiceImpl implements MarkdownService
             LabKeyScriptEngineManager svc = LabKeyScriptEngineManager.get();
             if (null == svc)
                 throw new ConfigurationException("LabKeyScriptEngineManager service not found.");
-
-            // Issue 47679 - suppress stdout logging from Graal about compilation mode, due to significant difficulties
-            // in getting the VM configured to use compilation mode
-            if (System.getProperty(POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY) == null)
-            {
-                System.setProperty(POLYGLOT_ENGINE_WARN_INTERPRETER_ONLY, "false");
-            }
 
             ScriptEngine engine = svc.getEngineByName("graal.js");
             if (null == engine)


### PR DESCRIPTION
#### Rationale
Newest version has different coordinates and dependencies

Note: Looks like the latest version broke the "polyglot.engine.WarnInterpreterOnly=false" system property, see https://github.com/oracle/graaljs/issues/794. They won't be fixing this until 24.x, so we'll have to just live with the logging until the next release.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/682
