### PR TITLE
Issue 49963: FileAlreadyExistsException on some file systems on file root

### DIFF
--- a/filecontent/src/org/labkey/filecontent/FileSystemAttachmentParent.java
+++ b/filecontent/src/org/labkey/filecontent/FileSystemAttachmentParent.java
@@ -127,7 +127,12 @@ public class FileSystemAttachmentParent implements AttachmentDirectory
             if (_contentType != null && !svc.isCloudRoot(container))    // don't need @files in cloud
             {
                 Path root = dir.resolve(svc.getFolderName(_contentType));
-                FileUtil.createDirectories(root);
+
+                // Issue 49963: avoid FileAlreadyExistsExceptions on certain file systems
+                if (!Files.exists(root))
+                {
+                    FileUtil.createDirectories(root);
+                }
                 return root;
             }
             return dir;


### PR DESCRIPTION
#### Rationale
Some file systems (certain NFS implementations, it seems) throw a FileAlreadyExistsExceptions when we call createDirectories(). That's spamming the error log file and preventing us from viewing the contents of the file root.

#### Changes
- Check if the directory exists before creating it