### PR TITLE
Fix folder import while impersonating

### DIFF
--- a/api/src/org/labkey/api/data/ButtonBar.java
+++ b/api/src/org/labkey/api/data/ButtonBar.java
@@ -42,8 +42,9 @@ public class ButtonBar extends DisplayElement
         separateButtons
     }
 
+    private final List<String> _missingOriginalCaptions = new ArrayList<>();
+
     private List<DisplayElement> _elementList = new ArrayList<>();
-    private List<String> _missingOriginalCaptions = new ArrayList<>();
     private Style _style = Style.toolbar;
     // It's possible to have multiple button bar configs, as in the case of a tableinfo-level config
     // that's partially overridden by a
@@ -109,7 +110,7 @@ public class ButtonBar extends DisplayElement
     @Override
     public boolean shouldRender(RenderContext ctx)
     {
-        return getList().size() > 0 && super.shouldRender(ctx);
+        return !getList().isEmpty() && super.shouldRender(ctx);
     }
 
     @Override

--- a/api/src/org/labkey/api/exp/SamplePropertyHelper.java
+++ b/api/src/org/labkey/api/exp/SamplePropertyHelper.java
@@ -56,8 +56,6 @@ import static java.util.Collections.emptySet;
 
 /**
  * Helper for mapping user-specified property values to the desired {@link DomainProperty} collection.
- * User: jeckels
- * Date: Oct 3, 2007
  */
 public abstract class SamplePropertyHelper<ObjectType>
 {

--- a/api/src/org/labkey/api/security/impersonation/AbstractImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/AbstractImpersonationContext.java
@@ -15,8 +15,7 @@
  */
 package org.labkey.api.security.impersonation;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.LoginUrls;
@@ -33,12 +32,11 @@ public abstract class AbstractImpersonationContext implements ImpersonationConte
 {
     private final User _adminUser;
     private final @Nullable Container _project;
+    @JsonIgnore // Can't be handled by remote pipelines
     private final ActionURL _returnURL;
     private final ImpersonationContextFactory _factory;
 
-    @JsonCreator
-    protected AbstractImpersonationContext(@JsonProperty("_adminUser") User adminUser, @JsonProperty("_project") @Nullable Container project,
-                                           @JsonProperty("_returnURL") ActionURL returnURL, @JsonProperty("_factory") ImpersonationContextFactory factory)
+    protected AbstractImpersonationContext(User adminUser, @Nullable Container project, ActionURL returnURL, ImpersonationContextFactory factory)
     {
         _adminUser = adminUser;
         _project = project;

--- a/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
@@ -16,6 +16,7 @@
 package org.labkey.api.security.impersonation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
@@ -49,6 +50,7 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
 {
     private final @Nullable GUID _projectId;
     private final int _groupId;
+    @JsonIgnore // Can't be handled by remote pipelines
     private final ActionURL _returnURL;
     private final int _adminUserId;
 
@@ -56,15 +58,13 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
     protected GroupImpersonationContextFactory(
             @JsonProperty("_projectId") @Nullable GUID projectId,
             @JsonProperty("_adminUserId") int adminUserId,
-            @JsonProperty("_groupId") int groupId,
-            @JsonProperty("_returnURL") ActionURL returnURL
+            @JsonProperty("_groupId") int groupId
     )
     {
-        super();
         _projectId = projectId;
         _groupId = groupId;
         _adminUserId = adminUserId;
-        _returnURL = returnURL;
+        _returnURL = null;
     }
 
     public GroupImpersonationContextFactory(@Nullable Container project, User adminUser, Group group, ActionURL returnURL)
@@ -83,7 +83,6 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
 
         return new GroupImpersonationContext(project, getAdminUser(), group, _returnURL, this);
     }
-
 
     @Override
     public void startImpersonating(ViewContext context)

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -16,6 +16,7 @@
 package org.labkey.api.security.impersonation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.collections4.CollectionUtils;
 import org.jetbrains.annotations.Nullable;
@@ -55,6 +56,7 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
     private final int _adminUserId;
     private final Set<String> _roleNames;
     private final Set<String> _previousRoleNames;
+    @JsonIgnore // Can't be handled by remote pipelines
     private final ActionURL _returnURL;
     private final String _cacheKey;
 
@@ -64,16 +66,14 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
             @JsonProperty("_adminUserId") int adminUserId,
             @JsonProperty("_roleNames") Set<String> roleNames,
             @JsonProperty("_previousRoleNames") Set<String> previousRoleNames,
-            @JsonProperty("_returnURL") ActionURL returnURL,
             @JsonProperty("_cacheKey") String cacheKey
     )
     {
-        super();
         _projectId = projectId;
         _adminUserId = adminUserId;
         _roleNames = roleNames;
         _previousRoleNames = previousRoleNames;
-        _returnURL = returnURL;
+        _returnURL = null;
         _cacheKey = cacheKey;
     }
     
@@ -215,9 +215,19 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
                 @JsonProperty("_project") @Nullable Container project,
                 @JsonProperty("_adminUser") User adminUser,
                 @JsonProperty("_roleNames") Set<String> roleNames,
-                @JsonProperty("_returnURL") ActionURL returnURL,
                 @JsonProperty("_factory") ImpersonationContextFactory factory,
                 @JsonProperty("_cacheKey") String cacheKey)
+        {
+            this(project, adminUser, roleNames, null, factory, cacheKey);
+        }
+
+        private RoleImpersonationContext(
+                @Nullable Container project,
+                User adminUser,
+                Set<String> roleNames,
+                ActionURL returnURL,
+                ImpersonationContextFactory factory,
+                String cacheKey)
         {
             super(adminUser, project, returnURL, factory);
             _roleNames = roleNames;

--- a/api/src/org/labkey/api/view/ViewBackgroundInfo.java
+++ b/api/src/org/labkey/api/view/ViewBackgroundInfo.java
@@ -26,8 +26,6 @@ import java.io.Serializable;
 
 /**
  * For use inside background threads with no request object, to scope them to a {@link Container}, {@link User}, etc.
- * Created: Oct 4, 2005
- * @author bmaclean
  */
 public class ViewBackgroundInfo implements Serializable, ContainerUser
 {
@@ -40,8 +38,8 @@ public class ViewBackgroundInfo implements Serializable, ContainerUser
 
     // Not supported outside the LabKey Server context
     private transient Container _container;
-    private transient User _user;
     private transient ActionURL _url;
+    private User _user; // non-transient for LabKey Server case -- need to round-trip the impersonation context, Issue 49513
 
     // Default constructor for serialization
     protected ViewBackgroundInfo()

--- a/assay/api-src/org/labkey/api/assay/plate/PlateSamplePropertyHelper.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateSamplePropertyHelper.java
@@ -28,10 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * User: jeckels
- * Date: Oct 3, 2007
- */
 public class PlateSamplePropertyHelper extends SamplePropertyHelper<String>
 {
     protected List<String> _sampleNames;

--- a/experiment/src/org/labkey/experiment/DerivedSamplePropertyHelper.java
+++ b/experiment/src/org/labkey/experiment/DerivedSamplePropertyHelper.java
@@ -55,8 +55,6 @@ import static org.labkey.api.exp.api.ExpRunItem.PARENT_IMPORT_ALIAS_MAP_PROP;
 /**
  * Gets the sample-specific values from user-provided information when creating child samples from an existing set
  * of parents.
- * User: jeckels
- * Date: Oct 3, 2007
  */
 public class DerivedSamplePropertyHelper extends SamplePropertyHelper<Lsid>
 {
@@ -255,5 +253,4 @@ public class DerivedSamplePropertyHelper extends SamplePropertyHelper<Lsid>
             return Collections.singletonList(_domainProperties.get(0));
         }
     }
-
 }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobMarshaller.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobMarshaller.java
@@ -145,7 +145,6 @@ public class PipelineJobMarshaller implements PipelineStatusFile.JobStore
         {
             throw UnexpectedException.wrap(e);
         }
-
     }
 
     @Override

--- a/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
@@ -17,7 +17,6 @@
 package org.labkey.pipeline.api;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
@@ -463,7 +462,7 @@ public class PipelineServiceImpl implements PipelineService, PipelineMXBean
     @Override
     public void queueJob(PipelineJob job, @Nullable String jobNotificationProvider) throws PipelineValidationException
     {
-        // Test serialization by serializing and deserializating every job
+        // Test serialization by serializing and deserializing every job
         PipelineJob deserializedJob = PipelineJob.deserializeJob(job.serializeJob(false));
         getPipelineQueue().addJob(deserializedJob);
 
@@ -710,7 +709,7 @@ public class PipelineServiceImpl implements PipelineService, PipelineMXBean
     private List<String> parseArray(String dbPaths)
     {
         if(dbPaths == null) return null;
-        if(dbPaths.length() == 0) return new ArrayList<>();
+        if(dbPaths.isEmpty()) return new ArrayList<>();
         String[] tokens = dbPaths.split("\\|");
         return new ArrayList<>(Arrays.asList(tokens));
     }
@@ -721,7 +720,7 @@ public class PipelineServiceImpl implements PipelineService, PipelineMXBean
         StringBuilder temp = new StringBuilder();
         for(String path:sequenceDbPathsList)
         {
-            if(temp.length() > 0)
+            if(!temp.isEmpty())
                 temp.append("|");
             temp.append(path);
         }
@@ -803,6 +802,7 @@ public class PipelineServiceImpl implements PipelineService, PipelineMXBean
         }
         catch (PipelineValidationException e)
         {
+            LOG.error("Queuing FolderImportJob failed", e);
             return false;
         }
     }
@@ -992,7 +992,7 @@ public class PipelineServiceImpl implements PipelineService, PipelineMXBean
             protocol.saveInstance(fileParameters, context.getContainer());
         }
 
-        Boolean allowNonExistentFiles = form.isAllowNonExistentFiles() != null ? form.isAllowNonExistentFiles() : false;
+        boolean allowNonExistentFiles = form.isAllowNonExistentFiles() != null ? form.isAllowNonExistentFiles() : false;
         List<Path> filesInputList = form.getValidatedPaths(context.getContainer(), allowNonExistentFiles);
 
         if (form.isActiveJobs())


### PR DESCRIPTION
#### Rationale
[Issue 49513: Importing folder archive as Impersonating Troubleshooter (Impersonating a Site Admin) doesn't work](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49513)

* Serialize and deserialize the `User` (including its `ImpersonationContext`) held by `ViewBackgroundInfo`
* Log exceptions that occur while attempting to queue folder import pipeline job (no quiet quitting)
* Clear up some random warnings
* Stop serializing returnURLs in impersonation contexts and their factories, since remote pipelines don't like them