### PR TITLE
Plate Set Assay Import - Assay Run PlateSet lookup and Results Plate lookup

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -230,11 +230,13 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                                 : rawPlateMetadata;
                     }
                     Domain runDomain = provider.getRunDomain(protocol);
-                    DomainProperty property = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME);
-                    if (property != null)
+                    DomainProperty propertyPlateTemplate = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME);
+                    DomainProperty propertyPlateSet = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_SET_COLUMN_NAME);
+                    if (propertyPlateTemplate != null || propertyPlateSet != null)
                     {
-                        Object lsid = ((AssayUploadXarContext)context).getContext().getRunProperties().get(property);
-                        dataRows = svc.mergePlateMetadata(context.getContainer(), context.getUser(), Lsid.parse(String.valueOf(lsid)), dataRows, plateMetadata, protocol);
+                        Object lsid = ((AssayUploadXarContext)context).getContext().getRunProperties().getOrDefault(propertyPlateTemplate, null);
+                        Lsid templateLsid = lsid != null && !StringUtils.isEmpty(String.valueOf(lsid)) ? Lsid.parse(String.valueOf(lsid)) : null;
+                        dataRows = svc.mergePlateMetadata(context.getContainer(), context.getUser(), templateLsid, dataRows, plateMetadata, protocol);
                     }
                 }
             }

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -246,7 +246,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                         Lsid templateLsid = lsid != null && !StringUtils.isEmpty(String.valueOf(lsid)) ? Lsid.parse(String.valueOf(lsid)) : null;
                         Object plateSetVal = runProps.getOrDefault(propertyPlateSet, null);
                         Integer plateSetId = plateSetVal != null ? Integer.parseInt(String.valueOf(plateSetVal)) : null;
-                        dataRows = svc.mergePlateMetadata(context.getContainer(), context.getUser(), templateLsid, plateSetId, dataRows, plateMetadata, protocol);
+                        dataRows = svc.mergePlateMetadata(context.getContainer(), context.getUser(), templateLsid, plateSetId, dataRows, plateMetadata, provider, protocol);
                     }
                 }
             }

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -229,9 +229,16 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                                 ? svc.parsePlateMetadata(plateMetadataFile)
                                 : rawPlateMetadata;
                     }
+
                     Domain runDomain = provider.getRunDomain(protocol);
                     DomainProperty propertyPlateTemplate = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME);
                     DomainProperty propertyPlateSet = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_SET_COLUMN_NAME);
+
+                    if (AssayPlateMetadataService.isExperimentalAppPlateEnabled() && propertyPlateSet == null)
+                    {
+                        throw new ExperimentException("The assay run domain for the assay '" + protocol.getName() + "' does not contain a plate set property.");
+                    }
+
                     if (propertyPlateTemplate != null || propertyPlateSet != null)
                     {
                         Map<DomainProperty, String> runProps = ((AssayUploadXarContext)context).getContext().getRunProperties();

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -234,9 +234,12 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                     DomainProperty propertyPlateSet = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_SET_COLUMN_NAME);
                     if (propertyPlateTemplate != null || propertyPlateSet != null)
                     {
-                        Object lsid = ((AssayUploadXarContext)context).getContext().getRunProperties().getOrDefault(propertyPlateTemplate, null);
+                        Map<DomainProperty, String> runProps = ((AssayUploadXarContext)context).getContext().getRunProperties();
+                        Object lsid = runProps.getOrDefault(propertyPlateTemplate, null);
                         Lsid templateLsid = lsid != null && !StringUtils.isEmpty(String.valueOf(lsid)) ? Lsid.parse(String.valueOf(lsid)) : null;
-                        dataRows = svc.mergePlateMetadata(context.getContainer(), context.getUser(), templateLsid, dataRows, plateMetadata, protocol);
+                        Object plateSetVal = runProps.getOrDefault(propertyPlateSet, null);
+                        Integer plateSetId = plateSetVal != null ? Integer.parseInt(String.valueOf(plateSetVal)) : null;
+                        dataRows = svc.mergePlateMetadata(context.getContainer(), context.getUser(), templateLsid, plateSetId, dataRows, plateMetadata, protocol);
                     }
                 }
             }

--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -73,7 +73,8 @@ public interface AssayPlateMetadataService
      *
      * @return the merged rows
      */
-    List<Map<String, Object>> mergePlateMetadata(Container container, User user, Lsid plateLsid, List<Map<String, Object>> rows, @Nullable Map<String, MetadataLayer> plateMetadata,
+    List<Map<String, Object>> mergePlateMetadata(Container container, User user, Lsid plateLsid, Integer plateSetId,
+                                                 List<Map<String, Object>> rows, @Nullable Map<String, MetadataLayer> plateMetadata,
                                                  ExpProtocol protocol) throws ExperimentException;
 
     /**

--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -24,6 +24,7 @@ import java.util.Map;
 public interface AssayPlateMetadataService
 {
     String PLATE_TEMPLATE_COLUMN_NAME = "PlateTemplate";
+    String PLATE_SET_COLUMN_NAME = "PlateSet";
     Map<AssayDataType, AssayPlateMetadataService> _handlers = new HashMap<>();
     String EXPERIMENTAL_APP_PLATE_SUPPORT = "experimental-app-plate-support";
 

--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -75,7 +75,7 @@ public interface AssayPlateMetadataService
      */
     List<Map<String, Object>> mergePlateMetadata(Container container, User user, Lsid plateLsid, Integer plateSetId,
                                                  List<Map<String, Object>> rows, @Nullable Map<String, MetadataLayer> plateMetadata,
-                                                 ExpProtocol protocol) throws ExperimentException;
+                                                 AssayProvider provider, ExpProtocol protocol) throws ExperimentException;
 
     /**
      * Methods to create the metadata model from either a JSON object or a file object

--- a/api/src/org/labkey/api/exp/property/PropertyService.java
+++ b/api/src/org/labkey/api/exp/property/PropertyService.java
@@ -140,6 +140,7 @@ public interface PropertyService
 
     ConceptURIVocabularyDomainProvider getConceptUriVocabularyDomainProvider(String conceptUri);
 
+    @Nullable
     Object getDomainPropertyValueFromRow(DomainProperty property, Map<String, Object> row);
 
     void replaceDomainPropertyValue(DomainProperty property, Map<String, Object> row, Object value);

--- a/api/src/org/labkey/api/exp/property/PropertyService.java
+++ b/api/src/org/labkey/api/exp/property/PropertyService.java
@@ -139,4 +139,8 @@ public interface PropertyService
     void registerConceptUriVocabularyDomainProvider(String conceptUri, ConceptURIVocabularyDomainProvider provider);
 
     ConceptURIVocabularyDomainProvider getConceptUriVocabularyDomainProvider(String conceptUri);
+
+    Object getDomainPropertyValueFromRow(DomainProperty property, Map<String, Object> row);
+
+    void replaceDomainPropertyValue(DomainProperty property, Map<String, Object> row, Object value);
 }

--- a/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
+++ b/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
@@ -318,7 +318,7 @@ public class TsvDataExchangeHandler implements DataExchangeHandler
                 if (property != null)
                 {
                     Object lsid = context.getRunProperties().get(property);
-                    rawData = svc.mergePlateMetadata(context.getContainer(), context.getUser(), Lsid.parse(String.valueOf(lsid)), rawData, rawPlateMetadata, protocol);
+                    rawData = svc.mergePlateMetadata(context.getContainer(), context.getUser(), Lsid.parse(String.valueOf(lsid)), null, rawData, rawPlateMetadata, protocol);
                 }
             }
             addToMergedMap(mergedDataMap, Map.of(dataType, rawData));

--- a/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
+++ b/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
@@ -318,7 +318,7 @@ public class TsvDataExchangeHandler implements DataExchangeHandler
                 if (property != null)
                 {
                     Object lsid = context.getRunProperties().get(property);
-                    rawData = svc.mergePlateMetadata(context.getContainer(), context.getUser(), Lsid.parse(String.valueOf(lsid)), null, rawData, rawPlateMetadata, protocol);
+                    rawData = svc.mergePlateMetadata(context.getContainer(), context.getUser(), Lsid.parse(String.valueOf(lsid)), null, rawData, rawPlateMetadata, provider, protocol);
                 }
             }
             addToMergedMap(mergedDataMap, Map.of(dataType, rawData));

--- a/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
@@ -44,6 +44,7 @@ import static org.labkey.api.data.Table.MODIFIED_COLUMN_NAME;
  */
 public class AssayResultDomainKind extends AssayDomainKind
 {
+    public static final String PLATE_COLUMN_NAME = "Plate";
     public static final String WELL_LOCATION_COLUMN_NAME = "WellLocation";
     public static final String WELL_LSID_COLUMN_NAME = "WellLsid";
 
@@ -137,6 +138,7 @@ public class AssayResultDomainKind extends AssayDomainKind
             {
                 if (provider.isPlateMetadataEnabled(protocol))
                 {
+                    mandatoryNames.add(PLATE_COLUMN_NAME);
                     mandatoryNames.add(WELL_LOCATION_COLUMN_NAME);
                     mandatoryNames.add(WELL_LSID_COLUMN_NAME);
                 }

--- a/assay/api-src/org/labkey/api/assay/AssayRunDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayRunDomainKind.java
@@ -69,6 +69,7 @@ public class AssayRunDomainKind extends AssayDomainKind
                 if (provider.isPlateMetadataEnabled(protocol))
                 {
                     mandatoryNames.add(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME);
+                    mandatoryNames.add(AssayPlateMetadataService.PLATE_SET_COLUMN_NAME);
                 }
             }
         }

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -163,6 +163,15 @@ public interface PlateService
     @Nullable Plate getPlate(ContainerFilter cf, String plateId);
 
     /**
+     * Gets a plate instance object by plate identifier within a given plate set.
+     * @param cf The container filter to find the plate
+     * @param plateSetId The plate set id.
+     * @param plateIdentifier The plate rowId, plateId, or name (checked in that order).
+     * @return The requested plate, or null if no plate exists with the specified plate identifier.
+     */
+    @Nullable Plate getPlate(ContainerFilter cf, Integer plateSetId, Object plateIdentifier);
+
+    /**
      * Gets all plate templates for the specified container. Plate templates are Plate instances
      * which have their template field set to TRUE.
      *

--- a/assay/api-src/org/labkey/api/assay/plate/PositionImpl.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PositionImpl.java
@@ -51,7 +51,7 @@ public class PositionImpl implements Position
     {
         if (rowChar < minChar || rowChar > maxChar)
         {
-            throw new IllegalArgumentException(String.format("The well row character must be between %s and %s but was %s", maxChar, maxChar, rowChar));
+            throw new IllegalArgumentException(String.format("The well row character must be between %s and %s but was %s", minChar, maxChar, rowChar));
         }
         return rowChar - 'A';
     }

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0"
+        "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
+      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -12919,9 +12919,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
+      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.2.2"
+        "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -2402,9 +2402,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.28.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.28.0.tgz",
-      "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
+      "version": "1.29.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.29.0.tgz",
+      "integrity": "sha512-1knTSIIcPXK89PPxcflBGApQtS3GuZjfQFbrlefO9fi2d8xNtYsRAuWwvCOuKGXDUuj96OxMRZEGBl1R6re8vA=="
     },
     "node_modules/@labkey/build": {
       "version": "7.0.2",
@@ -2443,11 +2443,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.2.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.2.tgz",
-      "integrity": "sha512-C/Gm7LbpFFFpmfD0D0RwnmPujDzasxoCPwqGuz4FFthj9+Ym0X0xgg3q99bw/wRHBxvsA+84w3SjiHH3xzwXsA==",
+      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
+      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
       "dependencies": {
-        "@labkey/api": "1.28.0",
+        "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -12878,9 +12878,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.28.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.28.0.tgz",
-      "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
+      "version": "1.29.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.29.0.tgz",
+      "integrity": "sha512-1knTSIIcPXK89PPxcflBGApQtS3GuZjfQFbrlefO9fi2d8xNtYsRAuWwvCOuKGXDUuj96OxMRZEGBl1R6re8vA=="
     },
     "@labkey/build": {
       "version": "7.0.2",
@@ -12919,11 +12919,11 @@
       }
     },
     "@labkey/components": {
-      "version": "3.2.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.2.tgz",
-      "integrity": "sha512-C/Gm7LbpFFFpmfD0D0RwnmPujDzasxoCPwqGuz4FFthj9+Ym0X0xgg3q99bw/wRHBxvsA+84w3SjiHH3xzwXsA==",
+      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
+      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
       "requires": {
-        "@labkey/api": "1.28.0",
+        "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0"
+        "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.1"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.1.tgz",
+      "integrity": "sha512-8lpUcdAxyzwrJBxPNrBK+xtqxwpVLRWBHBxh3fY4YF8afaSwMtAZbzjHclqQCBNQyUr8hTsaUV7xSex2WxO8hQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -12919,9 +12919,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.1.tgz",
+      "integrity": "sha512-8lpUcdAxyzwrJBxPNrBK+xtqxwpVLRWBHBxh3fY4YF8afaSwMtAZbzjHclqQCBNQyUr8hTsaUV7xSex2WxO8hQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0"
+        "@labkey/components": "3.20.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
+      "version": "3.20.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.20.0.tgz",
+      "integrity": "sha512-rHxquEKNTSlOTLy4K37x4XqffqgsZOG+P9pJu9bTJKEUPAWuqVE+HOkAZWzPx0dfteeeW4expDtDbPzjrG9i/g==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -12919,9 +12919,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
+      "version": "3.20.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.20.0.tgz",
+      "integrity": "sha512-rHxquEKNTSlOTLy4K37x4XqffqgsZOG+P9pJu9bTJKEUPAWuqVE+HOkAZWzPx0dfteeeW4expDtDbPzjrG9i/g==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.18.1"
+        "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.18.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1.tgz",
-      "integrity": "sha512-qffBYZDGthzy9+JPBxSnX/Xz/sitQSaexUQZXB3pI/6mRy8J2ggdiym7FcLOKCxZ+kcxl1hMVNBxKwGa5orkkQ==",
+      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -12919,9 +12919,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.18.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1.tgz",
-      "integrity": "sha512-qffBYZDGthzy9+JPBxSnX/Xz/sitQSaexUQZXB3pI/6mRy8J2ggdiym7FcLOKCxZ+kcxl1hMVNBxKwGa5orkkQ==",
+      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2"
+        "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
-      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -12919,9 +12919,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
-      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.2.2"
+    "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.18.1"
+    "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0"
+    "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2"
+    "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0"
+    "@labkey/components": "3.20.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0"
+    "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.1"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/assay/src/org/labkey/assay/TsvAssayProvider.java
+++ b/assay/src/org/labkey/assay/TsvAssayProvider.java
@@ -428,6 +428,7 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
         if (isPlateMetadataEnabled(protocol))
         {
             Set<String> existingFields = update.getFields().stream().map(GWTPropertyDescriptor::getName).collect(Collectors.toSet());
+            boolean hasRuns = !protocol.getExpRuns().isEmpty();
 
             // for plate metadata support we need to ensure specific fields on both the run and result domains
             Domain runDomain = getRunDomain(protocol);
@@ -461,7 +462,7 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
                     plateSet.setLookupSchema(PlateSchema.SCHEMA_NAME);
                     plateSet.setLookupQuery(PlateSetTable.NAME);
                     plateSet.setLookupContainer(null);
-                    plateSet.setRequired(AssayPlateMetadataService.isExperimentalAppPlateEnabled());
+                    plateSet.setRequired(AssayPlateMetadataService.isExperimentalAppPlateEnabled() && !hasRuns);
                     plateSet.setShownInUpdateView(false);
 
                     newFields.add(plateSet);
@@ -485,7 +486,8 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
                     plate.setLookupSchema(PlateSchema.SCHEMA_NAME);
                     plate.setLookupQuery(PlateTable.NAME);
                     plate.setLookupContainer(null);
-                    plate.setRequired(AssayPlateMetadataService.isExperimentalAppPlateEnabled());
+                    plate.setRequired(AssayPlateMetadataService.isExperimentalAppPlateEnabled() && !hasRuns);
+                    plate.setImportAliases("PlateID,\"Plate ID\"");
                     plate.setShownInUpdateView(false);
 
                     newFields.add(plate);
@@ -494,6 +496,7 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
                 if (!existingFields.contains(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME))
                 {
                     GWTPropertyDescriptor wellLocation = new GWTPropertyDescriptor(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME, PropertyType.STRING.getTypeUri());
+                    wellLocation.setImportAliases("Well,\"Well Location\"");
                     wellLocation.setShownInUpdateView(false);
 
                     newFields.add(wellLocation);

--- a/assay/src/org/labkey/assay/TsvAssayProvider.java
+++ b/assay/src/org/labkey/assay/TsvAssayProvider.java
@@ -489,6 +489,7 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
                     plate.setRequired(AssayPlateMetadataService.isExperimentalAppPlateEnabled() && !hasRuns);
                     plate.setImportAliases("PlateID,\"Plate ID\"");
                     plate.setShownInUpdateView(false);
+                    plate.setHidden(true);
 
                     newFields.add(plate);
                 }

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -313,15 +313,17 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                             positionToWell.put(new PositionImpl(plate.getContainer(), well.getRow(), well.getCol()), well);
                     }
 
-                    PositionImpl well = new PositionImpl(null, String.valueOf(row.get(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME)));
-                    // need to adjust the column value to be 0 based to match the template locations
-                    well.setColumn(well.getColumn()-1);
-
-                    if (positionToWell.containsKey(well))
+                    String wellLocationStr = (String) row.getOrDefault(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME, null);
+                    if (wellLocationStr != null)
                     {
-                        for (WellCustomField customField : PlateManager.get().getWellCustomFields(user, plate, positionToWell.get(well).getRowId()))
+                        PositionImpl well = new PositionImpl(null, wellLocationStr);
+                        // need to adjust the column value to be 0 based to match the template locations
+                        well.setColumn(well.getColumn() - 1);
+
+                        if (positionToWell.containsKey(well))
                         {
-                            row.put(customField.getName(), customField.getValue());
+                            for (WellCustomField customField : PlateManager.get().getWellCustomFields(user, plate, positionToWell.get(well).getRowId()))
+                                row.put(customField.getName(), customField.getValue());
                         }
                     }
                 }
@@ -557,9 +559,10 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 
             // to join plate based metadata to assay results we need to line up the incoming assay results with the
             // corresponding well on the plate used in the import
-            if (map.containsKey(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME))
+            String wellLocationStr = (String) map.getOrDefault(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME, null);
+            if (wellLocationStr != null)
             {
-                PositionImpl pos = new PositionImpl(_container, String.valueOf(map.get(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME)));
+                PositionImpl pos = new PositionImpl(_container, wellLocationStr);
                 // need to adjust the column value to be 0 based to match the template locations
                 pos.setCol(pos.getColumn() - 1);
                 if (positionToWellLsid.containsKey(pos))

--- a/assay/src/org/labkey/assay/plate/PlateCache.java
+++ b/assay/src/org/labkey/assay/plate/PlateCache.java
@@ -99,7 +99,7 @@ public class PlateCache
     public static @Nullable Plate getPlate(ContainerFilter cf, int rowId)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("RowId"), rowId);
-        Container c = getContainerWithIdentifier(cf, filter);
+        Container c = PlateManager.getContainerWithPlateIdentifier(cf, filter);
 
         return c != null ? PLATE_CACHE.get(PlateCacheKey.getCacheKey(c, rowId)) : null;
     }
@@ -107,7 +107,7 @@ public class PlateCache
     public static @Nullable Plate getPlate(ContainerFilter cf, Lsid lsid)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("Lsid"), lsid);
-        Container c = getContainerWithIdentifier(cf, filter);
+        Container c = PlateManager.getContainerWithPlateIdentifier(cf, filter);
 
         return c != null ? PLATE_CACHE.get(PlateCacheKey.getCacheKey(c, lsid)) : null;
     }
@@ -115,26 +115,9 @@ public class PlateCache
     public static @Nullable Plate getPlate(ContainerFilter cf, String plateId)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("plateId"), plateId);
-        Container c = getContainerWithIdentifier(cf, filter);
+        Container c = PlateManager.getContainerWithPlateIdentifier(cf, filter);
 
         return c != null ? PLATE_CACHE.get(PlateCacheKey.getCacheKey(c, plateId)) : null;
-    }
-
-    private static @Nullable Container getContainerWithIdentifier(ContainerFilter cf, SimpleFilter filter)
-    {
-        filter.addClause(cf.createFilterClause(AssayDbSchema.getInstance().getSchema(), FieldKey.fromParts("Container")));
-        List<String> containers = new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(),
-                Collections.singleton("Container"),
-                filter, null).getArrayList(String.class);
-
-        if (containers.size() > 1)
-            throw new IllegalStateException("More than one Plate found that matches that filter");
-
-        if (containers.size() == 1)
-        {
-            return ContainerManager.getForId(containers.get(0));
-        }
-        return null;
     }
 
     public static @Nullable Plate getPlate(Container c, String plateId)
@@ -159,6 +142,20 @@ public class PlateCache
         {
             plates.add(PLATE_CACHE.get(PlateCacheKey.getCacheKey(c, id)));
         }
+        return plates;
+    }
+
+    public static @NotNull Collection<Plate> getPlatesForPlateSet(Container c, Integer plateSetId)
+    {
+        List<Plate> plates = new ArrayList<>();
+        SimpleFilter filter = SimpleFilter.createContainerFilter(c);
+        filter.addCondition(FieldKey.fromParts("PlateSet"), plateSetId);
+        List<Integer> ids = new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(),
+                Collections.singleton("RowId"), filter, null)
+                .getArrayList(Integer.class);
+
+        for (Integer id : ids)
+            plates.add(PLATE_CACHE.get(PlateCacheKey.getCacheKey(c, id)));
         return plates;
     }
 

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -536,8 +536,10 @@ public class PlateManager implements PlateService
                 List<Plate> matchingPlates = plates.stream().filter(p -> p.getName().equals(plateIdentifier.toString())).toList();
                 if (matchingPlates.size() == 1)
                     plate = matchingPlates.get(0);
-                else if (matchingPlates.size() > 1)
-                    throw new IllegalArgumentException("More than one plate found with name " + plateIdentifier + " in plate set " + plateSet.getName() + ".");
+                else if (matchingPlates.isEmpty())
+                    throw new IllegalArgumentException("No plate found with the name \"" + plateIdentifier + "\" in plate set \"" + plateSet.getName() + "\".");
+                else
+                    throw new IllegalArgumentException("More than one plate found with name \"" + plateIdentifier + "\" in plate set " + plateSet.getName() + ". Please use the \"Plate ID\" to identify the plate instead.");
             }
         }
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2",
+        "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
-      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
-      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0",
+        "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
+      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
+      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0",
+        "@labkey/components": "3.20.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
+      "version": "3.20.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.20.0.tgz",
+      "integrity": "sha512-rHxquEKNTSlOTLy4K37x4XqffqgsZOG+P9pJu9bTJKEUPAWuqVE+HOkAZWzPx0dfteeeW4expDtDbPzjrG9i/g==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
+      "version": "3.20.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.20.0.tgz",
+      "integrity": "sha512-rHxquEKNTSlOTLy4K37x4XqffqgsZOG+P9pJu9bTJKEUPAWuqVE+HOkAZWzPx0dfteeeW4expDtDbPzjrG9i/g==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0",
+        "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.1",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.1.tgz",
+      "integrity": "sha512-8lpUcdAxyzwrJBxPNrBK+xtqxwpVLRWBHBxh3fY4YF8afaSwMtAZbzjHclqQCBNQyUr8hTsaUV7xSex2WxO8hQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.1.tgz",
+      "integrity": "sha512-8lpUcdAxyzwrJBxPNrBK+xtqxwpVLRWBHBxh3fY4YF8afaSwMtAZbzjHclqQCBNQyUr8hTsaUV7xSex2WxO8hQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.15.0",
+        "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.15.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.15.0.tgz",
-      "integrity": "sha512-eQbhIYzErMIyLWA8k9Xon5i5QiUo/EoyOwRKfA+XWg4arwLs4JaS1N7v4EPSrtaoOIJ1hsE6QuuOGDQvHLh+Dw==",
+      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
+      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.15.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.15.0.tgz",
-      "integrity": "sha512-eQbhIYzErMIyLWA8k9Xon5i5QiUo/EoyOwRKfA+XWg4arwLs4JaS1N7v4EPSrtaoOIJ1hsE6QuuOGDQvHLh+Dw==",
+      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
+      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.18.1",
+        "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.18.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1.tgz",
-      "integrity": "sha512-qffBYZDGthzy9+JPBxSnX/Xz/sitQSaexUQZXB3pI/6mRy8J2ggdiym7FcLOKCxZ+kcxl1hMVNBxKwGa5orkkQ==",
+      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.18.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1.tgz",
-      "integrity": "sha512-qffBYZDGthzy9+JPBxSnX/Xz/sitQSaexUQZXB3pI/6mRy8J2ggdiym7FcLOKCxZ+kcxl1hMVNBxKwGa5orkkQ==",
+      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0",
+    "@labkey/components": "3.20.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.15.0",
+    "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2",
+    "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0",
+    "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.18.1",
+    "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0",
+    "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.1",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.18.1"
+        "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.18.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1.tgz",
-      "integrity": "sha512-qffBYZDGthzy9+JPBxSnX/Xz/sitQSaexUQZXB3pI/6mRy8J2ggdiym7FcLOKCxZ+kcxl1hMVNBxKwGa5orkkQ==",
+      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17196,9 +17196,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.18.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1.tgz",
-      "integrity": "sha512-qffBYZDGthzy9+JPBxSnX/Xz/sitQSaexUQZXB3pI/6mRy8J2ggdiym7FcLOKCxZ+kcxl1hMVNBxKwGa5orkkQ==",
+      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0"
+        "@labkey/components": "3.20.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
+      "version": "3.20.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.20.0.tgz",
+      "integrity": "sha512-rHxquEKNTSlOTLy4K37x4XqffqgsZOG+P9pJu9bTJKEUPAWuqVE+HOkAZWzPx0dfteeeW4expDtDbPzjrG9i/g==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17196,9 +17196,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
+      "version": "3.20.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.20.0.tgz",
+      "integrity": "sha512-rHxquEKNTSlOTLy4K37x4XqffqgsZOG+P9pJu9bTJKEUPAWuqVE+HOkAZWzPx0dfteeeW4expDtDbPzjrG9i/g==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2"
+        "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
-      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17196,9 +17196,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
-      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0"
+        "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.1"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.1.tgz",
+      "integrity": "sha512-8lpUcdAxyzwrJBxPNrBK+xtqxwpVLRWBHBxh3fY4YF8afaSwMtAZbzjHclqQCBNQyUr8hTsaUV7xSex2WxO8hQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17196,9 +17196,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.1.tgz",
+      "integrity": "sha512-8lpUcdAxyzwrJBxPNrBK+xtqxwpVLRWBHBxh3fY4YF8afaSwMtAZbzjHclqQCBNQyUr8hTsaUV7xSex2WxO8hQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.15.0"
+        "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.15.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.15.0.tgz",
-      "integrity": "sha512-eQbhIYzErMIyLWA8k9Xon5i5QiUo/EoyOwRKfA+XWg4arwLs4JaS1N7v4EPSrtaoOIJ1hsE6QuuOGDQvHLh+Dw==",
+      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
+      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17196,9 +17196,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.15.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.15.0.tgz",
-      "integrity": "sha512-eQbhIYzErMIyLWA8k9Xon5i5QiUo/EoyOwRKfA+XWg4arwLs4JaS1N7v4EPSrtaoOIJ1hsE6QuuOGDQvHLh+Dw==",
+      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
+      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0"
+        "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
+      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17196,9 +17196,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
+      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.15.0"
+    "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0"
+    "@labkey/components": "3.20.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2"
+    "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0"
+    "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.1"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0"
+    "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.18.1"
+    "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
@@ -686,6 +686,7 @@ public class PropertyServiceImpl implements PropertyService, UsageMetricsProvide
     }
 
     @Override
+    @Nullable
     public Object getDomainPropertyValueFromRow(DomainProperty property, Map<String, Object> row)
     {
         if (property == null || row == null)

--- a/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
@@ -685,6 +685,55 @@ public class PropertyServiceImpl implements PropertyService, UsageMetricsProvide
         return _conceptUriVocabularyProvider.get(conceptUri);
     }
 
+    @Override
+    public Object getDomainPropertyValueFromRow(DomainProperty property, Map<String, Object> row)
+    {
+        if (property == null || row == null)
+            return null;
+
+        if (row.containsKey(property.getName()))
+            return row.get(property.getName());
+        else if (property.getLabel() != null && row.containsKey(property.getLabel()))
+            return row.get(property.getLabel());
+        else if (row.containsKey(property.getName().toLowerCase()))
+            return row.get(property.getName().toLowerCase());
+        else if (!property.getImportAliasSet().isEmpty())
+        {
+            for (String alias : property.getImportAliasSet())
+            {
+                if (row.containsKey(alias))
+                    return row.get(alias);
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public void replaceDomainPropertyValue(DomainProperty property, Map<String, Object> row, Object value)
+    {
+        if (property == null || row == null)
+            return;
+
+        if (row.containsKey(property.getName()))
+            row.put(property.getName(), value);
+        else if (property.getLabel() != null && row.containsKey(property.getLabel()))
+            row.put(property.getLabel(), value);
+        else if (row.containsKey(property.getName().toLowerCase()))
+            row.put(property.getName().toLowerCase(), value);
+        else if (!property.getImportAliasSet().isEmpty())
+        {
+            for (String alias : property.getImportAliasSet())
+            {
+                if (row.containsKey(alias))
+                {
+                    row.put(alias, value);
+                    return;
+                }
+            }
+        }
+    }
+
     public static class TestCase extends Assert
     {
         @Test

--- a/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
@@ -769,5 +769,84 @@ public class PropertyServiceImpl implements PropertyService, UsageMetricsProvide
             choices = service.getTextChoiceValidatorOptions(instance);
             Assert.assertEquals(Arrays.asList("a", "b", "c", "d"), choices);
         }
+
+        @Test
+        public void testTetDomainPropertyValueFromRow()
+        {
+            PropertyServiceImpl service = new PropertyServiceImpl();
+            PropertyDescriptor pd = new PropertyDescriptor();
+            pd.setName("MyName");
+            pd.setLabel("MyLabel");
+            pd.setImportAliases("Alias1,\"Alias 2\"");
+            DomainPropertyImpl dp = new DomainPropertyImpl(null, pd);
+
+            // null checks
+            Assert.assertNull(service.getDomainPropertyValueFromRow(null, null));
+            Assert.assertNull(service.getDomainPropertyValueFromRow(dp, null));
+            Assert.assertNull(service.getDomainPropertyValueFromRow(null, Map.of("name", "MyName")));
+
+            // no match in row
+            Assert.assertNull(service.getDomainPropertyValueFromRow(dp, Map.of("Bogus", "test")));
+            Assert.assertNull(service.getDomainPropertyValueFromRow(dp, Map.of("Name", "test")));
+            Assert.assertNull(service.getDomainPropertyValueFromRow(dp, Map.of("MyNamE", "test")));
+            Assert.assertNull(service.getDomainPropertyValueFromRow(dp, Map.of("Alias2", "test")));
+
+            // has match in row
+            Assert.assertEquals("test", service.getDomainPropertyValueFromRow(dp, Map.of("MyName", "test")));
+            Assert.assertEquals("test", service.getDomainPropertyValueFromRow(dp, Map.of("myname", "test")));
+            Assert.assertEquals("test", service.getDomainPropertyValueFromRow(dp, Map.of("MyLabel", "test")));
+            Assert.assertEquals("test", service.getDomainPropertyValueFromRow(dp, Map.of("Alias1", "test")));
+            Assert.assertEquals("test", service.getDomainPropertyValueFromRow(dp, Map.of("Alias 2", "test")));
+
+            // check order of precedence
+            Map<String, Object> row = new HashMap<>(Map.of("MyName", "name", "MyLabel", "label", "Alias1", "a1", "Alias 2", "a2"));
+            Assert.assertEquals("name", service.getDomainPropertyValueFromRow(dp, row));
+            row.remove("MyName");
+            Assert.assertEquals("label", service.getDomainPropertyValueFromRow(dp, row));
+            row.remove("MyLabel");
+            Assert.assertEquals("a1", service.getDomainPropertyValueFromRow(dp, row));
+            row.remove("Alias1");
+            Assert.assertEquals("a2", service.getDomainPropertyValueFromRow(dp, row));
+            row.remove("Alias 2");
+            Assert.assertNull(service.getDomainPropertyValueFromRow(dp, row));
+        }
+
+        @Test
+        public void replaceDomainPropertyValue()
+        {
+            PropertyServiceImpl service = new PropertyServiceImpl();
+            PropertyDescriptor pd = new PropertyDescriptor();
+            pd.setName("MyName");
+            pd.setLabel("MyLabel");
+            pd.setImportAliases("Alias1,\"Alias 2\"");
+            DomainPropertyImpl dp = new DomainPropertyImpl(null, pd);
+            Map<String, Object> row = new HashMap<>(Map.of("MyName", "name", "MyLabel", "label", "Alias1", "a1", "Alias 2", "a2"));
+
+            Assert.assertEquals("name", service.getDomainPropertyValueFromRow(dp, row));
+            service.replaceDomainPropertyValue(dp, row, "newName");
+            Assert.assertEquals("newName", row.get("MyName"));
+            Assert.assertEquals("newName", service.getDomainPropertyValueFromRow(dp, row));
+            row.remove("MyName");
+
+            Assert.assertEquals("label", service.getDomainPropertyValueFromRow(dp, row));
+            service.replaceDomainPropertyValue(dp, row, "newLabel");
+            Assert.assertEquals("newLabel", row.get("MyLabel"));
+            Assert.assertEquals("newLabel", service.getDomainPropertyValueFromRow(dp, row));
+            row.remove("MyLabel");
+
+            Assert.assertEquals("a1", service.getDomainPropertyValueFromRow(dp, row));
+            service.replaceDomainPropertyValue(dp, row, "newA1");
+            Assert.assertEquals("newA1", row.get("Alias1"));
+            Assert.assertEquals("newA1", service.getDomainPropertyValueFromRow(dp, row));
+            row.remove("Alias1");
+
+            Assert.assertEquals("a2", service.getDomainPropertyValueFromRow(dp, row));
+            service.replaceDomainPropertyValue(dp, row, "newA2");
+            Assert.assertEquals("newA2", row.get("Alias 2"));
+            Assert.assertEquals("newA2", service.getDomainPropertyValueFromRow(dp, row));
+            row.remove("Alias 2");
+
+            Assert.assertNull(service.getDomainPropertyValueFromRow(dp, row));
+        }
     }
 }

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2"
+        "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
-      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -15438,9 +15438,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
-      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0"
+        "@labkey/components": "3.20.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
+      "version": "3.20.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.20.0.tgz",
+      "integrity": "sha512-rHxquEKNTSlOTLy4K37x4XqffqgsZOG+P9pJu9bTJKEUPAWuqVE+HOkAZWzPx0dfteeeW4expDtDbPzjrG9i/g==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -15438,9 +15438,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
+      "version": "3.20.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.20.0.tgz",
+      "integrity": "sha512-rHxquEKNTSlOTLy4K37x4XqffqgsZOG+P9pJu9bTJKEUPAWuqVE+HOkAZWzPx0dfteeeW4expDtDbPzjrG9i/g==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.18.1"
+        "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.18.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1.tgz",
-      "integrity": "sha512-qffBYZDGthzy9+JPBxSnX/Xz/sitQSaexUQZXB3pI/6mRy8J2ggdiym7FcLOKCxZ+kcxl1hMVNBxKwGa5orkkQ==",
+      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -15438,9 +15438,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.18.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1.tgz",
-      "integrity": "sha512-qffBYZDGthzy9+JPBxSnX/Xz/sitQSaexUQZXB3pI/6mRy8J2ggdiym7FcLOKCxZ+kcxl1hMVNBxKwGa5orkkQ==",
+      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.2.2"
+        "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -2598,9 +2598,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.28.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.28.0.tgz",
-      "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
+      "version": "1.29.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.29.0.tgz",
+      "integrity": "sha512-1knTSIIcPXK89PPxcflBGApQtS3GuZjfQFbrlefO9fi2d8xNtYsRAuWwvCOuKGXDUuj96OxMRZEGBl1R6re8vA=="
     },
     "node_modules/@labkey/build": {
       "version": "7.0.2",
@@ -2703,11 +2703,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.2.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.2.tgz",
-      "integrity": "sha512-C/Gm7LbpFFFpmfD0D0RwnmPujDzasxoCPwqGuz4FFthj9+Ym0X0xgg3q99bw/wRHBxvsA+84w3SjiHH3xzwXsA==",
+      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
+      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
       "dependencies": {
-        "@labkey/api": "1.28.0",
+        "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -15355,9 +15355,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.28.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.28.0.tgz",
-      "integrity": "sha512-C4Ffk78pRgrC1efAUGToXtTocumqs/E8PhomXLSlnytIzx6NMcBFFyjDW6tgsxBKAWJliPwgGxwopUtMFm4zpA=="
+      "version": "1.29.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.29.0.tgz",
+      "integrity": "sha512-1knTSIIcPXK89PPxcflBGApQtS3GuZjfQFbrlefO9fi2d8xNtYsRAuWwvCOuKGXDUuj96OxMRZEGBl1R6re8vA=="
     },
     "@labkey/build": {
       "version": "7.0.2",
@@ -15438,11 +15438,11 @@
       }
     },
     "@labkey/components": {
-      "version": "3.2.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.2.2.tgz",
-      "integrity": "sha512-C/Gm7LbpFFFpmfD0D0RwnmPujDzasxoCPwqGuz4FFthj9+Ym0X0xgg3q99bw/wRHBxvsA+84w3SjiHH3xzwXsA==",
+      "version": "3.17.1-fb-plateSetAssayImportPart1.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.1-fb-plateSetAssayImportPart1.2.tgz",
+      "integrity": "sha512-j0DF9TewKFSP/3KlRlO2ixD3oVpyMkvv8/PrDvAj5jnkCUmEPSpF8l4Kro+iL6W2XOcxQVgaG/6esMCFxtFzeQ==",
       "requires": {
-        "@labkey/api": "1.28.0",
+        "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0"
+        "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.1"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.1.tgz",
+      "integrity": "sha512-8lpUcdAxyzwrJBxPNrBK+xtqxwpVLRWBHBxh3fY4YF8afaSwMtAZbzjHclqQCBNQyUr8hTsaUV7xSex2WxO8hQ==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -15438,9 +15438,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.17.2-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-TDr8LldcMMiW+eKis6VUo1liiqXSByO3paWfmd95R/IGmKzP6RTxt3CcuvH7BWuci0dYrGnLxDiTWF1VT1A1dQ==",
+      "version": "3.17.2-fb-plateSetAssayImportPart1.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.17.2-fb-plateSetAssayImportPart1.1.tgz",
+      "integrity": "sha512-8lpUcdAxyzwrJBxPNrBK+xtqxwpVLRWBHBxh3fY4YF8afaSwMtAZbzjHclqQCBNQyUr8hTsaUV7xSex2WxO8hQ==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0"
+        "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0"
       },
       "devDependencies": {
         "@labkey/build": "7.0.2",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
+      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
       "dependencies": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -15438,9 +15438,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.18.1-fb-plateSetAssayImportPart1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.18.1-fb-plateSetAssayImportPart1.0.tgz",
-      "integrity": "sha512-Y+xzIKOU7K7BMfNtwvR2c9WS8qSsF6dpe3BDG/E8DoHLi73igaLzl7tbAVLF3FFjdeCoMtYLJfJbwOSs6R6iTQ==",
+      "version": "3.19.0-fb-plateSetAssayImportPart1.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.19.0-fb-plateSetAssayImportPart1.0.tgz",
+      "integrity": "sha512-UdqM/HrNTy2TgaPfd4DP7Uz5hWFDBk8Mhc166zt4TZUL4I40nX8KbC39R58flnEYlSkJT6C/5n3Qv0sWnOaJhw==",
       "requires": {
         "@labkey/api": "1.29.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0"
+    "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.1"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2"
+    "@labkey/components": "3.17.2-fb-plateSetAssayImportPart1.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0"
+    "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.18.1"
+    "@labkey/components": "3.18.1-fb-plateSetAssayImportPart1.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.19.0-fb-plateSetAssayImportPart1.0"
+    "@labkey/components": "3.20.0"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.2.2"
+    "@labkey/components": "3.17.1-fb-plateSetAssayImportPart1.2"
   },
   "devDependencies": {
     "@labkey/build": "7.0.2",


### PR DESCRIPTION
#### Rationale
This is the first story in the epic to move from having an assay run reference a single plate at the run level to having an assay run reference the plate set at the run level and then reference the plates from that set within the results level.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5214 
- https://github.com/LabKey/labkey-ui-components/pull/1414
- https://github.com/LabKey/labkey-ui-premium/pull/329
- https://github.com/LabKey/biologics/pull/2705
- https://github.com/LabKey/inventory/pull/1196
- https://github.com/LabKey/sampleManagement/pull/2449

#### Changes
- Add Standard Assay run domain field for PlateSet lookup and result domain field for Plate lookup
- Change assay import plate resolution to use result plate lookup value instead of run prop value
- Null check for wellLocation string before determining PositionImpl
- Resolve assay result plate from the plate set based on rowId, plateId, or name
- add check for domain field existence on assay import
- Support import of Plate and WellLocation using import aliases from DomainProperty
- Add metrics for assay run count for "runs with plate template lookup"
- PlateManager.getRunIdsUsingPlateInResults to get run count for references to the results domain Plate field
