### PR TITLE
Check access for dataset change notifications

### DIFF
--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -3770,6 +3770,8 @@ public class ReportsController extends SpringActionController
 
                     for (Dataset ds : datasetList)
                     {
+                        if (!ds.hasPermission(getUser(), ReadPermission.class))
+                            continue;
                         datasets.add(Map.of("label", ds.getLabel(),
                                 "rowid", ds.getDatasetId(),
                                 "subscribed", getSubscribed(ReportContentEmailManager.NotifyOption.DATASET, ds.getDatasetId())));


### PR DESCRIPTION
[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49635)

#### Rationale
Need to do an additional access check for datasets in case study level security has been configured for the study. Currently the notification provider is only checking for container level access.