### PR TITLE
Fix 49234: CreatedBy is not displayed for some files

### DIFF
--- a/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
@@ -726,6 +726,8 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
                     list.addAll(provider.getExpDataByPath(path, container));
                 }
             }
+
+            //Sort the results by creation date so the original is used for metadata display
             _data = list.stream().sorted(Comparator.comparing(ExpObject::getCreated)).toList();
         }
         return _data;

--- a/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
@@ -26,6 +26,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.exp.LsidManager;
 import org.labkey.api.exp.api.ExpData;
+import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.resource.AbstractResource;
@@ -59,6 +60,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -157,21 +159,30 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
     public User getCreatedBy()
     {
         List<ExpData> data = getExpData();
-        return data != null && data.size() == 1 ? data.get(0).getCreatedBy() : null;
+        if (data == null || data.isEmpty())
+            return null;
+
+        return data.get(0).getCreatedBy();
     }
 
     @Override
     public String getDescription()
     {
         List<ExpData> data = getExpData();
-        return data != null && data.size() == 1 ? data.get(0).getComment() : null;
+        if (data == null || data.isEmpty())
+            return null;
+
+        return data.get(0).getComment();
     }
 
     @Override
     public User getModifiedBy()
     {
         List<ExpData> data = getExpData();
-        return data != null && data.size() == 1 ? data.get(0).getCreatedBy() : null;
+        if (data == null || data.isEmpty())
+            return null;
+
+        return data.get(0).getModifiedBy();
     }
 
 
@@ -715,7 +726,7 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
                     list.addAll(provider.getExpDataByPath(path, container));
                 }
             }
-            _data = list;
+            _data = list.stream().sorted(Comparator.comparing(ExpObject::getCreated)).toList();
         }
         return _data;
     }


### PR DESCRIPTION
#### Rationale
[Secure Issue 49234: FileContent isn't always displaying CreatedBy despite having CreatedBy in the audit log](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49234)

Notes: 
* Chose to use the first across the board to have a consistent source
* The usage column links use the expDatas link to runs and the analysis 

#### Related Pull Requests
* https://github.com/LabKey/commonAssays/pull/731
* https://github.com/LabKey/platform/pull/5208

#### Changes
* Modified the set of metadata properties to use the first/oldest always
