### PR TITLE
Issue 49470: Form binding for 'Container' fails without leading slash

### DIFF
--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -433,7 +433,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
                 return o;
 
             String str = o.toString().trim();
-            if ("".equals(str))
+            if (str.isEmpty())
                 return null;
 
             Container c;
@@ -452,6 +452,12 @@ public class ConvertHelper implements PropertyEditorRegistrar
             else
             {
                 c = ContainerManager.getForId(str);
+            }
+
+            if (c == null && !str.startsWith("/"))
+            {
+                // Try once more, as it might be a path without the leading slash. See issue 49470
+                c = ContainerManager.getForPath(str);
             }
 
             if (null == c)

--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -1369,7 +1369,14 @@ public class ProjectController extends SpringActionController
             MutablePropertyValues mpvs = new MutablePropertyValues(pvs);
             if (pvs.contains("container"))
                 mpvs.addPropertyValue("containers", pvs.getPropertyValue("container").getValue());
-            return BaseViewAction.springBindParameters(this, "form", mpvs);
+            BindException result = BaseViewAction.springBindParameters(this, "form", mpvs);
+
+            // Return a 404 if someone requests a bogus container. See issue 49470
+            if (mpvs.contains("containers") && _container == null)
+            {
+                throw new NotFoundException("Could not find requested container");
+            }
+            return result;
         }
     }
 


### PR DESCRIPTION
#### Rationale
We can be a little friendlier and tolerant of reasonable inputs for the container in API like LABKEY.Security.getContainers()

#### Changes
* Accept container paths with or without the leading slash
* Give a 404 when a bogus container is requested