### PR TITLE
Issue 49506: Throw exception instead of caching a null table

### DIFF
--- a/api/src/org/labkey/api/data/DbSchema.java
+++ b/api/src/org/labkey/api/data/DbSchema.java
@@ -305,7 +305,7 @@ public class DbSchema
 
         if (null == factory && isModuleSchema())
         {
-            throw new RuntimeException("SchemaTableInfoFactory for table \"" + getName() + "." + requestedTableName + "\" was null! This could indicate a problem with DbSchema.loadTableMetaData().");
+            _log.warn("SchemaTableInfoFactory for table \"" + getName() + "." + requestedTableName + "\" was null! This could indicate a problem with DbSchema.loadTableMetaData().");
         }
 
         return null != factory ? factory.getSchemaTableInfo(this) : null;

--- a/api/src/org/labkey/api/data/SchemaTableInfoCache.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfoCache.java
@@ -27,6 +27,8 @@ import org.labkey.api.data.DbScope.SchemaTableOptions;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.logging.LogHelper;
 
+import java.sql.SQLException;
+
 public class SchemaTableInfoCache
 {
     private static final Logger LOG = LogHelper.getLogger(SchemaTableInfoCache.class, "Loading of schema and table metadata from database schemas");
@@ -92,13 +94,13 @@ public class SchemaTableInfoCache
                 LOG.debug("loading schema table: " + fullName);
                 return options.getSchema().loadTable(options.getTableName(), options);
             }
-            catch (Throwable t)
+            catch (SQLException e)
             {
-                // Log all problems for the admin and report to mothership. Return null for now, but see Issue 49506.
-                LOG.warn("Exception while attempting to load schema table \"" + fullName + "\"", t);
-                ExceptionUtil.logExceptionToMothership(null, t, false);
+                // Issue 49506: Log all problems for the admin and report to mothership and throw instead of returning null.
+                LOG.warn("Exception while attempting to load schema table \"" + fullName + "\"", e);
+                ExceptionUtil.logExceptionToMothership(null, e, false);
 
-                return null;
+                throw new RuntimeSQLException(e);
             }
         }
     }


### PR DESCRIPTION
#### Rationale
Issue [49506](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49506)

In the [related PR](#5183), we threw an exception a bit too aggressively, not realizing that this kind of error can occur when we reference a foreign key to a table that doesn't exist in the database in a schema XML file.  Instead of throwing, we'll log a warning about this and then actually throw an error if we have a SQL exception when trying to load a table.  Note that we may still cache a null table if the table loader returns null without an exception, but the hope is that that is a legitimate null that won't change over time. 

#### Related Pull Requests
- #5183 

#### Changes
* Log warning instead of throwing  a runtime exception when `SchemaTableInfoFactory` is null
* Throw `RuntimeSqlException` from `SchemaTableLoader` instead of returning null so we don't cache the null value
