### PR TITLE
Add "Require Secondary Authentication" role

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationConfiguration.java
+++ b/api/src/org/labkey/api/security/AuthenticationConfiguration.java
@@ -204,8 +204,6 @@ public interface AuthenticationConfiguration<AP extends AuthenticationProvider> 
 
         ActionURL getRedirectURL(User candidate, Container c);
 
-        @NotNull RequiredFor getRequiredFor();
-
         boolean isRequired(User user);
 
         enum RequiredFor

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -1455,9 +1455,9 @@ public class AuthenticationManager
                     if (notRequired)
                     {
                         if (bypass)
-                            _log.info("Per configuration, bypassing secondary authentication for provider: " + provider.getClass());
+                            _log.info("Per application.properties configuration, bypassing secondary authentication for provider: " + provider.getClass());
                         else
-                            _log.info("Bypassing secondary authentication since authenticated user lacks the \"Require Secondary Authentication\" role: " + primaryAuthUser.getDisplayName(null));
+                            _log.debug("Bypassing secondary authentication since authenticated user lacks the \"Require Secondary Authentication\" role: " + primaryAuthUser.getDisplayName(null));
 
                         setSecondaryAuthenticationUser(session, configuration.getRowId(), primaryAuthUser);
                         continue;

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.api.security;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -99,8 +101,6 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -1450,9 +1450,15 @@ public class AuthenticationManager
                 if (null == secondaryAuthUser)
                 {
                     SecondaryAuthenticationProvider<?> provider = configuration.getAuthenticationProvider();
-                    if (provider.bypass())
+                    boolean bypass = provider.bypass();
+                    boolean notRequired = bypass || !configuration.isRequired(primaryAuthUser);
+                    if (notRequired)
                     {
-                        _log.info("Per configuration, bypassing secondary authentication for provider: " + provider.getClass());
+                        if (bypass)
+                            _log.info("Per configuration, bypassing secondary authentication for provider: " + provider.getClass());
+                        else
+                            _log.info("Bypassing secondary authentication since authenticated user lacks the \"Require Secondary Authentication\" role: " + primaryAuthUser.getDisplayName(null));
+
                         setSecondaryAuthenticationUser(session, configuration.getRowId(), primaryAuthUser);
                         continue;
                     }

--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.security;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -36,7 +37,6 @@ import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -241,6 +241,15 @@ public interface AuthenticationProvider
          * a 3rd party service provider is unavailable.
          */
         boolean bypass();
+
+        default JSONArray addRequiredForField(JSONArray fields, String name)
+        {
+            return fields
+                .put(OptionsField.of("requiredFor", "Require " + name + " for:", "Specifying the role option allows for a progressive roll-out of " + name + " to site users.", true, "all")
+                    .addOption("all", "All users")
+                    .addOption("role", "Only users assigned the \"Require Secondary Authentication\" site role")
+                );
+        }
     }
 
     interface DisableLoginProvider extends AuthenticationProvider

--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -251,7 +251,7 @@ public interface AuthenticationProvider
         @Override
         default <FORM extends SaveConfigurationForm, AC extends AuthenticationConfiguration, T extends Enum<T> & StartupProperty> void saveStartupProperties(String category, Class<FORM> formClass, Class<AC> configurationClass, Class<T> type)
         {
-            // Secondary authentication provider StartupProperty enums must define RequireFor constant
+            // Secondary authentication provider StartupProperty enums must define RequiredFor constant
             assert Arrays.stream(type.getEnumConstants()).filter(c -> c.name().equals(REQUIRED_FOR)).count() == 1 :
                 type.getName() + " does not define requiredFor constant!";
 

--- a/api/src/org/labkey/api/security/BaseSecondaryAuthenticationConfiguration.java
+++ b/api/src/org/labkey/api/security/BaseSecondaryAuthenticationConfiguration.java
@@ -8,6 +8,8 @@ import org.labkey.api.security.AuthenticationProvider.SecondaryAuthenticationPro
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.labkey.api.security.AuthenticationProvider.SecondaryAuthenticationProvider.REQUIRED_FOR;
+
 public abstract class BaseSecondaryAuthenticationConfiguration<AP extends SecondaryAuthenticationProvider<?>> extends BaseAuthenticationConfiguration<AP> implements SecondaryAuthenticationConfiguration<AP>
 {
     private final @NotNull AuthenticationConfiguration.SecondaryAuthenticationConfiguration.RequiredFor _requiredFor;
@@ -15,13 +17,7 @@ public abstract class BaseSecondaryAuthenticationConfiguration<AP extends Second
     public BaseSecondaryAuthenticationConfiguration(AP provider, Map<String, Object> standardSettings, Map<String, Object> properties)
     {
         super(provider, standardSettings);
-        _requiredFor = EnumUtils.getEnum(RequiredFor.class, (String)properties.get("requiredFor"), RequiredFor.all);
-    }
-
-    @Override
-    public @NotNull AuthenticationConfiguration.SecondaryAuthenticationConfiguration.RequiredFor getRequiredFor()
-    {
-        return _requiredFor;
+        _requiredFor = EnumUtils.getEnum(RequiredFor.class, (String)properties.get(REQUIRED_FOR), RequiredFor.all);
     }
 
     @Override
@@ -34,7 +30,7 @@ public abstract class BaseSecondaryAuthenticationConfiguration<AP extends Second
     public @NotNull Map<String, Object> getCustomProperties()
     {
         Map<String, Object> map = new HashMap<>();
-        map.put("requiredFor", getRequiredFor().name());
+        map.put(REQUIRED_FOR, _requiredFor.name());
 
         return map;
     }

--- a/api/src/org/labkey/api/security/BaseSecondaryAuthenticationConfiguration.java
+++ b/api/src/org/labkey/api/security/BaseSecondaryAuthenticationConfiguration.java
@@ -1,0 +1,41 @@
+package org.labkey.api.security;
+
+import org.apache.commons.lang3.EnumUtils;
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.security.AuthenticationConfiguration.SecondaryAuthenticationConfiguration;
+import org.labkey.api.security.AuthenticationProvider.SecondaryAuthenticationProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class BaseSecondaryAuthenticationConfiguration<AP extends SecondaryAuthenticationProvider<?>> extends BaseAuthenticationConfiguration<AP> implements SecondaryAuthenticationConfiguration<AP>
+{
+    private final @NotNull AuthenticationConfiguration.SecondaryAuthenticationConfiguration.RequiredFor _requiredFor;
+
+    public BaseSecondaryAuthenticationConfiguration(AP provider, Map<String, Object> standardSettings, Map<String, Object> properties)
+    {
+        super(provider, standardSettings);
+        _requiredFor = EnumUtils.getEnum(RequiredFor.class, (String)properties.get("requiredFor"), RequiredFor.all);
+    }
+
+    @Override
+    public @NotNull AuthenticationConfiguration.SecondaryAuthenticationConfiguration.RequiredFor getRequiredFor()
+    {
+        return _requiredFor;
+    }
+
+    @Override
+    public boolean isRequired(User user)
+    {
+        return _requiredFor.isRequired(user);
+    }
+
+    @Override
+    public @NotNull Map<String, Object> getCustomProperties()
+    {
+        Map<String, Object> map = new HashMap<>();
+        map.put("requiredFor", getRequiredFor().name());
+
+        return map;
+    }
+}

--- a/api/src/org/labkey/api/security/SecondarySaveConfigurationForm.java
+++ b/api/src/org/labkey/api/security/SecondarySaveConfigurationForm.java
@@ -5,6 +5,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.labkey.api.security.AuthenticationProvider.SecondaryAuthenticationProvider.REQUIRED_FOR;
+
 public abstract class SecondarySaveConfigurationForm extends SaveConfigurationForm
 {
     private String _requiredFor = null;
@@ -24,7 +26,7 @@ public abstract class SecondarySaveConfigurationForm extends SaveConfigurationFo
     public @NotNull Map<String, Object> getPropertyMap()
     {
         Map<String, Object> map = new HashMap<>();
-        map.put("requiredFor", getRequiredFor());
+        map.put(REQUIRED_FOR, getRequiredFor());
         return map;
     }
 }

--- a/api/src/org/labkey/api/security/SecondarySaveConfigurationForm.java
+++ b/api/src/org/labkey/api/security/SecondarySaveConfigurationForm.java
@@ -1,0 +1,30 @@
+package org.labkey.api.security;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class SecondarySaveConfigurationForm extends SaveConfigurationForm
+{
+    private String _requiredFor = null;
+
+    public String getRequiredFor()
+    {
+        return _requiredFor;
+    }
+
+    @SuppressWarnings("unused")
+    public void setRequiredFor(String requiredFor)
+    {
+        _requiredFor = requiredFor;
+    }
+
+    @Override
+    public @NotNull Map<String, Object> getPropertyMap()
+    {
+        Map<String, Object> map = new HashMap<>();
+        map.put("requiredFor", getRequiredFor());
+        return map;
+    }
+}

--- a/api/src/org/labkey/api/security/permissions/RequireSecondaryAuthenticationPermission.java
+++ b/api/src/org/labkey/api/security/permissions/RequireSecondaryAuthenticationPermission.java
@@ -1,0 +1,9 @@
+package org.labkey.api.security.permissions;
+
+public class RequireSecondaryAuthenticationPermission extends AbstractSitePermission
+{
+    public RequireSecondaryAuthenticationPermission()
+    {
+        super("Require Secondary Authentication", "Must authenticate via secondary authentication (TOTP, Duo) if a configuration is enabled.");
+    }
+}

--- a/core/webapp/Security/field/PrincipalComboBox.js
+++ b/core/webapp/Security/field/PrincipalComboBox.js
@@ -52,7 +52,6 @@ Ext4.define('Security.field.PrincipalComboBox', {
     constructor : function(config)
     {
         var a = Ext4.isArray(config.excludedPrincipals) ? config.excludedPrincipals : [];
-        a.push(Security.util.SecurityCache.groupAdministrators);
 
         delete config.excludedPrincipals;
         this.excludedPrincipals = {};

--- a/core/webapp/Security/panel/PolicyEditor.js
+++ b/core/webapp/Security/panel/PolicyEditor.js
@@ -301,7 +301,7 @@ Ext4.define('Security.panel.PolicyEditor', {
                         cache  : this.cache,
                         itemId : ('$add$'+role.uniqueName),
                         roleId : role.uniqueName,
-                        excludedPrincipals: [Security.util.SecurityCache.groupAdministrators].concat(role.excludedPrincipals),  // exclude SiteAdministrators who already has all permissions
+                        excludedPrincipals: role.excludedPrincipals,
                         listeners: {
                             select: this.onComboSelect,
                             scope: this

--- a/devtools/src/org/labkey/devtools/authentication/TestSecondaryConfiguration.java
+++ b/devtools/src/org/labkey/devtools/authentication/TestSecondaryConfiguration.java
@@ -1,18 +1,17 @@
 package org.labkey.devtools.authentication;
 
 import org.labkey.api.data.Container;
-import org.labkey.api.security.AuthenticationConfiguration.SecondaryAuthenticationConfiguration;
-import org.labkey.api.security.BaseAuthenticationConfiguration;
+import org.labkey.api.security.BaseSecondaryAuthenticationConfiguration;
 import org.labkey.api.security.User;
 import org.labkey.api.view.ActionURL;
 
 import java.util.Map;
 
-public class TestSecondaryConfiguration extends BaseAuthenticationConfiguration<TestSecondaryProvider> implements SecondaryAuthenticationConfiguration<TestSecondaryProvider>
+public class TestSecondaryConfiguration extends BaseSecondaryAuthenticationConfiguration<TestSecondaryProvider>
 {
-    public TestSecondaryConfiguration(TestSecondaryProvider provider, Map<String, Object> props)
+    public TestSecondaryConfiguration(TestSecondaryProvider provider, Map<String, Object> standardSettings, Map<String, Object> props)
     {
-        super(provider, props);
+        super(provider, standardSettings, props);
     }
 
     @Override

--- a/devtools/src/org/labkey/devtools/authentication/TestSecondaryController.java
+++ b/devtools/src/org/labkey/devtools/authentication/TestSecondaryController.java
@@ -26,7 +26,7 @@ import org.labkey.api.security.AuthenticationManager.PrimaryAuthenticationResult
 import org.labkey.api.security.RequiresNoPermission;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.SaveConfigurationAction;
-import org.labkey.api.security.SaveConfigurationForm;
+import org.labkey.api.security.SecondarySaveConfigurationForm;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.util.URLHelper;
@@ -40,11 +40,6 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
-/**
- * User: adam
- * Date: 3/27/2015
- * Time: 5:40 PM
- */
 public class TestSecondaryController extends SpringActionController
 {
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(TestSecondaryController.class);
@@ -169,7 +164,7 @@ public class TestSecondaryController extends SpringActionController
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public class TestSecondarySaveConfigurationAction extends SaveConfigurationAction<TestSecondarySaveConfigurationForm, TestSecondaryConfiguration>
+    public static class TestSecondarySaveConfigurationAction extends SaveConfigurationAction<TestSecondarySaveConfigurationForm, TestSecondaryConfiguration>
     {
         @Override
         public void validate(TestSecondarySaveConfigurationForm form, Errors errors)
@@ -177,7 +172,7 @@ public class TestSecondaryController extends SpringActionController
         }
     }
 
-    public static class TestSecondarySaveConfigurationForm extends SaveConfigurationForm
+    public static class TestSecondarySaveConfigurationForm extends SecondarySaveConfigurationForm
     {
         @Override
         public String getProvider()

--- a/devtools/src/org/labkey/devtools/authentication/TestSecondaryProvider.java
+++ b/devtools/src/org/labkey/devtools/authentication/TestSecondaryProvider.java
@@ -17,17 +17,13 @@ package org.labkey.devtools.authentication;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONArray;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.AuthenticationProvider.SecondaryAuthenticationProvider;
 import org.labkey.api.security.ConfigurationSettings;
 import org.labkey.api.view.ActionURL;
 import org.labkey.devtools.authentication.TestSecondaryController.TestSecondarySaveConfigurationAction;
 
-/**
- * User: adam
- * Date: 3/11/2015
- * Time: 7:45 AM
- */
 public class TestSecondaryProvider implements SecondaryAuthenticationProvider<TestSecondaryConfiguration>
 {
     public static final String NAME = "TestSecondary";
@@ -35,7 +31,7 @@ public class TestSecondaryProvider implements SecondaryAuthenticationProvider<Te
     @Override
     public TestSecondaryConfiguration getAuthenticationConfiguration(@NotNull ConfigurationSettings cs)
     {
-        return new TestSecondaryConfiguration(this, cs.getStandardSettings());
+        return new TestSecondaryConfiguration(this, cs.getStandardSettings(), cs.getProperties());
     }
 
     @Override
@@ -56,6 +52,12 @@ public class TestSecondaryProvider implements SecondaryAuthenticationProvider<Te
     public String getDescription()
     {
         return "Adds a trivial, insecure secondary authentication requirement (for test purposes only)";
+    }
+
+    @Override
+    public @NotNull JSONArray getSettingsFields()
+    {
+        return addRequiredForField(new JSONArray(), "Test 2FA");
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We want administrators to have the option to require Two-Factor Authentication (e.g., TOTP or Duo) for only a subset of highly privileged users, such as Site Administrators and Developers. This may be done on a long-term basis but the ability also allows a progressive roll-out of 2FA. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=50024

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/9

#### Changes
- Introduce a standard option (essentially, "Require 2FA for all users OR only users assigned the special 2FA role") to all secondary authentication configuration dialogs. Persist and respect it.
- Stop excluding "Site Administrators" group from all role assignments... this group is no longer special plus Site Admins are not granted all roles automatically