### PR TITLE
Add server version info to CSP reports

### DIFF
--- a/api/src/org/labkey/api/util/ContextListener.java
+++ b/api/src/org/labkey/api/util/ContextListener.java
@@ -25,13 +25,19 @@ import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ViewServlet;
+import org.labkey.filters.ContentSecurityPolicyFilter;
 import org.springframework.web.context.ContextLoaderListener;
 
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterRegistration;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import static java.util.EnumSet.allOf;
 
 /**
  * @see org.labkey.bootstrap.PipelineBootstrapConfig
@@ -73,6 +79,10 @@ public class ContextListener implements ServletContextListener
     public void contextInitialized(ServletContextEvent servletContextEvent)
     {
         getSpringContextListener().contextInitialized(servletContextEvent);
+
+        ServletContext context = servletContextEvent.getServletContext();
+        addCSPFilter(context, "csp.enforce", "enforce", "EnforceContentSecurityPolicyFilter");
+        addCSPFilter(context, "csp.report", "report", "ReportContentSecurityPolicyFilter");
     }
 
     @Override
@@ -90,7 +100,7 @@ public class ContextListener implements ServletContextListener
         org.apache.commons.beanutils.PropertyUtils.clearDescriptors();
         org.apache.commons.beanutils.ConvertUtils.deregister();
         java.beans.Introspector.flushCaches();
-        LogFactory.releaseAll();       // Might help with PermGen.  See 8/02/07 post at http://raibledesigns.com/rd/entry/why_i_like_tomcat_5
+        LogFactory.releaseAll();       // Might help with PermGen. See 8/02/07 post at http://raibledesigns.com/rd/entry/why_i_like_tomcat_5
     }
 
     public static void callShutdownListeners()
@@ -191,6 +201,17 @@ public class ContextListener implements ServletContextListener
             {
                 ExceptionUtil.logExceptionToMothership(null, t);
             }
+        }
+    }
+
+    private void addCSPFilter(ServletContext context, String parameterName, String disposition, String filterName)
+    {
+        String policy = context.getInitParameter(parameterName);
+        if (null != policy)
+        {
+            FilterRegistration registration = context.addFilter(filterName, new ContentSecurityPolicyFilter());
+            registration.addMappingForUrlPatterns(allOf(DispatcherType.class), false, "/*");
+            registration.setInitParameters(Map.of("policy", policy, "disposition", disposition));
         }
     }
 }

--- a/api/src/org/labkey/api/util/StringExpressionFactory.java
+++ b/api/src/org/labkey/api/util/StringExpressionFactory.java
@@ -672,7 +672,8 @@ public class StringExpressionFactory
                 }
             },
 
-            // Null fields get replaced with blank. Any missing field results in null eval.
+            // Null fields get replaced with blank. Any missing field results in null eval of the whole expression
+
             ReplaceNullWithBlank(StringExpressionType.ReplaceMissing.BLANK_VALUE)
             {
                 @Override

--- a/api/src/org/labkey/api/util/StringExpressionFactory.java
+++ b/api/src/org/labkey/api/util/StringExpressionFactory.java
@@ -664,34 +664,50 @@ public class StringExpressionFactory
         {
             // Any null field results in a null eval (good for URLs)
             NullResult(StringExpressionType.ReplaceMissing.NULL_RESULT)
-                    {
-                        @Override
-                        public String handleNull(StringExpressionFactory.StringPart part) throws StopIteratingException
-                        {
-                            throw new StopIteratingException();
-                        }
-                    },
+            {
+                @Override
+                public String handleNull(StringExpressionFactory.StringPart part) throws StopIteratingException
+                {
+                    throw new StopIteratingException();
+                }
+            },
 
-            // Null or missing fields get replaced with blank
+            // Null fields get replaced with blank. Any missing field results in null eval.
             ReplaceNullWithBlank(StringExpressionType.ReplaceMissing.BLANK_VALUE)
-                    {
-                        @Override
-                        public String handleNull(StringExpressionFactory.StringPart part)
-                        {
-                            return "";
-                        }
-                    },
+            {
+                @Override
+                public String handleNull(StringExpressionFactory.StringPart part)
+                {
+                    return "";
+                }
+            },
 
+            // Null and missing fields get replaced with blank
+            ReplaceNullAndMissingWithBlank(StringExpressionType.ReplaceMissing.BLANK_VALUE)
+            {
+                @Override
+                public String handleNull(StringExpressionFactory.StringPart part)
+                {
+                    return "";
+                }
+
+                @Override
+                public String handleUndefined(StringPart part)
+                {
+                    return "";
+                }
+            },
 
             // Insert "null" into the string
             OutputNull(StringExpressionType.ReplaceMissing.NULL_VALUE)
-                    {
-                        @Override
-                        public String handleNull(StringExpressionFactory.StringPart part)
-                        {
-                            return "null";
-                        }
-                    },
+            {
+                @Override
+                public String handleNull(StringExpressionFactory.StringPart part)
+                {
+                    return "null";
+                }
+            },
+
             KeepSubstitution(StringExpressionType.ReplaceMissing.KEEP_SUBSTITUTION)
             {
                 @Override

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -1,6 +1,7 @@
 package org.labkey.filters;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
@@ -116,6 +117,7 @@ public class ContentSecurityPolicyFilter implements Filter
     @Override
     public void init(FilterConfig filterConfig) throws ServletException
     {
+        LogManager.getLogger(ContentSecurityPolicyFilter.class).info("Initializing " + filterConfig.getFilterName());
         Enumeration<String> paramNames = filterConfig.getInitParameterNames();
         while (paramNames.hasMoreElements())
         {

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -1,0 +1,231 @@
+package org.labkey.filters;
+
+import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.settings.AppProps;
+import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.StringExpression;
+import org.labkey.api.util.StringExpressionFactory;
+import org.labkey.api.util.StringExpressionFactory.AbstractStringExpression.NullValueBehavior;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+
+/** example usage,
+
+ NOTE: LabKey does not yet support setting the "Report-To" header, so we do not support the report-to CSP directive.
+
+ Example 1 : very strict, disallows 'external' websites, disallows unsafe-inline, but only reports violations (does not enforce)
+ good for test automation!
+
+  <pre>
+      <filter>
+        <filter-name>Content Security Policy Filter Filter</filter-name>
+        <filter-class>org.labkey.filters.ContentSecurityPolicyFilter</filter-class>
+        <init-param>
+          <param-name>policy</param-name>
+          <param-value>
+            default-src 'self';
+            connect-src 'self' ${LABKEY.ALLOWED.CONNECTIONS} ;
+            object-src 'none' ;
+            style-src 'self' 'unsafe-inline' ;
+            img-src 'self' data: ;
+            font-src 'self' data: ;
+            script-src 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';
+            base-uri 'self' ;
+            upgrade-insecure-requests ;
+            frame-ancestors 'self' ;
+            report-uri /labkey/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
+          </param-value>
+        </init-param>
+        <init-param>
+          <param-name>disposition</param-name>
+          <param-value>report</param-value>
+        </init-param>
+      </filter>
+      <filter-mapping>
+        <filter-name>Content Security Policy Filter Filter</filter-name>
+        <url-pattern>/*</url-pattern>
+      </filter-mapping>
+  </pre>
+
+ Example 2 : less strict but enforces directives, (NOTE: unsafe-inline is still required for many modules)
+
+  <pre>
+      <filter>
+        <filter-name>Content Security Policy Filter Filter</filter-name>
+        <filter-class>org.labkey.filters.ContentSecurityPolicyFilter</filter-class>
+        <init-param>
+          <param-name>policy</param-name>
+          <param-value>
+            default-src 'self' https: ;
+            connect-src 'self' https: ${LABKEY.ALLOWED.CONNECTIONS} ;
+            object-src 'none' ;
+            style-src 'self' https: 'unsafe-inline' ;
+            img-src 'self' data: ;
+            font-src 'self' data: ;
+            script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' 'nonce-${REQUEST.SCRIPT.NONCE}';
+            base-uri 'self' ;
+            upgrade-insecure-requests ;
+            frame-ancestors 'self' ;
+            report-uri /labkey/admin-contentsecuritypolicyreport.api?${CSP.REPORT.PARAMS} ;
+          </param-value>
+        </init-param>
+        <init-param>
+          <param-name>disposition</param-name>
+          <param-value>enforce</param-value>
+        </init-param>
+      </filter>
+      <filter-mapping>
+        <filter-name>Content Security Policy Filter Filter</filter-name>
+        <url-pattern>/*</url-pattern>
+      </filter-mapping>
+  </pre>
+
+ Do not copy-and-paste these examples for any production environment without understanding the meaning of each directive!
+ */
+
+
+public class ContentSecurityPolicyFilter implements Filter
+{
+    private static final String NONCE_SUBST = "REQUEST.SCRIPT.NONCE";
+    private static final String ALLOWED_CONNECT_SUBSTITUTION = "LABKEY.ALLOWED.CONNECTIONS";
+    private static final String REPORT_PARAMETER_SUBSTITUTION = "CSP.REPORT.PARAMS";
+    private static final String HEADER_NONCE = "org.labkey.filters.ContentSecurityPolicyFilter#NONCE";  // needs to match PageConfig.HEADER_NONCE
+    private static final String CONTENT_SECURITY_POLICY_HEADER_NAME = "Content-Security-Policy";
+    private static final String CONTENT_SECURITY_POLICY_REPORT_ONLY_HEADER_NAME = "Content-Security-Policy-Report-Only";
+    private static final Map<String, String> allowedConnectionSources = new ConcurrentHashMap<>();
+    private static String connectionSrc = "";
+
+    private StringExpression policyExpression = null;
+    private boolean reportOnly = false;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException
+    {
+        Enumeration<String> paramNames = filterConfig.getInitParameterNames();
+        while (paramNames.hasMoreElements())
+        {
+            String paramName = paramNames.nextElement();
+            String paramValue = filterConfig.getInitParameter(paramName);
+            if ("policy".equalsIgnoreCase(paramName))
+            {
+                String s = paramValue.trim();
+                s = s.replace( '\n', ' ' );
+                s = s.replace( '\r', ' ' );
+                s = s.replace( '\t', ' ' );
+                s = s.replace((char)0x2018, (char)0x027);     // LEFT SINGLE QUOTATION MARK -> APOSTROPHE
+                s = s.replace((char)0x2019, (char)0x027);     // RIGHT SINGLE QUOTATION MARK -> APOSTROPHE
+
+                // This is temporary. TODO: Remove once we've propagated this substitution into our CSPs
+                String directive = "report-uri";
+                int reportUriIdx = StringUtils.indexOfIgnoreCase(s, directive);
+                if (reportUriIdx != -1)
+                {
+                    int semicolonIdx = s.indexOf(';', reportUriIdx);
+
+                    if (semicolonIdx != -1)
+                    {
+                        int urlStart = reportUriIdx + directive.length();
+                        String oldUrl = s.substring(urlStart, semicolonIdx).stripTrailing();
+                        if (!oldUrl.contains("?"))
+                        {
+                            String newUrl = oldUrl + "?${" + REPORT_PARAMETER_SUBSTITUTION + "}";
+                            s = s.substring(0, urlStart) + newUrl + s.substring(urlStart + oldUrl.length());
+                        }
+                    }
+                }
+
+                // Replace REPORT_PARAMETER_SUBSTITUTION now, since its value is static. Leave other substitutions in place.
+                s = StringExpressionFactory.create(s, false, NullValueBehavior.KeepSubstitution)
+                    .eval(Map.of(REPORT_PARAMETER_SUBSTITUTION, "labkeyVersion=" + PageFlowUtil.encodeURIComponent(AppProps.getInstance().getReleaseVersion())));
+
+                policyExpression = StringExpressionFactory.create(s, false, NullValueBehavior.ReplaceNullAndMissingWithBlank);
+            }
+            else if ("disposition".equalsIgnoreCase(paramName))
+            {
+                String s = paramValue.trim();
+                if (!"report".equalsIgnoreCase(s) && !"enforce".equalsIgnoreCase(s))
+                    throw new ServletException("ContentSecurityPolicyFilter is misconfigured, unexpected disposition value: " + s);
+                reportOnly = "report".equalsIgnoreCase(s);
+            }
+            else
+            {
+                throw new ServletException("ContentSecurityPolicyFilter is misconfigured, unexpected parameter name: " + paramName);
+            }
+        }
+    }
+
+    @Override
+    public void destroy()
+    {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
+    {
+        if (request instanceof HttpServletRequest req && response instanceof HttpServletResponse resp && null != policyExpression)
+        {
+            Map<String, String> map = Map.of(
+                NONCE_SUBST, getScriptNonceHeader(req),
+                ALLOWED_CONNECT_SUBSTITUTION, connectionSrc
+            );
+            var csp = policyExpression.eval(map);
+            var header = reportOnly ? CONTENT_SECURITY_POLICY_REPORT_ONLY_HEADER_NAME : CONTENT_SECURITY_POLICY_HEADER_NAME;
+            resp.setHeader(header, csp);
+        }
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * Return concatenated list of allowed connection hosts
+     */
+    private static String getAllowedConnectionsHeader(Collection<String> allowedConnectionSources)
+    {
+        //Remove substitution parameter if no sources are registered
+        if (allowedConnectionSources.isEmpty())
+            return "";
+
+        return allowedConnectionSources.stream().distinct().collect(Collectors.joining(" "));
+    }
+
+    public static String getScriptNonceHeader(HttpServletRequest request)
+    {
+        String nonce = (String)request.getAttribute(HEADER_NONCE);
+        if (nonce != null)
+            return nonce;
+
+        nonce = Long.toHexString(rand.nextLong());
+        rand.setSeed(request.getRequestURI().hashCode());
+
+        request.setAttribute(HEADER_NONCE, nonce);
+        return nonce;
+    }
+
+    private static final SecureRandom rand = new SecureRandom();
+
+    public static void registerAllowedConnectionSource(String key, String allowedUrl)
+    {
+        allowedConnectionSources.put(key, allowedUrl);
+        connectionSrc = getAllowedConnectionsHeader(allowedConnectionSources.values());
+    }
+
+    public static void unregisterAllowedConnectionSource(String key)
+    {
+        allowedConnectionSources.remove(key);
+        connectionSrc = getAllowedConnectionsHeader(allowedConnectionSources.values());
+    }
+}

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -11101,7 +11101,6 @@ public class AdminController extends SpringActionController
         }
     }
 
-
     @RequiresNoPermission
     @CSRF(CSRF.Method.NONE)
     public class ContentSecurityPolicyReportAction extends ReadOnlyApiAction<SimpleApiJsonForm>
@@ -11109,22 +11108,25 @@ public class AdminController extends SpringActionController
         private static final Logger _log = LogHelper.getLogger(ContentSecurityPolicyReportAction.class, "CSP warnings");
 
         // recent reports, to help avoid log spam
-        private static final Map<String,Boolean> reports = Collections.synchronizedMap(new LRUMap<>(20));
+        private static final Map<String, Boolean> reports = Collections.synchronizedMap(new LRUMap<>(20));
 
         @Override
         public Object execute(SimpleApiJsonForm form, BindException errors) throws Exception
         {
-            var ret = new JSONObject().put("success",true);
+            var ret = new JSONObject().put("success", true);
 
             // fail fast
             if (!_log.isWarnEnabled())
                 return ret;
 
-            var userAgent = getViewContext().getRequest().getHeader("User-Agent");
+            var request = getViewContext().getRequest();
+            assert null != request;
+
+            var userAgent = request.getHeader("User-Agent");
             if (PageFlowUtil.isRobotUserAgent(userAgent) && !_log.isDebugEnabled())
                 return ret;
 
-            // NOTE User will always be "guest".  Seems like a bad design to force the server to accept guest w/o CSRF here.
+            // NOTE User will always be "guest". Seems like a bad design to force the server to accept guest w/o CSRF here.
             var jsonObj = form.getJsonObject();
             if (null != jsonObj)
             {
@@ -11139,6 +11141,9 @@ public class AdminController extends SpringActionController
                         {
                             if (isNotBlank(userAgent))
                                 jsonObj.put("user-agent", userAgent);
+                            String labkeyVersion = request.getParameter("labkeyVersion");
+                            if (null != labkeyVersion)
+                                jsonObj.put("labkeyVersion", labkeyVersion);
                             var jsonStr = jsonObj.toString(2);
                             _log.warn("ContentSecurityPolicy warning on page: " + urlString + "\n" + jsonStr);
                         }


### PR DESCRIPTION
#### Rationale
We want CSP reports to include the originating server's version information (and potentially other properties in the future). https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49489

#### Related Pull Requests
* https://github.com/LabKey/server/pull/693

#### Changes
* Move `ContentSecurityPolicyFilter` to API to give it access to properties and helpers
* Register ContentSecurityPolicyFilter in `ContextListener.contextInitialized()` (embedded case). It seems that filters must be registered very, very early (e.g.,`ModuleLoader.init()` is too late).
* Add `${CSP.REPORT.PARAMS}` substitution to inject server properties into the CSP report JSON
* Use `StringExpression` to perform CSP substitutions
* Add `NullValueBehavior.ReplaceNullAndMissingWithBlank` and use it to ensure unknown substitutions are stripped from the CSP. Older servers ignoring unknown substitutions should ease the roll-out of future CSP changes.
* Fix comment on `NullValueBehavior.ReplaceNullWithBlank` for accuracy
* Temporarily append the ${CSP.REPORT.PARAMS} substitution on all `report-uri` URLs that lack query parameters. Will be removed once we propagate this substitution into our CSPs.