### PR TITLE
ExpMaterialTable: consistent initialization

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -574,7 +574,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     ExpExperimentTable createExperimentTable(String name, UserSchema schema, ContainerFilter cf);
 
-    ExpMaterialTable createMaterialTable(String name, UserSchema schema, ContainerFilter cf);
+    ExpMaterialTable createMaterialTable(String name, UserSchema schema, ContainerFilter cf, @Nullable ExpSampleType sampleType);
 
     ExpMaterialInputTable createMaterialInputTable(String name, ExpSchema expSchema, ContainerFilter cf);
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -151,7 +151,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     ExpObject findObjectFromLSID(String lsid);
 
     @Nullable
-    ExpRun getExpRun(int rowid);
+    ExpRun getExpRun(int rowId);
 
     List<? extends ExpRun> getExpRuns(Collection<Integer> rowIds);
 
@@ -182,12 +182,12 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     void syncRunEdges(Collection<ExpRun> runs);
 
-    ExpData getExpData(int rowid);
+    ExpData getExpData(int rowId);
 
     ExpData getExpData(String lsid);
 
     @NotNull
-    List<? extends ExpData> getExpDatas(int... rowid);
+    List<? extends ExpData> getExpDatas(int... rowIds);
 
     @NotNull
     List<? extends ExpData> getExpDatasByLSID(Collection<String> lsids);
@@ -338,10 +338,10 @@ public interface ExperimentService extends ExperimentRunTypeSource
     ExpMaterial createExpMaterial(Container container, String lsid, String name);
 
     @Nullable
-    ExpMaterial getExpMaterial(int rowid);
+    ExpMaterial getExpMaterial(int rowId);
 
     @Nullable
-    ExpMaterial getExpMaterial(int rowid, ContainerFilter containerFilter);
+    ExpMaterial getExpMaterial(int rowId, ContainerFilter containerFilter);
 
     /**
      * Get material by rowId in this, project, or shared container and within the provided sample type.
@@ -505,7 +505,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     }
 
     /**
-     * Find all child and grandchild samples Samples that are direct descendants of <code>start</code> ExpData,
+     * Find all child and grandchild samples that are direct descendants of <code>start</code> ExpData,
      * ignoring any sample children derived from ExpData children.
      */
     Set<ExpMaterial> getRelatedChildSamples(Container c, User user, ExpData start);
@@ -544,7 +544,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     ExpLineage getLineage(Container c, User user, @NotNull Identifiable start, @NotNull ExpLineageOptions options);
 
     @NotNull
-    public SQLFragment generateExperimentTreeSQL(SQLFragment lsidsFrag, ExpLineageOptions options);
+    SQLFragment generateExperimentTreeSQL(SQLFragment lsidsFrag, ExpLineageOptions options);
 
     /**
      * The following methods return TableInfo's suitable for using in queries.
@@ -574,7 +574,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     ExpExperimentTable createExperimentTable(String name, UserSchema schema, ContainerFilter cf);
 
-    ExpMaterialTable createMaterialTable(String name, UserSchema schema, ContainerFilter cf, @Nullable ExpSampleType sampleType);
+    ExpMaterialTable createMaterialTable(UserSchema schema, ContainerFilter cf, @Nullable ExpSampleType sampleType);
 
     ExpMaterialInputTable createMaterialInputTable(String name, ExpSchema expSchema, ContainerFilter cf);
 
@@ -780,20 +780,31 @@ public interface ExperimentService extends ExperimentRunTypeSource
      * @param log             output log target
      * @param loadDataFiles   When true, the files associated with <code>inputDatas</code> and <code>transformedDatas</code> will be loaded by their associated data handler.
      */
-    ExpRun saveSimpleExperimentRun(ExpRun run, Map<? extends ExpMaterial, String> inputMaterials, Map<? extends ExpData, String> inputDatas, Map<ExpMaterial, String> outputMaterials, Map<ExpData, String> outputDatas, Map<ExpData, String> transformedDatas, ViewBackgroundInfo info, Logger log, boolean loadDataFiles) throws ExperimentException;
+    ExpRun saveSimpleExperimentRun(
+        ExpRun run,
+        Map<? extends ExpMaterial, String> inputMaterials,
+        Map<? extends ExpData, String> inputDatas,
+        Map<ExpMaterial, String> outputMaterials,
+        Map<ExpData, String> outputDatas,
+        Map<ExpData, String> transformedDatas,
+        ViewBackgroundInfo info,
+        Logger log,
+        boolean loadDataFiles
+    ) throws ExperimentException;
 
-    ExpRun saveSimpleExperimentRun(ExpRun run,
-                                   Map<? extends ExpMaterial, String> inputMaterials,
-                                   Map<? extends ExpData, String> inputDatas,
-                                   Map<ExpMaterial, String> outputMaterials,
-                                   Map<ExpData, String> outputDatas,
-                                   Map<ExpData, String> transformedDatas,
-                                   ViewBackgroundInfo info,
-                                   Logger log,
-                                   boolean loadDataFiles,
-                                   @Nullable Set<String> runInputLsids,
-                                   @Nullable Set<Pair<String, String>> finalOutputLsids)
-            throws ExperimentException;
+    ExpRun saveSimpleExperimentRun(
+        ExpRun run,
+        Map<? extends ExpMaterial, String> inputMaterials,
+        Map<? extends ExpData, String> inputDatas,
+        Map<ExpMaterial, String> outputMaterials,
+        Map<ExpData, String> outputDatas,
+        Map<ExpData, String> transformedDatas,
+        ViewBackgroundInfo info,
+        Logger log,
+        boolean loadDataFiles,
+        @Nullable Set<String> runInputLsids,
+        @Nullable Set<Pair<String, String>> finalOutputLsids
+    ) throws ExperimentException;
 
     /**
      * Adds an extra protocol application to a run created by saveSimpleExperimentRun() to track more complex
@@ -807,10 +818,14 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     ExpRun deriveSamples(Map<ExpMaterial, String> inputMaterials, Map<ExpMaterial, String> outputMaterials, ViewBackgroundInfo info, Logger log) throws ExperimentException, ValidationException;
 
-    ExpRun derive(Map<? extends ExpMaterial, String> inputMaterials, Map<? extends ExpData, String> inputDatas,
-                  Map<ExpMaterial, String> outputMaterials, Map<ExpData, String> outputDatas,
-                  ViewBackgroundInfo info, Logger log)
-            throws ExperimentException, ValidationException;
+    ExpRun derive(
+        Map<? extends ExpMaterial, String> inputMaterials,
+        Map<? extends ExpData, String> inputDatas,
+        Map<ExpMaterial, String> outputMaterials,
+        Map<ExpData, String> outputDatas,
+        ViewBackgroundInfo info,
+        Logger log
+    ) throws ExperimentException, ValidationException;
 
     void deriveSamplesBulk(List<? extends SimpleRunRecord> runRecords, ViewBackgroundInfo info, Logger log) throws ExperimentException, ValidationException;
 

--- a/api/src/org/labkey/api/exp/query/ExpMaterialTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpMaterialTable.java
@@ -18,15 +18,10 @@ package org.labkey.api.exp.query;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.UpdateableTableInfo;
-import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpSampleType;
-
-import java.util.Set;
 
 public interface ExpMaterialTable extends ExpTable<ExpMaterialTable.Column>, UpdateableTableInfo
 {
-    void setMaterials(Set<ExpMaterial> predecessorMaterials);
-
     enum Column
     {
         Alias,
@@ -70,9 +65,4 @@ public interface ExpMaterialTable extends ExpTable<ExpMaterialTable.Column>, Upd
     }
 
     void populate(@Nullable ExpSampleType st);
-
-    // the filter parameter is left-over from pre-materialized table days and is not needed
-    // TODO : find usages in modules outside of the platform module
-    @Deprecated void setSampleType(ExpSampleType st, boolean filter);
-    void setSampleType(ExpSampleType st);
 }

--- a/api/src/org/labkey/api/exp/query/ExpMaterialTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpMaterialTable.java
@@ -16,9 +16,7 @@
 
 package org.labkey.api.exp.query;
 
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.UpdateableTableInfo;
-import org.labkey.api.exp.api.ExpSampleType;
 
 public interface ExpMaterialTable extends ExpTable<ExpMaterialTable.Column>, UpdateableTableInfo
 {
@@ -63,6 +61,4 @@ public interface ExpMaterialTable extends ExpTable<ExpMaterialTable.Column>, Upd
         StoredAmount,
         Units,
     }
-
-    void populate(@Nullable ExpSampleType st);
 }

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -121,8 +121,7 @@ public class ExpSchema extends AbstractExpSchema
             public TableInfo createTable(ExpSchema expSchema, String queryName, ContainerFilter cf)
             {
                 ExpMaterialTable ret = ExperimentService.get().createMaterialTable(expSchema, cf, null);
-                ret.populate(null);
-                return ret;
+                return expSchema.setupTable(ret);
             }
         },
         MaterialInputs

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -120,7 +120,7 @@ public class ExpSchema extends AbstractExpSchema
             @Override
             public TableInfo createTable(ExpSchema expSchema, String queryName, ContainerFilter cf)
             {
-                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), expSchema, cf);
+                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), expSchema, cf, null);
                 ret.populate(null);
                 return ret;
             }

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -120,7 +120,7 @@ public class ExpSchema extends AbstractExpSchema
             @Override
             public TableInfo createTable(ExpSchema expSchema, String queryName, ContainerFilter cf)
             {
-                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), expSchema, cf, null);
+                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(expSchema, cf, null);
                 ret.populate(null);
                 return ret;
             }

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -177,10 +177,9 @@ public class SamplesSchema extends AbstractExpSchema
     public ExpMaterialTable createSampleTable(@Nullable ExpSampleType st, ContainerFilter cf)
     {
         if (log.isTraceEnabled())
-        {
             log.trace("CREATE TABLE: " + (null==st ? "null" : st.getName()) + " schema=" + System.identityHashCode(this), new Throwable());
-        }
-        ExpMaterialTable ret = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), this, cf);
+
+        ExpMaterialTable ret = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), this, cf, null);
         ret.populate(st);
         return ret;
     }
@@ -210,8 +209,7 @@ public class SamplesSchema extends AbstractExpSchema
 
             private TableInfo createLookupTableInfo()
             {
-                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(tableName, SamplesSchema.this, null);
-                ret.populate(st);
+                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(tableName, SamplesSchema.this, null, st);
                 ret.setContainerFilter(getLookupContainerFilter());
                 ret.overlayMetadata(ret.getPublicName(), SamplesSchema.this, new ArrayList<>());
                 if (domainProperty != null && domainProperty.getPropertyType().getJdbcType().isText())

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -179,7 +179,7 @@ public class SamplesSchema extends AbstractExpSchema
         if (log.isTraceEnabled())
             log.trace("CREATE TABLE: " + (null==st ? "null" : st.getName()) + " schema=" + System.identityHashCode(this), new Throwable());
 
-        ExpMaterialTable ret = ExperimentService.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), this, cf, null);
+        ExpMaterialTable ret = ExperimentService.get().createMaterialTable(this, cf, null);
         ret.populate(st);
         return ret;
     }
@@ -194,7 +194,7 @@ public class SamplesSchema extends AbstractExpSchema
 
     public ForeignKey materialIdForeignKey(@Nullable final ExpSampleType st, @Nullable DomainProperty domainProperty, @Nullable ContainerFilter cfParent)
     {
-        final String tableName =  null == st ? ExpSchema.TableType.Materials.toString() : st.getName();
+        final String tableName = null == st ? ExpSchema.TableType.Materials.toString() : st.getName();
         final String schemaName = null == st ? ExpSchema.SCHEMA_NAME : SamplesSchema.SCHEMA_NAME;
 
         return new LookupForeignKey(null, null, schemaName, tableName, "RowId", null)
@@ -209,8 +209,7 @@ public class SamplesSchema extends AbstractExpSchema
 
             private TableInfo createLookupTableInfo()
             {
-                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(tableName, SamplesSchema.this, null, st);
-                ret.setContainerFilter(getLookupContainerFilter());
+                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(SamplesSchema.this, getLookupContainerFilter(), st);
                 ret.overlayMetadata(ret.getPublicName(), SamplesSchema.this, new ArrayList<>());
                 if (domainProperty != null && domainProperty.getPropertyType().getJdbcType().isText())
                 {

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -209,7 +209,8 @@ public class SamplesSchema extends AbstractExpSchema
 
             private TableInfo createLookupTableInfo()
             {
-                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(SamplesSchema.this, getLookupContainerFilter(), st);
+                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(SamplesSchema.this, getLookupContainerFilter(), null);
+                ret.populate(st);
                 ret.overlayMetadata(ret.getPublicName(), SamplesSchema.this, new ArrayList<>());
                 if (domainProperty != null && domainProperty.getPropertyType().getJdbcType().isText())
                 {

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -153,7 +153,7 @@ public class SamplesSchema extends AbstractExpSchema
     }
 
     @Override
-    public QueryView createView(ViewContext context, @NotNull QuerySettings settings, BindException errors)
+    public @NotNull QueryView createView(ViewContext context, @NotNull QuerySettings settings, BindException errors)
     {
         QueryView queryView = super.createView(context, settings, errors);
 
@@ -179,8 +179,8 @@ public class SamplesSchema extends AbstractExpSchema
         if (log.isTraceEnabled())
             log.trace("CREATE TABLE: " + (null==st ? "null" : st.getName()) + " schema=" + System.identityHashCode(this), new Throwable());
 
-        ExpMaterialTable ret = ExperimentService.get().createMaterialTable(this, cf, null);
-        ret.populate(st);
+        ExpMaterialTable ret = ExperimentService.get().createMaterialTable(this, cf, st);
+        ret.populate();
         return ret;
     }
 
@@ -209,8 +209,8 @@ public class SamplesSchema extends AbstractExpSchema
 
             private TableInfo createLookupTableInfo()
             {
-                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(SamplesSchema.this, getLookupContainerFilter(), null);
-                ret.populate(st);
+                ExpMaterialTable ret = ExperimentService.get().createMaterialTable(SamplesSchema.this, getLookupContainerFilter(), st);
+                ret.populate();
                 ret.overlayMetadata(ret.getPublicName(), SamplesSchema.this, new ArrayList<>());
                 if (domainProperty != null && domainProperty.getPropertyType().getJdbcType().isText())
                 {

--- a/experiment/src/org/labkey/experiment/ParentChildView.java
+++ b/experiment/src/org/labkey/experiment/ParentChildView.java
@@ -225,8 +225,8 @@ public class ParentChildView extends VBox
             protected TableInfo createTable()
             {
                 // Use ContainerFilter.EVERYTHING - We've already set an IN clause that restricts us to showing just data that we have permission to view
-                ExpMaterialTable table = ExperimentServiceImpl.get().createMaterialTable(getSchema(), ContainerFilter.EVERYTHING, null);
-                table.populate(st);
+                ExpMaterialTable table = ExperimentServiceImpl.get().createMaterialTable(getSchema(), ContainerFilter.EVERYTHING, st);
+                table.populate();
 
                 List<FieldKey> defaultVisibleColumns = new ArrayList<>();
                 if (st == null)

--- a/experiment/src/org/labkey/experiment/ParentChildView.java
+++ b/experiment/src/org/labkey/experiment/ParentChildView.java
@@ -225,7 +225,7 @@ public class ParentChildView extends VBox
             protected TableInfo createTable()
             {
                 // Use ContainerFilter.EVERYTHING - We've already set an IN clause that restricts us to showing just data that we have permission to view
-                ExpMaterialTable table = ExperimentServiceImpl.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), getSchema(), ContainerFilter.EVERYTHING, null);
+                ExpMaterialTable table = ExperimentServiceImpl.get().createMaterialTable(getSchema(), ContainerFilter.EVERYTHING, null);
                 table.populate(st);
 
                 List<FieldKey> defaultVisibleColumns = new ArrayList<>();

--- a/experiment/src/org/labkey/experiment/ParentChildView.java
+++ b/experiment/src/org/labkey/experiment/ParentChildView.java
@@ -50,12 +50,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-/**
- * User: kevink
- * Date: 10/20/15
- */
 public class ParentChildView extends VBox
 {
     public ParentChildView(ExpRunItem output, ViewContext context)
@@ -127,8 +122,7 @@ public class ParentChildView extends VBox
             }
         }
 
-        final List<Integer> rowIds = data.stream().map(ExpData::getRowId).collect(Collectors.toList());
-
+        final List<Integer> rowIds = data.stream().map(ExpData::getRowId).toList();
         final ExpDataClass dataClass = classId == null ? null : ExperimentServiceImpl.get().getDataClass(classId);
 
         UserSchema schema = new ExpSchema(getUser(), getContainer());
@@ -136,13 +130,13 @@ public class ParentChildView extends VBox
         if (dataClass == null)
         {
             settings = schema.getSettings(getViewContext(), dataRegionName, ExpSchema.TableType.Data.toString());
-            settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts("rowId"), rowIds, CompareType.IN));
+            settings.setBaseFilter(new SimpleFilter(FieldKey.fromParts(ExpDataTable.Column.RowId), rowIds, CompareType.IN));
         }
         else
         {
             schema = schema.getUserSchema(ExpSchema.NestedSchemas.data.toString());
             settings = schema.getSettings(getViewContext(), dataRegionName, dataClass.getName());
-            settings.getBaseFilter().addClause(new SimpleFilter.InClause(FieldKey.fromParts("rowId"), rowIds));
+            settings.getBaseFilter().addInClause(FieldKey.fromParts(ExpDataTable.Column.RowId), rowIds);
         }
 
         QueryView queryView = new QueryView(schema, settings, null);
@@ -222,14 +216,16 @@ public class ParentChildView extends VBox
             settings = schema.getSettings(getViewContext(), dataRegionName, st.getName());
         }
 
+        final List<Integer> rowIds = materials.stream().map(ExpMaterial::getRowId).toList();
+        settings.getBaseFilter().addInClause(FieldKey.fromParts(ExpMaterialTable.Column.RowId), rowIds);
+
         QueryView queryView = new QueryView(schema, settings, null)
         {
             @Override
             protected TableInfo createTable()
             {
                 // Use ContainerFilter.EVERYTHING - We've already set an IN clause that restricts us to showing just data that we have permission to view
-                ExpMaterialTable table = ExperimentServiceImpl.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), getSchema(), ContainerFilter.EVERYTHING);
-                table.setMaterials(materials);
+                ExpMaterialTable table = ExperimentServiceImpl.get().createMaterialTable(ExpSchema.TableType.Materials.toString(), getSchema(), ContainerFilter.EVERYTHING, null);
                 table.populate(st);
 
                 List<FieldKey> defaultVisibleColumns = new ArrayList<>();

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -532,6 +532,12 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         {
             setPublicSchemaName(SamplesSchema.SCHEMA_NAME);
             setName(st.getName());
+
+            String description = _ss.getDescription();
+            if (StringUtils.isEmpty(description))
+                description = "Contains one row per sample in the " + _ss.getName() + " sample type";
+            setDescription(description);
+
             if (canUserAccessPhi())
             {
                 ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getImportSamplesURL(getContainer(), _ss.getName());
@@ -548,33 +554,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     @Override
     protected void populateColumns()
     {
-        populate(null);
-    }
-
-    @Override
-    public final void populate(@Nullable ExpSampleType st)
-    {
-        populateColumns(st);
-        markPopulated();
-    }
-
-    protected void populateColumns(@Nullable ExpSampleType st)
-    {
-        if (st != null)
-        {
-            if (st.getDescription() != null)
-            {
-                setDescription(st.getDescription());
-            }
-            else
-            {
-                setDescription("Contains one row per sample in the " + st.getName() + " sample type");
-            }
-
-            if (!"urn:lsid:labkey.com:SampleSource:Default".equals(st.getDomain().getTypeURI()))
-                setSampleType(st);
-        }
-
+        var st = getSampleType();
         var rowIdCol = addColumn(Column.RowId);
         addColumn(Column.MaterialSourceId);
         addColumn(Column.SourceProtocolApplication);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -73,7 +73,6 @@ import org.labkey.api.security.permissions.MoveEntitiesPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
@@ -112,11 +111,11 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     public static final Set<String> MATERIAL_ALT_MERGE_KEYS;
     public static final Set<String> MATERIAL_ALT_UPDATE_KEYS;
     static {
-        MATERIAL_ALT_MERGE_KEYS = new HashSet<>(Arrays.asList(Column.MaterialSourceId.name(), Column.Name.name()));
-        MATERIAL_ALT_UPDATE_KEYS = new HashSet<>(Arrays.asList(Column.LSID.name()));
+        MATERIAL_ALT_MERGE_KEYS = Set.of(Column.MaterialSourceId.name(), Column.Name.name());
+        MATERIAL_ALT_UPDATE_KEYS = Set.of(Column.LSID.name());
     }
 
-    public ExpMaterialTableImpl(String name, UserSchema schema, ContainerFilter cf)
+    public ExpMaterialTableImpl(String name, UserSchema schema, ContainerFilter cf, @Nullable ExpSampleType sampleType)
     {
         super(name, ExperimentServiceImpl.get().getTinfoMaterial(), schema, cf);
         setDetailsURL(new DetailsURL(new ActionURL(ExperimentController.ShowMaterialAction.class, schema.getContainer()), Collections.singletonMap("rowId", "rowId"), NullResult));
@@ -126,6 +125,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         addAllowablePermission(UpdatePermission.class);
         addAllowablePermission(MoveEntitiesPermission.class);
         setAllowedInsertOption(QueryUpdateService.InsertOption.MERGE);
+        setSampleType(sampleType);
     }
 
     public Set<String> getUniqueIdFields()
@@ -174,10 +174,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             // Special case sample auditing to help build a useful timeline view
             return SampleTypeServiceImpl.get();
         }
-        else
-        {
-            return super.getAuditHandler(auditBehaviorType);
-        }
+
+        return super.getAuditHandler(auditBehaviorType);
     }
 
     @Override
@@ -523,15 +521,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         return ret;
     }
 
-    @Deprecated
-    public void setSampleType(ExpSampleType st, boolean filter)
-    {
-        assert( null == st || filter);
-        setSampleType(st);
-    }
-
-    @Override
-    public void setSampleType(ExpSampleType st)
+    private void setSampleType(@Nullable ExpSampleType st)
     {
         checkLocked();
         if (_ss != null)
@@ -561,30 +551,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     }
 
     @Override
-    public void setMaterials(Set<ExpMaterial> materials)
-    {
-        checkLocked();
-        if (materials.isEmpty())
-        {
-            addCondition(new SQLFragment("1 = 2"));
-        }
-        else
-        {
-            SQLFragment sql = new SQLFragment();
-            sql.append("RowId IN (");
-            String separator = "";
-            for (ExpMaterial material : materials)
-            {
-                sql.append(separator);
-                separator = ", ";
-                sql.appendValue(material.getRowId());
-            }
-            sql.append(")");
-            addCondition(sql);
-        }
-    }
-
-    @Override
     protected void populateColumns()
     {
         populate(null);
@@ -594,7 +560,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     public final void populate(@Nullable ExpSampleType st)
     {
         populateColumns(st);
-        _populated = true;
+        markPopulated();
     }
 
     protected void populateColumns(@Nullable ExpSampleType st)
@@ -657,7 +623,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             {
                 // Be sure that we can resolve the sample type if it's defined in a separate container.
                 // Same as CurrentPlusProjectAndShared but includes SampleSet's container as well.
-                // Issue 37982: Sample Type: Link to precursor sample type does not resolve correctly if sample has parents in current sample type and a sample type in the parent container
+                // Issue 37982: Sample Type: Link to precursor sample type does not resolve correctly if sample has
+                // parents in current sample type and a sample type in the parent container
                 Set<Container> containers = new HashSet<>();
                 if (null != st)
                     containers.add(st.getContainer());
@@ -817,7 +784,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         if (InventoryService.get() != null && (st == null || !st.isMedia()))
             defaultCols.addAll(InventoryService.get().addInventoryStatusColumns(st == null ? null : st.getMetricUnit(), this, getContainer(), _userSchema.getUser()));
 
-
         addVocabularyDomains();
         addColumn(Column.Properties);
 
@@ -864,7 +830,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     private ContainerFilter getSampleStatusLookupContainerFilter()
     {
         // The default lookup container filter is Current, but we want to have the default be CurrentPlusProjectAndShared
-        // for the sample status lookup since in the app project context we want to share status definitions accross
+        // for the sample status lookup since in the app project context we want to share status definitions across
         // a given project instead of creating duplicate statuses in each subfolder project.
         ContainerFilter.Type type = QueryService.get().getContainerFilterTypeForLookups(getContainer());
         type = type == null ? ContainerFilter.Type.CurrentPlusProjectAndShared : type;
@@ -883,7 +849,8 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             return currentDescription;
 
         StringBuilder sb = new StringBuilder();
-        if (currentDescription != null && !currentDescription.isEmpty()) {
+        if (currentDescription != null && !currentDescription.isEmpty())
+        {
             sb.append(currentDescription);
             if (!currentDescription.endsWith("."))
                 sb.append(".");
@@ -965,7 +932,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                     propColumn.setDisplayColumnFactory(new IdColumnRendererFactory());
                 }
 
-                //fix for Issue 38341: domain designer advanced settings 'show in default view' setting is not respected
+                // Issue 38341: domain designer advanced settings 'show in default view' setting is not respected
                 if (!propColumn.isHidden())
                 {
                     visibleColumns.add(propColumn.getFieldKey());
@@ -997,7 +964,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         setDefaultVisibleColumns(visibleColumns);
     }
 
-
     // These are mostly fields that are wrapped by fields with different names (see createColumn())
     // we could handle each case separately, but this is easier
     static final Set<FieldKey> wrappedFieldKeys = Set.of(
@@ -1009,8 +975,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             new FieldKey(null, "CpasType"));            // SampleSet
     static final Set<FieldKey> ALL_COLUMNS = Set.of();
 
-
-    @NotNull Set<FieldKey> computeInnerSelectedColumns(Set<FieldKey> selectedColumns)
+    private @NotNull Set<FieldKey> computeInnerSelectedColumns(Set<FieldKey> selectedColumns)
     {
         if (null == selectedColumns)
             return ALL_COLUMNS;
@@ -1066,12 +1031,9 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         return sql;
     }
 
-
     static final BlockingCache<String,MaterializedQueryHelper> _materializedQueries = CacheManager.getBlockingStringKeyCache(CacheManager.UNLIMITED, CacheManager.HOUR, "materialized sample types", null);
     static final Map<String, AtomicLong> _invalidationCounters = Collections.synchronizedMap(new HashMap<>());
     static final AtomicBoolean initializedListeners = new AtomicBoolean(false);
-
-
 
     // used by SampleTypeServiceImpl.refreshSampleTypeMaterializedView()
     public static void refreshMaterializedView(final String lsid, boolean schemaChange)
@@ -1108,7 +1070,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
     }
 
-
     private static AtomicLong getInvalidateCounter(String lsid)
     {
         if (!initializedListeners.getAndSet(true))
@@ -1119,7 +1080,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 new AtomicLong(System.currentTimeMillis())
         );
     }
-
 
     /* SELECT and JOIN, does not include WHERE, same as getJoinSQL() */
     private SQLFragment getMaterializedSQL()
@@ -1149,7 +1109,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         return new SQLFragment("SELECT * FROM ").append(mqh.getFromSql("_cached_view_"));
     }
 
-
     /* SELECT and JOIN, does not include WHERE */
     private SQLFragment getJoinSQL(Set<FieldKey> selectedColumns)
     {
@@ -1167,7 +1126,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         selectedColumns = computeInnerSelectedColumns(selectedColumns);
 
         SQLFragment sql = new SQLFragment();
-        sql.appendComment("<ExpMaterialTableImpl.getJoinSQL(" + (null==_ss ? "" : _ss.getName()) + ")>", getSqlDialect());
+        sql.appendComment("<ExpMaterialTableImpl.getJoinSQL(" + (null == _ss ? "" : _ss.getName()) + ")>", getSqlDialect());
         sql.append("SELECT ");
         String comma = "";
         for (String materialCol : materialCols)
@@ -1259,7 +1218,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         return new SampleTypeUpdateServiceDI(this, _ss);
     }
 
-
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
@@ -1269,24 +1227,22 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             // Don't allow insert/update on exp.Materials without a sample type.
             if (perm == DeletePermission.class || perm == ReadPermission.class)
                 return getContainer().hasPermission(user, perm);
-            else
-                return false;
+            return false;
         }
-        else
-        {
-            if (_ss.isMedia() && perm == ReadPermission.class)
-                return getContainer().hasPermission(user, MediaReadPermission.class);
-            return super.hasPermission(user, perm);
-        }
-    }
 
+        if (_ss.isMedia() && perm == ReadPermission.class)
+            return getContainer().hasPermission(user, MediaReadPermission.class);
+
+        return super.hasPermission(user, perm);
+    }
 
     @NotNull
     @Override
     public Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
     {
         // Rewrite the "idx_material_ak" unique index over "Folder", "SampleSet", "Name" to just "Name"
-        // Issue 25397: Don't include the "idx_material_ak" index if the "Name" column hasn't been added to the table.  Some FKs to ExpMaterialTable don't include the "Name" column (e.g. NabBaseTable.Specimen)
+        // Issue 25397: Don't include the "idx_material_ak" index if the "Name" column hasn't been added to the table.
+        // Some FKs to ExpMaterialTable don't include the "Name" column (e.g. NabBaseTable.Specimen)
         Map<String, Pair<IndexType, List<ColumnInfo>>> ret = new HashMap<>(super.getUniqueIndices());
         if (getColumn("Name") != null)
             ret.put("idx_material_ak", Pair.of(IndexType.Unique, Arrays.asList(getColumn("Name"))));
@@ -1379,7 +1335,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
     }
 
-
     static final Set<String> excludeFromDetailedAuditField;
     static
     {
@@ -1405,27 +1360,25 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
     @Override
     public List<Pair<String, String>> getImportTemplates(ViewContext ctx)
     {
+        // respect any metadata overrides
         if (getRawImportTemplates() != null)
-            // respect any metadata overrides
             return super.getImportTemplates(ctx);
-        else
+
+        List<Pair<String, String>> templates = new ArrayList<>();
+        ActionURL url = PageFlowUtil.urlProvider(QueryUrls.class).urlCreateExcelTemplate(ctx.getContainer(), getPublicSchemaName(), getName());
+        url.addParameter("headerType", ColumnHeaderType.DisplayFieldKey.name());
+        try
         {
-            List<Pair<String, String>> templates = new ArrayList<>();
-            ActionURL url = PageFlowUtil.urlProvider(QueryUrls.class).urlCreateExcelTemplate(ctx.getContainer(), getPublicSchemaName(), getName());
-            url.addParameter("headerType", ColumnHeaderType.DisplayFieldKey.name());
-            try
+            if (getSampleType() != null && !getSampleType().getImportAliasMap().isEmpty())
             {
-                if (getSampleType() != null && !getSampleType().getImportAliasMap().isEmpty())
-                {
-                    for (String aliasKey : getSampleType().getImportAliasMap().keySet())
-                        url.addParameter("includeColumn", aliasKey);
-                }
+                for (String aliasKey : getSampleType().getImportAliasMap().keySet())
+                    url.addParameter("includeColumn", aliasKey);
             }
-            catch (IOException e)
-            {}
-            templates.add(Pair.of("Download Template", url.toString()));
-            return templates;
         }
+        catch (IOException e)
+        {}
+        templates.add(Pair.of("Download Template", url.toString()));
+        return templates;
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -115,11 +115,10 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         MATERIAL_ALT_UPDATE_KEYS = Set.of(Column.LSID.name());
     }
 
-    public ExpMaterialTableImpl(String name, UserSchema schema, ContainerFilter cf, @Nullable ExpSampleType sampleType)
+    public ExpMaterialTableImpl(UserSchema schema, ContainerFilter cf, @Nullable ExpSampleType sampleType)
     {
-        super(name, ExperimentServiceImpl.get().getTinfoMaterial(), schema, cf);
+        super(ExpSchema.TableType.Materials.name(), ExperimentServiceImpl.get().getTinfoMaterial(), schema, cf);
         setDetailsURL(new DetailsURL(new ActionURL(ExperimentController.ShowMaterialAction.class, schema.getContainer()), Collections.singletonMap("rowId", "rowId"), NullResult));
-        setName(ExpSchema.TableType.Materials.name());
         setPublicSchemaName(ExpSchema.SCHEMA_NAME);
         addAllowablePermission(InsertPermission.class);
         addAllowablePermission(UpdatePermission.class);
@@ -145,15 +144,11 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         if (result == null)
         {
             if ("CpasType".equalsIgnoreCase(name))
-                return createColumn("SampleSet", Column.SampleSet);
-
-            if ("Property".equalsIgnoreCase(name))
-                return createPropertyColumn("Property");
-
-            if (Column.QueryableInputs.name().equalsIgnoreCase(name))
-            {
+                result = createColumn(Column.SampleSet.name(), Column.SampleSet);
+            else if (Column.Property.name().equalsIgnoreCase(name))
+                result = createPropertyColumn(Column.Property.name());
+            else if (Column.QueryableInputs.name().equalsIgnoreCase(name))
                 result = createColumn(Column.QueryableInputs.name(), Column.QueryableInputs);
-            }
         }
         return result;
     }

--- a/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
@@ -177,7 +177,6 @@ abstract public class ExpTableImpl<C extends Enum>
             }
         }
 
-
         return result;
     }
 
@@ -316,8 +315,8 @@ abstract public class ExpTableImpl<C extends Enum>
         if (perm == ReadPermission.class || getUpdateService() != null)
         {
             Set<Role> roles = null;
-            if (_userSchema instanceof UserSchema.HasContextualRoles)
-                roles = ((UserSchema.HasContextualRoles)_userSchema).getContextualRoles();
+            if (_userSchema instanceof UserSchema.HasContextualRoles contextualRolesSchema)
+                roles = contextualRolesSchema.getContextualRoles();
             return isAllowedPermission(perm) && _userSchema.getContainer().hasPermission(user, perm, roles);
         }
         return false;
@@ -367,7 +366,6 @@ abstract public class ExpTableImpl<C extends Enum>
      * Create a hidden column as a fake lookup to include all columns in the domain.
      * @param domain The domain to add columns from
      * @param lookupColName The column name
-     * @return
      */
     protected MutableColumnInfo addDomainColumns(Domain domain, @NotNull String lookupColName)
     {
@@ -396,7 +394,6 @@ abstract public class ExpTableImpl<C extends Enum>
             col.setDescription("Properties from " + domain.getLabel(getContainer()));
         }
     }
-
 
     @Override
     public Domain getDomain()

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1341,9 +1341,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public ExpMaterialTable createMaterialTable(String name, UserSchema schema, ContainerFilter cf)
+    public ExpMaterialTable createMaterialTable(String name, UserSchema schema, ContainerFilter cf, @Nullable ExpSampleType sampleType)
     {
-        return new ExpMaterialTableImpl(name, schema, cf);
+        return new ExpMaterialTableImpl(name, schema, cf, sampleType);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1341,9 +1341,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public ExpMaterialTable createMaterialTable(String name, UserSchema schema, ContainerFilter cf, @Nullable ExpSampleType sampleType)
+    public ExpMaterialTable createMaterialTable(UserSchema schema, ContainerFilter cf, @Nullable ExpSampleType sampleType)
     {
-        return new ExpMaterialTableImpl(name, schema, cf, sampleType);
+        return new ExpMaterialTableImpl(schema, cf, sampleType);
     }
 
     @Override
@@ -2798,7 +2798,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public SQLFragment generateExperimentTreeSQL(SQLFragment lsidsFrag, ExpLineageOptions options)
+    public @NotNull SQLFragment generateExperimentTreeSQL(SQLFragment lsidsFrag, ExpLineageOptions options)
     {
         SQLFragment sqlf = new SQLFragment();
         Pair<String,String> tokens = getRunGraphCommonTableExpressions(sqlf, lsidsFrag, options);
@@ -6613,7 +6613,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     public void savePropertyCollection(Map<String, ObjectProperty> propMap, String ownerLSID, Container container, boolean clearExisting) throws SQLException
     {
-        if (propMap.size() == 0)
+        if (propMap.isEmpty())
             return;
         ObjectProperty[] props = propMap.values().toArray(new ObjectProperty[0]);
         // Todo - make this more efficient - don't delete all the old ones if they're the same
@@ -6669,9 +6669,14 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     /** @return all the Data objects from this run */
-    private List<ExpData> ensureSimpleExperimentRunParameters(Collection<? extends ExpMaterial> inputMaterials,
-                                                     Collection<? extends ExpData> inputDatas, Collection<ExpMaterial> outputMaterials,
-                                                     Collection<ExpData> outputDatas, Collection<ExpData> transformedDatas, User user)
+    private @NotNull List<ExpData> ensureSimpleExperimentRunParameters(
+        Collection<? extends ExpMaterial> inputMaterials,
+        Collection<? extends ExpData> inputDatas,
+        Collection<ExpMaterial> outputMaterials,
+        Collection<ExpData> outputDatas,
+        Collection<ExpData> transformedDatas,
+        User user
+    )
     {
         // Save all the input and output objects to make sure they've been inserted
         try
@@ -6708,24 +6713,35 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public ExpRun saveSimpleExperimentRun(ExpRun run, Map<? extends ExpMaterial, String> inputMaterials, Map<? extends ExpData, String> inputDatas, Map<ExpMaterial, String> outputMaterials, Map<ExpData, String> outputDatas, Map<ExpData, String> transformedDatas, ViewBackgroundInfo info, Logger log, boolean loadDataFiles) throws ExperimentException
+    public ExpRun saveSimpleExperimentRun(
+        ExpRun run,
+        Map<? extends ExpMaterial, String> inputMaterials,
+        Map<? extends ExpData, String> inputDatas, 
+        Map<ExpMaterial, String> outputMaterials,
+        Map<ExpData, String> outputDatas, 
+        Map<ExpData, String> transformedDatas, 
+        ViewBackgroundInfo info, 
+        Logger log, 
+        boolean loadDataFiles
+    ) throws ExperimentException
     {
         return saveSimpleExperimentRun(run, inputMaterials, inputDatas, outputMaterials, outputDatas, transformedDatas, info, log, loadDataFiles, null, null);
     }
 
     @Override
-    public ExpRun saveSimpleExperimentRun(ExpRun baseRun,
-                                          Map<? extends ExpMaterial, String> inputMaterials,
-                                          Map<? extends ExpData, String> inputDatas,
-                                          Map<ExpMaterial, String> outputMaterials,
-                                          Map<ExpData, String> outputDatas,
-                                          Map<ExpData, String> transformedDatas,
-                                          ViewBackgroundInfo info,
-                                          @NotNull Logger log,
-                                          boolean loadDataFiles,
-                                          @Nullable Set<String> runInputLsids,
-                                          @Nullable Set<Pair<String, String>> finalOutputLsids)
-            throws ExperimentException
+    public ExpRun saveSimpleExperimentRun(
+        ExpRun baseRun,
+        Map<? extends ExpMaterial, String> inputMaterials,
+        Map<? extends ExpData, String> inputDatas,
+        Map<ExpMaterial, String> outputMaterials,
+        Map<ExpData, String> outputDatas,
+        Map<ExpData, String> transformedDatas,
+        ViewBackgroundInfo info,
+        @NotNull Logger log,
+        boolean loadDataFiles,
+        @Nullable Set<String> runInputLsids,
+        @Nullable Set<Pair<String, String>> finalOutputLsids
+    ) throws ExperimentException
     {
         ExpRunImpl run = (ExpRunImpl)baseRun;
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -201,7 +201,6 @@ import org.labkey.experiment.api.ExpDataClassImpl;
 import org.labkey.experiment.api.ExpDataImpl;
 import org.labkey.experiment.api.ExpExperimentImpl;
 import org.labkey.experiment.api.ExpMaterialImpl;
-import org.labkey.experiment.api.ExpMaterialTableImpl;
 import org.labkey.experiment.api.ExpProtocolApplicationImpl;
 import org.labkey.experiment.api.ExpProtocolImpl;
 import org.labkey.experiment.api.ExpRunImpl;
@@ -4016,7 +4015,15 @@ public class ExperimentController extends SpringActionController
         }
 
         @Override
-        protected int importData(DataLoader dl, FileStream file, String originalName, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent, @Nullable String auditUserComment) throws IOException
+        protected int importData(
+            DataLoader dl,
+            FileStream file,
+            String originalName,
+            BatchValidationException errors,
+            @Nullable AuditBehaviorType auditBehaviorType,
+            TransactionAuditProvider.@Nullable TransactionAuditEvent auditEvent,
+            @Nullable String auditUserComment
+        ) throws IOException
         {
             initContext(dl, errors, auditBehaviorType, auditUserComment);
 
@@ -4024,10 +4031,9 @@ public class ExperimentController extends SpringActionController
             QueryUpdateService updateService = _updateService;
             if (getOptionParamValue(Params.crossTypeImport))
             {
-                tInfo = new ExpMaterialTableImpl(ExpSchema.TableType.Materials.name(), new SamplesSchema(getUser(), getContainer()), ContainerFilter.current(getContainer()));
+                tInfo = ExperimentService.get().createMaterialTable(new SamplesSchema(getUser(), getContainer()), ContainerFilter.current(getContainer()), null);
                 updateService = tInfo.getUpdateService();
             }
-
 
             int count = importData(dl, tInfo, updateService, _context, auditEvent, getUser(), getContainer());
 


### PR DESCRIPTION
#### Rationale
Initialization of the `ExpMaterialTableImpl` is inconsistent and makes it difficult to track how/what initialized the table. This updates `ExpMaterialTable` interface to not include `populate`, `setMaterials` nor `setSampleType`. Setting materials in this way is not necessary and the single usage, `ParentChildView`, has been refactored to generate an IN clause as a base filter.

#### Related Pull Requests
- https://github.com/LabKey/commonAssays/pull/739

#### Changes
- Setting the `ExpSampleType` is now done via the constructor and consistently initialized.
- `ExpMaterialTableImpl.populate` no longer takes an `ExpSampleType` and initializes the sample type because it is done via construction.
- `ExpMaterialTableImpl.setMaterials` setting materials in this way is not necessary and the single usage, `ParentChildView`, has been refactored to generate an IN clause as a base filter.
- `ExpMaterialTableImpl` no longer accepts a name since we always want to initialize it to "Materials". Can still be set after initialization via `setName`.
- Miscellaneous nits