### PR TITLE
Fix DateUtil.TestCase.testDateTimeFormat

### DIFF
--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -2095,7 +2095,7 @@ Parse:
         @Test
         public void testDateTimeFormat()
         {
-            long longDate = 1556883120123L; // 2019-05-03 04:32:00.123
+            long longDate = parseDateTime("2019-05-03 04:32:00.123");
             Date date = new Date(longDate);
             Time time = new Time(longDate);
 


### PR DESCRIPTION
#### Rationale
Adjust recently added test case to parse source date from a string

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5251

#### Changes
* Use `parseDateTime`
