### PR TITLE
Add ViewUsageStatistics view

### DIFF
--- a/core/src/client/ViewUsageStatistics/UsageStatsViewer.tsx
+++ b/core/src/client/ViewUsageStatistics/UsageStatsViewer.tsx
@@ -19,12 +19,17 @@ interface SearchResult {
     validSegments: string[];
 }
 
+function computeKeys(node: any) {
+    if (node !== null && typeof node === 'object') return Object.keys(node).sort(naturalSort);
+    return [];
+}
+
 function searchStats(stats: Record<string, any>, path: string): SearchResult {
     if (stats === undefined) return undefined;
     if (path === '')
         return {
             invalidSegment: undefined,
-            keys: Object.keys(stats).sort(naturalSort),
+            keys: computeKeys(stats),
             node: JSON.stringify(stats, undefined, 2),
             validSegments: undefined,
         };
@@ -39,9 +44,7 @@ function searchStats(stats: Record<string, any>, path: string): SearchResult {
         } else {
             return {
                 invalidSegment: segment,
-                keys: Object.keys(node)
-                    .filter(k => k.startsWith(segment))
-                    .sort(naturalSort),
+                keys: computeKeys(node).filter(k => k.startsWith(segment)),
                 node: JSON.stringify(node, undefined, 2),
                 validSegments,
             };
@@ -50,7 +53,7 @@ function searchStats(stats: Record<string, any>, path: string): SearchResult {
 
     return {
         invalidSegment: undefined,
-        keys: node === null ? [] : Object.keys(node).sort(naturalSort),
+        keys: computeKeys(node),
         node: JSON.stringify(node, undefined, 2),
         validSegments: undefined,
     };
@@ -77,12 +80,12 @@ interface StatsDisplayProps {
 
 export const StatsDisplay: FC<StatsDisplayProps> = memo(({ searchResult, selectKey }) => {
     const { invalidSegment, keys, node, validSegments } = searchResult;
-    const invalidSeg = <code className="text-danger">{invalidSegment === '' ? '.' : invalidSegment}</code>;
+    const invalidEl = <code className="text-danger">{invalidSegment === '' ? '.' : invalidSegment}</code>;
     return (
         <div className="usage-stats__search-result">
             {invalidSegment !== undefined && (
                 <div className="usage-stats__invalid-messsage">
-                    {invalidSeg} not found{' '}
+                    {invalidEl} not found{' '}
                     {validSegments.length > 0 && (
                         <>
                             in <code className="text-success">{validSegments.join('.')}</code>
@@ -94,7 +97,7 @@ export const StatsDisplay: FC<StatsDisplayProps> = memo(({ searchResult, selectK
             <div className="usage-stats__valid-keys">
                 {keys.length > 0 && (
                     <>
-                        {invalidSegment && <label>Keys starting with {invalidSeg}:</label>}
+                        {invalidSegment && <label>Keys starting with {invalidEl}:</label>}
                         {!invalidSegment && <label>Keys:</label>}
                         <ul className="key-list">
                             {keys.map(key => (
@@ -103,7 +106,7 @@ export const StatsDisplay: FC<StatsDisplayProps> = memo(({ searchResult, selectK
                         </ul>
                     </>
                 )}
-                {keys.length === 0 && <>No valid keys starting with {invalidSeg}</>}
+                {invalidSegment && keys.length === 0 && <>No valid keys starting with {invalidEl}</>}
             </div>
             {node !== undefined && <pre>{node}</pre>}
         </div>

--- a/core/src/client/ViewUsageStatistics/UsageStatsViewer.tsx
+++ b/core/src/client/ViewUsageStatistics/UsageStatsViewer.tsx
@@ -1,0 +1,191 @@
+import React, { FC, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { ActionURL, Ajax, Utils } from '@labkey/api';
+import { Alert, LoadingSpinner, naturalSort } from '@labkey/components';
+
+function fetchUsageStatistics(): Promise<Record<string, any>> {
+    return new Promise((resolve, reject) => {
+        Ajax.request({
+            url: ActionURL.buildURL('admin', 'testMothershipReport', null, { type: 'CheckForUpdates', level: 'ON' }),
+            success: Utils.getCallbackWrapper(response => resolve(response)),
+            failure: Utils.getCallbackWrapper((error, response) => reject(response.exception)),
+        });
+    });
+}
+
+interface SearchResult {
+    invalidSegment: string;
+    keys: string[];
+    node: string; // Stringify'ed node value
+    validSegments: string[];
+}
+
+function searchStats(stats: Record<string, any>, path: string): SearchResult {
+    if (stats === undefined) return undefined;
+    if (path === '')
+        return {
+            invalidSegment: undefined,
+            keys: Object.keys(stats).sort(naturalSort),
+            node: JSON.stringify(stats, undefined, 2),
+            validSegments: undefined,
+        };
+    const parts = path.split('.');
+    let node = stats;
+    const validSegments = [];
+
+    for (const segment of parts) {
+        if (node[segment] !== undefined) {
+            validSegments.push(segment);
+            node = node[segment];
+        } else {
+            return {
+                invalidSegment: segment,
+                keys: Object.keys(node)
+                    .filter(k => k.startsWith(segment))
+                    .sort(naturalSort),
+                node: JSON.stringify(node, undefined, 2),
+                validSegments,
+            };
+        }
+    }
+
+    return {
+        invalidSegment: undefined,
+        keys: node === null ? [] : Object.keys(node).sort(naturalSort),
+        node: JSON.stringify(node, undefined, 2),
+        validSegments: undefined,
+    };
+}
+
+interface StatsKeyProps {
+    selectKey: (key: string) => void;
+    value: string;
+}
+
+const StatsKey: FC<StatsKeyProps> = memo(({ selectKey, value }) => {
+    const onClick = useCallback(() => selectKey(value), [value, selectKey]);
+    return (
+        <li className="clickable-text" onClick={onClick}>
+            {value}
+        </li>
+    );
+});
+
+interface StatsDisplayProps {
+    searchResult: SearchResult;
+    selectKey: (key: string) => void;
+}
+
+export const StatsDisplay: FC<StatsDisplayProps> = memo(({ searchResult, selectKey }) => {
+    const { invalidSegment, keys, node, validSegments } = searchResult;
+    const invalidSeg = <code className="text-danger">{invalidSegment === '' ? '.' : invalidSegment}</code>;
+    return (
+        <div className="usage-stats__search-result">
+            {invalidSegment !== undefined && (
+                <div className="usage-stats__invalid-messsage">
+                    {invalidSeg} not found{' '}
+                    {validSegments.length > 0 && (
+                        <>
+                            in <code className="text-success">{validSegments.join('.')}</code>
+                        </>
+                    )}
+                </div>
+            )}
+
+            <div className="usage-stats__valid-keys">
+                {keys.length > 0 && (
+                    <>
+                        {invalidSegment && <label>Keys starting with {invalidSeg}:</label>}
+                        {!invalidSegment && <label>Keys:</label>}
+                        <ul className="key-list">
+                            {keys.map(key => (
+                                <StatsKey key={key} selectKey={selectKey} value={key} />
+                            ))}
+                        </ul>
+                    </>
+                )}
+                {keys.length === 0 && <>No valid keys starting with {invalidSeg}</>}
+            </div>
+            {node !== undefined && <pre>{node}</pre>}
+        </div>
+    );
+});
+
+export const UsageStatsViewer: FC = memo(() => {
+    const [loading, setLoading] = useState<boolean>(false);
+    const [usageStatistics, setUsageStatistics] = useState(undefined);
+    const [jsonPath, setJsonPath] = useState<string>(ActionURL.getParameter('jsonPath') ?? '');
+    const [error, setError] = useState(undefined);
+    const loadStats = useCallback(async () => {
+        setError(undefined);
+        setLoading(true);
+        try {
+            const response = await fetchUsageStatistics();
+            setUsageStatistics(response.jsonMetrics);
+        } catch (e) {
+            setError(e);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+    const onChange = useCallback(event => setJsonPath(event.target.value), []);
+    const searchResult = useMemo(() => {
+        return searchStats(usageStatistics, jsonPath);
+    }, [usageStatistics, jsonPath]);
+    const clearPath = useCallback(() => setJsonPath(''), []);
+    const selectKey = useCallback(
+        (key: string) => {
+            setJsonPath(current => {
+                if (current === '') {
+                    return key;
+                } else if (searchResult.invalidSegment !== undefined) {
+                    let segments = current.split('.');
+                    segments = segments.slice(0, segments.length - 1); // Slice off the invalid segment
+                    segments.push(key); // append the key that was clicked
+                    return segments.join('.');
+                }
+
+                return current + '.' + key;
+            });
+        },
+        [searchResult]
+    );
+
+    useEffect(() => {
+        loadStats();
+    }, [loadStats]);
+    return (
+        <div>
+            <div className="usage-stats panel panel-default">
+                <div className="panel-body">
+                    <div className="usage-stats__button-bar">
+                        <button type="button" className="btn btn-primary" onClick={loadStats}>
+                            Reload Usage Statistics
+                        </button>
+                        {loading && <LoadingSpinner msg="Loading usage statistics..." />}
+                    </div>
+                    <div className="usage-stats__inputs">
+                        <div>
+                            <label htmlFor="stats-path">JSON Path:</label>
+                        </div>
+                        <input
+                            id="stats-path"
+                            className="form-control"
+                            type="text"
+                            value={jsonPath}
+                            onChange={onChange}
+                            placeholder="e.g. modules.Core"
+                        />
+                        <div>
+                            <button className="btn btn-primary" onClick={clearPath} type="button">
+                                clear
+                            </button>
+                        </div>
+                    </div>
+                    <Alert>{error}</Alert>
+                    {searchResult !== undefined && <StatsDisplay selectKey={selectKey} searchResult={searchResult} />}
+                </div>
+            </div>
+        </div>
+    );
+});
+UsageStatsViewer.displayName = 'UsageStatsViewer';

--- a/core/src/client/ViewUsageStatistics/app.tsx
+++ b/core/src/client/ViewUsageStatistics/app.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { UsageStatsViewer } from './UsageStatsViewer';
+
+import './viewUsageStatistics.scss';
+
+window.addEventListener('DOMContentLoaded', () => {
+    ReactDOM.render(<UsageStatsViewer />, document.getElementById('app'));
+});

--- a/core/src/client/ViewUsageStatistics/dev.tsx
+++ b/core/src/client/ViewUsageStatistics/dev.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { UsageStatsViewer } from './UsageStatsViewer';
+
+import './viewUsageStatistics.scss';
+
+const render = (): void => {
+    ReactDOM.render(<UsageStatsViewer />, document.getElementById('app'));
+};
+
+render();

--- a/core/src/client/ViewUsageStatistics/viewUsageStatistics.scss
+++ b/core/src/client/ViewUsageStatistics/viewUsageStatistics.scss
@@ -1,0 +1,42 @@
+.usage-stats ul.key-list {
+  display: inline;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.usage-stats .key-list li {
+  display: inline;
+  cursor: pointer;
+  color: #2980B9;
+
+  &:hover {
+    text-decoration: underline;
+    color: darken(#2980B9, 15);
+  }
+
+  &:after {
+    content: ", "
+  }
+  &:last-child:after {
+    content: "";
+  }
+}
+.usage-stats__button-bar,
+.usage-stats__inputs {
+  margin-bottom: 10px;
+}
+
+.usage-stats__inputs,
+.usage-stats__button-bar {
+  display: flex;
+  gap: 10px;
+}
+
+.usage-stats label {
+  font-weight: bold;
+  margin-right: 8px;
+}
+.usage-stats__inputs label {
+  width: 80px;
+  line-height: 27px;
+}

--- a/core/src/client/entryPoints.js
+++ b/core/src/client/entryPoints.js
@@ -14,6 +14,11 @@ module.exports = {
         title: '@labkey/components',
         permission: 'admin',
         path: './src/client/LabKeyUIComponentsPage'
+    }, {
+        name: 'viewUsageStatistics',
+        title: 'View Usage Statistics',
+        permission: 'admin',
+        path: './src/client/ViewUsageStatistics',
     },{
         name: 'errorHandler',
         title: 'Error Handler',

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -89,6 +89,7 @@ import org.labkey.api.module.FolderTypeManager;
 import org.labkey.api.module.IgnoresForbiddenProjectCheck;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleContext;
+import org.labkey.api.module.ModuleHtmlView;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.SimpleModule;
 import org.labkey.api.moduleeditor.api.ModuleEditorService;
@@ -11172,6 +11173,22 @@ public class AdminController extends SpringActionController
         public void setHourDelta(Integer hourDelta)
         {
             this.hourDelta = hourDelta;
+        }
+    }
+
+    @RequiresPermission(AdminPermission.class)
+    public static class ViewUsageStatistics extends SimpleViewAction<Object>
+    {
+        @Override
+        public ModelAndView getView(Object o, BindException errors)
+        {
+            return ModuleHtmlView.get(ModuleLoader.getInstance().getModule("core"), ModuleHtmlView.getGeneratedViewPath("ViewUsageStatistics"));
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+            // TODO: What would be appropriate here?
         }
     }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -11177,7 +11177,7 @@ public class AdminController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public static class ViewUsageStatistics extends SimpleViewAction<Object>
+    public class ViewUsageStatistics extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -11188,7 +11188,7 @@ public class AdminController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            // TODO: What would be appropriate here?
+            addAdminNavTrail(root, "Usage Statistics", this.getClass());
         }
     }
 

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -222,7 +222,7 @@ Click the Save button at any time to accept the current settings and continue.</
 %>
             <tr>
                 <td style="padding: 5px 0 5px;" colspan="2">
-                            <%=button("View").id("testUsageReport").onClick("testUsageReport(false); return false;")%>
+                            <%=link("View", AdminController.ViewUsageStatistics.class)%>
                             <%=button("Download").id("testUsageReportDownload").onClick("testUsageReport(true); return false;")%>
                     Generate an example usage report. <strong>No data will be submitted.</strong></td>
             </tr>

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -76,8 +76,8 @@ var enableTestButton = function(el, level) {
     }
 };
 
-var testUsageReport = function(download) {
-    testMothershipReport('CheckForUpdates', '<%=UsageReportingLevel.ON%>', download);
+var testUsageReport = function() {
+    testMothershipReport('CheckForUpdates', '<%=UsageReportingLevel.ON%>', true);
 };
 
 var testExceptionReport = function(download) {
@@ -223,7 +223,7 @@ Click the Save button at any time to accept the current settings and continue.</
             <tr>
                 <td style="padding: 5px 0 5px;" colspan="2">
                             <%=link("View", AdminController.ViewUsageStatistics.class)%>
-                            <%=button("Download").id("testUsageReportDownload").onClick("testUsageReport(true); return false;")%>
+                            <%=button("Download").id("testUsageReportDownload").onClick("testUsageReport(); return false;")%>
                     Generate an example usage report. <strong>No data will be submitted.</strong></td>
             </tr>
         </table>


### PR DESCRIPTION
#### Rationale
This PR adds a new action to the AdminController, ViewUsageStatisticsAction, which renders a react component that fetches the current usage statistics and renders them. The react component features a text box that lets users type a JSON path to filter down the results, as well as a list of keys in the current view that users can click to further filter the results. You can also navigate to the view with the query arg `?jsonPath=` to prefill the jsonPath text box e.g. `admin-viewUsageStatistics.view?jsonPath=modules.Assay`

This view is most useful when adding or modifying metrics to a module, as it allows you to easily filter the usage statistics object down to the module you care about, and then with the click of a button reload the usage statistics.

![Screenshot 2024-04-01 at 5 42 22 PM](https://github.com/LabKey/platform/assets/5341647/2269a59b-0368-412a-a4fc-c9497b87755f)


#### Related Pull Requests
- N/A

#### Changes
- Add ViewUsageStatisticsAction
- Add UsageStatsViewer.tsx and related component infrastructure
- Add link to ViewUsageStatisticsAction in `cusomizeSite.jsp`
