### PR TITLE
Plates: Hit Selection Persistence/API

### DIFF
--- a/api/src/org/labkey/api/assay/AssayListener.java
+++ b/api/src/org/labkey/api/assay/AssayListener.java
@@ -1,0 +1,12 @@
+package org.labkey.api.assay;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.exp.api.ExpRun;
+import org.labkey.api.security.User;
+
+import java.util.Map;
+
+public interface AssayListener
+{
+    default void beforeResultDelete(Container container, User user, ExpRun run, Map<String, Object> resultRow) { }
+}

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -66,6 +66,8 @@ public interface AssayService
 
     void registerAssayProvider(AssayProvider provider);
 
+    void registerAssayListener(AssayListener listener);
+
     @Nullable
     AssayProvider getProvider(String providerName);
 
@@ -151,7 +153,7 @@ public interface AssayService
      * and ExpBatch will be searched for the configured TargetStudy.
      *
      * @param run                  experiment run
-     * @param protocol             The run's protocol.  If null, the ExpRun.getProcotol() will be used.
+     * @param protocol             The run's protocol.  If null, the ExpRun.getProtocol() will be used.
      * @param provider             The assay provider.  If null, the provider will be found from the protocol.
      * @param targetStudyContainer The target study.  If null, the ExpRun and ExpBatch properties will be searched.
      * @return The resolver.
@@ -233,6 +235,8 @@ public interface AssayService
      * Returns the TableInfo for the given assay domain based on the assay domain ID.
      */
     TableInfo getTableInfoForDomainId(User user, Container container, int domainId, @Nullable ContainerFilter cf);
+
+    void onBeforeAssayResultDelete(Container container, User user, ExpRun run, Map<String, Object> resultRow);
 
     /**
      * Provides a mechanism to check or validate the results for a specified protocol. An instance of ResultsCheckHelper

--- a/api/src/org/labkey/api/exp/api/ExperimentListener.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentListener.java
@@ -21,60 +21,43 @@ import org.labkey.api.security.User;
 
 import java.util.List;
 
-/**
- * User: vsharma
- * Date: 8/23/2014
- */
 public interface ExperimentListener
 {
     /** Called after an experiment is deleted (in-transaction). */
-    default void afterExperimentDeleted(Container c, User user, ExpExperiment experiment)
-    {
-    }
+    default void afterExperimentDeleted(Container c, User user, ExpExperiment experiment) { }
 
     /** Called after an experiment is saved (post-transaction). */
-    default void afterExperimentSaved(Container c, User user, ExpExperiment experiment)
-    {
-    }
+    default void afterExperimentSaved(Container c, User user, ExpExperiment experiment) { }
 
     /** Called before deleting a row from exp.experiment */
-    default void beforeExperimentDeleted(Container c, User user, ExpExperiment experiment)
-    {}
+    default void beforeExperimentDeleted(Container c, User user, ExpExperiment experiment) { }
 
-    default void beforeProtocolsDeleted(Container c, User user, List<? extends ExpProtocol> protocols)
-    { }
+    default void beforeProtocolsDeleted(Container c, User user, List<? extends ExpProtocol> protocols) { }
 
     /** Called after an experiment run is deleted (in-transaction). */
-    default void afterRunDelete(ExpProtocol protocol, ExpRun run, User user)
-    {
-    }
+    default void afterRunDelete(ExpProtocol protocol, ExpRun run, User user) { }
 
     /** Called after an experiment run is saved (post-transaction). */
-    default void afterRunSaved(Container container, User user, ExpProtocol protocol, ExpRun run)
-    {
-    }
+    default void afterRunSaved(Container container, User user, ExpProtocol protocol, ExpRun run) { }
 
-    // called before the experiment run is created (and saved)
-    default void beforeRunCreated(Container container, User user, ExpProtocol protocol, ExpRun run) throws BatchValidationException
-    {
-    }
+    /** Called before the experiment run is created (and saved). */
+    default void beforeRunCreated(Container container, User user, ExpProtocol protocol, ExpRun run) throws BatchValidationException { }
 
-    // called after run data is uploaded
-    default void afterResultDataCreated(Container container, User user, ExpRun run, ExpProtocol protocol) throws BatchValidationException
-    {
-    }
+    /** Called after run data is uploaded. */
+    default void afterResultDataCreated(Container container, User user, ExpRun run, ExpProtocol protocol) throws BatchValidationException { }
 
-    // called before the experiment run is deleted
-    default void beforeRunDelete(ExpProtocol protocol, ExpRun run, User user){}
+    /** Called before the experiment run is deleted. */
+    default void beforeRunDelete(ExpProtocol protocol, ExpRun run, User user) { }
 
     /** Called before deleting the datas. */
-    default void beforeDataDelete(Container c, User user, List<? extends ExpData> data)
-    { }
+    default void beforeDataDelete(Container c, User user, List<? extends ExpData> data) { }
 
     /** Called after deleting the datas. */
     default void afterDataDelete(Container c, User user, List<? extends ExpData> data) { }
 
+    /** Called before deleting experiment materials (in-transaction). */
     default void beforeMaterialDelete(List<? extends ExpMaterial> materials, Container container, User user) { }
 
+    /** Called after a material has been created (and saved). NOTE: This is not currently implemented. */
     default void afterMaterialCreated(List<? extends ExpMaterial> materials, Container container, User user) { }
 }

--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -620,7 +620,7 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
         if (perm.equals(ReadPermission.class))
             return _userSchema.getContainer().hasPermission(user, perm, _userSchema.getContextualRoles());
         if (DeletePermission.class.isAssignableFrom(perm) || UpdatePermission.class.isAssignableFrom(perm))
-                return _provider.isEditableResults(_protocol) && _userSchema.getContainer().hasPermission(user, perm);
+            return _provider.isEditableResults(_protocol) && _userSchema.getContainer().hasPermission(user, perm);
         return false;
     }
 

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -35,11 +35,6 @@ import org.labkey.api.view.ActionURL;
 import java.sql.SQLException;
 import java.util.List;
 
-/**
- * User: brittp
- * Date: Oct 20, 2006
- * Time: 10:12:22 AM
- */
 public interface PlateService
 {
     int NO_RUNID = -1;
@@ -110,7 +105,6 @@ public interface PlateService
      * @param name The name of the well group.
      * @param type The type of well group to create.
      * @param positions A list of positions which comprises the group.
-     * @return
      */
     WellGroup createWellGroup(Plate plate, String name, WellGroup.Type type, List<Position> positions);
 
@@ -191,7 +185,6 @@ public interface PlateService
 
     /**
      * Returns the list of available plate types.
-     * @return
      */
     @NotNull List<? extends PlateType> getPlateTypes();
 
@@ -261,7 +254,7 @@ public interface PlateService
      * Copies a plate from one container to another.
      * @param source The source plate template
      * @param user The user performing the copy
-     * @param destination The destinatino container
+     * @param destination The destination container
      * @return The copied plate template
      * @throws SQLException Thrown in the event of a database failure.
      * @throws NameConflictException Thrown if the destination container already contains a template by the same name.

--- a/assay/resources/schemas/assay.xml
+++ b/assay/resources/schemas/assay.xml
@@ -232,4 +232,14 @@
       <column columnName="RootPlateSetId"/>
     </columns>
   </table>
+  <table tableName="Hit" tableDbType="TABLE">
+    <description>Contains one row per hit assay result.</description>
+    <columns>
+      <column columnName="Container"/>
+      <column columnName="ProtocolId"/>
+      <column columnName="ResultId"/>
+      <column columnName="RunId"/>
+      <column columnName="WellLsid"/>
+    </columns>
+  </table>
 </tables>

--- a/assay/resources/schemas/assay.xml
+++ b/assay/resources/schemas/assay.xml
@@ -238,6 +238,7 @@
       <column columnName="Container"/>
       <column columnName="ProtocolId"/>
       <column columnName="ResultId"/>
+      <column columnName="RowId"/>
       <column columnName="RunId"/>
       <column columnName="WellLsid"/>
     </columns>

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.003-24.004.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.003-24.004.sql
@@ -1,8 +1,8 @@
 ALTER TABLE assay.PlateSet ADD COLUMN Type VARCHAR(64);
 ALTER TABLE assay.PlateSet ADD COLUMN RootPlateSetId INT;
 ALTER TABLE assay.PlateSet ADD COLUMN PrimaryPlateSetId INT;
-ALTER TABLE assay.PlateSet ADD CONSTRAINT FK_PlateSet_RootPlateSetId FOREIGN KEY (RootPlateSetId) REFERENCES assay.PlateSet(RowId);
-ALTER TABLE assay.PlateSet ADD CONSTRAINT FK_PlateSet_PrimaryPlateSetId FOREIGN KEY (PrimaryPlateSetId) REFERENCES assay.PlateSet(RowId);
+ALTER TABLE assay.PlateSet ADD CONSTRAINT FK_PlateSet_RootPlateSetId FOREIGN KEY (RootPlateSetId) REFERENCES assay.PlateSet (RowId);
+ALTER TABLE assay.PlateSet ADD CONSTRAINT FK_PlateSet_PrimaryPlateSetId FOREIGN KEY (PrimaryPlateSetId) REFERENCES assay.PlateSet (RowId);
 
 -- Update all pre-existing plate sets to type "assay"
 UPDATE assay.PlateSet SET type = 'assay';
@@ -15,13 +15,13 @@ CREATE TABLE assay.PlateSetEdge
     ToPlateSetId INT NOT NULL,
     RootPlateSetId INT NOT NULL,
 
-    CONSTRAINT FK_PlateSet_FromPlate FOREIGN KEY (FromPlateSetId) REFERENCES assay.PlateSet(RowId),
-    CONSTRAINT FK_PlateSet_ToPlate FOREIGN KEY (ToPlateSetId) REFERENCES assay.PlateSet(RowId),
-    CONSTRAINT FK_PlateSet_RootPlate FOREIGN KEY (RootPlateSetId) REFERENCES assay.PlateSet(RowId),
+    CONSTRAINT FK_PlateSet_FromPlate FOREIGN KEY (FromPlateSetId) REFERENCES assay.PlateSet (RowId),
+    CONSTRAINT FK_PlateSet_ToPlate FOREIGN KEY (ToPlateSetId) REFERENCES assay.PlateSet (RowId),
+    CONSTRAINT FK_PlateSet_RootPlate FOREIGN KEY (RootPlateSetId) REFERENCES assay.PlateSet (RowId),
     CONSTRAINT UQ_PlateSetEdge_FromPlate_ToPlate UNIQUE (FromPlateSetId, ToPlateSetId)
 );
 
-CREATE INDEX IX_PlateSetEdge_FromPlateSetId ON assay.PlateSetEdge(FromPlateSetId);
-CREATE INDEX IX_PlateSetEdge_ToPlateSetId ON assay.PlateSetEdge(ToPlateSetId);
-CREATE INDEX IX_PlateSetEdge_RootPlateSetId ON assay.PlateSetEdge(RootPlateSetId);
+CREATE INDEX IX_PlateSetEdge_FromPlateSetId ON assay.PlateSetEdge (FromPlateSetId);
+CREATE INDEX IX_PlateSetEdge_ToPlateSetId ON assay.PlateSetEdge (ToPlateSetId);
+CREATE INDEX IX_PlateSetEdge_RootPlateSetId ON assay.PlateSetEdge (RootPlateSetId);
 

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.004-24.005.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.004-24.005.sql
@@ -1,13 +1,16 @@
 CREATE TABLE assay.Hit
 (
+    RowId SERIAL,
     Container ENTITYID NOT NULL,
     ProtocolId INT NOT NULL,
     ResultId INT NOT NULL,
     RunId INT NOT NULL,
     WellLsid VARCHAR(200) NOT NULL,
 
+    CONSTRAINT PK_Plate PRIMARY KEY (RowId),
     CONSTRAINT FK_Hit_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
     CONSTRAINT FK_Protocol_ProtocolId FOREIGN KEY (ProtocolId) REFERENCES exp.Protocol (RowId),
     CONSTRAINT FK_Run_RunId FOREIGN KEY (RunId) REFERENCES exp.ExperimentRun (RowId),
-    CONSTRAINT FK_Well_WellLsid FOREIGN KEY (WellLsid) REFERENCES assay.Well (Lsid)
+    CONSTRAINT FK_Well_WellLsid FOREIGN KEY (WellLsid) REFERENCES assay.Well (Lsid),
+    CONSTRAINT UQ_Hit_RunId_ResultId UNIQUE (RunId, ResultId)
 );

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.004-24.005.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.004-24.005.sql
@@ -1,0 +1,13 @@
+CREATE TABLE assay.Hit
+(
+    Container ENTITYID NOT NULL,
+    ProtocolId INT NOT NULL,
+    ResultId INT NOT NULL,
+    RunId INT NOT NULL,
+    WellLsid VARCHAR(200) NOT NULL,
+
+    CONSTRAINT FK_Hit_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),
+    CONSTRAINT FK_Protocol_ProtocolId FOREIGN KEY (ProtocolId) REFERENCES exp.Protocol (RowId),
+    CONSTRAINT FK_Run_RunId FOREIGN KEY (RunId) REFERENCES exp.ExperimentRun (RowId),
+    CONSTRAINT FK_Well_WellLsid FOREIGN KEY (WellLsid) REFERENCES assay.Well (Lsid)
+);

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.003-24.004.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.003-24.004.sql
@@ -3,8 +3,8 @@ ALTER TABLE assay.PlateSet ADD RootPlateSetId INT;
 ALTER TABLE assay.PlateSet ADD PrimaryPlateSetId INT;
 GO
 
-ALTER TABLE assay.PlateSet ADD CONSTRAINT FK_PlateSet_RootPlateSetId FOREIGN KEY (RootPlateSetId) REFERENCES assay.PlateSet(RowId);
-ALTER TABLE assay.PlateSet ADD CONSTRAINT FK_PlateSet_PrimaryPlateSetId FOREIGN KEY (PrimaryPlateSetId) REFERENCES assay.PlateSet(RowId);
+ALTER TABLE assay.PlateSet ADD CONSTRAINT FK_PlateSet_RootPlateSetId FOREIGN KEY (RootPlateSetId) REFERENCES assay.PlateSet (RowId);
+ALTER TABLE assay.PlateSet ADD CONSTRAINT FK_PlateSet_PrimaryPlateSetId FOREIGN KEY (PrimaryPlateSetId) REFERENCES assay.PlateSet (RowId);
 
 -- Update all pre-existing plate sets to type "assay"
 UPDATE assay.PlateSet SET type = 'assay';
@@ -17,12 +17,12 @@ CREATE TABLE assay.PlateSetEdge
     ToPlateSetId INT NOT NULL,
     RootPlateSetId INT NOT NULL,
 
-    CONSTRAINT FK_PlateSet_FromPlate FOREIGN KEY (FromPlateSetId) REFERENCES assay.PlateSet(RowId),
-    CONSTRAINT FK_PlateSet_ToPlate FOREIGN KEY (ToPlateSetId) REFERENCES assay.PlateSet(RowId),
-    CONSTRAINT FK_PlateSet_RootPlate FOREIGN KEY (RootPlateSetId) REFERENCES assay.PlateSet(RowId),
+    CONSTRAINT FK_PlateSet_FromPlate FOREIGN KEY (FromPlateSetId) REFERENCES assay.PlateSet (RowId),
+    CONSTRAINT FK_PlateSet_ToPlate FOREIGN KEY (ToPlateSetId) REFERENCES assay.PlateSet (RowId),
+    CONSTRAINT FK_PlateSet_RootPlate FOREIGN KEY (RootPlateSetId) REFERENCES assay.PlateSet (RowId),
     CONSTRAINT UQ_PlateSetEdge_FromPlate_ToPlate UNIQUE (FromPlateSetId, ToPlateSetId)
 );
 
-CREATE INDEX IX_PlateSetEdge_FromPlateSetId ON assay.PlateSetEdge(FromPlateSetId);
-CREATE INDEX IX_PlateSetEdge_ToPlateSetId ON assay.PlateSetEdge(ToPlateSetId);
-CREATE INDEX IX_PlateSetEdge_RootPlateSetId ON assay.PlateSetEdge(RootPlateSetId);
+CREATE INDEX IX_PlateSetEdge_FromPlateSetId ON assay.PlateSetEdge (FromPlateSetId);
+CREATE INDEX IX_PlateSetEdge_ToPlateSetId ON assay.PlateSetEdge (ToPlateSetId);
+CREATE INDEX IX_PlateSetEdge_RootPlateSetId ON assay.PlateSetEdge (RootPlateSetId);

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.004-24.005.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.004-24.005.sql
@@ -1,11 +1,11 @@
 CREATE TABLE assay.Hit
 (
-    RowId SERIAL,
+    RowId INT IDENTITY(1,1),
     Container ENTITYID NOT NULL,
     ProtocolId INT NOT NULL,
     ResultId INT NOT NULL,
     RunId INT NOT NULL,
-    WellLsid VARCHAR(200) NOT NULL,
+    WellLsid NVARCHAR(200) NOT NULL,
 
     CONSTRAINT PK_Hit PRIMARY KEY (RowId),
     CONSTRAINT FK_Hit_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId),

--- a/assay/src/org/labkey/assay/AssayContainerListener.java
+++ b/assay/src/org/labkey/assay/AssayContainerListener.java
@@ -44,9 +44,6 @@ public class AssayContainerListener implements ContainerListener
     @Override
     public void containerDeleted(Container c, User user)
     {
-        //
-        // plate service
-        //
         PlateManager.get().deleteAllPlateData(c);
 
         // Changing the container tree can change what assays are in scope

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -112,7 +112,7 @@ public class AssayModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 24.004;
+        return 24.005;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -259,6 +259,9 @@ public class AssayModule extends SpringModule
         });
 
         ExperimentService.get().addExperimentListener(new AssayExperimentListener());
+        ExperimentService.get().addExperimentListener(PlateManager.get());
+
+        AssayService.get().registerAssayListener(PlateManager.get());
 
         AdminConsole.addExperimentalFeatureFlag(EXPERIMENTAL_APP_PLATE_SUPPORT,
                 "Plate samples in Biologics", "Plate samples in Biologics for import and analysis.", false);

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -1062,7 +1062,7 @@ public class PlateController extends SpringActionController
     public static class HitForm
     {
         private int _assayProtocolId;
-        private boolean _markAsHit;
+        private Boolean _markAsHit;
         private List<Integer> _resultRowIds;
         private String _resultSelectionKey;
 
@@ -1076,12 +1076,12 @@ public class PlateController extends SpringActionController
             _assayProtocolId = assayProtocolId;
         }
 
-        public boolean isMarkAsHit()
+        public Boolean isMarkAsHit()
         {
             return _markAsHit;
         }
 
-        public void setMarkAsHit(boolean markAsHit)
+        public void setMarkAsHit(Boolean markAsHit)
         {
             _markAsHit = markAsHit;
         }
@@ -1111,6 +1111,13 @@ public class PlateController extends SpringActionController
     @RequiresPermission(UpdatePermission.class)
     public static class HitAction extends MutatingApiAction<HitForm>
     {
+        @Override
+        public void validateForm(HitForm form, Errors errors)
+        {
+            if (form.isMarkAsHit() == null)
+                errors.reject(ERROR_REQUIRED, "Specifying \"markAsHit\" is required.");
+        }
+
         @Override
         public Object execute(HitForm form, BindException errors) throws Exception
         {

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -930,7 +930,6 @@ public class PlateController extends SpringActionController
         }
     }
 
-    @Marshal(Marshaller.Jackson)
     @RequiresPermission(InsertPermission.class)
     public static class CreatePlateSetAction extends MutatingApiAction<CreatePlateSetForm>
     {
@@ -1057,6 +1056,73 @@ public class PlateController extends SpringActionController
                 cf = form.getContainerFilter().create(getViewContext());
 
             return PlateManager.get().getPlateSetLineage(getContainer(), getUser(), form.getSeed(), cf);
+        }
+    }
+
+    public static class HitForm
+    {
+        private int _assayProtocolId;
+        private boolean _markAsHit;
+        private List<Integer> _resultRowIds;
+        private String _resultSelectionKey;
+
+        public int getAssayProtocolId()
+        {
+            return _assayProtocolId;
+        }
+
+        public void setAssayProtocolId(int assayProtocolId)
+        {
+            _assayProtocolId = assayProtocolId;
+        }
+
+        public boolean isMarkAsHit()
+        {
+            return _markAsHit;
+        }
+
+        public void setMarkAsHit(boolean markAsHit)
+        {
+            _markAsHit = markAsHit;
+        }
+
+        public List<Integer> getResultRowIds()
+        {
+            return _resultRowIds;
+        }
+
+        public void setResultRowIds(List<Integer> resultRowIds)
+        {
+            _resultRowIds = resultRowIds;
+        }
+
+        public String getResultSelectionKey()
+        {
+            return _resultSelectionKey;
+        }
+
+        public void setResultSelectionKey(String resultSelectionKey)
+        {
+            _resultSelectionKey = resultSelectionKey;
+        }
+    }
+
+    @Marshal(Marshaller.JSONObject)
+    @RequiresPermission(UpdatePermission.class)
+    public static class HitAction extends MutatingApiAction<HitForm>
+    {
+        @Override
+        public Object execute(HitForm form, BindException errors) throws Exception
+        {
+            PlateManager.get().markHits(
+                getContainer(),
+                getUser(),
+                form.getAssayProtocolId(),
+                form.isMarkAsHit(),
+                form.getResultRowIds(),
+                form.getResultSelectionKey()
+            );
+            return success();
         }
     }
 }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -395,19 +395,17 @@ public class PlateManager implements PlateService
         if (se != null)
             count += (int) se.getRowCount();
 
-        List<Integer> runIds = getRunIdsUsingPlateInResults(c, user, plate);
-        if (runIds != null)
-            count += runIds.size();
+        count += getRunIdsUsingPlateInResults(c, user, plate).size();
 
         return count;
     }
 
-    private List<Integer> getRunIdsUsingPlateInResults(@NotNull Container c, @NotNull User user, @NotNull Plate plate)
+    private @NotNull List<Integer> getRunIdsUsingPlateInResults(@NotNull Container c, @NotNull User user, @NotNull Plate plate)
     {
         // first, get the list of GPAT protocols in the container
         AssayProvider provider = AssayService.get().getProvider(TsvAssayProvider.NAME);
         if (provider == null)
-            return null;
+            return Collections.emptyList();
 
         List<ExpProtocol> protocols = AssayService.get().getAssayProtocols(c, provider)
                 .stream().filter(provider::isPlateMetadataEnabled).toList();

--- a/assay/src/org/labkey/assay/plate/query/HitTable.java
+++ b/assay/src/org/labkey/assay/plate/query/HitTable.java
@@ -1,0 +1,55 @@
+package org.labkey.assay.plate.query;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.SimpleUserSchema;
+import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.DeletePermission;
+import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.assay.query.AssayDbSchema;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HitTable extends SimpleUserSchema.SimpleTable<UserSchema>
+{
+    public static final String NAME = "Hit";
+    private static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
+    private final boolean _allowInsertUpdate;
+
+    static
+    {
+        defaultVisibleColumns.add(FieldKey.fromParts("ProtocolId"));
+        defaultVisibleColumns.add(FieldKey.fromParts("ResultId"));
+        defaultVisibleColumns.add(FieldKey.fromParts("RunId"));
+        defaultVisibleColumns.add(FieldKey.fromParts("WellLsid"));
+    }
+
+    public HitTable(PlateSchema schema, @Nullable ContainerFilter cf, boolean allowInsertUpdate)
+    {
+        super(schema, AssayDbSchema.getInstance().getTableInfoHit(), cf);
+        _allowInsertUpdate = allowInsertUpdate;
+    }
+
+    @Override
+    public List<FieldKey> getDefaultVisibleColumns()
+    {
+        return defaultVisibleColumns;
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        if (!_allowInsertUpdate && (perm.equals(InsertPermission.class) || perm.equals(UpdatePermission.class)))
+            return false;
+        if (perm == DeletePermission.class)
+            return _userSchema.getContainer().hasPermission(user, AdminPermission.class);
+        return super.hasPermission(user, perm);
+    }
+}

--- a/assay/src/org/labkey/assay/plate/query/PlateSchema.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSchema.java
@@ -35,19 +35,20 @@ import java.util.Set;
 public class PlateSchema extends SimpleUserSchema
 {
     public static final String SCHEMA_NAME = "plate";
-    public static final String SCHEMA_DESCR = "Contains data about defined plates";
+    private static final String DESCRIPTION = "Contains data about defined plates";
 
     private static final Set<String> AVAILABLE_TABLES = new CaseInsensitiveTreeSet(List.of(
-            PlateTable.NAME,
-            WellGroupTable.NAME,
-            WellTable.NAME,
-            PlateSetTable.NAME,
-            PlateTypeTable.NAME
+        HitTable.NAME,
+        PlateTable.NAME,
+        PlateSetTable.NAME,
+        PlateTypeTable.NAME,
+        WellTable.NAME,
+        WellGroupTable.NAME
     ));
 
     public PlateSchema(User user, Container container)
     {
-        super(SCHEMA_NAME, SCHEMA_DESCR, user, container, AssayDbSchema.getInstance().getSchema(),
+        super(SCHEMA_NAME, DESCRIPTION, user, container, AssayDbSchema.getInstance().getSchema(),
                 null, AVAILABLE_TABLES, null);
     }
 
@@ -60,17 +61,19 @@ public class PlateSchema extends SimpleUserSchema
     @Override
     public TableInfo createTable(String name, ContainerFilter cf)
     {
-        if (name.equalsIgnoreCase(PlateTable.NAME))
+        if (PlateTable.NAME.equalsIgnoreCase(name))
             return new PlateTable(this, cf).init();
-        if (name.equalsIgnoreCase(WellGroupTable.NAME))
-            return new WellGroupTable(this, cf).init();
-        if (name.equalsIgnoreCase(WellTable.NAME))
+        if (WellTable.NAME.equalsIgnoreCase(name))
             return new WellTable(this, cf).init();
-        if (name.equalsIgnoreCase(PlateSetTable.NAME))
+        if (PlateSetTable.NAME.equalsIgnoreCase(name))
             return new PlateSetTable(this, cf).init();
-        if (name.equalsIgnoreCase(PlateTypeTable.NAME))
+        if (PlateTypeTable.NAME.equalsIgnoreCase(name))
             return new PlateTypeTable(this, cf).init();
-        if (name.equalsIgnoreCase(WellTable.WELL_PROPERTIES_TABLE))
+        if (HitTable.NAME.equalsIgnoreCase(name))
+            return new HitTable(this, cf, false).init();
+        if (WellGroupTable.NAME.equalsIgnoreCase(name))
+            return new WellGroupTable(this, cf).init();
+        if (WellTable.WELL_PROPERTIES_TABLE.equalsIgnoreCase(name))
         {
             Domain domain = PlateManager.get().getPlateMetadataDomain(getContainer(), getUser());
             if (domain != null)

--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -62,7 +62,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
     public static final String WELL_PROPERTIES_TABLE = "WellProperties";
     private static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
     private static final Set<String> ignoredColumns = new CaseInsensitiveHashSet();
-    private Map<FieldKey, ColumnInfo> _provisionedFieldMap = new HashMap<>();
+    private final Map<FieldKey, ColumnInfo> _provisionedFieldMap = new HashMap<>();
 
     static
     {
@@ -326,7 +326,8 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
 
     protected static class WellUpdateService extends DefaultQueryUpdateService
     {
-        private TableInfo _provisionedTable;
+        private final TableInfo _provisionedTable;
+
         public WellUpdateService(TableInfo queryTable, TableInfo dbTable, TableInfo provisionedTable)
         {
             super(queryTable, dbTable);
@@ -377,7 +378,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
                         .setKeyColumns(new CaseInsensitiveHashSet("Lsid"));
             }
             dib = LoggingDataIterator.wrap(dib);
-            dib = DetailedAuditLogDataIterator.getDataIteratorBuilder(getQueryTable(), dib, context.getInsertOption(), user, container);
+            dib = DetailedAuditLogDataIterator.getDataIteratorBuilder(wellTable, dib, context.getInsertOption(), user, container);
 
             return dib;
         }

--- a/assay/src/org/labkey/assay/query/AssayDbSchema.java
+++ b/assay/src/org/labkey/assay/query/AssayDbSchema.java
@@ -73,4 +73,9 @@ public class AssayDbSchema
     {
         return getSchema().getTable("PlateType");
     }
+
+    public TableInfo getTableInfoHit()
+    {
+        return getSchema().getTable("Hit");
+    }
 }

--- a/query/src/org/labkey/query/LinkedSchema.java
+++ b/query/src/org/labkey/query/LinkedSchema.java
@@ -69,10 +69,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-/**
- * User: kevink
- * Date: 12/10/12
- */
 public class LinkedSchema extends ExternalSchema
 {
     public static void register()
@@ -82,8 +78,7 @@ public class LinkedSchema extends ExternalSchema
             @Override
             public QuerySchema getSchema(User user, Container container, String name)
             {
-                QueryServiceImpl svc = (QueryServiceImpl)QueryService.get();
-                return svc.getLinkedSchema(user, container, name);
+                return QueryService.get().getLinkedSchema(user, container, name);
             }
 
             @NotNull


### PR DESCRIPTION
#### Rationale
Introduces hit selection capabilities to plates. This includes persistence, query, and API support as well as a "Hit Selection" column on plate-based assay results.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/77

#### Changes
- Introduce initial interface for `AssayListener` which currently includes one "event" `beforeResultDelete`. Assay listeners can be registered via `AssayService.registerListener()`.
- Introduce `assay.Hit` table for persisting hits. This is exposed to LK query as well.
- Adds `assay-hit.api` for marking and unmarking hits based on either supplied assay result rowIds or by data region selection key.
- Adds a "Hit Selection" `ExprColumn` on plate-based assay results.
