### PR TITLE
 Use native DatabaseMetaData.getColumns() for SQL Server

### DIFF
--- a/api/src/org/labkey/api/util/CPUTimer.java
+++ b/api/src/org/labkey/api/util/CPUTimer.java
@@ -109,17 +109,33 @@ public class CPUTimer
     public boolean save()
     {
         if (_stop > _start)
+            _update(_stop - _start);
+        _start = 0;
+        _stop = 0;
+        return true;
+    }
+
+    protected void _update(long elapsed)
+    {
+        _cumulative += elapsed;
+        _min = Math.min(_min, elapsed);
+        _max = Math.max(_max, elapsed);
+        if (_first == 0)
         {
-            long elapsed = (_stop - _start);
-            _cumulative += elapsed;
-            _min = Math.min(_min, elapsed);
-            _max = Math.max(_max, elapsed);
-            if (_first == 0)
+            _first = elapsed;
+        }
+        _last = elapsed;
+        _calls++;
+    }
+
+    public boolean saveTo(CPUTimer accumulator)
+    {
+        if (_stop > _start)
+        {
+            synchronized (accumulator)
             {
-                _first = elapsed;
+                accumulator._update(_stop-_start);
             }
-            _last = elapsed;
-            _calls++;
         }
         _start = 0;
         _stop = 0;


### PR DESCRIPTION
#### Rationale
 better compatibility, but slower
 avg 4.22ms vs 11.78ms

see [Issue 49411](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49411)

also CPUTimer.saveTo() for thread-safe timers

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
