### PR TITLE
Turn off JDBC caching when requesting an uncached result set

### DIFF
--- a/api/src/org/labkey/api/data/ConnectionWrapper.java
+++ b/api/src/org/labkey/api/data/ConnectionWrapper.java
@@ -16,7 +16,6 @@
 
 package org.labkey.api.data;
 
-import org.apache.commons.collections.map.MultiValueMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -910,9 +909,14 @@ public class ConnectionWrapper implements java.sql.Connection
         super.finalize();
     }
 
-    public void configureToDisableJdbcCaching(SQLFragment sql) throws SQLException
+    public Closer getRunOnClose()
     {
-        _runOnClose = _scope.getSqlDialect().configureToDisableJdbcCaching(this, _scope, sql);
+        return _runOnClose;
+    }
+
+    public void setRunOnClose(Closer runOnClose)
+    {
+        _runOnClose = runOnClose;
     }
 
     @Override

--- a/api/src/org/labkey/api/data/DatabaseCache.java
+++ b/api/src/org/labkey/api/data/DatabaseCache.java
@@ -395,7 +395,7 @@ public class DatabaseCache<K, V> implements Cache<K, V>
             }
 
             @Override
-            protected ConnectionWrapper getPooledConnection(ConnectionType type, Logger log)
+            public ConnectionWrapper getPooledConnection(ConnectionType type, Logger log)
             {
                 return new ConnectionWrapper(null, null, null, type, log)
                 {

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -16,6 +16,8 @@
 package org.labkey.api.data;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
@@ -61,8 +63,6 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.ServletException;
 import javax.sql.DataSource;
 import java.io.File;
 import java.io.IOException;
@@ -76,7 +76,26 @@ import java.sql.Driver;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Random;
+import java.util.RandomAccess;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -1275,7 +1294,7 @@ public class DbScope
 
     private static final int spidUnknown = -1;
 
-    protected ConnectionWrapper getPooledConnection(ConnectionType type, @Nullable Logger log) throws SQLException
+    public ConnectionWrapper getPooledConnection(ConnectionType type, @Nullable Logger log) throws SQLException
     {
         Connection conn;
 

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -2770,7 +2770,7 @@ public class QueryServiceImpl implements QueryService
         @Override
         public Results select(@Nullable Map<String, Object> parameters, boolean cache)
         {
-            SqlSelector selector = buildSqlSelector(parameters);
+            SqlSelector selector = buildSqlSelector(parameters).setJdbcCaching(cache);
             ResultSet rs = selector.getResultSet(cache, cache);
 
             // Keep track of whether we've successfully created the ResultSetImpl to return. If not, we should


### PR DESCRIPTION
#### Rationale
We're still seeing out-of-memory errors while exporting audit log rows. We previously instructed `QueryService` not to cache, but that didn't turn off PostgreSQL JDBC caching.

A simple change to `QueryServiceImpl.select()` (`cache == false` implies turn off JDBC caching) exposed some bad logic in `SqlExecutingSelector`: in short, it would happily use a new connection from the pool even when a transaction was active. (Issue indexing, I don't know why you turned off caching for a single issue select, but thank you for blowing up.) Pushing all the JDBC caching logic into the PostgreSQL dialect allows us to check all the conditions in one place and get a new connection only when we're really sure about it. Also, we don't need so many dialect methods and classes worrying about this very PostgreSQL-specific concept.

#### Related Pull Requests
- https://github.com/LabKey/professional/pull/21
