### PR TITLE
Separate the execution plan from the SQL a bit more

### DIFF
--- a/api/src/org/labkey/api/data/queryprofiler/QueryProfiler.java
+++ b/api/src/org/labkey/api/data/queryprofiler/QueryProfiler.java
@@ -454,7 +454,7 @@ public class QueryProfiler
             view = new HtmlView(
                 DOM.DIV(
                     DOM.DIV(copyToClipboardLink("copyToClipboard", "executionPlan")),
-                    DOM.PRE(DOM.at(DOM.Attribute.id, "executionPlan"), sqlWithParameters, fullPlan),
+                    DOM.PRE(DOM.at(DOM.Attribute.id, "executionPlan"), sqlWithParameters, "\n\n", fullPlan),
                     DOM.SCRIPT(HtmlString.unsafe("new Clipboard('#copyToClipboard');"))
                 )
             );


### PR DESCRIPTION
#### Rationale
We often show the SQL and execution plan on back-to-back lines in the Admin Console's Queries page. They're different things, so it's nice to have a little separation.

#### Changes
* Two beautiful newlines