### PR TITLE
Fix cloned user display name

### DIFF
--- a/api/src/org/labkey/api/security/ClonedUser.java
+++ b/api/src/org/labkey/api/security/ClonedUser.java
@@ -16,7 +16,7 @@ public abstract class ClonedUser extends User
 {
     protected ClonedUser(User user, ImpersonationContext ctx)
     {
-        this(user.getEmail(), user.getUserId(), user.getFirstName(), user.getLastName(), user.getFriendlyName(), user.isActive(), user.getLastLogin(), user.getPhone(), user.getLastActivity(), ctx);
+        this(user.getEmail(), user.getUserId(), user.getFriendlyName(), user.getFirstName(), user.getLastName(), user.isActive(), user.getLastLogin(), user.getPhone(), user.getLastActivity(), ctx);
     }
 
     protected ClonedUser(String email, int userId, String displayName, String firstName, String lastName, boolean active,


### PR DESCRIPTION
#### Rationale
New `ClonedUser` constructor was confused about which parameter was which, causing 
`org.labkey.inventory.query.InventoryBoxTable$TriggerTest` to fail and likely other problems

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5203
