### PR TITLE
49907: Assay plate support no longer working for non LKB folders

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1799,7 +1799,7 @@ public class PlateManager implements PlateService
     {
         Domain domain = getPlateMetadataDomain(container, user);
         if (domain == null)
-            throw new IllegalArgumentException("Failed to get plate custom fields. Custom fields domain does not exist. Try creating fields first.");
+            return Collections.emptyList();
 
         SQLFragment sql = new SQLFragment("SELECT PropertyURI FROM ").append(AssayDbSchema.getInstance().getTableInfoPlateProperty(), "PP")
                 .append(" WHERE PlateId = ?").add(plateId);


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49907)

We only ensure the plate metadata domain exists in LKB folders. It's fine if it doesn't exist so this just relaxes that requirement so the legacy plate metadata support still works on LKS.