### PR TITLE
Issue 49641: LKSM: Using formatted Date or Time in naming pattern results in error

### DIFF
--- a/api/src/org/labkey/api/util/SubstitutionFormat.java
+++ b/api/src/org/labkey/api/util/SubstitutionFormat.java
@@ -21,6 +21,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.NameGenerator;
 import org.labkey.api.exp.api.SampleTypeService;
 
+import java.sql.Time;
 import java.text.DecimalFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -387,6 +388,9 @@ public class SubstitutionFormat
         {
             if (value == null)
                 return null;
+
+            if (value instanceof java.sql.Date || value instanceof Time)
+                value = new Date(((Date)value).getTime());
 
             TemporalAccessor temporal;
             if (value instanceof TemporalAccessor)


### PR DESCRIPTION
#### Rationale
Issue [49641](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49641)
toInstant is used by SubstitutionFormat to format date values for naming expression, but it is not supported for java.sql.Time or Date types, which are the java classes for Time and DateOnly fields. 

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* convert sql.Date and sql.Time to util.Date before calling toInstant method
