### PR TITLE
CustomParticipantView should not cache ModuleHtmlView in member variable.

### DIFF
--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4170,7 +4170,7 @@ public class StudyManager
         {
             if (ModuleHtmlView.exists(module, path))
             {
-                return CustomParticipantView.create(ModuleHtmlView.get(module, path));
+                return CustomParticipantView.create(module, path);
             }
         }
 
@@ -4182,10 +4182,9 @@ public class StudyManager
             CustomParticipantView participantView = new TableSelector(ti, containerFilter, null).getObject(CustomParticipantView.class);
             if (null == participantView)
                 return null;
-
             Module studyModule = ModuleLoader.getInstance().getModule("study");
-            var htmlView = new ModuleHtmlView(studyModule, study.getSubjectNounSingular(), HtmlString.unsafe(participantView.getBody()));
-            participantView.setView(htmlView);
+            participantView.setModule(studyModule);
+            participantView.setTitle(study.getSubjectNounSingular());
             return participantView;
         });
     }


### PR DESCRIPTION
#### Rationale
Cached items need to be immutable, therefore CustomizeParticipantView can't hold onto an HttpView.  Also, the HttpView hangs onto a ViewContext which hangs onto a Request, so that's not good either.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
