### PR TITLE
Follow Google's CSP guidance for connect-src

### DIFF
--- a/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
@@ -118,7 +118,7 @@ public class AnalyticsServiceImpl implements AnalyticsService
 
         if (getTrackingStatus().contains(TrackingStatus.ga4FullUrl))
         {
-            ContentSecurityPolicyFilter.registerAllowedConnectionSource(ANALYTICS_CSP_KEY, GOOGLE_TAG_MANAGER_URL, "https://www.google-analytics.com");
+            ContentSecurityPolicyFilter.registerAllowedConnectionSource(ANALYTICS_CSP_KEY, "https://*.googletagmanager.com", "https://*.google-analytics.com", "https://*.analytics.google.com");
         }
     }
 


### PR DESCRIPTION
#### Rationale
My previous change was too restrictive in the Google Analytics hosts being allowed for the Content Security Policy

#### Changes
* Allow wildcards and one other domain