### PR TITLE
Fix expected column order.

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetIndexTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetIndexTest.java
@@ -101,13 +101,13 @@ public class StudyDatasetIndexTest extends StudyBaseTest
         viewRawTableMetadata("DEM-1");
         verifyTableIndices("dem_minus_1_", List.of("indexedcolumn", "sharedcolumn"));
 
-        int colNameIndex = 0;
-        int colSizeIndex = 3;
-        if (WebTestHelper.getDatabaseType() == WebTestHelper.DatabaseType.PostgreSQL)
-        {
-            colNameIndex = 3;
-            colSizeIndex = 6;
-        }
+        int colNameIndex = 3;
+        int colSizeIndex = 6;
+//        if (WebTestHelper.getDatabaseType() == WebTestHelper.DatabaseType.PostgreSQL)
+//        {
+//            colNameIndex = 3;
+//            colSizeIndex = 6;
+//        }
 
         // related BUG https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42229
         // Verify size column specified in datasets_metadata

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetIndexTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetIndexTest.java
@@ -103,11 +103,6 @@ public class StudyDatasetIndexTest extends StudyBaseTest
 
         int colNameIndex = 3;
         int colSizeIndex = 6;
-//        if (WebTestHelper.getDatabaseType() == WebTestHelper.DatabaseType.PostgreSQL)
-//        {
-//            colNameIndex = 3;
-//            colSizeIndex = 6;
-//        }
 
         // related BUG https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42229
         // Verify size column specified in datasets_metadata


### PR DESCRIPTION
#### Rationale
Looks like column orders are the same in Postgres and MSSQL. Related PR is the product change that is related.

#### Related Pull Requests
* [Use native DatabaseMetaData.getColumns() for SQL Server](https://github.com/LabKey/platform/pull/5276)

#### Changes
* Column order in the grid is now the same between Postgres and MSSQL.
