### PR TITLE
Use simpler check for authenticated user

### DIFF
--- a/api/src/org/labkey/api/security/AuthFilter.java
+++ b/api/src/org/labkey/api/security/AuthFilter.java
@@ -246,7 +246,7 @@ public class AuthFilter implements Filter
             // across Tomcat restarts. Ensure that all authenticated users have their sessions tracked, so we can
             // accurately assess if anyone is logged in
             HttpSession s = req.getSession(false);
-            if (s != null && !AuthenticatedRequest.isGuestSession(s))
+            if (s != null && !user.isGuest())
             {
                 UserManager.ensureSessionTracked(s);
             }

--- a/api/src/org/labkey/api/security/AuthenticatedRequest.java
+++ b/api/src/org/labkey/api/security/AuthenticatedRequest.java
@@ -123,12 +123,6 @@ public class AuthenticatedRequest extends HttpServletRequestWrapper implements A
         _loggedIn = true;
     }
 
-    public static boolean isGuestSession(HttpSession session)
-    {
-        return session.getAttribute(AuthenticatedRequest.GuestSessionMarker.class.getName()) != null;
-    }
-
-
     @Override
     public HttpSession getSession()
     {

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -100,6 +100,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.labkey.api.security.SecurityManager.USER_ID_KEY;
 import static org.labkey.api.security.permissions.AbstractActionPermissionTest.APPLICATION_ADMIN_EMAIL;
 import static org.labkey.api.security.permissions.AbstractActionPermissionTest.SITE_ADMIN_EMAIL;
 
@@ -505,10 +506,9 @@ public class UserManager
     {
         if (s != null)
         {
-            User user = SecurityManager.getSessionUser(s);
-            assert null != user;
-            assert !user.isGuest();
-            _activeSessions.add(s.getId());
+            Integer userId = (Integer)s.getAttribute(USER_ID_KEY);
+            if (null != userId && 0 != userId)
+               _activeSessions.add(s.getId());
         }
     }
 

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -507,7 +507,7 @@ public class UserManager
         if (s != null)
         {
             Integer userId = (Integer)s.getAttribute(USER_ID_KEY);
-            if (null != userId && 0 != userId)
+            if (null != userId && getGuestUser().getUserId() != userId)
                _activeSessions.add(s.getId());
         }
     }


### PR DESCRIPTION
#### Rationale
AuthenticatedRequest.isGuestSession() returns false for robots causing us to track sessions that won't ever fire SessionListener.sessionDestroyed()

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
