### PR TITLE
Issue 49783: UserManager Optimistic Concurrency Exception

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -709,7 +709,9 @@ public class DbScope
     }
 
     /**
-     * Starts a new transaction using a new Connection.
+     * Starts a new transaction using a new Connection. Most callers should use ensureTransaction() to join an existing
+     * transaction in the same database.
+     *
      * The preferred usage pattern is:
      * <pre>
      *     try (DbScope.Transaction transaction = scope.beginTransaction()) {
@@ -731,7 +733,9 @@ public class DbScope
     }
 
     /**
-     * Starts a new transaction using a new Connection.
+     * Starts a new transaction using a new Connection. Most callers should use ensureTransaction() to join an existing
+     * transaction in the same database.
+     *
      * The preferred usage pattern is:
      * <pre>
      *     try (DbScope.Transaction transaction = scope.beginTransaction()) {

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1419,7 +1419,7 @@ public class SecurityManager
                 groupId == Group.groupDevelopers)
             throw new IllegalArgumentException("The global groups cannot be deleted.");
 
-        try (Transaction transaction = core.getScope().beginTransaction())
+        try (Transaction transaction = core.getScope().ensureTransaction())
         {
             Group group = getGroup(groupId);
             if (null == group)
@@ -1516,7 +1516,7 @@ public class SecurityManager
             }
             core.getSqlDialect().appendInClauseSql(sql, userIds);
 
-            try (Transaction transaction = core.getScope().beginTransaction())
+            try (Transaction transaction = core.getScope().ensureTransaction())
             {
                 new SqlExecutor(core.getSchema()).execute(sql);
 

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -948,7 +948,7 @@ public class UserManager
                 throw new RuntimeException(first);
         }
 
-        try (Transaction transaction = CORE.getScope().beginTransaction())
+        try (Transaction transaction = CORE.getScope().ensureTransaction())
         {
             boolean needToEnsureRootAdmins = SecurityManager.isRootAdmin(user);
 
@@ -1017,7 +1017,7 @@ public class UserManager
                 throw new RuntimeException(first);
         }
 
-        try (Transaction transaction = CoreSchema.getInstance().getScope().beginTransaction())
+        try (Transaction transaction = CoreSchema.getInstance().getScope().ensureTransaction())
         {
             Table.update(currentUser, CoreSchema.getInstance().getTableInfoPrincipals(),
                     Collections.singletonMap("Active", active), userId);


### PR DESCRIPTION
#### Rationale
We generally want to reuse existing transactions for interactions with the same DB. Splitting related work across transactions via `beginTransaction()` can lead to self-deadlocking and other headaches.

#### Changes
* Migrate some calls to `ensureTransaction()`
* Add JavaDoc to give guidance