### PR TITLE
AbDisc: Plate Templates (Part 1)

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -24,7 +24,6 @@ import org.labkey.api.assay.actions.DesignerAction;
 import org.labkey.api.assay.actions.UploadWizardAction;
 import org.labkey.api.assay.pipeline.AssayRunAsyncContext;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
-import org.labkey.api.assay.plate.PlateMetadataDataHandler;
 import org.labkey.api.assay.security.DesignAssayPermission;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.ActionButton;
@@ -143,10 +142,6 @@ import java.util.function.Supplier;
 import static org.labkey.api.data.CompareType.IN;
 import static org.labkey.api.util.PageFlowUtil.jsString;
 
-/**
- * User: jeckels
- * Date: Sep 14, 2007
- */
 public abstract class AbstractAssayProvider implements AssayProvider
 {
     public static final String ASSAY_NAME_SUBSTITUTION = "${AssayName}";
@@ -911,15 +906,13 @@ public abstract class AbstractAssayProvider implements AssayProvider
         sortDomainList(domains);
 
         // see if there is a plate metadata domain associated with this protocol
-        if (AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE) != null)
+        Domain plateDomain = AssayPlateMetadataService.get().getPlateDataDomain(protocol);
+        if (plateDomain != null)
         {
-            Domain plateDomain = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE).getPlateDataDomain(protocol);
-            if (plateDomain != null)
-            {
-                Map<DomainProperty, Object> values = DefaultValueService.get().getDefaultValues(plateDomain.getContainer(), plateDomain);
-                domains.add(new Pair<>(plateDomain, values));
-            }
+            Map<DomainProperty, Object> values = DefaultValueService.get().getDefaultValues(plateDomain.getContainer(), plateDomain);
+            domains.add(new Pair<>(plateDomain, values));
         }
+
         return domains;
     }
 

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -97,10 +97,6 @@ import java.util.Set;
 import static java.util.stream.Collectors.toList;
 import static org.labkey.api.gwt.client.ui.PropertyType.SAMPLE_CONCEPT_URI;
 
-/**
- * User: jeckels
- * Date: Jan 3, 2008
- */
 public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentDataHandler implements ValidationDataHandler
 {
     protected static final Object ERROR_VALUE = new Object() {
@@ -210,18 +206,14 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             List<Map<String, Object>> dataRows = loader.load();
             boolean skipFirstRowAdjustment = dataRows.isEmpty();
 
-            if (plateMetadataEnabled)
+            if (plateMetadataEnabled && AssayPlateMetadataService.isExperimentalAppPlateEnabled())
             {
-                AssayPlateMetadataService svc = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE);
-                if (AssayPlateMetadataService.isExperimentalAppPlateEnabled() && svc != null)
-                {
-                    Pair<String, Boolean> plateIdAdded = new Pair<>("PlateIdAdded", false);
-                    Integer plateSetId = getPlateSetValueFromRunProps(context, provider, protocol);
-                    dataRows = svc.parsePlateData(context.getContainer(), context.getUser(), provider, protocol, plateSetId, dataFile, dataRows, plateIdAdded);
+                Pair<String, Boolean> plateIdAdded = new Pair<>("PlateIdAdded", false);
+                Integer plateSetId = getPlateSetValueFromRunProps(context, provider, protocol);
+                dataRows = AssayPlateMetadataService.get().parsePlateData(context.getContainer(), context.getUser(), provider, protocol, plateSetId, dataFile, dataRows, plateIdAdded);
 
-                    // need to do this otherwise the added plateID may get stripped
-                    skipFirstRowAdjustment = plateIdAdded.second;
-                }
+                // need to do this otherwise the added plateID may get stripped
+                skipFirstRowAdjustment = plateIdAdded.second;
             }
 
             // loader did not parse any rows
@@ -249,29 +241,27 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                                                          Map<String, AssayPlateMetadataService.MetadataLayer> rawPlateMetadata, File plateMetadataFile)
             throws ExperimentException
     {
-        AssayPlateMetadataService svc = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE);
-        if (svc != null)
+        Map<String, AssayPlateMetadataService.MetadataLayer> plateMetadata = null;
+        if (plateMetadataFile != null || rawPlateMetadata != null)
         {
-            Map<String, AssayPlateMetadataService.MetadataLayer> plateMetadata = null;
-            if (plateMetadataFile != null || rawPlateMetadata != null)
-            {
-                plateMetadata = plateMetadataFile != null
-                        ? svc.parsePlateMetadata(plateMetadataFile)
-                        : rawPlateMetadata;
-            }
-
-            Domain runDomain = provider.getRunDomain(protocol);
-            DomainProperty propertyPlateTemplate = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME);
-            DomainProperty propertyPlateSet = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_SET_COLUMN_NAME);
-            if (propertyPlateTemplate != null || propertyPlateSet != null)
-            {
-                Map<DomainProperty, String> runProps = ((AssayUploadXarContext)context).getContext().getRunProperties();
-                Object lsid = runProps.getOrDefault(propertyPlateTemplate, null);
-                Lsid templateLsid = lsid != null && !StringUtils.isEmpty(String.valueOf(lsid)) ? Lsid.parse(String.valueOf(lsid)) : null;
-                Integer plateSetId = getPlateSetValueFromRunProps(context, provider, protocol);
-                return svc.mergePlateMetadata(context.getContainer(), context.getUser(), templateLsid, plateSetId, dataRows, plateMetadata, provider, protocol);
-            }
+            if (plateMetadataFile != null)
+                plateMetadata = AssayPlateMetadataService.get().parsePlateMetadata(plateMetadataFile);
+            else
+                plateMetadata = rawPlateMetadata;
         }
+
+        Domain runDomain = provider.getRunDomain(protocol);
+        DomainProperty propertyPlateTemplate = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_TEMPLATE_COLUMN_NAME);
+        DomainProperty propertyPlateSet = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_SET_COLUMN_NAME);
+        if (propertyPlateTemplate != null || propertyPlateSet != null)
+        {
+            Map<DomainProperty, String> runProps = ((AssayUploadXarContext)context).getContext().getRunProperties();
+            Object lsid = runProps.getOrDefault(propertyPlateTemplate, null);
+            Lsid templateLsid = lsid != null && !StringUtils.isEmpty(String.valueOf(lsid)) ? Lsid.parse(String.valueOf(lsid)) : null;
+            Integer plateSetId = getPlateSetValueFromRunProps(context, provider, protocol);
+            return AssayPlateMetadataService.get().mergePlateMetadata(context.getContainer(), context.getUser(), templateLsid, plateSetId, dataRows, plateMetadata, provider, protocol);
+        }
+
         return dataRows;
     }
 
@@ -293,8 +283,6 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
     /**
      * Creates a DataLoader that can handle missing value indicators if the columns on the domain
      * are configured to support it.
-     *
-     * @throws ExperimentException
      */
     public static DataLoader createLoaderForImport(File dataFile, @Nullable Domain dataDomain, DataLoaderSettings settings, boolean shouldInferTypes) throws ExperimentException
     {
@@ -310,7 +298,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             {
                 if (col.isMvEnabled())
                 {
-                    // Check for all of the possible names for the column in the incoming data when deciding if we should
+                    // Check for all possible names for the column in the incoming data when deciding if we should
                     // check it for missing values
                     Set<String> columnAliases = ImportAliasable.Helper.createImportMap(Collections.singletonList(col), false).keySet();
                     mvEnabledColumns.addAll(columnAliases);
@@ -689,22 +677,16 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         if (datas.size() == 1)
         {
             ExpData plateData = datas.get(0);
-            AssayPlateMetadataService svc = AssayPlateMetadataService.getService((AssayDataType)plateData.getDataType());
-            if (svc != null)
-            {
-                Map<String, AssayPlateMetadataService.MetadataLayer> plateMetadata;
+            Map<String, AssayPlateMetadataService.MetadataLayer> plateMetadata;
 
-                if (plateData.getFile() != null)
-                    plateMetadata = svc.parsePlateMetadata(plateData.getFile());
-                else if (getRawPlateMetadata() != null)
-                    plateMetadata = getRawPlateMetadata();
-                else
-                    throw new ExperimentException("There was no plate metadata JSON available for this run");
-
-                svc.addAssayPlateMetadata(resultData, plateMetadata, container, user, run, provider, protocol, inserted, rowIdToLsidMap);
-            }
+            if (plateData.getFile() != null)
+                plateMetadata = AssayPlateMetadataService.get().parsePlateMetadata(plateData.getFile());
+            else if (getRawPlateMetadata() != null)
+                plateMetadata = getRawPlateMetadata();
             else
-                throw new ExperimentException("No PlateMetadataService registered for data type : " + plateData.getDataType().toString());
+                throw new ExperimentException("There was no plate metadata JSON available for this run");
+
+            AssayPlateMetadataService.get().addAssayPlateMetadata(resultData, plateMetadata, container, user, run, provider, protocol, inserted, rowIdToLsidMap);
         }
         else
         {
@@ -720,32 +702,31 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         return AssayService.get().createResolver(user, run, protocol, provider, null);
     }
 
-    /** Insert the data into the database.  Transaction is active. */
-    protected List<Map<String, Object>> insertRowData(ExpData data, User user, Container container, ExpRun run, ExpProtocol protocol, AssayProvider provider,Domain dataDomain, List<Map<String, Object>> fileData, TableInfo tableInfo, boolean autoFillDefaultColumns)
-            throws SQLException, ValidationException, ExperimentException
+    /** Insert the data into the database. Transaction is active. */
+    protected List<Map<String, Object>> insertRowData(
+        ExpData data,
+        User user,
+        Container container,
+        ExpRun run,
+        ExpProtocol protocol,
+        AssayProvider provider,
+        Domain dataDomain,
+        List<Map<String, Object>> fileData,
+        TableInfo tableInfo,
+        boolean autoFillDefaultColumns
+    ) throws SQLException, ValidationException, ExperimentException
     {
         OntologyManager.UpdateableTableImportHelper importHelper = new SimpleAssayDataImportHelper(data);
         if (provider.isPlateMetadataEnabled(protocol))
-        {
-            AssayPlateMetadataService svc = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE);
-            if (svc != null)
-            {
-                importHelper = svc.getImportHelper(container, user, run, data, protocol, provider);
-            }
-        }
+            importHelper = AssayPlateMetadataService.get().getImportHelper(container, user, run, data, protocol, provider);
 
         if (tableInfo instanceof UpdateableTableInfo)
-        {
             return OntologyManager.insertTabDelimited(tableInfo, container, user, importHelper, fileData, autoFillDefaultColumns, LOG);
-        }
-        else
-        {
-            Integer id = OntologyManager.ensureObject(container, data.getLSID());
-            List<String> lsids = OntologyManager.insertTabDelimited(container, user, id,
-                    importHelper, dataDomain, fileData, false);
-            // TODO: Add LSID values into return value rows
-            return fileData;
-        }
+
+        Integer id = OntologyManager.ensureObject(container, data.getLSID());
+        OntologyManager.insertTabDelimited(container, user, id, importHelper, dataDomain, fileData, false);
+
+        return fileData;
     }
 
     protected abstract boolean shouldAddInputMaterials();

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -99,10 +99,6 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.unmodifiableCollection;
 
-/**
- * User: jeckels
- * Date: Oct 12, 2011
- */
 public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> implements AssayRunCreator<ProviderType>
 {
     private static final Logger LOG = LogManager.getLogger(DefaultAssayRunCreator.class);
@@ -164,7 +160,7 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
 
             exp = saveExperimentRun(context, exp, run, false);
 
-            // re-fetch the run after is has been fully constructed
+            // re-fetch the run after it has been fully constructed
             run = ExperimentService.get().getExpRun(run.getRowId());
 
             context.uploadComplete(run);

--- a/api/src/org/labkey/api/assay/SimpleAssayDataImportHelper.java
+++ b/api/src/org/labkey/api/assay/SimpleAssayDataImportHelper.java
@@ -16,7 +16,6 @@
 
 package org.labkey.api.assay;
 
-import org.labkey.api.data.Parameter;
 import org.labkey.api.data.ParameterMapStatement;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.api.ExpData;
@@ -24,10 +23,6 @@ import org.labkey.api.query.ValidationException;
 
 import java.util.Map;
 
-/**
- * User: jeckels
- * Date: Jul 23, 2007
- */
 public class SimpleAssayDataImportHelper implements OntologyManager.ImportHelper, OntologyManager.UpdateableTableImportHelper
 {
     private int _id = 0;

--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -3,7 +3,6 @@ package org.labkey.api.assay.plate;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
-import org.labkey.api.assay.AssayDataType;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -15,11 +14,11 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.security.User;
+import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.util.Pair;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -27,17 +26,11 @@ public interface AssayPlateMetadataService
 {
     String PLATE_TEMPLATE_COLUMN_NAME = "PlateTemplate";
     String PLATE_SET_COLUMN_NAME = "PlateSet";
-    Map<AssayDataType, AssayPlateMetadataService> _handlers = new HashMap<>();
     String EXPERIMENTAL_APP_PLATE_SUPPORT = "experimental-app-plate-support";
 
-    static void registerService(AssayDataType dataType, AssayPlateMetadataService handler)
+    static void setInstance(AssayPlateMetadataService serviceImpl)
     {
-        if (dataType != null)
-        {
-            _handlers.put(dataType, handler);
-        }
-        else
-            throw new RuntimeException("The specified assay data type is null");
+        ServiceRegistry.get().registerService(AssayPlateMetadataService.class, serviceImpl);
     }
 
     static boolean isExperimentalAppPlateEnabled()
@@ -53,10 +46,9 @@ public interface AssayPlateMetadataService
         return false;
     }
 
-    @Nullable
-    static AssayPlateMetadataService getService(AssayDataType dataType)
+    static AssayPlateMetadataService get()
     {
-        return _handlers.get(dataType);
+        return ServiceRegistry.get().getService(AssayPlateMetadataService.class);
     }
 
     /**

--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -75,17 +75,33 @@ public interface AssayPlateMetadataService
      * @param inserted the inserted result data
      * @param rowIdToLsidMap a map of result data rowIds to result data lsids
      */
-    void addAssayPlateMetadata(ExpData resultData, Map<String, MetadataLayer> plateMetadata, Container container, User user, ExpRun run, AssayProvider provider,
-                               ExpProtocol protocol, List<Map<String, Object>> inserted, Map<Integer, String> rowIdToLsidMap) throws ExperimentException;
+    void addAssayPlateMetadata(
+        ExpData resultData,
+        Map<String, MetadataLayer> plateMetadata,
+        Container container,
+        User user,
+        ExpRun run,
+        AssayProvider provider,
+        ExpProtocol protocol,
+        List<Map<String, Object>> inserted,
+        Map<Integer, String> rowIdToLsidMap
+    ) throws ExperimentException;
 
     /**
      * Merges the results data with the plate metadata to produce a single row map
      *
      * @return the merged rows
      */
-    List<Map<String, Object>> mergePlateMetadata(Container container, User user, Lsid plateLsid, Integer plateSetId,
-                                                 List<Map<String, Object>> rows, @Nullable Map<String, MetadataLayer> plateMetadata,
-                                                 AssayProvider provider, ExpProtocol protocol) throws ExperimentException;
+    List<Map<String, Object>> mergePlateMetadata(
+        Container container,
+        User user,
+        Lsid plateLsid,
+        Integer plateSetId,
+        List<Map<String, Object>> rows,
+        @Nullable Map<String, MetadataLayer> plateMetadata,
+        AssayProvider provider,
+        ExpProtocol protocol
+    ) throws ExperimentException;
 
     /**
      * Methods to create the metadata model from either a JSON object or a file object
@@ -98,14 +114,14 @@ public interface AssayPlateMetadataService
      * well as cases where plate identifiers have not been supplied.
      */
     List<Map<String, Object>> parsePlateData(
-            Container container,
-            User user,
-            AssayProvider provider,
-            ExpProtocol protocol,
-            Integer plateSetId,
-            File dataFile,
-            List<Map<String, Object>> data,
-            Pair<String, Boolean> plateIdAdded
+        Container container,
+        User user,
+        AssayProvider provider,
+        ExpProtocol protocol,
+        Integer plateSetId,
+        File dataFile,
+        List<Map<String, Object>> data,
+        Pair<String, Boolean> plateIdAdded
     ) throws ExperimentException;
 
     /**
@@ -113,7 +129,14 @@ public interface AssayPlateMetadataService
      * with the plate used in the assay run import
      */
     @NotNull
-    OntologyManager.UpdateableTableImportHelper getImportHelper(Container container, User user, ExpRun run, ExpData data, ExpProtocol protocol, AssayProvider provider) throws ExperimentException;
+    OntologyManager.UpdateableTableImportHelper getImportHelper(
+        Container container,
+        User user,
+        ExpRun run,
+        ExpData data,
+        ExpProtocol protocol,
+        AssayProvider provider
+    ) throws ExperimentException;
 
     interface MetadataLayer
     {

--- a/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
+++ b/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
@@ -31,7 +31,6 @@ import org.labkey.api.assay.TsvDataHandler;
 import org.labkey.api.assay.actions.AssayRunUploadForm;
 import org.labkey.api.assay.actions.ProtocolIdForm;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
-import org.labkey.api.assay.plate.PlateMetadataDataHandler;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TSVWriter;
 import org.labkey.api.exp.ExperimentDataHandler;
@@ -307,7 +306,7 @@ public class TsvDataExchangeHandler implements DataExchangeHandler
             File runData = new File(scriptDir, RUN_DATA_FILE);
             result.add(runData);
 
-            AssayPlateMetadataService svc = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE);
+            AssayPlateMetadataService svc = AssayPlateMetadataService.get();
             if (svc != null)
             {
                 ExpProtocol protocol = run.getProtocol();

--- a/assay/api-src/org/labkey/api/assay/DefaultAssaySaveHandler.java
+++ b/assay/api-src/org/labkey/api/assay/DefaultAssaySaveHandler.java
@@ -298,17 +298,13 @@ public class DefaultAssaySaveHandler extends DefaultExperimentSaveHandler implem
 
             if (rawPlateMetadata != null)
             {
-                AssayPlateMetadataService svc = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE);
-                if (svc != null)
+                try
                 {
-                    try
-                    {
-                        factory.setRawPlateMetadata(svc.parsePlateMetadata(rawPlateMetadata));
-                    }
-                    catch(ExperimentException e)
-                    {
-                        throw new RuntimeException(e);
-                    }
+                    factory.setRawPlateMetadata(AssayPlateMetadataService.get().parsePlateMetadata(rawPlateMetadata));
+                }
+                catch (ExperimentException e)
+                {
+                    throw new RuntimeException(e);
                 }
             }
             factory.setInputDatas(inputData);

--- a/assay/api-src/org/labkey/api/assay/plate/AbstractPlateLayoutHandler.java
+++ b/assay/api-src/org/labkey/api/assay/plate/AbstractPlateLayoutHandler.java
@@ -26,16 +26,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-/**
- * User: klum
- * Date: Jun 13, 2012
- */
 public abstract class AbstractPlateLayoutHandler implements PlateLayoutHandler
 {
     Map<Pair<Integer, Integer>, PlateType> _plateTypeMap;
 
     @Override
-    public void validateTemplate(Container container, User user, Plate template) throws ValidationException
+    public void validatePlate(Container container, User user, Plate plate) throws ValidationException
     {
     }
 

--- a/assay/api-src/org/labkey/api/assay/plate/Plate.java
+++ b/assay/api-src/org/labkey/api/assay/plate/Plate.java
@@ -38,6 +38,8 @@ public interface Plate extends PropertySet, Identifiable
 
     int getPlateNumber();
 
+    boolean isArchived();
+
     boolean isTemplate();
 
     @NotNull PlateType getPlateType();

--- a/assay/api-src/org/labkey/api/assay/plate/Plate.java
+++ b/assay/api-src/org/labkey/api/assay/plate/Plate.java
@@ -72,7 +72,7 @@ public interface Plate extends PropertySet, Identifiable
 
     @NotNull WellGroup addWellGroup(String name, WellGroup.Type type, List<Position> positions);
 
-    @Nullable Integer getRowId();
+    Integer getRowId();
 
     @NotNull Position getPosition(int row, int col);
 
@@ -100,4 +100,6 @@ public interface Plate extends PropertySet, Identifiable
     @Nullable Integer getRunCount();
 
     boolean isIdentifierMatch(String id);
+
+    boolean isNew();
 }

--- a/assay/api-src/org/labkey/api/assay/plate/PlateLayoutHandler.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateLayoutHandler.java
@@ -31,16 +31,15 @@ import java.util.Map;
  */
 public interface PlateLayoutHandler
 {
-    @NotNull
-    String getAssayType();
+    @NotNull String getAssayType();
 
     @NotNull List<String> getLayoutTypes(PlateType plateType);
 
     /**
-     * createTemplate will be given a null value for templateTypeName when it is creating a new template which is a
+     * createPlate will be given a null value for plateName when it is creating a new plate which is a
      * default for that assay type.
      */
-    Plate createTemplate(@Nullable String templateTypeName, Container container, @NotNull PlateType plateType) throws SQLException;
+    Plate createPlate(@Nullable String plateName, Container container, @NotNull PlateType plateType) throws SQLException;
 
     List<PlateType> getSupportedPlateTypes();
 
@@ -52,9 +51,9 @@ public interface PlateLayoutHandler
     boolean canCreateNewGroups(WellGroup.Type type);
 
     /**
-     * Validate a new or edited plate template for handler specific errors.
+     * Validate a new or edited plate for handler specific errors.
      */
-    void validateTemplate(Container container, User user, Plate template) throws ValidationException;
+    void validatePlate(Container container, User user, Plate plate) throws ValidationException;
 
     Map<String, List<String>> getDefaultGroupsForTypes();
 

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -33,6 +33,7 @@ import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.view.ActionURL;
 
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
 
 public interface PlateService
@@ -89,17 +90,6 @@ public interface PlateService
      * @throws IllegalArgumentException Thrown if a template of the specified name already exists in the container.
      */
     @NotNull Plate createPlate(Container container, String templateType, @NotNull PlateType plateType);
-
-    /**
-     * Instantiates a new plate template instance.
-     * This plate template is not persisted to the database.
-     * @param container The template's container.
-     * @param templateType The type of plate template, if associated with a particular assay.
-     * @param plateType Specifies the overall shape of the plate
-     * @return A newly created plate template instance.
-     * @throws IllegalArgumentException Thrown if a template of the specified name already exists in the container.
-     */
-    @NotNull Plate createPlateTemplate(Container container, String templateType, @NotNull PlateType plateType);
 
     /**
      * Adds a new well group to the plate
@@ -166,6 +156,8 @@ public interface PlateService
      * @return The requested plate, or null if no plate exists with the specified plate identifier.
      */
     @Nullable Plate getPlate(ContainerFilter cf, Integer plateSetId, Object plateIdentifier);
+
+    @NotNull List<Plate> getPlates(Container c);
 
     /**
      * Gets all plate templates for the specified container. Plate templates are Plate instances

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -253,17 +253,6 @@ public interface PlateService
     void registerDetailsLinkResolver(PlateDetailsResolver resolver);
 
     /**
-     * Copies a plate from one container to another.
-     * @param source The source plate template
-     * @param user The user performing the copy
-     * @param destination The destination container
-     * @return The copied plate template
-     * @throws SQLException Thrown in the event of a database failure.
-     * @throws NameConflictException Thrown if the destination container already contains a template by the same name.
-     */
-    Plate copyPlate(Plate source, User user, Container destination) throws Exception;
-
-    /**
      * Registers a handler for a particular type of plate
      */
     void registerPlateLayoutHandler(PlateLayoutHandler handler);

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -80,7 +80,8 @@ public interface PlateService
     @Nullable Plate createPlate(Plate plate, double[][] wellValues, boolean[][] excludedWells);
 
     /**
-     * Creates a new plate
+     * Instantiates a new plate instance.
+     * This plate is not persisted to the database.
      * @param container The template's container.
      * @param templateType The type of plate, if associated with a particular assay.
      * @param plateType Specifies the overall shape of the plate
@@ -90,7 +91,8 @@ public interface PlateService
     @NotNull Plate createPlate(Container container, String templateType, @NotNull PlateType plateType);
 
     /**
-     * Creates a new plate template.
+     * Instantiates a new plate template instance.
+     * This plate template is not persisted to the database.
      * @param container The template's container.
      * @param templateType The type of plate template, if associated with a particular assay.
      * @param plateType Specifies the overall shape of the plate

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -33,7 +33,6 @@ import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.view.ActionURL;
 
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.List;
 
 public interface PlateService
@@ -157,16 +156,7 @@ public interface PlateService
      */
     @Nullable Plate getPlate(ContainerFilter cf, Integer plateSetId, Object plateIdentifier);
 
-    @NotNull List<Plate> getPlates(Container c);
-
-    /**
-     * Gets all plate templates for the specified container. Plate templates are Plate instances
-     * which have their template field set to TRUE.
-     *
-     * @return An array of all plates that are configured as templates from the specified container.
-     */
-    @NotNull
-    List<Plate> getPlateTemplates(Container container);
+    @NotNull List<Plate> getPlates(Container container);
 
     /**
      * Gets the plate set by ID
@@ -225,8 +215,8 @@ public interface PlateService
     Position createPosition(Container container, int row, int column);
 
     /**
-     * Deletes all plate and template data from the specified container.  Typically used
-     * only when a container is deleted.
+     * Deletes all plate and template data from the specified container.
+     * Typically used only when a container is deleted.
      * @param container The container from which to delete all plate data.
      */
     void deleteAllPlateData(Container container);

--- a/assay/api-src/org/labkey/api/assay/plate/PlateSet.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateSet.java
@@ -19,6 +19,8 @@ public interface PlateSet
 
     boolean isArchived();
 
+    boolean isTemplate();
+
     List<Plate> getPlates(User user);
 
     PlateSetType getType();

--- a/assay/api-src/org/labkey/api/assay/plate/PlateUtils.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateUtils.java
@@ -389,8 +389,8 @@ public class PlateUtils
 
     public static class Location
     {
-        private int _row;
-        private int _col;
+        private final int _row;
+        private final int _col;
 
         public Location(int row, int col)
         {

--- a/assay/resources/schemas/assay.xml
+++ b/assay/resources/schemas/assay.xml
@@ -101,6 +101,10 @@
       <column columnName="AssayType">
         <description>A text label of the plate assay type ("NAb", for example).</description>
       </column>
+      <column columnName="Archived">
+        <isHidden>true</isHidden>
+        <isUserEditable>false</isUserEditable>
+      </column>
     </columns>
   </table>
   <table tableName="Well" tableDbType="TABLE">

--- a/assay/resources/schemas/assay.xml
+++ b/assay/resources/schemas/assay.xml
@@ -90,6 +90,8 @@
       </column>
       <column columnName="Template">
         <description>Boolean indicating whether each plate is a template versus an uploaded instance of a plate template.</description>
+        <isHidden>true</isHidden>
+        <isUserEditable>false</isUserEditable>
         <shownInUpdateView>false</shownInUpdateView>
       </column>
       <column columnName="DataFileId">
@@ -209,6 +211,10 @@
           (a.k.a stand-alone plate set). For top-level "primary" plate sets this will always refer to itself.
         </description>
         <isHidden>true</isHidden>
+      </column>
+      <column columnName="Template">
+        <isHidden>true</isHidden>
+        <isUserEditable>false</isUserEditable>
       </column>
     </columns>
   </table>

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.006-24.007.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.006-24.007.sql
@@ -1,5 +1,3 @@
 ALTER TABLE assay.PlateSet ADD COLUMN Template BOOLEAN NOT NULL DEFAULT FALSE;
 
-UPDATE assay.PlateSet SET Template = true WHERE RowId IN (
-    SELECT PlateSet FROM assay.Plate WHERE Template = true
-)
+UPDATE assay.Plate SET Template = False WHERE Template = True;

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.006-24.007.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.006-24.007.sql
@@ -2,3 +2,6 @@ ALTER TABLE assay.PlateSet ADD COLUMN Template BOOLEAN NOT NULL DEFAULT FALSE;
 UPDATE assay.Plate SET Template = False WHERE Template = True;
 
 ALTER TABLE assay.Plate ADD COLUMN Archived BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE assay.Plate SET AssayType = 'Standard' WHERE AssayType IS NULL;
+ALTER TABLE assay.Plate ALTER COLUMN AssayType SET NOT NULL;

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.006-24.007.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.006-24.007.sql
@@ -1,0 +1,5 @@
+ALTER TABLE assay.PlateSet ADD COLUMN Template BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE assay.PlateSet SET Template = true WHERE RowId IN (
+    SELECT PlateSet FROM assay.Plate WHERE Template = true
+)

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.006-24.007.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.006-24.007.sql
@@ -1,3 +1,4 @@
 ALTER TABLE assay.PlateSet ADD COLUMN Template BOOLEAN NOT NULL DEFAULT FALSE;
-
 UPDATE assay.Plate SET Template = False WHERE Template = True;
+
+ALTER TABLE assay.Plate ADD COLUMN Archived BOOLEAN NOT NULL DEFAULT FALSE;

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.006-24.007.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.006-24.007.sql
@@ -2,3 +2,6 @@ ALTER TABLE assay.PlateSet ADD Template BIT NOT NULL DEFAULT 0;
 UPDATE assay.Plate SET Template = 0 WHERE Template = 1;
 
 ALTER TABLE assay.Plate ADD Archived BIT NOT NULL DEFAULT 0;
+
+UPDATE assay.Plate SET AssayType = 'Standard' WHERE AssayType IS NULL;
+ALTER TABLE assay.Plate ALTER COLUMN AssayType NVARCHAR(200) NOT NULL;

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.006-24.007.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.006-24.007.sql
@@ -1,0 +1,5 @@
+ALTER TABLE assay.PlateSet ADD Template BIT NOT NULL DEFAULT 0;
+
+UPDATE assay.PlateSet SET Template = true WHERE RowId IN (
+    SELECT PlateSet FROM assay.Plate WHERE Template = true
+)

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.006-24.007.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.006-24.007.sql
@@ -1,5 +1,3 @@
 ALTER TABLE assay.PlateSet ADD Template BIT NOT NULL DEFAULT 0;
 
-UPDATE assay.PlateSet SET Template = true WHERE RowId IN (
-    SELECT PlateSet FROM assay.Plate WHERE Template = true
-)
+UPDATE assay.Plate SET Template = 0 WHERE Template = 1;

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.006-24.007.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.006-24.007.sql
@@ -1,3 +1,4 @@
 ALTER TABLE assay.PlateSet ADD Template BIT NOT NULL DEFAULT 0;
-
 UPDATE assay.Plate SET Template = 0 WHERE Template = 1;
+
+ALTER TABLE assay.Plate ADD Archived BIT NOT NULL DEFAULT 0;

--- a/assay/src/org/labkey/assay/AssayListQueryView.java
+++ b/assay/src/org/labkey/assay/AssayListQueryView.java
@@ -86,9 +86,9 @@ public class AssayListQueryView extends QueryView
 
         if (getContainer().hasPermission(getUser(), DesignAssayPermission.class))
         {
-            ActionURL plateURL = PageFlowUtil.urlProvider(PlateUrls.class).getPlateTemplateListURL(getContainer());
+            ActionURL plateURL = PageFlowUtil.urlProvider(PlateUrls.class).getPlateListURL(getContainer());
             plateURL.addReturnURL(getViewContext().getActionURL());
-            ActionButton insert = new ActionButton("Configure Plate Templates", plateURL);
+            ActionButton insert = new ActionButton("Configure Plates", plateURL);
             insert.setActionType(ActionButton.Action.LINK);
             insert.setDisplayPermission(DesignAssayPermission.class);
             bar.add(insert);

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -77,6 +77,7 @@ import org.labkey.assay.plate.PlateCache;
 import org.labkey.assay.plate.PlateDocumentProvider;
 import org.labkey.assay.plate.PlateImpl;
 import org.labkey.assay.plate.PlateManager;
+import org.labkey.assay.plate.PlateManagerTest;
 import org.labkey.assay.plate.PlateMetadataDomainKind;
 import org.labkey.assay.plate.PlateMetricsProvider;
 import org.labkey.assay.plate.TsvPlateLayoutHandler;
@@ -331,7 +332,7 @@ public class AssayModule extends SpringModule
             TsvAssayProvider.TestCase.class,
             AssaySchemaImpl.TestCase.class,
             AssayProviderSchema.TestCase.class,
-            PlateManager.TestCase.class,
+            PlateManagerTest.class,
             PositionImpl.TestCase.class,
             PlateImpl.TestCase.class,
             PlateUtils.TestCase.class,

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -144,6 +144,7 @@ public class AssayModule extends SpringModule
     {
         AssayService.setInstance(new AssayManager());
         PlateService.setInstance(new PlateManager());
+        AssayPlateMetadataService.setInstance(new AssayPlateMetadataServiceImpl());
         addController("assay", AssayController.class);
         addController("plate", PlateController.class);
         PlateSchema.register(this);
@@ -155,7 +156,6 @@ public class AssayModule extends SpringModule
         ExperimentService.get().registerExperimentDataHandler(new TsvDataHandler());
         ExperimentService.get().registerExperimentDataHandler(new FileBasedModuleDataHandler());
         ExperimentService.get().registerExperimentDataHandler(new PlateMetadataDataHandler());
-        AssayPlateMetadataService.registerService(PlateMetadataDataHandler.DATA_TYPE, new AssayPlateMetadataServiceImpl());
         PropertyService.get().registerDomainKind(new AssayPlateDataDomainKind());
         PlateService.get().registerPlateLayoutHandler(new TsvPlateLayoutHandler());
 

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -115,7 +115,7 @@ public class AssayModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 24.006;
+        return 24.007;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -152,7 +152,6 @@ public class AssayUpgradeCode implements UpgradeCode
 
     private static void _ensureColumn(String colName, Domain domain, ExpProtocol protocol, SchemaTableInfo provisionedTable, AssayResultDomainKind kind)
     {
-
         ColumnInfo col = provisionedTable.getColumn(colName);
         if (col != null)
             _log.error("Column '" + colName + "' is already defined in result table for '" + protocol.getName() + "'.");
@@ -160,7 +159,6 @@ public class AssayUpgradeCode implements UpgradeCode
         PropertyStorageSpec colProp = kind.getBaseProperties(domain).stream().filter(p -> colName.equalsIgnoreCase(p.getName())).findFirst().orElseThrow();
         StorageProvisioner.get().addStorageProperties(domain, Arrays.asList(colProp), true);
         _log.info("Added '" + colName + "' column to '" + protocol.getName() + " provisioned result table.");
-
     }
 
     /**
@@ -169,7 +167,8 @@ public class AssayUpgradeCode implements UpgradeCode
      * Switch from storing the protocol plate template by name to the plate lsid.
      */
     @DeferredUpgrade
-    public static void updateProtocolPlateTemplate(ModuleContext ctx) throws Exception
+    @SuppressWarnings({"UnusedDeclaration"})
+    public static void updateProtocolPlateTemplate(ModuleContext ctx)
     {
         if (ctx.isNewInstall())
             return;
@@ -221,6 +220,7 @@ public class AssayUpgradeCode implements UpgradeCode
      * The referenced upgrade script creates a new plate set for every plate in the system. We now
      * want to iterate over each plate set to set the name using the configured name expression.
      */
+    @SuppressWarnings({"UnusedDeclaration"})
     public static void updatePlateSetNames(ModuleContext ctx) throws Exception
     {
         if (ctx.isNewInstall())
@@ -269,6 +269,7 @@ public class AssayUpgradeCode implements UpgradeCode
      * Iterate over each plate and plate set to generate a Plate ID and PlateSet ID based on the
      * configured name expression for each.
      */
+    @SuppressWarnings({"UnusedDeclaration"})
     public static void initializePlateAndPlateSetIDs(ModuleContext ctx) throws Exception
     {
         if (ctx.isNewInstall())
@@ -364,6 +365,7 @@ public class AssayUpgradeCode implements UpgradeCode
      * plate metadata. This upgrade transitions to using a provisioned table approach. Since the plate features are
      * still under an experimental flag we won't worry about upgrading the domains.
      */
+    @SuppressWarnings({"UnusedDeclaration"})
     public static void deletePlateVocabDomains(ModuleContext ctx) throws Exception
     {
         if (ctx.isNewInstall())
@@ -425,6 +427,7 @@ public class AssayUpgradeCode implements UpgradeCode
     /**
      * Called from assay-24.005-24.006.sql
      */
+    @SuppressWarnings({"UnusedDeclaration"})
     public static void populatePlateSetPaths(ModuleContext ctx) throws Exception
     {
         if (ctx.isNewInstall())

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -38,6 +38,8 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainKind;
+import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.User;
@@ -342,6 +344,22 @@ public class AssayUpgradeCode implements UpgradeCode
     }
 
     /**
+     * Well metadata has transitioned to a provisioned architecture.
+     */
+    private static @Nullable Domain getPlateMetadataVocabDomain(Container container, User user)
+    {
+        DomainKind<?> vocabDomainKind = PropertyService.get().getDomainKindByName("Vocabulary");
+
+        if (vocabDomainKind == null)
+            return null;
+
+        // the domain is scoped at the project level (project and subfolder scoping)
+        Container domainContainer = PlateManager.get().getPlateMetadataDomainContainer(container);
+        String domainURI = vocabDomainKind.generateDomainURI(null, "PlateMetadataDomain", domainContainer, user);
+        return PropertyService.get().getDomain(container, domainURI);
+    }
+
+    /**
      * Called from assay-24.002-24.003.sql to delete the vocabulary domains associated with
      * plate metadata. This upgrade transitions to using a provisioned table approach. Since the plate features are
      * still under an experimental flag we won't worry about upgrading the domains.
@@ -362,7 +380,7 @@ public class AssayUpgradeCode implements UpgradeCode
             {
                 if (container != null)
                 {
-                    Domain domain = PlateManager.get().getPlateMetadataVocabDomain(container, User.getAdminServiceUser());
+                    Domain domain = getPlateMetadataVocabDomain(container, User.getAdminServiceUser());
                     if (domain != null)
                     {
                         // delete the plate metadata values

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -417,7 +417,7 @@ public class PlateController extends SpringActionController
         @Override
         public boolean handlePost(CopyForm form, BindException errors) throws Exception
         {
-            PlateService.get().copyPlate(_plate, getUser(), _destination);
+            PlateManager.get().copyPlateDeprecated(_plate, getUser(), _destination);
             return true;
         }
 
@@ -1251,7 +1251,6 @@ public class PlateController extends SpringActionController
     public static class PlateSetAssaysForm
     {
         private ContainerFilter.Type _containerFilter;
-
         private int _plateSetId;
 
         public ContainerFilter.Type getContainerFilter()
@@ -1406,6 +1405,50 @@ public class PlateController extends SpringActionController
             }
 
             return null;
+        }
+    }
+
+    public static class CopyPlateForm
+    {
+        private String _name;
+        private Integer _sourcePlateRowId;
+
+        public String getName()
+        {
+            return _name;
+        }
+
+        public void setName(String name)
+        {
+            _name = name;
+        }
+
+        public Integer getSourcePlateRowId()
+        {
+            return _sourcePlateRowId;
+        }
+
+        public void setSourcePlateRowId(Integer sourcePlateRowId)
+        {
+            _sourcePlateRowId = sourcePlateRowId;
+        }
+    }
+
+    @RequiresPermission(InsertPermission.class)
+    public static class CopyPlateAction extends MutatingApiAction<CopyPlateForm>
+    {
+        @Override
+        public void validateForm(CopyPlateForm form, Errors errors)
+        {
+            if (form.getSourcePlateRowId() == null)
+                errors.reject(ERROR_REQUIRED, "Specifying \"sourcePlateRowId\" is required.");
+        }
+
+        @Override
+        public Object execute(CopyPlateForm form, BindException errors) throws Exception
+        {
+            Plate plate = PlateManager.get().copyPlate(getContainer(), getUser(), form.getSourcePlateRowId(), form.getName());
+            return success(plate);
         }
     }
 }

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -410,7 +410,7 @@ public class PlateController extends SpringActionController
             if (_plate == null)
                 errors.reject(ERROR_REQUIRED, "Unable to retrieve source plate with ID : " + form.getPlateId());
 
-            if (PlateManager.get().isDuplicatePlate(_destination, getUser(), _plate.getName(), null))
+            if (PlateManager.get().isDuplicatePlateName(_destination, getUser(), _plate.getName(), null))
                 errors.reject("copyForm", "A plate template with the same name already exists in the destination folder.");
         }
 
@@ -1410,8 +1410,30 @@ public class PlateController extends SpringActionController
 
     public static class CopyPlateForm
     {
+        private boolean _copyAsTemplate;
+        private String _description;
         private String _name;
         private Integer _sourcePlateRowId;
+
+        public boolean isCopyAsTemplate()
+        {
+            return _copyAsTemplate;
+        }
+
+        public void setCopyAsTemplate(boolean copyAsTemplate)
+        {
+            _copyAsTemplate = copyAsTemplate;
+        }
+
+        public String getDescription()
+        {
+            return _description;
+        }
+
+        public void setDescription(String description)
+        {
+            _description = description;
+        }
 
         public String getName()
         {
@@ -1447,7 +1469,7 @@ public class PlateController extends SpringActionController
         @Override
         public Object execute(CopyPlateForm form, BindException errors) throws Exception
         {
-            Plate plate = PlateManager.get().copyPlate(getContainer(), getUser(), form.getSourcePlateRowId(), form.getName());
+            Plate plate = PlateManager.get().copyPlate(getContainer(), getUser(), form.getSourcePlateRowId(), form.isCopyAsTemplate(), form.getName(), form.getDescription());
             return success(plate);
         }
     }

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -1061,8 +1061,19 @@ public class PlateController extends SpringActionController
 
     public static class ArchiveForm
     {
+        private List<Integer> _plateIds;
         private List<Integer> _plateSetIds;
         private boolean _restore;
+
+        public List<Integer> getPlateIds()
+        {
+            return _plateIds;
+        }
+
+        public void setPlateIds(List<Integer> plateIds)
+        {
+            _plateIds = plateIds;
+        }
 
         public List<Integer> getPlateSetIds()
         {
@@ -1087,13 +1098,13 @@ public class PlateController extends SpringActionController
 
     @Marshal(Marshaller.JSONObject)
     @RequiresPermission(UpdatePermission.class)
-    public static class ArchivePlateSetsAction extends MutatingApiAction<ArchiveForm>
+    public static class ArchiveAction extends MutatingApiAction<ArchiveForm>
     {
         @Override
         public void validateForm(ArchiveForm form, Errors errors)
         {
-            if (form.getPlateSetIds() == null)
-                errors.reject(ERROR_GENERIC, "\"plateSetIds\" is a required field.");
+            if (form.getPlateIds() == null && form.getPlateSetIds() == null)
+                errors.reject(ERROR_GENERIC, "Either \"plateIds\" or \"plateSetIds\" must be specified.");
         }
 
         @Override
@@ -1101,7 +1112,7 @@ public class PlateController extends SpringActionController
         {
             try
             {
-                PlateManager.get().archivePlateSets(getContainer(), getUser(), form.getPlateSetIds(), !form.isRestore());
+                PlateManager.get().archive(getContainer(), getUser(), form.getPlateSetIds(), form.getPlateIds(), !form.isRestore());
                 return success();
             }
             catch (Exception e)

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -558,11 +558,12 @@ public class PlateController extends SpringActionController
 
     public static class CreatePlateForm implements ApiJsonForm
     {
+        private String _assayType = TsvPlateLayoutHandler.TYPE;
+        private final List<Map<String, Object>> _data = new ArrayList<>();
         private String _name;
         private Integer _plateType;
         private Integer _plateSetId;
-        private List<Map<String, Object>> _data = new ArrayList<>();
-        private String _assayType = TsvPlateLayoutHandler.TYPE;
+        private boolean _template;
 
         public String getName()
         {
@@ -589,6 +590,11 @@ public class PlateController extends SpringActionController
             return _assayType;
         }
 
+        public Boolean isTemplate()
+        {
+            return _template;
+        }
+
         @Override
         public void bindJson(JSONObject json)
         {
@@ -603,6 +609,9 @@ public class PlateController extends SpringActionController
 
             if (json.has("assayType"))
                 _assayType = json.getString("assayType");
+
+            if (json.has("template"))
+                _template = json.getBoolean("template");
 
             if (json.has("data"))
             {
@@ -644,7 +653,16 @@ public class PlateController extends SpringActionController
         {
             try
             {
-                Plate plate = PlateManager.get().createAndSavePlate(getContainer(), getUser(), _plateType, form.getName(), form.getPlateSetId(), form.getAssayType(), form.getData());
+                Plate plate = PlateManager.get().createAndSavePlate(
+                    getContainer(),
+                    getUser(),
+                    _plateType,
+                    form.getName(),
+                    form.isTemplate(),
+                    form.getPlateSetId(),
+                    form.getAssayType(),
+                    form.getData()
+                );
                 return success(plate);
             }
             catch (Exception e)
@@ -885,8 +903,9 @@ public class PlateController extends SpringActionController
         private String _name;
         private List<PlateManager.CreatePlateSetPlate> _plates = new ArrayList<>();
         private Integer _parentPlateSetId;
-        private PlateSetType _type;
         private String _selectionKey;
+        private Boolean _template;
+        private PlateSetType _type;
 
         public String getDescription()
         {
@@ -973,6 +992,15 @@ public class PlateController extends SpringActionController
             return !_plates.isEmpty() && _selectionKey == null;
         }
 
+        public Boolean getTemplate()
+        {
+            return _template;
+        }
+
+        public void setTemplate(Boolean template)
+        {
+            _template = template;
+        }
     }
 
     @RequiresPermission(InsertPermission.class)
@@ -994,6 +1022,8 @@ public class PlateController extends SpringActionController
                 plateSet.setDescription(form.getDescription());
                 plateSet.setName(form.getName());
                 plateSet.setType(form.getType());
+                if (form.getTemplate() != null)
+                    plateSet.setTemplate(form.getTemplate());
 
                 List<PlateManager.CreatePlateSetPlate> plates = new ArrayList<>();
                 if (form.isStandaloneAssayPlateCase() || form.isRearrayCase())

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -562,8 +562,8 @@ public class PlateController extends SpringActionController
         private final List<Map<String, Object>> _data = new ArrayList<>();
         private String _description;
         private String _name;
-        private Integer _plateType;
         private Integer _plateSetId;
+        private Integer _plateType;
         private boolean _template;
 
         public String getDescription()

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -560,10 +560,16 @@ public class PlateController extends SpringActionController
     {
         private String _assayType = TsvPlateLayoutHandler.TYPE;
         private final List<Map<String, Object>> _data = new ArrayList<>();
+        private String _description;
         private String _name;
         private Integer _plateType;
         private Integer _plateSetId;
         private boolean _template;
+
+        public String getDescription()
+        {
+            return _description;
+        }
 
         public String getName()
         {
@@ -610,6 +616,9 @@ public class PlateController extends SpringActionController
             if (json.has("assayType"))
                 _assayType = json.getString("assayType");
 
+            if (json.has("description"))
+                _description = json.getString("description");
+
             if (json.has("template"))
                 _template = json.getBoolean("template");
 
@@ -653,17 +662,13 @@ public class PlateController extends SpringActionController
         {
             try
             {
-                Plate plate = PlateManager.get().createAndSavePlate(
-                    getContainer(),
-                    getUser(),
-                    _plateType,
-                    form.getName(),
-                    form.isTemplate(),
-                    form.getPlateSetId(),
-                    form.getAssayType(),
-                    form.getData()
-                );
-                return success(plate);
+                PlateImpl plate = new PlateImpl(getContainer(), form.getName(), form.getAssayType(), _plateType);
+                if (form.isTemplate() != null)
+                    plate.setTemplate(form.isTemplate());
+                plate.setDescription(form.getDescription());
+
+                Plate newPlate = PlateManager.get().createAndSavePlate(getContainer(), getUser(), plate, form.getPlateSetId(), form.getData());
+                return success(newPlate);
             }
             catch (Exception e)
             {

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -245,11 +245,11 @@ public class PlateController extends SpringActionController
             properties.put("templateRowCount", "" + form.getRowCount());
             properties.put("templateColumnCount", "" + form.getColCount());
 
-            List<Plate> templates = PlateService.get().getPlateTemplates(getContainer());
-            for (int i = 0; i < templates.size(); i++)
+            List<Plate> plates = PlateService.get().getPlates(getContainer());
+            for (int i = 0; i < plates.size(); i++)
             {
-                Plate template = templates.get(i);
-                properties.put("templateName[" + i + "]", template.getName());
+                Plate plate = plates.get(i);
+                properties.put("templateName[" + i + "]", plate.getName());
             }
             return new AssayGWTView(gwt.client.org.labkey.plate.designer.client.TemplateDesigner.class, properties);
         }
@@ -258,7 +258,7 @@ public class PlateController extends SpringActionController
         public void addNavTrail(NavTree root)
         {
             setHelpTopic("editPlateTemplate");
-            root.addChild("Plate Template Editor");
+            root.addChild("Plate Editor");
         }
     }
 
@@ -329,7 +329,7 @@ public class PlateController extends SpringActionController
                         Container dest = ContainerManager.getForPath(_selectedDestination);
                         if (dest != null)
                         {
-                            _destinationTemplates = PlateService.get().getPlateTemplates(dest);
+                            _destinationTemplates = PlateService.get().getPlates(dest);
                         }
                     }
 
@@ -436,8 +436,8 @@ public class PlateController extends SpringActionController
     private String getUniqueName(Container container, String originalName)
     {
         Set<String> existing = new HashSet<>();
-        for (Plate template : PlateService.get().getPlateTemplates(container))
-            existing.add(template.getName());
+        for (Plate plate : PlateService.get().getPlates(container))
+            existing.add(plate.getName());
         String baseUniqueName;
         if (!originalName.startsWith("Copy of "))
             baseUniqueName = "Copy of " + originalName;

--- a/assay/src/org/labkey/assay/TSVProtocolSchema.java
+++ b/assay/src/org/labkey/assay/TSVProtocolSchema.java
@@ -162,7 +162,6 @@ public class TSVProtocolSchema extends AssayProtocolSchema
                 Domain plateDataDomain = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE).getPlateDataDomain(getProtocol());
                 if (plateDataDomain != null)
                 {
-                    List<FieldKey> plateDefaultColumns = new ArrayList<>();
                     ColumnInfo lsidCol = getColumn("Lsid");
                     if (lsidCol != null)
                     {
@@ -175,6 +174,7 @@ public class TSVProtocolSchema extends AssayProtocolSchema
                         col.setCalculated(true);
                         addColumn(col);
 
+                        List<FieldKey> plateDefaultColumns = new ArrayList<>();
                         for (DomainProperty prop : plateDataDomain.getProperties())
                         {
                             plateDefaultColumns.add(FieldKey.fromParts("PlateData", prop.getName()));

--- a/assay/src/org/labkey/assay/TSVProtocolSchema.java
+++ b/assay/src/org/labkey/assay/TSVProtocolSchema.java
@@ -23,7 +23,6 @@ import org.labkey.api.assay.AssayResultTable;
 import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.assay.AssayWellExclusionService;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
-import org.labkey.api.assay.plate.PlateMetadataDataHandler;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
@@ -159,7 +158,7 @@ public class TSVProtocolSchema extends AssayProtocolSchema
             if (getProvider().isPlateMetadataEnabled(getProtocol()))
             {
                 // legacy standard assay plate metadata support
-                Domain plateDataDomain = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE).getPlateDataDomain(getProtocol());
+                Domain plateDataDomain = AssayPlateMetadataService.get().getPlateDataDomain(getProtocol());
                 if (plateDataDomain != null)
                 {
                     ColumnInfo lsidCol = getColumn("Lsid");
@@ -234,15 +233,9 @@ public class TSVProtocolSchema extends AssayProtocolSchema
     @Nullable
     private TableInfo createPlateDataTable(ContainerFilter cf)
     {
-        AssayPlateMetadataService svc = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE);
-        if (svc != null)
-        {
-            Domain domain = svc.getPlateDataDomain(getProtocol());
-            if (domain != null)
-            {
-                return new _AssayPlateDataTable(domain, this, cf);
-            }
-        }
+        Domain domain = AssayPlateMetadataService.get().getPlateDataDomain(getProtocol());
+        if (domain != null)
+            return new _AssayPlateDataTable(domain, this, cf);
         return null;
     }
 

--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -287,15 +287,10 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
 
         if (form.getPlateMetadata() != null)
         {
-            AssayPlateMetadataService svc = AssayPlateMetadataService.getService(PlateMetadataDataHandler.DATA_TYPE);
-            if (svc != null)
-            {
-                ExpData plateData = DefaultAssayRunCreator.createData(getContainer(), "Plate Metadata", PlateMetadataDataHandler.DATA_TYPE, null);
-                plateData.save(getUser());
-                outputData.put(plateData, ExpDataRunInput.DEFAULT_ROLE);
-
-                factory.setRawPlateMetadata(svc.parsePlateMetadata(form.getPlateMetadata()));
-            }
+            ExpData plateData = DefaultAssayRunCreator.createData(getContainer(), "Plate Metadata", PlateMetadataDataHandler.DATA_TYPE, null);
+            plateData.save(getUser());
+            outputData.put(plateData, ExpDataRunInput.DEFAULT_ROLE);
+            factory.setRawPlateMetadata(AssayPlateMetadataService.get().parsePlateMetadata(form.getPlateMetadata()));
         }
 
         factory.setInputDatas(inputData)

--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -78,10 +78,6 @@ import java.util.stream.Collectors;
 import static org.labkey.api.assay.AssayDataCollector.PRIMARY_FILE;
 import static org.labkey.api.assay.AssayFileWriter.createFile;
 
-/**
- * User: kevink
- * Date: 8/26/12
- */
 @ActionNames("importRun")
 @RequiresPermission(InsertPermission.class)
 @ApiVersion(12.3)
@@ -193,10 +189,10 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
 
         // Import the file at runFilePath if it is available, otherwise AssayRunUploadContextImpl.getUploadedData() will use the multi-part form POSTed file
         File file = null;
-        if (runFilePath != null && runFilePath.length() > 0)
+        if (runFilePath != null && !runFilePath.isEmpty())
         {
             // Resolve file under module resources
-            if (moduleName != null && moduleName.length() > 0)
+            if (moduleName != null && !moduleName.isEmpty())
             {
                 Module m = ModuleLoader.getInstance().getModule(moduleName);
                 if (m == null)
@@ -223,7 +219,7 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
                 if (!root.isUnderRoot(f))
                     f = root.resolvePath(runFilePath);
 
-                if (f == null || !NetworkDrive.exists(f) || !root.isUnderRoot(f))
+                if (!NetworkDrive.exists(f) || !root.isUnderRoot(f))
                     throw new NotFoundException("File not found: " + runFilePath);
 
                 file = f;

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -78,12 +78,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.labkey.api.assay.AssayResultDomainKind.WELL_LSID_COLUMN_NAME;
 
 public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 {
     private boolean _domainDirty;
-    private Map<String, Set<Object>> _propValues = new HashMap<>();
+    private final Map<String, Set<Object>> _propValues = new HashMap<>();
 
     @Override
     public void addAssayPlateMetadata(
@@ -116,7 +117,6 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             Map<String, PropertyDescriptor> descriptorMap = new CaseInsensitiveHashMap<>();
             domain.getProperties().forEach(dp -> descriptorMap.put(dp.getName(), dp.getPropertyDescriptor()));
             List<Map<String, Object>> jsonData = new ArrayList<>();
-            Set<PropertyDescriptor> propsToInsert = new HashSet<>();
 
             // merge the plate data with the uploaded result data
             for (Map<String, Object> row : inserted)
@@ -139,10 +139,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                                 if (descriptorMap.containsKey(k))
                                 {
                                     if (v != null)
-                                    {
                                         jsonRow.put(descriptorMap.get(k).getURI(), v);
-                                        propsToInsert.add(descriptorMap.get(k));
-                                    }
                                 }
                             });
                             jsonRow.put("Lsid", rowIdToLsidMap.get(rowId));
@@ -182,12 +179,12 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
      * to metadata properties.
      */
     private Map<Position, Map<String, Object>> prepareMergedPlateData(
-            Container container,
-            User user,
-            Lsid plateLsid,
-            Map<String, MetadataLayer> plateMetadata,
-            ExpProtocol protocol,
-            boolean ensurePlateDomain           // true to create the plate domain and properties if they don't exist
+        Container container,
+        User user,
+        Lsid plateLsid,
+        Map<String, MetadataLayer> plateMetadata,
+        ExpProtocol protocol,
+        boolean ensurePlateDomain           // true to create the plate domain and properties if they don't exist
     ) throws ExperimentException
     {
         _domainDirty = false;
@@ -492,7 +489,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         }
     }
 
-    private Map<String, MetadataLayer> _parsePlateMetadata(JsonNode rootNode) throws ExperimentException
+    private Map<String, MetadataLayer> _parsePlateMetadata(JsonNode rootNode)
     {
         Map<String, MetadataLayer> layers = new CaseInsensitiveHashMap<>();
 
@@ -529,14 +526,14 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 
     @Override
     public List<Map<String, Object>> parsePlateData(
-            Container container,
-            User user,
-            AssayProvider provider,
-            ExpProtocol protocol,
-            Integer plateSetId,
-            File dataFile,
-            List<Map<String, Object>> data,
-            Pair<String, Boolean> plateIdAdded
+        Container container,
+        User user,
+        AssayProvider provider,
+        ExpProtocol protocol,
+        Integer plateSetId,
+        File dataFile,
+        List<Map<String, Object>> data,
+        Pair<String, Boolean> plateIdAdded
     ) throws ExperimentException
     {
         // get the ordered list of plates for the plate set
@@ -544,6 +541,9 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         PlateSet plateSet = PlateManager.get().getPlateSet(cf, plateSetId);
         if (plateSet == null)
             throw new ExperimentException("Plate set " + plateSetId + " not found.");
+        if (plateSet.isTemplate())
+            throw new ExperimentException(String.format("Plate set \"%s\" is a template plate set. Template plate sets do not support associating assay data.", plateSet.getName()));
+
         List<Plate> plates = PlateManager.get().getPlatesForPlateSet(plateSet);
         if (plates.isEmpty())
             throw new ExperimentException("No plates were found for the plate set (" + plateSetId + ").");
@@ -556,10 +556,8 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             // best attempt at returning something we can import
             return (gridRows.isEmpty() && !data.isEmpty()) ? data : gridRows;
         }
-        else
-        {
-            return parsePlateRows(container, user, provider, protocol, plates, data, plateIdAdded);
-        }
+
+        return parsePlateRows(provider, protocol, plates, data, plateIdAdded);
     }
 
     private boolean isGridFormat(List<Map<String, Object>> data)
@@ -573,13 +571,11 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
     }
 
     private List<Map<String, Object>> parsePlateRows(
-            Container container,
-            User user,
-            AssayProvider provider,
-            ExpProtocol protocol,
-            List<Plate> plates,
-            List<Map<String, Object>> data,
-            Pair<String, Boolean> plateIdAdded
+        AssayProvider provider,
+        ExpProtocol protocol,
+        List<Plate> plates,
+        List<Map<String, Object>> data,
+        Pair<String, Boolean> plateIdAdded
     ) throws ExperimentException
     {
         DomainProperty plateProp = provider.getResultsDomain(protocol).getPropertyByName(AssayResultDomainKind.PLATE_COLUMN_NAME);
@@ -590,57 +586,57 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         String plateIdField = data.get(0).keySet().stream().filter(importAliases::contains).findFirst().orElse(null);
         boolean hasPlateIdentifiers = plateIdField != null && (data.stream().filter(row -> row.get(plateIdField) != null).findFirst().orElse(null) != null);
 
-        if (!hasPlateIdentifiers)
+        if (hasPlateIdentifiers)
+            return data;
+
+        final String ERROR_MESSAGE = "Unable to automatically assign plate identifiers to the data rows because %s. Please include plate identifiers for the data rows.";
+        plateIdAdded.second = true;
+
+        // verify all plates in the set have the same shape
+        Set<PlateType> types = plates.stream().map(Plate::getPlateType).collect(Collectors.toSet());
+        if (types.size() > 1)
+            throw new ExperimentException(String.format(ERROR_MESSAGE, "the plate set contains different plate types"));
+
+        PlateType type = types.stream().toList().get(0);
+        int plateSize = type.getRows() * type.getColumns();
+        if ((data.size() % plateSize) != 0)
+            throw new ExperimentException(String.format(ERROR_MESSAGE, "the number of rows in the data (" + data.size() + ") does not fit evenly and would result in a plate with partial wells filled"));
+
+        if (data.size() > (plates.size() * plateSize))
+            throw new ExperimentException(String.format(ERROR_MESSAGE, "the number of rows in the data (" + data.size() + ") exceeds the total number of wells available in the plate set (" + (plates.size() * plateSize) + ")"));
+
+        // attempt to add the plate identifier into the data rows in the order that they appear in the plate set
+        List<Map<String, Object>> newData = new ArrayList<>();
+        int rowCount = 0;
+        int curPlate = 0;
+        Set<Position> positions = new HashSet<>();
+        String plateFieldName = plateIdField != null ? plateIdField : AssayResultDomainKind.PLATE_COLUMN_NAME;
+        for (Map<String, Object> row : data)
         {
-            final String ERROR_MESSAGE = "Unable to automatically assign plate identifiers to the data rows because %s. Please include plate identifiers for the data rows.";
-            plateIdAdded.second = true;
+            // well location field is required, return if not provided or it will fail downstream
+            String well = String.valueOf(row.get(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME));
+            if (well == null)
+                return data;
 
-            // verify all plates in the set have the same shape
-            Set<PlateType> types = plates.stream().map(Plate::getPlateType).collect(Collectors.toSet());
-            if (types.size() > 1)
-                throw new ExperimentException(String.format(ERROR_MESSAGE, "the plate set contains different plate types"));
+            Position position = new PositionImpl(null, well);
+            if (positions.contains(position))
+                throw new ExperimentException(String.format(ERROR_MESSAGE, "there is more than one well referencing the same position in the plate " + position));
 
-            PlateType type = types.stream().toList().get(0);
-            int plateSize = type.getRows() * type.getColumns();
-            if ((data.size() % plateSize) != 0)
-                throw new ExperimentException(String.format(ERROR_MESSAGE, "the number of rows in the data (" + data.size() + ") does not fit evenly and would result in a plate with partial wells filled"));
+            positions.add(position);
+            Map<String, Object> newRow = new HashMap<>(row);
+            newRow.put(plateFieldName, plates.get(curPlate).getPlateId());
+            newData.add(newRow);
 
-            if (data.size() > (plates.size() * plateSize))
-                throw new ExperimentException(String.format(ERROR_MESSAGE, "the number of rows in the data (" + data.size() + ") exceeds the total number of wells available in the plate set (" + (plates.size() * plateSize) + ")"));
-
-            // attempt to add the plate identifier into the data rows in the order that they appear in the plate set
-            List<Map<String, Object>> newData = new ArrayList<>();
-            int rowCount = 0;
-            int curPlate = 0;
-            Set<Position> positions = new HashSet<>();
-            String plateFieldName = plateIdField != null ? plateIdField : AssayResultDomainKind.PLATE_COLUMN_NAME;
-            for (Map<String, Object> row : data)
+            if (++rowCount >= plateSize)
             {
-                // well location field is required, return if not provided or it will fail downstream
-                String well = String.valueOf(row.get(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME));
-                if (well == null)
-                    return data;
-
-                Position position = new PositionImpl(null, well);
-                if (positions.contains(position))
-                    throw new ExperimentException(String.format(ERROR_MESSAGE, "there is more than one well referencing the same position in the plate " + position));
-
-                positions.add(position);
-                Map<String, Object> newRow = new HashMap<>(row);
-                newRow.put(plateFieldName, plates.get(curPlate).getPlateId());
-                newData.add(newRow);
-
-                if (++rowCount >= plateSize)
-                {
-                    // move to the next plate in the set
-                    rowCount = 0;
-                    curPlate++;
-                    positions.clear();
-                }
+                // move to the next plate in the set
+                rowCount = 0;
+                curPlate++;
+                positions.clear();
             }
-            return newData;
         }
-        return data;
+
+        return newData;
     }
 
     /**
@@ -679,7 +675,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             }
         }
 
-        private @Nullable Plate getPlateForId(String annotation, List<Plate> platesetPlates) throws ExperimentException
+        private @NotNull Plate getPlateForId(String annotation, List<Plate> platesetPlates) throws ExperimentException
         {
             Plate plate = platesetPlates.stream().filter(p -> p.isIdentifierMatch(annotation)).findFirst().orElse(null);
             if (plate == null)
@@ -713,13 +709,13 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
     }
 
     private List<Map<String, Object>> parsePlateGrids(
-            Container container,
-            User user,
-            AssayProvider provider,
-            ExpProtocol protocol,
-            PlateSet plateSet,
-            List<Plate> plates,
-            File dataFile
+        Container container,
+        User user,
+        AssayProvider provider,
+        ExpProtocol protocol,
+        PlateSet plateSet,
+        List<Plate> plates,
+        File dataFile
     ) throws ExperimentException
     {
         // parse the data file for each distinct plate type found in the set of plates for the plateSetId
@@ -853,12 +849,13 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
     @Override
     @NotNull
     public OntologyManager.UpdateableTableImportHelper getImportHelper(
-            Container container,
-            User user,
-            ExpRun run,
-            ExpData data,
-            ExpProtocol protocol,
-            AssayProvider provider) throws ExperimentException
+        Container container,
+        User user,
+        ExpRun run,
+        ExpData data,
+        ExpProtocol protocol,
+        AssayProvider provider
+    )
     {
         return new PlateMetadataImportHelper(data, container, user, run, protocol, provider);
     }
@@ -947,8 +944,8 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 
     private static class MetadataLayerImpl implements MetadataLayer
     {
-        private String _name;
-        private Map<String, MetadataWellGroup> _wellGroupMap = new CaseInsensitiveHashMap<>();
+        private final String _name;
+        private final Map<String, MetadataWellGroup> _wellGroupMap = new CaseInsensitiveHashMap<>();
 
         public MetadataLayerImpl(String name)
         {
@@ -975,8 +972,8 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 
     private static class MetadataWellGroupImpl implements MetadataWellGroup
     {
-        private String _name;
-        private Map<String, Object> _properties = new CaseInsensitiveHashMap<>();
+        private final String _name;
+        private final Map<String, Object> _properties = new CaseInsensitiveHashMap<>();
 
         public MetadataWellGroupImpl(String name)
         {
@@ -1007,7 +1004,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         private static User user;
 
         @BeforeClass
-        public static void setupTest() throws Exception
+        public static void setupTest()
         {
             container = JunitUtil.getTestContainer();
             user = TestContext.get().getUser();
@@ -1016,7 +1013,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         }
 
         @After
-        public void cleanupTest() throws Exception
+        public void cleanupTest()
         {
             PlateManager.get().deleteAllPlateData(container);
         }
@@ -1024,7 +1021,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         @Test
         public void testGridAnnotations() throws Exception
         {
-            // create a plateset
+            // create a plate set
             PlateSetImpl plateSet = new PlateSetImpl();
             PlateType plateType = PlateManager.get().getPlateType(8, 12);
             List<PlateManager.CreatePlateSetPlate> plates = List.of(
@@ -1053,14 +1050,14 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             gridInfo = new PlateGridInfo(
                     new PlateUtils.GridInfo(new double[8][12], List.of(platesetPlates.get(0).getPlateId(), "Density")),
                     plateSet);
-            assertEquals("Expected plate to not resolve on annotation without a prefix", null, gridInfo.getPlate());
-            assertEquals("Expected measure to not resolve on annotation without a prefix", null, gridInfo.getMeasureName());
+            assertNull("Expected plate to not resolve on annotation without a prefix", gridInfo.getPlate());
+            assertNull("Expected measure to not resolve on annotation without a prefix", gridInfo.getMeasureName());
 
             gridInfo = new PlateGridInfo(
                     new PlateUtils.GridInfo(new double[8][12], List.of("PLATE:" + platesetPlates.get(0).getPlateId(), "Density")),
                     plateSet);
             assertEquals("Expected plate to resolve on annotation with a prefix", platesetPlates.get(0).getRowId(), gridInfo.getPlate().getRowId());
-            assertEquals("Expected measure to not resolve on annotation without a prefix", null, gridInfo.getMeasureName());
+            assertNull("Expected measure to not resolve on annotation without a prefix", gridInfo.getMeasureName());
 
             gridInfo = new PlateGridInfo(
                     new PlateUtils.GridInfo(new double[8][12], List.of("plate:" + platesetPlates.get(0).getPlateId(), "MEASURE : Density")),
@@ -1071,7 +1068,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             gridInfo = new PlateGridInfo(
                     new PlateUtils.GridInfo(new double[8][12], List.of(platesetPlates.get(0).getPlateId(), "measure : Density")),
                     plateSet);
-            assertEquals("Expected plate to not resolve on annotation without a prefix", null, gridInfo.getPlate());
+            assertNull("Expected plate to not resolve on annotation without a prefix", gridInfo.getPlate());
             assertEquals("Expected measure to resolve on annotation with a prefix", "Density", gridInfo.getMeasureName());
         }
     }

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -275,14 +275,15 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 
     @Override
     public List<Map<String, Object>> mergePlateMetadata(
-            Container container,
-            User user,
-            Lsid plateLsid,
-            Integer plateSetId,
-            List<Map<String, Object>> rows,
-            @Nullable Map<String, MetadataLayer> plateMetadata,
-            AssayProvider provider,
-            ExpProtocol protocol) throws ExperimentException
+        Container container,
+        User user,
+        Lsid plateLsid,
+        Integer plateSetId,
+        List<Map<String, Object>> rows,
+        @Nullable Map<String, MetadataLayer> plateMetadata,
+        AssayProvider provider,
+        ExpProtocol protocol
+    ) throws ExperimentException
     {
         Domain resultDomain = provider.getResultsDomain(protocol);
         DomainProperty plateProperty = resultDomain.getPropertyByName(AssayResultDomainKind.PLATE_COLUMN_NAME);

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -731,8 +731,8 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         {
             if (!plateTypeGrids.containsKey(plate.getPlateType()))
             {
-                Plate template = PlateService.get().createPlateTemplate(container, TsvPlateLayoutHandler.TYPE, plate.getPlateType());
-                for (PlateUtils.GridInfo gridInfo : plateReader.loadMultiGridFile(template, dataFile))
+                Plate p = PlateService.get().createPlate(container, TsvPlateLayoutHandler.TYPE, plate.getPlateType());
+                for (PlateUtils.GridInfo gridInfo : plateReader.loadMultiGridFile(p, dataFile))
                 {
                     PlateGridInfo plateInfo = new PlateGridInfo(gridInfo, plateSet);
                     plateTypeGrids.put(plate.getPlateType(), plateInfo);

--- a/assay/src/org/labkey/assay/plate/PlateCache.java
+++ b/assay/src/org/labkey/assay/plate/PlateCache.java
@@ -132,7 +132,7 @@ public class PlateCache
         return plate != null ? plate.copy() : null;
     }
 
-    public static @NotNull Collection<Plate> getPlates(Container c)
+    public static @NotNull List<Plate> getPlates(Container c)
     {
         List<Plate> plates = new ArrayList<>();
         List<Integer> ids = new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(),

--- a/assay/src/org/labkey/assay/plate/PlateCache.java
+++ b/assay/src/org/labkey/assay/plate/PlateCache.java
@@ -21,7 +21,6 @@ import org.labkey.assay.plate.model.PlateBean;
 import org.labkey.assay.query.AssayDbSchema;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;

--- a/assay/src/org/labkey/assay/plate/PlateCache.java
+++ b/assay/src/org/labkey/assay/plate/PlateCache.java
@@ -135,13 +135,15 @@ public class PlateCache
     public static @NotNull List<Plate> getPlates(Container c)
     {
         List<Plate> plates = new ArrayList<>();
-        List<Integer> ids = new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(),
-                Collections.singleton("RowId"),
-                SimpleFilter.createContainerFilter(c), null).getArrayList(Integer.class);
+        List<Integer> ids = new TableSelector(
+            AssayDbSchema.getInstance().getTableInfoPlate(),
+            Collections.singleton("RowId"),
+            SimpleFilter.createContainerFilter(c),
+            new Sort("RowId")
+        ).getArrayList(Integer.class);
+
         for (Integer id : ids)
-        {
             plates.add(PLATE_CACHE.get(PlateCacheKey.getCacheKey(c, id)));
-        }
         return plates;
     }
 

--- a/assay/src/org/labkey/assay/plate/PlateDataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateDataServiceImpl.java
@@ -161,7 +161,7 @@ public class PlateDataServiceImpl extends BaseRemoteService implements PlateData
                     throw new Exception("Plate template not found: " + gwtPlate.getRowId());
 
                 // check another plate of the same name doesn't already exist
-                if (PlateManager.get().isDuplicatePlate(getContainer(), getUser(), gwtPlate.getName(), null) && !replaceIfExisting)
+                if (PlateManager.get().isDuplicatePlateName(getContainer(), getUser(), gwtPlate.getName(), null) && !replaceIfExisting)
                     throw new Exception("A plate template with name '" + gwtPlate.getName() + "' already exists.");
 
                 if (!template.getAssayType().equals(gwtPlate.getType()))

--- a/assay/src/org/labkey/assay/plate/PlateImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateImpl.java
@@ -74,23 +74,20 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     private int _modifiedBy;
     private String _name;
     private String _plateId;
-    private int _plateNumber;
+    private int _plateNumber = 1;
     private PlateSet _plateSet;
     private PlateType _plateType;
     private Integer _rowId;
     private Integer _runCount;
-    private int _runId; // NO_RUNID means no run yet, well data comes from file, dilution data must be calculated
+    private int _runId = PlateService.NO_RUNID; // NO_RUNID means no run yet, well data comes from file, dilution data must be calculated
     private boolean _template;
-    private WellImpl[][] _wells;
+    private WellImpl[][] _wells = null;
     private Map<Integer, Well> _wellMap;
     private Integer _metadataDomainId;
 
+    // no-param constructor for reflection
     public PlateImpl()
     {
-        // no-param constructor for reflection
-        _wells = null;
-        _runId = PlateService.NO_RUNID;
-        _plateNumber = 1;
     }
 
     public PlateImpl(Container container, String name, String assayType, @NotNull PlateType plateType)
@@ -98,15 +95,16 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
         super(container);
         _name = StringUtils.trimToNull(name);
         _assayType = assayType;
-        _container = container;
         _dataFileId = GUID.makeGUID();
-        _plateNumber = 1;
         _plateType = plateType;
-        _runId = PlateService.NO_RUNID;
-        _wells = null;
     }
 
-    public PlateImpl(PlateImpl plate, double[][] wellValues, boolean[][] excluded, int runId, int plateNumber)
+    public PlateImpl(Container container, String name, @NotNull PlateType plateType)
+    {
+        this(container, name, TsvPlateLayoutHandler.TYPE, plateType);
+    }
+
+    public PlateImpl(@NotNull PlateImpl plate, double[][] wellValues, boolean[][] excluded, int runId, int plateNumber)
     {
         this(plate.getContainer(), plate.getName(), plate.getAssayType(), plate.getPlateType());
 
@@ -131,8 +129,6 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
 
         for (WellGroup group : plate.getWellGroups())
             addWellGroup(new WellGroupImpl(this, (WellGroupImpl) group));
-
-        setContainer(plate.getContainer());
     }
 
     public static PlateImpl from(PlateBean bean)

--- a/assay/src/org/labkey/assay/plate/PlateImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateImpl.java
@@ -61,6 +61,7 @@ import static org.junit.Assert.assertTrue;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
 {
+    private boolean _archived;
     private String _assayType;
     private long _created;
     private int _createdBy;
@@ -146,6 +147,7 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
         plate.setDataFileId(bean.getDataFileId());
         plate.setAssayType(bean.getAssayType());
         plate.setPlateId(bean.getPlateId());
+        plate.setArchived(bean.getArchived());
         plate.setDescription(bean.getDescription());
 
         // entity fields
@@ -338,6 +340,17 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
         }
 
         return wellgroupTypeMap;
+    }
+
+    @Override
+    public boolean isArchived()
+    {
+        return _archived;
+    }
+
+    public void setArchived(boolean archived)
+    {
+        _archived = archived;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -21,10 +21,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.labkey.api.assay.AssayListener;
 import org.labkey.api.assay.AssayProtocolSchema;
 import org.labkey.api.assay.AssayProvider;
@@ -77,14 +73,11 @@ import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.OntologyObject;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
-import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
-import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentListener;
 import org.labkey.api.exp.api.ExperimentService;
-import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainKind;
@@ -106,10 +99,8 @@ import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.GUID;
-import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
-import org.labkey.api.util.TestContext;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
@@ -123,7 +114,6 @@ import org.labkey.assay.plate.model.PlateBean;
 import org.labkey.assay.plate.model.PlateSetAssays;
 import org.labkey.assay.plate.model.PlateSetLineage;
 import org.labkey.assay.plate.model.PlateTypeBean;
-import org.labkey.assay.plate.model.WellBean;
 import org.labkey.assay.plate.model.WellGroupBean;
 import org.labkey.assay.plate.query.PlateSchema;
 import org.labkey.assay.plate.query.PlateSetTable;
@@ -151,13 +141,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.labkey.api.assay.plate.PlateSet.MAX_PLATES;
-import static org.labkey.api.util.JunitUtil.deleteTestContainer;
 
 public class PlateManager implements PlateService, AssayListener, ExperimentListener
 {
@@ -392,7 +376,6 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return null;
     }
 
-    @Override
     @NotNull
     public List<Plate> getPlateTemplates(Container container)
     {
@@ -517,7 +500,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return new SqlSelector(ExperimentService.get().getSchema(), sql);
     }
 
-    private @NotNull Plate createPlateTemplate(Container container, String assayType, @NotNull PlateType plateType)
+    @NotNull Plate createPlateTemplate(Container container, String assayType, @NotNull PlateType plateType)
     {
         Plate plate = createPlate(container, assayType, plateType);
         ((PlateImpl)plate).setTemplate(true);
@@ -2750,7 +2733,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             throw new IllegalStateException("This method must be called from within a transaction");
     }
 
-    private Pair<Integer, List<Map<String, Object>>> getWellSampleData(int[] sampleIdsSorted, Integer rowCount, Integer columnCount, int sampleIdsCounter, Container c)
+    Pair<Integer, List<Map<String, Object>>> getWellSampleData(int[] sampleIdsSorted, Integer rowCount, Integer columnCount, int sampleIdsCounter, Container c)
     {
         if (sampleIdsSorted.length == 0)
             throw new IllegalArgumentException("No samples are in the current selection.");
@@ -2851,12 +2834,12 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     }
 
     public List<Object[]> getWorklist(
-            int sourcePlateSetId,
-            int destinationPlateSetId,
-            Set<FieldKey> sourceIncludedMetadataCols,
-            Set<FieldKey> destinationIncludedMetadataCols,
-            Container c,
-            User u
+        int sourcePlateSetId,
+        int destinationPlateSetId,
+        Set<FieldKey> sourceIncludedMetadataCols,
+        Set<FieldKey> destinationIncludedMetadataCols,
+        Container c,
+        User u
     ) throws RuntimeSQLException
     {
         TableInfo wellTable = getWellTable(c, u);
@@ -2867,597 +2850,5 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     {
         TableInfo wellTable = getWellTable(c, u);
         return new PlateSetExport().getInstrumentInstructions(wellTable, plateSetId, includedMetadataCols);
-    }
-
-    public static final class TestCase
-    {
-        private static Container container;
-        private static User user;
-        private static ExpSampleType sampleType;
-
-        @BeforeClass
-        public static void setupTest() throws Exception
-        {
-            container = JunitUtil.getTestContainer();
-            user = TestContext.get().getUser();
-
-            PlateManager.get().deleteAllPlateData(container);
-            Domain domain = PlateManager.get().getPlateMetadataDomain(container ,user);
-            if (domain != null)
-                domain.delete(user);
-
-            // create custom properties
-            List<GWTPropertyDescriptor> customFields = List.of(
-                    new GWTPropertyDescriptor("barcode", "http://www.w3.org/2001/XMLSchema#string"),
-                    new GWTPropertyDescriptor("concentration", "http://www.w3.org/2001/XMLSchema#double"),
-                    new GWTPropertyDescriptor("negativeControl", "http://www.w3.org/2001/XMLSchema#double"));
-
-            PlateManager.get().createPlateMetadataFields(container, user, customFields);
-
-            // create sample type
-            List<GWTPropertyDescriptor> props = new ArrayList<>();
-            props.add(new GWTPropertyDescriptor("col1", "string"));
-            props.add(new GWTPropertyDescriptor("col2", "string"));
-            sampleType = SampleTypeService.get().createSampleType(container, user, "SampleType1", null, props, emptyList(), 0, -1, -1, -1, null, null);
-        }
-
-        @After
-        public void cleanupTest()
-        {
-            PlateManager.get().deleteAllPlateData(container);
-        }
-
-        @AfterClass
-        public static void onComplete()
-        {
-            deleteTestContainer();
-            container = null;
-            user = null;
-        }
-
-        @Test
-        public void createPlateTemplate() throws Exception
-        {
-            //
-            // INSERT
-            //
-
-            PlateLayoutHandler handler = PlateManager.get().getPlateLayoutHandler(TsvPlateLayoutHandler.TYPE);
-            PlateType plateType = PlateManager.get().getPlateType(8, 12);
-            assertNotNull("96 well plate type was not found", plateType);
-
-            Plate template = handler.createPlate("UNUSED", container, plateType);
-            template.setName("bob");
-            template.setProperty("friendly", "yes");
-            assertNull(template.getRowId());
-            assertNull(template.getLSID());
-
-            WellGroup wg1 = template.addWellGroup("wg1", WellGroup.Type.SAMPLE,
-                    PlateManager.get().createPosition(container, 0, 0),
-                    PlateManager.get().createPosition(container, 0, 11));
-            wg1.setProperty("score", "100");
-            assertNull(wg1.getRowId());
-            assertNull(wg1.getLSID());
-
-            int plateId = PlateManager.get().save(container, user, template);
-
-            //
-            // VERIFY INSERT
-            //
-
-            assertEquals(1, PlateManager.get().getPlateTemplates(container).size());
-
-            Plate savedTemplate = PlateManager.get().getPlateByName(container, "bob");
-            assertEquals(plateId, savedTemplate.getRowId().intValue());
-            assertEquals("bob", savedTemplate.getName());
-            assertEquals("yes", savedTemplate.getProperty("friendly")); assertNotNull(savedTemplate.getLSID());
-            assertEquals(plateType.getRowId(), savedTemplate.getPlateType().getRowId());
-
-            List<WellGroup> wellGroups = savedTemplate.getWellGroups();
-            assertEquals(3, wellGroups.size());
-
-            // TsvPlateTypeHandler creates two CONTROL well groups "Positive" and "Negative"
-            List<WellGroup> controlWellGroups = savedTemplate.getWellGroups(WellGroup.Type.CONTROL);
-            assertEquals(2, controlWellGroups.size());
-
-            List<WellGroup> sampleWellGroups = savedTemplate.getWellGroups(WellGroup.Type.SAMPLE);
-            assertEquals(1, sampleWellGroups.size());
-            WellGroup savedWg1 = sampleWellGroups.get(0);
-            assertEquals("wg1", savedWg1.getName());
-            assertEquals("100", savedWg1.getProperty("score"));
-
-            List<Position> savedWg1Positions = savedWg1.getPositions();
-            assertEquals(12, savedWg1Positions.size());
-
-            //
-            // UPDATE
-            //
-
-            // rename plate
-            savedTemplate.setName("sally");
-
-            // add well group
-            WellGroup wg2 = savedTemplate.addWellGroup("wg2", WellGroup.Type.SAMPLE,
-                    PlateManager.get().createPosition(container, 1, 0),
-                    PlateManager.get().createPosition(container, 1, 11));
-
-            // rename existing well group
-            ((WellGroupImpl)savedWg1).setName("wg1_renamed");
-
-            // add positions
-            controlWellGroups.get(0).setPositions(List.of(
-                    PlateManager.get().createPosition(container, 0, 0),
-                    PlateManager.get().createPosition(container, 0, 1)));
-
-            // delete well group
-            ((PlateImpl)savedTemplate).markWellGroupForDeletion(controlWellGroups.get(1));
-
-            int newPlateId = PlateManager.get().save(container, user, savedTemplate);
-            assertEquals(savedTemplate.getRowId().intValue(), newPlateId);
-
-            //
-            // VERIFY UPDATE
-            //
-
-            // verify plate
-            Plate updatedTemplate = PlateManager.get().getPlate(container, plateId);
-            assertEquals("sally", updatedTemplate.getName());
-            assertEquals(savedTemplate.getLSID(), updatedTemplate.getLSID());
-
-            // verify well group rename
-            WellGroup updatedWg1 = updatedTemplate.getWellGroup(savedWg1.getRowId());
-            assertNotNull(updatedWg1);
-            assertEquals(savedWg1.getLSID(), updatedWg1.getLSID());
-            assertEquals("wg1_renamed", updatedWg1.getName());
-
-            // verify added well group
-            WellGroup updatedWg2 = updatedTemplate.getWellGroup(wg2.getRowId());
-            assertNotNull(updatedWg2);
-
-            // verify deleted well group
-            List<WellGroup> updatedControlWellGroups = updatedTemplate.getWellGroups(WellGroup.Type.CONTROL);
-            assertEquals(1, updatedControlWellGroups.size());
-
-            // verify added positions
-            assertEquals(2, updatedControlWellGroups.get(0).getPositions().size());
-
-            // verify plate type information
-            assertEquals(plateType.getRows().intValue(), updatedTemplate.getRows());
-            assertEquals(plateType.getColumns().intValue(), updatedTemplate.getColumns());
-
-            //
-            // DELETE
-            //
-
-            PlateManager.get().deletePlate(container, user, updatedTemplate.getRowId());
-
-            assertNull(PlateManager.get().getPlate(container, updatedTemplate.getRowId()));
-            assertEquals(0, PlateManager.get().getPlateTemplates(container).size());
-        }
-
-        @Test
-        public void testCreateAndSavePlate() throws Exception
-        {
-            // Arrange
-            PlateType plateType = PlateManager.get().getPlateType(8, 12);
-            assertNotNull("96 well plate type was not found", plateType);
-
-            // Act
-            PlateImpl plateImpl = new PlateImpl(container, "testCreateAndSavePlate plate", plateType);
-            Plate plate = PlateManager.get().createAndSavePlate(container, user, plateImpl, null, null);
-
-            // Assert
-            assertTrue("Expected plate to have been persisted and provided with a rowId", plate.getRowId() > 0);
-            assertNotNull("Expected plate to have been persisted and provided with a plateId", plate.getPlateId());
-
-            // verify access via plate ID
-            Plate savedPlate = PlateManager.get().getPlate(container, plate.getPlateId());
-            assertNotNull("Expected plate to be accessible via it's plate ID", savedPlate);
-            assertEquals("Plate retrieved by plate ID doesn't match the original plate.", savedPlate.getRowId(), plate.getRowId());
-
-            // verify container filter access
-            savedPlate = PlateManager.get().getPlate(ContainerManager.getSharedContainer(), plate.getRowId());
-            assertNull("Saved plate should not exist in the shared container", savedPlate);
-
-            savedPlate = PlateManager.get().getPlate(ContainerFilter.Type.CurrentAndSubfolders.create(ContainerManager.getSharedContainer(), user), plate.getRowId());
-            assertEquals("Expected plate to be accessible via a container filter", plate.getRowId(), savedPlate.getRowId());
-        }
-
-        @Test
-        public void testAccessPlateByIdentifiers() throws Exception
-        {
-            // Arrange
-            PlateType plateType = PlateManager.get().getPlateType(8, 12);
-            assertNotNull("96 well plate type was not found", plateType);
-            PlateSetImpl plateSetImpl = new PlateSetImpl();
-            plateSetImpl.setName("testAccessPlateByIdentifiersPlateSet");
-            ContainerFilter cf = ContainerFilter.Type.CurrentAndSubfolders.create(ContainerManager.getSharedContainer(), user);
-
-            // Act
-            PlateSet plateSet = PlateManager.get().createPlateSet(container, user, plateSetImpl, List.of(
-                new CreatePlateSetPlate("testAccessPlateByIdentifiersFirst", plateType.getRowId(), null),
-                new CreatePlateSetPlate("testAccessPlateByIdentifiersSecond", plateType.getRowId(), null),
-                new CreatePlateSetPlate("testAccessPlateByIdentifiersThird", plateType.getRowId(), null)
-            ), null);
-
-            // Assert
-            assertTrue("Expected plateSet to have been persisted and provided with a rowId", plateSet.getRowId() > 0);
-            List<Plate> plates = plateSet.getPlates(user);
-            assertEquals("Expected plateSet to have 3 plates", 3, plates.size());
-
-            // verify access via plate rowId
-            assertNotNull("Expected plate to be accessible via it's rowId", PlateManager.get().getPlate(cf, plateSet.getRowId(), plates.get(0).getRowId()));
-            assertNotNull("Expected plate to be accessible via it's rowId", PlateManager.get().getPlate(cf, plateSet.getRowId(), plates.get(1).getRowId()));
-            assertNotNull("Expected plate to be accessible via it's rowId", PlateManager.get().getPlate(cf, plateSet.getRowId(), plates.get(2).getRowId()));
-
-            // verify access via plate ID
-            assertNotNull("Expected plate to be accessible via it's plate ID", PlateManager.get().getPlate(cf, plateSet.getRowId(), plates.get(0).getPlateId()));
-            assertNotNull("Expected plate to be accessible via it's plate ID", PlateManager.get().getPlate(cf, plateSet.getRowId(), plates.get(1).getPlateId()));
-            assertNotNull("Expected plate to be accessible via it's plate ID", PlateManager.get().getPlate(cf, plateSet.getRowId(), plates.get(2).getPlateId()));
-
-            // verify access via plate name
-            assertNotNull("Expected plate to be accessible via it's name", PlateManager.get().getPlate(cf, plateSet.getRowId(), "testAccessPlateByIdentifiersFirst"));
-            // verify error when trying to access non-existing plate name
-            try
-            {
-                PlateManager.get().getPlate(cf, plateSet.getRowId(), "testAccessPlateByIdentifiersBogus");
-                fail("Expected a validation error when accessing plates by non-existing name");
-            }
-            catch (IllegalArgumentException e)
-            {
-                assertEquals("Expected validation exception", "The plate identifier \"testAccessPlateByIdentifiersBogus\" does not match any plate in the plate set \"testAccessPlateByIdentifiersPlateSet\".", e.getMessage());
-            }
-        }
-
-        @Test
-        public void testCreatePlateTemplates() throws Exception
-        {
-            // Verify plate service assumptions about plate templates
-            PlateType plateType = PlateManager.get().getPlateType(16, 24);
-            assertNotNull("384 well plate type was not found", plateType);
-            Plate plate = PlateManager.get().createPlateTemplate(container, TsvPlateLayoutHandler.TYPE, plateType);
-            plate.setName("my plate template");
-            int plateId = PlateManager.get().save(container, user, plate);
-
-            // Assert
-            assertTrue("Expected saved plateId to be returned", plateId != 0);
-            assertTrue("Expected saved plate to have the template field set to true", PlateManager.get().getPlate(container, plateId).isTemplate());
-
-            // Verify only plate templates are returned
-            plateType = PlateManager.get().getPlateType(8, 12);
-            assertNotNull("96 well plate type was not found", plateType);
-
-            plate = PlateManager.get().createPlate(container, TsvPlateLayoutHandler.TYPE, plateType);
-            plate.setName("non plate template");
-            PlateManager.get().save(container, user, plate);
-
-            List<Plate> plates = PlateManager.get().getPlateTemplates(container);
-            assertEquals("Expected only a single plate to be returned", 1, plates.size());
-            for (Plate template : plates)
-            {
-                assertTrue("Expected saved plate to have the template field set to true", template.isTemplate());
-            }
-        }
-
-        @Test
-        public void testCreatePlateMetadata() throws Exception
-        {
-            PlateType plateType = PlateManager.get().getPlateType(16, 24);
-            assertNotNull("384 well plate type was not found", plateType);
-
-            Plate plate = PlateManager.get().createPlateTemplate(container, TsvPlateLayoutHandler.TYPE, plateType);
-            plate.setName("new plate with metadata");
-            int plateId = PlateManager.get().save(container, user, plate);
-
-            // Assert
-            assertTrue("Expected saved plateId to be returned", plateId != 0);
-
-            List<PlateCustomField> fields = PlateManager.get().getPlateMetadataFields(container, user);
-
-            // Verify returned sorted by name
-            assertEquals("Expected plate custom fields", 3, fields.size());
-            assertEquals("Expected barcode custom field", "barcode", fields.get(0).getName());
-            assertEquals("Expected concentration custom field", "concentration", fields.get(1).getName());
-            assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(2).getName());
-
-            // assign custom fields to the plate
-            assertEquals("Expected custom fields to be added to the plate", 3, PlateManager.get().addFields(container, user, plateId, fields).size());
-
-            // verification when adding custom fields to the plate
-            try
-            {
-                PlateManager.get().addFields(container, user, plateId, fields);
-                fail("Expected a validation error when adding existing fields");
-            }
-            catch (IllegalArgumentException e)
-            {
-                assertEquals("Expected validation exception", "Failed to add plate custom fields. Custom field \"barcode\" already is associated with this plate.", e.getMessage());
-            }
-
-            // remove a plate custom field
-            fields = PlateManager.get().removeFields(container, user, plateId, List.of(fields.get(0)));
-            assertEquals("Expected 2 plate custom fields", 2, fields.size());
-            assertEquals("Expected concentration custom field", "concentration", fields.get(0).getName());
-            assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(1).getName());
-
-            // select wells
-            SimpleFilter filter = SimpleFilter.createContainerFilter(container);
-            filter.addCondition(FieldKey.fromParts("PlateId"), plateId);
-            filter.addCondition(FieldKey.fromParts("Row"), 0);
-            List<WellBean> wells = new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), filter, new Sort("Col")).getArrayList(WellBean.class);
-
-            assertEquals("Expected 24 wells to be returned", 24, wells.size());
-
-            // update
-            TableInfo wellTable = QueryService.get().getUserSchema(user, container, PlateSchema.SCHEMA_NAME).getTable(WellTable.NAME);
-            QueryUpdateService qus = wellTable.getUpdateService();
-            assertNotNull(qus);
-            BatchValidationException errors = new BatchValidationException();
-
-            // add metadata to 2 rows
-            WellBean well = wells.get(0);
-            List<Map<String, Object>> rows = List.of(CaseInsensitiveHashMap.of(
-                    "rowid", well.getRowId(),
-                    "properties/concentration", 1.25,
-                    "properties/negativeControl", 5.25
-            ));
-
-            qus.updateRows(user, container, rows, null, errors, null, null);
-            if (errors.hasErrors())
-                fail(errors.getMessage());
-
-            well = wells.get(1);
-            rows = List.of(CaseInsensitiveHashMap.of(
-                    "rowid", well.getRowId(),
-                    "properties/concentration", 2.25,
-                    "properties/negativeControl", 6.25
-            ));
-
-            qus.updateRows(user, container, rows, null, errors, null, null);
-            if (errors.hasErrors())
-                fail(errors.getMessage());
-
-            FieldKey fkConcentration = FieldKey.fromParts("properties", "concentration");
-            FieldKey fkNegativeControl = FieldKey.fromParts("properties", "negativeControl");
-            Map<FieldKey, ColumnInfo> columns = QueryService.get().getColumns(wellTable, List.of(fkConcentration, fkNegativeControl));
-
-            // verify plate metadata property updates
-            try (Results r = QueryService.get().select(wellTable, columns.values(), filter, new Sort("Col")))
-            {
-                int row = 0;
-                while (r.next())
-                {
-                    if (row == 0)
-                    {
-                        assertEquals(1.25, r.getDouble(fkConcentration), 0);
-                        assertEquals(5.25, r.getDouble(fkNegativeControl), 0);
-                    }
-                    else if (row == 1)
-                    {
-                        assertEquals(2.25, r.getDouble(fkConcentration), 0);
-                        assertEquals(6.25, r.getDouble(fkNegativeControl), 0);
-                    }
-                    else
-                    {
-                        // the remainder should be null
-                        assertEquals(0, r.getDouble(fkConcentration), 0);
-                        assertEquals(0, r.getDouble(fkNegativeControl), 0);
-                    }
-                    row++;
-                }
-            }
-        }
-
-        @Test
-        public void testCreateAndSavePlateWithData() throws Exception
-        {
-            // Arrange
-            PlateType plateType = PlateManager.get().getPlateType(8, 12);
-            assertNotNull("96 well plate type was not found", plateType);
-
-            // Act
-            List<Map<String, Object>> rows = List.of(
-                    CaseInsensitiveHashMap.of(
-                            "wellLocation", "A1",
-                            "properties/concentration", 2.25,
-                            "properties/barcode", "B1234")
-                    ,
-                    CaseInsensitiveHashMap.of(
-                            "wellLocation", "A2",
-                            "properties/concentration", 1.25,
-                            "properties/barcode", "B5678"
-                    )
-            );
-
-            PlateImpl plateImpl = new PlateImpl(container, "hit selection plate", plateType);
-            Plate plate = PlateManager.get().createAndSavePlate(container, user, plateImpl, null, rows);
-            assertEquals("Expected 2 plate custom fields", 2, plate.getCustomFields().size());
-
-            TableInfo wellTable = QueryService.get().getUserSchema(user, container, PlateSchema.SCHEMA_NAME).getTable(WellTable.NAME);
-            FieldKey fkConcentration = FieldKey.fromParts("properties", "concentration");
-            FieldKey fkBarcode = FieldKey.fromParts("properties", "barcode");
-            Map<FieldKey, ColumnInfo> columns = QueryService.get().getColumns(wellTable, List.of(fkConcentration, fkBarcode));
-
-            // verify that well data was added
-            SimpleFilter filter = SimpleFilter.createContainerFilter(container);
-            filter.addCondition(FieldKey.fromParts("PlateId"), plate.getRowId());
-            filter.addCondition(FieldKey.fromParts("Row"), 0);
-            try (Results r = QueryService.get().select(wellTable, columns.values(), filter, new Sort("Col")))
-            {
-                int row = 0;
-                while (r.next())
-                {
-                    if (row == 0)
-                    {
-                        assertEquals(2.25, r.getDouble(fkConcentration), 0);
-                        assertEquals("B1234", r.getString(fkBarcode));
-                    }
-                    else if (row == 1)
-                    {
-                        assertEquals(1.25, r.getDouble(fkConcentration), 0);
-                        assertEquals("B5678", r.getString(fkBarcode));
-                    }
-                    else
-                    {
-                        // the remainder should be null
-                        assertEquals(0, r.getDouble(fkConcentration), 0);
-                        assertNull(r.getString(fkBarcode));
-                    }
-                    row++;
-                }
-            }
-        }
-
-        @Test
-        public void getWellSampleData()
-        {
-            // Act
-            int[] sampleIdsSorted = new int[]{0, 3, 5, 8, 10, 11, 12, 13, 15, 17, 19};
-            Pair<Integer, List<Map<String, Object>>> wellSampleDataFilledFull = PlateManager.get().getWellSampleData(sampleIdsSorted, 2, 3, 0, container);
-            Pair<Integer, List<Map<String, Object>>> wellSampleDataFilledPartial = PlateManager.get().getWellSampleData(sampleIdsSorted, 2, 3, 6, container);
-
-            // Assert
-            assertEquals(wellSampleDataFilledFull.first, 6, 0);
-            ArrayList<String> wellLocations = new ArrayList<>(Arrays.asList("A1", "A2", "A3", "B1", "B2", "B3"));
-            for (int i = 0; i < wellSampleDataFilledFull.second.size(); i++)
-            {
-                Map<String, Object> well = wellSampleDataFilledFull.second.get(i);
-                assertEquals(well.get("sampleId"), sampleIdsSorted[i]);
-                assertEquals(well.get("wellLocation"), wellLocations.get(i));
-            }
-
-            assertEquals(wellSampleDataFilledPartial.first, 11, 0);
-            for (int i = 0; i < wellSampleDataFilledPartial.second.size(); i++)
-            {
-                Map<String, Object> well = wellSampleDataFilledPartial.second.get(i);
-                assertEquals(well.get("sampleId"), sampleIdsSorted[i + 6]);
-                assertEquals(well.get("wellLocation"), wellLocations.get(i));
-            }
-
-            // Act
-            try
-            {
-                PlateManager.get().getWellSampleData(new int[]{}, 2, 3, 0, container);
-            }
-            // Assert
-            catch (IllegalArgumentException e)
-            {
-                assertEquals("Expected validation exception", "No samples are in the current selection.", e.getMessage());
-            }
-        }
-
-        @Test
-        public void getInstrumentInstructions() throws Exception
-        {
-            // Arrange
-            final ExpMaterial sample1 = ExperimentService.get().createExpMaterial(container, sampleType.generateSampleLSID().setObjectId("sampleOne").toString(), "sampleOne");
-            sample1.setCpasType(sampleType.getLSID());
-            sample1.save(user);
-            final ExpMaterial sample2 = ExperimentService.get().createExpMaterial(container, sampleType.generateSampleLSID().setObjectId("sampleTwo").toString(), "sampleTwo");
-            sample2.setCpasType(sampleType.getLSID());
-            sample2.save(user);
-
-            PlateType plateType = PlateManager.get().getPlateType(8, 12);
-            assertNotNull("96 well plate type was not found", plateType);
-
-            List<Map<String, Object>> rows = List.of(
-                    CaseInsensitiveHashMap.of(
-                            "wellLocation", "A1",
-                            "sampleId", sample1.getRowId(),
-                            "properties/concentration", 2.25,
-                            "properties/barcode", "B1234")
-                    ,
-                    CaseInsensitiveHashMap.of(
-                            "wellLocation", "A2",
-                            "sampleId", sample2.getRowId(),
-                            "properties/concentration", 1.25,
-                            "properties/barcode", "B5678"
-                    )
-            );
-            Plate plate = new PlateImpl(container, "myPlate", plateType);
-            plate = PlateManager.get().createAndSavePlate(container, user, plate, null, rows);
-
-            // Act
-            Set<FieldKey> includedMetadataCols = WellTable.getMetadataColumns(plate.getPlateSet().getRowId(), container, user);
-            List<Object[]> result = PlateManager.get().getInstrumentInstructions(plate.getPlateSet().getRowId(), includedMetadataCols, container, user);
-
-            // Assert
-            Object[] row1 = result.get(0);
-            String[] valuesRow1 = new String[]{"myPlate", "A1", "96-well", "sampleOne", "B1234", "2.25"};
-            for (int i = 0; i < row1.length; i++)
-                assertEquals(row1[i].toString(), valuesRow1[i]);
-
-            Object[] row2 = result.get(1);
-            String[] valuesRow2 = new String[]{"myPlate", "A2", "96-well", "sampleTwo", "B5678", "1.25"};
-            for (int i = 0; i < row1.length; i++)
-                assertEquals(row2[i].toString(), valuesRow2[i]);
-        }
-
-        @Test
-        public void getWorklist() throws Exception
-        {
-            // Arrange
-            final ExpMaterial sample1 = ExperimentService.get().createExpMaterial(container, sampleType.generateSampleLSID().setObjectId("sampleA").toString(), "sampleA");
-            sample1.setCpasType(sampleType.getLSID());
-            sample1.save(user);
-            final ExpMaterial sample2 = ExperimentService.get().createExpMaterial(container, sampleType.generateSampleLSID().setObjectId("sampleB").toString(), "sampleB");
-            sample2.setCpasType(sampleType.getLSID());
-            sample2.save(user);
-
-            PlateType plateType = PlateManager.get().getPlateType(8, 12);
-            assertNotNull("96 well plate type was not found", plateType);
-
-            List<Map<String, Object>> rows1 = List.of(
-                    CaseInsensitiveHashMap.of(
-                            "wellLocation", "A1",
-                            "sampleId", sample1.getRowId(),
-                            "properties/concentration", 2.25,
-                            "properties/barcode", "B1234")
-                    ,
-                    CaseInsensitiveHashMap.of(
-                            "wellLocation", "A2",
-                            "sampleId", sample2.getRowId(),
-                            "properties/concentration", 1.25,
-                            "properties/barcode", "B5678"
-                    )
-            );
-            Plate plateSource = PlateManager.get().createAndSavePlate(container, user, new PlateImpl(container, "myPlate1", plateType), null, rows1);
-
-            List<Map<String, Object>> rows2 = List.of(
-                    CaseInsensitiveHashMap.of(
-                            "wellLocation", "A1",
-                            "sampleId", sample2.getRowId())
-                    ,
-                    CaseInsensitiveHashMap.of(
-                            "wellLocation", "A2",
-                            "sampleId", sample1.getRowId())
-                    ,
-                    CaseInsensitiveHashMap.of(
-                            "wellLocation", "A3",
-                            "sampleId", sample2.getRowId())
-            );
-            Plate plateDestination = PlateManager.get().createAndSavePlate(container, user, new PlateImpl(container, "myPlate2", plateType), null, rows2);
-
-            // Act
-            Set<FieldKey> sourceIncludedMetadataCols = WellTable.getMetadataColumns(plateSource.getPlateSet().getRowId(), container, user);
-            Set<FieldKey> destinationIncludedMetadataCols = WellTable.getMetadataColumns(plateDestination.getPlateSet().getRowId(), container, user);
-            List<Object[]> plateDataRows = PlateManager.get().getWorklist(plateSource.getPlateSet().getRowId(), plateDestination.getPlateSet().getRowId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, container, user);
-
-            // Assert
-            Object[] row1 = plateDataRows.get(0);
-            String[] valuesRow1 = new String[]{"myPlate1", "A1", "96-well", "sampleA", "B1234", "2.25", "myPlate2", "A2", "96-well"};
-            for (int i = 0; i < row1.length; i++)
-                assertEquals(row1[i].toString(), valuesRow1[i]);
-
-            Object[] row2 = plateDataRows.get(1);
-            String[] valuesRow2 = new String[]{"myPlate1", "A2", "96-well", "sampleB", "B5678", "1.25", "myPlate2", "A1", "96-well"};
-            for (int i = 0; i < row2.length; i++)
-                assertEquals(row2[i].toString(), valuesRow2[i]);
-
-            Object[] row3 = plateDataRows.get(2);
-            String[] valuesRow3 = new String[]{"myPlate1", "A2", "96-well", "sampleB", "B5678", "1.25", "myPlate2", "A3", "96-well"};
-            for (int i = 0; i < row3.length; i++)
-                assertEquals(row3[i].toString(), valuesRow3[i]);
-        }
     }
 }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -31,6 +31,7 @@ import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.dilution.DilutionCurve;
 import org.labkey.api.assay.plate.AbstractPlateLayoutHandler;
+import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateCustomField;
 import org.labkey.api.assay.plate.PlateLayoutHandler;
@@ -196,6 +197,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             }
 
             @Override
+            @NotNull
             public String getAssayType()
             {
                 return "blank";
@@ -659,8 +661,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         // Identifying the "Biologics" folder type as the logic we pivot this behavior on is not intended to be
         // a long-term solution. We will be looking to introduce plating as a ProductFeature which we can then
         // leverage instead.
-        boolean isBiologicsProject = c.getProject() != null && "Biologics".equals(ContainerManager.getFolderTypeName(c.getProject()));
-        if (isBiologicsProject && plateSet != null)
+        if (plateSet != null && AssayPlateMetadataService.isBiologicsFolder(c))
         {
             for (Plate plate : plateSet.getPlates(user))
             {
@@ -669,11 +670,9 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             }
             return false;
         }
-        else
-        {
-            Plate plate = getPlateByName(c, name);
-            return plate != null && plate.getName().equals(name);
-        }
+
+        Plate plate = getPlateByName(c, name);
+        return plate != null && plate.getName().equals(name);
     }
 
     private Collection<Plate> getPlates(Container c)

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1879,22 +1879,6 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return PropertyService.get().getDomain(container, domainURI);
     }
 
-    /**
-     * Well metadata has transitioned to a provisioned architecture.
-     */
-    @Deprecated
-    public @Nullable Domain getPlateMetadataVocabDomain(Container container, User user)
-    {
-        DomainKind<?> vocabDomainKind = PropertyService.get().getDomainKindByName("Vocabulary");
-
-        if (vocabDomainKind == null)
-            return null;
-
-        // the domain is scoped at the project level (project and subfolder scoping)
-        String domainURI = vocabDomainKind.generateDomainURI(null, "PlateMetadataDomain", getPlateMetadataDomainContainer(container), user);
-        return PropertyService.get().getDomain(container, domainURI);
-    }
-
     public @Nullable TableInfo getPlateMetadataTable(Container container, User user)
     {
         Domain domain = getPlateMetadataDomain(container, user);
@@ -1903,7 +1887,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return null;
     }
 
-    private Container getPlateMetadataDomainContainer(Container container)
+    public Container getPlateMetadataDomainContainer(Container container)
     {
         // scope the metadata container to the project
         if (container.isRoot())

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -1,0 +1,649 @@
+package org.labkey.assay.plate;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateCustomField;
+import org.labkey.api.assay.plate.PlateLayoutHandler;
+import org.labkey.api.assay.plate.PlateSet;
+import org.labkey.api.assay.plate.PlateType;
+import org.labkey.api.assay.plate.Position;
+import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.Results;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.Sort;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.exp.api.ExpMaterial;
+import org.labkey.api.exp.api.ExpSampleType;
+import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.SampleTypeService;
+import org.labkey.api.exp.property.Domain;
+import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.security.User;
+import org.labkey.api.util.JunitUtil;
+import org.labkey.api.util.Pair;
+import org.labkey.api.util.TestContext;
+import org.labkey.assay.plate.model.WellBean;
+import org.labkey.assay.plate.query.PlateSchema;
+import org.labkey.assay.plate.query.WellTable;
+import org.labkey.assay.query.AssayDbSchema;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.labkey.api.util.JunitUtil.deleteTestContainer;
+
+public final class PlateManagerTest
+{
+    private static Container container;
+    private static User user;
+    private static ExpSampleType sampleType;
+
+    @BeforeClass
+    public static void setupTest() throws Exception
+    {
+        container = JunitUtil.getTestContainer();
+        user = TestContext.get().getUser();
+
+        PlateManager.get().deleteAllPlateData(container);
+        Domain domain = PlateManager.get().getPlateMetadataDomain(container, user);
+        if (domain != null)
+            domain.delete(user);
+
+        // create custom properties
+        List<GWTPropertyDescriptor> customFields = List.of(
+            new GWTPropertyDescriptor("barcode", "http://www.w3.org/2001/XMLSchema#string"),
+            new GWTPropertyDescriptor("concentration", "http://www.w3.org/2001/XMLSchema#double"),
+            new GWTPropertyDescriptor("negativeControl", "http://www.w3.org/2001/XMLSchema#double")
+        );
+
+        PlateManager.get().createPlateMetadataFields(container, user, customFields);
+
+        // create sample type
+        List<GWTPropertyDescriptor> props = new ArrayList<>();
+        props.add(new GWTPropertyDescriptor("col1", "string"));
+        props.add(new GWTPropertyDescriptor("col2", "string"));
+        sampleType = SampleTypeService.get().createSampleType(container, user, "SampleType1", null, props, emptyList(), 0, -1, -1, -1, null, null);
+    }
+
+    @After
+    public void cleanupTest()
+    {
+        PlateManager.get().deleteAllPlateData(container);
+    }
+
+    @AfterClass
+    public static void onComplete()
+    {
+        deleteTestContainer();
+        container = null;
+        user = null;
+    }
+
+    @Test
+    public void createPlateTemplate() throws Exception
+    {
+        //
+        // INSERT
+        //
+
+        PlateLayoutHandler handler = PlateManager.get().getPlateLayoutHandler(TsvPlateLayoutHandler.TYPE);
+        PlateType plateType = PlateManager.get().getPlateType(8, 12);
+        assertNotNull("96 well plate type was not found", plateType);
+
+        Plate template = handler.createPlate("UNUSED", container, plateType);
+        template.setName("bob");
+        template.setProperty("friendly", "yes");
+        assertNull(template.getRowId());
+        assertNull(template.getLSID());
+
+        WellGroup wg1 = template.addWellGroup("wg1", WellGroup.Type.SAMPLE,
+            PlateManager.get().createPosition(container, 0, 0),
+            PlateManager.get().createPosition(container, 0, 11)
+        );
+        wg1.setProperty("score", "100");
+        assertNull(wg1.getRowId());
+        assertNull(wg1.getLSID());
+
+        int plateId = PlateManager.get().save(container, user, template);
+
+        //
+        // VERIFY INSERT
+        //
+
+        assertNotNull(PlateManager.get().getPlate(container, plateId));
+
+        Plate savedTemplate = PlateManager.get().getPlateByName(container, "bob");
+        assertEquals(plateId, savedTemplate.getRowId().intValue());
+        assertEquals("bob", savedTemplate.getName());
+        assertEquals("yes", savedTemplate.getProperty("friendly"));
+        assertNotNull(savedTemplate.getLSID());
+        assertEquals(plateType.getRowId(), savedTemplate.getPlateType().getRowId());
+
+        List<WellGroup> wellGroups = savedTemplate.getWellGroups();
+        assertEquals(3, wellGroups.size());
+
+        // TsvPlateTypeHandler creates two CONTROL well groups "Positive" and "Negative"
+        List<WellGroup> controlWellGroups = savedTemplate.getWellGroups(WellGroup.Type.CONTROL);
+        assertEquals(2, controlWellGroups.size());
+
+        List<WellGroup> sampleWellGroups = savedTemplate.getWellGroups(WellGroup.Type.SAMPLE);
+        assertEquals(1, sampleWellGroups.size());
+        WellGroup savedWg1 = sampleWellGroups.get(0);
+        assertEquals("wg1", savedWg1.getName());
+        assertEquals("100", savedWg1.getProperty("score"));
+
+        List<Position> savedWg1Positions = savedWg1.getPositions();
+        assertEquals(12, savedWg1Positions.size());
+
+        //
+        // UPDATE
+        //
+
+        // rename plate
+        savedTemplate.setName("sally");
+
+        // add well group
+        WellGroup wg2 = savedTemplate.addWellGroup("wg2", WellGroup.Type.SAMPLE,
+                PlateManager.get().createPosition(container, 1, 0),
+                PlateManager.get().createPosition(container, 1, 11));
+
+        // rename existing well group
+        ((WellGroupImpl) savedWg1).setName("wg1_renamed");
+
+        // add positions
+        controlWellGroups.get(0).setPositions(List.of(
+                PlateManager.get().createPosition(container, 0, 0),
+                PlateManager.get().createPosition(container, 0, 1)));
+
+        // delete well group
+        ((PlateImpl) savedTemplate).markWellGroupForDeletion(controlWellGroups.get(1));
+
+        int newPlateId = PlateManager.get().save(container, user, savedTemplate);
+        assertEquals(savedTemplate.getRowId().intValue(), newPlateId);
+
+        //
+        // VERIFY UPDATE
+        //
+
+        // verify plate
+        Plate updatedTemplate = PlateManager.get().getPlate(container, plateId);
+        assertEquals("sally", updatedTemplate.getName());
+        assertEquals(savedTemplate.getLSID(), updatedTemplate.getLSID());
+
+        // verify well group rename
+        WellGroup updatedWg1 = updatedTemplate.getWellGroup(savedWg1.getRowId());
+        assertNotNull(updatedWg1);
+        assertEquals(savedWg1.getLSID(), updatedWg1.getLSID());
+        assertEquals("wg1_renamed", updatedWg1.getName());
+
+        // verify added well group
+        WellGroup updatedWg2 = updatedTemplate.getWellGroup(wg2.getRowId());
+        assertNotNull(updatedWg2);
+
+        // verify deleted well group
+        List<WellGroup> updatedControlWellGroups = updatedTemplate.getWellGroups(WellGroup.Type.CONTROL);
+        assertEquals(1, updatedControlWellGroups.size());
+
+        // verify added positions
+        assertEquals(2, updatedControlWellGroups.get(0).getPositions().size());
+
+        // verify plate type information
+        assertEquals(plateType.getRows().intValue(), updatedTemplate.getRows());
+        assertEquals(plateType.getColumns().intValue(), updatedTemplate.getColumns());
+
+        //
+        // DELETE
+        //
+
+        PlateManager.get().deletePlate(container, user, updatedTemplate.getRowId());
+
+        assertNull(PlateManager.get().getPlate(container, updatedTemplate.getRowId()));
+    }
+
+    @Test
+    public void testCreateAndSavePlate() throws Exception
+    {
+        // Arrange
+        PlateType plateType = PlateManager.get().getPlateType(8, 12);
+        assertNotNull("96 well plate type was not found", plateType);
+
+        // Act
+        PlateImpl plateImpl = new PlateImpl(container, "testCreateAndSavePlate plate", plateType);
+        Plate plate = PlateManager.get().createAndSavePlate(container, user, plateImpl, null, null);
+
+        // Assert
+        assertTrue("Expected plate to have been persisted and provided with a rowId", plate.getRowId() > 0);
+        assertNotNull("Expected plate to have been persisted and provided with a plateId", plate.getPlateId());
+
+        // verify access via plate ID
+        Plate savedPlate = PlateManager.get().getPlate(container, plate.getPlateId());
+        assertNotNull("Expected plate to be accessible via it's plate ID", savedPlate);
+        assertEquals("Plate retrieved by plate ID doesn't match the original plate.", savedPlate.getRowId(), plate.getRowId());
+
+        // verify container filter access
+        savedPlate = PlateManager.get().getPlate(ContainerManager.getSharedContainer(), plate.getRowId());
+        assertNull("Saved plate should not exist in the shared container", savedPlate);
+
+        savedPlate = PlateManager.get().getPlate(ContainerFilter.Type.CurrentAndSubfolders.create(ContainerManager.getSharedContainer(), user), plate.getRowId());
+        assertEquals("Expected plate to be accessible via a container filter", plate.getRowId(), savedPlate.getRowId());
+    }
+
+    @Test
+    public void testAccessPlateByIdentifiers() throws Exception
+    {
+        // Arrange
+        PlateType plateType = PlateManager.get().getPlateType(8, 12);
+        assertNotNull("96 well plate type was not found", plateType);
+        PlateSetImpl plateSetImpl = new PlateSetImpl();
+        plateSetImpl.setName("testAccessPlateByIdentifiersPlateSet");
+        ContainerFilter cf = ContainerFilter.Type.CurrentAndSubfolders.create(ContainerManager.getSharedContainer(), user);
+
+        // Act
+        PlateSet plateSet = PlateManager.get().createPlateSet(container, user, plateSetImpl, List.of(
+                new PlateManager.CreatePlateSetPlate("testAccessPlateByIdentifiersFirst", plateType.getRowId(), null),
+                new PlateManager.CreatePlateSetPlate("testAccessPlateByIdentifiersSecond", plateType.getRowId(), null),
+                new PlateManager.CreatePlateSetPlate("testAccessPlateByIdentifiersThird", plateType.getRowId(), null)
+        ), null);
+
+        // Assert
+        assertTrue("Expected plateSet to have been persisted and provided with a rowId", plateSet.getRowId() > 0);
+        List<Plate> plates = plateSet.getPlates(user);
+        assertEquals("Expected plateSet to have 3 plates", 3, plates.size());
+
+        // verify access via plate rowId
+        assertNotNull("Expected plate to be accessible via it's rowId", PlateManager.get().getPlate(cf, plateSet.getRowId(), plates.get(0).getRowId()));
+        assertNotNull("Expected plate to be accessible via it's rowId", PlateManager.get().getPlate(cf, plateSet.getRowId(), plates.get(1).getRowId()));
+        assertNotNull("Expected plate to be accessible via it's rowId", PlateManager.get().getPlate(cf, plateSet.getRowId(), plates.get(2).getRowId()));
+
+        // verify access via plate ID
+        assertNotNull("Expected plate to be accessible via it's plate ID", PlateManager.get().getPlate(cf, plateSet.getRowId(), plates.get(0).getPlateId()));
+        assertNotNull("Expected plate to be accessible via it's plate ID", PlateManager.get().getPlate(cf, plateSet.getRowId(), plates.get(1).getPlateId()));
+        assertNotNull("Expected plate to be accessible via it's plate ID", PlateManager.get().getPlate(cf, plateSet.getRowId(), plates.get(2).getPlateId()));
+
+        // verify access via plate name
+        assertNotNull("Expected plate to be accessible via it's name", PlateManager.get().getPlate(cf, plateSet.getRowId(), "testAccessPlateByIdentifiersFirst"));
+        // verify error when trying to access non-existing plate name
+        try
+        {
+            PlateManager.get().getPlate(cf, plateSet.getRowId(), "testAccessPlateByIdentifiersBogus");
+            fail("Expected a validation error when accessing plates by non-existing name");
+        }
+        catch (IllegalArgumentException e)
+        {
+            assertEquals("Expected validation exception", "The plate identifier \"testAccessPlateByIdentifiersBogus\" does not match any plate in the plate set \"testAccessPlateByIdentifiersPlateSet\".", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreatePlateTemplates() throws Exception
+    {
+        // Verify plate service assumptions about plate templates
+        PlateType plateType = PlateManager.get().getPlateType(16, 24);
+        assertNotNull("384 well plate type was not found", plateType);
+        Plate plate = PlateManager.get().createPlateTemplate(container, TsvPlateLayoutHandler.TYPE, plateType);
+        plate.setName("my plate template");
+        int templateId = PlateManager.get().save(container, user, plate);
+        Plate template = PlateManager.get().getPlate(container, templateId);
+
+        // Assert
+        assertNotNull("Expected plate template to be persisted", template);
+        assertTrue("Expected saved plate to have the template field set to true", template.isTemplate());
+
+        plateType = PlateManager.get().getPlateType(8, 12);
+        assertNotNull("96 well plate type was not found", plateType);
+
+        plate = PlateManager.get().createPlate(container, TsvPlateLayoutHandler.TYPE, plateType);
+        plate.setName("non plate template");
+        PlateManager.get().save(container, user, plate);
+
+        // Verify only plate templates are returned
+        List<Plate> templates = PlateManager.get().getPlateTemplates(container);
+        assertFalse("Expected there to be a plate template", templates.isEmpty());
+        for (Plate t : templates)
+            assertTrue("Expected saved plate to have the template field set to true", t.isTemplate());
+    }
+
+    @Test
+    public void testCreatePlateMetadata() throws Exception
+    {
+        PlateType plateType = PlateManager.get().getPlateType(16, 24);
+        assertNotNull("384 well plate type was not found", plateType);
+
+        Plate plate = PlateManager.get().createPlateTemplate(container, TsvPlateLayoutHandler.TYPE, plateType);
+        plate.setName("new plate with metadata");
+        int plateId = PlateManager.get().save(container, user, plate);
+
+        // Assert
+        assertTrue("Expected saved plateId to be returned", plateId != 0);
+
+        List<PlateCustomField> fields = PlateManager.get().getPlateMetadataFields(container, user);
+
+        // Verify returned sorted by name
+        assertEquals("Expected plate custom fields", 3, fields.size());
+        assertEquals("Expected barcode custom field", "barcode", fields.get(0).getName());
+        assertEquals("Expected concentration custom field", "concentration", fields.get(1).getName());
+        assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(2).getName());
+
+        // assign custom fields to the plate
+        assertEquals("Expected custom fields to be added to the plate", 3, PlateManager.get().addFields(container, user, plateId, fields).size());
+
+        // verification when adding custom fields to the plate
+        try
+        {
+            PlateManager.get().addFields(container, user, plateId, fields);
+            fail("Expected a validation error when adding existing fields");
+        }
+        catch (IllegalArgumentException e)
+        {
+            assertEquals("Expected validation exception", "Failed to add plate custom fields. Custom field \"barcode\" already is associated with this plate.", e.getMessage());
+        }
+
+        // remove a plate custom field
+        fields = PlateManager.get().removeFields(container, user, plateId, List.of(fields.get(0)));
+        assertEquals("Expected 2 plate custom fields", 2, fields.size());
+        assertEquals("Expected concentration custom field", "concentration", fields.get(0).getName());
+        assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(1).getName());
+
+        // select wells
+        SimpleFilter filter = SimpleFilter.createContainerFilter(container);
+        filter.addCondition(FieldKey.fromParts("PlateId"), plateId);
+        filter.addCondition(FieldKey.fromParts("Row"), 0);
+        List<WellBean> wells = new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), filter, new Sort("Col")).getArrayList(WellBean.class);
+
+        assertEquals("Expected 24 wells to be returned", 24, wells.size());
+
+        // update
+        TableInfo wellTable = QueryService.get().getUserSchema(user, container, PlateSchema.SCHEMA_NAME).getTable(WellTable.NAME);
+        QueryUpdateService qus = wellTable.getUpdateService();
+        assertNotNull(qus);
+        BatchValidationException errors = new BatchValidationException();
+
+        // add metadata to 2 rows
+        WellBean well = wells.get(0);
+        List<Map<String, Object>> rows = List.of(CaseInsensitiveHashMap.of(
+                "rowid", well.getRowId(),
+                "properties/concentration", 1.25,
+                "properties/negativeControl", 5.25
+        ));
+
+        qus.updateRows(user, container, rows, null, errors, null, null);
+        if (errors.hasErrors())
+            fail(errors.getMessage());
+
+        well = wells.get(1);
+        rows = List.of(CaseInsensitiveHashMap.of(
+                "rowid", well.getRowId(),
+                "properties/concentration", 2.25,
+                "properties/negativeControl", 6.25
+        ));
+
+        qus.updateRows(user, container, rows, null, errors, null, null);
+        if (errors.hasErrors())
+            fail(errors.getMessage());
+
+        FieldKey fkConcentration = FieldKey.fromParts("properties", "concentration");
+        FieldKey fkNegativeControl = FieldKey.fromParts("properties", "negativeControl");
+        Map<FieldKey, ColumnInfo> columns = QueryService.get().getColumns(wellTable, List.of(fkConcentration, fkNegativeControl));
+
+        // verify plate metadata property updates
+        try (Results r = QueryService.get().select(wellTable, columns.values(), filter, new Sort("Col")))
+        {
+            int row = 0;
+            while (r.next())
+            {
+                if (row == 0)
+                {
+                    assertEquals(1.25, r.getDouble(fkConcentration), 0);
+                    assertEquals(5.25, r.getDouble(fkNegativeControl), 0);
+                }
+                else if (row == 1)
+                {
+                    assertEquals(2.25, r.getDouble(fkConcentration), 0);
+                    assertEquals(6.25, r.getDouble(fkNegativeControl), 0);
+                }
+                else
+                {
+                    // the remainder should be null
+                    assertEquals(0, r.getDouble(fkConcentration), 0);
+                    assertEquals(0, r.getDouble(fkNegativeControl), 0);
+                }
+                row++;
+            }
+        }
+    }
+
+    @Test
+    public void testCreateAndSavePlateWithData() throws Exception
+    {
+        // Arrange
+        PlateType plateType = PlateManager.get().getPlateType(8, 12);
+        assertNotNull("96 well plate type was not found", plateType);
+
+        // Act
+        List<Map<String, Object>> rows = List.of(
+                CaseInsensitiveHashMap.of(
+                        "wellLocation", "A1",
+                        "properties/concentration", 2.25,
+                        "properties/barcode", "B1234")
+                ,
+                CaseInsensitiveHashMap.of(
+                        "wellLocation", "A2",
+                        "properties/concentration", 1.25,
+                        "properties/barcode", "B5678"
+                )
+        );
+
+        PlateImpl plateImpl = new PlateImpl(container, "hit selection plate", plateType);
+        Plate plate = PlateManager.get().createAndSavePlate(container, user, plateImpl, null, rows);
+        assertEquals("Expected 2 plate custom fields", 2, plate.getCustomFields().size());
+
+        TableInfo wellTable = QueryService.get().getUserSchema(user, container, PlateSchema.SCHEMA_NAME).getTable(WellTable.NAME);
+        FieldKey fkConcentration = FieldKey.fromParts("properties", "concentration");
+        FieldKey fkBarcode = FieldKey.fromParts("properties", "barcode");
+        Map<FieldKey, ColumnInfo> columns = QueryService.get().getColumns(wellTable, List.of(fkConcentration, fkBarcode));
+
+        // verify that well data was added
+        SimpleFilter filter = SimpleFilter.createContainerFilter(container);
+        filter.addCondition(FieldKey.fromParts("PlateId"), plate.getRowId());
+        filter.addCondition(FieldKey.fromParts("Row"), 0);
+        try (Results r = QueryService.get().select(wellTable, columns.values(), filter, new Sort("Col")))
+        {
+            int row = 0;
+            while (r.next())
+            {
+                if (row == 0)
+                {
+                    assertEquals(2.25, r.getDouble(fkConcentration), 0);
+                    assertEquals("B1234", r.getString(fkBarcode));
+                }
+                else if (row == 1)
+                {
+                    assertEquals(1.25, r.getDouble(fkConcentration), 0);
+                    assertEquals("B5678", r.getString(fkBarcode));
+                }
+                else
+                {
+                    // the remainder should be null
+                    assertEquals(0, r.getDouble(fkConcentration), 0);
+                    assertNull(r.getString(fkBarcode));
+                }
+                row++;
+            }
+        }
+    }
+
+    @Test
+    public void getWellSampleData()
+    {
+        // Act
+        int[] sampleIdsSorted = new int[]{0, 3, 5, 8, 10, 11, 12, 13, 15, 17, 19};
+        Pair<Integer, List<Map<String, Object>>> wellSampleDataFilledFull = PlateManager.get().getWellSampleData(sampleIdsSorted, 2, 3, 0, container);
+        Pair<Integer, List<Map<String, Object>>> wellSampleDataFilledPartial = PlateManager.get().getWellSampleData(sampleIdsSorted, 2, 3, 6, container);
+
+        // Assert
+        assertEquals(wellSampleDataFilledFull.first, 6, 0);
+        ArrayList<String> wellLocations = new ArrayList<>(Arrays.asList("A1", "A2", "A3", "B1", "B2", "B3"));
+        for (int i = 0; i < wellSampleDataFilledFull.second.size(); i++)
+        {
+            Map<String, Object> well = wellSampleDataFilledFull.second.get(i);
+            assertEquals(well.get("sampleId"), sampleIdsSorted[i]);
+            assertEquals(well.get("wellLocation"), wellLocations.get(i));
+        }
+
+        assertEquals(wellSampleDataFilledPartial.first, 11, 0);
+        for (int i = 0; i < wellSampleDataFilledPartial.second.size(); i++)
+        {
+            Map<String, Object> well = wellSampleDataFilledPartial.second.get(i);
+            assertEquals(well.get("sampleId"), sampleIdsSorted[i + 6]);
+            assertEquals(well.get("wellLocation"), wellLocations.get(i));
+        }
+
+        // Act
+        try
+        {
+            PlateManager.get().getWellSampleData(new int[]{}, 2, 3, 0, container);
+        }
+        // Assert
+        catch (IllegalArgumentException e)
+        {
+            assertEquals("Expected validation exception", "No samples are in the current selection.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void getInstrumentInstructions() throws Exception
+    {
+        // Arrange
+        final ExpMaterial sample1 = ExperimentService.get().createExpMaterial(container, sampleType.generateSampleLSID().setObjectId("sampleOne").toString(), "sampleOne");
+        sample1.setCpasType(sampleType.getLSID());
+        sample1.save(user);
+        final ExpMaterial sample2 = ExperimentService.get().createExpMaterial(container, sampleType.generateSampleLSID().setObjectId("sampleTwo").toString(), "sampleTwo");
+        sample2.setCpasType(sampleType.getLSID());
+        sample2.save(user);
+
+        PlateType plateType = PlateManager.get().getPlateType(8, 12);
+        assertNotNull("96 well plate type was not found", plateType);
+
+        List<Map<String, Object>> rows = List.of(
+                CaseInsensitiveHashMap.of(
+                        "wellLocation", "A1",
+                        "sampleId", sample1.getRowId(),
+                        "properties/concentration", 2.25,
+                        "properties/barcode", "B1234")
+                ,
+                CaseInsensitiveHashMap.of(
+                        "wellLocation", "A2",
+                        "sampleId", sample2.getRowId(),
+                        "properties/concentration", 1.25,
+                        "properties/barcode", "B5678"
+                )
+        );
+        Plate plate = new PlateImpl(container, "myPlate", plateType);
+        plate = PlateManager.get().createAndSavePlate(container, user, plate, null, rows);
+
+        // Act
+        Set<FieldKey> includedMetadataCols = WellTable.getMetadataColumns(plate.getPlateSet().getRowId(), container, user);
+        List<Object[]> result = PlateManager.get().getInstrumentInstructions(plate.getPlateSet().getRowId(), includedMetadataCols, container, user);
+
+        // Assert
+        Object[] row1 = result.get(0);
+        String[] valuesRow1 = new String[]{"myPlate", "A1", "96-well", "sampleOne", "B1234", "2.25"};
+        for (int i = 0; i < row1.length; i++)
+            assertEquals(row1[i].toString(), valuesRow1[i]);
+
+        Object[] row2 = result.get(1);
+        String[] valuesRow2 = new String[]{"myPlate", "A2", "96-well", "sampleTwo", "B5678", "1.25"};
+        for (int i = 0; i < row1.length; i++)
+            assertEquals(row2[i].toString(), valuesRow2[i]);
+    }
+
+    @Test
+    public void getWorklist() throws Exception
+    {
+        // Arrange
+        final ExpMaterial sample1 = ExperimentService.get().createExpMaterial(container, sampleType.generateSampleLSID().setObjectId("sampleA").toString(), "sampleA");
+        sample1.setCpasType(sampleType.getLSID());
+        sample1.save(user);
+        final ExpMaterial sample2 = ExperimentService.get().createExpMaterial(container, sampleType.generateSampleLSID().setObjectId("sampleB").toString(), "sampleB");
+        sample2.setCpasType(sampleType.getLSID());
+        sample2.save(user);
+
+        PlateType plateType = PlateManager.get().getPlateType(8, 12);
+        assertNotNull("96 well plate type was not found", plateType);
+
+        List<Map<String, Object>> rows1 = List.of(
+                CaseInsensitiveHashMap.of(
+                        "wellLocation", "A1",
+                        "sampleId", sample1.getRowId(),
+                        "properties/concentration", 2.25,
+                        "properties/barcode", "B1234")
+                ,
+                CaseInsensitiveHashMap.of(
+                        "wellLocation", "A2",
+                        "sampleId", sample2.getRowId(),
+                        "properties/concentration", 1.25,
+                        "properties/barcode", "B5678"
+                )
+        );
+        Plate plateSource = PlateManager.get().createAndSavePlate(container, user, new PlateImpl(container, "myPlate1", plateType), null, rows1);
+
+        List<Map<String, Object>> rows2 = List.of(
+                CaseInsensitiveHashMap.of(
+                        "wellLocation", "A1",
+                        "sampleId", sample2.getRowId())
+                ,
+                CaseInsensitiveHashMap.of(
+                        "wellLocation", "A2",
+                        "sampleId", sample1.getRowId())
+                ,
+                CaseInsensitiveHashMap.of(
+                        "wellLocation", "A3",
+                        "sampleId", sample2.getRowId())
+        );
+        Plate plateDestination = PlateManager.get().createAndSavePlate(container, user, new PlateImpl(container, "myPlate2", plateType), null, rows2);
+
+        // Act
+        Set<FieldKey> sourceIncludedMetadataCols = WellTable.getMetadataColumns(plateSource.getPlateSet().getRowId(), container, user);
+        Set<FieldKey> destinationIncludedMetadataCols = WellTable.getMetadataColumns(plateDestination.getPlateSet().getRowId(), container, user);
+        List<Object[]> plateDataRows = PlateManager.get().getWorklist(plateSource.getPlateSet().getRowId(), plateDestination.getPlateSet().getRowId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, container, user);
+
+        // Assert
+        Object[] row1 = plateDataRows.get(0);
+        String[] valuesRow1 = new String[]{"myPlate1", "A1", "96-well", "sampleA", "B1234", "2.25", "myPlate2", "A2", "96-well"};
+        for (int i = 0; i < row1.length; i++)
+            assertEquals(row1[i].toString(), valuesRow1[i]);
+
+        Object[] row2 = plateDataRows.get(1);
+        String[] valuesRow2 = new String[]{"myPlate1", "A2", "96-well", "sampleB", "B5678", "1.25", "myPlate2", "A1", "96-well"};
+        for (int i = 0; i < row2.length; i++)
+            assertEquals(row2[i].toString(), valuesRow2[i]);
+
+        Object[] row3 = plateDataRows.get(2);
+        String[] valuesRow3 = new String[]{"myPlate1", "A2", "96-well", "sampleB", "B5678", "1.25", "myPlate2", "A3", "96-well"};
+        for (int i = 0; i < row3.length; i++)
+            assertEquals(row3[i].toString(), valuesRow3[i]);
+    }
+}

--- a/assay/src/org/labkey/assay/plate/PlateSetImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetImpl.java
@@ -150,6 +150,12 @@ public class PlateSetImpl extends Entity implements PlateSet
         return new SqlSelector(table.getSchema(), sql).getObject(Integer.class);
     }
 
+    @JsonIgnore
+    public boolean isFull()
+    {
+        return getPlateCount() >= MAX_PLATES;
+    }
+
     public String getDescription()
     {
         return _description;

--- a/assay/src/org/labkey/assay/plate/PlateSetImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetImpl.java
@@ -33,6 +33,7 @@ public class PlateSetImpl extends Entity implements PlateSet
     private Integer _primaryPlateSetId;
     private Integer _rootPlateSetId;
     private Integer _rowId;
+    private boolean _template;
     private PlateSetType _type;
 
     @Override
@@ -177,6 +178,17 @@ public class PlateSetImpl extends Entity implements PlateSet
     public void setRootPlateSetId(Integer rootPlateSetId)
     {
         _rootPlateSetId = rootPlateSetId;
+    }
+
+    @Override
+    public boolean isTemplate()
+    {
+        return _template;
+    }
+
+    public void setTemplate(boolean template)
+    {
+        _template = template;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/PlateUrls.java
+++ b/assay/src/org/labkey/assay/plate/PlateUrls.java
@@ -20,13 +20,8 @@ import org.labkey.api.action.UrlProvider;
 import org.labkey.api.data.Container;
 import org.labkey.api.view.ActionURL;
 
-/*
-* User: adam
-* Date: Aug 30, 2009
-* Time: 9:10:07 PM
-*/
 public interface PlateUrls extends UrlProvider
 {
-    ActionURL getPlateTemplateListURL(Container c);
+    ActionURL getPlateListURL(Container c);
     ActionURL getPlateDetailsURL(Container c);
 }

--- a/assay/src/org/labkey/assay/plate/TsvPlateLayoutHandler.java
+++ b/assay/src/org/labkey/assay/plate/TsvPlateLayoutHandler.java
@@ -20,7 +20,7 @@ public class TsvPlateLayoutHandler extends AbstractPlateLayoutHandler
     public static final String TYPE = "Standard";
 
     @Override
-    public String getAssayType()
+    public @NotNull String getAssayType()
     {
         return TYPE;
     }
@@ -33,15 +33,15 @@ public class TsvPlateLayoutHandler extends AbstractPlateLayoutHandler
     }
 
     @Override
-    public Plate createTemplate(@Nullable String templateTypeName, Container container, @NotNull PlateType plateType)
+    public Plate createPlate(@Nullable String plateName, Container container, @NotNull PlateType plateType)
     {
         validatePlateType(plateType);
-        Plate template = PlateService.get().createPlateTemplate(container, getAssayType(), plateType);
+        Plate plate = PlateService.get().createPlate(container, getAssayType(), plateType);
 
-        template.addWellGroup("Positive", WellGroup.Type.CONTROL, Collections.emptyList());
-        template.addWellGroup("Negative", WellGroup.Type.CONTROL, Collections.emptyList());
+        plate.addWellGroup("Positive", WellGroup.Type.CONTROL, Collections.emptyList());
+        plate.addWellGroup("Negative", WellGroup.Type.CONTROL, Collections.emptyList());
 
-        return template;
+        return plate;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/model/PlateBean.java
+++ b/assay/src/org/labkey/assay/plate/model/PlateBean.java
@@ -1,6 +1,5 @@
 package org.labkey.assay.plate.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import org.labkey.api.data.Entity;
 import org.labkey.assay.plate.PlateImpl;
 
@@ -9,6 +8,7 @@ import org.labkey.assay.plate.PlateImpl;
  */
 public class PlateBean extends Entity
 {
+    private Boolean _archived;
     private Integer _rowId;
     private String _lsid;
     private String _name;
@@ -25,6 +25,7 @@ public class PlateBean extends Entity
         PlateBean bean = new PlateBean();
 
         bean.setRowId(plate.getRowId());
+        bean.setArchived(plate.isArchived());
         bean.setLsid(plate.getLSID());
         bean.setName(plate.getName());
         bean.setTemplate(plate.isTemplate());
@@ -36,6 +37,16 @@ public class PlateBean extends Entity
         bean.setDescription(plate.getDescription());
 
         return bean;
+    }
+
+    public Boolean getArchived()
+    {
+        return _archived;
+    }
+
+    public void setArchived(Boolean archived)
+    {
+        _archived = archived;
     }
 
     public Integer getRowId()

--- a/assay/src/org/labkey/assay/plate/query/DuplicatePlateValidator.java
+++ b/assay/src/org/labkey/assay/plate/query/DuplicatePlateValidator.java
@@ -48,7 +48,7 @@ public class DuplicatePlateValidator extends WrapperDataIterator
         if (name != null & plateSet != null)
         {
             PlateSet ps = PlateManager.get().getPlateSet(_container, plateSet);
-            if (PlateManager.get().isDuplicatePlate(_container, _user, name, ps))
+            if (PlateManager.get().isDuplicatePlateName(_container, _user, name, ps))
                 _context.getErrors().addRowError(new ValidationException("Plate with name : " + name + " already exists."));
         }
         return true;

--- a/assay/src/org/labkey/assay/plate/query/PlateTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTable.java
@@ -276,7 +276,9 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
                 String newName = (String) row.get("Name");
                 if (newName != null && !newName.equals(oldName))
                 {
-                    if (PlateManager.get().isDuplicatePlate(container, user, newName, plate.getPlateSet()))
+                    if (plate.isTemplate() && PlateManager.get().isDuplicatePlateTemplateName(container, newName))
+                        throw new QueryUpdateServiceException(String.format("Plate template with name \"%s\" already exists.", newName));
+                    if (PlateManager.get().isDuplicatePlateName(container, user, newName, plate.getPlateSet()))
                         throw new QueryUpdateServiceException("Plate with name : " + newName + " already exists.");
                 }
             }

--- a/assay/src/org/labkey/assay/plate/view/copyTemplate.jsp
+++ b/assay/src/org/labkey/assay/plate/view/copyTemplate.jsp
@@ -20,7 +20,7 @@
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.assay.PlateController.CopyTemplateBean" %>
 <%@ page import="org.labkey.assay.PlateController.HandleCopyAction" %>
-<%@ page import="org.labkey.assay.PlateController.PlateTemplateListAction" %>
+<%@ page import="org.labkey.assay.PlateController.PlateListAction" %>
 <%@ page import="java.util.List" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -41,7 +41,7 @@
             <labkey:form action="<%=urlFor(HandleCopyAction.class)%>" method="POST">
                 <input type="hidden" name="destination" value="<%= h(bean.getSelectedDestination()) %>">
                 <input type="hidden" name="plateId" value="<%= bean.getPlate().getRowId() %>">
-                <%= button("Cancel").href(PlateTemplateListAction.class, getContainer()) %>
+                <%= button("Cancel").href(PlateListAction.class, getContainer()) %>
                 <%= bean.getSelectedDestination() != null ? button("Copy").submit(true) : button("Copy").submit(true).onClick("alert('Please select a destination folder.'); return false;") %>
             </labkey:form>
         </td>

--- a/assay/src/org/labkey/assay/plate/view/plateList.jsp
+++ b/assay/src/org/labkey/assay/plate/view/plateList.jsp
@@ -123,13 +123,12 @@
                     .build());
         }
 %>
-<br/>
 <h4>Create New Plate</h4>
 <labkey:form method="POST" layout="inline" id="qc_form">
     <%= new Select.SelectBuilder()
             .name("template")
             .id("plate_template")
-            .layout(Input.Layout.HORIZONTAL)
+            .layout(Input.Layout.INLINE)
             .required(true)
             .formGroup(true)
             .addOptions(options)
@@ -139,7 +138,7 @@
 <%
     }
 %>
-
+<br/>
 <h4>Available Plates</h4>
 <table class="labkey-data-region-legacy labkey-show-borders">
     <tr>

--- a/assay/src/org/labkey/assay/plate/view/plateList.jsp
+++ b/assay/src/org/labkey/assay/plate/view/plateList.jsp
@@ -41,12 +41,13 @@
 <%
     JspView<PlateController.PlateTemplateListBean> me = (JspView<PlateController.PlateTemplateListBean>) HttpView.currentView();
     Container c = getContainer();
-    List<? extends Plate> plateTemplates = me.getModelBean().getTemplates();
-    Map<Plate, Integer> plateTemplateRunCount = new HashMap<>();
-    for (Plate template : plateTemplates)
+    List<? extends Plate> plates = me.getModelBean().getTemplates();
+    Map<Plate, Integer> plateRunCount = new HashMap<>();
+    boolean isAssayDesigner = c.hasPermission(getUser(), DesignAssayPermission.class);
+    for (Plate plate : plates)
     {
-        int count = PlateService.get().getRunCountUsingPlate(c, getUser(), template);
-        plateTemplateRunCount.put(template, count);
+        int count = PlateService.get().getRunCountUsingPlate(c, getUser(), plate);
+        plateRunCount.put(plate, count);
     }
 %>
 
@@ -102,7 +103,44 @@
     <input type="hidden" name="plateId" id="plateId" value="">
 </labkey:form>
 
-<h4>Available Plate Templates</h4>
+<%
+    if (isAssayDesigner || c.hasPermission(getUser(), InsertPermission.class))
+    {
+        List<Option> options = new ArrayList<>();
+        for (PlateManager.PlateLayout layout : PlateManager.get().getPlateLayouts())
+        {
+            ActionURL designerURL = new ActionURL(PlateController.DesignerAction.class, c);
+            designerURL.addParameter("rowCount", layout.type().getRows());
+            designerURL.addParameter("colCount", layout.type().getColumns());
+            designerURL.addParameter("assayType", layout.assayType());
+
+            if (layout.name() != null)
+                designerURL.replaceParameter("templateType", layout.name());
+
+            options.add(new Option.OptionBuilder()
+                    .label("new " + layout.description() + " template")
+                    .value(designerURL.toString())
+                    .build());
+        }
+%>
+<br/>
+<h4>Create New Plate</h4>
+<labkey:form method="POST" layout="inline" id="qc_form">
+    <%= new Select.SelectBuilder()
+            .name("template")
+            .id("plate_template")
+            .layout(Input.Layout.HORIZONTAL)
+            .required(true)
+            .formGroup(true)
+            .addOptions(options)
+    %>
+    <labkey:button text="create" submit="false" onclick="createPlateTemplate();" id="create-btn"/>
+</labkey:form>
+<%
+    }
+%>
+
+<h4>Available Plates</h4>
 <table class="labkey-data-region-legacy labkey-show-borders">
     <tr>
         <td class="labkey-column-header">Name</td>
@@ -112,10 +150,9 @@
     </tr>
 <%
     int index = 0;
-    boolean isAssayDesigner = c.hasPermission(getUser(), DesignAssayPermission.class);
-    for (Plate template : plateTemplates)
+    for (Plate plate : plates)
     {
-        Integer runCount = plateTemplateRunCount.get(template);
+        Integer runCount = plateRunCount.get(plate);
 
         Link.LinkBuilder editLink = new Link.LinkBuilder("edit");
         if (runCount > 0)
@@ -126,12 +163,12 @@
         }
         else
         {
-            editLink.href(template.detailsURL());
+            editLink.href(plate.detailsURL());
         }
 %>
     <tr class="<%=getShadeRowClass(index)%>">
-        <td><%= h(template.getName()) %></td>
-        <td><%= h(template.getAssayType()) %></td>
+        <td><%= h(plate.getName()) %></td>
+        <td><%= h(plate.getAssayType()) %></td>
         <td><%= h(runCount) %></td>
         <td>
         <%
@@ -146,20 +183,20 @@
         %>
             <%= link("edit a copy", new ActionURL(PlateController.DesignerAction.class, getContainer()).
                 addParameter("copy", true).
-                addParameter("templateName", template.getName()).
-                addParameter("plateId", template.getRowId())) %>
+                addParameter("templateName", plate.getName()).
+                addParameter("plateId", plate.getRowId())) %>
         <%
             }
             if (c.hasPermission(getUser(), InsertPermission.class))
             {
         %>
             <%= link("copy to another folder", new ActionURL(PlateController.CopyTemplateAction.class, getContainer()).
-                addParameter("plateId", template.getRowId())) %>
+                addParameter("plateId", plate.getRowId())) %>
         <%
             }
             if (isAssayDesigner || c.hasPermission(getUser(), DeletePermission.class))
             {
-                if (plateTemplates.size() > 1)
+                if (plates.size() > 1)
                 {
                     Link.LinkBuilder deleteLink = new Link.LinkBuilder("delete");
                     if (runCount > 0)
@@ -170,7 +207,7 @@
                     }
                     else
                     {
-                        deleteLink.onClick("deletePlate(" + q(template.getName()) + "," + template.getRowId() + ")");
+                        deleteLink.onClick("deletePlate(" + q(plate.getName()) + "," + plate.getRowId() + ")");
                     }
         %>
                     <%= deleteLink %>
@@ -190,46 +227,11 @@
         index++;
     }
 
-    if (plateTemplates == null || plateTemplates.isEmpty())
+    if (plates == null || plates.isEmpty())
     {
 %>
-        <tr><td colspan="2" style="padding: 3px;">No plate templates available.</td></tr>
+        <tr><td colspan="2" style="padding: 3px;">No plates available.</td></tr>
 <%
     }
 %>
 </table>
-
-<%
-    if (isAssayDesigner || c.hasPermission(getUser(), InsertPermission.class))
-    {
-        List<Option> templates = new ArrayList<>();
-        for (PlateManager.PlateLayout layout : PlateManager.get().getPlateLayouts())
-        {
-            ActionURL designerURL = new ActionURL(PlateController.DesignerAction.class, c);
-            designerURL.addParameter("rowCount", layout.type().getRows());
-            designerURL.addParameter("colCount", layout.type().getColumns());
-            designerURL.addParameter("assayType", layout.assayType());
-
-            if (layout.name() != null)
-                designerURL.replaceParameter("templateType", layout.name());
-
-            templates.add(new Option.OptionBuilder()
-                    .label("new " + layout.description() + " template")
-                    .value(designerURL.toString())
-                    .build());
-        }
-%>
-        <br/>
-        <h4>Create New Plate Template</h4>
-        <labkey:form method="POST" layout="inline" id="qc_form">
-            <%= new Select.SelectBuilder().name("template").id("plate_template")
-                    .layout(Input.Layout.HORIZONTAL)
-                    .required(true)
-                    .formGroup(true)
-                    .addOptions(templates)
-            %>
-            <labkey:button text="create" submit="false" onclick="createPlateTemplate();" id="create-btn"/>
-        </labkey:form>
-<%
-    }
-%>

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -918,6 +918,10 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
     public Map<String, Attachment> getAttachments(AttachmentParent parent, Collection<String> names)
     {
         checkSecurityPolicy(parent);
+
+        if (names == null || names.isEmpty())
+            return Collections.emptyMap();
+
         Map<String, Attachment> attachments = new HashMap<>();
 
         if (parent instanceof AttachmentDirectory)


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-ui-premium/pull/400 for primary rationale. The "Plate Templates" support of plates in LKS has been re-labeled as "Plates". The plate listing page will now only show non-standard assay type plates and only supports creation of non-standard assay type plates.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/400
- https://github.com/LabKey/platform/pull/5467
- https://github.com/LabKey/limsModules/pull/213
- https://github.com/LabKey/commonAssays/pull/755
- https://github.com/LabKey/testAutomation/pull/1911

#### Changes
- Schema upgrade to add templates bit to plate sets and plates and archive to plates.
- Update schema XML accordingly.
- Use `ServiceRegistry` pattern for `AssayPlateMetadataService`. Refactor usages.
- Update `createAndSavePlate()` to take a `Plate` instead of a bunch of properties.
- Extract `saveWellData` method from `createAndSavePlate()` for slightly better incapsulation.
- Remove `copyPlate()` from the `PlateService` as this is not needed externally.
- New `PlateManager.copyPlate()` method that fully hydrates and persists a copy of a plate or plate template.
- Rename `PlateManager.copyPlate()` to `PlateManager.copyPlateDeprecated()` in favor of new `copyPlate()` method.
- Add capability to clear plate cache for an arbitrary set of plate rowIds.
- Refactor `archivePlateSets()` to `archive()` which now handles archive/restore of plates and plate sets.