### PR TITLE
Option to continue server startup if existing connections are detected

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -47,6 +47,7 @@ import org.labkey.api.util.GUID;
 import org.labkey.api.util.LoggerWriter;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.util.SimpleLoggerWriter;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.TestContext;
@@ -1721,30 +1722,39 @@ public class DbScope
 
         SqlDialect dialect = primaryScope.getSqlDialect();
         String databaseName = primaryScope.getDatabaseName();
-        String sql = dialect.getApplicationConnectionCountSql();
+        String sql = dialect.getApplicationConnectionsSql();
         assert sql != null : "Need to implement both getApplicationName() and getApplicationConnectionCountSql() (or neither of them)";
-        int count;
 
-        try
+        int count;
+        ConfigurationException exception = null;
+        SqlSelector selector = new SqlSelector(primaryScope, new SQLFragment(sql, databaseName, _applicationName));
+
+        // This creates the first pooled connection on the primary scope
+        try (TableResultSet rs = selector.getResultSet())
         {
-            // This creates the first pooled connection on the primary scope. Application name should be set on this
-            // connection in both the default and custom cases.
-            SqlSelector selector = new SqlSelector(primaryScope, new SQLFragment(sql, databaseName, _applicationName));
-            count = selector.getObject(Integer.class) - 1; // Exclude this connection from the count
+            count = rs.getSize();
+            if (count != 0)
+            {
+                String message = "There " + (1 == count ? "is " : "are ") + StringUtilsLabKey.pluralize(count, "other connection") +
+                    " to database \"" + databaseName + "\" with the application name \"" + _applicationName +
+                    "\"! This likely means another LabKey Server instance is already using this database.";
+                LOG.fatal(message + " Information about existing connections:\n" + ResultSetUtil.getData(rs));
+                boolean terminate = Boolean.valueOf(Objects.toString(System.getProperty("terminateOnExistingConnections"), "true"));
+                if (terminate)
+                {
+                    exception = new ConfigurationException(message);
+                }
+            }
         }
         catch (Exception e)
         {
             LOG.warn("Attempt to detect other LabKey Server instances using this database failed", e);
-            return;
         }
 
-        if (count > 0)
-            throw new ConfigurationException("There " + (1 == count ? "is " : "are ") +
-                StringUtilsLabKey.pluralize(count, "other connection") + " to database \"" +
-                databaseName + "\" with the application name \"" + _applicationName +
-                "\"! This likely means another LabKey Server instance is already using this database.");
-        else if (count < 0)
-            LOG.warn("Expected one connection with the application name \"" + _applicationName + "\", but saw " + count + 1 + ".");
+        if (exception != null)
+        {
+            throw exception;
+        }
     }
 
     // It's too early to use SqlSelector since DbScopes haven't been set up yet, so use vanilla JDBC

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1715,8 +1715,31 @@ public class DbScope
         throw new ConfigurationException("Can't connect to data source \"" + ds.getDsName() + "\".", "Make sure that your LabKey Server configuration file includes the correct user name, password, url, port, etc. for your database and that the database server is running.", lastException);
     }
 
+    // Set to true to test detection of unexpected connections
+    private static final boolean MOCK_EXISTING_CONNECTIONS = false;
+
     // Called on primary data source only
     private static void detectOtherLabKeyInstances(DbScope primaryScope)
+    {
+        if (MOCK_EXISTING_CONNECTIONS)
+        {
+            // For testing purposes only - create a couple unexpected connections
+            try (Connection ignored1 = primaryScope.getPooledConnection(); Connection ignored2 = primaryScope.getPooledConnection())
+            {
+                detectUnexpectedConnections(primaryScope);
+            }
+            catch (SQLException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+        else
+        {
+            detectUnexpectedConnections(primaryScope);
+        }
+    }
+
+    private static void detectUnexpectedConnections(DbScope primaryScope)
     {
         assert _applicationName != null;
 

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -1958,8 +1958,8 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     }
 
     @Override
-    public @Nullable String getApplicationConnectionCountSql()
+    public @NotNull String getApplicationConnectionsSql()
     {
-        return "SELECT COUNT(*) FROM pg_stat_activity WHERE datname = ? AND application_name = ?";
+        return "SELECT pid, usename, client_addr, client_hostname, xact_start, query_start, state, query FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND datname = ? AND application_name = ?";
     }
 }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1817,9 +1817,9 @@ public abstract class SqlDialect
         return null;
     }
 
-    // Returns SQL that counts connections that are using a specific database and are tagged with a specific application
+    // Returns SQL that queries all other connections to a specific database and are tagged with a specific application
     // name. SQL must have two parameter placeholders for database name and application name (in that order).
-    public @Nullable String getApplicationConnectionCountSql()
+    public @Nullable String getApplicationConnectionsSql()
     {
         return null;
     }

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -2486,8 +2486,8 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     }
 
     @Override
-    public @Nullable String getApplicationConnectionCountSql()
+    public @NotNull String getApplicationConnectionsSql()
     {
-        return "SELECT COUNT(*) FROM sys.sysprocesses WHERE DB_NAME(dbid) = ? AND program_name = ?";
+        return "SELECT spid, loginame, hostname, net_address, last_batch, status, cmd FROM sys.sysprocesses WHERE spid <> @@SPID AND DB_NAME(dbid) = ? AND program_name = ?";
     }
 }


### PR DESCRIPTION
#### Rationale
Some deployments want to bravely continue in the face of existing database connections. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49494

LabKey will continue to terminate if existing connections are detected to the same database with the same application name, but setting this property will skip termination:

`-DterminateOnExistingConnections=false`

Also added a simple mechanism to test the detection of unexpected connections. This is especially helpful when using embedded Tomcat, since the trivial standalone repro of "copy the context file" no longer works in embedded.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4937