### PR TITLE
Eliminate JSON object serialization

### DIFF
--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.data;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.beanutils.DynaBean;
@@ -38,7 +39,6 @@ import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
@@ -52,7 +52,6 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.beans.Introspector;
 import java.io.File;
 import java.sql.SQLException;
@@ -84,8 +83,6 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
 
     public static final String DATA_SUBMIT_NAME = ".dataSubmit";
     public static final String BULK_UPDATE_NAME = ".bulkUpdate";
-    // TODO: Remove in 24.4
-    public static final String EXPERIMENTAL_DESERIALIZE_BEANS = "experimental-deserialize-beans-in-forms";
 
     /**
      * Creates a TableViewForm with no underlying dynaclass.
@@ -792,24 +789,8 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         String oldValues = request.getParameter(DataRegion.OLD_VALUES_NAME);
         if (null != StringUtils.trimToNull(oldValues))
         {
-            if (ExperimentalFeatureService.get().isFeatureEnabled(EXPERIMENTAL_DESERIALIZE_BEANS))
-            {
-                try
-                {
-                    String className = getDynaClass().getName();
-                    Class beanClass = "className".equals(className) ? Map.class : Class.forName(className);
-                    _oldValues = DataRegion.decodeObject(beanClass, oldValues);
-                    _isDataLoaded = true;
-                }
-                catch (Exception ignored)
-                {
-                }
-            }
-            else
-            {
-                // Just the PK and version values
-                _oldValues = new JSONObject(oldValues).toMap();
-            }
+            // Just the PK and version values
+            _oldValues = new JSONObject(oldValues).toMap();
         }
     }
 

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -17,6 +17,9 @@ package org.labkey.core;
 
 import com.fasterxml.jackson.core.io.CharTypes;
 import com.google.common.collect.Sets;
+import jakarta.servlet.MultipartConfigElement;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletRegistration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,7 +45,34 @@ import org.labkey.api.audit.provider.ContainerAuditProvider;
 import org.labkey.api.audit.provider.FileSystemAuditProvider;
 import org.labkey.api.audit.provider.GroupAuditProvider;
 import org.labkey.api.cache.CacheManager;
-import org.labkey.api.data.*;
+import org.labkey.api.data.CompareType;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.ContainerService;
+import org.labkey.api.data.ContainerServiceImpl;
+import org.labkey.api.data.ContainerTypeRegistry;
+import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DataRegion;
+import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.data.MvUtil;
+import org.labkey.api.data.NormalContainerType;
+import org.labkey.api.data.OutOfRangeDisplayColumn;
+import org.labkey.api.data.PropertySchema;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SchemaTableInfoFactory;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.TSVWriter;
+import org.labkey.api.data.TabContainerType;
+import org.labkey.api.data.Table;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.data.TempTableTracker;
+import org.labkey.api.data.TestSchema;
+import org.labkey.api.data.WorkbookContainerType;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.SqlDialectManager;
 import org.labkey.api.data.dialect.SqlDialectRegistry;
@@ -270,9 +300,6 @@ import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.impl.StdSchedulerFactory;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.MultipartConfigElement;
-import jakarta.servlet.ServletRegistration;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -292,7 +319,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.labkey.api.data.TableViewForm.EXPERIMENTAL_DESERIALIZE_BEANS;
 import static org.labkey.api.settings.StashedStartupProperties.homeProjectFolderType;
 import static org.labkey.api.settings.StashedStartupProperties.homeProjectResetPermissions;
 import static org.labkey.api.settings.StashedStartupProperties.homeProjectWebparts;
@@ -1071,10 +1097,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_BLOCKER,
                 "Block malicious clients",
                 "Reject requests from clients that appear malicious. Turn this feature off if you want to run a security scanner.",
-                false);
-        AdminConsole.addExperimentalFeatureFlag(EXPERIMENTAL_DESERIALIZE_BEANS,
-                "Deserialize objects from update forms",
-                "We no longer deserialize objects encoded into update forms. Turn this feature on if the removal of object deserialization is causing specific update operations to fail.",
                 false);
         AdminConsole.addExperimentalFeatureFlag(new AdminConsole.ExperimentalFeatureFlag(EXPERIMENTAL_LOCAL_MARKETING_UPDATE,
                 "Self test marketing updates", "Test marketing updates from this local server (requires the mothership module).", false, true));


### PR DESCRIPTION
#### Rationale
In 24.3, we eliminated all JSON object serialization/deserialization... except for when an experimental flag is turned on. This removes it for good. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49205

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4622