### PR TITLE
Improve site validation

### DIFF
--- a/api/src/org/labkey/api/jsp/JspContext.java
+++ b/api/src/org/labkey/api/jsp/JspContext.java
@@ -21,12 +21,6 @@ import org.labkey.api.view.HttpView;
 
 import jakarta.servlet.jsp.JspWriter;
 
-/**
- * User: adam
- * Date: Aug 10, 2010
- * Time: 4:05:51 PM
- */
-
 // Simple base class for JSP templates that aren't rendering HTML (see JspTemplate)
 public abstract class JspContext extends HttpJspBase
 {

--- a/api/src/org/labkey/api/view/FolderManagement.java
+++ b/api/src/org/labkey/api/view/FolderManagement.java
@@ -202,7 +202,7 @@ public class FolderManagement
         }
 
         @Override
-        public ModelAndView getView(Object form, BindException errors) throws Exception
+        public final ModelAndView getView(Object form, BindException errors) throws Exception
         {
             return wrapViewInTabStrip(this, getType(), getTabView(), errors);
         }
@@ -216,7 +216,6 @@ public class FolderManagement
             getType().addNavTrail(this, root, getContainer(), getUser());
         }
     }
-
 
     /**
      * Base action class for management actions that display a view and handle a post.

--- a/core/api-src/org/labkey/api/admin/sitevalidation/SiteValidationProvider.java
+++ b/core/api-src/org/labkey/api/admin/sitevalidation/SiteValidationProvider.java
@@ -19,18 +19,12 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 
-/**
- * User: tgaluhn
- * Date: 4/8/2015
- */
 public interface SiteValidationProvider extends SiteValidatorDescriptor
 {
     /**
-     *
      * Return false to indicate the validator shouldn't be run for that container.
      * Useful if we know in advance the validator isn't applicable; e.g., the
      * validator is module-dependent and that module isn't enabled in this container.
-     *
      */
     default boolean shouldRun(Container c, User u)
     {

--- a/core/api-src/org/labkey/api/admin/sitevalidation/SiteValidationService.java
+++ b/core/api-src/org/labkey/api/admin/sitevalidation/SiteValidationService.java
@@ -20,17 +20,14 @@ import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
- * User: tgaluhn
- * Date: 4/8/2015
- *
  * Service for registering/running validators for site configuration, schemas, data heuristics, etc.
- *
  * Validators may declare themselves to either apply to site wide scope (e.g., a schema integrity check),
  * or to container level scope (e.g., business rules for the data visible within that container).
- *
  */
 public interface SiteValidationService
 {
@@ -46,13 +43,16 @@ public interface SiteValidationService
 
     void registerProvider(String module, SiteValidationProvider provider);
 
+    Map<String, Set<SiteValidationProvider>> getSiteProviders();
+    Map<String, Set<SiteValidationProvider>> getContainerProviders();
+
     /**
      * Returns a map of module name -> map of ValidatorDescriptor -> result list for all validators registered by that module
      * Will return an empty map if no validators are registered.
      * ValidatorDescriptor map entry will have empty SiteValidationResultList if no validation errors found by that module
      */
     @NotNull
-    Map<String, Map<SiteValidatorDescriptor, SiteValidationResultList>> runSiteScopeValidators(User u);
+    Map<String, Map<SiteValidatorDescriptor, SiteValidationResultList>> runSiteScopeValidators(List<String> providers, User u);
 
     /**
      * Returns a map of module names -> map ValidatorProviders -> map of projects names ->
@@ -67,5 +67,5 @@ public interface SiteValidationService
      *
      */
     @NotNull
-    Map<String, Map<SiteValidatorDescriptor, Map<String, Map<String, SiteValidationResultList>>>> runContainerScopeValidators(Container topLevel, User u);
+    Map<String, Map<SiteValidatorDescriptor, Map<String, Map<String, SiteValidationResultList>>>> runContainerScopeValidators(Container topLevel, boolean includeSubFolders, List<String> providers, User u);
 }

--- a/core/api-src/org/labkey/api/admin/sitevalidation/SiteValidatorDescriptor.java
+++ b/core/api-src/org/labkey/api/admin/sitevalidation/SiteValidatorDescriptor.java
@@ -17,10 +17,6 @@ package org.labkey.api.admin.sitevalidation;
 
 import org.jetbrains.annotations.NotNull;
 
-/**
- * User: tgaluhn
- * Date: 10/30/2016
- */
 public interface SiteValidatorDescriptor extends Comparable<SiteValidatorDescriptor>
 {
     String getName();

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -33,8 +33,6 @@ import org.labkey.api.admin.FolderSerializationRegistry;
 import org.labkey.api.admin.HealthCheck;
 import org.labkey.api.admin.HealthCheckRegistry;
 import org.labkey.api.admin.notification.NotificationService;
-import org.labkey.api.admin.sitevalidation.SiteValidationProvider;
-import org.labkey.api.admin.sitevalidation.SiteValidationResultList;
 import org.labkey.api.admin.sitevalidation.SiteValidationService;
 import org.labkey.api.analytics.AnalyticsService;
 import org.labkey.api.attachments.AttachmentService;
@@ -481,54 +479,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         if (null != svc)
         {
             svc.registerProvider("core", new PermissionsValidator());
-            svc.registerProvider("core", new SiteValidationProvider()
-            {
-                @Override
-                public @Nullable SiteValidationResultList runValidation(Container c, User u)
-                {
-                    SiteValidationResultList rl = new SiteValidationResultList();
-                    rl.addError("Oh that's bad!");
-                    rl.addWarn("That's not quite as bad");
-
-                    return rl;
-                }
-
-                @Override
-                public String getName()
-                {
-                    return "Test 1";
-                }
-
-                @Override
-                public String getDescription()
-                {
-                    return "Some random validator";
-                }
-            });
-            svc.registerProvider("core", new SiteValidationProvider()
-            {
-                @Override
-                public @Nullable SiteValidationResultList runValidation(Container c, User u)
-                {
-                    SiteValidationResultList rl = new SiteValidationResultList();
-                    rl.addError("It's an error!");
-                    rl.addWarn("Just a warning");
-
-                    return rl;
-                }
-
-                @Override
-                public String getName()
-                {
-                    return "Test 2";
-                }
-
-                @Override
-                public String getDescription()
-                {
-                    return "Another random validator";
-                }
-            });
         }
 
         registerHealthChecks();

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -33,6 +33,8 @@ import org.labkey.api.admin.FolderSerializationRegistry;
 import org.labkey.api.admin.HealthCheck;
 import org.labkey.api.admin.HealthCheckRegistry;
 import org.labkey.api.admin.notification.NotificationService;
+import org.labkey.api.admin.sitevalidation.SiteValidationProvider;
+import org.labkey.api.admin.sitevalidation.SiteValidationResultList;
 import org.labkey.api.admin.sitevalidation.SiteValidationService;
 import org.labkey.api.analytics.AnalyticsService;
 import org.labkey.api.attachments.AttachmentService;
@@ -479,6 +481,54 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         if (null != svc)
         {
             svc.registerProvider("core", new PermissionsValidator());
+            svc.registerProvider("core", new SiteValidationProvider()
+            {
+                @Override
+                public @Nullable SiteValidationResultList runValidation(Container c, User u)
+                {
+                    SiteValidationResultList rl = new SiteValidationResultList();
+                    rl.addError("Oh that's bad!");
+                    rl.addWarn("That's not quite as bad");
+
+                    return rl;
+                }
+
+                @Override
+                public String getName()
+                {
+                    return "Test 1";
+                }
+
+                @Override
+                public String getDescription()
+                {
+                    return "Some random validator";
+                }
+            });
+            svc.registerProvider("core", new SiteValidationProvider()
+            {
+                @Override
+                public @Nullable SiteValidationResultList runValidation(Container c, User u)
+                {
+                    SiteValidationResultList rl = new SiteValidationResultList();
+                    rl.addError("It's an error!");
+                    rl.addWarn("Just a warning");
+
+                    return rl;
+                }
+
+                @Override
+                public String getName()
+                {
+                    return "Test 2";
+                }
+
+                @Override
+                public String getDescription()
+                {
+                    return "Another random validator";
+                }
+            });
         }
 
         registerHealthChecks();

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -268,7 +268,6 @@ import static org.labkey.api.util.DOM.at;
 import static org.labkey.api.util.DOM.cl;
 import static org.labkey.api.util.DOM.createHtmlFragment;
 import static org.labkey.api.util.HtmlString.NBSP;
-import static org.labkey.api.util.HtmlString.unsafe;
 import static org.labkey.api.util.logging.LogHelper.getLabKeyLogDir;
 import static org.labkey.api.view.FolderManagement.EVERY_CONTAINER;
 import static org.labkey.api.view.FolderManagement.FOLDERS_AND_PROJECTS;
@@ -340,7 +339,7 @@ public class AdminController extends SpringActionController
         AdminConsole.addLink(Diagnostics, "queries", getQueriesURL(null));
         AdminConsole.addLink(Diagnostics, "reset site errors", new ActionURL(ResetErrorMarkAction.class, root), AdminPermission.class);
         AdminConsole.addLink(Diagnostics, "running threads", new ActionURL(ShowThreadsAction.class, root));
-        AdminConsole.addLink(Diagnostics, "site validation", new ActionURL(SiteValidationAction.class, root), AdminPermission.class);
+        AdminConsole.addLink(Diagnostics, "site validation", new ActionURL(ConfigureSiteValidationAction.class, root), AdminPermission.class);
         AdminConsole.addLink(Diagnostics, "sql scripts", new ActionURL(SqlScriptController.ScriptsAction.class, root), AdminOperationsPermission.class);
         AdminConsole.addLink(Diagnostics, "suspicious activity", new ActionURL(SuspiciousAction.class,root));
         AdminConsole.addLink(Diagnostics, "system properties", new ActionURL(SystemPropertiesAction.class, root), SiteAdminPermission.class);
@@ -377,6 +376,7 @@ public class AdminController extends SpringActionController
         addTab(TYPE.FolderManagement,"Files", "files", FOLDERS_AND_PROJECTS, FileRootsAction.class);
         addTab(TYPE.FolderManagement,"Formats", "settings", FOLDERS_ONLY, FolderSettingsAction.class);
         addTab(TYPE.FolderManagement,"Information", "info", NOT_ROOT, FolderInformationAction.class);
+        addTab(TYPE.FolderManagement,"Validate", "validate", EVERY_CONTAINER, ConfigureSiteValidationAction.class);
         addTab(TYPE.FolderManagement,"R Config", "rConfig", NOT_ROOT, RConfigurationAction.class);
 
         addTab(TYPE.ProjectSettings, "Properties", "properties", PROJECTS_ONLY, ProjectSettingsAction.class);
@@ -1383,19 +1383,62 @@ public class AdminController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class SiteValidationAction extends SimpleViewAction<Object>
+    public class ConfigureSiteValidationAction extends FolderManagementViewAction
     {
         @Override
-        public ModelAndView getView(Object o, BindException errors)
+        protected JspView<?> getTabView()
         {
-            return new JspView<>("/org/labkey/core/admin/sitevalidation/siteValidation.jsp");
+            return new JspView<>("/org/labkey/core/admin/sitevalidation/configureSiteValidation.jsp");
         }
 
         @Override
         public void addNavTrail(NavTree root)
         {
             setHelpTopic("siteValidation");
-            addAdminNavTrail(root, "Site Validation", this.getClass());
+            addAdminNavTrail(root, "Configure " + (getContainer().isRoot() ? "Site" : "Folder") + " Validation", getClass());
+        }
+    }
+
+    public static class SiteValidationForm
+    {
+        private boolean _includeSubfolders = false;
+        private List<String> _providers;
+
+        public boolean isIncludeSubfolders()
+        {
+            return _includeSubfolders;
+        }
+
+        public void setIncludeSubfolders(boolean includeSubfolders)
+        {
+            _includeSubfolders = includeSubfolders;
+        }
+
+        public List<String> getProviders()
+        {
+            return _providers;
+        }
+
+        public void setProviders(List<String> providers)
+        {
+            _providers = providers;
+        }
+    }
+
+    @RequiresPermission(AdminPermission.class)
+    public class SiteValidationAction extends SimpleViewAction<SiteValidationForm>
+    {
+        @Override
+        public ModelAndView getView(SiteValidationForm form, BindException errors)
+        {
+            return new JspView<>("/org/labkey/core/admin/sitevalidation/siteValidation.jsp", form);
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+            setHelpTopic("siteValidation");
+            addAdminNavTrail(root, (getContainer().isRoot() ? "Site" : "Folder") + " Validation", getClass());
         }
     }
 
@@ -3016,7 +3059,6 @@ public class AdminController extends SpringActionController
             _enableSystemMaintenance = enableSystemMaintenance;
         }
     }
-
 
     @AdminConsoleAction(AdminOperationsPermission.class)
     public class ConfigureSystemMaintenanceAction extends FormViewAction<ConfigureSystemMaintenanceForm>

--- a/core/src/org/labkey/core/admin/sitevalidation/SiteValidationServiceImpl.java
+++ b/core/src/org/labkey/core/admin/sitevalidation/SiteValidationServiceImpl.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 
@@ -58,13 +59,24 @@ public class SiteValidationServiceImpl implements SiteValidationService
     @Override
     public Map<String, Set<SiteValidationProvider>> getSiteProviders()
     {
-        return siteValidators;
+        return getImmutable(siteValidators);
     }
 
     @Override
     public Map<String, Set<SiteValidationProvider>> getContainerProviders()
     {
-        return containerValidators;
+        return getImmutable(containerValidators);
+    }
+
+    private Map<String, Set<SiteValidationProvider>> getImmutable(Map<String, Set<SiteValidationProvider>> map)
+    {
+        Map<String, Set<SiteValidationProvider>> copy = new TreeMap<>();
+        for (String key : map.keySet())
+        {
+            Set<SiteValidationProvider> set = Collections.unmodifiableSet(new TreeSet<>(map.get(key)));
+            copy.put(key, set);
+        }
+        return Collections.unmodifiableMap(copy);
     }
 
     @NotNull

--- a/core/src/org/labkey/core/admin/sitevalidation/configureSiteValidation.jsp
+++ b/core/src/org/labkey/core/admin/sitevalidation/configureSiteValidation.jsp
@@ -66,6 +66,7 @@
     else
     {
 %>
+Clicking the "Validate" button will run the selected validators in the designated folder(s). Producing the results could take some time, especially with many folders, providers, and/or objects that need to be validated.<br><br>
 <labkey:form action="<%=urlFor(AdminController.SiteValidationAction.class)%>" method="post">
     <%
         if (getContainer().isRoot())

--- a/core/src/org/labkey/core/admin/sitevalidation/configureSiteValidation.jsp
+++ b/core/src/org/labkey/core/admin/sitevalidation/configureSiteValidation.jsp
@@ -1,0 +1,106 @@
+<%
+/*
+ * Copyright (c) 2024 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+%>
+<%@ page import="org.labkey.api.admin.sitevalidation.SiteValidationProvider" %>
+<%@ page import="org.labkey.api.admin.sitevalidation.SiteValidationService" %>
+<%@ page import="org.labkey.api.util.DOM" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
+<%@ page import="org.labkey.core.admin.AdminController" %>
+<%@ page import="java.io.IOException" %>
+<%@ page import="java.util.Collection" %>
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="java.util.Set" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%!
+    private void renderProviderList(String title, Map<String, Set<SiteValidationProvider>> providerMap, JspWriter out) throws IOException
+    {
+        if (!providerMap.isEmpty())
+        {
+            renderTitle(title, out);
+
+            List<SiteValidationProvider> providers = providerMap.values().stream()
+                .flatMap(Collection::stream)
+                .toList();
+
+            for (SiteValidationProvider provider : providers)
+            {
+                out.println(
+                    DOM.createHtmlFragment(
+                        input().type("checkbox").name("providers").value(provider.getName()).checked(true),
+                        provider.getName() + ": " + provider.getDescription(),
+                        DOM.BR()
+                    )
+                );
+            }
+            out.println(HtmlString.BR);
+        }
+    }
+
+    private void renderTitle(String title, JspWriter out) throws IOException
+    {
+        out.println(DOM.createHtmlFragment(DOM.B(title), DOM.BR()));
+    }
+%>
+<%
+    SiteValidationService validationService = SiteValidationService.get();
+    if (null == validationService)
+    {
+%><span>SiteValidationService has not been registered.</span><%
+    }
+    else
+    {
+%>
+<labkey:form action="<%=urlFor(AdminController.SiteValidationAction.class)%>" method="post">
+    <%
+        if (getContainer().isRoot())
+            renderProviderList("Site Validation Providers", validationService.getSiteProviders(), out);
+        renderProviderList("Folder Validation Providers", validationService.getContainerProviders(), out);
+        renderTitle("Folder Validation Options", out);
+        if (getContainer().isRoot())
+        {
+            out.println(
+                DOM.createHtmlFragment(
+                    input().name("includeSubfolders").type("radio").value("true").checked(true),
+                    "All projects and folders in this site",
+                    DOM.BR(),
+                    input().name("includeSubfolders").type("radio").value("false").checked(false),
+                    "Just the projects",
+                    DOM.BR(),
+                    DOM.BR()
+                )
+            );
+        }
+        else
+        {
+            out.println(
+                DOM.createHtmlFragment(
+                    input().type("checkbox").checked(true).name("includeSubfolders"),
+                    "Include subfolders",
+                    DOM.BR(),
+                    DOM.BR()
+                )
+            );
+        }
+    %>
+    <%=button("Validate").usePost().submit(true)%>
+    <%=generateBackButton("Cancel")%>
+</labkey:form>
+<%
+    }
+%>

--- a/core/src/org/labkey/core/admin/sitevalidation/siteValidation.jsp
+++ b/core/src/org/labkey/core/admin/sitevalidation/siteValidation.jsp
@@ -143,69 +143,93 @@
             for (Map.Entry<String, Map<SiteValidatorDescriptor, Map<String, Map<String, SiteValidationResultList>>>> moduleResults : containerResults.entrySet())
             {
 %>
-          <li><strong>Module: </strong><%=h(moduleResults.getKey())%>
-              <ul>
-                  <% for (Map.Entry<SiteValidatorDescriptor, Map<String, Map<String, SiteValidationResultList>>> validatorResults : moduleResults.getValue().entrySet()) { %>
-                  <li><strong>Validator: </strong><%=h(validatorResults.getKey().getName() + " ")%><span style="font-style: italic;"><%=h(validatorResults.getKey().getDescription())%></span>
-                      <ul>
-                          <% if (validatorResults.getValue().isEmpty()) { %>
-                          <li>Nothing to report</li>
-                          <% } else {
-                              for (Map.Entry<String, Map<String, SiteValidationResultList>> projectResult : validatorResults.getValue().entrySet()) { %>
-                  <li><%=h("Project: " + projectResult.getKey())%>
+            <li><strong>Module: </strong><%=h(moduleResults.getKey())%>
                 <ul>
-                    <% for (Map.Entry<String, SiteValidationResultList> subtreeResult : projectResult.getValue().entrySet()) { %>
-                    <li><%=h("Folder: " + subtreeResult.getKey())%>
+<%
+                    for (Map.Entry<SiteValidatorDescriptor, Map<String, Map<String, SiteValidationResultList>>> validatorResults : moduleResults.getValue().entrySet())
+                    {
+%>
+                    <li><strong>Validator: </strong><%=h(validatorResults.getKey().getName() + " ")%><span style="font-style: italic;"><%=h(validatorResults.getKey().getDescription())%></span>
                         <ul>
-                            <% if (subtreeResult.getValue() != null)
+<%                      if (validatorResults.getValue().isEmpty())
+                        {
+%>
+                            <li>Nothing to report</li>
+<%                      }
+                        else
+                        {
+                            for (Map.Entry<String, Map<String, SiteValidationResultList>> projectResult : validatorResults.getValue().entrySet())
                             {
-                                containerInfos = subtreeResult.getValue().getResults(Level.INFO);
-                                containerErrors = subtreeResult.getValue().getResults(Level.ERROR);
-                                containerWarnings = subtreeResult.getValue().getResults(Level.WARN);
-                                for (SiteValidationResult result : containerInfos) { %>
-                                <li><%=h(result.getMessage())%>
-                                    <% if (null != result.getLink()) { %>
-                                    <span><%=link(LINK_HEADING, result.getLink())%></span>
-                                    <% } %>
-                                </li>
-                                <% } %>
-                                <% if (!containerErrors.isEmpty()) { %>
-                                    <li>Errors:
-                                    <ul>
-                                    <% for (SiteValidationResult result : containerErrors) { %>
-                                        <li><span class="labkey-error"><%=h(result.getMessage())%></span>
-                                        <% if (null != result.getLink()) { %>
-                                        <span><%=link(LINK_HEADING, result.getLink())%></span>
-                                        <% } %>
-                                    </li>
-                                    <% } %></ul></li>
-                                <% } %>
-                                <% if (!containerWarnings.isEmpty()) { %>
-                                    <li>Warnings:
+%>
+                            <li><%=h("Project: " + projectResult.getKey())%>
+                                <ul>
+<%                              for (Map.Entry<String, SiteValidationResultList> subtreeResult : projectResult.getValue().entrySet())
+                                {
+%>
+                                    <li><%=h("Folder: " + subtreeResult.getKey())%>
                                         <ul>
-                                        <% for (SiteValidationResult result : containerWarnings) { %>
-                                        <li><%=h(result.getMessage())%>
-                                            <% if (null != result.getLink()) { %>
-                                            <span><%=link(LINK_HEADING, result.getLink())%></span>
+                                        <% if (subtreeResult.getValue() != null)
+                                        {
+                                            containerInfos = subtreeResult.getValue().getResults(Level.INFO);
+                                            containerErrors = subtreeResult.getValue().getResults(Level.ERROR);
+                                            containerWarnings = subtreeResult.getValue().getResults(Level.WARN);
+                                            for (SiteValidationResult result : containerInfos) { %>
+                                            <li><%=h(result.getMessage())%>
+                                                <% if (null != result.getLink()) { %>
+                                                <span><%=link(LINK_HEADING, result.getLink())%></span>
+                                                <% } %>
+                                            </li>
                                             <% } %>
-                                        </li>
-                                    <% } %></ul></li>
-                                <% } %>
-                            <% } %>
+                                            <% if (!containerErrors.isEmpty()) { %>
+                                            <li>Errors:
+                                                <ul>
+                                                <% for (SiteValidationResult result : containerErrors) { %>
+                                                    <li><span class="labkey-error"><%=h(result.getMessage())%></span>
+                                                    <% if (null != result.getLink()) { %>
+                                                    <span><%=link(LINK_HEADING, result.getLink())%></span>
+                                                    <% } %>
+                                                    </li>
+                                                <% } %>
+                                                </ul>
+                                            </li>
+                                            <%  }
+                                                if (!containerWarnings.isEmpty())
+                                                { %>
+                                            <li>Warnings:
+                                                <ul>
+                                                <%  for (SiteValidationResult result : containerWarnings)
+                                                    { %>
+                                                <li><%=h(result.getMessage())%>
+                                                    <% if (null != result.getLink()) { %>
+                                                    <span><%=link(LINK_HEADING, result.getLink())%></span>
+                                                    <% } %>
+                                                </li>
+                                                <% } %>
+                                                </ul>
+                                            </li>
+                                            <% } %>
+                                        <% } %>
+                                        </ul>
+                                    </li>
+<%
+                                }
+%>
+                                </ul>
+                            </li>
+<%
+                            }
+                        }
+%>
                         </ul>
                     </li>
-                    <% } %>
-                        </ul>
-                    </li>
-                  <% } %>
-                        </ul>
-                    </li>
-                  <% } %>
-
-                    <% } %>
+<%
+                }
+%>
                 </ul><br/>
             </li>
-            <% } %>
+<%
+            }
+%>
         </ul>
 <%
         }

--- a/core/src/org/labkey/core/admin/sitevalidation/siteValidation.jsp
+++ b/core/src/org/labkey/core/admin/sitevalidation/siteValidation.jsp
@@ -20,6 +20,7 @@
 <%@ page import="org.labkey.api.admin.sitevalidation.SiteValidationResultList" %>
 <%@ page import="org.labkey.api.admin.sitevalidation.SiteValidationService" %>
 <%@ page import="org.labkey.api.admin.sitevalidation.SiteValidatorDescriptor" %>
+<%@ page import="org.labkey.core.admin.AdminController.SiteValidationForm" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
@@ -28,6 +29,7 @@
     ul {list-style-type: none; padding-left: 5px;}
 </style>
 <%
+    SiteValidationForm form = (SiteValidationForm)getModelBean();
     final String LINK_HEADING = "More info";
     SiteValidationService validationService = SiteValidationService.get();
     if (null == validationService)
@@ -36,11 +38,11 @@
     <%}
     else { %>
         <% if (getContainer().isRoot()) {
-            Map<String,Map<SiteValidatorDescriptor, SiteValidationResultList>> siteResults = validationService.runSiteScopeValidators(getUser());
+            Map<String,Map<SiteValidatorDescriptor, SiteValidationResultList>> siteResults = validationService.runSiteScopeValidators(form.getProviders(), getUser());
         %>
             <strong>Site Level Validation Results</strong>
             <% if (siteResults.isEmpty()) { %>
-            <p>No site-wide validators have been registered.</p>
+            <p>No site-wide validators were run.</p>
             <% }
                 else {
             %>
@@ -70,8 +72,7 @@
                                     <% } %>
                                 </li>
                                 <% } %>
-                                <% if (errors.size() > 0) { %>
-                                        <li><br/></li>
+                                <% if (!errors.isEmpty()) { %>
                                         <li>Errors:
                                 <ul>
                                 <% for (SiteValidationResult result : errors) { %>
@@ -83,9 +84,8 @@
                                 </li>
                                 <% } %></ul>
                                 <% } %>
-                                <% if (warnings.size() > 0) { %>
-                                        <%--<li><br/></li>--%>
-                                        <li>Warnings:
+                                <% if (!warnings.isEmpty()) { %>
+                                         <li>Warnings:
                                 <ul>
                                 <% for (SiteValidationResult result : warnings) { %>
                                 <li>
@@ -103,9 +103,9 @@
         <% } %>
 
         <strong>Folder Validation Results</strong>
-        <%  Map<String, Map<SiteValidatorDescriptor, Map<String, Map<String, SiteValidationResultList>>>> containerResults = validationService.runContainerScopeValidators(getContainer(), getUser());
+        <%  Map<String, Map<SiteValidatorDescriptor, Map<String, Map<String, SiteValidationResultList>>>> containerResults = validationService.runContainerScopeValidators(getContainer(), form.isIncludeSubfolders(), form.getProviders(), getUser());
             if (containerResults.isEmpty()) { %>
-            <span>No folder validators have been registered.</span>
+            <p>No folder validators were run.</p>
         <%} else {
         %>
         <ul>
@@ -142,7 +142,7 @@
                                     <% } %>
                                 </li>
                                 <% } %>
-                                <% if (containerErrors.size() > 0) { %>
+                                <% if (!containerErrors.isEmpty()) { %>
                                     <li>Errors:
                                     <ul>
                                     <% for (SiteValidationResult result : containerErrors) { %>
@@ -153,7 +153,7 @@
                                     </li>
                                     <% } %></ul></li>
                                 <% } %>
-                                <% if (containerWarnings.size() > 0) { %>
+                                <% if (!containerWarnings.isEmpty()) { %>
                                     <li>Warnings:
                                         <ul>
                                         <% for (SiteValidationResult result : containerWarnings) { %>

--- a/core/src/org/labkey/core/admin/sitevalidation/siteValidation.jsp
+++ b/core/src/org/labkey/core/admin/sitevalidation/siteValidation.jsp
@@ -33,89 +33,116 @@
     final String LINK_HEADING = "More info";
     SiteValidationService validationService = SiteValidationService.get();
     if (null == validationService)
-    { %>
+    {
+%>
         <span>SiteValidationService has not been registered.</span>
-    <%}
-    else { %>
-        <% if (getContainer().isRoot()) {
-            Map<String,Map<SiteValidatorDescriptor, SiteValidationResultList>> siteResults = validationService.runSiteScopeValidators(form.getProviders(), getUser());
-        %>
+<%
+    }
+    else
+    {
+        if (getContainer().isRoot())
+        {
+%>
             <strong>Site Level Validation Results</strong>
-            <% if (siteResults.isEmpty()) { %>
-            <p>No site-wide validators were run.</p>
-            <% }
-                else {
-            %>
-            <ul>
-                <%  List<SiteValidationResult> infos;
-                    List<SiteValidationResult> errors;
-                    List<SiteValidationResult> warnings;
-                    for (Map.Entry<String, Map<SiteValidatorDescriptor, SiteValidationResultList>> moduleResults : siteResults.entrySet())
-                    {
-                %>
-                <li><strong>Module: </strong><%=h(moduleResults.getKey())%>
-                    <ul>
-                    <% for (Map.Entry<SiteValidatorDescriptor, SiteValidationResultList> results : moduleResults.getValue().entrySet()) { %>
-                        <li><strong>Validator: </strong><%=h(results.getKey().getName() + " ")%><span style="font-style: italic;"><%=h(results.getKey().getDescription())%></span>
-                            <ul>
-                                <% if (results.getValue().getResults().isEmpty()) { %>
-                                   <li>Nothing to report</li>
-                                <% } else {
-                                    infos = results.getValue().getResults(Level.INFO);
-                                    warnings = results.getValue().getResults(Level.WARN);
-                                    errors = results.getValue().getResults(Level.ERROR);
-                                    for (SiteValidationResult result : infos) { %>
-                                <li>
-                                    <%=h(result.getMessage())%>
-                                    <% if (null != result.getLink()) { %>
-                                    <span><%=link(LINK_HEADING, result.getLink())%></span>
-                                    <% } %>
-                                </li>
-                                <% } %>
-                                <% if (!errors.isEmpty()) { %>
-                                        <li>Errors:
+<%
+            if (validationService.getSiteProviders().isEmpty())
+            {
+%>
+                <p>No site-wide validators are registered.</p>
+<%
+            }
+            else
+            {
+                Map<String,Map<SiteValidatorDescriptor, SiteValidationResultList>> siteResults = validationService.runSiteScopeValidators(form.getProviders(), getUser());
+                if (siteResults.isEmpty())
+                {
+%>
+                    <p>No site-wide validators were selected.</p>
+<%
+                }
+                else
+                {
+%>
+                <ul>
+                    <%  List<SiteValidationResult> infos;
+                        List<SiteValidationResult> errors;
+                        List<SiteValidationResult> warnings;
+                        for (Map.Entry<String, Map<SiteValidatorDescriptor, SiteValidationResultList>> moduleResults : siteResults.entrySet())
+                        {
+                    %>
+                    <li><strong>Module: </strong><%=h(moduleResults.getKey())%>
+                        <ul>
+                        <% for (Map.Entry<SiteValidatorDescriptor, SiteValidationResultList> results : moduleResults.getValue().entrySet()) { %>
+                            <li><strong>Validator: </strong><%=h(results.getKey().getName() + " ")%><span style="font-style: italic;"><%=h(results.getKey().getDescription())%></span>
                                 <ul>
-                                <% for (SiteValidationResult result : errors) { %>
-                                <li>
-                                    <span class="labkey-error"><%=h(result.getMessage())%></span>
-                                    <% if (null != result.getLink()) { %>
-                                    <span><%=link(LINK_HEADING, result.getLink())%></span>
+                                    <% if (results.getValue().getResults().isEmpty()) { %>
+                                       <li>Nothing to report</li>
+                                    <% } else {
+                                        infos = results.getValue().getResults(Level.INFO);
+                                        warnings = results.getValue().getResults(Level.WARN);
+                                        errors = results.getValue().getResults(Level.ERROR);
+                                        for (SiteValidationResult result : infos) { %>
+                                    <li>
+                                        <%=h(result.getMessage())%>
+                                        <% if (null != result.getLink()) { %>
+                                        <span><%=link(LINK_HEADING, result.getLink())%></span>
+                                        <% } %>
+                                    </li>
                                     <% } %>
-                                </li>
-                                <% } %></ul>
-                                <% } %>
-                                <% if (!warnings.isEmpty()) { %>
-                                         <li>Warnings:
-                                <ul>
-                                <% for (SiteValidationResult result : warnings) { %>
-                                <li>
-                                    <%=h(result.getMessage())%>
-                                    <% if (null != result.getLink()) { %>
-                                    <span><%=link(LINK_HEADING, result.getLink())%></span>
+                                    <% if (!errors.isEmpty()) { %>
+                                            <li>Errors:
+                                    <ul>
+                                    <% for (SiteValidationResult result : errors) { %>
+                                    <li>
+                                        <span class="labkey-error"><%=h(result.getMessage())%></span>
+                                        <% if (null != result.getLink()) { %>
+                                        <span><%=link(LINK_HEADING, result.getLink())%></span>
+                                        <% } %>
+                                    </li>
+                                    <% } %></ul>
                                     <% } %>
-                                </li>
-                                <% } %></ul></li>
-                                <% } %>
-                    <% } %></ul></li>
-                <% } %> </ul><br/></li>
-             <% } %>
-            </ul><% } %>
-        <% } %>
-
+                                    <% if (!warnings.isEmpty()) { %>
+                                             <li>Warnings:
+                                    <ul>
+                                    <% for (SiteValidationResult result : warnings) { %>
+                                    <li>
+                                        <%=h(result.getMessage())%>
+                                        <% if (null != result.getLink()) { %>
+                                        <span><%=link(LINK_HEADING, result.getLink())%></span>
+                                        <% } %>
+                                    </li>
+                                    <% } %></ul></li>
+                                    <% } %>
+                        <% } %></ul></li>
+                    <% } %> </ul><br/></li>
+                 <% } %>
+                </ul>
+<%
+                }
+            }
+        }
+%>
         <strong>Folder Validation Results</strong>
-        <%  Map<String, Map<SiteValidatorDescriptor, Map<String, Map<String, SiteValidationResultList>>>> containerResults = validationService.runContainerScopeValidators(getContainer(), form.isIncludeSubfolders(), form.getProviders(), getUser());
-            if (containerResults.isEmpty()) { %>
-            <p>No folder validators were run.</p>
-        <%} else {
-        %>
+<%
+        Map<String, Map<SiteValidatorDescriptor, Map<String, Map<String, SiteValidationResultList>>>> containerResults = validationService.runContainerScopeValidators(getContainer(), form.isIncludeSubfolders(), form.getProviders(), getUser());
+        if (containerResults.isEmpty())
+        {
+%>
+            <p>No folder validators were selected.</p>
+<%
+        }
+        else
+        {
+%>
         <ul>
-          <%
+<%
             List<SiteValidationResult> containerInfos;
             List<SiteValidationResult> containerErrors;
             List<SiteValidationResult> containerWarnings;
 
-            for (Map.Entry<String, Map<SiteValidatorDescriptor, Map<String, Map<String, SiteValidationResultList>>>> moduleResults : containerResults.entrySet()) {
-          %>
+            for (Map.Entry<String, Map<SiteValidatorDescriptor, Map<String, Map<String, SiteValidationResultList>>>> moduleResults : containerResults.entrySet())
+            {
+%>
           <li><strong>Module: </strong><%=h(moduleResults.getKey())%>
               <ul>
                   <% for (Map.Entry<SiteValidatorDescriptor, Map<String, Map<String, SiteValidationResultList>>> validatorResults : moduleResults.getValue().entrySet()) { %>
@@ -180,5 +207,7 @@
             </li>
             <% } %>
         </ul>
-    <% } %>
-<% } %>
+<%
+        }
+    }
+%>

--- a/core/src/org/labkey/core/security/validators/PermissionsValidator.java
+++ b/core/src/org/labkey/core/security/validators/PermissionsValidator.java
@@ -28,9 +28,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * User: tgaluhn
- * Date: 10/25/2015
- *
  * Validates appropriate container level permissions for the guest user.
  */
 public class PermissionsValidator implements SiteValidationProvider
@@ -44,7 +41,7 @@ public class PermissionsValidator implements SiteValidationProvider
     @Override
     public String getDescription()
     {
-        return "Check that the guest user permissions are set appropriately.";
+        return "Check that guest user permissions are set appropriately";
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Current site validation UI is very primitive and inflexible. It's available only in the root and full validation (which can take a long time, even timing out on large sites) takes place immediately after clicking the admin console link.

#### Changes
- Configuration page to provide guidance and options
- Folder management tab to run validation in a project or folder
- Include subfolders (or not) option
- Choose which validators to run
- Various results formatting improvements

![image](https://github.com/LabKey/platform/assets/5107383/21511759-42a6-4eb0-a51e-35e9ba34f3b8)
