### PR TITLE
Cache property descriptors on demand

### DIFF
--- a/api/src/org/labkey/api/data/DatabaseCache.java
+++ b/api/src/org/labkey/api/data/DatabaseCache.java
@@ -47,8 +47,8 @@ public class DatabaseCache<K, V> implements Cache<K, V>
     private final Cache<K, V> _sharedCache;
     private final DbScope _scope;
 
-    @Deprecated // Use the factory methods that return a BlockingDatabaseCache instead
-    public DatabaseCache(DbScope scope, int maxSize, long defaultTimeToLive, String debugName)
+    // Use the factory methods that return a BlockingDatabaseCache instead
+    private DatabaseCache(DbScope scope, int maxSize, long defaultTimeToLive, String debugName)
     {
         _sharedCache = createSharedCache(maxSize, defaultTimeToLive, debugName);
         _scope = scope;

--- a/api/src/org/labkey/api/exp/PropertyDescriptor.java
+++ b/api/src/org/labkey/api/exp/PropertyDescriptor.java
@@ -56,8 +56,6 @@ import static org.labkey.api.exp.api.ExperimentJSONConverter.VOCABULARY_DOMAIN;
  * Bean class for property types managed via the ontology system and stored in exp.PropertyDescriptor.
  * Most code should not reference PropertyDescriptors
  * directly but should instead use the wrapper {@link org.labkey.api.exp.property.DomainProperty}.
- * User: migra
- * Date: Aug 15, 2005
  */
 public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements ParameterDescription, Serializable, Cloneable
 {                           


### PR DESCRIPTION
#### Rationale
Property descriptor cache is the last one using a deprecated `DatabaseCache` constructor; convert to use the standard factory method.

Domain properties cache loader is doing a lot more work than it needs to, querying all the property descriptor columns and proactively filling that cache as well. Simplify its query to retrieve just PropertyURI and Required, which is all it returns.