### PR TITLE
Adjust security policy validation checks

### DIFF
--- a/api/src/org/labkey/api/security/GroupManager.java
+++ b/api/src/org/labkey/api/security/GroupManager.java
@@ -560,7 +560,7 @@ public class GroupManager
 
             MutableSecurityPolicy op = new MutableSecurityPolicy(_project);
             op.addRoleAssignment(_groupA, ReaderRole.class);
-            SecurityPolicyManager.savePolicy(op, getUser());
+            SecurityPolicyManager.savePolicyForTests(op, getUser());
 
             String newContainerPath = "GroupManagerJunitTestProject";
             Container newProject = ContainerService.get().getForPath("GroupManagerJunitTestProject");
@@ -574,7 +574,7 @@ public class GroupManager
 
             MutableSecurityPolicy np = new MutableSecurityPolicy(newProject);
             np.addRoleAssignment(newGroupA, ReaderRole.class);
-            SecurityPolicyManager.savePolicy(np, getUser());
+            SecurityPolicyManager.savePolicyForTests(np, getUser());
 
             //should be copied from the previous project though groupB membership
             assertTrue(np.hasPermission(getUser(), ReadPermission.class));

--- a/api/src/org/labkey/api/security/SecurityPolicyManager.java
+++ b/api/src/org/labkey/api/security/SecurityPolicyManager.java
@@ -40,7 +40,6 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exceptions.OptimisticConflictException;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.logging.LogHelper;
@@ -140,6 +139,13 @@ public class SecurityPolicyManager
         return policy.getResourceId();
     }
 
+    // Functionally identical to the method below, but tests should call this variant to ease validation of proper
+    // permission checking in non-test code
+    public static boolean savePolicyForTests(@NotNull MutableSecurityPolicy policy, @NotNull User user)
+    {
+        return savePolicy(policy, user);
+    }
+
     // Preferred method: this one validates, creates audit events, and returns whether roles were changed
     public static boolean savePolicy(@NotNull MutableSecurityPolicy policy, @NotNull User user)
     {
@@ -155,10 +161,6 @@ public class SecurityPolicyManager
         SecurableResource resource = c.findSecurableResource(policy.getResourceId(), user);
         if (null == resource)
             throw new IllegalStateException("No resource with the id '" + policy.getResourceId() + "' was found in this container!");
-
-        // Ensure that user has admin permission on resource
-        if (!resource.hasPermission(user, AdminPermission.class))
-            throw new IllegalArgumentException("You do not have permission to modify the security policy for this resource!");
 
         // Get the existing policy so we can audit how it's changed and check for unauthorized changes
         SecurityPolicy oldPolicy = SecurityPolicyManager.getPolicy(resource);

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -1308,7 +1308,7 @@ public class UserManager
             MutableSecurityPolicy policy = new MutableSecurityPolicy(root, root.getPolicy());
             policy.addRoleAssignment(_users.get(APPLICATION_ADMIN_EMAIL), ApplicationAdminRole.class);
             policy.addRoleAssignment(_users.get(SITE_ADMIN_EMAIL), SiteAdminRole.class);
-            SecurityPolicyManager.savePolicy(policy, TestContext.get().getUser());
+            SecurityPolicyManager.savePolicyForTests(policy, TestContext.get().getUser());
         }
 
         @Test

--- a/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
+++ b/api/src/org/labkey/api/security/permissions/AbstractActionPermissionTest.java
@@ -102,7 +102,7 @@ public abstract class AbstractActionPermissionTest extends Assert
         policy.addRoleAssignment(users.get(SUBMITTER_EMAIL), SubmitterRole.class);
         policy.addRoleAssignment(users.get(TRUSTED_EDITOR_EMAIL), EditorRole.class);
         policy.addRoleAssignment(users.get(TRUSTED_AUTHOR_EMAIL), AuthorRole.class);
-        SecurityPolicyManager.savePolicy(policy, TestContext.get().getUser());
+        SecurityPolicyManager.savePolicyForTests(policy, TestContext.get().getUser());
 
         MutableSecurityPolicy projectPolicy = new MutableSecurityPolicy(c.getProject(), c.getProject().getPolicy());
         projectPolicy.addRoleAssignment(users.get(PROJECT_ADMIN_EMAIL), ProjectAdminRole.class);
@@ -117,7 +117,7 @@ public abstract class AbstractActionPermissionTest extends Assert
             rootPolicy.addRoleAssignment(users.get(TRUSTED_EDITOR_EMAIL), TRUSTED_ANALYST_ROLE);
             rootPolicy.addRoleAssignment(users.get(TRUSTED_AUTHOR_EMAIL), TRUSTED_ANALYST_ROLE);
         }
-        SecurityPolicyManager.savePolicy(rootPolicy, TestContext.get().getUser());
+        SecurityPolicyManager.savePolicyForTests(rootPolicy, TestContext.get().getUser());
         return users;
     }
 
@@ -136,7 +136,7 @@ public abstract class AbstractActionPermissionTest extends Assert
             rootPolicy.removeRoleAssignment(_users.get(TRUSTED_EDITOR_EMAIL), TRUSTED_ANALYST_ROLE);
             rootPolicy.removeRoleAssignment(_users.get(TRUSTED_AUTHOR_EMAIL), TRUSTED_ANALYST_ROLE);
         }
-        SecurityPolicyManager.savePolicy(rootPolicy, TestContext.get().getUser());
+        SecurityPolicyManager.savePolicyForTests(rootPolicy, TestContext.get().getUser());
 
         cleanupUsers(LKS_ROLE_EMAILS);
     }

--- a/api/src/org/labkey/api/webdav/WebdavResolverImpl.java
+++ b/api/src/org/labkey/api/webdav/WebdavResolverImpl.java
@@ -263,7 +263,7 @@ public class WebdavResolverImpl extends AbstractWebdavResolver
             MutableSecurityPolicy policyNone = new MutableSecurityPolicy(cTest);
             policyNone.addRoleAssignment(SecurityManager.getGroup(Group.groupGuests), NoPermissionsRole.class);
             policyNone.addRoleAssignment(user, ReaderRole.class);
-            SecurityPolicyManager.savePolicy(policyNone, TestContext.get().getUser());
+            SecurityPolicyManager.savePolicyForTests(policyNone, TestContext.get().getUser());
 
             WebdavResource rTest = resolver.lookup(rootPath.append(pathTest));
             assertNotNull(rTest);
@@ -279,7 +279,7 @@ public class WebdavResolverImpl extends AbstractWebdavResolver
 
             MutableSecurityPolicy policyRead = new MutableSecurityPolicy(cTest);
             policyRead.addRoleAssignment(SecurityManager.getGroup(Group.groupGuests), ReaderRole.class);
-            SecurityPolicyManager.savePolicy(policyRead, TestContext.get().getUser());
+            SecurityPolicyManager.savePolicyForTests(policyRead, TestContext.get().getUser());
             rTest = resolver.lookup(rootPath.append(pathTest));
             assertTrue(rTest.canRead(guest,true));
 

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -726,7 +726,9 @@ public class SecurityApiActions
             if (null == resource)
                 throw new IllegalArgumentException("No resource with the id '" + resourceId + "' was found in this container!");
 
-            // Note: savePolicy() checks for admin permissions on old policy
+            // Ensure that user has admin permission on resource
+            if (!resource.hasPermission(user, AdminPermission.class))
+                throw new IllegalArgumentException("You do not have permission to modify the security policy for this resource!");
 
             MutableSecurityPolicy policy = null;
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -8261,7 +8261,7 @@ public class QueryController extends SpringActionController
 
             MutableSecurityPolicy securityPolicy = new MutableSecurityPolicy(SecurityPolicyManager.getPolicy(project1));
             securityPolicy.addRoleAssignment(withoutPermissions, EditorRole.class);
-            SecurityPolicyManager.savePolicy(securityPolicy, TestContext.get().getUser());
+            SecurityPolicyManager.savePolicyForTests(securityPolicy, TestContext.get().getUser());
 
             assertTrue("Should have insert permission", project1.hasPermission(withoutPermissions, InsertPermission.class));
             assertFalse("Should not have insert permission", project2.hasPermission(withoutPermissions, InsertPermission.class));


### PR DESCRIPTION
#### Rationale
Related PR moved a too-strict permission check into `savePolicy()` along with audit logging and privileged role checking, so move it back. [Issue 50103: folder and project admins cannot edit custom dataset security in a study](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50103)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/4292
