### PR TITLE
49665: Plate names should be unique within a plate set

### DIFF
--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.assay;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
@@ -45,13 +44,10 @@ import org.labkey.api.gwt.server.BaseRemoteService;
 import org.labkey.api.security.RequiresAnyOf;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.User;
-import org.labkey.api.security.permissions.AddUserPermission;
-import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.security.roles.EditorRole;
 import org.labkey.api.util.ContainerTree;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.JsonUtil;
@@ -405,7 +401,7 @@ public class PlateController extends SpringActionController
             if (_plate == null)
                 errors.reject(ERROR_REQUIRED, "Unable to retrieve source plate with ID : " + form.getPlateId());
 
-            if (PlateManager.get().plateExists(_destination, _plate.getName()))
+            if (PlateManager.get().isDuplicatePlate(_destination, getUser(), _plate.getName(), null))
                 errors.reject("copyForm", "A plate template with the same name already exists in the destination folder.");
         }
 

--- a/assay/src/org/labkey/assay/plate/PlateDataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateDataServiceImpl.java
@@ -161,7 +161,7 @@ public class PlateDataServiceImpl extends BaseRemoteService implements PlateData
                     throw new Exception("Plate template not found: " + gwtPlate.getRowId());
 
                 // check another plate of the same name doesn't already exist
-                if (PlateManager.get().plateExists(getContainer(), gwtPlate.getName()) && !replaceIfExisting)
+                if (PlateManager.get().isDuplicatePlate(getContainer(), getUser(), gwtPlate.getName(), null) && !replaceIfExisting)
                     throw new Exception("A plate template with name '" + gwtPlate.getName() + "' already exists.");
 
                 if (!template.getAssayType().equals(gwtPlate.getType()))

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -621,11 +621,14 @@ public class PlateManager implements PlateService
     }
 
     /**
-     * Checks to see if there is a plate with the same name in the folder, or for
+     * Issue 49665 : Checks to see if there is a plate with the same name in the folder, or for
      * Biologics folders if there is a duplicate plate name in the plate set.
      */
     public boolean isDuplicatePlate(Container c, User user, String name, @Nullable PlateSet plateSet)
     {
+        // Identifying the "Biologics" folder type as the logic we pivot this behavior on is not intended to be
+        // a long-term solution. We will be looking to introduce plating as a ProductFeature which we can then
+        // leverage instead.
         boolean isBiologicsProject = c.getProject() != null && "Biologics".equals(ContainerManager.getFolderTypeName(c.getProject()));
         if (isBiologicsProject && plateSet != null)
         {

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -621,12 +621,26 @@ public class PlateManager implements PlateService
     }
 
     /**
-     * Checks to see if there is a plate with the same name in the folder
+     * Checks to see if there is a plate with the same name in the folder, or for
+     * Biologics folders if there is a duplicate plate name in the plate set.
      */
-    public boolean plateExists(Container c, String name)
+    public boolean isDuplicatePlate(Container c, User user, String name, @Nullable PlateSet plateSet)
     {
-        Plate plate = getPlateByName(c, name);
-        return plate != null && plate.getName().equals(name);
+        boolean isBiologicsProject = c.getProject() != null && "Biologics".equals(ContainerManager.getFolderTypeName(c.getProject()));
+        if (isBiologicsProject && plateSet != null)
+        {
+            for (Plate plate : plateSet.getPlates(user))
+            {
+                if (plate.getName().equalsIgnoreCase(name))
+                    return true;
+            }
+            return false;
+        }
+        else
+        {
+            Plate plate = getPlateByName(c, name);
+            return plate != null && plate.getName().equals(name);
+        }
     }
 
     private Collection<Plate> getPlates(Container c)
@@ -1375,7 +1389,7 @@ public class PlateManager implements PlateService
     public Plate copyPlate(Plate source, User user, Container destContainer)
             throws Exception
     {
-        if (plateExists(destContainer, source.getName()))
+        if (isDuplicatePlate(destContainer, user, source.getName(), null))
             throw new PlateService.NameConflictException(source.getName());
         Plate newPlate = createPlateTemplate(destContainer, source.getAssayType(), source.getPlateType());
         newPlate.setName(source.getName());

--- a/assay/src/org/labkey/assay/plate/query/DuplicatePlateValidator.java
+++ b/assay/src/org/labkey/assay/plate/query/DuplicatePlateValidator.java
@@ -1,0 +1,56 @@
+package org.labkey.assay.plate.query;
+
+import org.labkey.api.assay.plate.PlateSet;
+import org.labkey.api.data.Container;
+import org.labkey.api.dataiterator.DataIterator;
+import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.dataiterator.DataIteratorUtil;
+import org.labkey.api.dataiterator.MapDataIterator;
+import org.labkey.api.dataiterator.WrapperDataIterator;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.security.User;
+import org.labkey.assay.plate.PlateManager;
+
+import java.util.Map;
+
+public class DuplicatePlateValidator extends WrapperDataIterator
+{
+    private final DataIteratorContext _context;
+    private final Map<String, Integer> _nameMap;
+    private final Container _container;
+    private final User _user;
+
+    public DuplicatePlateValidator(DataIterator di, DataIteratorContext context, Container container, User user)
+    {
+        super(DataIteratorUtil.wrapMap(di, false));
+
+        _context = context;
+        _container = container;
+        _nameMap = DataIteratorUtil.createColumnNameMap(di);
+        _user = user;
+    }
+
+    MapDataIterator getInput()
+    {
+        return (MapDataIterator) _delegate;
+    }
+
+    @Override
+    public boolean next() throws BatchValidationException
+    {
+        boolean hasNext = super.next();
+        if (!hasNext)
+            return false;
+
+        String name = String.valueOf(_delegate.get(_nameMap.get("name")));
+        Integer plateSet = (Integer)_delegate.get(_nameMap.get("plateSet"));
+        if (name != null & plateSet != null)
+        {
+            PlateSet ps = PlateManager.get().getPlateSet(_container, plateSet);
+            if (PlateManager.get().isDuplicatePlate(_container, _user, name, ps))
+                _context.getErrors().addRowError(new ValidationException("Plate with name : " + name + " already exists."));
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
[tracking issue
](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49665)

#### Rationale
Modify the existing checks for plate name uniqueness:
- For Biologics projects or subfolders, the names within the plate set must be unique.
- For everything else, it will default to container uniqueness. 