### PR TITLE
Add support for export storage map

### DIFF
--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -335,12 +335,13 @@ public class ExcelColumn extends RenderColumn
     }
 
 
-    public void writeCell(Sheet sheet, int column, int row, RenderContext ctx)
+    public Cell writeCell(Sheet sheet, int column, int row, RenderContext ctx)
     {
         Object o = _dc.getExcelCompatibleValue(ctx);
         ColumnInfo columnInfo = _dc.getColumnInfo();
         Row rowObject = getRow(sheet, row);
 
+        Cell cell = null;
         if (null == o)
         {
             // For null values, don't create the cell unless there's a conditional format that applies
@@ -348,13 +349,13 @@ public class ExcelColumn extends RenderColumn
             if (cellFormat != null)
             {
                 // Set the format but there's no value to set
-                Cell cell = rowObject.getCell(column, MissingCellPolicy.CREATE_NULL_AS_BLANK);
+                cell = rowObject.getCell(column, MissingCellPolicy.CREATE_NULL_AS_BLANK);
                 cell.setCellStyle(cellFormat);
             }
-            return;
+            return cell;
         }
 
-        Cell cell = rowObject.getCell(column, MissingCellPolicy.CREATE_NULL_AS_BLANK);
+        cell = rowObject.getCell(column, MissingCellPolicy.CREATE_NULL_AS_BLANK);
 
         try
         {
@@ -520,6 +521,7 @@ public class ExcelColumn extends RenderColumn
                     }
                 }
             }
+            return cell;
         }
         catch(ClassCastException cce)
         {

--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -335,7 +335,7 @@ public class ExcelColumn extends RenderColumn
     }
 
 
-    public Cell writeCell(Sheet sheet, int column, int row, RenderContext ctx)
+    public void writeCell(Sheet sheet, int column, int row, RenderContext ctx)
     {
         Object o = _dc.getExcelCompatibleValue(ctx);
         ColumnInfo columnInfo = _dc.getColumnInfo();
@@ -352,7 +352,7 @@ public class ExcelColumn extends RenderColumn
                 cell = rowObject.getCell(column, MissingCellPolicy.CREATE_NULL_AS_BLANK);
                 cell.setCellStyle(cellFormat);
             }
-            return cell;
+            return;
         }
 
         cell = rowObject.getCell(column, MissingCellPolicy.CREATE_NULL_AS_BLANK);
@@ -521,7 +521,6 @@ public class ExcelColumn extends RenderColumn
                     }
                 }
             }
-            return cell;
         }
         catch(ClassCastException cce)
         {

--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -335,7 +335,7 @@ public class ExcelColumn extends RenderColumn
     }
 
 
-    protected void writeCell(Sheet sheet, int column, int row, RenderContext ctx)
+    public void writeCell(Sheet sheet, int column, int row, RenderContext ctx)
     {
         Object o = _dc.getExcelCompatibleValue(ctx);
         ColumnInfo columnInfo = _dc.getColumnInfo();
@@ -703,7 +703,7 @@ public class ExcelColumn extends RenderColumn
 
     // Note: width of the column will be adjusted once per call to ExcelWriter.render(), which potentially means
     // multiple times per sheet.  This shouldn't be a problem, though.
-    protected void adjustWidth(RenderContext ctx, Sheet sheet, int column, int startRow, int endRow)
+    public void adjustWidth(RenderContext ctx, Sheet sheet, int column, int startRow, int endRow)
     {
         if (_autoSize)
         {

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -485,6 +485,11 @@ public class ExcelWriter implements ExportWriter
 
     protected Sheet ensureSheet(RenderContext ctx, Workbook workbook, int sheetNumber)
     {
+        return ensureSheet(ctx, workbook, sheetNumber, true);
+    }
+
+    protected Sheet ensureSheet(RenderContext ctx, Workbook workbook, int sheetNumber, boolean withDrawing)
+    {
         if (workbook.getNumberOfSheets() > sheetNumber)
         {
             return workbook.getSheetAt(sheetNumber);
@@ -495,12 +500,15 @@ public class ExcelWriter implements ExportWriter
             if (sheet == null)
             {
                 sheet = workbook.createSheet(getSheetName(sheetNumber));
-                sheet.getPrintSetup().setPaperSize(PrintSetup.LETTER_PAPERSIZE);
+                if (withDrawing)
+                {
+                    sheet.getPrintSetup().setPaperSize(PrintSetup.LETTER_PAPERSIZE);
 
-                Drawing<?> drawing = sheet.createDrawingPatriarch();
-                ctx.put(SHEET_DRAWING, drawing);
-                ctx.put(SHEET_IMAGE_SIZES, new HashMap<>());
-                ctx.put(SHEET_IMAGE_PICTURES, new HashMap<>());
+                    Drawing<?> drawing = sheet.createDrawingPatriarch();
+                    ctx.put(SHEET_DRAWING, drawing);
+                    ctx.put(SHEET_IMAGE_SIZES, new HashMap<>());
+                    ctx.put(SHEET_IMAGE_PICTURES, new HashMap<>());
+                }
             }
             return sheet;
         }

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -545,11 +545,11 @@ public class ExcelWriter implements ExportWriter
         }
     }
 
-    private List<ExcelColumn> getVisibleColumns(Workbook workbook, RenderContext ctx)
+    protected List<ExcelColumn> getVisibleColumns(Workbook workbook, RenderContext ctx, List<DisplayColumn> columns)
     {
-        List<ExcelColumn> visibleColumns = new ArrayList<>(_columns.size());
+        List<ExcelColumn> visibleColumns = new ArrayList<>(columns.size());
 
-        for (DisplayColumn dc : _columns)
+        for (DisplayColumn dc : columns)
         {
             ExcelColumn column = new ExcelColumn(dc, _formatters, workbook);
             if (column.isVisible(ctx))
@@ -566,6 +566,11 @@ public class ExcelWriter implements ExportWriter
         }
 
         return visibleColumns;
+    }
+
+    private List<ExcelColumn> getVisibleColumns(Workbook workbook, RenderContext ctx)
+    {
+        return getVisibleColumns(workbook, ctx, _columns);
     }
 
     // Should be called within a try/catch

--- a/api/src/org/labkey/api/query/QueryParam.java
+++ b/api/src/org/labkey/api/query/QueryParam.java
@@ -25,6 +25,7 @@ public enum QueryParam implements SafeToRenderEnum
     queryName,
     viewName,
     columns,
+    extraColumns,
     reportId,
 
     offset,

--- a/api/src/org/labkey/api/query/QuerySettings.java
+++ b/api/src/org/labkey/api/query/QuerySettings.java
@@ -67,6 +67,7 @@ public class QuerySettings
     private String _viewName;
     private String _dataRegionName;
     private List<FieldKey> _fieldKeys;
+    private List<FieldKey> _extraFieldKeys;
     private ReportIdentifier _reportId;
     private boolean _allowChooseQuery = false;
     private boolean _allowChooseView = true;
@@ -345,6 +346,20 @@ public class QuerySettings
             }
         }
 
+        String extraColumns = StringUtils.trimToNull(_getParameter(param(QueryParam.extraColumns)));
+        if (null != extraColumns)
+        {
+            String[] colArray = extraColumns.split(",");
+            _extraFieldKeys = new ArrayList<>();
+            for (String key : colArray)
+            {
+                if (!(StringUtils.isEmpty(key)))
+                {
+                    _extraFieldKeys.add(FieldKey.fromString(StringUtils.trim(key)));
+                }
+            }
+        }
+
         String selectionKey = StringUtils.trimToNull(_getParameter(param(QueryParam.selectionKey)));
         if (null != selectionKey)
             setSelectionKey(selectionKey);
@@ -381,7 +396,7 @@ public class QuerySettings
         }
     }
 
-    void setQueryParameter(String name, Object value)
+    public void setQueryParameter(String name, Object value)
     {
         _queryParameters.put(name,value);
     }
@@ -802,6 +817,16 @@ public class QuerySettings
     public void setFieldKeys(List<FieldKey> keys)
     {
         _fieldKeys = keys;
+    }
+
+    public List<FieldKey> getExtraFieldKeys()
+    {
+        return _extraFieldKeys;
+    }
+
+    public void setExtraFieldKeys(List<FieldKey> keys)
+    {
+        _extraFieldKeys = keys;
     }
 
     /** Optional scoping, beyond the folder itself, for .lastFilter */

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -2191,7 +2191,21 @@ public class QueryView extends WebPartView<Object>
                     getSettings().setFieldKeys(null);
                 }
 
-                if (keys.size() > 0)
+                if (!keys.isEmpty())
+                {
+                    Map<FieldKey, ColumnInfo> selectedCols = QueryService.get().getColumns(table, keys);
+                    for (ColumnInfo col : selectedCols.values())
+                        rgn.addColumn(col);
+                }
+            }
+        }
+        else if (null != getSettings().getExtraFieldKeys())
+        {
+            TableInfo table = getTable();
+            if (table != null)
+            {
+                List<FieldKey> keys = getSettings().getExtraFieldKeys();
+                if (!keys.isEmpty())
                 {
                     Map<FieldKey, ColumnInfo> selectedCols = QueryService.get().getColumns(table, keys);
                     for (ColumnInfo col : selectedCols.values())


### PR DESCRIPTION
#### Rationale
We are adding an item to the Export menu for terminal storage units. This item will produce an Excel spreadsheet containing the data in the default view for the samples in the terminal storage unit.  For this, we extend the `ExcelWriter` class and need some of its methods to be exposed to subclasses.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/184
- https://github.com/LabKey/labkey-ui-components/pull/1478

#### Changes
- Add `ExcelWriter.ensureSheet` and `ExcelWriter.ensureRow` methods
- Elevate visibility of some methods in `ExcelWriter` and `ExcelColumn`
