### PR TITLE
Backport - Issue 49511: Domain designer lookup validation for custom queries

### DIFF
--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -201,7 +201,16 @@ public class DomainUtil
             return false;
 
         // Only checking names here to avoid creating tableinfo each time. Avoids potential infinite loop.
-        CaseInsensitiveHashSet tableNames = new CaseInsensitiveHashSet(schema.getTableNames());
+        CaseInsensitiveHashSet tableNames;
+        if (schema instanceof UserSchema us)
+        {
+            // Issue 49511: Valid lookups for custom queries
+            tableNames = new CaseInsensitiveHashSet(us.getTableAndQueryNames(true));
+        }
+        else
+        {
+            tableNames = new CaseInsensitiveHashSet(schema.getTableNames());
+        }
 
         if (tableNames.contains(p.getLookupQuery()))
             return true;


### PR DESCRIPTION
#### Rationale
Backport validation fix for custom queries as domain designer lookups.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5227

#### Changes
* For user schemas, look at table and query names when validating lookups
