### PR TITLE
Fix excel factory test after commons-compress upgrade

### DIFF
--- a/api/src/org/labkey/api/reader/ExcelFactory.java
+++ b/api/src/org/labkey/api/reader/ExcelFactory.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.poi.UnsupportedFileFormatException;
 import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.apache.poi.openxml4j.exceptions.InvalidOperationException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.opc.PackageAccess;
 import org.apache.poi.ss.format.CellGeneralFormatter;
@@ -921,7 +922,7 @@ public class ExcelFactory
 
             attemptImportExpectError(new File(dataloading, "doesntexist.xls"), FileNotFoundException.class);
             attemptImportExpectError(new File(dataloading, ""), FileNotFoundException.class);
-            attemptImportExpectError(new File(dataloading, "notreallyexcel.xls"), InvalidFormatException.class);
+            attemptImportExpectError(new File(dataloading, "notreallyexcel.xls"), InvalidOperationException.class);
         }
 
         private void attemptImportExpectError(File excelFile, Class exceptionClass)


### PR DESCRIPTION
#### Rationale
Test fix post commons-compress upgrade to 1.26

#### Related Pull Requests
* https://github.com/LabKey/server/pull/744
* https://github.com/LabKey/platform/pull/5256

#### Changes
* Type of exception thrown by the library changed
