### PR TITLE
Issue 50212: ScriptsResourceProvider.resolve to catch AccessDeniedException for @scripts dir

### DIFF
--- a/experiment/src/org/labkey/experiment/ScriptsResourceProvider.java
+++ b/experiment/src/org/labkey/experiment/ScriptsResourceProvider.java
@@ -17,6 +17,7 @@ import org.labkey.api.webdav.WebdavResource;
 import org.labkey.api.webdav.WebdavService;
 
 import java.io.File;
+import java.nio.file.AccessDeniedException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -74,6 +75,12 @@ public class ScriptsResourceProvider implements WebdavService.Provider
         catch (MissingRootDirectoryException e)
         {
             // Don't complain here, just hide the @scripts subfolder
+        }
+        catch (RuntimeException e)
+        {
+            // Don't complain here if AccessDeniedException, just hide the @scripts subfolder (Issue 50212)
+            if (!(e.getCause() instanceof AccessDeniedException))
+                throw e;
         }
 
         return null;


### PR DESCRIPTION
#### Rationale
See related PR for rationale. This is a second attempt to fix the issue. This PR updates ScriptsResourceProvider.resolve to catch AccessDeniedException for @scripts dir attempted creation.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5453

#### Changes
- ScriptsResourceProvider.resolve to catch AccessDeniedException
