### PR TITLE
Issue 50132: importing folder archive with identical sample IDs in diferent sample types fails

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -505,7 +505,17 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             final ContainerFilter cf = QueryService.get().getContainerFilterForLookups(container, user);
             final TableInfo dataTable = provider.createProtocolSchema(user, container, protocol, null).createDataTable(cf);
 
-            Map<ExpMaterial, String> inputMaterials = checkData(container, user, dataTable, dataDomain, rawData, settings, resolver, cf);
+            Map<String, ExpMaterial> protocolInputMaterials = new HashMap<>();
+            List<? extends ExpProtocolApplication> protocolApplications = run.getProtocolApplications();
+            if (protocolApplications != null)
+            {
+                for (ExpProtocolApplication protocolApplication : protocolApplications)
+                {
+                    for (ExpMaterial material : protocolApplication.getInputMaterials())
+                        protocolInputMaterials.put(material.getName(), material);
+                }
+            }
+            Map<ExpMaterial, String> inputMaterials = checkData(container, user, dataTable, dataDomain, rawData, settings, resolver, protocolInputMaterials, cf);
 
             List<Map<String, Object>> fileData = convertPropertyNamesToURIs(rawData, dataDomain);
 
@@ -793,6 +803,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                                                List<Map<String, Object>> rawData,
                                                DataLoaderSettings settings,
                                                ParticipantVisitResolver resolver,
+                                               Map<String, ExpMaterial> inputMaterials,
                                                ContainerFilter containerFilter)
             throws ValidationException, ExperimentException
     {
@@ -1113,9 +1124,15 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                     // Issue 47509: When samples have names that are numbers, they can be incorrectly interpreted as rowIds during the insert.
                     // If allowLookupByAlternateKey is true or the sample lookup is by name, we call findExpMaterial which will attempt to resolve by name first and then rowId.
                     // If allowLookupByAlternateKey is false, we will only try resolving by the rowId.
-                    ExpMaterial material;
+                    ExpMaterial material = null;
                     if (settings.isAllowLookupByAlternateKey() || isSampleLookupByName)
-                        material = exp.findExpMaterial(lookupContainer, user, byNameSS, ssName, o.toString(), cache, materialCache);
+                    {
+                        String materialName = o.toString();
+                        if (inputMaterials.containsKey(materialName))
+                            material = inputMaterials.get(materialName);
+                        if (material == null)
+                            material = exp.findExpMaterial(lookupContainer, user, byNameSS, ssName, materialName, cache, materialCache);
+                    }
                     else
                         material = materialCache.computeIfAbsent((Integer)o, (id) -> exp.getExpMaterial(id, containerFilter));
 


### PR DESCRIPTION
#### Rationale
The sample lookup columns in assay data are exported as sample names during folder export. When there are duplicate sample names across different samples types, the folder import fails with unable to resolve sample error. 

This PR modifies assay result data import to first try to resolve assay result samples names from already processed material inputs information (which was exported using lsid and hence resolvable). 

This PR does not address sample resolution for assay Run fields, which currently exports sample row id, and doesn't resolve (but doesn't error out either).

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- try to use assay run's input material to resolve assay result samples during import
