### PR TITLE
Issue 49501: Update the maximum depth for the ancestor closure query

### DIFF
--- a/api/src/org/labkey/api/audit/data/RunColumn.java
+++ b/api/src/org/labkey/api/audit/data/RunColumn.java
@@ -69,7 +69,7 @@ public class RunColumn extends ExperimentAuditColumn<ExpRun>
                     protocol = run.getProtocol();
                 AssayProvider provider = null;
                 if (protocol != null)
-                    provider = AssayService.get().getProvider(protocol);
+                    provider = AssayService.get() == null ? null : AssayService.get().getProvider(protocol);
 
                 ActionURL url = null;
                 if (provider != null)

--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -75,8 +75,8 @@ public class ClosureQueryHelper
         });
     }
 
-
-    static final int MAX_LINEAGE_LOOKUP_DEPTH = 10;
+    // N.B., This should be twice the number of generations we expect as a maximum number of ancestors due to the run nodes.
+    static final int MAX_LINEAGE_LOOKUP_DEPTH = 20;
 
     static String pgClosureCTE = String.format("""
             WITH RECURSIVE CTE_ AS (


### PR DESCRIPTION
#### Rationale
Issue [49501](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49501): Clients are relying on pulling from ancestors that are more than 5 generations away to get the data they need for printing barcodes. For most usages, where there are fewer than 5 generations, the change in this PR will have no effect. For those who have more than 5, this is modest increase in the maximum. They may experience some performance issues at some point, of course, but it should mostly be when recomputing the closure query table (during server startup or inserting or deleting of samples).

#### Changes
* Increase maximum lineage lookup depth to 10 generations
