### PR TITLE
study column !== container column

### DIFF
--- a/study/src/org/labkey/study/query/BaseStudyTable.java
+++ b/study/src/org/labkey/study/query/BaseStudyTable.java
@@ -880,7 +880,16 @@ public abstract class BaseStudyTable extends FilteredTable<StudyQuerySchema>
 
     protected ColumnInfo addStudyColumn()
     {
-        var study = new AliasedColumn(this, "Study", _rootTable.getColumn("Container"));
+        // Don't copy the container concepturi, we don't want a ContainerDisplayFactory
+        // NOTE: we can't just setConcentURI(null) because AliasedColumn will just ask the wrapped column
+        var study = new AliasedColumn(this, "Study", _rootTable.getColumn("Container"))
+        {
+            @Override
+            public String getConceptURI()
+            {
+                return null;
+            }
+        };
 
 //      NOTE: QFK doesn't seem to support container joins
 //      study.setFk(new QueryForeignKey("study", getUserSchema().getContainer(), null, getUserSchema().getUser(), "studyproperties", "Container", "Label", false));


### PR DESCRIPTION
#### Rationale
Study columns shouldn't use ContainerDisplayColumn.  A regular display column works just fine.

Without this change the "study" columns in the "study" schema show the container label instead of the study label, but use study label for filtering.  Very confusing.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
