### PR TITLE
Address various issues with export to script

### DIFF
--- a/api/src/org/labkey/api/query/JavaExportScriptFactory.java
+++ b/api/src/org/labkey/api/query/JavaExportScriptFactory.java
@@ -15,11 +15,6 @@
  */
 package org.labkey.api.query;
 
-/*
-* User: Dave
-* Date: Apr 2, 2009
-* Time: 12:42:49 PM
-*/
 public class JavaExportScriptFactory implements ExportScriptFactory
 {
     @Override

--- a/api/src/org/labkey/api/query/JavaExportScriptModel.java
+++ b/api/src/org/labkey/api/query/JavaExportScriptModel.java
@@ -136,7 +136,7 @@ public class JavaExportScriptModel extends ExportScriptModel
 
             for (Entry<String, String> entry : getQueryParameters().entrySet())
             {
-                sb.append("parameters.put(\"").append(entry.getKey()).append("\", \"").append(entry.getValue()).append("\");\n");
+                sb.append("parameters.put(").append(quote(entry.getKey())).append(", ").append(quote(entry.getValue())).append(");\n");
             }
 
             sb.append("cmd.setQueryParameters(parameters);\n");

--- a/api/src/org/labkey/api/query/JavaScriptExportScriptModel.java
+++ b/api/src/org/labkey/api/query/JavaScriptExportScriptModel.java
@@ -36,27 +36,12 @@ public class JavaScriptExportScriptModel extends ExportScriptModel
     @Override
     public String getFilters()
     {
-        List<String> filterExprs = getFilterExpressions();
-        if (null == filterExprs || filterExprs.isEmpty())
-            return "null";
-        
-        StringBuilder ret = new StringBuilder("[");
-        String sep = "";
-        for (String filterExpr : filterExprs)
-        {
-            ret.append(sep);
-            ret.append(filterExpr);
-            sep = ",";
-        }
-        ret.append("]");
-        return ret.toString();
+        return getFilters("null", "[", "", ",", "]");
     }
-
 
     /**
      * This is very close to getStandardJavaScriptParameters(), however,
      * getStandardJavaScriptParameters() may inject JavaScript _code_ e.g. Filter constructors etc.
-     *
      * This method returns a pure JSON representation of the view.
      *
      * @return
@@ -136,7 +121,6 @@ public class JavaScriptExportScriptModel extends ExportScriptModel
         return config;
     }
 
-
     public JSONArray getJSONFilters()
     {
         // Returns filters in a JSON format for use with the GetData API.
@@ -165,7 +149,6 @@ public class JavaScriptExportScriptModel extends ExportScriptModel
         return filters;
     }
 
-
     public JSONArray getJSONColumns()
     {
         // Returns columns in a JSON format for use with the GetData API.
@@ -183,10 +166,15 @@ public class JavaScriptExportScriptModel extends ExportScriptModel
     }
 
     @Override
+    protected String quote(String value)
+    {
+        return PageFlowUtil.jsString(value);
+    }
+
+    @Override
     protected String makeFilterExpression(String name, CompareType operator, String value)
     {
-        return "LABKEY.Filter.create(" + PageFlowUtil.jsString(name) + ", "
-                + PageFlowUtil.jsString(value) + ", LABKEY.Filter.Types." + operator.getScriptName() + ")";
+        return "LABKEY.Filter.create(" + quote(name) + ", " + quote(value) + ", LABKEY.Filter.Types." + operator.getScriptName() + ")";
     }
 
     // Produce javascript code block containing all the standard query parameters. Callers need to wrap this block in
@@ -196,20 +184,20 @@ public class JavaScriptExportScriptModel extends ExportScriptModel
         String indent = StringUtils.repeat(" ", indentSpaces);
         StringBuilder params = new StringBuilder();
         params.append(indent).append("requiredVersion: 9.1,\n");
-        params.append(indent).append("schemaName: ").append(PageFlowUtil.jsString(getSchemaName())).append(",\n");
+        params.append(indent).append("schemaName: ").append(quote(getSchemaName())).append(",\n");
 
         if (null != getViewName())
-            params.append(indent).append("viewName: ").append(PageFlowUtil.jsString(getViewName())).append(",\n");
+            params.append(indent).append("viewName: ").append(quote(getViewName())).append(",\n");
 
-        params.append(indent).append("queryName: ").append(PageFlowUtil.jsString(getQueryName())).append(",\n");
-        params.append(indent).append("columns: ").append(PageFlowUtil.jsString(getColumns())).append(",\n");  // TODO: Inconsistent with R and SAS, which don't include view columns
+        params.append(indent).append("queryName: ").append(quote(getQueryName())).append(",\n");
+        params.append(indent).append("columns: ").append(quote(getColumns())).append(",\n");
         params.append(indent).append("filterArray: ").append(getFilters());
 
         if (hasSort())
-            params.append(",\n").append(indent).append("sort: ").append(PageFlowUtil.jsString(getSort()));
+            params.append(",\n").append(indent).append("sort: ").append(quote(getSort()));
 
         if (hasContainerFilter())
-            params.append(",\n").append(indent).append("containerFilter: ").append(PageFlowUtil.jsString(getContainerFilterTypeName()));
+            params.append(",\n").append(indent).append("containerFilter: ").append(quote(getContainerFilterTypeName()));
 
         if (hasQueryParameters())
         {

--- a/api/src/org/labkey/api/query/PerlExportScriptModel.java
+++ b/api/src/org/labkey/api/query/PerlExportScriptModel.java
@@ -20,14 +20,8 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.util.PageFlowUtil;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
-/**
- * User: bbimber
- * Date: 2/5/12
- * Time: 8:39 PM
- */
 public class PerlExportScriptModel extends ExportScriptModel
 {
     private int _indentSpaces = 0;
@@ -43,31 +37,24 @@ public class PerlExportScriptModel extends ExportScriptModel
     {
         String indent = StringUtils.repeat(" ", _indentSpaces);
 
-        List<String> filterExprs = getFilterExpressions();
-        if (null == filterExprs || filterExprs.size() == 0)
-            return null;
+        return getFilters(null, "[", "\n" + indent + indent, ",", "\n" + indent + "]");
+    }
 
-        StringBuilder ret = new StringBuilder("[");
-        String sep = "\n";
-        for (String filterExpr : filterExprs)
-        {
-            ret.append(sep).append(indent).append(indent);
-            ret.append(filterExpr);
-            sep = ",\n";
-        }
-        ret.append("\n").append(indent).append("]");
-        return ret.toString();
+    @Override
+    protected String quote(String value)
+    {
+        // JavaScript quoting is close
+        return PageFlowUtil.jsString(value);
     }
 
     // Our Perl clientapi expects filters with operators in the middle
     @Override
     protected String makeFilterExpression(String name, CompareType operator, String value)
     {
-        return "[" + PageFlowUtil.jsString(name) + ", "
-                + operator.getPreferredUrlKey() + ", '" + PageFlowUtil.jsString(value) + "']";
+        return "[" + quote(name) + ", " + quote(operator.getPreferredUrlKey()) + ", " + quote(value) + "]";
     }
 
-    // Produce Perl code block containing all the standard query parameters.  Callers need to wrap this block in
+    // Produce Perl code block containing all the standard query parameters. Callers need to wrap this block in
     // curly braces (at a minimum) and modify/add parameters as appropriate.
     public String getStandardScriptParameters(int indentSpaces)
     {
@@ -75,15 +62,15 @@ public class PerlExportScriptModel extends ExportScriptModel
         _indentSpaces = indentSpaces;
         StringBuilder params = new StringBuilder();
         //params.append(indent).append("requiredVersion => 9.1,\n");
-        params.append(indent).append("-baseUrl => ").append(PageFlowUtil.jsString(getBaseUrl())).append(",\n");
-        params.append(indent).append("-containerPath => ").append(PageFlowUtil.jsString(getFolderPath())).append(",\n");
-        params.append(indent).append("-schemaName => ").append(PageFlowUtil.jsString(getSchemaName())).append(",\n");
+        params.append(indent).append("-baseUrl => ").append(quote(getBaseUrl())).append(",\n");
+        params.append(indent).append("-containerPath => ").append(quote(getFolderPath())).append(",\n");
+        params.append(indent).append("-schemaName => ").append(quote(getSchemaName())).append(",\n");
 
         if (null != getViewName())
-            params.append(indent).append("-viewName => ").append(PageFlowUtil.jsString(getViewName())).append(",\n");
+            params.append(indent).append("-viewName => ").append(quote(getViewName())).append(",\n");
 
-        params.append(indent).append("-queryName => ").append(PageFlowUtil.jsString(getQueryName())).append(",\n");
-        params.append(indent).append("-columns => ").append(PageFlowUtil.jsString(getColumns()));  // TODO: Inconsistent with R and SAS, which don't include view columns
+        params.append(indent).append("-queryName => ").append(quote(getQueryName())).append(",\n");
+        params.append(indent).append("-columns => ").append(quote(getColumns()));
 
         String filters = getFilters();
 
@@ -91,7 +78,7 @@ public class PerlExportScriptModel extends ExportScriptModel
             params.append(",\n").append(indent).append("-filterArray => ").append(filters);
 
         if (hasSort())
-            params.append(",\n").append(indent).append("-sort => ").append(PageFlowUtil.jsString(getSort()));
+            params.append(",\n").append(indent).append("-sort => ").append(quote(getSort()));
 
         if (hasContainerFilter())
             params.append(",\n").append(indent).append("-containerFilterName => '").append(getContainerFilterTypeName()).append("'");

--- a/api/src/org/labkey/api/query/PerlExportScriptModel.java
+++ b/api/src/org/labkey/api/query/PerlExportScriptModel.java
@@ -81,13 +81,13 @@ public class PerlExportScriptModel extends ExportScriptModel
             params.append(",\n").append(indent).append("-sort => ").append(quote(getSort()));
 
         if (hasContainerFilter())
-            params.append(",\n").append(indent).append("-containerFilterName => '").append(getContainerFilterTypeName()).append("'");
+            params.append(",\n").append(indent).append("-containerFilterName => ").append(quote(getContainerFilterTypeName()));
 
         if (hasQueryParameters())
         {
             params.append(",\n").append(indent).append("-parameters => [\n");
             params.append(getQueryParameters().entrySet().stream()
-                .map(e -> indent + indent + "['" + e.getKey() + "', '" + e.getValue() + "']")
+                .map(e -> indent + indent + "[" + quote(e.getKey()) + ", " + quote(e.getValue()) + "]")
                 .collect(Collectors.joining(",\n")));
             params.append("\n").append(indent).append("]");
         }

--- a/api/src/org/labkey/api/query/RExportScriptModel.java
+++ b/api/src/org/labkey/api/query/RExportScriptModel.java
@@ -139,7 +139,7 @@ public class RExportScriptModel extends ExportScriptModel
             sb.append(",").append(nl);
             sb.append(indent).append("parameters=c(");
             sb.append(getQueryParameters().entrySet().stream()
-                .map(entry -> "\"" + entry.getKey() + "=" + entry.getValue() + "\"")
+                .map(entry -> quote(entry.getKey() + "=" + entry.getValue()))
                 .collect(Collectors.joining(",")));
             sb.append(")");
         }

--- a/api/src/org/labkey/api/query/RExportScriptModel.java
+++ b/api/src/org/labkey/api/query/RExportScriptModel.java
@@ -21,7 +21,6 @@ import org.labkey.api.util.HelpTopic;
 import org.labkey.api.view.ActionURL;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -29,11 +28,6 @@ import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import static org.apache.commons.lang3.StringUtils.startsWith;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
-/*
-* User: Dave
-* Date: Aug 13, 2008
-* Time: 1:21:48 PM
-*/
 public class RExportScriptModel extends ExportScriptModel
 {
     private static final String DEFAULT_VARIABLE_NAME = "labkey.data";
@@ -85,35 +79,24 @@ public class RExportScriptModel extends ExportScriptModel
     @Override
     public String getFilters()
     {
-        List<String> filterExprs = getFilterExpressions();
+        return getFilters("NULL", "makeFilter(", "", ",", ")");
+    }
 
-        if (filterExprs.isEmpty())
-            return "NULL";
-
-        StringBuilder filtersExpr = new StringBuilder("makeFilter(");
-        String sep = "";
-
-        for (String mf : filterExprs)
-        {
-            filtersExpr.append(sep);
-            filtersExpr.append(mf);
-            sep = ",";
-        }
-
-        filtersExpr.append(")");
-
-        return filtersExpr.toString();
+    @Override
+    protected String quote(String value)
+    {
+        return doubleQuote(value);
     }
 
     @Override
     protected String makeFilterExpression(String name, CompareType operator, String value)
     {
-        return "c(" + doubleQuote(name) + ", " + doubleQuote(operator.getScriptName()) + ", " + doubleQuote(value) + ")";
+        return "c(" + quote(name) + ", " + quote(operator.getScriptName()) + ", " + quote(value) + ")";
     }
 
     private String getContainerFilterString()
     {
-        return hasContainerFilter() ? (" " + doubleQuote(getContainerFilterTypeName()) + " ") : "NULL";
+        return hasContainerFilter() ? (" " + quote(getContainerFilterTypeName()) + " ") : "NULL";
     }
 
     @Override
@@ -132,24 +115,24 @@ public class RExportScriptModel extends ExportScriptModel
             sb.append("\n");
             sb.append("library(Rlabkey)").append("\n");
             sb.append("\n");
-            sb.append("# Select rows into a data frame called '" + variableName + "'").append("\n");
+            sb.append("# Select rows into a data frame called '").append(variableName).append("'").append("\n");
             sb.append("\n");
         }
         String nl = "\n"; //clean ? "" : "\n";
         String indent = "    "; //clean ? StringUtils.repeat(" ", 4) : "";
         sb.append(variableName).append(" <- labkey.selectRows(").append(nl);
-        sb.append(indent).append("baseUrl=").append(doubleQuote(getBaseUrl())).append(", ").append(nl);
-        sb.append(indent).append("folderPath=").append(doubleQuote(getFolderPath())).append(", ").append(nl);
-        sb.append(indent).append("schemaName=").append(doubleQuote(getSchemaName())).append(", ").append(nl);
-        sb.append(indent).append("queryName=").append(doubleQuote(getQueryName())).append(", ").append(nl);
-        sb.append(indent).append("viewName=").append(doubleQuote(getViewName())).append(", ").append(nl);
-        sb.append(indent).append("colSelect=").append(doubleQuote(getColumns())).append(", ").append(nl);
+        sb.append(indent).append("baseUrl=").append(quote(getBaseUrl())).append(", ").append(nl);
+        sb.append(indent).append("folderPath=").append(quote(getFolderPath())).append(", ").append(nl);
+        sb.append(indent).append("schemaName=").append(quote(getSchemaName())).append(", ").append(nl);
+        sb.append(indent).append("queryName=").append(quote(getQueryName())).append(", ").append(nl);
+        sb.append(indent).append("viewName=").append(quote(getViewName())).append(", ").append(nl);
+        sb.append(indent).append("colSelect=").append(quote(getColumns())).append(", ").append(nl);
 
         if (hasSort())
-            sb.append(indent).append("colSort=").append(doubleQuote(getSort())).append(", ").append(nl);
+            sb.append(indent).append("colSort=").append(quote(getSort())).append(", ").append(nl);
         sb.append(indent).append("colFilter=").append(getFilters()).append(", ").append(nl);
         sb.append(indent).append("containerFilter=").append(getContainerFilterString()).append(", ").append(nl);
-        sb.append(indent).append("colNameOpt=").append(doubleQuote("rname"));
+        sb.append(indent).append("colNameOpt=").append(quote("rname"));
 
         if (hasQueryParameters())
         {

--- a/api/src/org/labkey/api/query/SasExportScriptModel.java
+++ b/api/src/org/labkey/api/query/SasExportScriptModel.java
@@ -19,13 +19,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.util.HelpTopic;
 
-import java.util.List;
-
-/**
- * User: adam
- * Date: Jan 27, 2009
- * Time: 3:13:06 PM
- */
 public class SasExportScriptModel extends ExportScriptModel
 {
     public SasExportScriptModel(QueryView view)
@@ -36,32 +29,22 @@ public class SasExportScriptModel extends ExportScriptModel
     @Override
     public String getFilters()
     {
-        List<String> filterExprs = getFilterExpressions();
+        return getFilters(null, "%labkeyMakeFilter(", "", ",", ")");
+    }
 
-        if (filterExprs.isEmpty())
-            return null;
-
-        StringBuilder filtersExpr = new StringBuilder("%labkeyMakeFilter(");
-        String sep = "";
-
-        for(String mf : filterExprs)
-        {
-            filtersExpr.append(sep);
-            filtersExpr.append(mf);
-            sep = ",";
-        }
-        filtersExpr.append(")");
-
-        return filtersExpr.toString();
+    @Override
+    protected String quote(String value)
+    {
+        return doubleQuote(value);
     }
 
     @Override
     protected String makeFilterExpression(String name, CompareType operator, String value)
     {
         if (operator.isDataValueRequired())
-            return "\"" + name + "\",\"" + operator.getScriptName() + "\",\"" + value + "\"";
+            return quote(name) + "," + quote(operator.getScriptName()) + "," + quote(value);
         else
-            return "\"" + name + "\",\"" + operator.getScriptName() + "\"";
+            return quote(name) + "," + quote(operator.getScriptName());
     }
 
     @Override
@@ -87,19 +70,20 @@ public class SasExportScriptModel extends ExportScriptModel
             sb.append("\n");
         }
 
+        // Note: Does not output the list a columns for some reason
         sb.append("%labkeySelectRows(dsn=mydata,").append("\n");
-        sb.append(indent).append("baseUrl=").append(doubleQuote(getBaseUrl())).append(",").append("\n");
-        sb.append(indent).append("folderPath=").append(doubleQuote(getFolderPath())).append(",").append("\n");
-        sb.append(indent).append("schemaName=").append(doubleQuote(getSchemaName())).append(",").append("\n");
-        sb.append(indent).append("queryName=").append(doubleQuote(getQueryName()));
+        sb.append(indent).append("baseUrl=").append(quote(getBaseUrl())).append(",").append("\n");
+        sb.append(indent).append("folderPath=").append(quote(getFolderPath())).append(",").append("\n");
+        sb.append(indent).append("schemaName=").append(quote(getSchemaName())).append(",").append("\n");
+        sb.append(indent).append("queryName=").append(quote(getQueryName()));
         if (null != getViewName()) {
             sb.append(",\n");
-            sb.append(indent).append("viewName=").append(doubleQuote(getViewName()));
+            sb.append(indent).append("viewName=").append(quote(getViewName()));
         }
 
         if (hasSort()) {
             sb.append(",\n");
-            sb.append(indent).append("sort=").append(doubleQuote(getSort()));
+            sb.append(indent).append("sort=").append(quote(getSort()));
         }
 
         if (null != getFilters()) {
@@ -109,7 +93,7 @@ public class SasExportScriptModel extends ExportScriptModel
 
         if (hasContainerFilter()) {
             sb.append(",\n");
-            sb.append(indent).append("containerFilter=").append(doubleQuote(getContainerFilterTypeName()));
+            sb.append(indent).append("containerFilter=").append(quote(getContainerFilterTypeName()));
         }
 
         sb.append(");\n");

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -420,6 +420,7 @@ public class PageFlowUtil
         StringBuilder js = new StringBuilder(s.length() + 10);
         js.append("'");
         int len = s.length();
+        char prev = 0;
         for (int i = 0 ; i<len ; i++)
         {
             char c = s.charAt(i);
@@ -429,7 +430,10 @@ public class PageFlowUtil
                     js.append("\\\\");
                     break;
                 case '/':
-                    js.append("\\/"); // JSONObject.toString() escapes '/'
+                    if (prev == '<')
+                        js.append("\\/"); // JSONObject.toString() escapes '/'
+                    else
+                        js.append('/');
                     break;
                 case '\n':
                     js.append("\\n");
@@ -453,6 +457,7 @@ public class PageFlowUtil
                     js.append(c);
                     break;
             }
+            prev = c;
         }
         js.append("'");
         return js.toString();


### PR DESCRIPTION
#### Rationale
Bit of a rewrite due to incorrect quoting, improper escaping, missing features, IntelliJ warnings, etc. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50035

#### Changes
- Fix `PageFlowUtil.jsString()` to escape `/` only when preceeded by `<`
- Force every `ExportScriptModel` to define and use a `quote()` method
- Reduce duplication by introducing a generalized `getFilters()` method
- Remove a couple redundant `getColumns()` overrides
- Switch Python export to use Java double quote string literals instead of JavaScript
- Output column list for Python (was missing!)
- Add proper quoting to parameters for Python
- Correct quoting for Perl filter expression
- Address some IntelliJ warnings