### PR TITLE
Expand width of missing value indicator text boxes

### DIFF
--- a/api/src/org/labkey/api/data/MvUtil.java
+++ b/api/src/org/labkey/api/data/MvUtil.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.Constants;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
-import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.CaseInsensitiveTreeMap;
 import org.labkey.api.collections.CsvSet;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.Pair;
@@ -32,9 +32,6 @@ import java.util.Set;
 
 /**
  * Utility class for dealing with Missing Value Indicators
- *
- * User: jgarms
- * Date: Jan 14, 2009
  */
 public class MvUtil
 {
@@ -53,7 +50,7 @@ public class MvUtil
      */
     public static boolean isValidMvIndicator(String indicator, @NotNull Container c)
     {
-        if (indicator == null || "".equals(indicator))
+        if (indicator == null || indicator.isEmpty())
             return true;
         return isMvIndicator(indicator, c);
     }
@@ -155,7 +152,7 @@ public class MvUtil
         Filter filter = new SimpleFilter(FieldKey.fromParts("container"), c.getId());
         Map<String, String> indicatorsAndLabels = new TableSelector(mvTable, selectColumns, filter, null).getValueMap();
 
-        return indicatorsAndLabels.isEmpty() ? null : Collections.unmodifiableMap(new CaseInsensitiveHashMap<>(indicatorsAndLabels));
+        return indicatorsAndLabels.isEmpty() ? null : Collections.unmodifiableMap(new CaseInsensitiveTreeMap<>(indicatorsAndLabels));
     }
 
     public static void containerDeleted(@NotNull Container c)
@@ -170,9 +167,7 @@ public class MvUtil
 
     /**
      * Returns the default indicators as originally implemented: "Q" and "N",
-     * mapped to their labels.
-     *
-     * This should only be necessary at bootstrap time.
+     * mapped to their labels. This should only be necessary at bootstrap time.
      */
     public static Map<String, String> getDefaultMvIndicators()
     {

--- a/core/src/org/labkey/core/admin/mvIndicators.jsp
+++ b/core/src/org/labkey/core/admin/mvIndicators.jsp
@@ -132,7 +132,7 @@
                         <tr id="rowId<%=++rowId%>">
                             <% addHandler("removeRow" + rowId, "click", "return removeRow(" + rowId + ");"); %>
                             <td><img id="removeRow<%=rowId%>" style="margin-right: 8px; cursor: pointer" src="<%=getWebappURL("_images/partdelete.gif")%>" alt="delete"></td>
-                            <td><input name="mvIndicators" type="TEXT" size=3 id="mvIndicators<%=rowId%>" value="<%=h(indicator)%>"></td>
+                            <td><input name="mvIndicators" type="TEXT" id="mvIndicators<%=rowId%>" value="<%=h(indicator)%>"></td>
                             <td><input name="mvLabels" type="TEXT" size=60 value="<%=h(label)%>"></td>
                         </tr>
                         <%


### PR DESCRIPTION
#### Rationale
These text boxes are too narrow for some clients. Also, MVIs are displayed in random order; sort them by indicator (case insensitive). https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50242