### PR TITLE
ContainerManager.getForPath to check for GUID and call getForId() instead

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1142,6 +1142,9 @@ public class ContainerManager
 
     public static Container getForPath(@NotNull String path)
     {
+        if (GUID.isGUID(path))
+            return getForId(path);
+
         Path p = Path.parse(path);
         return getForPath(p);
     }

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1143,7 +1143,11 @@ public class ContainerManager
     public static Container getForPath(@NotNull String path)
     {
         if (GUID.isGUID(path))
-            return getForId(path);
+        {
+            Container c = getForId(path);
+            if (c != null)
+                return c;
+        }
 
         Path p = Path.parse(path);
         return getForPath(p);


### PR DESCRIPTION
#### Rationale
SM SQLServer runs started hitting an issue after a recent change that made use of saveRows to make sample updates across containers. The commands for the saveRows API call are split by container GUID and the containerPath prop of the command is set to that GUID. This works fine in PG but was failing in SQL Server because the container cache stashes upper case GUID values but the call that goes through getForPath() uses toLowerCase() on the GUID before trying to find it in the cache. This PR fixes that by having getForPath check for a GUID first and call getForId if one is found.

#### Changes
- ContainerManager.getForPath to check for GUID and call getForId() instead
