### PR TITLE
Make sure to only find executable pipeline tools

### DIFF
--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -788,7 +788,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
                             relPackageExpected = relPackageExpected.toLowerCase();
                         }
 
-                        return fileName.startsWith(relNameExpected + ".") || fileName.equals(relNameExpected) &&
+                        return (fileName.startsWith(relNameExpected + ".") || fileName.equals(relNameExpected)) &&
                                 parentName.endsWith(relPackageExpected) &&
                                 file1.canExecute();
                     });


### PR DESCRIPTION
#### Rationale
Due to some missing parentheses, `PipelineJobServiceImpl.getPathToTool` can find a non-executable file (such as `tail.exe` on a linux system) causing the pipeline job to fail.
```
org.labkey.api.pipeline.PipelineJobException: Failed starting process '[/mnt/teamcity/work/b48711bd5e50ff6d/build/deploy/embedded/bin/tail, -n, 10, ../report-47-1.testIn.tsv]'
	at org.labkey.api.pipeline.PipelineJob.runSubProcess(PipelineJob.java:1337) ~[api-24.2-SNAPSHOT.jar:?]
	at org.labkey.pipeline.analysis.CommandTaskImpl.runCommand(CommandTaskImpl.java:746) ~[pipeline-24.2-SNAPSHOT.jar:?]
	at org.labkey.pipeline.analysis.CommandTaskImpl.run(CommandTaskImpl.java:655) ~[pipeline-24.2-SNAPSHOT.jar:?]
	at org.labkey.api.pipeline.PipelineJob.runActiveTask(PipelineJob.java:833) [api-24.2-SNAPSHOT.jar:?]
	at org.labkey.api.pipeline.PipelineJob.run(PipelineJob.java:1075) [api-24.2-SNAPSHOT.jar:?]
	at org.labkey.di.pipeline.TransformPipelineJob.run(TransformPipelineJob.java:340) [dataintegration-24.2-SNAPSHOT.jar:?]
```

#### Related Pull Requests
* N/A

#### Changes
* Add missing parentheses to file filter when searching for pipeline tool
