### PR TITLE
Plate Set Assays Page

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.32.1-fb-plate-set-assays.0"
+        "@labkey/components": "3.32.1-fb-plate-set-assays.1"
       },
       "devDependencies": {
         "@labkey/build": "7.1.0",
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
-      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
+      "version": "3.32.1-fb-plate-set-assays.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
+      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
       "dependencies": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -12919,9 +12919,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
-      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
+      "version": "3.32.1-fb-plate-set-assays.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
+      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
       "requires": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.32.1-fb-plate-set-assays.1"
+        "@labkey/components": "3.33.1"
       },
       "devDependencies": {
         "@labkey/build": "7.1.0",
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
-      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
+      "version": "3.33.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.33.1.tgz",
+      "integrity": "sha512-VycdfAjAmncKF64dXohCBX58lWgqTKYt02Ovvtptg4NazNK8ovW6WrHcgIMNtx2aQIWq/E3hX76D6T+2AvoAvg==",
       "dependencies": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -12919,9 +12919,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
-      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
+      "version": "3.33.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.33.1.tgz",
+      "integrity": "sha512-VycdfAjAmncKF64dXohCBX58lWgqTKYt02Ovvtptg4NazNK8ovW6WrHcgIMNtx2aQIWq/E3hX76D6T+2AvoAvg==",
       "requires": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.30.0"
+        "@labkey/components": "3.32.1-fb-plate-set-assays.0"
       },
       "devDependencies": {
         "@labkey/build": "7.1.0",
@@ -2402,9 +2402,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.30.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.30.0.tgz",
-      "integrity": "sha512-GyLw10GI0+aRfecK4S4a4yXRhRufWMYv/ltJIUv9LcxuuPklgr3s4twCaZDPdWG8sUDXAai+ciLJMPGPUPTnag=="
+      "version": "1.32.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.32.0.tgz",
+      "integrity": "sha512-cU9AcMuzdRKKGnazIfrVR3jPoZQ0v6dHY5YwWFDZ5FUuxUzgxY4PTIfpq7vYn10pLQCBGAJP385T5JrY83JYNA=="
     },
     "node_modules/@labkey/build": {
       "version": "7.1.0",
@@ -2443,11 +2443,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.30.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.30.0.tgz",
-      "integrity": "sha512-k/qg3Ybx9g09K36ZmJS04GEpSA07eSFBHA4QsShsAwW3Bj0KyBcUGRfNqTSl0zCmK0S9wf737bMZg+LC3vQFzg==",
+      "version": "3.32.1-fb-plate-set-assays.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
+      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
       "dependencies": {
-        "@labkey/api": "1.30.0",
+        "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -12878,9 +12878,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.30.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.30.0.tgz",
-      "integrity": "sha512-GyLw10GI0+aRfecK4S4a4yXRhRufWMYv/ltJIUv9LcxuuPklgr3s4twCaZDPdWG8sUDXAai+ciLJMPGPUPTnag=="
+      "version": "1.32.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.32.0.tgz",
+      "integrity": "sha512-cU9AcMuzdRKKGnazIfrVR3jPoZQ0v6dHY5YwWFDZ5FUuxUzgxY4PTIfpq7vYn10pLQCBGAJP385T5JrY83JYNA=="
     },
     "@labkey/build": {
       "version": "7.1.0",
@@ -12919,11 +12919,11 @@
       }
     },
     "@labkey/components": {
-      "version": "3.30.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.30.0.tgz",
-      "integrity": "sha512-k/qg3Ybx9g09K36ZmJS04GEpSA07eSFBHA4QsShsAwW3Bj0KyBcUGRfNqTSl0zCmK0S9wf737bMZg+LC3vQFzg==",
+      "version": "3.32.1-fb-plate-set-assays.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
+      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
       "requires": {
-        "@labkey/api": "1.30.0",
+        "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.32.1-fb-plate-set-assays.0"
+    "@labkey/components": "3.32.1-fb-plate-set-assays.1"
   },
   "devDependencies": {
     "@labkey/build": "7.1.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.32.1-fb-plate-set-assays.1"
+    "@labkey/components": "3.33.1"
   },
   "devDependencies": {
     "@labkey/build": "7.1.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.30.0"
+    "@labkey/components": "3.32.1-fb-plate-set-assays.0"
   },
   "devDependencies": {
     "@labkey/build": "7.1.0",

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -1132,4 +1132,54 @@ public class PlateController extends SpringActionController
             return success();
         }
     }
+
+    public static class PlateSetAssaysForm
+    {
+        private ContainerFilter.Type _containerFilter;
+
+        private int _plateSetId;
+
+        public ContainerFilter.Type getContainerFilter()
+        {
+            return _containerFilter;
+        }
+
+        public void setContainerFilter(ContainerFilter.Type containerFilter)
+        {
+            _containerFilter = containerFilter;
+        }
+
+        public int getPlateSetId()
+        {
+            return _plateSetId;
+        }
+
+        public void setPlateSetId(int plateSetId)
+        {
+            _plateSetId = plateSetId;
+        }
+    }
+
+    @RequiresPermission(ReadPermission.class)
+    public static class AssaysAction extends ReadOnlyApiAction<PlateSetAssaysForm>
+    {
+        @Override
+        public void validateForm(PlateSetAssaysForm form, Errors errors)
+        {
+            if (form.getPlateSetId() <= 0)
+                errors.reject(ERROR_REQUIRED, "\"plateSetId\" is required.");
+        }
+
+        @Override
+        public Object execute(PlateSetAssaysForm form, BindException errors) throws Exception
+        {
+            ContainerFilter cf = null;
+
+            // if an optional container filter is specified
+            if (form.getContainerFilter() != null)
+                cf = form.getContainerFilter().create(getViewContext());
+
+            return PlateManager.get().getPlateSetAssays(getContainer(), getUser(), form.getPlateSetId(), cf);
+        }
+    }
 }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2197,8 +2197,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
     public PlateSetLineage getPlateSetLineage(Container container, User user, int seedPlateSetId, @Nullable ContainerFilter cf)
     {
-        ContainerFilter cf_ = ensureContainerFilterForLineage(container, user, cf);
-        PlateSetImpl seedPlateSet = (PlateSetImpl) getPlateSet(cf_, seedPlateSetId);
+        cf = ensureContainerFilterForLineage(container, user, cf);
+        PlateSetImpl seedPlateSet = (PlateSetImpl) getPlateSet(cf, seedPlateSetId);
         if (seedPlateSet == null)
             throw new NotFoundException();
 
@@ -2226,7 +2226,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         }
 
         UserSchema schema = getPlateUserSchema(container, user);
-        TableInfo plateSetTable = schema.getTableOrThrow(PlateSetTable.NAME, cf_);
+        TableInfo plateSetTable = schema.getTableOrThrow(PlateSetTable.NAME, cf);
         SimpleFilter filterPS = new SimpleFilter();
         filterPS.addInClause(FieldKey.fromParts("RowId"), nodeIds);
         List<PlateSetImpl> nodes = new TableSelector(plateSetTable, filterPS, null).getArrayList(PlateSetImpl.class);
@@ -2411,13 +2411,13 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         if (provider == null)
             return plateSetAssays;
 
-        ContainerFilter cf_ = ensureContainerFilterForLineage(container, user, cf);
+        cf = ensureContainerFilterForLineage(container, user, cf);
         PlateSetLineage lineage = getPlateSetLineage(container, user, plateSetId, cf);
         Map<Integer, List<Integer>> protocolPlateSets = new HashMap<>();
         Map<Integer, PlateSet> plateSets = lineage.getPlateSetAndDescendents(plateSetId);
         plateSetAssays.setPlateSets(plateSets);
         UserSchema schema = getPlateUserSchema(container, user);
-        TableInfo plateTable = schema.getTableOrThrow(PlateTable.NAME, cf_);
+        TableInfo plateTable = schema.getTableOrThrow(PlateTable.NAME, cf);
         List<ExpProtocol> protocols = AssayService.get().getAssayProtocols(container, provider)
                 .stream().filter(provider::isPlateMetadataEnabled).toList();
 

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2428,7 +2428,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
             if (assayDataTable != null)
             {
-                // Query for the distinct set of plate sets that have data in
+                // Query for the distinct set of plate sets that have data in their results domain for the given assay
                 SQLFragment sql = new SQLFragment("SELECT DISTINCT pt.plateset FROM ")
                         .append(assayDataTable, "ad")
                         .append(" JOIN ")

--- a/assay/src/org/labkey/assay/plate/model/PlateSetAssays.java
+++ b/assay/src/org/labkey/assay/plate/model/PlateSetAssays.java
@@ -10,7 +10,9 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PlateSetAssays
 {
+    // A map of Assay Protocol ID to Plate Set IDs
     private Map<Integer, List<Integer>> _protocolPlateSets = Collections.emptyMap();
+    // A map of Plate Set ID to Plate Set
     private Map<Integer, PlateSet> _plateSets = Collections.emptyMap();
 
     public PlateSetAssays()

--- a/assay/src/org/labkey/assay/plate/model/PlateSetAssays.java
+++ b/assay/src/org/labkey/assay/plate/model/PlateSetAssays.java
@@ -1,0 +1,39 @@
+package org.labkey.assay.plate.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.labkey.api.assay.plate.PlateSet;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PlateSetAssays
+{
+    private Map<Integer, List<Integer>> _protocolPlateSets = Collections.emptyMap();
+    private Map<Integer, PlateSet> _plateSets = Collections.emptyMap();
+
+    public PlateSetAssays()
+    {
+    }
+
+    public Map<Integer, List<Integer>> getProtocolPlateSets()
+    {
+        return _protocolPlateSets;
+    }
+
+    public void setProtocolPlateSets(Map<Integer, List<Integer>> protocolPlateSets)
+    {
+        _protocolPlateSets = protocolPlateSets;
+    }
+
+    public Map<Integer, PlateSet> getPlateSets()
+    {
+        return _plateSets;
+    }
+
+    public void setPlateSets(Map<Integer, PlateSet> plateSets)
+    {
+        _plateSets = plateSets;
+    }
+}

--- a/assay/src/org/labkey/assay/plate/model/PlateSetLineage.java
+++ b/assay/src/org/labkey/assay/plate/model/PlateSetLineage.java
@@ -1,5 +1,6 @@
 package org.labkey.assay.plate.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateSetEdge;
@@ -70,6 +71,7 @@ public class PlateSetLineage
      * @param plateSetId the plateSetId to return with descendents
      * @return Map<Integer, PlateSet>
      */
+    @JsonIgnore
     public Map<Integer, PlateSet> getPlateSetAndDescendents(Integer plateSetId) {
         Map<Integer, PlateSet> allPlateSets = new HashMap<>();
         allPlateSets.put(plateSetId, _plateSets.get(plateSetId));

--- a/assay/src/org/labkey/assay/plate/model/PlateSetLineage.java
+++ b/assay/src/org/labkey/assay/plate/model/PlateSetLineage.java
@@ -4,9 +4,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateSetEdge;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PlateSetLineage
@@ -58,5 +62,35 @@ public class PlateSetLineage
     public void setSeed(Integer seed)
     {
         _seed = seed;
+    }
+
+    /**
+     * Returns a Map<Integer, PlateSet> containing the PlateSet for the given plateSetId as well as all the PlateSets
+     * for the descendents of the given plateSetId.
+     * @param plateSetId the plateSetId to return with descendents
+     * @return Map<Integer, PlateSet>
+     */
+    public Map<Integer, PlateSet> getPlateSetAndDescendents(Integer plateSetId) {
+        Map<Integer, PlateSet> allPlateSets = new HashMap<>();
+        allPlateSets.put(plateSetId, _plateSets.get(plateSetId));
+        Set<Integer> parents = new HashSet<>(Arrays.asList(plateSetId));
+
+        while (!parents.isEmpty())
+        {
+            Set<Integer> children = new HashSet<>();
+
+            for (PlateSetEdge edge : _edges)
+            {
+                if (parents.contains(edge.getFromPlateSetId())) {
+                    Integer to = edge.getToPlateSetId();
+                    children.add(to);
+                    allPlateSets.put(to, _plateSets.get(to));
+                }
+            }
+
+            parents = children;
+        }
+
+        return allPlateSets;
     }
 }

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.32.1-fb-plate-set-assays.1",
+        "@labkey/components": "3.33.1",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
-      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
+      "version": "3.33.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.33.1.tgz",
+      "integrity": "sha512-VycdfAjAmncKF64dXohCBX58lWgqTKYt02Ovvtptg4NazNK8ovW6WrHcgIMNtx2aQIWq/E3hX76D6T+2AvoAvg==",
       "dependencies": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
-      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
+      "version": "3.33.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.33.1.tgz",
+      "integrity": "sha512-VycdfAjAmncKF64dXohCBX58lWgqTKYt02Ovvtptg4NazNK8ovW6WrHcgIMNtx2aQIWq/E3hX76D6T+2AvoAvg==",
       "requires": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.32.1-fb-plate-set-assays.0",
+        "@labkey/components": "3.32.1-fb-plate-set-assays.1",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
-      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
+      "version": "3.32.1-fb-plate-set-assays.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
+      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
       "dependencies": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
-      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
+      "version": "3.32.1-fb-plate-set-assays.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
+      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
       "requires": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.33.0",
+        "@labkey/components": "3.32.1-fb-plate-set-assays.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3339,9 +3339,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.33.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.33.0.tgz",
-      "integrity": "sha512-t/MlhzFYohKphOqIhilEUrzDNPFM6pREaJ8VV0C/laEdfiTDYgseoLKLG9Krb9UC15cvMqJGzzHBa9uuVBD8Wg==",
+      "version": "3.32.1-fb-plate-set-assays.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
+      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
       "dependencies": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -19555,9 +19555,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.33.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.33.0.tgz",
-      "integrity": "sha512-t/MlhzFYohKphOqIhilEUrzDNPFM6pREaJ8VV0C/laEdfiTDYgseoLKLG9Krb9UC15cvMqJGzzHBa9uuVBD8Wg==",
+      "version": "3.32.1-fb-plate-set-assays.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
+      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
       "requires": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.32.1-fb-plate-set-assays.1",
+    "@labkey/components": "3.33.1",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.32.1-fb-plate-set-assays.0",
+    "@labkey/components": "3.32.1-fb-plate-set-assays.1",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.33.0",
+    "@labkey/components": "3.32.1-fb-plate-set-assays.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.32.1-fb-plate-set-assays.0"
+        "@labkey/components": "3.32.1-fb-plate-set-assays.1"
       },
       "devDependencies": {
         "@labkey/build": "7.1.0",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
-      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
+      "version": "3.32.1-fb-plate-set-assays.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
+      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
       "dependencies": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17196,9 +17196,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
-      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
+      "version": "3.32.1-fb-plate-set-assays.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
+      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
       "requires": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.32.1-fb-plate-set-assays.1"
+        "@labkey/components": "3.33.1"
       },
       "devDependencies": {
         "@labkey/build": "7.1.0",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
-      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
+      "version": "3.33.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.33.1.tgz",
+      "integrity": "sha512-VycdfAjAmncKF64dXohCBX58lWgqTKYt02Ovvtptg4NazNK8ovW6WrHcgIMNtx2aQIWq/E3hX76D6T+2AvoAvg==",
       "dependencies": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -17196,9 +17196,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
-      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
+      "version": "3.33.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.33.1.tgz",
+      "integrity": "sha512-VycdfAjAmncKF64dXohCBX58lWgqTKYt02Ovvtptg4NazNK8ovW6WrHcgIMNtx2aQIWq/E3hX76D6T+2AvoAvg==",
       "requires": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.30.0"
+        "@labkey/components": "3.32.1-fb-plate-set-assays.0"
       },
       "devDependencies": {
         "@labkey/build": "7.1.0",
@@ -3183,9 +3183,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.30.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.30.0.tgz",
-      "integrity": "sha512-GyLw10GI0+aRfecK4S4a4yXRhRufWMYv/ltJIUv9LcxuuPklgr3s4twCaZDPdWG8sUDXAai+ciLJMPGPUPTnag=="
+      "version": "1.32.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.32.0.tgz",
+      "integrity": "sha512-cU9AcMuzdRKKGnazIfrVR3jPoZQ0v6dHY5YwWFDZ5FUuxUzgxY4PTIfpq7vYn10pLQCBGAJP385T5JrY83JYNA=="
     },
     "node_modules/@labkey/build": {
       "version": "7.1.0",
@@ -3224,11 +3224,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.30.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.30.0.tgz",
-      "integrity": "sha512-k/qg3Ybx9g09K36ZmJS04GEpSA07eSFBHA4QsShsAwW3Bj0KyBcUGRfNqTSl0zCmK0S9wf737bMZg+LC3vQFzg==",
+      "version": "3.32.1-fb-plate-set-assays.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
+      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
       "dependencies": {
-        "@labkey/api": "1.30.0",
+        "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -17155,9 +17155,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.30.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.30.0.tgz",
-      "integrity": "sha512-GyLw10GI0+aRfecK4S4a4yXRhRufWMYv/ltJIUv9LcxuuPklgr3s4twCaZDPdWG8sUDXAai+ciLJMPGPUPTnag=="
+      "version": "1.32.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.32.0.tgz",
+      "integrity": "sha512-cU9AcMuzdRKKGnazIfrVR3jPoZQ0v6dHY5YwWFDZ5FUuxUzgxY4PTIfpq7vYn10pLQCBGAJP385T5JrY83JYNA=="
     },
     "@labkey/build": {
       "version": "7.1.0",
@@ -17196,11 +17196,11 @@
       }
     },
     "@labkey/components": {
-      "version": "3.30.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.30.0.tgz",
-      "integrity": "sha512-k/qg3Ybx9g09K36ZmJS04GEpSA07eSFBHA4QsShsAwW3Bj0KyBcUGRfNqTSl0zCmK0S9wf737bMZg+LC3vQFzg==",
+      "version": "3.32.1-fb-plate-set-assays.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
+      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
       "requires": {
-        "@labkey/api": "1.30.0",
+        "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.30.0"
+    "@labkey/components": "3.32.1-fb-plate-set-assays.0"
   },
   "devDependencies": {
     "@labkey/build": "7.1.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.32.1-fb-plate-set-assays.1"
+    "@labkey/components": "3.33.1"
   },
   "devDependencies": {
     "@labkey/build": "7.1.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.32.1-fb-plate-set-assays.0"
+    "@labkey/components": "3.32.1-fb-plate-set-assays.1"
   },
   "devDependencies": {
     "@labkey/build": "7.1.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.32.1-fb-plate-set-assays.1"
+        "@labkey/components": "3.33.1"
       },
       "devDependencies": {
         "@labkey/build": "7.1.0",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
-      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
+      "version": "3.33.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.33.1.tgz",
+      "integrity": "sha512-VycdfAjAmncKF64dXohCBX58lWgqTKYt02Ovvtptg4NazNK8ovW6WrHcgIMNtx2aQIWq/E3hX76D6T+2AvoAvg==",
       "dependencies": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -15438,9 +15438,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
-      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
+      "version": "3.33.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.33.1.tgz",
+      "integrity": "sha512-VycdfAjAmncKF64dXohCBX58lWgqTKYt02Ovvtptg4NazNK8ovW6WrHcgIMNtx2aQIWq/E3hX76D6T+2AvoAvg==",
       "requires": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.30.0"
+        "@labkey/components": "3.32.1-fb-plate-set-assays.0"
       },
       "devDependencies": {
         "@labkey/build": "7.1.0",
@@ -2598,9 +2598,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.30.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.30.0.tgz",
-      "integrity": "sha512-GyLw10GI0+aRfecK4S4a4yXRhRufWMYv/ltJIUv9LcxuuPklgr3s4twCaZDPdWG8sUDXAai+ciLJMPGPUPTnag=="
+      "version": "1.32.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.32.0.tgz",
+      "integrity": "sha512-cU9AcMuzdRKKGnazIfrVR3jPoZQ0v6dHY5YwWFDZ5FUuxUzgxY4PTIfpq7vYn10pLQCBGAJP385T5JrY83JYNA=="
     },
     "node_modules/@labkey/build": {
       "version": "7.1.0",
@@ -2703,11 +2703,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.30.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.30.0.tgz",
-      "integrity": "sha512-k/qg3Ybx9g09K36ZmJS04GEpSA07eSFBHA4QsShsAwW3Bj0KyBcUGRfNqTSl0zCmK0S9wf737bMZg+LC3vQFzg==",
+      "version": "3.32.1-fb-plate-set-assays.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
+      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
       "dependencies": {
-        "@labkey/api": "1.30.0",
+        "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",
@@ -15355,9 +15355,9 @@
       }
     },
     "@labkey/api": {
-      "version": "1.30.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.30.0.tgz",
-      "integrity": "sha512-GyLw10GI0+aRfecK4S4a4yXRhRufWMYv/ltJIUv9LcxuuPklgr3s4twCaZDPdWG8sUDXAai+ciLJMPGPUPTnag=="
+      "version": "1.32.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.32.0.tgz",
+      "integrity": "sha512-cU9AcMuzdRKKGnazIfrVR3jPoZQ0v6dHY5YwWFDZ5FUuxUzgxY4PTIfpq7vYn10pLQCBGAJP385T5JrY83JYNA=="
     },
     "@labkey/build": {
       "version": "7.1.0",
@@ -15438,11 +15438,11 @@
       }
     },
     "@labkey/components": {
-      "version": "3.30.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.30.0.tgz",
-      "integrity": "sha512-k/qg3Ybx9g09K36ZmJS04GEpSA07eSFBHA4QsShsAwW3Bj0KyBcUGRfNqTSl0zCmK0S9wf737bMZg+LC3vQFzg==",
+      "version": "3.32.1-fb-plate-set-assays.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
+      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
       "requires": {
-        "@labkey/api": "1.30.0",
+        "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.32.1-fb-plate-set-assays.0"
+        "@labkey/components": "3.32.1-fb-plate-set-assays.1"
       },
       "devDependencies": {
         "@labkey/build": "7.1.0",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
-      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
+      "version": "3.32.1-fb-plate-set-assays.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
+      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
       "dependencies": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",
@@ -15438,9 +15438,9 @@
       }
     },
     "@labkey/components": {
-      "version": "3.32.1-fb-plate-set-assays.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.0.tgz",
-      "integrity": "sha512-Az3nWrJ6iGGPEo8U/H+RlhITYCwLRzOWvPPetsRVsw64Xl9UH/R/3axNNnIlwsFTiv9rmOC81YDHHHrdUDOUOg==",
+      "version": "3.32.1-fb-plate-set-assays.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.32.1-fb-plate-set-assays.1.tgz",
+      "integrity": "sha512-+2SXUL9Zq/HoMNkmaQ0Bc2gGdBec2ssApzS6f8Ib7+9GlJoUr0vWAEJdPPqAQ06pP1avgBP863gc6O3U/69J2A==",
       "requires": {
         "@labkey/api": "1.32.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.32.1-fb-plate-set-assays.0"
+    "@labkey/components": "3.32.1-fb-plate-set-assays.1"
   },
   "devDependencies": {
     "@labkey/build": "7.1.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.30.0"
+    "@labkey/components": "3.32.1-fb-plate-set-assays.0"
   },
   "devDependencies": {
     "@labkey/build": "7.1.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.32.1-fb-plate-set-assays.1"
+    "@labkey/components": "3.33.1"
   },
   "devDependencies": {
     "@labkey/build": "7.1.0",


### PR DESCRIPTION
#### Rationale
This PR adds a method to PlateManager, and an associated action to the PlateController, to return all assay protocol IDs that have results data for a given Plate Set ID and its descendants.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5352
- https://github.com/LabKey/labkey-ui-components/pull/1454
- https://github.com/LabKey/labkey-ui-premium/pull/365
- https://github.com/LabKey/limsModules/pull/74

#### Changes
- Add PlateSetAssays class
- PlateManager: add `getPlateSetAssays` method
- PlateController: add `AssaysAction`
- PlateLineage: add `getPlateSetAndDescendents` method
