### PR TITLE
Remove usages of DOM.onclick, etc.

### DIFF
--- a/api/src/org/labkey/api/util/Button.java
+++ b/api/src/org/labkey/api/util/Button.java
@@ -28,7 +28,6 @@ import java.util.Map;
 
 import static org.labkey.api.util.DOM.A;
 import static org.labkey.api.util.DOM.Attribute;
-import static org.labkey.api.util.DOM.Attribute.onclick;
 import static org.labkey.api.util.DOM.Attribute.tabindex;
 import static org.labkey.api.util.DOM.Attribute.title;
 import static org.labkey.api.util.DOM.Attribute.type;
@@ -71,7 +70,6 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
     private final String style;
     private final String confirmMessage;
     private final String target;
-    private final boolean inlineScript;
 
     private Button(ButtonBuilder builder)
     {
@@ -94,7 +92,6 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
         this.style = builder.style;
         this.confirmMessage = builder.confirmMessage;
         this.target = builder.target;
-        this.inlineScript = builder.inlineScript;
 
         if (this.usePost && null != this.onClick)
             throw new IllegalStateException("Can't specify both usePost and onClick");
@@ -245,7 +242,6 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
             .id(id)
             .at(title, tip, Attribute.rel, getRel(), Attribute.name, getName(), Attribute.style, getStyle(), Attribute.target, getTarget())
             .at(!usePost, Attribute.href, StringUtils.defaultIfBlank(this.href,  "#"), "#")
-            .at(inlineScript, onclick, clickHandler)
             .data(usePost, "href", this.href)
             .data(usePost, "confirmmessage", confirmMessage)
             .data("submitid", submitId)         // this id is used by the event handler, stash in a data attribute rather than hard-coding in the handler source
@@ -257,8 +253,7 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
             .cl(isDropdown(), "dropdown-toggle")
             .cl(iconOnly, "icon-only");
 
-        if (!inlineScript)
-            page.addHandler(id, "click", clickHandler);
+        page.addHandler(id, "click", clickHandler);
         return createHtmlFragment(
             isSubmit() ?
             INPUT(at(type,"submit",tabindex,"-1",Attribute.style,"position:absolute;left:-9999px;width:1px;height:1px;",Attribute.id,submitId)) : null,
@@ -275,7 +270,6 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
         private boolean dropdown;
         private boolean enabled = true;
         private boolean submit;
-        private boolean inlineScript = false;
 
         public ButtonBuilder(@NotNull String text)
         {
@@ -325,14 +319,6 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
         {
             this.submit = submit;
             this.primary(true);
-            return this;
-        }
-
-        /* ONLY WHEN RENDER MARKUP INTO JAVASCRIPT CODE */
-
-        public ButtonBuilder inlineScript()
-        {
-            this.inlineScript = true;
             return this;
         }
 

--- a/api/src/org/labkey/api/util/DOM.java
+++ b/api/src/org/labkey/api/util/DOM.java
@@ -424,13 +424,9 @@ public class DOM
         width,
         wrap,
 
-        /* ON attributes are deprecated and will go away */
+        /* Delete once 24.3 is merged to develop (panoramapublic/ExperimentAnnotationsTableInfo.java) */
         @Deprecated
         onclick,
-        @Deprecated
-        onmouseout,
-        @Deprecated
-        onmouseover
         ;
 
         Appendable render(Appendable builder, Object value) throws IOException

--- a/api/src/org/labkey/api/util/DomTestCase.java
+++ b/api/src/org/labkey/api/util/DomTestCase.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 
 import static org.labkey.api.util.DOM.Attribute.id;
 import static org.labkey.api.util.DOM.Attribute.method;
-import static org.labkey.api.util.DOM.Attribute.onclick;
 import static org.labkey.api.util.DOM.Attribute.selected;
 import static org.labkey.api.util.DOM.DIV;
 import static org.labkey.api.util.DOM.Element;
@@ -44,11 +43,6 @@ public class DomTestCase extends Assert
                             "Hello Seattle"),
                     "A&B"));
         assertEquals("<div><h1 id=\"header1\">Hello&nbsp;World</h1><h2 id=\"header2\">Hello Seattle</h2>A&amp;B</div>", h.toString());
-
-        h = createHtml(
-                SPAN(at(onclick, "alert('hello world')"),
-                        HtmlString.unsafe(">>here&lt;&lt")));
-        assertEquals("<span onclick=\"alert(&#039;hello world&#039;)\">>>here&lt;&lt</span>", h.toString());
 
         h = createHtml(
                 SPAN(cl("a","b","c"),

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -1489,7 +1489,7 @@ public class PageFlowUtil
             return this;
         }
 
-        /* ONLY USE TO RENDER INTO JAVASCRIPT CODE */
+        @Deprecated // This will be removed shortly. editSpecLibInfo.jsp is the only caller.
         public HelpPopupBuilder inlineScript()
         {
             this.inlineScript = true;

--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -144,6 +144,22 @@ LABKEY.Utils = new function(impl, $) {
         return nextRow;
     };
 
+    // JavaScript version of PageFlowUtil.helpPopup(), returns html and callback to be invoked after element is inserted
+    // into page. Useful for including LabKey-style help in Ext components.
+    impl.helpPopup = function(titleText, helpText)
+    {
+        const h = Ext4.util.Format.htmlEncode;
+        const id = Ext4.id();
+        const html = '<a id="' + id + '" href="#" tabindex="-1" class="_helpPopup"><span class="labkey-help-pop-up">?</span></a>';
+        const callback = function()
+        {
+            LABKEY.Utils.attachEventHandler(id, "click", function() {return showHelpDivDelay(this, titleText, h(helpText), 'auto');});
+            LABKEY.Utils.attachEventHandler(id, "mouseover", function() {return showHelpDivDelay(this, titleText, h(helpText), 'auto');});
+            LABKEY.Utils.attachEventHandler(id, "mouseout", hideHelpDivDelay);
+        };
+        return {"html":html, "callback":callback};
+    };
+
     /**
      * Shows an error dialog box to the user in response to an error from an AJAX request, including
      * any error messages from the server.

--- a/core/src/org/labkey/core/admin/exportFolder.jsp
+++ b/core/src/org/labkey/core/admin/exportFolder.jsp
@@ -65,23 +65,6 @@ boolean isCloudRoot = FileContentService.get().isCloudRoot(c);
 
 Ext4.onReady(function(){
 
-    // javascript version of PageFlowUtil.helpPopup(), returns html and callback to be invoked after element is inserted into page.
-    // Useful for including LabKey-style help in Ext components
-    // CONSIDER: move to dom/Utils.js if this can be used elsewhere
-    function helpPopup(titleText, helpText)
-    {
-        const h = Ext4.util.Format.htmlEncode;
-        const id = Ext4.id();
-        const html = '<a id="' + id + '" href="#" tabindex="-1" class="_helpPopup"><span class="labkey-help-pop-up">?</span></a>';
-        const callback = function()
-        {
-            LABKEY.Utils.attachEventHandler(id, "click", function() {return showHelpDivDelay(this, titleText, h(helpText), 'auto');});
-            LABKEY.Utils.attachEventHandler(id, "mouseover", function() {return showHelpDivDelay(this, titleText, h(helpText), 'auto');});
-            LABKEY.Utils.attachEventHandler(id, "mouseout", hideHelpDivDelay);
-        };
-        return {"html":html, "callback":callback};
-    }
-
     // Literals for PHI
     var restrictedPhi = <%=PHI.Restricted.ordinal()%>;
     var fullPhi = <%=PHI.PHI.ordinal()%>;
@@ -154,11 +137,11 @@ Ext4.onReady(function(){
 
         const subjectNoun = <%=q(subjectNoun)%>;
         const subjectNounLowercase = <%=q(subjectNounLowercase)%>;
-        const popupSubfolder = helpPopup("Include Subfolders", "Recursively export subfolders.");
-        const popupPHI = helpPopup("Include PHI Columns", "Include all dataset and list columns, study properties, and specimen data that have been tagged with this PHI level or below.");
-        const popupShiftDate = helpPopup("Shift Date Columns", "Selecting this option will shift selected date values associated with a " + subjectNounLowercase + " by a random, " + subjectNounLowercase + " specific, offset (from 1 to 365 days).");
-        const popupAlternate = helpPopup("Export Alternate " + subjectNoun + " IDs", "Selecting this option will replace each " + subjectNounLowercase + " id by an alternate randomly generated id.");
-        const popupClinic = helpPopup("Mask Clinic Names", "Selecting this option will change the labels for clinics in the exported list of locations to a generic label (i.e. Clinic).");
+        const popupSubfolder = LABKEY.Utils.helpPopup("Include Subfolders", "Recursively export subfolders.");
+        const popupPHI = LABKEY.Utils.helpPopup("Include PHI Columns", "Include all dataset and list columns, study properties, and specimen data that have been tagged with this PHI level or below.");
+        const popupShiftDate = LABKEY.Utils.helpPopup("Shift Date Columns", "Selecting this option will shift selected date values associated with a " + subjectNounLowercase + " by a random, " + subjectNounLowercase + " specific, offset (from 1 to 365 days).");
+        const popupAlternate = LABKEY.Utils.helpPopup("Export Alternate " + subjectNoun + " IDs", "Selecting this option will replace each " + subjectNounLowercase + " id by an alternate randomly generated id.");
+        const popupClinic = LABKEY.Utils.helpPopup("Mask Clinic Names", "Selecting this option will change the labels for clinics in the exported list of locations to a generic label (i.e. Clinic).");
 
         formItemsCol2.push({xtype: 'box', cls: 'labkey-announcement-title', html: '<span>Options:</span>'});
         formItemsCol2.push({xtype: 'box', cls: 'labkey-title-area-line', html: ''});

--- a/devtools/src/org/labkey/devtools/view/dom.jsp
+++ b/devtools/src/org/labkey/devtools/view/dom.jsp
@@ -42,10 +42,6 @@
 
         HR(),
 
-        SPAN(A(at(onclick,"alert('hello world')"), "<>>click here<<>")),
-
-        HR(),
-
         SPAN(css("a.b.c"), unsafe("A&nbsp;B&nbsp;C")),
 
         HR(),


### PR DESCRIPTION
#### Rationale
Strict CSPs don't like inline event handlers. Introduce `LABKEY.Utils.helpPopup()` and eliminate use of `DOM.onclick`, `DOM.onmouseout`, and `DOM.onmouseover`. (The last onclick reference will be removed once 24.3 is merged to develop.)