### PR TITLE
Remove properties that are defined in server

### DIFF
--- a/query/build.gradle
+++ b/query/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "eigenbase:eigenbase-properties:${eigenbasePropertiesVersion}",
+            "net.hydromatic:eigenbase-properties:${eigenbasePropertiesVersion}",
             "Mondrian",
             "Pentaho",
             "http://mondrian.pentaho.com/",
@@ -56,7 +56,7 @@ dependencies {
     BuildUtils.addExternalDependency(
         project,
         new ExternalDependency(
-            "eigenbase:eigenbase-resgen:${eigenbaseResgenVersion}",
+            "net.hydromatic:eigenbase-resgen:${eigenbaseResgenVersion}",
             "Mondrian",
             "Pentaho",
             "http://mondrian.pentaho.com/",

--- a/query/gradle.properties
+++ b/query/gradle.properties
@@ -1,5 +1,3 @@
 antlrVersion=3.5.2
-eigenbasePropertiesVersion=1.1.2
-eigenbaseResgenVersion=1.3.1
 mondrianVersion=9.4.0.1-465
 olap4jVersion=1.2.0


### PR DESCRIPTION
#### Rationale
These properties are moved to `server/gradle.properties`

#### Related Pull Requests
* https://github.com/LabKey/server/pull/705

#### Changes
* Remove eigenbase version properties
