### PR TITLE
Fix exception logged after delete index

### DIFF
--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -399,6 +399,8 @@ public interface SearchService extends SearchMXBean
     void startCrawler();
     void pauseCrawler();
     void updateIndex();
+    void refreshNow();
+
     @Nullable Throwable getConfigurationError();
 
     IndexTask defaultTask();

--- a/core/src/org/labkey/core/search/NoopSearchService.java
+++ b/core/src/org/labkey/core/search/NoopSearchService.java
@@ -374,6 +374,11 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
+    public void refreshNow()
+    {
+    }
+
+    @Override
     public IndexTask indexContainer(@Nullable IndexTask task, Container c, Date since)
     {
         return null==task?_dummyTask:task;

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -2153,6 +2153,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         }
     }
 
+    @Override
     public void refreshNow()
     {
         try
@@ -2161,7 +2162,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         }
         catch (IOException x)
         {
-            /* pass */
+            _log.warn("Unable to refresh index manager", x);
         }
     }
 


### PR DESCRIPTION
#### Rationale
While fixing data finder search issues, I noticed that our near-real-time search background job was throwing after I invoked delete index from the admin page. I don't see what change caused this (maybe https://github.com/LabKey/platform/pull/5272 ?), but I suspect a race condition and there's no reason for the job to hold a `WritableIndexManagerImpl` instance.

```
INFO  JobRunShell              2024-03-29T11:06:36,429 QuartzScheduler_Worker-4 : Job DEFAULT.6da64b5bd2ee-4ee7def1-8db0-4006-a7ab-5918250ed329 threw a JobExecutionException: 
org.quartz.JobExecutionException: org.apache.lucene.store.AlreadyClosedException: this ReferenceManager is closed
	at org.labkey.search.model.WritableIndexManagerImpl$MaybeRefreshJob.execute(WritableIndexManagerImpl.java:399) ~[search-24.3-SNAPSHOT.jar:?]
	at org.quartz.core.JobRunShell.run(JobRunShell.java:202) [quartz-2.3.2.jar:?]
	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573) [quartz-2.3.2.jar:?]
Caused by: org.apache.lucene.store.AlreadyClosedException: this ReferenceManager is closed
	at org.apache.lucene.search.ReferenceManager.ensureOpen(ReferenceManager.java:49) ~[lucene-core-9.10.0.jar:9.10.0 695c0ac84508438302cd346a812cfa2fdc5a10df - 2024-02-14 16:48:06]
	at org.apache.lucene.search.ReferenceManager.maybeRefresh(ReferenceManager.java:207) ~[lucene-core-9.10.0.jar:9.10.0 695c0ac84508438302cd346a812cfa2fdc5a10df - 2024-02-14 16:48:06]
	at org.labkey.search.model.WritableIndexManagerImpl.refreshNow(WritableIndexManagerImpl.java:407) ~[search-24.3-SNAPSHOT.jar:?]
	at org.labkey.search.model.WritableIndexManagerImpl$MaybeRefreshJob.execute(WritableIndexManagerImpl.java:394) ~[search-24.3-SNAPSHOT.jar:?]
```