### PR TITLE
Data Generator Plate Set Support

### DIFF
--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -209,11 +209,17 @@ public class DataGenerator<T extends DataGenerator.Config>
                 _sampleTypes.addAll(service.getSampleTypes(getContainer(), getUser(), false));
             else
             {
-                sampleTypeNames.forEach(typeName -> {
-                    _sampleTypes.add(service.getSampleType(getContainer(), getUser(), typeName));
-                });
+                for (String typeName : sampleTypeNames)
+                {
+                    ExpSampleType sampleType = service.getSampleType(getContainer(), getUser(), typeName);
+                    if (sampleType == null)
+                        _log.warn(String.format("Unable to resolve sample type by name '%s'.", typeName));
+                    else
+                        _sampleTypes.add(sampleType);
+                }
             }
         }
+
         return _sampleTypes;
     }
 

--- a/api/src/org/labkey/api/data/generator/DataGeneratorRegistry.java
+++ b/api/src/org/labkey/api/data/generator/DataGeneratorRegistry.java
@@ -12,6 +12,7 @@ public class DataGeneratorRegistry
         SamplesInStorage,
         WorkflowJobs,
         Notebooks,
+        PlateSets,
     };
 
     private static final Map<DataType, DataGenerator.DataGenerationDriver> _dataGeneratorMap = new HashMap<>();

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -69,6 +69,7 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.assay.data.generator.AssayDesignGenerator;
 import org.labkey.assay.data.generator.AssayRunDataGenerator;
+import org.labkey.assay.data.generator.PlateSetDataGenerator;
 import org.labkey.assay.pipeline.AssayImportRunTask;
 import org.labkey.assay.plate.AssayPlateDataDomainKind;
 import org.labkey.assay.plate.AssayPlateMetadataServiceImpl;
@@ -170,6 +171,7 @@ public class AssayModule extends SpringModule
 
         DataGeneratorRegistry.registerGenerator(DataGeneratorRegistry.DataType.AssayDesigns, new AssayDesignGenerator.Driver());
         DataGeneratorRegistry.registerGenerator(DataGeneratorRegistry.DataType.AssayRunData, new AssayRunDataGenerator.Driver());
+        DataGeneratorRegistry.registerGenerator(DataGeneratorRegistry.DataType.PlateSets, new PlateSetDataGenerator.Driver());
 
         PropertyService.get().registerDomainKind(new PlateMetadataDomainKind());
         CacheManager.addListener(PlateCache::clearCache);

--- a/assay/src/org/labkey/assay/data/generator/AssayDesignGenerator.java
+++ b/assay/src/org/labkey/assay/data/generator/AssayDesignGenerator.java
@@ -65,6 +65,10 @@ public class AssayDesignGenerator extends DataGenerator<AssayDesignGenerator.Con
 
         GWTProtocol assayTemplate = assayDomainService.getAssayTemplate("General");
         assayTemplate.setName(name);
+
+        if (getConfig().isAssayDesignPlateSupport())
+            assayTemplate.setPlateMetadata(true);
+
         List<GWTDomain<GWTPropertyDescriptor>> domains = assayTemplate.getDomains();
 
         // clear the batch domain fields
@@ -108,15 +112,18 @@ public class AssayDesignGenerator extends DataGenerator<AssayDesignGenerator.Con
     {
         public static final String NUM_ASSAY_DESIGNS = "numAssayDesigns";
         public static final String ASSAY_DESIGN_SAMPLE_TYPES = "assayDesignSampleTypes";
+        public static final String ASSAY_DESIGN_PLATE_SUPPORT = "assayDesignPlateSupport";
 
         int _numAssayDesigns = 0;
         List<String> _assayDesignSampleTypes;
+        boolean _assayDesignPlateSupport;
 
         public Config(Properties properties)
         {
             super(properties);
             _numAssayDesigns = Integer.parseInt(properties.getProperty(NUM_ASSAY_DESIGNS, "0"));
             _assayDesignSampleTypes = parseNameList(properties, ASSAY_DESIGN_SAMPLE_TYPES);
+            _assayDesignPlateSupport = Boolean.parseBoolean(properties.getProperty(ASSAY_DESIGN_PLATE_SUPPORT, "false"));
         }
 
 
@@ -138,6 +145,11 @@ public class AssayDesignGenerator extends DataGenerator<AssayDesignGenerator.Con
         public void setAssayDesignSampleTypes(List<String> assayDesignSampleTypes)
         {
             _assayDesignSampleTypes = assayDesignSampleTypes;
+        }
+
+        public boolean isAssayDesignPlateSupport()
+        {
+            return _assayDesignPlateSupport;
         }
     }
 

--- a/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
+++ b/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
@@ -293,6 +293,7 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
 
             for (PlateSet plateSet : _assayPlateSets)
             {
+                checkAlive(_job);
                 List<Map<String, Object>> rawData = createRunData(plateSet, measure);
                 var factory = provider.createRunUploadFactory(assayToImport, context)
                         .setRunProperties(Map.of(AssayPlateMetadataService.PLATE_SET_COLUMN_NAME, plateSet.getRowId()))

--- a/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
+++ b/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
@@ -1,0 +1,255 @@
+package org.labkey.assay.data.generator;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.plate.PlateSet;
+import org.labkey.api.assay.plate.PlateSetType;
+import org.labkey.api.assay.plate.PlateType;
+import org.labkey.api.assay.plate.Position;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.generator.DataGenerator;
+import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.gwt.client.assay.AssayException;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.util.CPUTimer;
+import org.labkey.api.util.UnexpectedException;
+import org.labkey.assay.plate.PlateManager;
+import org.labkey.assay.plate.PlateSetImpl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import static org.labkey.assay.plate.PlateManager.CreatePlateSetPlate;
+
+public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.Config>
+{
+    private PlateType _plateType;
+    private int _plateSetsCreated = 0;
+
+    public PlateSetDataGenerator(PipelineJob job, PlateSetDataGenerator.Config config)
+    {
+        super(job, config);
+    }
+
+    public void generatePlateSets()
+    {
+        Config config = getConfig();
+
+        if (config.getNumPlatesets() <= 0)
+        {
+            _log.info(String.format("No platesets generated because %s=%d", Config.NUM_PLATESETS, config.getNumPlatesets()));
+            return;
+        }
+
+        if (config.getPlatesPerPlateset() > PlateSet.MAX_PLATES)
+        {
+            _log.info(String.format("The number of plates per platesets cannot exceed %d", PlateSet.MAX_PLATES));
+            return;
+        }
+
+        _plateType = getPlateType();
+        if (_plateType == null)
+        {
+            _log.error(String.format("Unable to resolve plate type (%s). Plate types must be expressed in the format : <rows>x<columns> eg: 8x12", config.getPlateType()));
+            return;
+        }
+
+        // generate plates and plate sets
+        if (config.getPlateLineageDepth() > 0)
+            _log.info(String.format("Generating %d root Plate sets with %d level(s)",
+                    config.getNumPlatesets(),
+                    config.getPlateLineageDepth()));
+        else
+            _log.info(String.format("Generating %d root Plate sets", config.getNumPlatesets()));
+
+        CPUTimer timer = addTimer("Plate Sets");
+        timer.start();
+        try
+        {
+            for (int i = 0; i < config.getNumPlatesets(); i++)
+            {
+                // root primary plate set
+                PlateSet parentPlateSet = createPlateSet(PlateSetType.primary, null);
+
+                if (config.getPlateLineageDepth() > 0)
+                    createLevel(parentPlateSet, 0);
+            }
+            _log.info(String.format("Created a total of %d plate sets.", _plateSetsCreated));
+        }
+        catch (Exception e)
+        {
+            _log.error(e.getMessage());
+            throw UnexpectedException.wrap(e);
+        }
+        timer.stop();
+    }
+
+    private void createLevel(PlateSet parent, int depth) throws Exception
+    {
+        if (depth > getConfig().getPlateLineageDepth())
+            return;
+
+        for (int i=0; i < getConfig().getPrimaryPlateSetsPerLevel(); i++)
+        {
+            int currentDepth = depth + 1;
+            PlateSet plateSet = createPlateSet(PlateSetType.primary, parent);
+            createLevel(plateSet, currentDepth);
+        }
+
+        for (int i=0; i < getConfig().getAssayPlateSetsPerLevel(); i++)
+        {
+            createPlateSet(PlateSetType.assay, parent);
+        }
+    }
+
+    private @Nullable PlateType getPlateType()
+    {
+        String plateType = getConfig().getPlateType();
+        if (!StringUtils.isEmpty(plateType))
+        {
+            String[] parts = plateType.split("x");
+            if (parts.length == 2)
+            {
+                int rows = Integer.parseInt(parts[0]);
+                int cols = Integer.parseInt(parts[1]);
+
+                return PlateManager.get().getPlateType(rows, cols);
+            }
+        }
+        return null;
+    }
+
+    private PlateSet createPlateSet(PlateSetType plateSetType, @Nullable PlateSet parentPlateSet) throws Exception
+    {
+        int plateWells = _plateType.getColumns() * _plateType.getRows();
+        int samplesNeeded = plateWells;
+
+        // make sure we have enough distinct samples to populate a primary plate set
+        if (plateSetType.equals(PlateSetType.primary))
+            samplesNeeded = plateWells * getConfig().getPlatesPerPlateset();
+        else
+            samplesNeeded = plateWells * getConfig().getPlatesPerPlateset();
+
+        List<Integer> ids = selectExistingSampleIds(samplesNeeded, samplesNeeded, ContainerFilter.current(getContainer()));
+        if (ids.size() < samplesNeeded)
+            throw new IllegalStateException(String.format("There are not enough samples to properly plate all of the data, you need at least (%d) samples.", samplesNeeded));
+
+        PlateSetImpl plateSet = new PlateSetImpl();
+        plateSet.setType(plateSetType);
+
+        List<CreatePlateSetPlate> plates = new ArrayList<>();
+        int sampleIdx = 0;
+        for (int i=0; i < getConfig().getPlatesPerPlateset(); i++)
+        {
+            List<Map<String, Object>> rows = new ArrayList<>();
+
+            // row, column ordering
+            for (int row=0; row < _plateType.getRows(); row++)
+            {
+                for (int col=0; col < _plateType.getColumns(); col++)
+                {
+                    Position position = PlateManager.get().createPosition(getContainer(), row, col);
+                    rows.add(Map.of(
+                            "wellLocation", position.getDescription(),
+                            "sampleId", ids.get(sampleIdx++)));
+                }
+            }
+            plates.add(new CreatePlateSetPlate(null, _plateType.getRowId(), rows));
+        }
+        _plateSetsCreated++;
+        return PlateManager.get().createPlateSet(getContainer(), getUser(), plateSet, plates, parentPlateSet != null ? parentPlateSet.getRowId() : null);
+    }
+
+    public static class Config extends DataGenerator.Config
+    {
+        public static final String NUM_PLATESETS = "numPlatesets";
+        public static final String PLATES_PER_PLATESET = "platesPerPlateset";
+        public static final String MIN_NUM_CUSTOM_PROPERTIES = "minCustomProperties";
+        public static final String MAX_NUM_CUSTOM_PROPERTIES = "maxCustomProperties";
+        public static final String PLATE_TYPE = "plateType";
+
+        public static final String PLATE_LINEAGE_DEPTH = "plateLineageDepth";
+        public static final String ASSAY_PLATE_SETS_PER_LEVEL = "assayPlateSetsPerLevel";
+        public static final String PRIMARY_PLATE_SETS_PER_LEVEL = "primaryPlateSetsPerLevel";
+
+        int _numPlatesets;
+        int _platesPerPlateset;
+        int _minCustomProperties;
+        int _maxCustomProperties;
+        int _plateLineageDepth;
+        int _assayPlateSetsPerLevel;
+        int _primaryPlateSetsPerLevel;
+
+        String _plateType;
+
+        public Config(Properties properties)
+        {
+            super(properties);
+            _numPlatesets = Integer.parseInt(properties.getProperty(NUM_PLATESETS, "0"));
+            _platesPerPlateset = Integer.parseInt(properties.getProperty(PLATES_PER_PLATESET, "0"));
+            _minCustomProperties = Integer.parseInt(properties.getProperty(MIN_NUM_CUSTOM_PROPERTIES, "0"));
+            _maxCustomProperties = Integer.parseInt(properties.getProperty(MAX_NUM_CUSTOM_PROPERTIES, "0"));
+
+            _plateLineageDepth = Integer.parseInt(properties.getProperty(PLATE_LINEAGE_DEPTH, "0"));
+            _assayPlateSetsPerLevel = Integer.parseInt(properties.getProperty(ASSAY_PLATE_SETS_PER_LEVEL, "0"));
+            _primaryPlateSetsPerLevel = Integer.parseInt(properties.getProperty(PRIMARY_PLATE_SETS_PER_LEVEL, "0"));
+
+            _plateType = properties.getProperty(PLATE_TYPE, "8x12");
+        }
+
+        public int getNumPlatesets()
+        {
+            return _numPlatesets;
+        }
+
+        public int getPlatesPerPlateset()
+        {
+            return _platesPerPlateset;
+        }
+
+        public int getMinCustomProperties()
+        {
+            return _minCustomProperties;
+        }
+
+        public int getMaxCustomProperties()
+        {
+            return _maxCustomProperties;
+        }
+
+        public int getPlateLineageDepth()
+        {
+            return _plateLineageDepth;
+        }
+
+        public int getAssayPlateSetsPerLevel()
+        {
+            return _assayPlateSetsPerLevel;
+        }
+
+        public int getPrimaryPlateSetsPerLevel()
+        {
+            return _primaryPlateSetsPerLevel;
+        }
+
+        public String getPlateType()
+        {
+            return _plateType;
+        }
+    }
+
+    public static class Driver implements DataGenerationDriver
+    {
+        @Override
+        public List<CPUTimer> generateData(PipelineJob job, Properties properties) throws ValidationException, AssayException, ExperimentException
+        {
+            PlateSetDataGenerator generator = new PlateSetDataGenerator(job, new PlateSetDataGenerator.Config(properties));
+            generator.generatePlateSets();
+            return generator.getTimers();
+        }
+    }
+}

--- a/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
+++ b/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
@@ -333,16 +333,16 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
 
     public static class Config extends DataGenerator.Config
     {
-        public static final String NUM_PLATESETS = "numPlatesets";
-        public static final String PLATES_PER_PLATESET = "platesPerPlateset";
-        public static final String MIN_NUM_CUSTOM_PROPERTIES = "minCustomProperties";
-        public static final String MAX_NUM_CUSTOM_PROPERTIES = "maxCustomProperties";
+        public static final String NUM_PLATESETS = "numPlateSets";
+        public static final String PLATES_PER_PLATESET = "platesPerPlateSet";
+        public static final String MIN_NUM_CUSTOM_PROPERTIES = "minCustomWellProperties";
+        public static final String MAX_NUM_CUSTOM_PROPERTIES = "maxCustomWellProperties";
         public static final String PLATE_TYPE = "plateType";
 
         public static final String PLATE_LINEAGE_DEPTH = "plateLineageDepth";
         public static final String ASSAY_PLATE_SETS_PER_LEVEL = "assayPlateSetsPerLevel";
         public static final String PRIMARY_PLATE_SETS_PER_LEVEL = "primaryPlateSetsPerLevel";
-        public static final String IMPORT_PLATE_SETS = "importPlatesets";
+        public static final String IMPORT_PLATE_SETS = "importPlateSets";
 
         int _numPlatesets;
         int _platesPerPlateset;

--- a/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
+++ b/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
@@ -2,6 +2,11 @@ package org.labkey.assay.data.generator;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssayService;
+import org.labkey.api.assay.DefaultAssayRunCreator;
+import org.labkey.api.assay.plate.AssayPlateMetadataService;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateSetType;
 import org.labkey.api.assay.plate.PlateType;
@@ -9,26 +14,37 @@ import org.labkey.api.assay.plate.Position;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.generator.DataGenerator;
 import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.gwt.client.assay.AssayException;
+import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.util.CPUTimer;
 import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.view.ViewContext;
 import org.labkey.assay.plate.PlateManager;
 import org.labkey.assay.plate.PlateSetImpl;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
 import static org.labkey.assay.plate.PlateManager.CreatePlateSetPlate;
 
 public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.Config>
 {
+    private static final int MAX_LINEAGE_DEPTH = 10;
+    private static final int MAX_PLATESETS_PER_LEVEL = 10;
     private PlateType _plateType;
     private int _plateSetsCreated = 0;
+    private List<String> _wellProperties = new ArrayList<>();
+    private static final String INT_PROP_PREFIX = "IntegerProp";
+    private static final String DOUBLE_PROP_PREFIX = "DoubleProp";
+    private List<PlateSet> _assayPlateSets = new ArrayList<>();
 
     public PlateSetDataGenerator(PipelineJob job, PlateSetDataGenerator.Config config)
     {
@@ -38,54 +54,111 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
     public void generatePlateSets()
     {
         Config config = getConfig();
+        if (validateConfiguration(config))
+        {
+            _plateType = getPlateType();
+            if (_plateType == null)
+            {
+                _log.error(String.format("Unable to resolve plate type (%s). Plate types must be expressed in the format : <rows>x<columns> eg: 8x12", config.getPlateType()));
+                return;
+            }
 
+            // generate plates and plate sets
+            if (config.getPlateLineageDepth() > 0)
+                _log.info(String.format("Generating %d root Plate set(s) with %d level(s)",
+                        config.getNumPlatesets(),
+                        config.getPlateLineageDepth()));
+            else
+                _log.info(String.format("Generating %d root Plate set(s)", config.getNumPlatesets()));
+
+            try
+            {
+                CPUTimer timer = addTimer("Plate Sets");
+                timer.start();
+                createWellProperties(config);
+                for (int i = 0; i < config.getNumPlatesets(); i++)
+                {
+                    // root primary plate set
+                    PlateSet parentPlateSet = createPlateSet(PlateSetType.primary, null);
+
+                    if (config.getPlateLineageDepth() > 0)
+                        createLevel(parentPlateSet, 0);
+                }
+                _log.info(String.format("Created a total of %d plate sets.", _plateSetsCreated));
+                timer.stop();
+
+                if (config._importPlatesets)
+                {
+                    CPUTimer importTimer = addTimer("Plate Sets Assay Import");
+                    importTimer.start();
+                    importPlatesets();
+                    importTimer.stop();
+                }
+            }
+            catch (Exception e)
+            {
+                _log.error(e.getMessage());
+                throw UnexpectedException.wrap(e);
+            }
+        }
+    }
+
+    private boolean validateConfiguration(Config config)
+    {
         if (config.getNumPlatesets() <= 0)
         {
             _log.info(String.format("No platesets generated because %s=%d", Config.NUM_PLATESETS, config.getNumPlatesets()));
-            return;
+            return false;
         }
 
         if (config.getPlatesPerPlateset() > PlateSet.MAX_PLATES)
         {
-            _log.info(String.format("The number of plates per platesets cannot exceed %d", PlateSet.MAX_PLATES));
-            return;
+            _log.error(String.format("The number of plates per platesets cannot exceed %d", PlateSet.MAX_PLATES));
+            return false;
         }
 
-        _plateType = getPlateType();
-        if (_plateType == null)
+        if (config.getPlateLineageDepth() > MAX_LINEAGE_DEPTH)
         {
-            _log.error(String.format("Unable to resolve plate type (%s). Plate types must be expressed in the format : <rows>x<columns> eg: 8x12", config.getPlateType()));
-            return;
+            _log.error(String.format("The max plate set lineage depth cannot exceed %d", MAX_LINEAGE_DEPTH));
+            return false;
         }
 
-        // generate plates and plate sets
-        if (config.getPlateLineageDepth() > 0)
-            _log.info(String.format("Generating %d root Plate sets with %d level(s)",
-                    config.getNumPlatesets(),
-                    config.getPlateLineageDepth()));
-        else
-            _log.info(String.format("Generating %d root Plate sets", config.getNumPlatesets()));
-
-        CPUTimer timer = addTimer("Plate Sets");
-        timer.start();
-        try
+        if ((config.getPrimaryPlateSetsPerLevel() + config.getAssayPlateSetsPerLevel()) > MAX_PLATESETS_PER_LEVEL)
         {
-            for (int i = 0; i < config.getNumPlatesets(); i++)
+            _log.error(String.format("The max number of plate sets per level cannot exceed %d", MAX_PLATESETS_PER_LEVEL));
+            return false;
+        }
+
+        if (config.getMinCustomProperties() > config.getMaxCustomProperties())
+        {
+            _log.error(String.format("The max number of plate sets per level cannot exceed %d", MAX_PLATESETS_PER_LEVEL));
+            return false;
+        }
+
+        if (config.isImportPlatesets() && (config.getPlateLineageDepth() == 0 || config.getAssayPlateSetsPerLevel() == 0))
+        {
+            _log.error("Unable to import plate set data into an assay, there must be at least one assay plate set. This can be created by " +
+                    "specifying a lineage depth greater than zero and at least one assay plate set per level.");
+            return false;
+        }
+        return true;
+    }
+
+    private void createWellProperties(Config config) throws Exception
+    {
+        if (config.getMaxCustomProperties() > 0)
+        {
+            List<GWTPropertyDescriptor> customFields = new ArrayList<>();
+            for (int i=0; i < config.getMaxCustomProperties(); i++)
             {
-                // root primary plate set
-                PlateSet parentPlateSet = createPlateSet(PlateSetType.primary, null);
-
-                if (config.getPlateLineageDepth() > 0)
-                    createLevel(parentPlateSet, 0);
+                String prefix = ((i % 2) == 0) ? INT_PROP_PREFIX : DOUBLE_PROP_PREFIX;
+                String rangeUri = ((i % 2) == 0) ? "http://www.w3.org/2001/XMLSchema#int" : "http://www.w3.org/2001/XMLSchema#double";
+                String name = prefix + "_" + i;
+                _wellProperties.add(name);
+                customFields.add(new GWTPropertyDescriptor(name, rangeUri));
             }
-            _log.info(String.format("Created a total of %d plate sets.", _plateSetsCreated));
+            PlateManager.get().createPlateMetadataFields(getContainer(), getUser(), customFields);
         }
-        catch (Exception e)
-        {
-            _log.error(e.getMessage());
-            throw UnexpectedException.wrap(e);
-        }
-        timer.stop();
     }
 
     private void createLevel(PlateSet parent, int depth) throws Exception
@@ -102,7 +175,7 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
 
         for (int i=0; i < getConfig().getAssayPlateSetsPerLevel(); i++)
         {
-            createPlateSet(PlateSetType.assay, parent);
+            _assayPlateSets.add(createPlateSet(PlateSetType.assay, parent));
         }
     }
 
@@ -127,11 +200,13 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
     {
         int plateWells = _plateType.getColumns() * _plateType.getRows();
         int samplesNeeded = plateWells;
+        checkAlive(_job);
 
-        // make sure we have enough distinct samples to populate a primary plate set
         if (plateSetType.equals(PlateSetType.primary))
+            // make sure we have enough distinct samples to populate a primary plate set
             samplesNeeded = plateWells * getConfig().getPlatesPerPlateset();
         else
+            // for now assay plate sets will have distinct samples per plate (even though this is not enforced)
             samplesNeeded = plateWells * getConfig().getPlatesPerPlateset();
 
         List<Integer> ids = selectExistingSampleIds(samplesNeeded, samplesNeeded, ContainerFilter.current(getContainer()));
@@ -143,6 +218,16 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
 
         List<CreatePlateSetPlate> plates = new ArrayList<>();
         int sampleIdx = 0;
+
+        // custom well properties to add to this plate set
+        List<String> wellProperties = new ArrayList<>();
+        if (getConfig().getMaxCustomProperties() > 0)
+        {
+            int count = randomInt(getConfig().getMinCustomProperties(), getConfig().getMaxCustomProperties());
+            for (int i=0; i < count; i++)
+                wellProperties.add(_wellProperties.get(i));
+        }
+
         for (int i=0; i < getConfig().getPlatesPerPlateset(); i++)
         {
             List<Map<String, Object>> rows = new ArrayList<>();
@@ -153,15 +238,96 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
                 for (int col=0; col < _plateType.getColumns(); col++)
                 {
                     Position position = PlateManager.get().createPosition(getContainer(), row, col);
-                    rows.add(Map.of(
-                            "wellLocation", position.getDescription(),
-                            "sampleId", ids.get(sampleIdx++)));
+                    Map<String, Object> rowMap = new HashMap<>();
+
+                    rowMap.put("wellLocation", position.getDescription());
+                    rowMap.put("sampleId", ids.get(sampleIdx++));
+
+                    for (String name : wellProperties)
+                    {
+                        if (name.startsWith(INT_PROP_PREFIX))
+                            rowMap.put("properties/" + name, randomInt(1, 5000));
+                        else
+                            rowMap.put("properties/" + name, randomDouble(1, 100000));
+                    }
+                    rows.add(rowMap);
                 }
             }
             plates.add(new CreatePlateSetPlate(null, _plateType.getRowId(), rows));
         }
         _plateSetsCreated++;
         return PlateManager.get().createPlateSet(getContainer(), getUser(), plateSet, plates, parentPlateSet != null ? parentPlateSet.getRowId() : null);
+    }
+
+    private void importPlatesets() throws Exception
+    {
+        if (_assayPlateSets.isEmpty())
+            throw new ValidationException("There are no assay plate sets to import");
+        else
+            _log.info(String.format("Importing data for %d plate sets.", _assayPlateSets.size()));
+
+        AssayProvider provider = AssayService.get().getProvider("General");
+        if (provider == null)
+            throw new ValidationException("No provider for 'General' assays.");
+
+        ExpProtocol assayToImport = null;
+        for (ExpProtocol protocol : AssayService.get().getAssayProtocols(getContainer(), provider))
+        {
+            if (provider.isPlateMetadataEnabled(protocol))
+            {
+                assayToImport = protocol;
+                break;
+            }
+        }
+
+        if (assayToImport != null)
+        {
+            ViewContext context = new ViewContext();
+            context.setUser(getUser());
+            context.setContainer(getContainer());
+
+            DomainProperty measure = provider.getResultsDomain(assayToImport)
+                    .getProperties()
+                    .stream()
+                    .filter(dp -> dp.getName().startsWith("FloatField")).findFirst().orElse(null);
+
+            for (PlateSet plateSet : _assayPlateSets)
+            {
+                List<Map<String, Object>> rawData = createRunData(plateSet, measure);
+                var factory = provider.createRunUploadFactory(assayToImport, context)
+                        .setRunProperties(Map.of(AssayPlateMetadataService.PLATE_SET_COLUMN_NAME, plateSet.getRowId()))
+                        .setRawData(rawData)
+                        .setUploadedData(Collections.emptyMap());
+                Map<Object, String> outputData = new HashMap<>();
+
+                DefaultAssayRunCreator.generateResultData(getUser(), getContainer(), provider, rawData, outputData, null);
+                factory.setOutputDatas(outputData);
+                provider.getRunCreator().saveExperimentRun(factory.create(), null);
+            }
+        }
+        else
+            throw new ValidationException("No protocols with plate support enabled");
+    }
+
+    private List<Map<String, Object>> createRunData(PlateSet plateSet, @Nullable DomainProperty measure)
+    {
+        // create a row for every plate in the plate set
+        List<Map<String, Object>> data = new ArrayList<>();
+        for (Plate plate : plateSet.getPlates(getUser()))
+        {
+            for (int row=0; row < _plateType.getRows(); row++)
+            {
+                for (int col=0; col < _plateType.getColumns(); col++)
+                {
+                    Position pos = PlateManager.get().createPosition(getContainer(), row, col);
+                    if (measure != null)
+                        data.add(Map.of("plate", plate.getPlateId(), "wellLocation", pos.getDescription(), measure.getName(), randomDouble(1, 100000)));
+                    else
+                        data.add(Map.of("plate", plate.getPlateId(), "wellLocation", pos.getDescription()));
+                }
+            }
+        }
+        return data;
     }
 
     public static class Config extends DataGenerator.Config
@@ -175,6 +341,7 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
         public static final String PLATE_LINEAGE_DEPTH = "plateLineageDepth";
         public static final String ASSAY_PLATE_SETS_PER_LEVEL = "assayPlateSetsPerLevel";
         public static final String PRIMARY_PLATE_SETS_PER_LEVEL = "primaryPlateSetsPerLevel";
+        public static final String IMPORT_PLATE_SETS = "importPlatesets";
 
         int _numPlatesets;
         int _platesPerPlateset;
@@ -183,6 +350,7 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
         int _plateLineageDepth;
         int _assayPlateSetsPerLevel;
         int _primaryPlateSetsPerLevel;
+        boolean _importPlatesets;
 
         String _plateType;
 
@@ -197,6 +365,7 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
             _plateLineageDepth = Integer.parseInt(properties.getProperty(PLATE_LINEAGE_DEPTH, "0"));
             _assayPlateSetsPerLevel = Integer.parseInt(properties.getProperty(ASSAY_PLATE_SETS_PER_LEVEL, "0"));
             _primaryPlateSetsPerLevel = Integer.parseInt(properties.getProperty(PRIMARY_PLATE_SETS_PER_LEVEL, "0"));
+            _importPlatesets = Boolean.parseBoolean(properties.getProperty(IMPORT_PLATE_SETS, "false"));
 
             _plateType = properties.getProperty(PLATE_TYPE, "8x12");
         }
@@ -239,6 +408,11 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
         public String getPlateType()
         {
             return _plateType;
+        }
+
+        public boolean isImportPlatesets()
+        {
+            return _importPlatesets;
         }
     }
 


### PR DESCRIPTION
#### Rationale
Add data generator functionality to create and manipulate plate sets. This will serve as the foundation for some of the AbDisc performance benchmarking / testing that is being established. 

This PR introduces a new `PlateSetDataGenerator` class which is responsible for the following plate set actions:
- Create root primary plate sets.
- Populate plate set plates with sample data.
- Create custom plate metadata fields, associate with plates and assign values.
- Generate plate set lineage relationships
- Import (terminal) plate sets into assay designs. The creation of assay designs existed prior to this story but the ability to set plate support on the protocol was added.

#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/166

#### Changes
The following data generator configuration options were introduced in this story:
```
# Whether the assay design includes plate support (default is false)
assayDesignPlateSupport=true

# Plate Set Properties

# The plate type to use for plate creation, this should be expressed in a row, column description format (8x12, 16x24), 
# must be valid plate types.
plateType=8x12

# Total number of top level primary plate sets to create
numPlatesets=1

# Number of plates per platesets to create (max of 60)
platesPerPlateset=20

# Minimum number of custom well properties to create per plate
minCustomProperties=0

# Maximum number of custom well properties to create per plate
maxCustomProperties=0

# Generates nested plate sets from the root PPS, each level will be controlled by the config properties 
# for number of primary and assay plate set types. Assay platesets are terminal so no additional children 
# will be generated, but each additional primary plate set level will generate a new set. For 
# example the config below will generate a total of 10 plate sets (7 primary, 3 assay)
plateLineageDepth=1
assayPlateSetsPerLevel=1
primaryPlateSetsPerLevel=2

# import the assay plate sets into an assay design (designs must be created separately)
importPlatesets=true

# supress pausing of the search indexer
pauseSearchIndexer=false
```
