### PR TITLE
Add Time class as TimeType acceptable class

### DIFF
--- a/api/src/org/labkey/api/exp/property/Type.java
+++ b/api/src/org/labkey/api/exp/property/Type.java
@@ -41,7 +41,7 @@ public enum Type
     LongType("Long", "xsd:long", "bigint", Long.class, long.class),
     DoubleType("Number (Double)", "xsd:double", "double", Double.class, Double.TYPE, BigDecimal.class), // Double.TYPE is here because manually created datasets with required doubles return Double.TYPE as Class
     FloatType("Number (Float)", "xsd:float", "float", Float.class, Float.TYPE),
-    TimeType("Time", PropertyType.TIME.getTypeUri(), "time", SimpleTime.class),
+    TimeType("Time", PropertyType.TIME.getTypeUri(), "time", Time.class, SimpleTime.class),
     DateTimeType("DateTime", "xsd:dateTime", "timestamp", Date.class, Timestamp.class, java.sql.Date.class),
     BooleanType("Boolean", "xsd:boolean", "boolean", Boolean.class, Boolean.TYPE),
     AttachmentType("Attachment", "xsd:attachment", "varchar", String.class, File.class);


### PR DESCRIPTION
#### Rationale
java.sql.Time should be a valid class for TimeType.

See related [TC failures](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySuites_DailyEPostgres/2966316?buildTab=tests&status=failed&expandedTest=build%3A%28id%3A2966316%29%2Cid%3A2000000040).

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
