### PR TITLE
Issue 50299: Sample Type grid "Edit in Bulk" doesn't always save files to the file system

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2182,7 +2182,8 @@ public class ExpDataIterators
             if (null != _fileLinkDirectory)
             {
                 boolean hasFileLink = false;
-                // Issue 50299: getColumnCount() is 1-based, so we need <= (see comment at top of DataIterator.java re: 1-based and _rowNumber column)
+                // Issue 50299: getColumnCount() subtracts 1 for the _rowNumber column at the 0-index,
+                // so we need <= here to make sure to check all columnInfos (see comment at top of DataIterator.java re: 1-based and _rowNumber column)
                 for (int i = 0; i <= input.getColumnCount(); i++)
                     hasFileLink |= PropertyType.FILE_LINK == input.getColumnInfo(i).getPropertyType();
                 if (hasFileLink)

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2182,7 +2182,8 @@ public class ExpDataIterators
             if (null != _fileLinkDirectory)
             {
                 boolean hasFileLink = false;
-                for (int i = 0; i < input.getColumnCount(); i++)
+                // Issue 50299: getColumnCount() is 1-based, so we need <= (see comment at top of DataIterator.java re: 1-based and _rowNumber column)
+                for (int i = 0; i <= input.getColumnCount(); i++)
                     hasFileLink |= PropertyType.FILE_LINK == input.getColumnInfo(i).getPropertyType();
                 if (hasFileLink)
                     input = LoggingDataIterator.wrap(new FileLinkDataIterator(input, context, _container, _fileLinkDirectory));


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50299
- "off by one column count" when checking for hasFileLink column in the updated columnInfos

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/222

#### Changes
- ExpDataIterator update to look at all input columnInfos to determine if FileLinkDataIterator is needed
