### PR TITLE
Plates: switch to non-hidden experimental flag

### DIFF
--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -252,8 +252,8 @@ public class AssayModule extends SpringModule
 
         ExperimentService.get().addExperimentListener(new AssayExperimentListener());
 
-        AdminConsole.addExperimentalFeatureFlag(new AdminConsole.ExperimentalFeatureFlag(EXPERIMENTAL_APP_PLATE_SUPPORT,
-                "Plate samples in Biologics", "Plate samples in Biologics for import and analysis.", false, true));
+        AdminConsole.addExperimentalFeatureFlag(EXPERIMENTAL_APP_PLATE_SUPPORT,
+                "Plate samples in Biologics", "Plate samples in Biologics for import and analysis.", false);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Retain and display publicly the experimental support for plating samples.

#### Changes
- Default to displaying the experimental flag publicly
