### PR TITLE
Plate: expose container column as "Folder"

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -513,7 +513,8 @@ public class PlateManager implements PlateService
      */
     public boolean plateExists(Container c, String name)
     {
-        return PlateCache.getPlate(c, name) != null;
+        Plate plate = PlateCache.getPlate(c, name);
+        return plate != null && plate.getName().equals(name);
     }
 
     private Collection<Plate> getPlates(Container c)

--- a/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
@@ -96,6 +96,8 @@ public class PlateSetTable extends SimpleUserSchema.SimpleTable<UserSchema>
     @Override
     protected void fixupWrappedColumn(MutableColumnInfo wrap, ColumnInfo col)
     {
+        super.fixupWrappedColumn(wrap, col);
+
         if ("Container".equalsIgnoreCase(col.getName()))
         {
             wrap.setFieldKey(FieldKey.fromParts("Folder"));

--- a/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
@@ -50,7 +50,7 @@ public class PlateSetTable extends SimpleUserSchema.SimpleTable<UserSchema>
     static
     {
         defaultVisibleColumns.add(FieldKey.fromParts("Name"));
-        defaultVisibleColumns.add(FieldKey.fromParts("Container"));
+        defaultVisibleColumns.add(FieldKey.fromParts("Folder"));
         defaultVisibleColumns.add(FieldKey.fromParts("Description"));
         defaultVisibleColumns.add(FieldKey.fromParts("PlateCount"));
         defaultVisibleColumns.add(FieldKey.fromParts("Created"));
@@ -91,6 +91,16 @@ public class PlateSetTable extends SimpleUserSchema.SimpleTable<UserSchema>
             columnInfo.setIsRootDbSequence(true);
         }
         return columnInfo;
+    }
+
+    @Override
+    protected void fixupWrappedColumn(MutableColumnInfo wrap, ColumnInfo col)
+    {
+        if ("Container".equalsIgnoreCase(col.getName()))
+        {
+            wrap.setFieldKey(FieldKey.fromParts("Folder"));
+            wrap.setLabel(getContainer().hasProductProjects() ? "Project" : "Folder");
+        }
     }
 
     private void addPlateCountColumn()

--- a/assay/src/org/labkey/assay/plate/query/PlateTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTable.java
@@ -110,6 +110,8 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
     @Override
     protected void fixupWrappedColumn(MutableColumnInfo wrap, ColumnInfo col)
     {
+        super.fixupWrappedColumn(wrap, col);
+
         if ("Container".equalsIgnoreCase(col.getName()))
         {
             wrap.setFieldKey(FieldKey.fromParts("Folder"));

--- a/assay/src/org/labkey/assay/plate/query/PlateTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTable.java
@@ -108,6 +108,16 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
     }
 
     @Override
+    protected void fixupWrappedColumn(MutableColumnInfo wrap, ColumnInfo col)
+    {
+        if ("Container".equalsIgnoreCase(col.getName()))
+        {
+            wrap.setFieldKey(FieldKey.fromParts("Folder"));
+            wrap.setLabel(getContainer().hasProductProjects() ? "Project" : "Folder");
+        }
+    }
+
+    @Override
     public List<FieldKey> getDefaultVisibleColumns()
     {
         return defaultVisibleColumns;


### PR DESCRIPTION
#### Rationale
Changes the field key for the "Container" column on both plates and plate sets to "Folder" as well as relabels the column depending on application context.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/317
- https://github.com/LabKey/biologics/pull/2671
- https://github.com/LabKey/platform/pull/5168

#### Changes
* Change field key from "Container" to "Folder".
* Change label from "Container" to "Folder" or "Project" depending on context.
