### PR TITLE
Issues 50133 & 50175: Fix some date handling issues

### DIFF
--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -363,33 +363,44 @@ public class ExcelColumn extends RenderColumn
                 case(TYPE_DATE):
                     // Careful here... need to make sure we adjust dates for GMT.  This constructor automatically does the conversion, but there seem to be
                     // bugs in other jxl 2.5.7 constructors: DateTime(c, r, d) forces the date to time-only, DateTime(c, r, d, gmt) doesn't adjust for gmt
-                    Date dateVal = (Date) o;
-                    if (dateVal.compareTo(EXCEL_DATE_0) < 0)
+                    if (o instanceof Date dateVal)
                     {
-                        String format = getFormatString();
-                        if (StringUtils.isEmpty(format))
-                            cell.setCellValue(o.toString());
-                        else
+                        if (dateVal.compareTo(EXCEL_DATE_0) < 0)
                         {
-                            // date is invalid for excel, export as formatted string instead
-                            format = format.replaceAll("AM/PM", "a");
-                            Format formatter = FastDateFormat.getInstance(format);
-                            cell.setCellValue(formatter.format(dateVal));
+                            String format = getFormatString();
+                            if (StringUtils.isEmpty(format))
+                                cell.setCellValue(o.toString());
+                            else
+                            {
+                                // date is invalid for excel, export as formatted string instead
+                                format = format.replaceAll("AM/PM", "a");
+                                Format formatter = FastDateFormat.getInstance(format);
+                                cell.setCellValue(formatter.format(dateVal));
+                            }
                         }
+                        else
+                            cell.setCellValue((Date) o);
+                        cell.setCellStyle(_style);
                     }
                     else
-                        cell.setCellValue((Date) o);
-                    cell.setCellStyle(_style);
+                    {
+                        cell.setCellValue(o.toString());
+                    }
                     break;
                 case(TYPE_TIME):
-                    cell.setCellValue((Time) o);
-                    cell.setCellStyle(_style);
+                    if (o instanceof Time t)
+                    {
+                        cell.setCellValue(t);
+                        cell.setCellStyle(_style);
+                    }
+                    else
+                        cell.setCellValue(o.toString());
                     break;
                 case(TYPE_INT):
                 case(TYPE_DOUBLE):
-                    if (o instanceof Number)
+                    if (o instanceof Number n)
                     {
-                        cell.setCellValue(((java.lang.Number) o).doubleValue());
+                        cell.setCellValue(n.doubleValue());
                         cell.setCellStyle(_style);
                     }
                     //Issue 47268: Export Does Not Include Failed Lookup Values
@@ -439,7 +450,7 @@ public class ExcelColumn extends RenderColumn
                             {
                                 int height = img.getHeight();
                                 int width = img.getWidth();
-//
+
                                 double ratio = (double) width/height;
                                 if (ratio >= MAX_IMAGE_RATIO)
                                 {
@@ -512,7 +523,7 @@ public class ExcelColumn extends RenderColumn
         }
         catch(ClassCastException cce)
         {
-            _log.error("Can't cast \'" + o.toString() + "\', class \'" + o.getClass().getName() + "\', to class corresponding to simple type \'" + _simpleType + "\'");
+            _log.error("Can't cast '" + o.toString() + "', class '" + o.getClass().getName() + "', to class corresponding to simple type '" + _simpleType + "'");
             _log.error("DisplayColumn.getCaption(): " + _dc.getCaption());
             _log.error("DisplayColumn.getClass().getName(): " + _dc.getClass().getName());
             _log.error("DisplayColumn.getDisplayValueClass(): " + _dc.getDisplayValueClass());

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -96,6 +96,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.usageMetrics.SimpleMetricsService;
+import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.Pair;
@@ -115,11 +116,13 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.sql.Time;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -2865,6 +2868,13 @@ public class ExpDataIterators
             return new TypeData(container, sampleType, samplesTable, dataFile, fieldIndexes, dependencyIndexes, dataRows, new ArrayList<>());
         }
 
+        private Object getSerializingObject(Object data)
+        {
+            if (data instanceof Date d && !(data instanceof Time))
+                return DateUtil.formatIsoDateLongTime(d);
+            return data;
+        }
+
         private void addDataRow(TypeData typeData)
         {
             if (typeData.dataRows.size() == BATCH_SIZE)
@@ -2873,7 +2883,7 @@ public class ExpDataIterators
             List<Object> dataRow = new ArrayList<>();
             typeData.fieldIndexes.forEach(index -> {
                 Object data = get(index);
-                dataRow.add(data);
+                dataRow.add(getSerializingObject(data));
                 if (data != null)
                 {
                     if (index == _dataIdIndex)

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2871,7 +2871,7 @@ public class ExpDataIterators
         private Object getSerializingObject(Object data)
         {
             if (data instanceof Date d && !(data instanceof Time))
-                return DateUtil.formatIsoDateLongTime(d);
+                return DateUtil.formatIsoDateLongTime(d, true);
             return data;
         }
 
@@ -2908,7 +2908,7 @@ public class ExpDataIterators
 
         private void writeRowsToFile(TypeData typeData)
         {
-            if (typeData.dataRows.size() == 0)
+            if (typeData.dataRows.isEmpty())
                 return;
 
             try (FileWriter writer = new FileWriter(typeData.dataFile, true))


### PR DESCRIPTION
#### Rationale
Issue [50133](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50133): When an entity has more than one ancestor of a particular type, our Ancestor display columns return string values such as "2 values", which can't be cast to dates or times for writing to Excel workbooks, so we check the type before trying to cast to a Date or Time (which is a good idea anyway, I think).

Issue [50175](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50175): When splitting up an input file that may span sample types, source types, or containers, we use the default toString() methods for the fields involved. For Date fields, this means we will convert an input string such as "10-Apr-2024" to something like "Wed Apr 10 00:00:00 BST 2024". Generally, this will round trip and come back in as the 10th of April 2024, but the three-letter abbreviations for timezones are ambiguous and, in particular, "BST" can mean "British Summer Time" (as written by the default `toString()` method for `java.util.Date`) but it can also mean "Bangladesh Standard Time" (as read by Java), and that causes an unwanted time shift to occur. Here we update the method that writes out values to the separate files so it will use `DateUtil.formatIsoDateLongTime`, which does not include the timezone (since the value will have already been converted to the local timezone upon reading it from the original file) for writing out `Date` values.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Update `ExcelColumn.writeCell` to check types before casting
- Update `MultiDataTypeCrossProjectDataIterator` to better handle round-tripping of Date and DateTime values
