### PR TITLE
modify the wrapper column not the underlying column

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -883,19 +883,17 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 continue;
             }
 
-            // TODO this seems bad to me, why isn't this done in ss.getTinfo()
-            if (dbColumn.getName().equalsIgnoreCase("genid"))
-            {
-                ((BaseColumnInfo)dbColumn).setHidden(true);
-                ((BaseColumnInfo)dbColumn).setUserEditable(false);
-                ((BaseColumnInfo)dbColumn).setShownInDetailsView(false);
-                ((BaseColumnInfo)dbColumn).setShownInInsertView(false);
-                ((BaseColumnInfo)dbColumn).setShownInUpdateView(false);
-            }
-
             // TODO missing values? comments? flags?
             DomainProperty dp = domain.getPropertyByURI(dbColumn.getPropertyURI());
             var propColumn = copyColumnFromJoinedTable(null==dp?dbColumn.getName():dp.getName(), dbColumn);
+            if (propColumn.getName().equalsIgnoreCase("genid"))
+            {
+                propColumn.setHidden(true);
+                propColumn.setUserEditable(false);
+                propColumn.setShownInDetailsView(false);
+                propColumn.setShownInInsertView(false);
+                propColumn.setShownInUpdateView(false);
+            }
             if (null != dp)
             {
                 PropertyColumn.copyAttributes(schema.getUser(), propColumn, dp.getPropertyDescriptor(), schema.getContainer(),


### PR DESCRIPTION
#### Rationale
Discovered this while investigating different bug.  It happens that dbTable is actually a wrapper, too.  Still it's not good form to randomly modify the wrong TableInfo.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
