### PR TITLE
Enable editing of workflow templates with no associated jobs

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -775,7 +775,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
      * @param inputDatas      map from input role name to input data
      * @param outputMaterials map from output role name to output material
      * @param outputDatas     map from output role name to output data
-     * @param transformedDatas map of output rolw name to transformed output data
+     * @param transformedDatas map of output role name to transformed output data
      * @param info            context information, including the user
      * @param log             output log target
      * @param loadDataFiles   When true, the files associated with <code>inputDatas</code> and <code>transformedDatas</code> will be loaded by their associated data handler.

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -762,6 +762,8 @@ public interface ExperimentService extends ExperimentRunTypeSource
      */
     ExpProtocol insertProtocol(@NotNull ExpProtocol baseProtocol, @Nullable List<ExpProtocol> steps, @Nullable Map<String, List<String>> predecessors, User user) throws ExperimentException;
 
+    ExpProtocol updateProtocol(@NotNull ExpProtocol baseProtocol, @Nullable List<ExpProtocol> steps, @Nullable Map<String, List<String>> predecessors, User user) throws ExperimentException;
+
     ExpProtocol insertSimpleProtocol(ExpProtocol baseProtocol, User user) throws ExperimentException;
 
     /**

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -654,7 +654,7 @@ public class AssayManager implements AssayService
     {
         AssayProvider provider = getProvider(protocol);
 
-        if (null == provider)
+        if (null == provider || null == c)
             return;
 
         String name = protocol.getName();

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8199,9 +8199,15 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public ExpProtocol updateProtocol(@NotNull ExpProtocol wrappedProtocol, @Nullable List<ExpProtocol> steps, @Nullable Map<String, List<String>> predecessors, User user) throws ExperimentException
     {
-        Protocol baseProtocol = ((ExpProtocolImpl) wrappedProtocol).getDataObject();
-        insertProtocolSteps(baseProtocol, steps, predecessors, user, true);
-        return getExpProtocol(baseProtocol.getRowId());
+        try (DbScope.Transaction tx = getSchema().getScope().ensureTransaction(getProtocolImportLock()))
+        {
+            Protocol baseProtocol = ((ExpProtocolImpl) wrappedProtocol).getDataObject();
+            insertProtocolSteps(baseProtocol, steps, predecessors, user, true);
+
+            tx.commit();
+
+            return getExpProtocol(baseProtocol.getRowId());
+        }
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8197,6 +8197,14 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
+    public ExpProtocol updateProtocol(@NotNull ExpProtocol wrappedProtocol, @Nullable List<ExpProtocol> steps, @Nullable Map<String, List<String>> predecessors, User user) throws ExperimentException
+    {
+        Protocol baseProtocol = ((ExpProtocolImpl) wrappedProtocol).getDataObject();
+        insertProtocolSteps(baseProtocol, steps, predecessors, user, true);
+        return getExpProtocol(baseProtocol.getRowId());
+    }
+
+    @Override
     public ExpProtocol insertProtocol(@NotNull ExpProtocol wrappedProtocol, @Nullable List<ExpProtocol> steps, @Nullable Map<String, List<String>> predecessors, User user) throws ExperimentException
     {
         if (wrappedProtocol == null)
@@ -8213,72 +8221,84 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
             Protocol baseProtocol = insertProtocol(wrappedProtocol, user);
 
-            List<Protocol> stepProtocols = new ArrayList<>();
-            if (steps != null)
-            {
-                for (ExpProtocol wrappedStepProtocol : steps)
-                {
-                    if (wrappedStepProtocol == null)
-                    {
-                        throw new ExperimentException("Cannot insert a \"null\" protocol step");
-                    }
-
-                    stepProtocols.add(insertProtocol(wrappedStepProtocol, user));
-                }
-            }
-
-            // all protocols are now inserted, now link them together
-            int actionSequence = 1;
-            Map<String, ProtocolAction> stepActions = new HashMap<>();
-
-            // insert base ProtocolAction prior to inserting steps
-            ProtocolAction previousAction = insertProtocolAction(baseProtocol, baseProtocol, actionSequence, user);
-            insertProtocolPredecessor(user, previousAction.getRowId(), previousAction.getRowId());
-            stepActions.put(baseProtocol.getLSID(), previousAction);
-            actionSequence = 10;
-
-            // insert ProtocolAction for each step prior to mapping actionSequence
-            for (Protocol stepProtocol : stepProtocols)
-            {
-                ProtocolAction stepAction = insertProtocolAction(baseProtocol, stepProtocol, actionSequence, user);
-                stepActions.put(stepProtocol.getLSID(), stepAction);
-                actionSequence += 10;
-            }
-
-            // map actionSequences
-            for (Protocol stepProtocol : stepProtocols)
-            {
-                String LSID = stepProtocol.getLSID();
-                ProtocolAction stepAction = stepActions.get(LSID);
-
-                if (predecessors != null)
-                {
-                    List<String> stepPredecessors = predecessors.get(LSID);
-
-                    if (stepPredecessors == null)
-                        throw new ExperimentException("Invalid predecessor map provided. Unable to find entry for \"" + LSID + "\". Each step protocol must have an entry.");
-
-                    for (String predecessorLSID : stepPredecessors)
-                    {
-                        ProtocolAction predecessorAction = stepActions.get(predecessorLSID);
-
-                        if (predecessorAction == null)
-                            throw new ExperimentException("Invalid predecessor map provided. Unable to find \"" + predecessorLSID + "\" in set of steps.");
-
-                        insertProtocolPredecessor(user, stepAction.getRowId(), predecessorAction.getRowId());
-                        previousAction = stepAction;
-                    }
-                }
-                else
-                {
-                    insertProtocolPredecessor(user, stepAction.getRowId(), previousAction.getRowId());
-                    previousAction = stepAction;
-                }
-            }
+            insertProtocolSteps(baseProtocol, steps, predecessors, user, false);
 
             tx.commit();
 
             return getExpProtocol(baseProtocol.getRowId());
+        }
+    }
+
+    private void insertProtocolSteps(Protocol baseProtocol, @Nullable List<ExpProtocol> steps, @Nullable Map<String, List<String>> predecessors, User user, boolean isUpdate) throws ExperimentException
+    {
+        List<Protocol> stepProtocols = new ArrayList<>();
+        if (steps != null)
+        {
+            for (ExpProtocol wrappedStepProtocol : steps)
+            {
+                if (wrappedStepProtocol == null)
+                {
+                    throw new ExperimentException("Cannot insert a \"null\" protocol step");
+                }
+
+                stepProtocols.add(insertProtocol(wrappedStepProtocol, user));
+            }
+        }
+
+        // all protocols are now inserted, now link them together
+        int actionSequence = 1;
+        Map<String, ProtocolAction> stepActions = new HashMap<>();
+
+        // insert base ProtocolAction prior to inserting steps
+        ProtocolAction previousAction;
+        if (isUpdate)
+            previousAction = getProtocolActions(baseProtocol.getRowId()).get(0);
+        else
+        {
+            previousAction = insertProtocolAction(baseProtocol, baseProtocol, actionSequence, user);
+            insertProtocolPredecessor(user, previousAction.getRowId(), previousAction.getRowId());
+        }
+        stepActions.put(baseProtocol.getLSID(), previousAction);
+        actionSequence = 10;
+
+        // insert ProtocolAction for each step prior to mapping actionSequence
+        for (Protocol stepProtocol : stepProtocols)
+        {
+            ProtocolAction stepAction = insertProtocolAction(baseProtocol, stepProtocol, actionSequence, user);
+            stepActions.put(stepProtocol.getLSID(), stepAction);
+            actionSequence += 10;
+        }
+
+        // map actionSequences
+        for (Protocol stepProtocol : stepProtocols)
+        {
+            String LSID = stepProtocol.getLSID();
+            ProtocolAction stepAction = stepActions.get(LSID);
+
+            if (predecessors != null)
+            {
+                List<String> stepPredecessors = predecessors.get(LSID);
+
+                if (stepPredecessors == null)
+                    throw new ExperimentException("Invalid predecessor map provided. Unable to find entry for \"" + LSID + "\". Each step protocol must have an entry.");
+
+                for (String predecessorLSID : stepPredecessors)
+                {
+                    ProtocolAction predecessorAction = stepActions.get(predecessorLSID);
+
+                    if (predecessorAction == null)
+                        throw new ExperimentException("Invalid predecessor map provided. Unable to find \"" + predecessorLSID + "\" in set of steps.");
+
+                    insertProtocolPredecessor(user, stepAction.getRowId(), predecessorAction.getRowId());
+                    previousAction = stepAction;
+                }
+            }
+            else
+            {
+                if (previousAction != null)
+                    insertProtocolPredecessor(user, stepAction.getRowId(), previousAction.getRowId());
+                previousAction = stepAction;
+            }
         }
     }
 
@@ -8291,7 +8311,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         if (protocol.getApplicationType() == null)
         {
-            throw new ExperimentException("Protocol '" + protocol.getLSID() + "' needs to declare it's applicationType before being inserted");
+            throw new ExperimentException("Protocol '" + protocol.getLSID() + "' needs to declare its applicationType before being inserted");
         }
 
         if (baseProtocol.getOutputDataType() == null)


### PR DESCRIPTION
#### Rationale
When a job template has no jobs associated with it, we want to allow users to edit the template so they don't have to know everything about the template before they click "Save" the first time. Previously, we had allowed editing of the name, description, and any domain fields. Now we allow users to edit attachments and tasks as well when there are no jobs using the template. When there are jobs, we still allow editing of the name, description, and fields (consistent with our treatment of other domains), and will display read-only versions of the attachments and tasks.

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-premium/pull/337

#### Changes
* Add `ExperimentService.updateProtocol` method
