### PR TITLE
visit error messages : test and product fixes

### DIFF
--- a/study/src/org/labkey/study/model/SequenceNumImportHelper.java
+++ b/study/src/org/labkey/study/model/SequenceNumImportHelper.java
@@ -178,7 +178,7 @@ translateToDouble:
                 sequencenum = parseDouble((String)seq);
                 if (null != sequencenum)
                     break translateToDouble;
-                if (!_translateMap.containsKey(seq) && !_translateMap.isEmpty())
+                if (_timetype.isVisitBased() && !_translateMap.containsKey(seq) && !_translateMap.isEmpty())
                 {
                     // issue : 49375 return an appropriate error message if we can't match on a visit map label
                     throw new ValidationException("Visit : " + seq + " does not exist in the visit map");

--- a/study/test/src/org/labkey/test/tests/study/StudyManualTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyManualTest.java
@@ -232,8 +232,8 @@ public abstract class StudyManualTest extends StudyTest
 
         String errorRow = "\tbadvisitd\t1/1/2006\t\ttext\t";
         importDataPage.setText(_tsv + "\n" + errorRow);
-        importDataPage.submitExpectingErrorContaining(getConversionErrorMessage("badvisitd", "SequenceNum", BigDecimal.class));
-        assertTextPresent(getConversionErrorMessage("text", "DateField", Timestamp.class));
+        importDataPage.submitExpectingErrorContaining("Visit : badvisitd does not exist in the visit map");
+        assertTextPresent("Visit : badvisitd does not exist in the visit map");
 
         importDataPage.setText(_tsv).submit();
         assertTextPresent("1234", "2006-02-01", "1.2", "aliasedData");


### PR DESCRIPTION
#### Rationale
Adjusted the tests to expect the newer message about visit label mismatches instead of expecting the conversion error. The date based test also uncovered a product bug because the test imports a visit field into a date based study. I've adjusted the code to ignore unless it's a visit based study.
