### PR TITLE
Feature flag to disable the sending of enforce CSP headers

### DIFF
--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -2,6 +2,7 @@ package org.labkey.filters;
 
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
@@ -102,17 +103,34 @@ import java.util.stream.Collectors;
 
 public class ContentSecurityPolicyFilter implements Filter
 {
+    public static final String FEATURE_FLAG_DISABLE_ENFORCE_CSP = "disableEnforceCsp";
+
     private static final String NONCE_SUBST = "REQUEST.SCRIPT.NONCE";
     private static final String ALLOWED_CONNECT_SUBSTITUTION = "LABKEY.ALLOWED.CONNECTIONS";
     private static final String REPORT_PARAMETER_SUBSTITUTION = "CSP.REPORT.PARAMS";
     private static final String HEADER_NONCE = "org.labkey.filters.ContentSecurityPolicyFilter#NONCE";  // needs to match PageConfig.HEADER_NONCE
-    private static final String CONTENT_SECURITY_POLICY_HEADER_NAME = "Content-Security-Policy";
-    private static final String CONTENT_SECURITY_POLICY_REPORT_ONLY_HEADER_NAME = "Content-Security-Policy-Report-Only";
     private static final Map<String, String> allowedConnectionSources = new ConcurrentHashMap<>();
     private static String connectionSrc = "";
 
     private StringExpression policyExpression = null;
-    private String header = CONTENT_SECURITY_POLICY_HEADER_NAME;
+    private ContentSecurityPolicyType type = ContentSecurityPolicyType.Enforce;
+
+    public enum ContentSecurityPolicyType
+    {
+        Report("Content-Security-Policy-Report-Only"), Enforce("Content-Security-Policy");
+
+        private final String _headerName;
+
+        ContentSecurityPolicyType(String headerName)
+        {
+            _headerName = headerName;
+        }
+
+        public String getHeaderName()
+        {
+            return _headerName;
+        }
+    }
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException
@@ -167,7 +185,7 @@ public class ContentSecurityPolicyFilter implements Filter
                 if (!"report".equalsIgnoreCase(s) && !"enforce".equalsIgnoreCase(s))
                     throw new ServletException("ContentSecurityPolicyFilter is misconfigured, unexpected disposition value: " + s);
                 if ("report".equalsIgnoreCase(s))
-                    header = CONTENT_SECURITY_POLICY_REPORT_ONLY_HEADER_NAME;
+                    type = ContentSecurityPolicyType.Report;
             }
             else
             {
@@ -186,13 +204,16 @@ public class ContentSecurityPolicyFilter implements Filter
     {
         if (request instanceof HttpServletRequest req && response instanceof HttpServletResponse resp && null != policyExpression)
         {
-            Map<String, String> map = Map.of(
-                NONCE_SUBST, getScriptNonceHeader(req),
-                ALLOWED_CONNECT_SUBSTITUTION, connectionSrc,
-                REPORT_PARAMETER_SUBSTITUTION, "labkeyVersion=" + PageFlowUtil.encodeURIComponent(AppProps.getInstance().getReleaseVersion())
-            );
-            var csp = policyExpression.eval(map);
-            resp.setHeader(header, csp);
+            if (type != ContentSecurityPolicyType.Enforce || !ExperimentalFeatureService.get().isFeatureEnabled(FEATURE_FLAG_DISABLE_ENFORCE_CSP))
+            {
+                Map<String, String> map = Map.of(
+                    NONCE_SUBST, getScriptNonceHeader(req),
+                    ALLOWED_CONNECT_SUBSTITUTION, connectionSrc,
+                    REPORT_PARAMETER_SUBSTITUTION, "labkeyVersion=" + PageFlowUtil.encodeURIComponent(AppProps.getInstance().getReleaseVersion())
+                );
+                var csp = policyExpression.eval(map);
+                resp.setHeader(type.getHeaderName(), csp);
+            }
         }
         chain.doFilter(request, response);
     }

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -265,6 +265,7 @@ import org.labkey.core.wiki.WikiRenderingServiceImpl;
 import org.labkey.core.workbook.WorkbookFolderType;
 import org.labkey.core.workbook.WorkbookQueryView;
 import org.labkey.core.workbook.WorkbookSearchView;
+import org.labkey.filters.ContentSecurityPolicyFilter;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.impl.StdSchedulerFactory;
@@ -299,6 +300,7 @@ import static org.labkey.api.settings.StashedStartupProperties.siteAvailableEmai
 import static org.labkey.api.settings.StashedStartupProperties.siteAvailableEmailMessage;
 import static org.labkey.api.settings.StashedStartupProperties.siteAvailableEmailSubject;
 import static org.labkey.api.util.MothershipReport.EXPERIMENTAL_LOCAL_MARKETING_UPDATE;
+import static org.labkey.filters.ContentSecurityPolicyFilter.FEATURE_FLAG_DISABLE_ENFORCE_CSP;
 
 public class CoreModule extends SpringModule implements SearchService.DocumentProvider
 {
@@ -445,7 +447,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         AdminConsole.addExperimentalFeatureFlag(SQLFragment.FEATUREFLAG_DISABLE_STRICT_CHECKS, "Disable SQLFragment strict checks",
                 "SQLFragment now has very strict usage validation, these checks may cause errors in code that has not been updated. Turn on this feature to disable checks.", false);
         AdminConsole.addExperimentalFeatureFlag(LoginController.FEATUREFLAG_DISABLE_LOGIN_XFRAME, "Disable Login X-FRAME-OPTIONS=DENY",
-                "By default LabKey disables all framing of login related actions.  Disabling this feature will revert to using the standard site settings.", false);
+                "By default LabKey disables all framing of login related actions. Disabling this feature will revert to using the standard site settings.", false);
 
         SiteValidationService svc = SiteValidationService.get();
         if (null != svc)
@@ -543,7 +545,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         }
         // For audit purposes, we use the first user as the originator of the message.
         // Would be better to have this be a site admin, but we aren't guaranteed to have such a user
-        // for hosted sites.  Another option is to use the guest user here, but that's strange.
+        // for hosted sites. Another option is to use the guest user here, but that's strange.
         svc.sendMessages(messages, users.get(0), ContainerManager.getRoot());
     }
 
@@ -1066,7 +1068,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                 false);
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_BLOCKER,
                 "Block malicious clients",
-                "Reject requests from clients that appear malicious.  Turn this feature off if you want to run a security scanner.",
+                "Reject requests from clients that appear malicious. Turn this feature off if you want to run a security scanner.",
                 false);
         AdminConsole.addExperimentalFeatureFlag(EXPERIMENTAL_DESERIALIZE_BEANS,
                 "Deserialize objects from update forms",
@@ -1074,6 +1076,13 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                 false);
         AdminConsole.addExperimentalFeatureFlag(new AdminConsole.ExperimentalFeatureFlag(EXPERIMENTAL_LOCAL_MARKETING_UPDATE,
                 "Self test marketing updates", "Test marketing updates from this local server (requires the mothership module).", false, true));
+        AdminConsole.addExperimentalFeatureFlag(FEATURE_FLAG_DISABLE_ENFORCE_CSP,
+                "Disable enforce Content Security Policy",
+                "Stop sending the " + ContentSecurityPolicyFilter.ContentSecurityPolicyType.Enforce.getHeaderName() + " header to browsers, " +
+                "but continue sending the " + ContentSecurityPolicyFilter.ContentSecurityPolicyType.Report.getHeaderName() + " header. " +
+                "This turns off an important layer of security for the entire site, so use it as a last resort only on a temporary basis " +
+                "(e.g., if an enforce CSP breaks critical functionality).",
+                false);
 
         ExperimentalFeatureService.get().addFeatureListener(EXPERIMENTAL_LOCAL_MARKETING_UPDATE, (feature, enabled) -> {
             // update the timer task when this setting changes


### PR DESCRIPTION
#### Rationale
We want a quick way to disable enforce Content Security Policies without restarting/reconfiguring the server