### PR TITLE
Issue 49681: Change ancestor columns to show a maximum lineage depth of 20 instead of 10

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -76,7 +76,7 @@ public class ClosureQueryHelper
     }
 
     // N.B., This should be twice the number of generations we expect as a maximum number of ancestors due to the run nodes.
-    static final int MAX_LINEAGE_LOOKUP_DEPTH = 20;
+    static final int MAX_LINEAGE_LOOKUP_DEPTH = 40;
 
     static String pgClosureCTE = String.format("""
             WITH RECURSIVE CTE_ AS (


### PR DESCRIPTION
#### Rationale
We want to be able to capture additional lineage depth in the ancestor columns and a depth of 20 is currently reasonable for know client use cases.

#### Changes
- Increase depth of lineage for Ancestor closure query table.
