### PR TITLE
Add a metric to track dev vs prod mode servers

### DIFF
--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1123,6 +1123,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             String labkeyContextPath = AppProps.getInstance().getContextPath();
             results.put("webappContextPath", labkeyContextPath);
             results.put("embeddedTomcat", AppProps.getInstance().isEmbeddedTomcat());
+            results.put("runtimeMode", AppProps.getInstance().isDevMode() ? "development" : "production");
             Set<String> deployedApps = new HashSet<>(CoreWarningProvider.collectAllDeployedApps());
             deployedApps.remove(labkeyContextPath);
             if (labkeyContextPath.startsWith("/"))


### PR DESCRIPTION
#### Rationale
It's always nice to understand more about how our deployments are configured.

#### Changes
- `modules.Core.runtimeMode` metric - either `development` or `production`