### PR TITLE
Eliminate inline handler

### DIFF
--- a/filecontent/webapp/File/panel/Upload.js
+++ b/filecontent/webapp/File/panel/Upload.js
@@ -603,7 +603,7 @@ Ext4.define('File.panel.Upload', {
             return this.multiUpload;
         }
 
-        var helpLinkHtml =  '[<a class="help-link" href="javascript:void(0);">upload help</a>]';
+        var helpLinkHtml =  '[<a class="help-link">upload help</a>]';
 
         var html;
         if (window.Dropzone && window.Dropzone.isBrowserSupported()) {
@@ -666,6 +666,8 @@ Ext4.define('File.panel.Upload', {
             icon: Ext4.Msg.INFO,
             buttons: Ext4.Msg.OK
         });
+
+        return false;
     },
 
     cancelUpload : function () {


### PR DESCRIPTION
#### Rationale
Inline handlers are forbidden by our strict CSP

Note: The help link in question appeared for me only when I added a narrow files webpart to a portal page. Maybe there are other ways to coax it to render...