### PR TITLE
Issue 49926: Commit task leak during large ETLs

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -2548,6 +2548,7 @@ public class DbScope
                 getConnection().commit();
                 _caches.clear();
                 CommitTaskOption.POSTCOMMIT.run(this);
+                clearCommitTasks();
             }
             catch (SQLException e)
             {


### PR DESCRIPTION
#### Rationale
During a large ETL that commits in batches, we're accumulating CommitTasks that both leak memory and cause a tremendous amount of work clearing and repopulating caches for the same values over and over and over.

#### Changes
- Clear the commit tasks after we've run them during the batch's commit