### PR TITLE
Prevent NPE when calculating NAb dilution curves

### DIFF
--- a/assay/api-src/org/labkey/api/assay/dilution/DilutionSummary.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/DilutionSummary.java
@@ -16,18 +16,18 @@
 
 package org.labkey.api.assay.dilution;
 
+import org.labkey.api.assay.AbstractAssayProvider;
 import org.labkey.api.assay.nab.Luc5Assay;
+import org.labkey.api.assay.plate.AbstractPlateBasedAssayProvider;
+import org.labkey.api.assay.plate.PlateService;
+import org.labkey.api.assay.plate.WellData;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.statistics.CurveFit;
 import org.labkey.api.data.statistics.DoublePoint;
 import org.labkey.api.data.statistics.FitFailedException;
 import org.labkey.api.data.statistics.StatsService;
-import org.labkey.api.assay.plate.PlateService;
-import org.labkey.api.assay.plate.WellData;
-import org.labkey.api.assay.plate.WellGroup;
-import org.labkey.api.assay.AbstractAssayProvider;
-import org.labkey.api.assay.plate.AbstractPlateBasedAssayProvider;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -36,6 +36,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * User: brittp
@@ -46,7 +47,7 @@ public class DilutionSummary implements Serializable
 {
     private final List<WellGroup> _sampleGroups;
     private final WellGroup _firstGroup;
-    private final Map<StatsService.CurveFitType, DilutionCurve> _dilutionCurve = new HashMap<>() ;
+    private final Map<StatsService.CurveFitType, DilutionCurve> _dilutionCurve = new ConcurrentHashMap<>() ;
     private final Luc5Assay _assay;
     private final String _lsid;
     private final StatsService.CurveFitType _curveFitType;
@@ -169,7 +170,7 @@ public class DilutionSummary implements Serializable
         return _assay.getPercent(getDataToSampleMap().get(data), data);
     }
 
-    private DilutionCurve getDilutionCurve(StatsService.CurveFitType type) throws FitFailedException
+    private synchronized DilutionCurve getDilutionCurve(StatsService.CurveFitType type) throws FitFailedException
     {
         if (!_dilutionCurve.containsKey(type))
         {


### PR DESCRIPTION
#### Rationale
Been seeing this NPE intermittently on TeamCity.
```
java.lang.NullPointerException: Cannot invoke "org.labkey.api.assay.dilution.DilutionCurve.getCurve()" because the return value of "org.labkey.api.assay.dilution.DilutionSummary.getDilutionCurve(org.labkey.api.data.statistics.StatsService$CurveFitType)" is null
	at org.labkey.api.assay.dilution.DilutionSummary.getCurve(DilutionSummary.java:229) ~[assay_api-23.11-SNAPSHOT.jar:?]
	at org.labkey.api.assay.nab.NabGraph.renderChartPNG(NabGraph.java:388) ~[assay_api-23.11-SNAPSHOT.jar:?]
	at org.labkey.api.assay.nab.NabGraph.renderChartPNG(NabGraph.java:285) ~[assay_api-23.11-SNAPSHOT.jar:?]
	at org.labkey.api.assay.nab.NabGraph.renderChartPNG(NabGraph.java:298) ~[assay_api-23.11-SNAPSHOT.jar:?]
	at org.labkey.api.assay.nab.view.DilutionGraphAction.getView(DilutionGraphAction.java:57) ~[assay_api-23.11-SNAPSHOT.jar:?]
	at org.labkey.api.assay.nab.view.DilutionGraphAction.getView(DilutionGraphAction.java:40) ~[assay_api-23.11-SNAPSHOT.jar:?]
```

There doesn't seem to be any way for `DilutionSummary.getDilutionCurve` to return `null` so I'm presuming that there's a concurrency issue with the Map of dilution curves. This fix is mostly just a shot in the dark.

#### Related Pull Requests
* N/A

#### Changes
* Synchronize `DilutionSummary.getDilutionCurve` to avoid NPEs
