### PR TITLE
Issue 49835: Assay import workflow task isn't set when assay is "import in background"

### DIFF
--- a/api/src/org/labkey/api/assay/pipeline/AssayUploadPipelineJob.java
+++ b/api/src/org/labkey/api/assay/pipeline/AssayUploadPipelineJob.java
@@ -140,6 +140,7 @@ public class AssayUploadPipelineJob<ProviderType extends AssayProvider> extends 
             // Create the basic run
             _run = AssayService.get().createExperimentRun(_context.getName(), getContainer(), _context.getProtocol(), _primaryFile);
             _run.setComments(_context.getComments());
+            _run.setWorkflowTaskId(_context.getWorkflowTask());
             // remember which job created the run so we can show this run on the job details page
             _run.setJobId(PipelineService.get().getJobId(getUser(), getContainer(), getJobGUID()));
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49835

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1443

#### Changes
- set run workflowTaskId on import of assay from background job
