### PR TITLE
fix for queryrecursioncheck

### DIFF
--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -123,6 +123,7 @@ import org.labkey.query.reports.view.ReportAndDatasetChangeDigestEmailTemplate;
 import org.labkey.query.reports.view.ReportUIProvider;
 import org.labkey.query.sql.Method;
 import org.labkey.query.sql.QNode;
+import org.labkey.query.sql.Query;
 import org.labkey.query.sql.SqlParser;
 import org.labkey.query.view.InheritedQueryDataViewProvider;
 import org.labkey.query.view.QueryDataViewProvider;
@@ -385,6 +386,7 @@ public class QueryModule extends DefaultModule
             MetadataElementBase.TestCase.class,
             Method.TestCase.class,
             QNode.TestCase.class,
+            Query.TestCase.class,
             ReportsController.SerializationTest.class,
             SqlParser.SqlParserTestCase.class,
             TableWriter.TestCase.class

--- a/query/src/org/labkey/query/sql/Query.java
+++ b/query/src/org/labkey/query/sql/Query.java
@@ -21,6 +21,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
@@ -704,14 +706,16 @@ public class Query
      * resolveTable() catches most cases of recursion.  However, some indirect forms of recursion will show themselves in getSql().
      * This can happen if a Filter tries to compile a query. For instance, see the custom Filter code in {@link DatasetTableCustomizer.addRestrictedReadFilter()}
      */
-    QueryRecursionReturn queryRecursionCheck(String message, @Nullable QNode node) throws QueryParseException
+    static QueryRecursionReturn queryRecursionCheck(String message, @Nullable QNode node) throws QueryParseException
     {
-        if (resolveDepth.get().incrementAndGet() > MAX_RESOLVE_DEPTH)
+        AtomicInteger ai = resolveDepth.get();
+        if (ai.get() >= MAX_RESOLVE_DEPTH)
         {
             ArrayList<QueryException> list = new ArrayList<>();
             parseError(list, message, node);
             throw list.get(0);
         }
+        ai.incrementAndGet();
         return new QueryRecursionReturn();
     }
 
@@ -1087,5 +1091,52 @@ public class Query
     public TableType lookupMetadataTable(String tableName)
     {
         return null != _metadataTableMap ? _metadataTableMap.get(tableName) : null;
+    }
+
+
+    public static class TestCase extends Assert
+    {
+        @Test
+        public void testQueryRecursionCheck()
+        {
+            assertEquals(0, resolveDepth.get().get());
+            try (var unused1 = queryRecursionCheck("test", null))
+            {
+                assertEquals(1, resolveDepth.get().get());
+                try (var unused2 = queryRecursionCheck("test", null))
+                {
+                    assertEquals(2, resolveDepth.get().get());
+                }
+                assertEquals(1, resolveDepth.get().get());
+            }
+            assertEquals(0, resolveDepth.get().get());
+        }
+
+        private void recurseToFailure()
+        {
+            try (var unused2 = queryRecursionCheck("test", null))
+            {
+                recurseToFailure();
+            }
+        }
+
+        @Test
+        public void testQueryRecursionCheckFail()
+        {
+            try
+            {
+                assertEquals(0, resolveDepth.get().get());
+                recurseToFailure();
+                fail("should have thrown");
+            }
+            catch (StackOverflowError e)
+            {
+                fail("definitely shouldn't be here");
+            }
+            catch (Exception e)
+            {
+                assertEquals(0, resolveDepth.get().get());
+            }
+        }
     }
 }

--- a/query/src/org/labkey/query/sql/QuerySelect.java
+++ b/query/src/org/labkey/query/sql/QuerySelect.java
@@ -1323,7 +1323,7 @@ public class QuerySelect extends AbstractQueryRelation implements Cloneable
             @Override
             public SQLFragment getFromSQL(String alias)
             {
-                try (var recursion = _query.queryRecursionCheck("Too many tables used in this query.  Query may be recursive.", null))
+                try (var recursion = Query.queryRecursionCheck("Too many tables used in this query.  Query may be recursive.", null))
                 {
                     SQLFragment f = new SQLFragment();
                     if (_sqlAllColumns == null)

--- a/query/src/org/labkey/query/sql/QueryTableInfo.java
+++ b/query/src/org/labkey/query/sql/QueryTableInfo.java
@@ -70,7 +70,7 @@ public class QueryTableInfo extends AbstractTableInfo implements ContainerFilter
     @Override
     public SQLFragment getFromSQL(String alias)
     {
-        try (var recursion = _relation._query.queryRecursionCheck("Too many tables used in this query.  Query may be recursive.", null))
+        try (var recursion = Query.queryRecursionCheck("Too many tables used in this query.  Query may be recursive.", null))
         {
             SQLFragment sql = _relation.getSql();
             if (null == sql)


### PR DESCRIPTION
#### Rationale
Customer started hitting the recursion limit check inconsistently with the same query. That behavior is consistent with the discovered bug.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
