### PR TITLE
Support additional context paths

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -109,6 +109,7 @@ import org.labkey.api.view.FileServlet;
 import org.labkey.api.view.JspTemplate;
 import org.labkey.api.view.LabKeyKaptchaServlet;
 import org.labkey.api.view.Portal;
+import org.labkey.api.view.RedirectorServlet;
 import org.labkey.api.view.ViewServlet;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.api.webdav.WebdavResolverImpl;
@@ -197,6 +198,14 @@ public class ApiModule extends CodeOnlyModule
         // http://host/labkey/filecontent/proj/dir/sendFile.view?file=test.html
         servletCtx.addServlet("FileServlet", new FileServlet()).
             addMapping("/files/*");
+
+        String legacyContextPath = servletCtx.getInitParameter("legacyContextPath");
+        if (legacyContextPath != null)
+        {
+            ServletRegistration.Dynamic redirectorDynamic = servletCtx.addServlet("RedirectorServlet", new RedirectorServlet(legacyContextPath));
+            redirectorDynamic.addMapping(legacyContextPath + "/*");
+            redirectorDynamic.setMultipartConfig(new MultipartConfigElement(SpringActionController.getTempUploadDir().getPath()));
+        }
     }
 
     @Override

--- a/api/src/org/labkey/api/view/RedirectorServlet.java
+++ b/api/src/org/labkey/api/view/RedirectorServlet.java
@@ -1,0 +1,51 @@
+//
+// Source code recreated from a .class file by IntelliJ IDEA
+// (powered by FernFlower decompiler)
+//
+
+package org.labkey.api.view;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/** Simple redirector to redirect and forward from legacy context paths to the root context */
+public class RedirectorServlet extends HttpServlet
+{
+    private final String _legacyContextPath;
+
+    public RedirectorServlet(String legacyContextPath)
+    {
+        if (!legacyContextPath.startsWith("/") || legacyContextPath.length() < 2)
+        {
+            throw new IllegalArgumentException("Invalid legacy context path: " + legacyContextPath);
+        }
+        _legacyContextPath = legacyContextPath;
+    }
+
+    @Override
+    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+    {
+
+        if ("get".equalsIgnoreCase(request.getMethod()))
+        {
+            // Send a redirect to let the client know there's a new preferred URL
+            String originalUrl = request.getRequestURL().toString();
+            String redirectUrl = originalUrl.replaceFirst(_legacyContextPath, "");
+
+            response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+            response.setHeader("Location", redirectUrl);
+        }
+        else
+        {
+            // For non-GETs, use a forward so that we don't lose POST parameters, etc
+            String originalUri = request.getRequestURI();
+            String forwardUri = originalUri.replaceFirst(_legacyContextPath, "");
+
+            getServletContext().getRequestDispatcher(forwardUri).forward(request, response);
+        }
+    }
+}

--- a/api/src/org/labkey/api/view/RedirectorServlet.java
+++ b/api/src/org/labkey/api/view/RedirectorServlet.java
@@ -1,8 +1,3 @@
-//
-// Source code recreated from a .class file by IntelliJ IDEA
-// (powered by FernFlower decompiler)
-//
-
 package org.labkey.api.view;
 
 import java.io.IOException;
@@ -21,7 +16,7 @@ public class RedirectorServlet extends HttpServlet
     {
         if (!legacyContextPath.startsWith("/") || legacyContextPath.length() < 2)
         {
-            throw new IllegalArgumentException("Invalid legacy context path: " + legacyContextPath);
+            throw new IllegalArgumentException("Legacy context path must start with / and cannot be the root context path. Invalid path: " + legacyContextPath + ", specified via context.legacyContextPath in application.properties");
         }
         _legacyContextPath = legacyContextPath;
     }
@@ -29,7 +24,6 @@ public class RedirectorServlet extends HttpServlet
     @Override
     protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
     {
-
         if ("get".equalsIgnoreCase(request.getMethod()))
         {
             // Send a redirect to let the client know there's a new preferred URL


### PR DESCRIPTION
#### Rationale
Some server configurations have historically used non-root context paths, and/or deployed additional web apps for delivering static content.

#### Related Pull Requests
* https://github.com/LabKey/server/pull/687

#### Changes
* Property to control LabKey's context path: `context.contextPath`
* Property to automatically redirect/forward requests from a legacy context path to the root: `context.legacyContextPath`
* Properties to deploy extra web apps: `webapps.contextPath` and `webapps.docBase`
