### PR TITLE
Fix package to match log4j2.xml packages attribute

### DIFF
--- a/api/src/org/labkey/api/util/LabKeyDeleteAction.java
+++ b/api/src/org/labkey/api/util/LabKeyDeleteAction.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.labkey.api.util.logging;
+package org.labkey.api.util;
 
 import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.appender.rolling.action.AbstractPathAction;


### PR DESCRIPTION
#### Rationale
@labkey-willm flagged a log4j2 error on Tomcat standalone which pointed out that this class is in the wrong package for that deployment scenario

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5257