### PR TITLE
Ignore FK violation during concurrent material/data indexing and delete

### DIFF
--- a/devtools/src/org/labkey/devtools/TestController.java
+++ b/devtools/src/org/labkey/devtools/TestController.java
@@ -51,7 +51,7 @@ import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.template.ClientDependency;
-import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
@@ -771,7 +771,7 @@ public class TestController extends SpringActionController
         {
             if (getViewContext().getRequest().getParameterMap().containsKey("_retry_"))
                 return new HtmlView(HtmlString.of("Second time's a charm"));
-            throw new DeadlockLoserDataAccessException("Try again", null);
+            throw new PessimisticLockingFailureException("Try again", null);
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -174,7 +174,7 @@ public class ExperimentModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 24.001;
+        return 24.002;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -174,7 +174,7 @@ public class ExperimentModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 24.002;
+        return 24.001;
     }
 
     @Nullable


### PR DESCRIPTION
#### Rationale
I don't see an easy way to completely avoid these FK violations without increasing the risk of deadlocks.

```
ERROR ExceptionUtil            2024-02-23T03:00:43,221            JobThread-1.1 : Exception detected and logged to mothership with error code: PJYHSJ
org.springframework.dao.DataIntegrityViolationException: Attempting to prepare a statement; ERROR: insert or update on table "materialindexed" violates foreign key constraint "fk_materialid"
  Detail: Key (materialid)=(1457) is not present in table "material".
	at org.springframework.jdbc.support.SQLErrorCodeSQLExceptionTranslator.doTranslate(SQLErrorCodeSQLExceptionTranslator.java:258) ~[spring-jdbc-6.1.3.jar:6.1.3]
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:107) ~[spring-jdbc-6.1.3.jar:6.1.3]
	at org.labkey.api.data.ExceptionFramework$1.translate(ExceptionFramework.java:44) ~[api-24.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.ParameterMapStatement.executeBatch(ParameterMapStatement.java:292) ~[api-24.3-SNAPSHOT.jar:?]
	at org.labkey.experiment.api.ExperimentServiceImpl.lambda$setMaterialLastIndexed$16(ExperimentServiceImpl.java:983) ~[experiment-24.3-SNAPSHOT.jar:?]
	at java.base/java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
	at org.labkey.experiment.api.ExperimentServiceImpl.setMaterialLastIndexed(ExperimentServiceImpl.java:968) ~[experiment-24.3-SNAPSHOT.jar:?]
	at org.labkey.experiment.api.ExpMaterialImpl$3.lambda$setLastIndexed$0(ExpMaterialImpl.java:512) ~[experiment-24.3-SNAPSHOT.jar:?]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
```
#### Changes
* Ignore the FK violation exception and move on
* Follow Spring's guidance for the best deadlock detection exception to use