### PR TITLE
Fix expected column order. (Backporting fix from develop)

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetIndexTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetIndexTest.java
@@ -101,13 +101,8 @@ public class StudyDatasetIndexTest extends StudyBaseTest
         viewRawTableMetadata("DEM-1");
         verifyTableIndices("dem_minus_1_", List.of("indexedcolumn", "sharedcolumn"));
 
-        int colNameIndex = 0;
-        int colSizeIndex = 3;
-        if (WebTestHelper.getDatabaseType() == WebTestHelper.DatabaseType.PostgreSQL)
-        {
-            colNameIndex = 3;
-            colSizeIndex = 6;
-        }
+        int colNameIndex = 3;
+        int colSizeIndex = 6;
 
         // related BUG https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=42229
         // Verify size column specified in datasets_metadata


### PR DESCRIPTION
#### Rationale
Backporting [this fix](https://github.com/LabKey/platform/pull/5285) from develop. This should keep the noise down in 24.3.

#### Related Pull Requests
* [Fix in Develop](https://github.com/LabKey/platform/pull/5285)

#### Changes
* Column order is the same in MSSQL and Postgres now.
