### PR TITLE
Issue 50202: AuditLogImpl.TRANSACTION_EVENT_CACHE issue

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditHandler.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditHandler.java
@@ -63,7 +63,7 @@ public abstract class AbstractAuditHandler implements AuditHandler
     }
 
     @Override
-    public void addAuditEvent(User user, Container c, TableInfo table, @Nullable AuditBehaviorType auditType, @Nullable String userComment, QueryService.AuditAction action, List<Map<String, Object>> rows, @Nullable List<Map<String, Object>> existingRows)
+    public void addAuditEvent(User user, Container c, TableInfo table, @Nullable AuditBehaviorType auditType, @Nullable String userComment, QueryService.AuditAction action, List<Map<String, Object>> rows, @Nullable List<Map<String, Object>> existingRows, boolean useTransactionAuditCache)
     {
         if (table.supportsAuditTracking())
         {
@@ -152,13 +152,13 @@ public abstract class AbstractAuditHandler implements AuditHandler
                         batch.add(event);
                         if (batch.size() > 1000)
                         {
-                            auditLog.addEvents(user, batch);
+                            auditLog.addEvents(user, batch, useTransactionAuditCache);
                             batch.clear();
                         }
                     }
                     if (batch.size() > 0)
                     {
-                        auditLog.addEvents(user, batch);
+                        auditLog.addEvents(user, batch, useTransactionAuditCache);
                         batch.clear();
                     }
                     break;

--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -31,9 +31,15 @@ public interface AuditHandler
 {
     void addSummaryAuditEvent(User user, Container c, TableInfo table, QueryService.AuditAction action, Integer dataRowCount, @Nullable AuditBehaviorType auditBehaviorType, @Nullable String userComment);
 
-    /* In the case of update the 'existingRows' is the 'before' version of the record. Caller is not expected to provide existingRows without rows. */
     void addAuditEvent(User user, Container c, TableInfo table, @Nullable AuditBehaviorType auditType, @Nullable String userComment, QueryService.AuditAction action,
-                       @Nullable List<Map<String, Object>> rows, @Nullable List<Map<String, Object>> existingRows);
+                       @Nullable List<Map<String, Object>> rows, @Nullable List<Map<String, Object>> existingRows, boolean useTransactionAuditCache);
+
+    /* In the case of update the 'existingRows' is the 'before' version of the record. Caller is not expected to provide existingRows without rows. */
+    default void addAuditEvent(User user, Container c, TableInfo table, @Nullable AuditBehaviorType auditType, @Nullable String userComment, QueryService.AuditAction action,
+                       @Nullable List<Map<String, Object>> rows, @Nullable List<Map<String, Object>> existingRows)
+    {
+        addAuditEvent(user, c, table, auditType, userComment, action, rows, existingRows, false);
+    }
 
 
     static Map<String, Object> getRecordForInsert(Map<String, Object> updatedRow)

--- a/api/src/org/labkey/api/audit/AuditLogService.java
+++ b/api/src/org/labkey/api/audit/AuditLogService.java
@@ -101,6 +101,11 @@ public interface AuditLogService
     /** If user is null, default to the Guest user */
     <K extends AuditTypeEvent> void addEvents(@Nullable User user, List<K> events);
 
+    default <K extends AuditTypeEvent> void addEvents(@Nullable User user, List<K> events, boolean useTransactionAuditCache)
+    {
+        addEvents(user, events);
+    }
+
     @Nullable
     <K extends AuditTypeEvent> K getAuditEvent(User user, String eventType, int rowId);
 

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -154,7 +154,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
         }
 
         @Override
-        public void addAuditEvent(User user, Container c, TableInfo table, @Nullable AuditBehaviorType auditType, @Nullable String userComment, QueryService.AuditAction action, List<Map<String, Object>> rows, @Nullable List<Map<String, Object>> updatedRows)
+        public void addAuditEvent(User user, Container c, TableInfo table, @Nullable AuditBehaviorType auditType, @Nullable String userComment, QueryService.AuditAction action, List<Map<String, Object>> rows, @Nullable List<Map<String, Object>> updatedRows, boolean useTransactionAuditCache)
         {
         }
     }

--- a/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
@@ -52,6 +52,7 @@ public class DataIteratorContext
     boolean _crossTypeImport = false;
     boolean _crossFolderImport = false;
     boolean _allowCreateStorage = false;
+    boolean _useTransactionAuditCache = false;
     private final Set<String> _passThroughBuiltInColumnNames = new CaseInsensitiveHashSet();
     private final Set<String> _dontUpdateColumnNames = new CaseInsensitiveHashSet();
     private final Set<String> _alternateKeys = new CaseInsensitiveHashSet();
@@ -198,6 +199,16 @@ public class DataIteratorContext
     public void setAllowCreateStorage(boolean allowCreateStorage)
     {
         _allowCreateStorage = allowCreateStorage;
+    }
+
+    public boolean isUseTransactionAuditCache()
+    {
+        return _useTransactionAuditCache;
+    }
+
+    public void setUseTransactionAuditCache(boolean useTransactionAuditCache)
+    {
+        _useTransactionAuditCache = useTransactionAuditCache;
     }
 
     /** Normally all built in columns (created, createdBy, etc) are populated with newly calculated values on writing to target.

--- a/api/src/org/labkey/api/dataiterator/DetailedAuditLogDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/DetailedAuditLogDataIterator.java
@@ -52,6 +52,7 @@ public class DetailedAuditLogDataIterator extends AbstractDataIterator
     final String _userComment;
     final QueryService.AuditAction _auditAction;
     final AuditHandler _auditHandler;
+    final boolean _useTransactionAuditCache;
 
     // for batching
     final ArrayList<Map<String,Object>> _updatedRows = new ArrayList<>();
@@ -65,6 +66,7 @@ public class DetailedAuditLogDataIterator extends AbstractDataIterator
         _user = user;
         _container = c;
         _userComment = (String) _context.getConfigParameter(AuditConfigs.AuditUserComment);
+        _useTransactionAuditCache = !context.getInsertOption().updateOnly && context.isUseTransactionAuditCache();
         _auditAction = auditAction;
         _auditHandler = table.getAuditHandler(DETAILED);
 
@@ -95,7 +97,7 @@ public class DetailedAuditLogDataIterator extends AbstractDataIterator
         if (!hasNext || _updatedRows.size() > 1000)
         {
             if (!_updatedRows.isEmpty())
-                _auditHandler.addAuditEvent(_user, _container, _table, DETAILED, _userComment, _auditAction, _updatedRows, _existingRows);
+                _auditHandler.addAuditEvent(_user, _container, _table, DETAILED, _userComment, _auditAction, _updatedRows, _existingRows, _useTransactionAuditCache);
             _updatedRows.clear();
             if (null != _existingRows)
                 _existingRows.clear();

--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -73,7 +73,7 @@ public interface InventoryService
 
     static InventoryService get() { return ServiceRegistry.get().getService(InventoryService.class); }
 
-    void addAuditEvent(User user, Container c, TableInfo table, AuditBehaviorType auditBehaviorType, @Nullable String userComment, QueryService.AuditAction action, @Nullable List<Map<String, Object>> rows, @Nullable List<Map<String, Object>> existingRows);
+    void addAuditEvent(User user, Container c, TableInfo table, AuditBehaviorType auditBehaviorType, @Nullable String userComment, QueryService.AuditAction action, @Nullable List<Map<String, Object>> rows, @Nullable List<Map<String, Object>> existingRows, boolean useTransactionAuditCache);
 
     Map<String, Integer> moveSamples(Collection<Integer> sampleIds, Container targetContainer, User user);
 

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -307,7 +307,8 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         insertOption,
         crossTypeImport,
         allowCreateStorage,
-        crossFolderImport
+        crossFolderImport,
+        useTransactionAuditCache
     }
 
     @Nullable
@@ -326,6 +327,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
             _optionParamsMap.put(Params.crossTypeImport, Boolean.valueOf(getParam(Params.crossTypeImport)));
             _optionParamsMap.put(Params.allowCreateStorage, Boolean.valueOf(getParam(Params.allowCreateStorage)));
             _optionParamsMap.put(Params.crossFolderImport, Boolean.valueOf(getParam(Params.crossFolderImport)));
+            _optionParamsMap.put(Params.useTransactionAuditCache, Boolean.valueOf(getParam(Params.useTransactionAuditCache)));
         }
         return _optionParamsMap;
     }
@@ -790,6 +792,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         boolean crossTypeImport = optionParamsMap.getOrDefault(AbstractQueryImportAction.Params.crossTypeImport, false);
         boolean allowCreateStorage = optionParamsMap.getOrDefault(AbstractQueryImportAction.Params.allowCreateStorage, false);
         boolean crossFolderImport = optionParamsMap.getOrDefault(AbstractQueryImportAction.Params.crossFolderImport, false);
+        boolean useTransactionAuditCache = optionParamsMap.getOrDefault(Params.useTransactionAuditCache, false);
 
         DataIteratorContext context = new DataIteratorContext(errors);
         context.setInsertOption(insertOption);
@@ -810,6 +813,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         context.setCrossTypeImport(crossTypeImport);
         context.setCrossFolderImport(crossFolderImport && QueryService.get().isCrossProjectsImportEnabled(container));
         context.setAllowCreateStorage(allowCreateStorage);
+        context.setUseTransactionAuditCache(useTransactionAuditCache);
         context.setLogger(logger);
         return context;
     }

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -1215,7 +1215,7 @@ quickScan:
             os.write(buf,0,r);
     }
 
-    private static final char[] ILLEGAL_CHARS = {'/','\\',':','?','<','>','*','|','"','^', '\n', '\r'};
+    private static final char[] ILLEGAL_CHARS = {'/','\\',':','?','<','>','*','|','"','^', '\n', '\r', '\''};
     private static final String ILLEGAL_CHARS_STRING = new String(ILLEGAL_CHARS);
 
     public static boolean isLegalName(String name)

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2181,6 +2181,10 @@ public class ExpDataIterators
             if (null == input)
                 return null;           // Can happen if context has errors
 
+            // skipTransactionAuditCache already set for import and merge in AbstractQueryImportAction.createDataIteratorContext
+            if (context.getInsertOption() == QueryUpdateService.InsertOption.INSERT)
+                context.setUseTransactionAuditCache(true);
+
             // add FileLink DataIterator if any input columns are of type FILE_LINK
             if (null != _fileLinkDirectory)
             {

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2181,7 +2181,7 @@ public class ExpDataIterators
             if (null == input)
                 return null;           // Can happen if context has errors
 
-            // skipTransactionAuditCache already set for import and merge in AbstractQueryImportAction.createDataIteratorContext
+            // useTransactionAuditCache already set for import and merge in AbstractQueryImportAction.createDataIteratorContext
             if (context.getInsertOption() == QueryUpdateService.InsertOption.INSERT)
                 context.setUseTransactionAuditCache(true);
 

--- a/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTimelineAuditProvider.java
@@ -205,6 +205,7 @@ public class SampleTimelineAuditProvider extends AbstractAuditTypeProvider
             Set<PropertyStorageSpec.Index> indexes = super.getPropertyIndices(domain);
             indexes.add(new PropertyStorageSpec.Index(false, SAMPLE_ID_COLUMN_NAME));
             indexes.add(new PropertyStorageSpec.Index(false, SAMPLE_NAME_COLUMN_NAME));
+            indexes.add(new PropertyStorageSpec.Index(false, COLUMN_NAME_TRANSACTION_ID)); // Issue 50202
             return indexes;
         }
     }


### PR DESCRIPTION
#### Rationale
Issue [50202](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50202): AuditLogImpl.TRANSACTION_EVENT_CACHE grows to > 1GB of heap during large sample imports
Issue [50083](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50083): SM: Exporting samples from a sample type with an apostrophe issue

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/392
- https://github.com/LabKey/platform/pull/5447
- https://github.com/LabKey/limsModules/pull/182

#### Changes
- modify TRANSACTION_EVENT_CACHE to only live 1 hour
- added index on sampletimelineevent.transactionid column
- added AbstractQueryImportAction.Params.useTransactionAuditCache
- for import, only use TRANSACTION_EVENT_CACHE if useTransactionAuditCache param is set
- for insert, always use TRANSACTION_EVENT_CACHE
- Issue 50083: Add apostrophe to not allowed filename characters 