### PR TITLE
Issue 49794: use getProductContainerFilterForLookups for closure lookups

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -198,7 +198,9 @@ public class ClosureQueryHelper
         UserSchema schema = Objects.requireNonNull(parentTable.getUserSchema());
 
         // Determine the container scope of the lookup
-        ContainerFilter cf = QueryService.get().getProductContainerFilterForLookups(schema.getContainer(), schema.getUser(), parentTable.getContainerFilter());
+        ContainerFilter cf = QueryService.get().getProductContainerFilterForLookups(schema.getContainer(), schema.getUser(), null);
+        if (cf == null)
+            cf = parentTable.getContainerFilter();
 
         var builder = new QueryForeignKey.Builder(schema, cf).table(target.getName()).key("rowid");
         builder.schema(targetType.schemaKey);

--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -198,9 +198,7 @@ public class ClosureQueryHelper
         UserSchema schema = Objects.requireNonNull(parentTable.getUserSchema());
 
         // Determine the container scope of the lookup
-        ContainerFilter cf = QueryService.get().getContainerFilterForLookups(schema.getContainer(), schema.getUser());
-        if (cf == null)
-            cf = parentTable.getContainerFilter();
+        ContainerFilter cf = QueryService.get().getProductContainerFilterForLookups(schema.getContainer(), schema.getUser(), parentTable.getContainerFilter());
 
         var builder = new QueryForeignKey.Builder(schema, cf).table(target.getName()).key("rowid");
         builder.schema(targetType.schemaKey);


### PR DESCRIPTION
#### Rationale
This addresses [Issue 49794](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49794) by utilizing `getProductContainerFilterForLookups` instead when composing the container filtering. The logical difference is subtle:

1. When the "Less restrictive product project lookups" experimental flag is disabled fall back to the provided table container filter. When the applications are making these requests they supply the expected "data" container filter.
2. When the "Less restrictive product project lookups" experimental flag is enabled then respect the container filter for lookups which will be "AllInProjectPlusShared".

#### Changes
- Call `getProductContainerFilterForLookups` rather than `getContainerFilterForLookups`.
