### PR TITLE
Remove support for PostgreSQL 11.x

### DIFF
--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 public enum PostgreSqlVersion
 {
     POSTGRESQL_UNSUPPORTED(-1, true, false, null),
-    POSTGRESQL_11(110, true, true, PostgreSql_11_Dialect::new),
     POSTGRESQL_12(120, false, true, PostgreSql_12_Dialect::new),
     POSTGRESQL_13(130, false, true, PostgreSql_13_Dialect::new),
     POSTGRESQL_14(140, false, true, PostgreSql_14_Dialect::new),
@@ -27,9 +26,9 @@ public enum PostgreSqlVersion
     private final int _version;
     private final boolean _deprecated;
     private final boolean _tested;
-    private final Supplier<? extends PostgreSql_11_Dialect> _dialectFactory;
+    private final Supplier<? extends PostgreSql_12_Dialect> _dialectFactory;
 
-    PostgreSqlVersion(int version, boolean deprecated, boolean tested, Supplier<? extends PostgreSql_11_Dialect> dialectFactory)
+    PostgreSqlVersion(int version, boolean deprecated, boolean tested, Supplier<? extends PostgreSql_12_Dialect> dialectFactory)
     {
         _version = version;
         _deprecated = deprecated;
@@ -48,7 +47,7 @@ public enum PostgreSqlVersion
         return _tested;
     }
 
-    public PostgreSql_11_Dialect getDialect()
+    public PostgreSql_12_Dialect getDialect()
     {
         return _dialectFactory.get();
     }
@@ -83,7 +82,6 @@ public enum PostgreSqlVersion
         public void test()
         {
             // Good
-            test(110, POSTGRESQL_11);
             test(120, POSTGRESQL_12);
             test(130, POSTGRESQL_13);
             test(140, POSTGRESQL_14);
@@ -110,6 +108,7 @@ public enum PostgreSqlVersion
             test(98, POSTGRESQL_UNSUPPORTED);
             test(99, POSTGRESQL_UNSUPPORTED);
             test(100, POSTGRESQL_UNSUPPORTED);
+            test(110, POSTGRESQL_UNSUPPORTED);
         }
 
         private void test(int version, PostgreSqlVersion expectedVersion)

--- a/core/src/org/labkey/core/dialect/PostgreSql_11_Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql_11_Dialect.java
@@ -15,6 +15,6 @@
  */
 package org.labkey.core.dialect;
 
-public class PostgreSql_11_Dialect extends PostgreSql_10_Dialect
+public abstract class PostgreSql_11_Dialect extends PostgreSql_10_Dialect
 {
 }


### PR DESCRIPTION
#### Rationale
PostgreSQL 11.x reached end-of-life in early November, 2023. It's time to remove support for this unmaintained version.

https://www.postgresql.org/support/versioning/
