### PR TITLE
IOOBE fix

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -208,7 +208,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         {
             Map<DataType, List<Map<String, Object>>> datas = new HashMap<>();
             List<Map<String, Object>> dataRows = loader.load();
-            boolean skipFirstRowAdjustment = false;
+            boolean skipFirstRowAdjustment = dataRows.isEmpty();
 
             if (plateMetadataEnabled)
             {


### PR DESCRIPTION
#### Rationale
This fixes an error caught by the SM suites:

```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[?:?]
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266) ~[?:?]
	at java.base/java.util.Objects.checkIndex(Objects.java:361) ~[?:?]
	at java.base/java.util.ArrayList.remove(ArrayList.java:504) ~[?:?]
	at org.labkey.api.assay.AbstractAssayTsvDataHandler.adjustFirstRowOrder(AbstractAssayTsvDataHandler.java:384) ~[api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.assay.AbstractAssayTsvDataHandler.getValidationDataMap(AbstractAssayTsvDataHandler.java:232) ~[api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.assay.AbstractAssayTsvDataHandler.importFile(AbstractAssayTsvDataHandler.java:152) ~[api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.assay.DefaultAssayRunCreator.importStandardResultData(DefaultAssayRunCreator.java:547) ~[api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.assay.DefaultAssayRunCreator.importResultData(DefaultAssayRunCreator.java:565) ~[api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.assay.DefaultAssayRunCreator.saveExperimentRun(DefaultAssayRunCreator.java:375) ~[api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.assay.DefaultAssayRunCreator.saveExperimentRun(DefaultAssayRunCreator.java:165) ~[api-24.4-SNAPSHOT.jar:?]
	at org.labkey.assay.actions.ImportRunApiAction.execute(ImportRunApiAction.java:314) ~[assay-24.4-SNAPSHOT.jar:?]
	at org.labkey.assay.actions.ImportRunApiAction.execute(ImportRunApiAction.java:85) ~[assay-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.action.BaseApiAction.handlePost(BaseApiAction.java:239) [api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.action.BaseApiAction.handleRequest(BaseApiAction.java:129) [api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.action.BaseViewAction.handleRequest(BaseViewAction.java:193) [api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.action.SpringActionController.handleRequest(SpringActionController.java:508) [api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.module.DefaultModule.dispatch(DefaultModule.java:1128) [api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.view.ViewServlet._service(ViewServlet.java:240) [api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.view.ViewServlet.service(ViewServlet.java:159) [api-24.4-SNAPSHOT.jar:?]
```