### PR TITLE
Issue 50190: Plate Well Position Label Update for Expected Sorting

### DIFF
--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -112,6 +112,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
         }
         positionSql.append(" END)");
         var positionCol = new ExprColumn(this, "Position", positionSql, JdbcType.VARCHAR);
+        positionCol.setSortFieldKeys(List.of(FieldKey.fromParts("RowId")));
         positionCol.setUserEditable(false);
         addColumn(positionCol);
 

--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -3,6 +3,7 @@ package org.labkey.assay.plate.query;
 import org.apache.logging.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateCustomField;
 import org.labkey.api.assay.plate.PlateSet;
@@ -48,6 +49,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.util.UnexpectedException;
 import org.labkey.assay.plate.PlateManager;
 import org.labkey.assay.query.AssayDbSchema;
 
@@ -308,7 +310,23 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
     public QueryUpdateService getUpdateService()
     {
         TableInfo provisionedTable = null;
-        Domain domain = PlateManager.get().getPlateMetadataDomain(getContainer(), getUserSchema().getUser());
+        final Container container = getContainer();
+        final User user = getUserSchema().getUser();
+
+        // Ensure the plate metadata domain exists for Biologics folders before creating a plate.
+        Domain domain = PlateManager.get().getPlateMetadataDomain(container, user);
+        if (domain == null && AssayPlateMetadataService.isBiologicsFolder(container))
+        {
+            try
+            {
+                domain = PlateManager.get().ensurePlateMetadataDomain(container, user);
+            }
+            catch (ValidationException e)
+            {
+                throw UnexpectedException.wrap(e);
+            }
+        }
+
         if (domain != null)
             provisionedTable = StorageProvisioner.createTableInfo(domain);
 


### PR DESCRIPTION
#### Rationale
This seeks to address [Issue 50190](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50190) by sorting by Well.RowId instead of Well.Position in the hit selection queries. This assumes that the rows are fully populated (as opposed to sparsely) in order in the well table.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/218

#### Changes
- Add a "sort column" of plate.Well.RowId for the plate.Well.Position column
- Add defensive creation of the plate metadata domain before inserting/updating rows.
