### PR TITLE
Plate cache updates and DB serialization clean up.

### DIFF
--- a/assay/api-src/org/labkey/api/assay/plate/Plate.java
+++ b/assay/api-src/org/labkey/api/assay/plate/Plate.java
@@ -40,9 +40,9 @@ public interface Plate extends PropertySet, Identifiable
 
     boolean isTemplate();
 
-    @NotNull PlateType getPlateTypeObject();
+    @NotNull PlateType getPlateType();
 
-    @Nullable PlateSet getPlateSetObject();
+    @Nullable PlateSet getPlateSet();
 
     /**
      * Returns an existing well, or creates a new well if one

--- a/assay/api-src/org/labkey/api/assay/plate/Plate.java
+++ b/assay/api-src/org/labkey/api/assay/plate/Plate.java
@@ -44,6 +44,8 @@ public interface Plate extends PropertySet, Identifiable
 
     @Nullable PlateSet getPlateSet();
 
+    @NotNull String getPlateId();
+
     /**
      * Returns an existing well, or creates a new well if one
      * had not previously existed.

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -131,6 +131,14 @@ public interface PlateService
     @Nullable Plate getPlate(Container container, int rowId);
 
     /**
+     * Gets a plate instance object by plate id.
+     * @param container The plate's container.
+     * @param plateId The plate id of the plate.
+     * @return The requested plate, or null if no plate exists with the specified plate id.
+     */
+    @Nullable Plate getPlate(Container container, String plateId);
+
+    /**
      * Gets a plate instance object by row id.
      * @param cf The container filter to find the plate
      * @param rowId The row id of the plate.
@@ -145,6 +153,14 @@ public interface PlateService
      * @return The requested plate, or null if no plate exists with the specified row id.
      */
     @Nullable Plate getPlate(ContainerFilter cf, Lsid lsid);
+
+    /**
+     * Gets a plate instance object by plate id.
+     * @param cf The container filter to find the plate
+     * @param plateId The plate id of the plate.
+     * @return The requested plate, or null if no plate exists with the specified plate id.
+     */
+    @Nullable Plate getPlate(ContainerFilter cf, String plateId);
 
     /**
      * Gets all plate templates for the specified container. Plate templates are Plate instances

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -26,7 +26,6 @@ import org.labkey.api.assay.AbstractAssayProvider;
 import org.labkey.api.assay.AssayDomainService;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayQCService;
-import org.labkey.api.assay.AssaySchema;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.DetectionMethodAssayProvider;
 import org.labkey.api.assay.plate.Plate;
@@ -58,9 +57,7 @@ import org.labkey.api.gwt.client.assay.model.GWTProtocol;
 import org.labkey.api.gwt.client.model.GWTContainer;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
-import org.labkey.api.query.QueryChangeListener;
 import org.labkey.api.query.QueryService;
-import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
@@ -484,7 +481,7 @@ public class AssayDomainServiceImpl extends DomainEditorServiceBase implements A
                     if (provider instanceof PlateBasedAssayProvider && assay.getSelectedPlateTemplate() != null)
                     {
                         PlateBasedAssayProvider plateProvider = (PlateBasedAssayProvider)provider;
-                        Plate plate = PlateManager.get().getPlate(getContainer(), assay.getSelectedPlateTemplate());
+                        Plate plate = PlateManager.get().getPlateByName(getContainer(), assay.getSelectedPlateTemplate());
                         if (plate != null)
                             plateProvider.setPlate(getContainer(), protocol, plate);
                         else

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -205,7 +205,7 @@ public class AssayUpgradeCode implements UpgradeCode
     {
         // resolve plate by the legacy deprecated plate name method
         ObjectProperty prop = protocol.getObjectProperties().get(protocol.getLSID() + AbstractPlateBasedAssayProvider.PLATE_TEMPLATE_SUFFIX);
-        return prop != null ? PlateManager.get().getPlate(protocol.getContainer(), prop.getStringValue()) : null;
+        return prop != null ? PlateManager.get().getPlateByName(protocol.getContainer(), prop.getStringValue()) : null;
     }
 
     /**

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -282,6 +282,9 @@ public class PlateController extends SpringActionController
 
         public CopyTemplateBean(final Container container, final User user, final Integer plateId, final String selectedDestination)
         {
+            if (plateId == null)
+                throw new IllegalArgumentException("Plate ID cannot be null");
+
             _plate = PlateService.get().getPlate(container, plateId);
             if (_plate == null)
                 throw new IllegalStateException("Could not resolve the plate with ID : " + plateId);

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -45,7 +45,7 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.assay.TSVProtocolSchema;
-import org.labkey.assay.plate.model.Well;
+import org.labkey.assay.plate.model.WellBean;
 import org.labkey.assay.query.AssayDbSchema;
 
 import java.io.File;
@@ -296,11 +296,11 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             if (!plate.getCustomFields().isEmpty())
             {
                 // create the map of well locations to the well
-                Map<Position, Well> positionToWell = new HashMap<>();
+                Map<Position, WellBean> positionToWell = new HashMap<>();
 
                 SimpleFilter filter = SimpleFilter.createContainerFilter(plate.getContainer());
                 filter.addCondition(FieldKey.fromParts("PlateId"), plate.getRowId());
-                for (Well well : new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), filter, null).getArrayList(Well.class))
+                for (WellBean well : new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), filter, null).getArrayList(WellBean.class))
                     positionToWell.put(new PositionImpl(plate.getContainer(), well.getRow(), well.getCol()), well);
 
                 for (Map<String, Object> row : mergedRows)
@@ -503,7 +503,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 
         SimpleFilter filter = SimpleFilter.createContainerFilter(plate.getContainer());
         filter.addCondition(FieldKey.fromParts("PlateId"), plate.getRowId());
-        for (Well well : new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), filter, null).getArrayList(Well.class))
+        for (WellBean well : new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), filter, null).getArrayList(WellBean.class))
             positionToWellLsid.put(new PositionImpl(plate.getContainer(), well.getRow(), well.getCol()), Lsid.parse(well.getLsid()));
 
         return new PlateMetadataImportHelper(plate.getContainer(), data, Collections.unmodifiableMap(positionToWellLsid));

--- a/assay/src/org/labkey/assay/plate/PlateCache.java
+++ b/assay/src/org/labkey/assay/plate/PlateCache.java
@@ -16,6 +16,7 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.query.FieldKey;
+import org.labkey.assay.plate.model.PlateBean;
 import org.labkey.assay.query.AssayDbSchema;
 
 import java.util.ArrayList;
@@ -46,13 +47,14 @@ public class PlateCache
             SimpleFilter filter = SimpleFilter.createContainerFilter(cacheKey._container);
             filter.addCondition(FieldKey.fromParts(cacheKey._type.name()), cacheKey._identifier);
 
-            List<PlateImpl> plates = new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(), filter, null).getArrayList(PlateImpl.class);
+            List<PlateBean> plates = new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(), filter, null).getArrayList(PlateBean.class);
             assert plates.size() <= 1;
 
             if (plates.size() == 1)
             {
-                PlateImpl plate = plates.get(0);
-                PlateManager.get().populatePlate(plate);
+                PlateBean bean = plates.get(0);
+
+                Plate plate = PlateManager.get().populatePlate(bean);
                 LOG.info(String.format("Caching plate \"%s\" for folder %s", plate.getName(), cacheKey._container.getPath()));
 
                 // add all cache keys for this plate

--- a/assay/src/org/labkey/assay/plate/PlateDataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateDataServiceImpl.java
@@ -177,7 +177,7 @@ public class PlateDataServiceImpl extends BaseRemoteService implements PlateData
             else
             {
                 // check another plate of the same name doesn't already exist
-                Plate other = PlateManager.get().getPlate(getContainer(), gwtPlate.getName());
+                Plate other = PlateManager.get().getPlateByName(getContainer(), gwtPlate.getName());
                 if (other != null)
                 {
                     if (!replaceIfExisting)

--- a/assay/src/org/labkey/assay/plate/PlateDocumentProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateDocumentProvider.java
@@ -73,7 +73,7 @@ public class PlateDocumentProvider implements SearchService.DocumentProvider
 
         StringBuilder body = new StringBuilder();
 
-        PlateType plateType = plate.getPlateTypeObject();
+        PlateType plateType = plate.getPlateType();
         if (plateType != null)
             append(body, plateType.getDescription());
 

--- a/assay/src/org/labkey/assay/plate/PlateImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateImpl.java
@@ -588,7 +588,6 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     }
 
     @Override
-    //@JsonProperty("plateType")
     public @NotNull PlateType getPlateType()
     {
         return _plateType;
@@ -674,6 +673,8 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
         _runCount = runCount;
     }
 
+    @NotNull
+    @Override
     public String getPlateId()
     {
         return _plateId;

--- a/assay/src/org/labkey/assay/plate/PlateImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateImpl.java
@@ -31,12 +31,14 @@ import org.labkey.api.assay.plate.PositionImpl;
 import org.labkey.api.assay.plate.Well;
 import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.Transient;
 import org.labkey.api.query.QueryRowReference;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.assay.PlateController;
+import org.labkey.assay.plate.model.PlateBean;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,12 +61,10 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     private String _dataFileId;
     private String _assayType;
     private boolean _isTemplate;
-    private Integer _plateSetId;
-    private Integer _plateType;
     private String _description;
     private String _plateId;
-    private PlateType _plateTypeObject;
-    private PlateSet _plateSetObject;
+    private PlateType _plateType;
+    private PlateSet _plateSet;
 
     private Map<WellGroup.Type, Map<String, WellGroupImpl>> _groups;
     private List<WellGroupImpl> _deletedGroups;
@@ -94,13 +94,12 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
         _assayType = assayType;
         _container = container;
         _dataFileId = GUID.makeGUID();
-        _plateType = plateType.getRowId();
-        _plateTypeObject = plateType;
+        _plateType = plateType;
     }
 
     public PlateImpl(PlateImpl plate, double[][] wellValues, boolean[][] excluded, int runId, int plateNumber)
     {
-        this(plate.getContainer(), plate.getName(), plate.getAssayType(), plate.getPlateTypeObject());
+        this(plate.getContainer(), plate.getName(), plate.getAssayType(), plate.getPlateType());
 
         if (wellValues == null)
             wellValues = new double[plate.getRows()][plate.getColumns()];
@@ -125,6 +124,42 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
             addWellGroup(new WellGroupImpl(this, (WellGroupImpl) group));
 
         setContainer(plate.getContainer());
+    }
+
+    public static PlateImpl from(PlateBean bean)
+    {
+        PlateImpl plate = new PlateImpl();
+
+        // plate fields
+        plate.setRowId(bean.getRowId());
+        plate.setLsid(bean.getLsid());
+        plate.setName(bean.getName());
+        plate.setTemplate(bean.getTemplate());
+        plate.setDataFileId(bean.getDataFileId());
+        plate.setAssayType(bean.getAssayType());
+        plate.setPlateId(bean.getPlateId());
+        plate.setDescription(bean.getDescription());
+
+        // entity fields
+        Container container = ContainerManager.getForId(bean.getContainerId());
+        plate.setContainer(container);
+        plate.setCreated(bean.getCreated());
+        plate.setCreatedBy(bean.getCreatedBy());
+        plate.setModified(bean.getModified());
+        plate.setModifiedBy(bean.getModifiedBy());
+
+        // plate type and plate set objects
+        PlateType plateType = PlateManager.get().getPlateType(bean.getPlateType());
+        if (plateType == null)
+            throw new IllegalStateException("Unable to get Plate Type with id : " + bean.getPlateType());
+        plate.setPlateType(plateType);
+
+        PlateSet plateSet = PlateManager.get().getPlateSet(container, bean.getPlateSet());
+        if (plateSet == null)
+            throw new IllegalStateException("Unable to get Plate Set with id : " + bean.getPlateSet());
+        plate.setPlateSet(plateSet);
+
+        return plate;
     }
 
     @JsonIgnore
@@ -291,9 +326,9 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     @JsonIgnore
     public int getColumns()
     {
-        if (_plateTypeObject == null)
+        if (_plateType == null)
             return 0;
-        return _plateTypeObject.getColumns();
+        return _plateType.getColumns();
     }
 
     @Override
@@ -306,9 +341,9 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     @JsonIgnore
     public int getRows()
     {
-        if (_plateTypeObject == null)
+        if (_plateType == null)
             return 0;
-        return _plateTypeObject.getRows();
+        return _plateType.getRows();
     }
 
     @JsonIgnore
@@ -534,25 +569,34 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
         _isTemplate = template;
     }
 
-    public void setPlateSet(Integer plateSetId)
+    @Override
+    @JsonIgnore
+    public @Nullable PlateSet getPlateSet()
     {
-        _plateSetId = plateSetId;
+        return _plateSet;
     }
 
-    public Integer getPlateSet()
+    public void setPlateSet(PlateSet plateSet)
     {
-        return _plateSetId;
+        _plateSet = plateSet;
     }
 
-    public void setPlateType(Integer plateType)
+    @JsonProperty("plateSet")
+    public Integer getPlateSetId()
     {
-        _plateType = plateType;
+        return _plateSet.getRowId();
     }
 
-    @JsonIgnore // Ignored for client serialization due to full serialization of "plateType"
-    public Integer getPlateType()
+    @Override
+    //@JsonProperty("plateType")
+    public @NotNull PlateType getPlateType()
     {
         return _plateType;
+    }
+
+    public void setPlateType(PlateType plateType)
+    {
+        _plateType = plateType;
     }
 
     public String getDescription()
@@ -563,32 +607,6 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     public void setDescription(String description)
     {
         _description = description;
-    }
-
-    @Override
-    @JsonProperty("plateType")
-    public @NotNull PlateType getPlateTypeObject()
-    {
-        if (_plateTypeObject == null)
-            _plateTypeObject = PlateManager.get().getPlateType(_plateType);
-        return _plateTypeObject;
-    }
-
-    public void setPlateTypeObject(PlateType plateTypeObject)
-    {
-        _plateTypeObject = plateTypeObject;
-    }
-
-    @Override
-    @JsonIgnore
-    public @Nullable PlateSet getPlateSetObject()
-    {
-        return _plateSetObject;
-    }
-
-    public void setPlateSetObject(PlateSet plateSetObject)
-    {
-        _plateSetObject = plateSetObject;
     }
 
     @JsonIgnore

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1290,6 +1290,7 @@ public class PlateManager implements PlateService
     }
 
     @Override
+    @NotNull
     public List<? extends PlateType> getPlateTypes()
     {
         return new TableSelector(AssayDbSchema.getInstance().getTableInfoPlateType()).getArrayList(PlateTypeBean.class);

--- a/assay/src/org/labkey/assay/plate/model/PlateBean.java
+++ b/assay/src/org/labkey/assay/plate/model/PlateBean.java
@@ -1,0 +1,140 @@
+package org.labkey.assay.plate.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.labkey.api.data.Entity;
+import org.labkey.assay.plate.PlateImpl;
+
+/**
+ * Serializes a row in the assay.plate table.
+ */
+public class PlateBean extends Entity
+{
+    private Integer _rowId;
+    private String _lsid;
+    private String _name;
+    private Boolean _template;
+    private String _dataFileId;
+    private String _assayType;
+    private Integer _plateSet;
+    private Integer _plateType;
+    private String _plateId;
+    private String _description;
+
+    public static PlateBean from(PlateImpl plate)
+    {
+        PlateBean bean = new PlateBean();
+
+        bean.setRowId(plate.getRowId());
+        bean.setLsid(plate.getLSID());
+        bean.setName(plate.getName());
+        bean.setTemplate(plate.isTemplate());
+        bean.setDataFileId(plate.getDataFileId());
+        bean.setAssayType(plate.getAssayType());
+        bean.setPlateSet(plate.getPlateSet() != null ? plate.getPlateSet().getRowId() : null);
+        bean.setPlateType(plate.getPlateType().getRowId());
+        bean.setPlateId(plate.getPlateId());
+        bean.setDescription(plate.getDescription());
+
+        return bean;
+    }
+
+    public Integer getRowId()
+    {
+        return _rowId;
+    }
+
+    public void setRowId(Integer rowId)
+    {
+        _rowId = rowId;
+    }
+
+    public String getLsid()
+    {
+        return _lsid;
+    }
+
+    public void setLsid(String lsid)
+    {
+        _lsid = lsid;
+    }
+
+    public String getName()
+    {
+        return _name;
+    }
+
+    public void setName(String name)
+    {
+        _name = name;
+    }
+
+    public Boolean getTemplate()
+    {
+        return _template;
+    }
+
+    public void setTemplate(Boolean template)
+    {
+        _template = template;
+    }
+
+    public String getDataFileId()
+    {
+        return _dataFileId;
+    }
+
+    public void setDataFileId(String dataFileId)
+    {
+        _dataFileId = dataFileId;
+    }
+
+    public String getAssayType()
+    {
+        return _assayType;
+    }
+
+    public void setAssayType(String assayType)
+    {
+        _assayType = assayType;
+    }
+
+    public Integer getPlateSet()
+    {
+        return _plateSet;
+    }
+
+    public void setPlateSet(Integer plateSet)
+    {
+        _plateSet = plateSet;
+    }
+
+    public Integer getPlateType()
+    {
+        return _plateType;
+    }
+
+    public void setPlateType(Integer plateType)
+    {
+        _plateType = plateType;
+    }
+
+    public String getPlateId()
+    {
+        return _plateId;
+    }
+
+    public void setPlateId(String plateId)
+    {
+        _plateId = plateId;
+    }
+
+    public String getDescription()
+    {
+        return _description;
+    }
+
+    public void setDescription(String description)
+    {
+        _description = description;
+    }
+}

--- a/assay/src/org/labkey/assay/plate/model/PlateTypeBean.java
+++ b/assay/src/org/labkey/assay/plate/model/PlateTypeBean.java
@@ -6,7 +6,7 @@ import org.labkey.api.assay.plate.PlateType;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class PlateTypeImpl implements PlateType
+public class PlateTypeBean implements PlateType
 {
     private Integer _rowId;
     private Integer _rows;
@@ -14,7 +14,7 @@ public class PlateTypeImpl implements PlateType
     private String _description;
     private boolean _archived;
 
-    public PlateTypeImpl()
+    public PlateTypeBean()
     {
     }
 
@@ -92,7 +92,7 @@ public class PlateTypeImpl implements PlateType
         if (this == obj) return true;
         if (obj == null || getClass() != obj.getClass()) return false;
 
-        if (!Objects.equals(_rows, ((PlateTypeImpl) obj)._rows)) return false;
-        return Objects.equals(_cols, ((PlateTypeImpl) obj)._cols);
+        if (!Objects.equals(_rows, ((PlateTypeBean) obj)._rows)) return false;
+        return Objects.equals(_cols, ((PlateTypeBean) obj)._cols);
     }
 }

--- a/assay/src/org/labkey/assay/plate/model/WellBean.java
+++ b/assay/src/org/labkey/assay/plate/model/WellBean.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * Represents a row in the plate.well table
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class Well
+public class WellBean
 {
     private Integer _rowId;
     private String _lsid;


### PR DESCRIPTION
#### Rationale
Removes support for plate name in the cache. Plate by name is `deprecated` and could eventually be removed. Instead the more recent `plateId` has been added to the cache.

This PR also introduces a `PlateBean` to help with serialization to and from the database. This allows us to be a bit cleaner with the `Plate` instance which is a richer, composed object so we don't have to have methods like:
- `getPlateType` & `getPlateTypeObject`
- `getPlateSet` & `getPlateSetObject`

Which were needed to support DB binding plus returning the underlying object instances.