### PR TITLE
Export Plates to TSV, CSV, and Excel

### DIFF
--- a/api/src/org/labkey/api/data/ExcelCellUtils.java
+++ b/api/src/org/labkey/api/data/ExcelCellUtils.java
@@ -15,6 +15,11 @@ import java.text.Format;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
+/**
+ * This is a utility class that contains the necessary methods for writing properly formatted values to Excel cells.
+ * This logic was previously housed directly in ExcelColumn, however with the introduction of PlateMapExcelWriter we
+ * needed a shared location for rendering formatted values to Excel cells.
+ */
 public class ExcelCellUtils
 {
     public static final int TYPE_UNKNOWN = 0;

--- a/api/src/org/labkey/api/data/ExcelCellUtils.java
+++ b/api/src/org/labkey/api/data/ExcelCellUtils.java
@@ -1,0 +1,213 @@
+package org.labkey.api.data;
+
+import jakarta.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.FastDateFormat;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.labkey.api.util.DateUtil;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.sql.Time;
+import java.text.Format;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+public class ExcelCellUtils
+{
+    public static final int TYPE_UNKNOWN = 0;
+    public static final int TYPE_INT = 1;
+    public static final int TYPE_DOUBLE = 2;
+    public static final int TYPE_STRING = 3;
+    public static final int TYPE_MULTILINE_STRING = 4;
+    public static final int TYPE_DATE = 5;
+    public static final int TYPE_BOOLEAN = 6;
+    public static final int TYPE_FILE = 7;
+    public static final int TYPE_TIME = 8;
+
+    private static final Date EXCEL_DATE_0 = (new GregorianCalendar(1900, 1, 1)).getTime();
+
+    public static int getSimpleType(DisplayColumn dc)
+    {
+        Class valueClass = dc.getDisplayValueClass();
+
+        if (Integer.class.isAssignableFrom(valueClass) || Integer.TYPE.isAssignableFrom(valueClass) ||
+                Long.class.isAssignableFrom(valueClass) || Long.TYPE.isAssignableFrom(valueClass) ||
+                Short.class.isAssignableFrom(valueClass) || Short.TYPE.isAssignableFrom(valueClass))
+            return TYPE_INT;
+        else if (Float.class.isAssignableFrom(valueClass) || Float.TYPE.isAssignableFrom(valueClass) ||
+                Double.class.isAssignableFrom(valueClass) || Double.TYPE.isAssignableFrom(valueClass) ||
+                BigDecimal.class.isAssignableFrom(valueClass))
+            return TYPE_DOUBLE;
+        else if (String.class.isAssignableFrom(valueClass))
+        {
+            if (dc.getColumnInfo() != null && dc.getColumnInfo().getInputRows() > 1)
+            {
+                return TYPE_MULTILINE_STRING;
+            }
+            return TYPE_STRING;
+        }
+        else if (Date.class.isAssignableFrom(valueClass))
+        {
+            if (Time.class.isAssignableFrom(valueClass))
+                return TYPE_TIME;
+            else
+                return TYPE_DATE;
+        }
+        else if (Boolean.class.isAssignableFrom(valueClass) || Boolean.TYPE.isAssignableFrom(valueClass))
+            return TYPE_BOOLEAN;
+        else if (File.class.isAssignableFrom(valueClass))
+            return TYPE_FILE;
+        else
+        {
+            return TYPE_UNKNOWN;
+        }
+    }
+
+    public static String getFormatString(int simpleType, @Nullable String formatString)
+    {
+        if (formatString != null)
+        {
+            if (simpleType == TYPE_DATE || simpleType == TYPE_TIME)
+            {
+                formatString = formatString.replaceAll("aa", "a").replaceAll("a", "AM/PM");
+            } else if (simpleType == TYPE_INT || simpleType == TYPE_DOUBLE)
+            {
+                // Excel has a different idea of how to represent scientific notation, so be sure that we
+                // transform the Java format if needed.
+                // https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=17735
+                formatString = formatString.replaceAll("[eE][^\\+]", "E+0");
+            }
+
+            return formatString;
+        }
+
+        switch (simpleType)
+        {
+            case(TYPE_DATE):
+                return DateUtil.getStandardDateFormatString();
+            case(TYPE_TIME):
+                return DateUtil.getStandardTimeFormatString();
+            case(TYPE_INT):
+                return "0";
+            case(TYPE_DOUBLE):
+                return "0.0000";
+            default:
+                return null;
+        }
+    }
+
+    public static CellStyle createCellStyle(Workbook workbook, int simpleType, @Nullable String formatString)
+    {
+        if (formatString == null)
+            formatString = getFormatString(simpleType, formatString);
+
+        CellStyle style = workbook.createCellStyle();
+
+        switch (simpleType)
+        {
+            case(TYPE_INT):
+            case(TYPE_DOUBLE):
+            case(TYPE_DATE):
+            case(TYPE_TIME):
+            {
+                short formatIndex = workbook.createDataFormat().getFormat(formatString);
+                style.setDataFormat(formatIndex);
+                return style;
+            }
+            case(TYPE_MULTILINE_STRING):
+            {
+                style.setWrapText(true);
+                return style;
+            }
+            default:
+                return null;
+        }
+    }
+
+    public static void writeCell(Cell cell, CellStyle style, int simpleType, String formatString, ColumnInfo columnInfo, Object value)
+    {
+        switch (simpleType)
+        {
+            case (TYPE_DATE):
+                // Careful here... need to make sure we adjust dates for GMT.  This constructor automatically does the conversion, but there seem to be
+                // bugs in other jxl 2.5.7 constructors: DateTime(c, r, d) forces the date to time-only, DateTime(c, r, d, gmt) doesn't adjust for gmt
+                if (value instanceof Date dateVal)
+                {
+                    if (dateVal.compareTo(EXCEL_DATE_0) < 0)
+                    {
+                        if (StringUtils.isEmpty(formatString))
+                            cell.setCellValue(value.toString());
+                        else
+                        {
+                            // dates before 1900 are invalid for excel, export as formatted string instead
+                            formatString = formatString.replaceAll("AM/PM", "a");
+                            Format formatter = FastDateFormat.getInstance(formatString);
+                            cell.setCellValue(formatter.format(dateVal));
+                        }
+                    }
+                    else
+                        cell.setCellValue((Date) value);
+                    cell.setCellStyle(style);
+                }
+                else
+                {
+                    cell.setCellValue(value.toString());
+                }
+                break;
+            case (TYPE_TIME):
+                if (value instanceof Time t)
+                {
+                    cell.setCellValue(t);
+                    cell.setCellStyle(style);
+                }
+                else
+                    cell.setCellValue(value.toString());
+                break;
+            case (TYPE_INT):
+            case (TYPE_DOUBLE):
+                if (value instanceof Number n)
+                {
+                    cell.setCellValue(n.doubleValue());
+                    cell.setCellStyle(style);
+                }
+                //Issue 47268: Export Does Not Include Failed Lookup Values
+                //Set Integer broken lookup values as String
+                else if (columnInfo != null && columnInfo.isLookup() && value.toString().startsWith("<") && value.toString().endsWith(">"))
+                {
+                    cell.setCellValue(value.toString());
+                }
+                break;
+            case(TYPE_STRING):
+            default:
+                // 9729 : CRs are doubled in list data exported to Excel, normalize newlines as '\n'
+                String s = value.toString().replaceAll("\r\n", "\n");
+
+                // Check if the string is too long
+                if (s.length() > 32767)
+                {
+                    s = s.substring(0, 32762) + "...";
+                }
+
+                cell.setCellValue(s);
+                if (style != null)
+                    cell.setCellStyle(style);
+                break;
+        }
+    }
+
+    public static void writeCell(Workbook workbook, Cell cell, DisplayColumn displayColumn, Object value)
+    {
+        int simpleType = getSimpleType(displayColumn);
+        String formatString = displayColumn.getExcelFormatString();
+
+        if (formatString == null)
+            formatString = displayColumn.getFormatString();
+
+        formatString = getFormatString(simpleType, formatString);
+        CellStyle style = createCellStyle(workbook, simpleType, formatString);
+        writeCell(cell, style, simpleType, formatString, displayColumn.getColumnInfo(), value);
+    }
+}

--- a/api/src/org/labkey/api/data/ExcelCellUtils.java
+++ b/api/src/org/labkey/api/data/ExcelCellUtils.java
@@ -1,6 +1,6 @@
 package org.labkey.api.data;
 
-import jakarta.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.apache.poi.ss.usermodel.Cell;

--- a/api/src/org/labkey/api/data/ExcelCellUtils.java
+++ b/api/src/org/labkey/api/data/ExcelCellUtils.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.math.BigDecimal;
 import java.sql.Time;
 import java.text.Format;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
@@ -32,7 +33,7 @@ public class ExcelCellUtils
     public static final int TYPE_FILE = 7;
     public static final int TYPE_TIME = 8;
 
-    private static final Date EXCEL_DATE_0 = (new GregorianCalendar(1900, 1, 1)).getTime();
+    private static final Date EXCEL_DATE_0 = (new GregorianCalendar(1900, Calendar.JANUARY, 1)).getTime();
 
     public static int getSimpleType(DisplayColumn dc)
     {
@@ -78,7 +79,8 @@ public class ExcelCellUtils
             if (simpleType == TYPE_DATE || simpleType == TYPE_TIME)
             {
                 formatString = formatString.replaceAll("aa", "a").replaceAll("a", "AM/PM");
-            } else if (simpleType == TYPE_INT || simpleType == TYPE_DOUBLE)
+            }
+            else if (simpleType == TYPE_INT || simpleType == TYPE_DOUBLE)
             {
                 // Excel has a different idea of how to represent scientific notation, so be sure that we
                 // transform the Java format if needed.
@@ -89,19 +91,14 @@ public class ExcelCellUtils
             return formatString;
         }
 
-        switch (simpleType)
+        return switch (simpleType)
         {
-            case(TYPE_DATE):
-                return DateUtil.getStandardDateFormatString();
-            case(TYPE_TIME):
-                return DateUtil.getStandardTimeFormatString();
-            case(TYPE_INT):
-                return "0";
-            case(TYPE_DOUBLE):
-                return "0.0000";
-            default:
-                return null;
-        }
+            case (TYPE_DATE) -> DateUtil.getStandardDateFormatString();
+            case (TYPE_TIME) -> DateUtil.getStandardTimeFormatString();
+            case (TYPE_INT) -> "0";
+            case (TYPE_DOUBLE) -> "0.0000";
+            default -> null;
+        };
     }
 
     public static CellStyle createCellStyle(Workbook workbook, int simpleType, @Nullable String formatString)
@@ -111,25 +108,21 @@ public class ExcelCellUtils
 
         CellStyle style = workbook.createCellStyle();
 
-        switch (simpleType)
+        return switch (simpleType)
         {
-            case(TYPE_INT):
-            case(TYPE_DOUBLE):
-            case(TYPE_DATE):
-            case(TYPE_TIME):
+            case (TYPE_INT), (TYPE_DOUBLE), (TYPE_DATE), (TYPE_TIME) ->
             {
                 short formatIndex = workbook.createDataFormat().getFormat(formatString);
                 style.setDataFormat(formatIndex);
-                return style;
+                yield style;
             }
-            case(TYPE_MULTILINE_STRING):
+            case (TYPE_MULTILINE_STRING) ->
             {
                 style.setWrapText(true);
-                return style;
+                yield style;
             }
-            default:
-                return null;
-        }
+            default -> null;
+        };
     }
 
     public static void writeCell(Cell cell, CellStyle style, int simpleType, String formatString, ColumnInfo columnInfo, Object value)

--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -78,7 +78,6 @@ import java.text.Format;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,8 +101,6 @@ public class ExcelColumn extends RenderColumn
     private static final double MAX_IMAGE_RATIO = 0.75;
     private static final double MAX_IMAGE_HEIGHT = 400.0;
     private static final double MAX_IMAGE_WIDTH = 300.0;
-
-    private static final Date EXCEL_DATE_0 = (new GregorianCalendar(1900, 1, 1)).getTime();
 
     // CONSIDER: Add support for left/right/center alignment (from DisplayColumn)
     private int _simpleType = ExcelCellUtils.TYPE_UNKNOWN;

--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -195,39 +195,12 @@ public class ExcelColumn extends RenderColumn
 
     private void setSimpleType(DisplayColumn dc)
     {
-        Class valueClass = dc.getDisplayValueClass();
+        _simpleType = ExcelCellUtils.getSimpleType(dc);
 
-        if (Integer.class.isAssignableFrom(valueClass) || Integer.TYPE.isAssignableFrom(valueClass) ||
-                Long.class.isAssignableFrom(valueClass) || Long.TYPE.isAssignableFrom(valueClass) ||
-                Short.class.isAssignableFrom(valueClass) || Short.TYPE.isAssignableFrom(valueClass))
-            _simpleType = TYPE_INT;
-        else if (Float.class.isAssignableFrom(valueClass) || Float.TYPE.isAssignableFrom(valueClass) ||
-                Double.class.isAssignableFrom(valueClass) || Double.TYPE.isAssignableFrom(valueClass) ||
-                BigDecimal.class.isAssignableFrom(valueClass))
-            _simpleType = TYPE_DOUBLE;
-        else if (String.class.isAssignableFrom(valueClass))
+        if (_simpleType == ExcelCellUtils.TYPE_UNKNOWN)
         {
-            _simpleType = TYPE_STRING;
-            if (_dc.getColumnInfo() != null && _dc.getColumnInfo().getInputRows() > 1)
-            {
-                _simpleType = TYPE_MULTILINE_STRING;
-            }
-        }
-        else if (Date.class.isAssignableFrom(valueClass))
-        {
-            if (Time.class.isAssignableFrom(valueClass))
-                _simpleType = TYPE_TIME;
-            else
-                _simpleType = TYPE_DATE;
-        }
-        else if (Boolean.class.isAssignableFrom(valueClass) || Boolean.TYPE.isAssignableFrom(valueClass))
-            _simpleType = TYPE_BOOLEAN;
-        else if (File.class.isAssignableFrom(valueClass))
-            _simpleType = TYPE_FILE;
-        else
-        {
+            Class valueClass = dc.getDisplayValueClass();
             _log.error("init: Unknown Class " + valueClass + " " + getName());
-            _simpleType = TYPE_UNKNOWN;
         }
     }
 
@@ -236,28 +209,7 @@ public class ExcelColumn extends RenderColumn
     public String getFormatString()
     {
         String formatString = super.getFormatString();
-
-        if (formatString != null && (_simpleType == TYPE_DATE || _simpleType == TYPE_TIME))
-        {
-            formatString = formatString.replaceAll("aa", "a").replaceAll("a", "AM/PM");
-        }
-
-        if (null != formatString)
-            return formatString;
-
-        switch (_simpleType)
-        {
-            case(TYPE_DATE):
-                return DateUtil.getStandardDateFormatString();
-            case(TYPE_TIME):
-                return DateUtil.getStandardTimeFormatString();
-            case(TYPE_INT):
-                return "0";
-            case(TYPE_DOUBLE):
-                return "0.0000";
-        }
-
-        return null;
+        return ExcelCellUtils.getFormatString(_simpleType, formatString);
     }
 
 
@@ -266,51 +218,41 @@ public class ExcelColumn extends RenderColumn
     {
         super.setFormatString(formatString);
 
+        ExcelFormatDescriptor formatDescriptor = null;
+
         switch (_simpleType)
         {
             case(TYPE_INT):
             case(TYPE_DOUBLE):
             {
-                ExcelFormatDescriptor formatDescriptor = new ExcelFormatDescriptor(Number.class, getFormatString());
-                _style = _formatters.get(formatDescriptor);
-                if (_style == null)
-                {
-                    _style = _workbook.createCellStyle();
-                    String excelFormatString = getFormatString();
-                    // Excel has a different idea of how to represent scientific notation, so be sure that we
-                    // transform the Java format if needed.
-                    // https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=17735
-                    excelFormatString = excelFormatString.replaceAll("[eE][^\\+]", "E+0");
-                    short formatIndex = _workbook.createDataFormat().getFormat(excelFormatString);
-                    _style.setDataFormat(formatIndex);
-                    _formatters.put(formatDescriptor, _style);
-                }
+                formatDescriptor = new ExcelFormatDescriptor(Number.class, getFormatString());
                 break;
             }
             case(TYPE_DATE):
+            {
+                formatDescriptor = new ExcelFormatDescriptor(Date.class, getFormatString());
+                break;
+            }
             case(TYPE_TIME):
             {
-                ExcelFormatDescriptor formatDescriptor = new ExcelFormatDescriptor(_simpleType == TYPE_TIME ? Time.class : Date.class, getFormatString());
-                _style = _formatters.get(formatDescriptor);
-                if (_style == null)
-                {
-                    _style = _workbook.createCellStyle();
-                    short formatIndex = _workbook.createDataFormat().getFormat(getFormatString());
-                    _style.setDataFormat(formatIndex);
-                    _formatters.put(formatDescriptor, _style);
-                }
+                formatDescriptor = new ExcelFormatDescriptor(Time.class, getFormatString());
                 break;
             }
             case(TYPE_MULTILINE_STRING):
             {
-                ExcelFormatDescriptor formatDescriptor = new ExcelFormatDescriptor(String.class, getFormatString());
-                _style = _formatters.get(formatDescriptor);
-                if (_style == null)
-                {
-                    _style = _workbook.createCellStyle();
-                    _style.setWrapText(true);
-                    _formatters.put(formatDescriptor, _style);
-                }
+                formatDescriptor = new ExcelFormatDescriptor(String.class, getFormatString());
+                break;
+            }
+        }
+
+        if (formatDescriptor != null)
+        {
+            _style = _formatters.get(formatDescriptor);
+
+            if (_style == null)
+            {
+                _style = ExcelCellUtils.createCellStyle(_workbook, _simpleType, getFormatString());
+                _formatters.put(formatDescriptor, _style);
             }
         }
     }
@@ -359,155 +301,91 @@ public class ExcelColumn extends RenderColumn
 
         try
         {
-            switch (_simpleType)
+            if (_simpleType == TYPE_FILE)
             {
-                case(TYPE_DATE):
-                    // Careful here... need to make sure we adjust dates for GMT.  This constructor automatically does the conversion, but there seem to be
-                    // bugs in other jxl 2.5.7 constructors: DateTime(c, r, d) forces the date to time-only, DateTime(c, r, d, gmt) doesn't adjust for gmt
-                    if (o instanceof Date dateVal)
+                String filePath = o.toString().toLowerCase().replaceAll("\r\n", "\n");
+                cell.setCellValue(filePath);
+                if (_style != null)
+                    cell.setCellStyle(_style);
+
+                Drawing drawing = (Drawing)ctx.get(ExcelWriter.SHEET_DRAWING);
+                if (drawing != null && _dc instanceof AbstractFileDisplayColumn)
+                {
+                    String path = (String)o;
+                    int imageType = -1;
+                    if (path.endsWith(".png"))
+                        imageType = Workbook.PICTURE_TYPE_PNG;
+                    else if (path.endsWith(".jpeg") || path.endsWith(".jpg"))
+                        imageType = Workbook.PICTURE_TYPE_JPEG;
+
+                    if (imageType != -1)
                     {
-                        if (dateVal.compareTo(EXCEL_DATE_0) < 0)
+                        BufferedImage img = null;
+                        byte[] data = null;
+                        try(InputStream is = ((AbstractFileDisplayColumn)_dc).getFileContents(ctx, o))
                         {
-                            String format = getFormatString();
-                            if (StringUtils.isEmpty(format))
-                                cell.setCellValue(o.toString());
+                            if (is != null)
+                            {
+                                data = IOUtils.toByteArray(is);
+                                img = ImageIO.read(new ByteArrayInputStream(data));
+                            }
+                        }
+                        catch (IOException e)
+                        {
+                            _log.error("Error reading image file data", e);
+                            //throw new RuntimeException(e);
+                            data = null; //will change to throw exception after fixing file lookups
+                        }
+
+                        if (data != null && data.length > 0)
+                        {
+                            int height = img.getHeight();
+                            int width = img.getWidth();
+
+                            double ratio = (double) width/height;
+                            if (ratio >= MAX_IMAGE_RATIO)
+                            {
+                                // resize to max width
+                                if (width > MAX_IMAGE_WIDTH)
+                                {
+                                    height = (int) (height / (width / MAX_IMAGE_WIDTH));
+                                    width = (int) MAX_IMAGE_WIDTH;
+                                }
+                            }
                             else
                             {
-                                // date is invalid for excel, export as formatted string instead
-                                format = format.replaceAll("AM/PM", "a");
-                                Format formatter = FastDateFormat.getInstance(format);
-                                cell.setCellValue(formatter.format(dateVal));
-                            }
-                        }
-                        else
-                            cell.setCellValue((Date) o);
-                        cell.setCellStyle(_style);
-                    }
-                    else
-                    {
-                        cell.setCellValue(o.toString());
-                    }
-                    break;
-                case(TYPE_TIME):
-                    if (o instanceof Time t)
-                    {
-                        cell.setCellValue(t);
-                        cell.setCellStyle(_style);
-                    }
-                    else
-                        cell.setCellValue(o.toString());
-                    break;
-                case(TYPE_INT):
-                case(TYPE_DOUBLE):
-                    if (o instanceof Number n)
-                    {
-                        cell.setCellValue(n.doubleValue());
-                        cell.setCellStyle(_style);
-                    }
-                    //Issue 47268: Export Does Not Include Failed Lookup Values
-                    //Set Integer broken lookup values as String
-                    else if (columnInfo.isLookup() && o.toString().startsWith("<") && o.toString().endsWith(">"))
-                    {
-                        cell.setCellValue(o.toString());
-                    }
-                    break;
-
-                case TYPE_FILE:
-                    String filePath = o.toString().toLowerCase().replaceAll("\r\n", "\n");
-                    cell.setCellValue(filePath);
-                    if (_style != null)
-                        cell.setCellStyle(_style);
-
-                    Drawing drawing = (Drawing)ctx.get(ExcelWriter.SHEET_DRAWING);
-                    if (drawing != null && _dc instanceof AbstractFileDisplayColumn)
-                    {
-                        String path = (String)o;
-                        int imageType = -1;
-                        if (path.endsWith(".png"))
-                            imageType = Workbook.PICTURE_TYPE_PNG;
-                        else if (path.endsWith(".jpeg") || path.endsWith(".jpg"))
-                            imageType = Workbook.PICTURE_TYPE_JPEG;
-
-                        if (imageType != -1)
-                        {
-                            BufferedImage img = null;
-                            byte[] data = null;
-                            try(InputStream is = ((AbstractFileDisplayColumn)_dc).getFileContents(ctx, o))
-                            {
-                                if (is != null)
+                                // resize to max height
+                                if (height > MAX_IMAGE_HEIGHT)
                                 {
-                                    data = IOUtils.toByteArray(is);
-                                    img = ImageIO.read(new ByteArrayInputStream(data));
+                                    width = (int) (width / (height / MAX_IMAGE_HEIGHT));
+                                    height = (int) MAX_IMAGE_HEIGHT;
                                 }
                             }
-                            catch (IOException e)
-                            {
-                                _log.error("Error reading image file data", e);
-                                //throw new RuntimeException(e);
-                                data = null; //will change to throw exception after fixing file lookups
-                            }
+                            setImageSize(ctx, row, column, Pair.of(width, height));
 
-                            if (data != null && data.length > 0)
-                            {
-                                int height = img.getHeight();
-                                int width = img.getWidth();
+                            Workbook wb = cell.getSheet().getWorkbook();
+                            CreationHelper helper = wb.getCreationHelper();
+                            int pictureIdx = wb.addPicture(data, imageType);
 
-                                double ratio = (double) width/height;
-                                if (ratio >= MAX_IMAGE_RATIO)
-                                {
-                                    // resize to max width
-                                    if (width > MAX_IMAGE_WIDTH)
-                                    {
-                                        height = (int) (height / (width / MAX_IMAGE_WIDTH));
-                                        width = (int) MAX_IMAGE_WIDTH;
-                                    }
-                                }
-                                else
-                                {
-                                    // resize to max height
-                                    if (height > MAX_IMAGE_HEIGHT)
-                                    {
-                                        width = (int) (width / (height / MAX_IMAGE_HEIGHT));
-                                        height = (int) MAX_IMAGE_HEIGHT;
-                                    }
-                                }
-                                setImageSize(ctx, row, column, Pair.of(width, height));
-
-                                Workbook wb = cell.getSheet().getWorkbook();
-                                CreationHelper helper = wb.getCreationHelper();
-                                int pictureIdx = wb.addPicture(data, imageType);
-
-                                double rowRatio = height / /*maxRowHeight*/40.0;
-                                double colRatio = width / /*maxColWidth*/120.0;
-                                ClientAnchor anchor = createAnchor(row, column, rowRatio, colRatio, helper);
-                                Picture pict = drawing.createPicture(anchor, pictureIdx);
-                                setImagePicture(ctx, row, column, pict);
-                            }
+                            double rowRatio = height / /*maxRowHeight*/40.0;
+                            double colRatio = width / /*maxColWidth*/120.0;
+                            ClientAnchor anchor = createAnchor(row, column, rowRatio, colRatio, helper);
+                            Picture pict = drawing.createPicture(anchor, pictureIdx);
+                            setImagePicture(ctx, row, column, pict);
                         }
                     }
-                    break;
-
-                case TYPE_BOOLEAN:
-                    String s = _dc.getTsvFormattedValue(ctx);
-                    cell.setCellValue(s);
-                    if (_style != null)
-                        cell.setCellStyle(_style);
-                    break;
-                case(TYPE_STRING):
-                default:
-                    // 9729 : CRs are doubled in list data exported to Excel, normalize newlines as '\n'
-                    s = o.toString().replaceAll("\r\n", "\n");
-
-                    // Check if the string is too long
-                    if (s.length() > 32767)
-                    {
-                        s = s.substring(0, 32762) + "...";
-                    }
-
-                    cell.setCellValue(s);
-                    if (_style != null)
-                        cell.setCellStyle(_style);
-                    break;
+                }
+            }
+            else if (_simpleType == TYPE_BOOLEAN)
+            {
+                String s = _dc.getTsvFormattedValue(ctx);
+                cell.setCellValue(s);
+                if (_style != null)
+                    cell.setCellStyle(_style);
+            }
+            else
+            {
+                ExcelCellUtils.writeCell(cell, _style, _simpleType, getFormatString(), columnInfo, o);
             }
 
             if (cell != null)

--- a/assay/api-src/org/labkey/api/assay/plate/PlateMapExcelWriter.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateMapExcelWriter.java
@@ -1,0 +1,336 @@
+package org.labkey.api.assay.plate;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.streaming.SXSSFSheet;
+import org.labkey.api.collections.ResultSetRowMapFactory;
+import org.labkey.api.collections.RowMap;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.ExcelWriter;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.data.Results;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryView;
+import org.labkey.api.util.logging.LogHelper;
+import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.HttpView;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class PlateMapExcelWriter extends ExcelWriter
+{
+    private static final Logger logger = LogHelper.getLogger(PlateMapExcelWriter.class, "Plate map export");
+
+    private final Plate _plate;
+
+    private final QueryView _queryView;
+
+    private final List<DisplayColumn> _displayColumns;
+
+    // Map of Row label (A, B, etc.) to Column Data, which is a Map of Column Label (1, 2, etc.) to Well Data (Sample
+    // ID, metadata column values)
+    private final Map<Integer, Map<Integer, RowMap<Object>>> _wellData = new HashMap<>();
+
+    public PlateMapExcelWriter(Plate plate, List<DisplayColumn> displayColumns, QueryView queryView) throws SQLException, IOException
+    {
+        super(ExcelDocumentType.xlsx);
+        setAutoSize(true);
+        _plate = plate;
+        _displayColumns = displayColumns;
+        _queryView = queryView;
+        initializeWellData();
+    }
+
+    private void initializeWellData() throws SQLException, IOException
+    {
+        // Iterate through the data in the _queryView
+        // for every row insert into _wellData:
+        //  Get the rowHashMap from _wellData via the row.Row value, if null insert a new HashMap into wellData
+        //  Insert the row object into the rowHashMap with row.Col as  the key
+        try (Results results = _queryView.getResults())
+        {
+            ResultSetRowMapFactory factory = ResultSetRowMapFactory.create(results);
+            while (results.next())
+            {
+                RowMap<Object> well = factory.getRowMap(results);
+                Integer row = (Integer) well.get("Row");
+                Integer col = (Integer) well.get("Col");
+
+                Map<Integer, RowMap<Object>> rowMap = _wellData.computeIfAbsent(row, k -> new HashMap<>());
+
+                rowMap.put(col, well);
+            }
+        }
+    }
+
+    private Row getOrCreateRow(Sheet sheet)
+    {
+        Row row = sheet.getRow(getCurrentRow());
+        if (row == null)
+        {
+            row = sheet.createRow(getCurrentRow());
+        }
+
+        return row;
+    }
+
+    protected void renderSheetHeader(Sheet sheet) throws MaxRowsExceededException
+    {
+        Row row = getOrCreateRow(sheet);
+
+        // First column is blank, the rest should use PositionImpl.ALPHABET for column header values
+        for (int idx = 1; idx <= _plate.getColumns(); idx++)
+        {
+            Cell cell = row.getCell(idx, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+            cell.setCellValue(idx);
+        }
+
+        incrementRow();
+    }
+
+    protected void renderGridRow(Sheet sheet, List<DisplayColumn> displayColumns)
+    {
+        Row excelRow = getOrCreateRow(sheet);
+        for (int colIdx = 0; colIdx <= _plate.getColumns(); colIdx++)
+        {
+            Cell cell = excelRow.getCell(colIdx, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+            if (colIdx == 0)
+                cell.setCellValue(PositionImpl.ALPHABET[getCurrentRow() - 1]);
+            else
+            {
+                int rowIdx = getCurrentRow() - 1; // account for header
+                Map<Integer, RowMap<Object>> row = _wellData.get(rowIdx);
+
+                if (row == null)
+                {
+                    logger.error("Well data not found for row " + rowIdx);
+                    continue;
+                }
+
+                RowMap<Object> well = row.get(colIdx - 1);
+
+                if (well == null)
+                {
+                    logger.error("Well data not found for row: " + rowIdx + ", col: " + (colIdx - 1));
+                    continue;
+                }
+
+                if (displayColumns.size() == 1)
+                {
+                    DisplayColumn displayColumn = displayColumns.get(0);
+//                    displayColumn.getExcelFormatString();
+//                    displayColumn.getExcelCompatibleValue()
+                    Object value = well.get(displayColumn.getColumnInfo().getAlias());
+                    if (value != null)
+                    {
+                        // TODO: is there a better way to render the value other than callin to string? Surely we should
+                        //  be able to render based on information we have in the DisplayColumn
+                        cell.setCellValue(value.toString());
+                    }
+                }
+                else
+                {
+                    List<String> values = displayColumns.stream()
+                            .map(dc -> well.get(dc.getColumnInfo().getAlias()))
+                            .filter(Objects::nonNull)
+                            .map(Object::toString)
+                            .toList();
+                    cell.setCellValue(String.join("\n", values));
+                }
+            }
+        }
+    }
+
+    protected void renderGrid(Sheet sheet, List<DisplayColumn> displayColumns) throws MaxRowsExceededException
+    {
+        for (int idx = 0; idx < _plate.getRows(); idx++)
+        {
+            renderGridRow(sheet, displayColumns);
+            incrementRow();
+        }
+    }
+
+    @Override
+    protected void renderSheet(Workbook workbook, int sheetNumber)
+    {
+        RenderContext ctx = new RenderContext(HttpView.currentContext());
+        Sheet sheet = ensureSheet(ctx, workbook, sheetNumber, false);
+        ((SXSSFSheet) sheet).trackAllColumnsForAutoSizing();
+
+        try
+        {
+            renderSheetHeader(sheet);
+            List<DisplayColumn> displayColumns;
+
+            if (sheetNumber == 0) // Summary view, render all values in each cell
+                displayColumns = _displayColumns.stream().filter(dc -> !dc.getName().equals("row") && !dc.getName().equals("col")).toList();
+            else if (sheetNumber == 1) // Sample ID view
+                displayColumns = List.of(_displayColumns.get(0));
+            else // CustomField view
+            {
+                PlateCustomField customField = _plate.getCustomFields().get(sheetNumber - 2);
+                FieldKey fieldKey = FieldKey.fromParts("Properties", customField.getName());
+                displayColumns = _displayColumns.stream().filter(dc -> dc.getColumnInfo().getFieldKey().equals(fieldKey)).toList();
+            }
+
+            renderGrid(sheet, displayColumns);
+        }
+        catch (Exception e)
+        {
+            logger.error("Error rendering sheet " + sheetNumber + ": " + e.getMessage());
+        }
+    }
+
+    @Override
+    protected void renderSheets(Workbook workbook)
+    {
+        List<PlateCustomField> customFields = _plate.getCustomFields();
+        // Summary sheet, SampleId sheet, and one sheet per custom field
+        int sheetCount = 2 + customFields.size();
+
+        for (int sheetNum = 0; sheetNum < sheetCount; sheetNum++)
+        {
+            if (sheetNum == 0)
+                setSheetName("Summary");
+            else if (sheetNum == 1)
+                setSheetName("Sample ID");
+            else
+                setSheetName(customFields.get(sheetNum - 2).getName());
+
+            renderNewSheet(workbook);
+        }
+    }
+
+    public class PlateMapDisplayColumn extends DisplayColumn
+    {
+        Class valueClass;
+
+        public PlateMapDisplayColumn(String name, Class valueClass)
+        {
+            this(name, name, valueClass);
+        }
+
+        public PlateMapDisplayColumn(String name, String caption, Class valueClass)
+        {
+            setName(name);
+            setCaption(caption);
+            this.valueClass = valueClass;
+        }
+
+        @Override
+        public Object getValue(RenderContext ctx)
+        {
+            //Ignore the context.
+//            return maps.get(currentRow).get(getName());
+            return null;
+        }
+
+        @Override
+        public Class getValueClass()
+        {
+            return valueClass;
+        }
+
+
+        //NOTE: Methods beyond here are unimplemented, just abstract in base class!
+        @Override
+        public void renderGridCellContents(RenderContext ctx, Writer out)
+        {
+            throw new UnsupportedOperationException("This is for excel only.");
+        }
+
+        @Override
+        public void renderDetailsCellContents(RenderContext ctx, Writer out)
+        {
+            throw new UnsupportedOperationException("This is for excel only.");
+        }
+
+        @Override
+        public void renderTitle(RenderContext ctx, Writer out)
+        {
+            throw new UnsupportedOperationException("This is for excel only.");
+        }
+
+        @Override
+        public boolean isSortable()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isFilterable()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isEditable()
+        {
+            return false;
+        }
+
+        @Override
+        public void renderFilterOnClick(RenderContext ctx, Writer out)
+        {
+            throw new UnsupportedOperationException("This is for excel only.");
+        }
+
+        @Override
+        public void renderInputHtml(RenderContext ctx, Writer out, Object value)
+        {
+            throw new UnsupportedOperationException("This is for excel only.");
+        }
+
+        @Override
+        public void setURL(ActionURL url)
+        {
+            throw new UnsupportedOperationException("This is for excel only.");
+        }
+
+        @Override
+        public void setURL(String url)
+        {
+            throw new UnsupportedOperationException("This is for excel only.");
+        }
+
+        @Override
+        public String getURL()
+        {
+            return null;
+        }
+
+        @Override
+        public String renderURL(RenderContext ctx)
+        {
+            return null;
+        }
+
+        @Override
+        public boolean isQueryColumn()
+        {
+            return false;
+        }
+
+        @Override
+        public ColumnInfo getColumnInfo()
+        {
+            return null;
+        }
+
+        @Override
+        public void render(RenderContext ctx, Writer out)
+        {
+            throw new UnsupportedOperationException("This is for excel only.");
+        }
+    }
+}

--- a/assay/api-src/org/labkey/api/assay/plate/PlateMapExcelWriter.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateMapExcelWriter.java
@@ -27,7 +27,6 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 public class PlateMapExcelWriter extends ExcelWriter
 {

--- a/assay/api-src/org/labkey/api/assay/plate/PlateMapExcelWriter.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateMapExcelWriter.java
@@ -150,7 +150,8 @@ public class PlateMapExcelWriter extends ExcelWriter
                 {
                     DisplayColumn displayColumn = displayColumns.get(0);
                     Object value = well.get(displayColumn.getColumnInfo().getAlias());
-                    ExcelCellUtils.writeCell(sheet.getWorkbook(), cell, displayColumn, value);
+                    if (value != null)
+                        ExcelCellUtils.writeCell(sheet.getWorkbook(), cell, displayColumn, value);
                 }
                 else
                 {

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -1509,11 +1509,10 @@ public class PlateController extends SpringActionController
             else if (form.getExportType() == PlateExportType.TSV)
                 files = PlateManager.get().exportPlateData(getContainer(), getUser(), cf, form.getPlateIds(), TSVWriter.DELIM.TAB);
             else
-                files = PlateManager.get().exportPlateMaps(getContainer(), getUser(), cf, form.getPlateIds(), getViewContext());
+                files = PlateManager.get().exportPlateMaps(getContainer(), getUser(), cf, form.getPlateIds());
 
             if (files.isEmpty())
             {
-                // TODO: what does the empty response look like? Should it be an error?
                 return null;
             }
             else if (files.size() == 1)
@@ -1530,6 +1529,8 @@ public class PlateController extends SpringActionController
                 filename = "plates.zip";
             else
                 filename = filename + ".zip";
+
+            filename = FileUtil.makeLegalName(filename + ".zip");
 
             // Export to a temporary file first so exceptions are displayed by the standard error page
             Path tempDir = FileUtil.getTempDirectory().toPath();

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -1490,6 +1490,9 @@ public class PlateController extends SpringActionController
             if (form.getPlateIds() == null)
                 errors.reject(ERROR_REQUIRED, "\"plateIds\" is required");
 
+            if (form.getPlateIds().size() >= PlateSet.MAX_PLATES)
+                errors.reject(ERROR_GENERIC, "Too many \"plateIds\", maximum of " + PlateSet.MAX_PLATES + " can be exported at a time");
+
             if (form.getExportType() == null)
                 errors.reject(ERROR_REQUIRED, "\"exportType\" is required");
         }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2936,6 +2936,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         // correct columns that we set via QuerySettings in getPlateQueryView, if we don't then we'll only get the
         // columns from the default view of the Well table, which could be anything.
         DataRegion dataRegion = queryView.createDataView().getDataRegion();
+
+        // Filter on isQueryColumn so we don't get the details or update columns
         return dataRegion.getDisplayColumns().stream().filter(DisplayColumn::isQueryColumn).toList();
     }
 

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -16,6 +16,7 @@
 
 package org.labkey.assay.plate;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,6 +32,7 @@ import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateCustomField;
 import org.labkey.api.assay.plate.PlateLayoutHandler;
+import org.labkey.api.assay.plate.PlateMapExcelWriter;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateSetEdge;
@@ -44,6 +46,7 @@ import org.labkey.api.assay.plate.WellCustomField;
 import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.collections.ArrayListMap;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.data.ColumnHeaderType;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -51,6 +54,7 @@ import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DataRegionSelection;
 import org.labkey.api.data.DbScope;
+import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.ImportAliasable;
 import org.labkey.api.data.ObjectFactory;
 import org.labkey.api.data.Results;
@@ -60,6 +64,8 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.TSVGridWriter;
+import org.labkey.api.data.TSVWriter;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -89,7 +95,10 @@ import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.QueryView;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchService;
@@ -98,6 +107,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -122,6 +132,10 @@ import org.labkey.assay.plate.query.WellGroupTable;
 import org.labkey.assay.plate.query.WellTable;
 import org.labkey.assay.query.AssayDbSchema;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1630,7 +1644,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     /**
      * @deprecated Use {@link #copyPlate(Container, User, Integer, boolean, String, String)}
      */
-    @Deprecated 
+    @Deprecated
     public Plate copyPlateDeprecated(Plate source, User user, Container destContainer)
             throws Exception
     {
@@ -2850,5 +2864,145 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     {
         TableInfo wellTable = getWellTable(c, u);
         return new PlateSetExport().getInstrumentInstructions(wellTable, plateSetId, includedMetadataCols);
+    }
+
+    private List<FieldKey> getPlateExportFieldKeys(Plate plate, boolean isMapView)
+    {
+        List<FieldKey> fieldKeys = new ArrayList<>(List.of(
+                FieldKey.fromParts("SampleId", "Name")
+        ));
+
+        if (isMapView)
+        {
+            fieldKeys.add(FieldKey.fromParts("Row"));
+            fieldKeys.add(FieldKey.fromParts("Col"));
+        }
+        else
+        {
+            // For non-map export view we always want the position FieldKey first
+            fieldKeys.add(0, FieldKey.fromParts("Position"));
+        }
+        for (PlateCustomField customField : plate.getCustomFields())
+        {
+            fieldKeys.add(FieldKey.fromParts("Properties", customField.getName()));
+        }
+
+        return fieldKeys;
+    }
+
+    private QueryView getPlateQueryView(Container container, User user, ContainerFilter cf, Plate plate, boolean isMapView)
+    {
+        UserSchema userSchema = QueryService.get().getUserSchema(user, container, PlateSchema.SCHEMA_NAME);
+        List<FieldKey> fieldKeys = getPlateExportFieldKeys(plate, isMapView);
+        ViewContext viewContext = new ViewContext();
+        viewContext.setUser(user);
+        QuerySettings settings = new QuerySettings(viewContext, plate.getName());
+        settings.setFieldKeys(fieldKeys);
+        settings.setContainerFilterName(cf.getType().name());
+        settings.setSchemaName(userSchema.getSchemaName());
+        settings.setQueryName(WellTable.NAME);
+        settings.getBaseFilter().addCondition(FieldKey.fromParts("PlateId"), plate.getRowId());
+        return new QueryView(userSchema, settings, null);
+    }
+
+    private Map<String, String> getPlateRenameColumnMap(Plate plate)
+    {
+        Map<String, String> renameColumnMap = new HashMap<>(Collections.singletonMap("SampleId/Name", "Sample Id"));
+
+        for (PlateCustomField customField : plate.getCustomFields())
+        {
+            renameColumnMap.put(FieldKey.fromParts("Properties", customField.getName()).toString(), customField.getName());
+        }
+
+        return renameColumnMap;
+    }
+
+    private DisplayColumn getDisplayColumnForFieldKey(List<DisplayColumn> displayColumns, FieldKey fieldKey)
+    {
+        for (DisplayColumn displayColumn : displayColumns)
+        {
+            ColumnInfo ci = displayColumn.getColumnInfo();
+            if (ci != null && ci.getFieldKey().equals(fieldKey))
+                return displayColumn;
+        }
+
+        return null;
+    }
+
+    private List<DisplayColumn> getPlateDisplayColumns(Plate plate, QueryView queryView, boolean isMapView)
+    {
+        List<FieldKey> fieldKeys = getPlateExportFieldKeys(plate, isMapView);
+        List<DisplayColumn> viewColumns = queryView.getDisplayColumns();
+        List<DisplayColumn> displayColumns = new ArrayList<>();
+
+        // We iterate through the fieldKeys instead of streaming/filtering the viewColumns because we want to retain
+        // the order.
+        for (FieldKey fieldKey : fieldKeys)
+        {
+            DisplayColumn displayColumn = getDisplayColumnForFieldKey(viewColumns, fieldKey);
+
+            if (displayColumn != null)
+            {
+                displayColumns.add(displayColumn);
+            }
+        }
+
+        return displayColumns;
+    }
+
+    public List<File> exportPlateData(Container c, User user, ContainerFilter cf, List<Integer> plateIds, TSVWriter.DELIM delim) throws Exception
+    {
+        if (plateIds.isEmpty()) return emptyList();
+
+        Path tempDir = FileUtil.getTempDirectory().toPath();
+        List<File> files = new ArrayList<>();
+        for (Integer plateId : plateIds)
+        {
+            Plate plate = getPlate(cf, plateId);
+            if (plate != null)
+            {
+                QueryView plateQueryView = getPlateQueryView(c, user, cf, plate, false);
+                String filename = FileUtil.makeLegalName(plate.getName());
+                File tempFile = FileUtil.createTempFile(FileUtil.getBaseName(FileUtil.getFileName(tempDir.resolve(filename))), "." + delim.extension);
+                List<DisplayColumn> displayColumns = getPlateDisplayColumns(plate, plateQueryView, false);
+                Map<String, String> renameColumnMap = getPlateRenameColumnMap(plate);
+
+                try (TSVGridWriter writer = new TSVGridWriter(plateQueryView::getResults, displayColumns, renameColumnMap))
+                {
+                    writer.setDelimiterCharacter(delim);
+                    writer.setColumnHeaderType(ColumnHeaderType.FieldKey);
+                    writer.write(tempFile);
+                }
+
+                files.add(tempFile);
+            }
+        }
+
+        return files;
+    }
+
+    public List<File> exportPlateMaps(Container c, User user, ContainerFilter cf, List<Integer> plateIds, ViewContext viewContext)  throws Exception
+    {
+        if (plateIds.isEmpty()) return emptyList();
+
+        Path tempDir = FileUtil.getTempDirectory().toPath();
+        List<File> files = new ArrayList<>();
+
+        for (Integer plateId : plateIds)
+        {
+            Plate plate = getPlate(cf, plateId);
+            if (plate != null)
+            {
+                QueryView plateQueryView = getPlateQueryView(c, user, cf, plate, true);
+                List<DisplayColumn> displayColumns = getPlateDisplayColumns(plate, plateQueryView, true);
+                PlateMapExcelWriter writer = new PlateMapExcelWriter(plate, displayColumns, plateQueryView);
+                String filename = FileUtil.makeLegalName(plate.getName());
+                File tempFile = FileUtil.createTempFile(FileUtil.getBaseName(FileUtil.getFileName(tempDir.resolve(filename))), ".xlsx");
+                writer.renderWorkbook(new FileOutputStream(tempFile));
+                files.add(tempFile);
+            }
+        }
+
+        return files;
     }
 }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2981,7 +2981,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return files;
     }
 
-    public List<File> exportPlateMaps(Container c, User user, ContainerFilter cf, List<Integer> plateIds, ViewContext viewContext)  throws Exception
+    public List<File> exportPlateMaps(Container c, User user, ContainerFilter cf, List<Integer> plateIds)  throws Exception
     {
         if (plateIds.isEmpty()) return emptyList();
 


### PR DESCRIPTION
#### Rationale
This PR adds a `PlateExportAction` to the `PlateController` which allows callers to export one or more plates as TSV, CSV, or Excel "map" files.

The CSV and TSV exports are in the same format as the Plate Editable Grid, one row per cell. The Excel "map" files are laid out in the format of the actual underlying plate, with a summary sheet that includes all data, a sheet for the Sample ID, and one sheet per Plate Custom Field.

*Note for reviewers*: with the changes to ExcelColumn in this PR I am concerned that some regressions may have been introduced. I am currently unsure of what our test coverage looks like for Excel export, so an especially eagle eyed approach would be appreciated when reviewing this PR.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5476
- https://github.com/LabKey/labkey-ui-premium/pull/407
- https://github.com/LabKey/limsModules/pull/229

#### Changes
- Add PlateExportAction
- Add `exportPlateData` and `exportPlateMaps` to PlateManager
- Add `PlateMapExcelWriter`, an ExcelWriter that exports plates to excel in their "map" form
- Add `ExcelCellUtils`, a helper class containing methods for writing properly formatted values to Excel cells
  - The majority of the code in this class was directly extracted from `ExcelColumn` so it could be re-used in `PlateMapExcelWriter`
- Refactor `ExcelColumn` to use `ExcelCellUtils`
