### PR TITLE
Plates: fix unit test cleanup

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -49,6 +49,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.ImportAliasable;
 import org.labkey.api.data.ObjectFactory;
+import org.labkey.api.data.Results;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -21,7 +21,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.junit.Before;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.labkey.api.assay.AssayProvider;
@@ -49,7 +49,6 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.ImportAliasable;
 import org.labkey.api.data.ObjectFactory;
-import org.labkey.api.data.Results;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
@@ -1879,8 +1878,8 @@ public class PlateManager implements PlateService
             PlateManager.get().createPlateMetadataFields(container, user, customFields);
         }
 
-        @Before
-        public void initTest() throws Exception
+        @After
+        public void cleanupTest() throws Exception
         {
             PlateManager.get().deleteAllPlateData(container);
         }


### PR DESCRIPTION
#### Rationale
Fixes memory leak(s) that can occur after `PlateManager` unit tests have been run.

#### Changes
- Switch cleanup of unit tests to be `@After`
