### PR TITLE
Use server GUID to tie database to full-text search index

### DIFF
--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -68,11 +68,6 @@ import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 
-/**
- * User: matthewb
- * Date: Nov 12, 2009
- * Time: 12:54:01 PM
- */
 public interface SearchService extends SearchMXBean
 {
     // create logger for package which can be set via logger-manage.view
@@ -423,7 +418,7 @@ public interface SearchService extends SearchMXBean
     IndexTask indexContainer(@Nullable IndexTask task, Container c, Date since);
     // TODO: Remove? This is never called
     IndexTask indexProject(@Nullable IndexTask task, Container project /*boolean incremental*/);
-    void indexFull(boolean force);
+    void indexFull(boolean force, String reason);
 
     void waitForIdle() throws InterruptedException;
 
@@ -433,7 +428,7 @@ public interface SearchService extends SearchMXBean
 
     void deleteContainer(String id);
 
-    void deleteIndex();          // close the index if it's been initialized, then delete the index directory and reset lastIndexed values
+    void deleteIndex(String reason);          // close the index if it's been initialized, then delete the index directory and reset lastIndexed values
     void clearLastIndexed();     // reset lastIndexed values and initiate aggressive crawl. must be callable before (and after) start() has been called.
     void maintenance();
 
@@ -464,8 +459,7 @@ public interface SearchService extends SearchMXBean
         void enumerateDocuments(IndexTask task, @NotNull Container c, @Nullable Date modifiedSince);
 
         /**
-         *if the full-text search is deleted, providers may need to clear
-         * any stored lastIndexed values.
+         * if the full-text search index is deleted, providers may need to clear stored lastIndexed values.
          */
         default void indexDeleted() throws SQLException
         {

--- a/core/src/org/labkey/core/search/NoopSearchService.java
+++ b/core/src/org/labkey/core/search/NoopSearchService.java
@@ -276,7 +276,7 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
-    public void deleteIndex()
+    public void deleteIndex(String reason)
     {
     }
 
@@ -294,7 +294,6 @@ public class NoopSearchService implements SearchService
     @Override
     public void addSearchCategory(SearchCategory category)
     {
-
     }
 
     @Override
@@ -391,7 +390,7 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
-    public void indexFull(boolean force)
+    public void indexFull(boolean force, String reason)
     {
     }
 

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -341,7 +341,7 @@ public class SearchController extends SpringActionController
             }
             else if (form.isDelete())
             {
-                ss.deleteIndex();
+                ss.deleteIndex("a site admin requested it");
                 ss.start();
                 SearchPropertyManager.audit(getUser(), "Index Deleted");
                 _msgid = 1;
@@ -553,7 +553,7 @@ public class SearchController extends SpringActionController
             {
                 if (form.isFull())
                 {
-                    ss.indexFull(true);
+                    ss.indexFull(true, "a site admin requested it");
                 }
                 else if (form.isSince())
                 {

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -237,13 +237,11 @@ public class SearchModule extends DefaultModule
         {
             if (_deleteIndex)
             {
-                LOG.info("Deleting full-text search index and clearing last indexed because: " + _deleteIndexReasons);
-                ss.deleteIndex();
+                ss.deleteIndex(_deleteIndexReasons.toString());
             }
             if (_indexFull)
             {
-                LOG.info("Initiating an aggressive full-text search reindex because: " + _indexFullReasons);
-                ss.indexFull(true);
+                ss.indexFull(true, _indexFullReasons.toString());
             }
         }
     };

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -1315,8 +1315,9 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     //
 
     @Override
-    public void indexFull(final boolean force)
+    public void indexFull(final boolean force, String reason)
     {
+        _log.info("Initiating an aggressive full-text search reindex because: " + reason);
         // crank crawler into high gear!
         DavCrawler.getInstance().startFull(WebdavService.getPath(), force);
     }

--- a/search/src/org/labkey/search/model/WritableIndexManager.java
+++ b/search/src/org/labkey/search/model/WritableIndexManager.java
@@ -25,11 +25,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
-/*
-* User: adam
-* Date: Mar 9, 2011
-* Time: 10:26:44 PM
-*/
 public interface WritableIndexManager
 {
     void deleteDocument(String id);


### PR DESCRIPTION
#### Rationale
Improve the ability to link a full-text-search index with the database that produced it. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=50201

#### Changes
- Add ability to save arbitrary global properties to the Lucene index
- On every crawler start, retrieve the saved GUID. If it doesn't match the database GUID, delete the index (and lastIndexed).
- Log a reason for every delete index and reindex operation