### PR TITLE
Issue 49452: Apply appropriate data class read permission in container filter

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -833,7 +833,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
     private @NotNull Class<? extends Permission> getReadPermissionClass()
     {
-        return _dataClass.isMedia() ? MediaReadPermission.class : DataClassReadPermission.class;
+        return _dataClass != null && _dataClass.isMedia() ? MediaReadPermission.class : DataClassReadPermission.class;
     }
 
     //

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -817,12 +817,23 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
         if (perm == ReadPermission.class)
-        {
-            if (_dataClass.isMedia())
-                return getContainer().hasPermission(user, MediaReadPermission.class);
-            return getContainer().hasPermission(user, DataClassReadPermission.class);
-        }
+            return getContainer().hasPermission(user, getReadPermissionClass());
         return super.hasPermission(user, perm);
+    }
+
+    /**
+     * Issue 49452: Apply the appropriate data class read permission to the container filter so that folder filters
+     * do not include unauthorized rows.
+     */
+    @Override
+    protected SimpleFilter.FilterClause getContainerFilterClause(ContainerFilter filter, FieldKey fieldKey)
+    {
+        return filter.createFilterClause(getSchema(), fieldKey, getReadPermissionClass(), null);
+    }
+
+    private @NotNull Class<? extends Permission> getReadPermissionClass()
+    {
+        return _dataClass.isMedia() ? MediaReadPermission.class : DataClassReadPermission.class;
     }
 
     //


### PR DESCRIPTION
#### Rationale
This addresses [Issue 49452](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49452) by ensuring container filters constructed via `ExpDataClassDataTableImpl` specify the appropriate permission class.

#### Related Pull Requests
- https://github.com/LabKey/biologics/pull/2666

#### Changes
- Resolve container filter permissions based on data class
