### PR TITLE
Issue 50212: Check if parent directory isWritable before calling FileUtil.createDirectories()

### DIFF
--- a/filecontent/src/org/labkey/filecontent/FileSystemAttachmentParent.java
+++ b/filecontent/src/org/labkey/filecontent/FileSystemAttachmentParent.java
@@ -129,7 +129,7 @@ public class FileSystemAttachmentParent implements AttachmentDirectory
                 Path root = dir.resolve(svc.getFolderName(_contentType));
 
                 // Issue 49963: avoid FileAlreadyExistsExceptions on certain file systems
-                if (!Files.exists(root))
+                if (!Files.exists(root) && Files.isWritable(dir))
                 {
                     FileUtil.createDirectories(root);
                 }


### PR DESCRIPTION
#### Rationale
When the FileSystemAttachmentParent attempts to ensure that the @scripts dir exists, it will create it if not already present. however if the file system for the parent dir is read-only, this can results in a AccessDeniedException. This PR adds a Files.isWritable() check for the parent dir before the call to FileUtil.createDirectories().

#### Changes
- Check if parent directory isWritable before calling FileUtil.createDirectories()
