### PR TITLE
Prevent login form from posting

### DIFF
--- a/core/resources/views/login.html
+++ b/core/resources/views/login.html
@@ -20,7 +20,7 @@
         </div>
         <input type="hidden" name="termsOfUseType" id="termsOfUseType">
         <div class="auth-item auth-credentials-submit">
-            <!-- Note: login.js attaches an authenticateUser() click event to elements with class "loginSubmitButton" -->
+            <!-- Note: login.js attaches an authenticateUser() click event to elements with classes "loginSubmitButton" and "signin-btn" -->
             <input type="submit" tabindex="-1" class="loginSubmitButton"/>
             <a tabindex="5" class="labkey-button primary signin-btn"><span>Sign In</span></a>
             <span class="registrationSection" hidden>

--- a/core/webapp/login.js
+++ b/core/webapp/login.js
@@ -68,6 +68,8 @@
                 }
             }, this)
         });
+
+        return false;
     }
 
     function setSubmitting(isSubmitting, errors) {


### PR DESCRIPTION
#### Rationale
Related pull request removed `action="javascript:void(0)"` from all login page `<form>` elements. That seems to have broken the use of `Enter` on the login form. I believe after that change, `authenticateUser()` was issuing an AJAX post to the login action AND the form was posting to the action, which interfered with the AJAX post and generated a CSRF error. Returning `false` blocks the form post.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5334