### PR TITLE
Better support for arbitrary API key expirations

### DIFF
--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -357,7 +357,7 @@ Click the Save button at any time to accept the current settings and continue.</
     for (int days : new int[]{7, 30, 90, 180, 365})
         expirationOptions.put(days * SECONDS_PER_DAY, days + " days");
 
-    // If current expiration is non-standard (perhaps set by a startup property) then add, formatting label as a duration
+    // If current expiration is non-standard (perhaps set by a startup property) then add it, formatting label as a duration
     if (!expirationOptions.containsKey(currentExpiration))
         expirationOptions.put(currentExpiration, DateUtil.formatDuration(1000L * currentExpiration));
 %>


### PR DESCRIPTION
#### Rationale
Via startup properties (or hacking a post) one can set the API expiration setting to any arbitrary value. The site settings page populates a drop-down list with standard expiration durations, but doesn't know how to handle a non-standard value. This change adds a currently set non-standard setting to the drop-down, formatting its label as a duration. It also adds "180 days" as a standard option (requested by systems engineering).