### PR TITLE
Tolerate OLAP descriptors referencing missing modules

### DIFF
--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3207,21 +3207,28 @@ public class QueryServiceImpl implements QueryService
     public Collection<QueryService.Hierarchy> getOlapHierarchies(String configId, Container c, String cubeName, String dimension)
     {
         OlapSchemaDescriptor descriptor = ServerManager.getDescriptor(c, configId);
+        List<QueryService.Hierarchy> ret = new ArrayList<>();
 
         if (null == descriptor)
-            throw new IllegalArgumentException("OLAP schema descriptor not found: " + configId);
+        {
+            LOG.warn("OLAP schema descriptor not found: " + configId);
+        }
+        else
+        {
+            RolapCubeDef rolap = descriptor.getRolapCubeDefinitionByName(cubeName);
 
-        RolapCubeDef rolap = descriptor.getRolapCubeDefinitionByName(cubeName);
+            if (null == rolap)
+                throw new IllegalArgumentException("Unable to find cube definition for cubeName: " + cubeName);
 
-        if (null == rolap)
-            throw new IllegalArgumentException("Unable to find cube definition for cubeName: " + cubeName);
+            DimensionDef def = rolap.getDimension(dimension);
 
-        DimensionDef def = rolap.getDimension(dimension);
+            if (null == def)
+                throw new IllegalArgumentException("Unable to find dimension " + dimension);
 
-        if (null == def)
-            throw new IllegalArgumentException("Unable to find dimension " + dimension);
+            ret.addAll(def.getHierarchies());
+        }
 
-        return new ArrayList<>(def.getHierarchies());
+        return ret;
     }
 
     @Override

--- a/query/src/org/labkey/query/olap/ServerManager.java
+++ b/query/src/org/labkey/query/olap/ServerManager.java
@@ -190,7 +190,7 @@ public class ServerManager
         // crack the schemaId into module and name parts
         CacheId id = OlapSchemaCacheHandler.parseOlapCacheKey(schemaId);
 
-        if (null != id)
+        if (null != id && null != id.getModule())
         {
             // look for descriptor in database cache by container and name
             OlapSchemaDescriptor d = DB_DESCRIPTOR_CACHE.get(c).get(id.getName());


### PR DESCRIPTION
#### Rationale
DataFinder references OLAP cubes defined in other modules. When one of those modules wasn't present, the current code threw an NPE. Fixing the NPE led to throwing an IllegalArgumentException. We now log a warning and show an error pop-up ("Olap configuration not found: PNNL:/FCIC_PublicationCube") when navigating to the data finder folder. That seems sufficient.