### PR TITLE
AbDisc: Worklist Column Ordering

### DIFF
--- a/api/src/org/labkey/api/data/ArrayExcelWriter.java
+++ b/api/src/org/labkey/api/data/ArrayExcelWriter.java
@@ -21,7 +21,7 @@ public class ArrayExcelWriter extends ExcelWriter
      */
     public ArrayExcelWriter(List<Object[]> data, ColumnDescriptor[] cols)
     {
-        super(ExcelDocumentType.xls);
+        super(ExcelDocumentType.xlsx);
         this.data = data;
         List<DisplayColumn> xlcols = new ArrayList<>();
 

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -1292,8 +1292,8 @@ public class PlateController extends SpringActionController
                 if (plateSetSource == null || plateSetDestination == null)
                     throw new NotFoundException("Unable to resolve Plate Set.");
 
-                List<FieldKey> sourceIncludedMetadataCols = WellTable.getMetadataColumns(form.getSourcePlateSetId(), getContainer(), getUser()).stream().sorted(Comparator.comparing(FieldKey::getName)).toList();
-                List<FieldKey> destinationIncludedMetadataCols = WellTable.getMetadataColumns(form.getDestinationPlateSetId(), getContainer(), getUser()).stream().sorted(Comparator.comparing(FieldKey::getName)).toList();
+                List<FieldKey> sourceIncludedMetadataCols = WellTable.getMetadataColumns(plateSetSource, getUser());
+                List<FieldKey> destinationIncludedMetadataCols = WellTable.getMetadataColumns(plateSetDestination, getUser());
 
                 ColumnDescriptor[] sourceXlCols = PlateSetExport.getColumnDescriptors(PlateSetExport.SOURCE, sourceIncludedMetadataCols);
                 ColumnDescriptor[] destinationXlCols = PlateSetExport.getColumnDescriptors(PlateSetExport.DESTINATION, destinationIncludedMetadataCols);
@@ -1345,7 +1345,7 @@ public class PlateController extends SpringActionController
                 if (plateSet.getType() != PlateSetType.assay)
                     throw new ValidationException("Instrument Instructions cannot be generated for non-Assay Plate Sets.");
 
-                List<FieldKey> includedMetadataCols = WellTable.getMetadataColumns(form.getPlateSetId(), getContainer(), getUser()).stream().sorted(Comparator.comparing(FieldKey::getName)).toList();
+                List<FieldKey> includedMetadataCols = WellTable.getMetadataColumns(plateSet, getUser());
                 ColumnDescriptor[] xlCols = PlateSetExport.getColumnDescriptors("", includedMetadataCols);
                 List<Object[]> plateDataRows = PlateManager.get().getInstrumentInstructions(form.getPlateSetId(), includedMetadataCols, getContainer(), getUser());
 

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -81,6 +81,7 @@ import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1291,8 +1292,8 @@ public class PlateController extends SpringActionController
                 if (plateSetSource == null || plateSetDestination == null)
                     throw new NotFoundException("Unable to resolve Plate Set.");
 
-                Set<FieldKey> sourceIncludedMetadataCols = WellTable.getMetadataColumns(form.getSourcePlateSetId(), getContainer(), getUser());
-                Set<FieldKey> destinationIncludedMetadataCols = WellTable.getMetadataColumns(form.getDestinationPlateSetId(), getContainer(), getUser());
+                List<FieldKey> sourceIncludedMetadataCols = WellTable.getMetadataColumns(form.getSourcePlateSetId(), getContainer(), getUser()).stream().sorted(Comparator.comparing(FieldKey::getName)).toList();
+                List<FieldKey> destinationIncludedMetadataCols = WellTable.getMetadataColumns(form.getDestinationPlateSetId(), getContainer(), getUser()).stream().sorted(Comparator.comparing(FieldKey::getName)).toList();
 
                 ColumnDescriptor[] sourceXlCols = PlateSetExport.getColumnDescriptors(PlateSetExport.SOURCE, sourceIncludedMetadataCols);
                 ColumnDescriptor[] destinationXlCols = PlateSetExport.getColumnDescriptors(PlateSetExport.DESTINATION, destinationIncludedMetadataCols);
@@ -1344,7 +1345,7 @@ public class PlateController extends SpringActionController
                 if (plateSet.getType() != PlateSetType.assay)
                     throw new ValidationException("Instrument Instructions cannot be generated for non-Assay Plate Sets.");
 
-                Set<FieldKey> includedMetadataCols = WellTable.getMetadataColumns(form.getPlateSetId(), getContainer(), getUser());
+                List<FieldKey> includedMetadataCols = WellTable.getMetadataColumns(form.getPlateSetId(), getContainer(), getUser()).stream().sorted(Comparator.comparing(FieldKey::getName)).toList();
                 ColumnDescriptor[] xlCols = PlateSetExport.getColumnDescriptors("", includedMetadataCols);
                 List<Object[]> plateDataRows = PlateManager.get().getInstrumentInstructions(form.getPlateSetId(), includedMetadataCols, getContainer(), getUser());
 

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -1302,7 +1302,7 @@ public class PlateController extends SpringActionController
                 List<Object[]> plateDataRows = PlateManager.get().getWorklist(form.getSourcePlateSetId(), form.getDestinationPlateSetId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, getContainer(), getUser());
 
                 ArrayExcelWriter xlWriter = new ArrayExcelWriter(plateDataRows, xlCols);
-                xlWriter.setFullFileName(plateSetSource.getName() + "To" + plateSetDestination.getName() + ".xls");
+                xlWriter.setFullFileName(plateSetSource.getName() + " - " + plateSetDestination.getName());
                 xlWriter.renderWorkbook(getViewContext().getResponse());
 
                 return null; // Returning anything here will cause error as excel writer will close the response stream
@@ -1350,7 +1350,7 @@ public class PlateController extends SpringActionController
                 List<Object[]> plateDataRows = PlateManager.get().getInstrumentInstructions(form.getPlateSetId(), includedMetadataCols, getContainer(), getUser());
 
                 ArrayExcelWriter xlWriter = new ArrayExcelWriter(plateDataRows, xlCols);
-                xlWriter.setFullFileName(plateSet.getName() + ".xls");
+                xlWriter.setFullFileName(plateSet.getName());
                 xlWriter.renderWorkbook(getViewContext().getResponse());
 
                 return null; // Returning anything here will cause error as excel writer will close the response stream

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2642,7 +2642,10 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             List<GWTPropertyDescriptor> customFields = List.of(
                     new GWTPropertyDescriptor("barcode", "http://www.w3.org/2001/XMLSchema#string"),
                     new GWTPropertyDescriptor("concentration", "http://www.w3.org/2001/XMLSchema#double"),
-                    new GWTPropertyDescriptor("negativeControl", "http://www.w3.org/2001/XMLSchema#double"));
+                    new GWTPropertyDescriptor("negativeControl", "http://www.w3.org/2001/XMLSchema#double"),
+                    new GWTPropertyDescriptor("Z", "http://www.w3.org/2001/XMLSchema#string"),
+                    new GWTPropertyDescriptor("a", "http://www.w3.org/2001/XMLSchema#string")
+            );
 
             PlateManager.get().createPlateMetadataFields(container, user, customFields);
 
@@ -3156,18 +3159,19 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             PlateType plateType = PlateManager.get().getPlateType(8, 12);
             assertNotNull("96 well plate type was not found", plateType);
 
+            // Test sorting
             List<Map<String, Object>> rows1 = List.of(
                     CaseInsensitiveHashMap.of(
                             "wellLocation", "A1",
                             "sampleId", sample1.getRowId(),
-                            "properties/concentration", 2.25,
-                            "properties/barcode", "B1234")
+                            "properties/a", 2.25,
+                            "properties/Z", "B1234")
                     ,
                     CaseInsensitiveHashMap.of(
                             "wellLocation", "A2",
                             "sampleId", sample2.getRowId(),
-                            "properties/concentration", 1.25,
-                            "properties/barcode", "B5678"
+                            "properties/a", 1.25,
+                            "properties/Z", "B5678"
                     )
             );
             Plate plateSource = PlateManager.get().createAndSavePlate(container, user, plateType, "myPlate1", null, null, rows1);

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3130,7 +3130,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             Plate p = PlateManager.get().createAndSavePlate(container, user, plateType, "myPlate", null, null, rows);
 
             // Act
-            List<FieldKey> includedMetadataCols = WellTable.getMetadataColumns(p.getPlateSet().getRowId(), container, user).stream().sorted(Comparator.comparing(FieldKey::getName)).toList();
+            List<FieldKey> includedMetadataCols = WellTable.getMetadataColumns(p.getPlateSet(), user);
             List<Object[]> result = PlateManager.get().getInstrumentInstructions(p.getPlateSet().getRowId(), includedMetadataCols, container, user);
 
             // Assert
@@ -3175,6 +3175,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                     )
             );
             Plate plateSource = PlateManager.get().createAndSavePlate(container, user, plateType, "myPlate1", null, null, rows1);
+            assertNotNull("Expected plate set to be specified on plate", plateSource.getPlateSet());
 
             List<Map<String, Object>> rows2 = List.of(
                     CaseInsensitiveHashMap.of(
@@ -3189,11 +3190,12 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                             "wellLocation", "A3",
                             "sampleId", sample2.getRowId())
             );
-            Plate plateDestination =PlateManager.get().createAndSavePlate(container, user, plateType, "myPlate2", null, null, rows2);
+            Plate plateDestination = PlateManager.get().createAndSavePlate(container, user, plateType, "myPlate2", null, null, rows2);
+            assertNotNull("Expected plate set to be specified on plate", plateDestination.getPlateSet());
 
             // Act
-            List<FieldKey> sourceIncludedMetadataCols = WellTable.getMetadataColumns(plateSource.getPlateSet().getRowId(), container, user).stream().sorted(Comparator.comparing(FieldKey::getName)).toList();
-            List<FieldKey> destinationIncludedMetadataCols = WellTable.getMetadataColumns(plateDestination.getPlateSet().getRowId(), container, user).stream().sorted(Comparator.comparing(FieldKey::getName)).toList();
+            List<FieldKey> sourceIncludedMetadataCols = WellTable.getMetadataColumns(plateSource.getPlateSet(), user);
+            List<FieldKey> destinationIncludedMetadataCols = WellTable.getMetadataColumns(plateDestination.getPlateSet(), user);
             List<Object[]> plateDataRows = PlateManager.get().getWorklist(plateSource.getPlateSet().getRowId(), plateDestination.getPlateSet().getRowId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, container, user);
 
             // Assert

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2605,8 +2605,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     public List<Object[]> getWorklist(
             int sourcePlateSetId,
             int destinationPlateSetId,
-            Set<FieldKey> sourceIncludedMetadataCols,
-            Set<FieldKey> destinationIncludedMetadataCols,
+            List<FieldKey> sourceIncludedMetadataCols,
+            List<FieldKey> destinationIncludedMetadataCols,
             Container c,
             User u
     ) throws RuntimeSQLException
@@ -2615,7 +2615,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return new PlateSetExport().getWorklist(wellTable, sourcePlateSetId, destinationPlateSetId, sourceIncludedMetadataCols, destinationIncludedMetadataCols);
     }
 
-    public List<Object[]> getInstrumentInstructions(int plateSetId, Set<FieldKey> includedMetadataCols, Container c, User u)
+    public List<Object[]> getInstrumentInstructions(int plateSetId, List<FieldKey> includedMetadataCols, Container c, User u)
     {
         TableInfo wellTable = getWellTable(c, u);
         return new PlateSetExport().getInstrumentInstructions(wellTable, plateSetId, includedMetadataCols);
@@ -3127,7 +3127,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             Plate p = PlateManager.get().createAndSavePlate(container, user, plateType, "myPlate", null, null, rows);
 
             // Act
-            Set<FieldKey> includedMetadataCols = WellTable.getMetadataColumns(p.getPlateSet().getRowId(), container, user);
+            List<FieldKey> includedMetadataCols = WellTable.getMetadataColumns(p.getPlateSet().getRowId(), container, user).stream().sorted(Comparator.comparing(FieldKey::getName)).toList();
             List<Object[]> result = PlateManager.get().getInstrumentInstructions(p.getPlateSet().getRowId(), includedMetadataCols, container, user);
 
             // Assert
@@ -3188,8 +3188,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             Plate plateDestination =PlateManager.get().createAndSavePlate(container, user, plateType, "myPlate2", null, null, rows2);
 
             // Act
-            Set<FieldKey> sourceIncludedMetadataCols = WellTable.getMetadataColumns(plateSource.getPlateSet().getRowId(), container, user);
-            Set<FieldKey> destinationIncludedMetadataCols = WellTable.getMetadataColumns(plateDestination.getPlateSet().getRowId(), container, user);
+            List<FieldKey> sourceIncludedMetadataCols = WellTable.getMetadataColumns(plateSource.getPlateSet().getRowId(), container, user).stream().sorted(Comparator.comparing(FieldKey::getName)).toList();
+            List<FieldKey> destinationIncludedMetadataCols = WellTable.getMetadataColumns(plateDestination.getPlateSet().getRowId(), container, user).stream().sorted(Comparator.comparing(FieldKey::getName)).toList();
             List<Object[]> plateDataRows = PlateManager.get().getWorklist(plateSource.getPlateSet().getRowId(), plateDestination.getPlateSet().getRowId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, container, user);
 
             // Assert

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2642,10 +2642,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             List<GWTPropertyDescriptor> customFields = List.of(
                     new GWTPropertyDescriptor("barcode", "http://www.w3.org/2001/XMLSchema#string"),
                     new GWTPropertyDescriptor("concentration", "http://www.w3.org/2001/XMLSchema#double"),
-                    new GWTPropertyDescriptor("negativeControl", "http://www.w3.org/2001/XMLSchema#double"),
-                    new GWTPropertyDescriptor("Z", "http://www.w3.org/2001/XMLSchema#string"),
-                    new GWTPropertyDescriptor("a", "http://www.w3.org/2001/XMLSchema#string")
-            );
+                    new GWTPropertyDescriptor("negativeControl", "http://www.w3.org/2001/XMLSchema#double"));
 
             PlateManager.get().createPlateMetadataFields(container, user, customFields);
 
@@ -2909,13 +2906,13 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             List<PlateCustomField> fields = PlateManager.get().getPlateMetadataFields(container, user);
 
             // Verify returned sorted by name
-            assertEquals("Expected plate custom fields", 5, fields.size());
-            assertEquals("Expected barcode custom field", "barcode", fields.get(2).getName());
-            assertEquals("Expected concentration custom field", "concentration", fields.get(3).getName());
-            assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(4).getName());
+            assertEquals("Expected plate custom fields", 3, fields.size());
+            assertEquals("Expected barcode custom field", "barcode", fields.get(0).getName());
+            assertEquals("Expected concentration custom field", "concentration", fields.get(1).getName());
+            assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(2).getName());
 
             // assign custom fields to the plate
-            assertEquals("Expected custom fields to be added to the plate", 5, PlateManager.get().addFields(container, user, plateId, fields).size());
+            assertEquals("Expected custom fields to be added to the plate", 3, PlateManager.get().addFields(container, user, plateId, fields).size());
 
             // verification when adding custom fields to the plate
             try
@@ -2925,14 +2922,14 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             }
             catch (IllegalArgumentException e)
             {
-                assertEquals("Expected validation exception", "Failed to add plate custom fields. Custom field \"Z\" already is associated with this plate.", e.getMessage());
+                assertEquals("Expected validation exception", "Failed to add plate custom fields. Custom field \"barcode\" already is associated with this plate.", e.getMessage());
             }
 
             // remove a plate custom field
             fields = PlateManager.get().removeFields(container, user, plateId, List.of(fields.get(0)));
-            assertEquals("Expected 4 plate custom fields", 4, fields.size());
-            assertEquals("Expected concentration custom field", "concentration", fields.get(2).getName());
-            assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(3).getName());
+            assertEquals("Expected 2 plate custom fields", 2, fields.size());
+            assertEquals("Expected concentration custom field", "concentration", fields.get(0).getName());
+            assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(1).getName());
 
             // select wells
             SimpleFilter filter = SimpleFilter.createContainerFilter(container);
@@ -3156,6 +3153,13 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             sample2.setCpasType(sampleType.getLSID());
             sample2.save(user);
 
+            List<GWTPropertyDescriptor> customFields = List.of(
+                    new GWTPropertyDescriptor("Z", "http://www.w3.org/2001/XMLSchema#string"),
+                    new GWTPropertyDescriptor("a", "http://www.w3.org/2001/XMLSchema#string")
+            );
+
+            PlateManager.get().createPlateMetadataFields(container, user, customFields);
+
             PlateType plateType = PlateManager.get().getPlateType(8, 12);
             assertNotNull("96 well plate type was not found", plateType);
 
@@ -3213,6 +3217,12 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             String[] valuesRow3 = new String[]{"myPlate1", "A2", "96-well", "sampleB", "B5678", "1.25", "myPlate2", "A3", "96-well"};
             for (int i = 0; i < row3.length; i++)
                 assertEquals(row3[i].toString(), valuesRow3[i]);
+
+            // Clean Up
+            List<PlateCustomField> fields = PlateManager.get().getPlateMetadataFields(container, user);
+            List<PlateCustomField> fieldsToRemove = List.of(fields.get(0), fields.get(1));
+            PlateManager.get().removeFields(container, user, plateSource.getRowId(), fieldsToRemove);
+            PlateManager.get().deletePlateMetadataFields(container, user, fieldsToRemove);
         }
     }
 }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2909,13 +2909,13 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             List<PlateCustomField> fields = PlateManager.get().getPlateMetadataFields(container, user);
 
             // Verify returned sorted by name
-            assertEquals("Expected plate custom fields", 3, fields.size());
-            assertEquals("Expected barcode custom field", "barcode", fields.get(0).getName());
-            assertEquals("Expected concentration custom field", "concentration", fields.get(1).getName());
-            assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(2).getName());
+            assertEquals("Expected plate custom fields", 5, fields.size());
+            assertEquals("Expected barcode custom field", "barcode", fields.get(2).getName());
+            assertEquals("Expected concentration custom field", "concentration", fields.get(3).getName());
+            assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(4).getName());
 
             // assign custom fields to the plate
-            assertEquals("Expected custom fields to be added to the plate", 3, PlateManager.get().addFields(container, user, plateId, fields).size());
+            assertEquals("Expected custom fields to be added to the plate", 5, PlateManager.get().addFields(container, user, plateId, fields).size());
 
             // verification when adding custom fields to the plate
             try
@@ -2925,14 +2925,14 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             }
             catch (IllegalArgumentException e)
             {
-                assertEquals("Expected validation exception", "Failed to add plate custom fields. Custom field \"barcode\" already is associated with this plate.", e.getMessage());
+                assertEquals("Expected validation exception", "Failed to add plate custom fields. Custom field \"Z\" already is associated with this plate.", e.getMessage());
             }
 
             // remove a plate custom field
             fields = PlateManager.get().removeFields(container, user, plateId, List.of(fields.get(0)));
-            assertEquals("Expected 2 plate custom fields", 2, fields.size());
-            assertEquals("Expected concentration custom field", "concentration", fields.get(0).getName());
-            assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(1).getName());
+            assertEquals("Expected 4 plate custom fields", 4, fields.size());
+            assertEquals("Expected concentration custom field", "concentration", fields.get(2).getName());
+            assertEquals("Expected negativeControl custom field", "negativeControl", fields.get(3).getName());
 
             // select wells
             SimpleFilter filter = SimpleFilter.createContainerFilter(container);

--- a/assay/src/org/labkey/assay/plate/PlateSetExport.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetExport.java
@@ -17,11 +17,9 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 public class PlateSetExport
 {
@@ -78,24 +76,23 @@ public class PlateSetExport
     public static ColumnDescriptor[] getColumnDescriptors(String prefix, List<FieldKey> includedMetadataCols)
     {
         List<ColumnDescriptor> baseColumns = new ArrayList<>(
-                Arrays.asList(
-                        new ColumnDescriptor(prefix + "Plate ID", String.class),
-                        new ColumnDescriptor(prefix + "Well", String.class),
-                        new ColumnDescriptor(prefix + "Plate Type", String.class)
-                )
+            Arrays.asList(
+                new ColumnDescriptor(prefix + "Plate ID"),
+                new ColumnDescriptor(prefix + "Well"),
+                new ColumnDescriptor(prefix + "Plate Type")
+            )
         );
 
-        if (!prefix.equals(PlateSetExport.DESTINATION))
-            baseColumns.add(new ColumnDescriptor("Sample ID", String.class));
+        if (!PlateSetExport.DESTINATION.equals(prefix))
+            baseColumns.add(new ColumnDescriptor("Sample ID"));
 
         List<ColumnDescriptor> metadataColumns = includedMetadataCols
                 .stream()
-                .sorted(Comparator.comparing(FieldKey::getName))
-                .map(fk -> new ColumnDescriptor(fk.getCaption(), String.class))
+                .map(fk -> new ColumnDescriptor(fk.getCaption()))
                 .toList();
 
-        int baseColumCount = !prefix.equals(PlateSetExport.DESTINATION) ? 4 : 3;
-        return Stream.concat(baseColumns.stream(), metadataColumns.stream()).toList().toArray(new ColumnDescriptor[baseColumCount + includedMetadataCols.size()]);
+        baseColumns.addAll(metadataColumns);
+        return baseColumns.toArray(new ColumnDescriptor[0]);
     }
 
     public List<Object[]> getWorklist(

--- a/assay/src/org/labkey/assay/plate/PlateSetExport.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetExport.java
@@ -3,7 +3,6 @@ package org.labkey.assay.plate;
 import org.apache.commons.lang3.ArrayUtils;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Results;
-import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableInfo;
@@ -19,11 +18,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Stream;
 
 public class PlateSetExport

--- a/assay/src/org/labkey/assay/plate/PlateSetExport.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetExport.java
@@ -51,14 +51,14 @@ public class PlateSetExport
     public PlateSetExport(){};
 
     // Returns the base set of columns as well as the metadata columns included on default plate view
-    private Collection<ColumnInfo> getWellColumns(TableInfo wellTable, Set<FieldKey> includedMetaDataCols)
+    private Collection<ColumnInfo> getWellColumns(TableInfo wellTable, List<FieldKey> includedMetaDataCols)
     {
         List<FieldKey> defaultCols = new ArrayList<>(FKMap.values());
         defaultCols.addAll(includedMetaDataCols);
         return QueryService.get().getColumns(wellTable, defaultCols).values();
     }
 
-    private Object[] getDataRow(String prefix, Results rs, Set<FieldKey> includedMetaDataCols) throws SQLException
+    private Object[] getDataRow(String prefix, Results rs, List<FieldKey> includedMetaDataCols) throws SQLException
     {
         List<Object> baseColumns = new ArrayList<>(
                 Arrays.asList(
@@ -78,7 +78,7 @@ public class PlateSetExport
     }
 
     // Returns array of ColumnDescriptors used as column layout once fed to an ArrayExcelWriter
-    public static ColumnDescriptor[] getColumnDescriptors(String prefix, Set<FieldKey> includedMetadataCols)
+    public static ColumnDescriptor[] getColumnDescriptors(String prefix, List<FieldKey> includedMetadataCols)
     {
         List<ColumnDescriptor> baseColumns = new ArrayList<>(
                 Arrays.asList(
@@ -105,8 +105,8 @@ public class PlateSetExport
             TableInfo wellTable,
             int sourcePlateSetId,
             int destinationPlateSetId,
-            Set<FieldKey> sourceIncludedMetadataCols,
-            Set<FieldKey> destinationIncludedMetadataCols
+            List<FieldKey> sourceIncludedMetadataCols,
+            List<FieldKey> destinationIncludedMetadataCols
     )
     {
         List<Object[]> plateDataRows = new ArrayList<>();
@@ -163,7 +163,7 @@ public class PlateSetExport
         return plateDataRows;
     }
 
-    public List<Object[]> getInstrumentInstructions(TableInfo wellTable, int plateSetId, Set<FieldKey> includedMetadataCols)
+    public List<Object[]> getInstrumentInstructions(TableInfo wellTable, int plateSetId, List<FieldKey> includedMetadataCols)
     {
         List<Object[]> plateDataRows = new ArrayList<>();
         try (Results rs = QueryService.get().select(wellTable, getWellColumns(wellTable, includedMetadataCols), new SimpleFilter(FKMap.get(PLATE_SET_ID_COL), plateSetId), new Sort(ROW_ID_COL)))


### PR DESCRIPTION
#### Rationale
Previously, metadata columns were retrieved as a set. This commit orders the data columns in the same way the column names are ordered.
Note that `.sorted().toList()` would not work, as capital letters are sorted differently than `.sorted(Comparator.comparing(FieldKey::getName)).toList()`. The used sort is what aligns with the column ordering on a plate grid page.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5459

#### Changes
- Update tests
- Use List<FieldKey>
- Sort appropriately 
