### PR TITLE
Update documentation version to 24.3

### DIFF
--- a/api/src/org/labkey/api/Constants.java
+++ b/api/src/org/labkey/api/Constants.java
@@ -56,7 +56,7 @@ public class Constants
      */
     public static String getDocumentationVersion()
     {
-        return "23.11";
+        return "24.3";
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Version is now 24.3-SNAPSHOT. Make documentation version match

#### Related Pull Requests
* https://github.com/LabKey/server/pull/707

#### Changes
* Update documentation version to 24.3
