### PR TITLE
Add Commons Text and switch to commons.text.StringEscapeUtils

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,5 +1,4 @@
 import org.labkey.gradle.util.BuildUtils
-import org.labkey.gradle.util.ExternalDependency
 
 plugins {
     id 'java-library'
@@ -273,6 +272,19 @@ dependencies {
             ExternalDependency.APACHE_2_LICENSE_NAME,
             ExternalDependency.APACHE_2_LICENSE_URL,
             "Object pooling - Pipeline & TargetedMS dependency",
+        )
+    )
+
+    BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
+            "org.apache.commons:commons-text:${commonsTextVersion}",
+            "Commons Text",
+            "Apache",
+            "https://commons.apache.org/proper/commons-text/",
+            ExternalDependency.APACHE_2_LICENSE_NAME,
+            ExternalDependency.APACHE_2_LICENSE_URL,
+            "String algorithms",
         )
     )
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,4 +1,5 @@
 import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.ExternalDependency
 
 plugins {
     id 'java-library'

--- a/api/src/org/labkey/api/reader/TabLoader.java
+++ b/api/src/org/labkey/api/reader/TabLoader.java
@@ -17,8 +17,8 @@ package org.labkey.api.reader;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.CharSequenceReader;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -64,9 +64,6 @@ import java.util.stream.Collectors;
  * NOTE: Column descriptors should not be changed in the midst of iterating; a single set of column descriptors is used
  * to key all the maps.
  * <p/>
- * User: migra
- * Date: Jun 28, 2004
- * Time: 2:25:19 PM
  */
 public class TabLoader extends DataLoader
 {


### PR DESCRIPTION
#### Rationale
`commons.lang3.StringEscapeUtils` is deprecated in favor of `commons.text.StringEscapeUtils`. And Commons Text is already used by multiple modules and could be useful in more places.