### PR TITLE
49954: Add PHI options for folder templates

### DIFF
--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -144,6 +144,22 @@ LABKEY.Utils = new function(impl, $) {
         return nextRow;
     };
 
+    // JavaScript version of PageFlowUtil.helpPopup(), returns html and callback to be invoked after element is inserted
+    // into page. Useful for including LabKey-style help in Ext components.
+    impl.helpPopup = function(titleText, helpText)
+    {
+        const h = Ext4.util.Format.htmlEncode;
+        const id = Ext4.id();
+        const html = '<a id="' + id + '" href="#" tabindex="-1" class="_helpPopup"><span class="labkey-help-pop-up">?</span></a>';
+        const callback = function()
+        {
+            LABKEY.Utils.attachEventHandler(id, "click", function() {return showHelpDivDelay(this, titleText, h(helpText), 'auto');});
+            LABKEY.Utils.attachEventHandler(id, "mouseover", function() {return showHelpDivDelay(this, titleText, h(helpText), 'auto');});
+            LABKEY.Utils.attachEventHandler(id, "mouseout", hideHelpDivDelay);
+        };
+        return {"html":html, "callback":callback};
+    };
+
     /**
      * Shows an error dialog box to the user in response to an error from an AJAX request, including
      * any error messages from the server.

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -6661,8 +6661,8 @@ public class AdminController extends SpringActionController
         private String templateSourceId;
         private String[] templateWriterTypes;
         private boolean templateIncludeSubfolders = false;
-
         private String[] targets;
+        private PHI _exportPhiLevel = PHI.NotPHI;
 
         public boolean getHasLoaded()
         {
@@ -6828,6 +6828,16 @@ public class AdminController extends SpringActionController
         public void setTargets(String[] targets)
         {
             this.targets = targets;
+        }
+
+        public PHI getExportPhiLevel()
+        {
+            return _exportPhiLevel;
+        }
+
+        public void setExportPhiLevel(PHI exportPhiLevel)
+        {
+            _exportPhiLevel = exportPhiLevel;
         }
 
         /**
@@ -7164,6 +7174,7 @@ public class AdminController extends SpringActionController
                     // If a default folder type has been configured by a site admin set that as the default folder type choice
                     form.setFolderType(folderType.getName());
                 }
+                form.setExportPhiLevel(ComplianceService.get().getMaxAllowedPhi(getContainer(), getUser()));
             }
             JspView<FORM> statusView = new JspView<>("/org/labkey/core/admin/createFolder.jsp", form, errors);
             vbox.addView(statusView);
@@ -7246,7 +7257,7 @@ public class AdminController extends SpringActionController
                         }
 
                         FolderExportContext exportCtx = new FolderExportContext(getUser(), sourceContainer, PageFlowUtil.set(form.getTemplateWriterTypes()), "new",
-                                form.getTemplateIncludeSubfolders(), PHI.NotPHI, false, false, false,
+                                form.getTemplateIncludeSubfolders(), form.getExportPhiLevel(), false, false, false,
                                 new StaticLoggerGetter(LogManager.getLogger(FolderWriterImpl.class)));
 
                         container = ContainerManager.createContainerFromTemplate(parent, folderName, folderTitle, sourceContainer, getUser(), exportCtx, afterCreateHandler);

--- a/core/src/org/labkey/core/admin/createFolder.jsp
+++ b/core/src/org/labkey/core/admin/createFolder.jsp
@@ -511,7 +511,7 @@
                     // get the panel holding the list of folder objects
                     let pnl = this.down('#template_folder_writers');
                     if (pnl) {
-                        this.down('#templateIncludeSubfolders').setVisible(true);
+                        this.down('#template_folder_options').setVisible(true);
                         this.down('#folderObjectsLabel').setVisible(true);
                         this.down('#folderOptionsLabel').setVisible(true);
 
@@ -566,14 +566,21 @@
                             cls: 'labkey-wizard-header',
                             itemId: 'folderOptionsLabel',
                             hidden: true
-                        },{
-                            xtype: 'checkbox',
-                            hideLabel: true,
+                        }, {
+                            xtype: 'panel',
+                            border: false,
+                            itemId: 'template_folder_options',
                             hidden: true,
-                            boxLabel: 'Include Subfolders',
-                            name: 'templateIncludeSubfolders',
-                            itemId: 'templateIncludeSubfolders',
-                            checked: <%=form.getTemplateIncludeSubfolders()%>
+                            items: [{
+                                xtype: 'checkbox',
+                                hideLabel: true,
+                                boxLabel: 'Include Subfolders',
+                                name: 'templateIncludeSubfolders',
+                                checked: <%=form.getTemplateIncludeSubfolders()%>
+                            },{
+                                xtype: 'labkey_phi_option',
+                                maxAllowedLevel: <%=q(form.getExportPhiLevel().name())%>
+                            }]
                         }
                     ]);
 

--- a/core/src/org/labkey/core/admin/createFolder.jsp
+++ b/core/src/org/labkey/core/admin/createFolder.jsp
@@ -572,14 +572,14 @@
                             itemId: 'template_folder_options',
                             hidden: true,
                             items: [{
+                                xtype: 'labkey_phi_option',
+                                maxAllowedLevel: <%=q(form.getExportPhiLevel().name())%>
+                            },{
                                 xtype: 'checkbox',
                                 hideLabel: true,
                                 boxLabel: 'Include Subfolders',
                                 name: 'templateIncludeSubfolders',
                                 checked: <%=form.getTemplateIncludeSubfolders()%>
-                            },{
-                                xtype: 'labkey_phi_option',
-                                maxAllowedLevel: <%=q(form.getExportPhiLevel().name())%>
                             }]
                         }
                     ]);

--- a/core/src/org/labkey/core/admin/exportFolder.jsp
+++ b/core/src/org/labkey/core/admin/exportFolder.jsp
@@ -116,10 +116,10 @@ Ext4.onReady(function(){
 
         const subjectNoun = <%=q(subjectNoun)%>;
         const subjectNounLowercase = <%=q(subjectNounLowercase)%>;
-        const popupSubfolder = LABKEY.export.Util.helpPopup("Include Subfolders", "Recursively export subfolders.");
-        const popupShiftDate = LABKEY.export.Util.helpPopup("Shift Date Columns", "Selecting this option will shift selected date values associated with a " + subjectNounLowercase + " by a random, " + subjectNounLowercase + " specific, offset (from 1 to 365 days).");
-        const popupAlternate = LABKEY.export.Util.helpPopup("Export Alternate " + subjectNoun + " IDs", "Selecting this option will replace each " + subjectNounLowercase + " id by an alternate randomly generated id.");
-        const popupClinic = LABKEY.export.Util.helpPopup("Mask Clinic Names", "Selecting this option will change the labels for clinics in the exported list of locations to a generic label (i.e. Clinic).");
+        const popupSubfolder = LABKEY.Utils.helpPopup("Include Subfolders", "Recursively export subfolders.");
+        const popupShiftDate = LABKEY.Utils.helpPopup("Shift Date Columns", "Selecting this option will shift selected date values associated with a " + subjectNounLowercase + " by a random, " + subjectNounLowercase + " specific, offset (from 1 to 365 days).");
+        const popupAlternate = LABKEY.Utils.helpPopup("Export Alternate " + subjectNoun + " IDs", "Selecting this option will replace each " + subjectNounLowercase + " id by an alternate randomly generated id.");
+        const popupClinic = LABKEY.Utils.helpPopup("Mask Clinic Names", "Selecting this option will change the labels for clinics in the exported list of locations to a generic label (i.e. Clinic).");
 
         formItemsCol2.push({xtype: 'box', cls: 'labkey-announcement-title', html: '<span>Options:</span>'});
         formItemsCol2.push({xtype: 'box', cls: 'labkey-title-area-line', html: ''});

--- a/core/webapp/AdminWizardForm.js
+++ b/core/webapp/AdminWizardForm.js
@@ -33,3 +33,113 @@ Ext4.define('LABKEY.ext4.AdminWizardForm', {
     }
 
 });
+
+Ext4.define('LABKEY.ext4.PHIStore', {
+    extend: 'Ext.data.Store',
+
+    constructor: function (config) {
+        Ext4.apply(this, config);
+
+        this.fields = ['label', 'value'];
+
+        if (config.maxAllowedLevel) {
+            let data = [];
+
+            switch (config.maxAllowedLevel) {
+                case 'Restricted':
+                    data.push({ value: 'Restricted', label: 'Restricted, Full and Limited PHI' });
+                case 'PHI':
+                    data.push({ value: 'PHI', label: 'Full and Limited PHI' });
+                case 'Limited':
+                    data.push({ value: 'Limited', label: 'Limited PHI' });
+                    break;
+            }
+            // want the PHI to be ordered from least to most restrictive
+            this.data = data.reverse();
+        }
+        this.callParent(config);
+    }
+});
+
+Ext4.define('LABKEY.ext4.PHIExport', {
+    extend: 'Ext.container.Container',
+    alias: 'widget.labkey_phi_option',
+
+    constructor: function (config) {
+        Ext4.applyIf(config, {
+            maxAllowedLevel: 'NotPHI',
+            fieldName: 'exportPhiLevel'
+        });
+
+        this.phiHelp = LABKEY.export.Util.helpPopup("Include PHI Columns", "Include all dataset and list columns, study properties, and specimen data that have been tagged with this PHI level or below.");
+        let isIncludePhiChecked = config.maxAllowedLevel !== 'NotPHI';
+        let phiStore = Ext4.create('LABKEY.ext4.PHIStore', {
+            maxAllowedLevel: config.maxAllowedLevel
+        });
+
+        this.layout = 'hbox';
+        this.items = [{
+            xtype: 'checkbox',
+            hideLabel: true,
+            boxLabel: 'Include PHI Columns: ' + this.phiHelp.html + '&nbsp&nbsp',
+            itemId: 'includePhi',
+            name: 'includePhi',
+            objectType: 'otherOptions',
+            checked: isIncludePhiChecked,
+            listeners: {
+                change: function (cmp, checked) {
+                    let combo = cmp.ownerCt.getComponent('phi_level');
+                    if (combo) {
+                        combo.setValue(checked ? config.maxAllowedLevel : 'NotPHI');
+                        combo.setDisabled(!checked);
+                    }
+                }
+            }
+        }, {
+            xtype: 'combobox',
+            hideLabel: true,
+            disabled: !isIncludePhiChecked,
+            itemId: 'phi_level',
+            name: config.fieldName,
+            store: phiStore,
+            displayField: 'label',
+            valueField: 'value',
+            queryMode: 'local',
+            margin: '0 0 0 2',
+            matchFieldWidth: false,
+            width: 195,
+            valueNotFoundText: 'NotPHI',
+            value: config.maxAllowedLevel
+        }];
+
+        this.listeners = {
+            render : function(cmp){cmp.phiHelp.callback();}
+        };
+        this.callParent(config);
+    }
+});
+
+LABKEY.export = LABKEY.export || {};
+LABKEY.export.Util = new function () {
+
+    return {
+        // javascript version of PageFlowUtil.helpPopup(), returns html and callback to be invoked after element is inserted into page.
+        // Useful for including LabKey-style help in Ext components
+        // CONSIDER: move to dom/Utils.js if this can be used elsewhere
+        helpPopup: function (titleText, helpText) {
+            const h = Ext4.util.Format.htmlEncode;
+            const id = Ext4.id();
+            const html = '<a id="' + id + '" href="#" tabindex="-1" class="_helpPopup"><span class="labkey-help-pop-up">?</span></a>';
+            const callback = function () {
+                LABKEY.Utils.attachEventHandler(id, "click", function () {
+                    return showHelpDivDelay(this, titleText, h(helpText), 'auto');
+                });
+                LABKEY.Utils.attachEventHandler(id, "mouseover", function () {
+                    return showHelpDivDelay(this, titleText, h(helpText), 'auto');
+                });
+                LABKEY.Utils.attachEventHandler(id, "mouseout", hideHelpDivDelay);
+            };
+            return { "html": html, "callback": callback };
+        }
+    }
+};

--- a/core/webapp/AdminWizardForm.js
+++ b/core/webapp/AdminWizardForm.js
@@ -71,9 +71,9 @@ Ext4.define('LABKEY.ext4.PHIExport', {
             fieldName: 'exportPhiLevel'
         });
 
-        this.phiHelp = LABKEY.export.Util.helpPopup("Include PHI Columns", "Include all dataset and list columns, study properties, and specimen data that have been tagged with this PHI level or below.");
-        let isIncludePhiChecked = config.maxAllowedLevel !== 'NotPHI';
-        let phiStore = Ext4.create('LABKEY.ext4.PHIStore', {
+        this.phiHelp = LABKEY.Utils.helpPopup("Include PHI Columns", "Include all dataset and list columns, study properties, and specimen data that have been tagged with this PHI level or below.");
+        const isIncludePhiChecked = config.maxAllowedLevel !== 'NotPHI';
+        const phiStore = Ext4.create('LABKEY.ext4.PHIStore', {
             maxAllowedLevel: config.maxAllowedLevel
         });
 
@@ -118,28 +118,3 @@ Ext4.define('LABKEY.ext4.PHIExport', {
         this.callParent(config);
     }
 });
-
-LABKEY.export = LABKEY.export || {};
-LABKEY.export.Util = new function () {
-
-    return {
-        // javascript version of PageFlowUtil.helpPopup(), returns html and callback to be invoked after element is inserted into page.
-        // Useful for including LabKey-style help in Ext components
-        // CONSIDER: move to dom/Utils.js if this can be used elsewhere
-        helpPopup: function (titleText, helpText) {
-            const h = Ext4.util.Format.htmlEncode;
-            const id = Ext4.id();
-            const html = '<a id="' + id + '" href="#" tabindex="-1" class="_helpPopup"><span class="labkey-help-pop-up">?</span></a>';
-            const callback = function () {
-                LABKEY.Utils.attachEventHandler(id, "click", function () {
-                    return showHelpDivDelay(this, titleText, h(helpText), 'auto');
-                });
-                LABKEY.Utils.attachEventHandler(id, "mouseover", function () {
-                    return showHelpDivDelay(this, titleText, h(helpText), 'auto');
-                });
-                LABKEY.Utils.attachEventHandler(id, "mouseout", hideHelpDivDelay);
-            };
-            return { "html": html, "callback": callback };
-        }
-    }
-};


### PR DESCRIPTION
[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=49954)

#### Rationale
Allow users to select PHI levels when creating folders from a template. The PHI selection combo will render in the Options section when the template folder option (and folder) are selected during the new folder creation wizard.

#### Changes
- Create a shared component for PHI options that could be reused between the existing export and create folder forms.
- Moved over some other utilities that previously existed in the folder export code for registering help popup event listeners that were previously refactored for CSP inline event handlers.
