### PR TITLE
Issue 49370: allow HTML for TransformResult warnings

### DIFF
--- a/api/src/org/labkey/api/assay/actions/newUploadWarnings.jsp
+++ b/api/src/org/labkey/api/assay/actions/newUploadWarnings.jsp
@@ -43,7 +43,7 @@
     if (bean.getTransformResult().getWarnings() != null)
     {
 %>
-        <div class="labkey-error"><%= text(bean.getTransformResult().getWarnings()) %></div>
+        <div class="labkey-error"><%= bean.getTransformResult().getWarnings() %></div>
 <%
         if (!bean.getTransformResult().getFiles().isEmpty())
         {

--- a/api/src/org/labkey/api/qc/DefaultTransformResult.java
+++ b/api/src/org/labkey/api/qc/DefaultTransformResult.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.util.HtmlString;
 
 import java.io.File;
 import java.util.Collections;
@@ -38,7 +39,7 @@ public class DefaultTransformResult implements TransformResult
     private List<File> _uploadedFiles;
     private String _assayId;
     private String _comments;
-    private String _warnings;
+    private HtmlString _warnings;
     private List<File> _files;
     private static final Logger LOG = LogManager.getLogger(DefaultTransformResult.class);
 
@@ -55,13 +56,13 @@ public class DefaultTransformResult implements TransformResult
     }
 
     @Override
-    public String getWarnings()
+    public HtmlString getWarnings()
     {
         return _warnings;
     }
 
     @Override
-    public void setWarnings(String warnings)
+    public void setWarnings(HtmlString warnings)
     {
         _warnings = warnings;
     }

--- a/api/src/org/labkey/api/qc/TransformResult.java
+++ b/api/src/org/labkey/api/qc/TransformResult.java
@@ -18,6 +18,7 @@ package org.labkey.api.qc;
 
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.util.HtmlString;
 
 import java.io.File;
 import java.util.List;
@@ -52,7 +53,7 @@ public interface TransformResult
      *
      * @return      the string containing the error message
      */
-    String getWarnings();
+    HtmlString getWarnings();
 
     /**
      * Set transform script warnings. If severity level in run properties level is set to WARN, then these warnings
@@ -62,7 +63,7 @@ public interface TransformResult
      *
      * @param   warnings    String containing warnings
      */
-    void setWarnings(String warnings);
+    void setWarnings(HtmlString warnings);
 
     /**
      * Get transform script output files.  These files are collected from the transform scripts operating directory and

--- a/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
+++ b/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
@@ -58,6 +58,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
@@ -610,9 +611,9 @@ public class TsvDataExchangeHandler implements DataExchangeHandler
             }
 
             if(null != warning)
-                result.setWarnings(warning);
+                result.setWarnings(HtmlString.unsafe(warning)); // Issue 49370
             else
-                result.setWarnings("Warnings found in transform script!");
+                result.setWarnings(HtmlString.unsafe("Warnings found in transform script!"));
 
             if(null != files && !files.isEmpty())
                 result.setFiles(files);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49370

#### Changes
- use HtmlString for TransformResult warnings
