### PR TITLE
Improve-cross project actions - Edit in Bulk

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -72,7 +72,6 @@ import org.labkey.api.query.QueryViewProvider;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
-import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.HttpView;
@@ -561,26 +560,6 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     @NotNull
     SQLFragment generateExperimentTreeSQL(SQLFragment lsidsFrag, ExpLineageOptions options);
-
-    /**
-     * Given a set or rowIds and a base schemaName, returns the subset of rowIds for which the given user has
-     * the given permission for the row's container
-     * @param user user in question
-     * @param rowIds set of rowIds to check
-     * @param tableInfo table info for the rows being checked
-     * @param permissionClass the permission to check
-     * @return null if there is no
-     */
-    @Nullable
-    Collection<Integer> getIdsNotPermitted(@NotNull User user, Collection<Container> containers, Collection<Integer> rowIds, TableInfo tableInfo, @Nullable Class<? extends Permission> permissionClass);
-
-    /**
-     * Given a set or rowIds and a base schemaName, returns the set of containers for which the rows exist
-     * @param rowIds set of rowIds to check
-     * @param tableInfo table info for the rows being checked
-     * @return Collection of containers
-     */
-    Collection<Container> getUniqueContainers(Collection<Integer> rowIds, TableInfo tableInfo);
 
     /**
      * The following methods return TableInfo's suitable for using in queries.

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -557,7 +557,15 @@ public interface ExperimentService extends ExperimentRunTypeSource
      * @return null if there is no
      */
     @Nullable
-    Collection<Integer> getIdsNotPermitted(@NotNull User user, Collection<Integer> rowIds, TableInfo tableInfo, @Nullable Class<? extends Permission> permissionClass);
+    Collection<Integer> getIdsNotPermitted(@NotNull User user, Collection<Container> containers, Collection<Integer> rowIds, TableInfo tableInfo, @Nullable Class<? extends Permission> permissionClass);
+
+    /**
+     * Given a set or rowIds and a base schemaName, returns the set of containers for which the rows exist
+     * @param rowIds set of rowIds to check
+     * @param tableInfo table info for the rows being checked
+     * @return Collection of containers
+     */
+    Collection<Container> getUniqueContainers(Collection<Integer> rowIds, TableInfo tableInfo);
 
     /**
      * The following methods return TableInfo's suitable for using in queries.

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -460,6 +460,21 @@ public interface ExperimentService extends ExperimentRunTypeSource
                ExpData.DATA_OUTPUT_CHILD.equalsIgnoreCase(prefix) ||
                ExpMaterial.MATERIAL_OUTPUT_CHILD.equalsIgnoreCase(prefix);
     }
+
+    static Pair<String, String> parseInputOutputAlias(String columnName)
+    {
+        if (!isInputOutputColumn(columnName))
+            return null;
+
+        String[] parts = columnName.split("[./]");
+        if (parts.length < 2)
+            return null;
+
+        // Issue 50245: use substring to get second part of the alias instead of relying on parts[]
+        String prefix = parts[0];
+        String suffix = columnName.substring(prefix.length() + 1); // +1 for the separator
+        return Pair.of(prefix, suffix);
+    }
     
     static boolean parentAliasHasCorrectFormat(String parentAlias)
     {

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1690,14 +1690,15 @@ public class AssayController extends SpringActionController
             Map<String, Object> response = new HashMap<>();
 
             TableInfo tableInfo = ExperimentService.get().getTinfoExperimentRun();
+            Class<? extends Permission> permClass = form.getDataOperation().getPermissionClass();
             Collection<Container> containers = service.getUniqueContainers(allowedIds, tableInfo);
             response.put("containers", containers == null ? Collections.emptyList(): containers.stream().map(c -> Map.of(
                     "id", c.getEntityId(),
                     "path", (Object) c.getPath(),
-                    "permitted", c.hasPermission(getUser(), form.getDataOperation().getPermissionClass())
+                    "permitted", permClass == null || c.hasPermission(getUser(), permClass)
             )).toList());
 
-            Collection<Integer> notPermittedIds = service.getIdsNotPermitted(getUser(), containers, allowedIds, tableInfo, form.getDataOperation().getPermissionClass());
+            Collection<Integer> notPermittedIds = service.getIdsNotPermitted(getUser(), containers, allowedIds, tableInfo, permClass);
             List<Map<String, Object>> notPermitted = notPermittedIds == null ? Collections.emptyList() : notPermittedIds.stream().map(id -> Map.of("RowId", (Object) id)).toList();
             if (form.getDataOperation() == AssayRunOperations.Delete)
             {
@@ -1765,10 +1766,11 @@ public class AssayController extends SpringActionController
             List<Map<String, Integer>> notPermitted = allowedIds.stream().filter(id -> !permittedRowIds.contains(id)).map(id -> Map.of("RowId", id)).toList();
 
             Map<String, Object> response = new HashMap<>();
+            Class<? extends Permission> permClass = form.getDataOperation().getPermissionClass();
             response.put("containers", uniqueContainers.stream().map(c -> Map.of(
                     "id", c.getEntityId(),
                     "path", (Object) c.getPath(),
-                    "permitted", c.hasPermission(getUser(), form.getDataOperation().getPermissionClass())
+                    "permitted", permClass == null || c.hasPermission(getUser(), permClass)
             )).toList());
             response.put("allowed", allowedIds.stream().map(id -> Map.of("RowId", id)).toList());
             response.put("notAllowed", new HashSet<>());

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -848,6 +848,7 @@ public class ExperimentModule extends SpringModule
             ExpDataTableImpl.TestCase.class,
             ExperimentServiceImpl.TestCase.class,
             ExperimentServiceImpl.LineageQueryTestCase.class,
+            ExperimentServiceImpl.ParseInputOutputAliasTestCase.class,
             ExperimentStressTest.class,
             LineagePerfTest.class,
             LineageTest.class,

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -9119,14 +9119,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     @Override
     @Nullable
-    public Collection<Integer> getIdsNotPermitted(@NotNull User user, @NotNull Collection<Integer> rowIds, @NotNull TableInfo tableInfo, @Nullable Class<? extends Permission> permissionClass)
+    public Collection<Integer> getIdsNotPermitted(@NotNull User user, @Nullable Collection<Container> containers, @NotNull Collection<Integer> rowIds, @NotNull TableInfo tableInfo, @Nullable Class<? extends Permission> permissionClass)
     {
-        if (permissionClass == null)
-            return null;
-
-        // get the set of containers involved and find the ones the user does not have requisite permissions to
-        List<Container> containers = getUniqueContainers(rowIds, tableInfo);
-        if (containers == null)
+        if (permissionClass == null || containers == null)
             return null;
 
         List<Container> notPermittedContainers = containers.stream().filter(container -> !container.hasPermission(user, permissionClass)).toList();
@@ -9148,7 +9143,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return new SqlSelector(expSchema, notPermittedIdsSql).getArrayList(Integer.class);
     }
 
-    private static List<Container> getUniqueContainers(Collection<Integer> rowIds, TableInfo tableInfo)
+    @Override
+    public List<Container> getUniqueContainers(Collection<Integer> rowIds, TableInfo tableInfo)
     {
         DbSchema expSchema = DbSchema.get("exp", DbSchemaType.Module);
         SqlDialect dialect = expSchema.getSqlDialect();

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -10081,6 +10081,53 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
     }
 
+    public static class ParseInputOutputAliasTestCase extends Assert
+    {
+        @Test
+        public void nullCases()
+        {
+            assertNull(ExperimentService.parseInputOutputAlias(""));
+            assertNull(ExperimentService.parseInputOutputAlias(" "));
+            assertNull(ExperimentService.parseInputOutputAlias("bogus"));
+            assertNull(ExperimentService.parseInputOutputAlias(ExpData.DATA_INPUT_PARENT));
+            assertNull(ExperimentService.parseInputOutputAlias(ExpData.DATA_OUTPUT_CHILD));
+            assertNull(ExperimentService.parseInputOutputAlias(ExpMaterial.MATERIAL_INPUT_PARENT));
+            assertNull(ExperimentService.parseInputOutputAlias(ExpMaterial.MATERIAL_OUTPUT_CHILD));
+        }
+
+        @Test
+        public void nonNullCases()
+        {
+            nonNullCases(ExpData.DATA_INPUT_PARENT);
+            nonNullCases(ExpData.DATA_OUTPUT_CHILD);
+            nonNullCases(ExpMaterial.MATERIAL_INPUT_PARENT);
+            nonNullCases(ExpMaterial.MATERIAL_OUTPUT_CHILD);
+        }
+
+        private void nonNullCases(String prefix)
+        {
+            Pair<String, String> pair = ExperimentService.parseInputOutputAlias(prefix + "/foo");
+            assertEquals(prefix, pair.first);
+            assertEquals("foo", pair.second);
+
+            pair = ExperimentService.parseInputOutputAlias(prefix + "/foo.bar");
+            assertEquals(prefix, pair.first);
+            assertEquals("foo.bar", pair.second);
+
+            pair = ExperimentService.parseInputOutputAlias(prefix + "/foo$Pbar");
+            assertEquals(prefix, pair.first);
+            assertEquals("foo$Pbar", pair.second);
+
+            pair = ExperimentService.parseInputOutputAlias(prefix + "/foo/bar");
+            assertEquals(prefix, pair.first);
+            assertEquals("foo/bar", pair.second);
+
+            pair = ExperimentService.parseInputOutputAlias(prefix + "/foo$Sbar");
+            assertEquals(prefix, pair.first);
+            assertEquals("foo$Sbar", pair.second);
+        }
+    }
+
     private static class _ExpLineageOptions extends ExpLineageOptions
     {
         final String _tableName;

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3482,17 +3482,24 @@ public class ExperimentController extends SpringActionController
 
             Map<String, Collection<Map<String, Object>>> response = ExperimentServiceImpl.partitionRequestedOperationObjects(requestIds, notAllowedIds, allData);
 
-            TableInfo tableInfo = ExperimentService.get().getTinfoData();
+            Collection<Container> containers = new HashSet<>();
+            Collection<Integer> notPermittedIds = new ArrayList<>();
             Class<? extends Permission> permClass = form.getDataOperation().getPermissionClass();
-            Collection<Container> containers = service.getUniqueContainers(requestIds, tableInfo);
-            response.put("containers", containers == null ? Collections.emptyList(): containers.stream().map(c -> Map.of(
+            for (ExpDataImpl expData : allData)
+            {
+                Container c = expData.getContainer();
+                containers.add(c);
+                if (permClass != null && !c.hasPermission(getUser(), permClass))
+                    notPermittedIds.add(expData.getRowId());
+            }
+
+            response.put("containers", containers.stream().map(c -> Map.of(
                     "id", c.getEntityId(),
                     "path", (Object) c.getPath(),
                     "permitted", permClass == null || c.hasPermission(getUser(), permClass)
             )).toList());
 
-            Collection<Integer> notPermittedIds = service.getIdsNotPermitted(getUser(), containers, requestIds, tableInfo, permClass);
-            response.put("notPermitted", notPermittedIds == null ? Collections.emptyList(): notPermittedIds.stream().map(id -> Map.of("RowId", (Object) id)).toList());
+            response.put("notPermitted", notPermittedIds.stream().map(id -> Map.of("RowId", (Object) id)).toList());
 
             return success(response);
         }
@@ -3546,17 +3553,24 @@ public class ExperimentController extends SpringActionController
 
             Map<String, Collection<Map<String, Object>>> response = ExperimentServiceImpl.partitionRequestedOperationObjects(requestIds, notAllowedIds, allMaterials);
 
-            TableInfo tableInfo = ExperimentService.get().getTinfoMaterial();
+            Collection<Container> containers = new HashSet<>();
+            Collection<Integer> notPermittedIds = new ArrayList<>();
             Class<? extends Permission> permClass = form.getSampleOperation().getPermissionClass();
-            Collection<Container> containers = service.getUniqueContainers(requestIds, tableInfo);
-            response.put("containers", containers == null ? Collections.emptyList(): containers.stream().map(c -> Map.of(
+            for (ExpMaterial material : allMaterials)
+            {
+                Container c = material.getContainer();
+                containers.add(c);
+                if (permClass != null && !c.hasPermission(getUser(), permClass))
+                    notPermittedIds.add(material.getRowId());
+            }
+
+            response.put("containers", containers.stream().map(c -> Map.of(
                     "id", c.getEntityId(),
                     "path", (Object) c.getPath(),
                     "permitted", permClass == null || c.hasPermission(getUser(), permClass)
             )).toList());
 
-            Collection<Integer> notPermittedIds = service.getIdsNotPermitted(getUser(), containers, requestIds, tableInfo, permClass);
-            response.put("notPermitted", notPermittedIds == null ? Collections.emptyList() : notPermittedIds.stream().map(id -> Map.of("RowId", (Object) id)).toList());
+            response.put("notPermitted", notPermittedIds.stream().map(id -> Map.of("RowId", (Object) id)).toList());
 
             if (form.getSampleOperation() == SampleTypeService.SampleOperations.Delete)
                 // String 'associatedDatasets' must be synced to its handling in confirmDelete.js, confirmDelete()

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3481,7 +3481,15 @@ public class ExperimentController extends SpringActionController
 
             Map<String, Collection<Map<String, Object>>> response = ExperimentServiceImpl.partitionRequestedOperationObjects(requestIds, notAllowedIds, allData);
 
-            Collection<Integer> notPermittedIds = service.getIdsNotPermitted(getUser(), requestIds, ExperimentService.get().getTinfoData(), form.getDataOperation().getPermissionClass());
+            TableInfo tableInfo = ExperimentService.get().getTinfoData();
+            Collection<Container> containers = service.getUniqueContainers(requestIds, tableInfo);
+            response.put("containers", containers == null ? Collections.emptyList(): containers.stream().map(c -> Map.of(
+                    "id", c.getEntityId(),
+                    "path", (Object) c.getPath(),
+                    "permitted", c.hasPermission(getUser(), form.getDataOperation().getPermissionClass())
+            )).toList());
+
+            Collection<Integer> notPermittedIds = service.getIdsNotPermitted(getUser(), containers, requestIds, tableInfo, form.getDataOperation().getPermissionClass());
             response.put("notPermitted", notPermittedIds == null ? Collections.emptyList(): notPermittedIds.stream().map(id -> Map.of("RowId", (Object) id)).toList());
 
             return success(response);
@@ -3536,8 +3544,15 @@ public class ExperimentController extends SpringActionController
 
             Map<String, Collection<Map<String, Object>>> response = ExperimentServiceImpl.partitionRequestedOperationObjects(requestIds, notAllowedIds, allMaterials);
 
-            Collection<Integer> notPermittedIds = service.getIdsNotPermitted(getUser(), requestIds, ExperimentService.get().getTinfoMaterial(), form.getSampleOperation().getPermissionClass());
+            TableInfo tableInfo = ExperimentService.get().getTinfoMaterial();
+            Collection<Container> containers = service.getUniqueContainers(requestIds, tableInfo);
+            response.put("containers", containers == null ? Collections.emptyList(): containers.stream().map(c -> Map.of(
+                    "id", c.getEntityId(),
+                    "path", (Object) c.getPath(),
+                    "permitted", c.hasPermission(getUser(), form.getSampleOperation().getPermissionClass())
+            )).toList());
 
+            Collection<Integer> notPermittedIds = service.getIdsNotPermitted(getUser(), containers, requestIds, tableInfo, form.getSampleOperation().getPermissionClass());
             response.put("notPermitted", notPermittedIds == null ? Collections.emptyList() : notPermittedIds.stream().map(id -> Map.of("RowId", (Object) id)).toList());
 
             if (form.getSampleOperation() == SampleTypeService.SampleOperations.Delete)

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -139,6 +139,7 @@ import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.DesignDataClassPermission;
 import org.labkey.api.security.permissions.DesignSampleTypePermission;
 import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.SampleWorkflowDeletePermission;
 import org.labkey.api.security.permissions.TroubleshooterPermission;
@@ -3482,14 +3483,15 @@ public class ExperimentController extends SpringActionController
             Map<String, Collection<Map<String, Object>>> response = ExperimentServiceImpl.partitionRequestedOperationObjects(requestIds, notAllowedIds, allData);
 
             TableInfo tableInfo = ExperimentService.get().getTinfoData();
+            Class<? extends Permission> permClass = form.getDataOperation().getPermissionClass();
             Collection<Container> containers = service.getUniqueContainers(requestIds, tableInfo);
             response.put("containers", containers == null ? Collections.emptyList(): containers.stream().map(c -> Map.of(
                     "id", c.getEntityId(),
                     "path", (Object) c.getPath(),
-                    "permitted", c.hasPermission(getUser(), form.getDataOperation().getPermissionClass())
+                    "permitted", permClass == null || c.hasPermission(getUser(), permClass)
             )).toList());
 
-            Collection<Integer> notPermittedIds = service.getIdsNotPermitted(getUser(), containers, requestIds, tableInfo, form.getDataOperation().getPermissionClass());
+            Collection<Integer> notPermittedIds = service.getIdsNotPermitted(getUser(), containers, requestIds, tableInfo, permClass);
             response.put("notPermitted", notPermittedIds == null ? Collections.emptyList(): notPermittedIds.stream().map(id -> Map.of("RowId", (Object) id)).toList());
 
             return success(response);
@@ -3545,14 +3547,15 @@ public class ExperimentController extends SpringActionController
             Map<String, Collection<Map<String, Object>>> response = ExperimentServiceImpl.partitionRequestedOperationObjects(requestIds, notAllowedIds, allMaterials);
 
             TableInfo tableInfo = ExperimentService.get().getTinfoMaterial();
+            Class<? extends Permission> permClass = form.getSampleOperation().getPermissionClass();
             Collection<Container> containers = service.getUniqueContainers(requestIds, tableInfo);
             response.put("containers", containers == null ? Collections.emptyList(): containers.stream().map(c -> Map.of(
                     "id", c.getEntityId(),
                     "path", (Object) c.getPath(),
-                    "permitted", c.hasPermission(getUser(), form.getSampleOperation().getPermissionClass())
+                    "permitted", permClass == null || c.hasPermission(getUser(), permClass)
             )).toList());
 
-            Collection<Integer> notPermittedIds = service.getIdsNotPermitted(getUser(), containers, requestIds, tableInfo, form.getSampleOperation().getPermissionClass());
+            Collection<Integer> notPermittedIds = service.getIdsNotPermitted(getUser(), containers, requestIds, tableInfo, permClass);
             response.put("notPermitted", notPermittedIds == null ? Collections.emptyList() : notPermittedIds.stream().map(id -> Map.of("RowId", (Object) id)).toList());
 
             if (form.getSampleOperation() == SampleTypeService.SampleOperations.Delete)


### PR DESCRIPTION
#### Rationale
As part of the effort to make "cross folder" action improvements in the apps, this set of PRs takes on the "Edit in Bulk" and "Edit Parents/Sources" actions. This will allow for users with proper permission to edit selected rows in a sample, source, and assay runs/results grid when the set of selections includes rows from multiple containers.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1479

#### Changes
- Add container information (id, path, permitted) to the response for OperationConfirmationData
- Issue 50245: use substring to get second part of the alias instead of relying on parts[]
- Remove ExperimentService.getUniqueContainers() and ExperimentService.getIdsNotPermitted() and use exp rows to get their container instead
