### PR TITLE
Set AdminServiceUser to active

### DIFF
--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -113,6 +113,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
         AdminServiceUser()
         {
             super(new User("@serviceUserAdmin", User.guest.getUserId()), SiteAdminRole.class);
+            setActive(true);
             setPrincipalType(PrincipalType.SERVICE);
         }
 


### PR DESCRIPTION
#### Rationale
Evaluation content initialization started failing after the related PR because pipeline queues really want to execute jobs with active users. Set admin service user to active.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5203
