### PR TITLE
Refactor ModuleLoader from Filter to standard singleton

### DIFF
--- a/api/src/org/labkey/api/data/TransactionFilter.java
+++ b/api/src/org/labkey/api/data/TransactionFilter.java
@@ -16,14 +16,14 @@
 
 package org.labkey.api.data;
 
-import org.labkey.api.util.FileUtil;
-
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
+import org.labkey.api.util.FileUtil;
+
 import java.io.IOException;
 
 public class TransactionFilter implements Filter
@@ -44,6 +44,7 @@ public class TransactionFilter implements Filter
         }
         finally
         {
+            ConnectionWrapper.dumpLeaksForThread(Thread.currentThread());
             DbScope.closeAllConnectionsForCurrentThread();
         }
         FileUtil.stopRequest();

--- a/api/src/org/labkey/api/module/Module.java
+++ b/api/src/org/labkey/api/module/Module.java
@@ -17,6 +17,10 @@
 package org.labkey.api.module;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.collections4.Factory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -38,10 +42,6 @@ import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.writer.ContainerUser;
 import org.springframework.web.servlet.mvc.Controller;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,8 +56,6 @@ import java.util.stream.Collectors;
  * Modules are the basic unit of deployment for code and resources within LabKey Server. Modules are deployable
  * independently of one another. They can have dependencies on services or other resources provided by other modules,
  * but should declare these dependencies.
- * User: migra
- * Date: Jul 14, 2005
  */
 public interface Module
 {
@@ -65,6 +63,8 @@ public interface Module
     default void registerServlets(ServletContext servletCtx) {}
     /** Register any final servlet mappings after the main mappings are in place */
     default void registerFinalServlets(ServletContext servletCtx) {}
+    /** Register filters and their mappings. */
+    default void registerFilters(ServletContext servletCtx) {}
 
     enum TabDisplayMode
     {

--- a/api/src/org/labkey/api/util/ContextListener.java
+++ b/api/src/org/labkey/api/util/ContextListener.java
@@ -15,6 +15,9 @@
  */
 package org.labkey.api.util;
 
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
 import org.apache.commons.logging.LogFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -25,19 +28,10 @@ import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ViewServlet;
-import org.labkey.filters.ContentSecurityPolicyFilter;
 import org.springframework.web.context.ContextLoaderListener;
 
-import jakarta.servlet.DispatcherType;
-import jakarta.servlet.FilterRegistration;
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletContextEvent;
-import jakarta.servlet.ServletContextListener;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import static java.util.EnumSet.allOf;
 
 /**
  * @see org.labkey.bootstrap.PipelineBootstrapConfig
@@ -80,9 +74,7 @@ public class ContextListener implements ServletContextListener
     {
         getSpringContextListener().contextInitialized(servletContextEvent);
 
-        ServletContext context = servletContextEvent.getServletContext();
-        addCSPFilter(context, "csp.enforce", "enforce", "EnforceContentSecurityPolicyFilter");
-        addCSPFilter(context, "csp.report", "report", "ReportContentSecurityPolicyFilter");
+        ModuleLoader.getInstance().init(servletContextEvent.getServletContext());
     }
 
     @Override
@@ -101,6 +93,7 @@ public class ContextListener implements ServletContextListener
         org.apache.commons.beanutils.ConvertUtils.deregister();
         java.beans.Introspector.flushCaches();
         LogFactory.releaseAll();       // Might help with PermGen. See 8/02/07 post at http://raibledesigns.com/rd/entry/why_i_like_tomcat_5
+        ModuleLoader.getInstance().destroy();
     }
 
     public static void callShutdownListeners()
@@ -201,17 +194,6 @@ public class ContextListener implements ServletContextListener
             {
                 ExceptionUtil.logExceptionToMothership(null, t);
             }
-        }
-    }
-
-    private void addCSPFilter(ServletContext context, String parameterName, String disposition, String filterName)
-    {
-        String policy = context.getInitParameter(parameterName);
-        if (null != policy)
-        {
-            FilterRegistration registration = context.addFilter(filterName, new ContentSecurityPolicyFilter());
-            registration.addMappingForUrlPatterns(allOf(DispatcherType.class), false, "/*");
-            registration.setInitParameters(Map.of("policy", policy, "disposition", disposition));
         }
     }
 }

--- a/api/webapp/WEB-INF/web.xml
+++ b/api/webapp/WEB-INF/web.xml
@@ -33,11 +33,6 @@
         <url-pattern>*.url</url-pattern>
     </filter-mapping>
 
-    <filter>
-        <filter-name>Module Loader</filter-name>
-        <filter-class>org.labkey.api.module.ModuleLoader</filter-class>
-    </filter>
-
     <filter-mapping>
         <filter-name>Set Character Encoding</filter-name>
         <url-pattern>/*</url-pattern>
@@ -45,11 +40,6 @@
 
     <filter-mapping>
         <filter-name>Form Authentication Filter</filter-name>
-        <url-pattern>/*</url-pattern>
-    </filter-mapping>
-
-    <filter-mapping>
-        <filter-name>Module Loader</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
 

--- a/pipeline/src/org/labkey/pipeline/AbstractPipelineStartup.java
+++ b/pipeline/src/org/labkey/pipeline/AbstractPipelineStartup.java
@@ -59,7 +59,7 @@ public abstract class AbstractPipelineStartup
         LoggerUtil.initLogging(name, log4JConfigPath);
 
         //load the modules and sort them by dependencies
-        ModuleLoader moduleLoader = new ModuleLoader();
+        ModuleLoader moduleLoader = ModuleLoader.getInstance();
         List<Module> modules = moduleLoader.doInit(moduleFiles);
         moduleLoader.setWebappDir(webappDir);
         ModuleDependencySorter sorter = new ModuleDependencySorter();


### PR DESCRIPTION
#### Rationale
In Tomcat, `Filter`s are initialized in random order. `ModuleLoader` is currently implemented as a Filter, so it may get initialized before other filters are initialized... or it may be after. By switching `ModuleLoader` from a `Filter` to a singleton that's initialized by `ContextListener`, we guarantee that `ModuleLoader.init()` is finished before any filters are initialized. A couple advantages:

* During their initialization, filters like `ContentSecurityPolicyFilter` can reference modules and properties that ModuleLoader handles
* Modules can programmatically register filters via a mechanism similar to our programmatic `Servlet` registration. Previously, all filters had to be registered before ModuleLoader was initialized, since new filters aren't recognized once the initialization process begins.