### PR TITLE
Issue 49731: Assay import from subfolder-defined plate fails to resolve plate

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -581,8 +581,9 @@ public class PlateManager implements PlateService
      */
     public ContainerFilter getPlateContainerFilter(@Nullable ExpProtocol protocol, Container container, User user)
     {
-        ContainerFilter defaultCf = ContainerFilter.Type.Current.create(protocol != null ? protocol.getContainer() : container, user);
-        return QueryService.get().getProductContainerFilterForLookups(container, user, defaultCf);
+        ContainerFilter lookupCf = QueryService.get().getContainerFilterForLookups(container, user);
+        ContainerFilter currentCf = ContainerFilter.Type.Current.create(protocol != null ? protocol.getContainer() : container, user);
+        return lookupCf != null ? lookupCf : currentCf;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49731

PlateManager.getPlateContainerFilter() was using getProductContainerFilterForLookups() to create the container filter for resolving a plate. This is the helper that we use for the isProductProjectsAllFolderScopeEnabled() setting and to resolve lookup fields. Since the plate set grid for a app subfolder shows the parent project plate sets based on the getContainerFilterForLookups() helper, I believe that is the one we should be using here when resolving the plate set.

#### Related Pull Requests
- https://github.com/LabKey/biologics/pull/2727

#### Changes
- PlateManager.getPlateContainerFilter update to use getContainerFilterForLookups() instead of getProductContainerFilterForLookups()
