### PR TITLE
Update classpath construction for RecompilingJspClassLoader 

### DIFF
--- a/api/src/org/labkey/api/jsp/RecompilingJspClassLoader.java
+++ b/api/src/org/labkey/api/jsp/RecompilingJspClassLoader.java
@@ -113,13 +113,7 @@ public class RecompilingJspClassLoader extends JspClassLoader
 
                     ClassPath cp = new ClassPath();
                     cp.addDirectory(new File(finder.getBuildPath(), "/explodedModule/lib"));
-                    // N.B. Our build references specific tomcat versions (set in the root-level gradle.properties file),
-                    // whereas here we add the tomcat libraries for the local installation to the classpath. This should
-                    // mostly be OK, but if seeing different behavior between the JSPs from the Gradle build and those
-                    // compiled while in dev mode, this may be a culprit.
-                    File tomcatLib = ModuleLoader.getInstance().getTomcatLib();
-                    if (null != tomcatLib)
-                        cp.addDirectory(tomcatLib);
+                    cp.addDirectory(getTomcatClassesDir());
                     // Include api lib directory on the compilation classpath
                     Collection<ResourceFinder> apiResourceFinders = ModuleLoader.getInstance().getResourceFindersForPath("/org/labkey/api/");
                     for (ResourceFinder apiFinder : apiResourceFinders)
@@ -291,5 +285,10 @@ public class RecompilingJspClassLoader extends JspClassLoader
     private String getModulesApiLib()
     {
         return AppProps.getInstance().getProjectRoot() + "/build/modules-api";
+    }
+
+    private String getTomcatClassesDir()
+    {
+        return AppProps.getInstance().getProjectRoot() + "/build/jspRecompiling";
     }
 }


### PR DESCRIPTION
#### Rationale
The `RecompilingJspClassLoader` currently depends on getting the tomcat libraries it needs from the local installation of tomcat. As we march toward using embedded Tomcat, we need a different way to make these jar files available for the classpath. The related PR adds a task (and its cleaning partner) to copy the same dependencies used by Gradle to a `build/jspRecompiling` directory. Here we update the classpath construction to use that directory

#### Related Pull Requests
* https://github.com/LabKey/server/pull/702

#### Changes
* Update classpath construction for `RecompilingJspClassLoader`
