### PR TITLE
query recursion check doesn't clean up properly when it throws.

### DIFF
--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -123,6 +123,7 @@ import org.labkey.query.reports.view.ReportAndDatasetChangeDigestEmailTemplate;
 import org.labkey.query.reports.view.ReportUIProvider;
 import org.labkey.query.sql.Method;
 import org.labkey.query.sql.QNode;
+import org.labkey.query.sql.Query;
 import org.labkey.query.sql.SqlParser;
 import org.labkey.query.view.InheritedQueryDataViewProvider;
 import org.labkey.query.view.QueryDataViewProvider;
@@ -382,6 +383,7 @@ public class QueryModule extends DefaultModule
             MetadataElementBase.TestCase.class,
             Method.TestCase.class,
             QNode.TestCase.class,
+            Query.TestCase.class,
             ReportsController.SerializationTest.class,
             SqlParser.SqlParserTestCase.class,
             TableWriter.TestCase.class

--- a/query/src/org/labkey/query/sql/Query.java
+++ b/query/src/org/labkey/query/sql/Query.java
@@ -1123,7 +1123,13 @@ public class Query
         {
             try
             {
+                assertEquals(0, resolveDepth.get().get());
                 recurseToFailure();
+                fail("should have thrown");
+            }
+            catch (StackOverflowError e)
+            {
+                fail("definitely shouldn't be here");
             }
             catch (Exception e)
             {

--- a/query/src/org/labkey/query/sql/QuerySelect.java
+++ b/query/src/org/labkey/query/sql/QuerySelect.java
@@ -1323,7 +1323,7 @@ public class QuerySelect extends AbstractQueryRelation implements Cloneable
             @Override
             public SQLFragment getFromSQL(String alias)
             {
-                try (var recursion = _query.queryRecursionCheck("Too many tables used in this query.  Query may be recursive.", null))
+                try (var recursion = Query.queryRecursionCheck("Too many tables used in this query.  Query may be recursive.", null))
                 {
                     SQLFragment f = new SQLFragment();
                     if (_sqlAllColumns == null)

--- a/query/src/org/labkey/query/sql/QueryTableInfo.java
+++ b/query/src/org/labkey/query/sql/QueryTableInfo.java
@@ -70,7 +70,7 @@ public class QueryTableInfo extends AbstractTableInfo implements ContainerFilter
     @Override
     public SQLFragment getFromSQL(String alias)
     {
-        try (var recursion = _relation._query.queryRecursionCheck("Too many tables used in this query.  Query may be recursive.", null))
+        try (var recursion = Query.queryRecursionCheck("Too many tables used in this query.  Query may be recursive.", null))
         {
             SQLFragment sql = _relation.getSql();
             if (null == sql)


### PR DESCRIPTION
#### Rationale
Customer started hitting the recursion limit check inconsistently with the same query.  That behavior is consistent with the discovered bug.

Are we still hot-fixing 23.11?

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
