### PR TITLE
Switch ImportPanel from client-side LABKEY.requiresScript() to server-side XML

### DIFF
--- a/core/webapp/extWidgets/ImportPanel.js
+++ b/core/webapp/extWidgets/ImportPanel.js
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
 
-LABKEY.requiresScript("/extWidgets/ExcelUploadPanel.js");
-LABKEY.requiresScript("/extWidgets/Ext4FormPanel.js");
-
+/*
+ * NOTE: ExcelUploadPanel.js and Ext4FormPanel.js are required for this component
+ */
 Ext4.define('LABKEY.ext.ImportPanel', {
     extend: 'Ext.tab.Panel',
     initComponent: function(){

--- a/query/resources/views/importData.view.xml
+++ b/query/resources/views/importData.view.xml
@@ -4,6 +4,8 @@
     </permissions>
     <dependencies>
         <dependency path="Ext4ClientApi"/>
+        <dependency path="/extWidgets/ExcelUploadPanel.js"/>
+        <dependency path="/extWidgets/Ext4FormPanel.js"/>
         <dependency path="/extWidgets/ImportPanel.js"/>
     </dependencies>
 </view>


### PR DESCRIPTION
Starting a little while ago (~3-4 months), we started to get error logs from query-importData, which suggested some kind of problem with loading timing of the Ext4 dependencies. I have been able to repro this intermittently as well. Looking at importData.html, one thing I see is that the problem components, ExcelUploadPanel and Ext4FormPanel, were being loaded using the client-side requiresScript(). I dont think there is any good reason to use this mechanism. I dont have a great answer as to the root cause, but my guess is that some change in browser JS loading behavior might cause instances where requireScript() properly load the dependency.

This PR is a simple change to remove requiresScript() and replace it with ClientDependencies in the XML file. This should be a much more reliable mechanism. The only usage I see of LABKEY.ext.ImportPanel is in importData.html, so the impact of this change should be limited.