### PR TITLE
Fail test for any CSP violation in a module view

### DIFF
--- a/api/src/org/labkey/api/module/ModuleHtmlView.java
+++ b/api/src/org/labkey/api/module/ModuleHtmlView.java
@@ -238,8 +238,7 @@ public class ModuleHtmlView extends HtmlView
                 {
                     CspUtils.enumerateCspViolations(doc, message -> {
                         String name = "[" + module.getName() + "] " + key;
-                        if (!"[LINCS] views/CustomGCT.html".equals(name)) // TODO: Remove check once this view is fixed
-                            violations.add(name + ": " + message);
+                        violations.add(name + ": " + message);
                     });
                 }
             }));

--- a/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
+++ b/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
@@ -177,7 +177,7 @@ public class ModuleHtmlViewDefinition
     {
         try
         {
-            Class c = Class.forName(permissionClassName);
+            Class<?> c = Class.forName(permissionClassName);
             if (Permission.class.isAssignableFrom(c))
             {
                 _requiredPermissionClasses.add((Class<? extends Permission>)c);

--- a/api/src/org/labkey/api/view/ModuleHtmlViewCacheHandler.java
+++ b/api/src/org/labkey/api/view/ModuleHtmlViewCacheHandler.java
@@ -30,9 +30,6 @@ import static org.labkey.api.module.ModuleHtmlViewDefinition.HTML_VIEW_EXTENSION
 /**
  * Cache for views provided by modules as simple HTML files (along with metadata from an associated .view.xml file) in
  * the /resources/views directory or /resources/assays/[provider name]/views.
- *
- * User: adam
- * Date: 1/21/14
  */
 public class ModuleHtmlViewCacheHandler implements ModuleResourceCacheHandler<Map<Path, ModuleHtmlViewDefinition>>
 {


### PR DESCRIPTION
#### Rationale
Keeping us honest. All module HTML views should now be free of inline script and have nonces on their script tags. Remove the last exception.
