### PR TITLE
AbDisc: Hit Selection Summary - scope to plate set path

### DIFF
--- a/assay/resources/schemas/assay.xml
+++ b/assay/resources/schemas/assay.xml
@@ -210,9 +210,6 @@
         </description>
         <isHidden>true</isHidden>
       </column>
-      <column columnName="PlateSetPath">
-        <isHidden>true</isHidden>
-      </column>
     </columns>
   </table>
   <table tableName="PlateType" tableDbType="TABLE">

--- a/assay/resources/schemas/assay.xml
+++ b/assay/resources/schemas/assay.xml
@@ -210,6 +210,9 @@
         </description>
         <isHidden>true</isHidden>
       </column>
+      <column columnName="PlateSetPath">
+        <isHidden>true</isHidden>
+      </column>
     </columns>
   </table>
   <table tableName="PlateType" tableDbType="TABLE">
@@ -241,6 +244,9 @@
       <column columnName="RowId"/>
       <column columnName="RunId"/>
       <column columnName="WellLsid"/>
+      <column columnName="PlateSetPath">
+        <isHidden>true</isHidden>
+      </column>
     </columns>
   </table>
 </tables>

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.005-24.006.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.005-24.006.sql
@@ -1,35 +1,6 @@
-ALTER TABLE assay.PlateSet ADD COLUMN PlateSetPath VARCHAR (4000);
-ALTER TABLE assay.PlateSet ADD CONSTRAINT UQ_PlateSet_PlateSetPath UNIQUE (PlateSetPath);
-
--- stand-alone assay plate sets
-UPDATE assay.PlateSet
-    SET PlateSetPath = '/' || RowId ||'/'
-    WHERE RootPlateSetId IS NULL;
-
--- top-level primary plate sets
-UPDATE assay.PlateSet
-    SET PlateSetPath = '/' || RowId || '/'
-    WHERE PlateSetPath IS NULL AND PrimaryPlateSetId IS NULL AND RootPlateSetId = RowId;
-
--- direct assay plate set descendants of top-level primary plate sets
-UPDATE assay.PlateSet
-    SET PlateSetPath = '/' || RootPlateSetId || '/' || RowId || '/'
-    WHERE PlateSetPath IS NULL AND RootPlateSetId IS NOT NULL AND (
-        RootPlateSetId = PrimaryPlateSetId OR PrimaryPlateSetId IS NULL
-    );
-
--- Handle deeply nested plate sets
-SELECT core.executeJavaUpgradeCode('populatePlateSetPaths');
-
 ALTER TABLE assay.Hit ADD COLUMN PlateSetPath VARCHAR (4000);
 
 -- Populate paths of pre-existing hits
-UPDATE assay.Hit AS H SET PlateSetPath = (
-    SELECT PS.PlateSetPath
-    FROM assay.PlateSet AS PS
-    INNER JOIN assay.Plate AS P ON P.PlateSet = PS.RowId
-    INNER JOIN assay.Well AS W ON W.PlateId = P.RowId
-    WHERE W.Lsid = H.WellLsid
-);
+SELECT core.executeJavaUpgradeCode('populatePlateSetPaths');
 
 ALTER TABLE assay.Hit ALTER COLUMN PlateSetPath SET NOT NULL;

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.005-24.006.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.005-24.006.sql
@@ -1,0 +1,35 @@
+ALTER TABLE assay.PlateSet ADD COLUMN PlateSetPath VARCHAR (4000);
+ALTER TABLE assay.PlateSet ADD CONSTRAINT UQ_PlateSet_PlateSetPath UNIQUE (PlateSetPath);
+
+-- stand-alone assay plate sets
+UPDATE assay.PlateSet
+    SET PlateSetPath = '/' || RowId ||'/'
+    WHERE RootPlateSetId IS NULL;
+
+-- top-level primary plate sets
+UPDATE assay.PlateSet
+    SET PlateSetPath = '/' || RowId || '/'
+    WHERE PlateSetPath IS NULL AND PrimaryPlateSetId IS NULL AND RootPlateSetId = RowId;
+
+-- direct assay plate set descendants of top-level primary plate sets
+UPDATE assay.PlateSet
+    SET PlateSetPath = '/' || RootPlateSetId || '/' || RowId || '/'
+    WHERE PlateSetPath IS NULL AND RootPlateSetId IS NOT NULL AND (
+        RootPlateSetId = PrimaryPlateSetId OR PrimaryPlateSetId IS NULL
+    );
+
+-- Handle deeply nested plate sets
+SELECT core.executeJavaUpgradeCode('populatePlateSetPaths');
+
+ALTER TABLE assay.Hit ADD COLUMN PlateSetPath VARCHAR (4000);
+
+-- Populate paths of pre-existing hits
+UPDATE assay.Hit AS H SET PlateSetPath = (
+    SELECT PS.PlateSetPath
+    FROM assay.PlateSet AS PS
+    INNER JOIN assay.Plate AS P ON P.PlateSet = PS.RowId
+    INNER JOIN assay.Well AS W ON W.PlateId = P.RowId
+    WHERE W.Lsid = H.WellLsid
+);
+
+ALTER TABLE assay.Hit ALTER COLUMN PlateSetPath SET NOT NULL;

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.005-24.006.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.005-24.006.sql
@@ -1,43 +1,8 @@
-ALTER TABLE assay.PlateSet DROP COLUMN PlateSetPath;
-GO
-
-ALTER TABLE assay.PlateSet ADD CONSTRAINT UQ_PlateSet_PlateSetPath UNIQUE (PlateSetPath);
-GO
-
-ALTER TABLE assay.PlateSet ADD PlateSetPath NVARCHAR (4000);
-GO
-
--- stand-alone assay plate sets
-UPDATE assay.PlateSet
-    SET PlateSetPath = CONCAT('/', RowId, '/')
-    WHERE RootPlateSetId IS NULL;
-
--- top-level primary plate sets
-UPDATE assay.PlateSet
-    SET PlateSetPath = CONCAT('/', RowId, '/')
-    WHERE PlateSetPath IS NULL AND PrimaryPlateSetId IS NULL AND RootPlateSetId = RowId;
-
--- direct assay plate set descendants of top-level primary plate sets
-UPDATE assay.PlateSet
-    SET PlateSetPath = CONCAT('/', RootPlateSetId, '/', RowId, '/')
-    WHERE PlateSetPath IS NULL AND RootPlateSetId IS NOT NULL AND (
-        RootPlateSetId = PrimaryPlateSetId OR PrimaryPlateSetId IS NULL
-    );
-
--- Handle deeply nested plate sets
-EXEC core.executeJavaUpgradeCode 'populatePlateSetPaths';
-
 ALTER TABLE assay.Hit ADD PlateSetPath NVARCHAR (4000);
 GO
 
 -- Populate paths of pre-existing hits
-UPDATE assay.Hit SET PlateSetPath = (
-    SELECT PlateSet.PlateSetPath
-    FROM assay.PlateSet
-    INNER JOIN assay.Plate ON Plate.PlateSet = PlateSet.RowId
-    INNER JOIN assay.Well ON Well.PlateId = Plate.RowId
-    WHERE Well.Lsid = Hit.WellLsid
-);
+EXEC core.executeJavaUpgradeCode 'populatePlateSetPaths';
 
 ALTER TABLE assay.Hit ALTER COLUMN PlateSetPath NVARCHAR (4000) NOT NULL;
 GO

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.005-24.006.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.005-24.006.sql
@@ -1,0 +1,43 @@
+ALTER TABLE assay.PlateSet DROP COLUMN PlateSetPath;
+GO
+
+ALTER TABLE assay.PlateSet ADD CONSTRAINT UQ_PlateSet_PlateSetPath UNIQUE (PlateSetPath);
+GO
+
+ALTER TABLE assay.PlateSet ADD PlateSetPath NVARCHAR (4000);
+GO
+
+-- stand-alone assay plate sets
+UPDATE assay.PlateSet
+    SET PlateSetPath = CONCAT('/', RowId, '/')
+    WHERE RootPlateSetId IS NULL;
+
+-- top-level primary plate sets
+UPDATE assay.PlateSet
+    SET PlateSetPath = CONCAT('/', RowId, '/')
+    WHERE PlateSetPath IS NULL AND PrimaryPlateSetId IS NULL AND RootPlateSetId = RowId;
+
+-- direct assay plate set descendants of top-level primary plate sets
+UPDATE assay.PlateSet
+    SET PlateSetPath = CONCAT('/', RootPlateSetId, '/', RowId, '/')
+    WHERE PlateSetPath IS NULL AND RootPlateSetId IS NOT NULL AND (
+        RootPlateSetId = PrimaryPlateSetId OR PrimaryPlateSetId IS NULL
+    );
+
+-- Handle deeply nested plate sets
+EXEC core.executeJavaUpgradeCode 'populatePlateSetPaths';
+
+ALTER TABLE assay.Hit ADD PlateSetPath NVARCHAR (4000);
+GO
+
+-- Populate paths of pre-existing hits
+UPDATE assay.Hit SET PlateSetPath = (
+    SELECT PlateSet.PlateSetPath
+    FROM assay.PlateSet
+    INNER JOIN assay.Plate ON Plate.PlateSet = PlateSet.RowId
+    INNER JOIN assay.Well ON Well.PlateId = Plate.RowId
+    WHERE Well.Lsid = Hit.WellLsid
+);
+
+ALTER TABLE assay.Hit ALTER COLUMN PlateSetPath NVARCHAR (4000) NOT NULL;
+GO

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -114,7 +114,7 @@ public class AssayModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 24.005;
+        return 24.006;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -9,9 +9,12 @@ import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.plate.AbstractPlateBasedAssayProvider;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateBasedAssayProvider;
+import org.labkey.api.assay.plate.PlateSet;
+import org.labkey.api.assay.plate.PlateSetEdge;
 import org.labkey.api.collections.ArrayListMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
@@ -38,6 +41,7 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.module.ModuleContext;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
@@ -45,6 +49,7 @@ import org.labkey.api.security.roles.SiteAdminRole;
 import org.labkey.api.util.Pair;
 import org.labkey.assay.plate.PlateManager;
 import org.labkey.assay.plate.PlateSetImpl;
+import org.labkey.assay.plate.model.PlateSetLineage;
 import org.labkey.assay.query.AssayDbSchema;
 
 import java.util.ArrayList;
@@ -53,6 +58,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.labkey.api.data.Table.CREATED_BY_COLUMN_NAME;
@@ -397,6 +403,57 @@ public class AssayUpgradeCode implements UpgradeCode
                     new SqlExecutor(AssayDbSchema.getInstance().getScope()).execute(sql);
                 }
             }
+            tx.commit();
+        }
+    }
+
+    /**
+     * Called from assay-24.005-24.006.sql
+     */
+    public static void populatePlateSetPaths(ModuleContext ctx)
+    {
+        if (ctx.isNewInstall())
+            return;
+
+        DbScope scope = AssayDbSchema.getInstance().getSchema().getScope();
+        try (DbScope.Transaction tx = scope.ensureTransaction())
+        {
+            SQLFragment sql = new SQLFragment("SELECT RowId FROM ")
+                    .append(AssayDbSchema.getInstance().getTableInfoPlateSet(), "")
+                    .append(" WHERE PlateSetPath IS NULL");
+            List<Integer> plateSetRowIds = new SqlSelector(scope, sql).getArrayList(Integer.class);
+
+            for (Integer plateSetRowId : plateSetRowIds)
+            {
+                PlateSetImpl plateSet = (PlateSetImpl) PlateManager.get().getPlateSet(ContainerFilter.EVERYTHING, plateSetRowId);
+                if (plateSet == null)
+                    throw new IllegalArgumentException(String.format("Failed to resolve a plate set with rowId (%d)", plateSetRowId));
+                if (plateSet.getRootPlateSetId() == null)
+                    throw new IllegalStateException(String.format("Cannot upgrade plate set with Row Id (%d). Assay upgrade script expected to have already handled all NULL values for RootPlateSetId.", plateSetRowId));
+
+                Map<Integer, Integer> edges = new HashMap<>();
+                PlateSetLineage lineage = PlateManager.get().getPlateSetLineage(ContainerManager.getRoot(), User.getAdminServiceUser(), plateSetRowId, ContainerFilter.EVERYTHING);
+                for (PlateSetEdge edge : lineage.getEdges())
+                    edges.put(edge.getToPlateSetId(), edge.getFromPlateSetId());
+
+                StringBuilder path = new StringBuilder();
+                Integer targetId = plateSetRowId;
+                while (!Objects.equals(targetId, plateSet.getRootPlateSetId()))
+                {
+                    path.insert(0, "/" + targetId);
+                    targetId = edges.get(targetId) == null ? plateSet.getRootPlateSetId() : edges.get(targetId);
+                }
+
+                path.insert(0, "/" + plateSet.getRootPlateSetId());
+                path.append("/");
+
+                sql = new SQLFragment("UPDATE ")
+                        .append(AssayDbSchema.getInstance().getTableInfoPlateSet(), "")
+                        .append(" SET PlateSetPath = ?").add(path.toString())
+                        .append(" WHERE RowId = ? ").add(plateSetRowId);
+                new SqlExecutor(scope).execute(sql);
+            }
+
             tx.commit();
         }
     }

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -39,7 +39,6 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.module.ModuleContext;
-import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
@@ -59,7 +58,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.labkey.api.data.ContainerFilter.EVERYTHING;
 import static org.labkey.api.data.Table.CREATED_BY_COLUMN_NAME;
 import static org.labkey.api.data.Table.CREATED_COLUMN_NAME;
 import static org.labkey.api.data.Table.MODIFIED_BY_COLUMN_NAME;
@@ -441,10 +439,7 @@ public class AssayUpgradeCode implements UpgradeCode
                         plateSetRowId,
                         ContainerFilter.EVERYTHING
                     );
-
                     String lineagePath = lineage.getSeedPath();
-                    if (lineagePath == null)
-                        throw new ValidationException("");
 
                     plateSetPaths.put(plateSetRowId, lineagePath);
                     plateSetsToHits.put(plateSetRowId, new ArrayList<>());

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2202,8 +2202,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         if (seedPlateSet == null)
             throw new NotFoundException();
 
-        PlateSetLineage lineage = new PlateSetLineage();
-        lineage.setSeed(seedPlateSetId);
+        PlateSetLineage lineage = new PlateSetLineage(seedPlateSetId);
         Integer rootPlateSetId = seedPlateSet.getRootPlateSetId();
 
         // stand-alone plate set
@@ -2344,8 +2343,6 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
                             PlateSetLineage lineage = getPlateSetLineage(container, user, plateSet.getRowId(), ContainerFilter.EVERYTHING);
                             String plateSetPath = lineage.getSeedPath();
-                            if (plateSetPath == null)
-                                throw new ValidationException(String.format("Failed to mark hits. Unable to resolve path for plate set (Row Id %d)", resultId));
 
                             cache.put(plateId, Pair.of(plate.getContainer().getEntityId(), plateSetPath));
                         }

--- a/assay/src/org/labkey/assay/plate/PlateSetImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetImpl.java
@@ -29,7 +29,6 @@ public class PlateSetImpl extends Entity implements PlateSet
     private Container _container;
     private String _description;
     private String _name;
-    private String _plateSetPath;
     private String _plateSetId;
     private Integer _primaryPlateSetId;
     private Integer _rootPlateSetId;
@@ -158,16 +157,6 @@ public class PlateSetImpl extends Entity implements PlateSet
     public void setDescription(String description)
     {
         _description = description;
-    }
-
-    public String getPlateSetPath()
-    {
-        return _plateSetPath;
-    }
-
-    public void setPlateSetPath(String plateSetPath)
-    {
-        _plateSetPath = plateSetPath;
     }
 
     public Integer getPrimaryPlateSetId()

--- a/assay/src/org/labkey/assay/plate/PlateSetImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetImpl.java
@@ -29,6 +29,7 @@ public class PlateSetImpl extends Entity implements PlateSet
     private Container _container;
     private String _description;
     private String _name;
+    private String _plateSetPath;
     private String _plateSetId;
     private Integer _primaryPlateSetId;
     private Integer _rootPlateSetId;
@@ -157,6 +158,16 @@ public class PlateSetImpl extends Entity implements PlateSet
     public void setDescription(String description)
     {
         _description = description;
+    }
+
+    public String getPlateSetPath()
+    {
+        return _plateSetPath;
+    }
+
+    public void setPlateSetPath(String plateSetPath)
+    {
+        _plateSetPath = plateSetPath;
     }
 
     public Integer getPrimaryPlateSetId()

--- a/assay/src/org/labkey/assay/plate/model/PlateSetLineage.java
+++ b/assay/src/org/labkey/assay/plate/model/PlateSetLineage.java
@@ -2,7 +2,7 @@ package org.labkey.assay.plate.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateSetEdge;
 import org.labkey.api.query.ValidationException;
@@ -23,10 +23,11 @@ public class PlateSetLineage
     private List<PlateSetEdge> _edges = Collections.emptyList();
     private Map<Integer, PlateSet> _plateSets = Collections.emptyMap();
     private Integer _root;
-    private Integer _seed;
+    private final Integer _seed;
 
-    public PlateSetLineage()
+    public PlateSetLineage(@NotNull Integer seed)
     {
+        _seed = seed;
     }
 
     public List<PlateSetEdge> getEdges()
@@ -64,11 +65,6 @@ public class PlateSetLineage
         return _seed;
     }
 
-    public void setSeed(Integer seed)
-    {
-        _seed = seed;
-    }
-
     /**
      * Returns a Map<Integer, PlateSet> containing the PlateSet for the given plateSetId as well as all the PlateSets
      * for the descendents of the given plateSetId.
@@ -102,11 +98,18 @@ public class PlateSetLineage
         return allPlateSets;
     }
 
-    public @Nullable String getSeedPath() throws ValidationException
+    /**
+     * Returns a string "lineage path" that expresses all plate sets along the path between the seed
+     * plate set and the root plate set for this lineage. This path is the Row IDs of each plate set along the path
+     * from root to seed read left to right separated by "/".
+     * Example:
+     * seed: 19
+     * root: 4
+     * ancestors: 12, 16
+     * path: "/4/12/16/19/"
+     */
+    public @NotNull String getSeedPath() throws ValidationException
     {
-        if (_seed == null)
-            return null;
-
         if (_edges.isEmpty() || _plateSets.isEmpty() || _root == null || _seed.equals(_root))
             return "/" + _seed + "/";
 

--- a/assay/src/org/labkey/assay/plate/model/PlateSetLineage.java
+++ b/assay/src/org/labkey/assay/plate/model/PlateSetLineage.java
@@ -72,7 +72,8 @@ public class PlateSetLineage
      * @return Map<Integer, PlateSet>
      */
     @JsonIgnore
-    public Map<Integer, PlateSet> getPlateSetAndDescendents(Integer plateSetId) {
+    public Map<Integer, PlateSet> getPlateSetAndDescendents(Integer plateSetId)
+    {
         Map<Integer, PlateSet> allPlateSets = new HashMap<>();
         allPlateSets.put(plateSetId, _plateSets.get(plateSetId));
         Set<Integer> parents = new HashSet<>(Arrays.asList(plateSetId));
@@ -83,7 +84,8 @@ public class PlateSetLineage
 
             for (PlateSetEdge edge : _edges)
             {
-                if (parents.contains(edge.getFromPlateSetId())) {
+                if (parents.contains(edge.getFromPlateSetId()))
+                {
                     Integer to = edge.getToPlateSetId();
                     children.add(to);
                     allPlateSets.put(to, _plateSets.get(to));


### PR DESCRIPTION
#### Rationale
Hit selection summary should respect lineage scope of plate set when aggregating hit selection results. This updates the backing query for "primary" plate set hit selection to scope to the "PlateSetPath" of the hit.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/383
- https://github.com/LabKey/limsModules/pull/133
- https://github.com/LabKey/platform/pull/5421

#### Changes
- Calculate a path for each hit and persist to a new assay.Hit.PlateSetPath column
- Upgrade script for pre-existing hits