### PR TITLE
ELN: Customize signing checkbox and export to PDF

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -650,7 +650,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         if (loader != null && target != null)
             loader.setKnownColumns(target.getColumns());
 
-        if (loader != null && renamedColumns != null)
+        if (loader != null && renamedColumns != null && !renamedColumns.isEmpty())
         {
             ColumnDescriptor[]  columnDescriptors = loader.getColumns(renamedColumns);
             for (ColumnDescriptor columnDescriptor : columnDescriptors)

--- a/api/src/org/labkey/api/settings/AbstractCustomLabelProvider.java
+++ b/api/src/org/labkey/api/settings/AbstractCustomLabelProvider.java
@@ -1,0 +1,102 @@
+package org.labkey.api.settings;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.PropertyManager;
+import org.labkey.api.data.PropertyStore;
+import org.labkey.api.query.ValidationException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AbstractCustomLabelProvider implements CustomLabelProvider
+{
+    public static final PropertyStore _normalStore = PropertyManager.getNormalStore();
+
+    public record CustomLabel(String key, String defaultLabel, String description, String tooltip)
+    {}
+
+    public Map<String, String> getLabels(@Nullable Container container)
+    {
+        Container labelContainer = getLabelContainer(container);
+        Map<String, String> consolidatedLabels = new HashMap<>();
+        Map<String, String> savedLabels = labelContainer == null ? _normalStore.getProperties(getLabelGroup()) : _normalStore.getProperties(labelContainer, getLabelGroup());
+        for (CustomLabel defaultLabel : getDefaultLabels())
+        {
+            if (defaultLabel != null)
+            {
+                String key = defaultLabel.key();
+                String consolidatedLabel = savedLabels.containsKey(key) && !StringUtils.isEmpty(savedLabels.get(key))? savedLabels.get(key) : defaultLabel.defaultLabel();
+                if (!StringUtils.isEmpty(consolidatedLabel))
+                    consolidatedLabels.put(key, consolidatedLabel);
+            }
+        }
+        return consolidatedLabels;
+    }
+
+    public int getUpdatedLabelCount(@Nullable Container container)
+    {
+        Container labelContainer = getLabelContainer(container);
+        Map<String, String> savedLabels = labelContainer == null ? _normalStore.getProperties(getLabelGroup()) : _normalStore.getProperties(labelContainer, getLabelGroup());
+        int updatedLabelsCount = 0;
+        if (savedLabels.isEmpty())
+            return updatedLabelsCount;
+
+        for (CustomLabel defaultLabel : getDefaultLabels())
+        {
+            if (defaultLabel != null)
+            {
+                String key = defaultLabel.key();
+                boolean isUpdated = savedLabels.containsKey(key) && !StringUtils.isEmpty(savedLabels.get(key)) && !defaultLabel.defaultLabel().equals(savedLabels.get(key));
+                if (isUpdated)
+                    updatedLabelsCount++;
+            }
+        }
+        return updatedLabelsCount;
+    }
+
+    protected abstract String getLabelGroup();
+
+    protected abstract List<CustomLabel> getDefaultLabels();
+
+
+    public @Nullable Container getLabelContainer(@Nullable Container container)
+    {
+        return container;
+    }
+
+    @Override
+    public void saveLabels(HashMap<String, String> updatedLabels, @Nullable Container container) throws ValidationException
+    {
+        Map<String, String> sanitizedLabels = new HashMap<>();
+        for (Map.Entry<String, String> labelEntry: updatedLabels.entrySet())
+        {
+            String rawLabel = labelEntry.getValue();
+            if (rawLabel == null || StringUtils.isEmpty(rawLabel.trim()))
+                continue;
+            String label = rawLabel.trim();
+            if (label.length() > 400)
+                throw new ValidationException("Label cannot be longer than 400 characters.");
+            sanitizedLabels.put(labelEntry.getKey(), label);
+        }
+        if (sanitizedLabels.isEmpty())
+            return;
+
+        Container labelContainer = getLabelContainer(container);
+        PropertyManager.PropertyMap labelStore = labelContainer == null ? _normalStore.getWritableProperties(getLabelGroup(), true) : _normalStore.getWritableProperties(labelContainer, getLabelGroup(), true);
+        labelStore.putAll(sanitizedLabels);
+        labelStore.save();
+    }
+
+    @Override
+    public void resetLabels(@Nullable Container container)
+    {
+        Container labelContainer = getLabelContainer(container);
+        if (labelContainer == null)
+            _normalStore.deletePropertySet(getLabelGroup());
+        else
+            _normalStore.deletePropertySet(labelContainer, getLabelGroup());
+    }
+}

--- a/api/src/org/labkey/api/settings/AbstractCustomLabelProvider.java
+++ b/api/src/org/labkey/api/settings/AbstractCustomLabelProvider.java
@@ -74,12 +74,15 @@ public abstract class AbstractCustomLabelProvider implements CustomLabelProvider
         for (Map.Entry<String, String> labelEntry: updatedLabels.entrySet())
         {
             String rawLabel = labelEntry.getValue();
-            if (rawLabel == null || StringUtils.isEmpty(rawLabel.trim()))
-                continue;
-            String label = rawLabel.trim();
-            if (label.length() > 400)
-                throw new ValidationException("Label cannot be longer than 400 characters.");
-            sanitizedLabels.put(labelEntry.getKey(), label);
+            if (rawLabel == null)
+                sanitizedLabels.put(labelEntry.getKey(), "");
+            else
+            {
+                String label = rawLabel.trim();
+                if (label.length() > 400)
+                    throw new ValidationException("Label cannot be longer than 400 characters.");
+                sanitizedLabels.put(labelEntry.getKey(), label);
+            }
         }
         if (sanitizedLabels.isEmpty())
             return;

--- a/api/src/org/labkey/api/settings/CustomLabelProvider.java
+++ b/api/src/org/labkey/api/settings/CustomLabelProvider.java
@@ -17,7 +17,9 @@ package org.labkey.api.settings;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.query.ValidationException;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public interface CustomLabelProvider
@@ -28,7 +30,11 @@ public interface CustomLabelProvider
      */
     Map<String, String> getCustomLabels(@Nullable Container container);
 
-    Map<String, String> getSiteCustomLabels();
+    void resetLabels(@Nullable Container container);
+
+    void saveLabels(HashMap<String, String> updatedLabels, @Nullable Container container) throws ValidationException;
 
     String getName();
+
+    Map<String, Integer> getMetrics();
 }

--- a/api/src/org/labkey/api/settings/CustomLabelService.java
+++ b/api/src/org/labkey/api/settings/CustomLabelService.java
@@ -19,6 +19,8 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.services.ServiceRegistry;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -37,6 +39,8 @@ public interface CustomLabelService
     void registerProvider(CustomLabelProvider customLabelProvider);
     CustomLabelProvider getCustomLabelProvider(@NotNull String name);
     Collection<CustomLabelProvider> getCustomLabelProviders();
+
+    Map<String, Map<String, Integer>> getCustomLabelMetrics();
 
     class CustomLabelServiceImpl implements CustomLabelService
     {
@@ -59,6 +63,17 @@ public interface CustomLabelService
         public Collection<CustomLabelProvider> getCustomLabelProviders()
         {
             return REGISTERED_PROVIDERS.values();
+        }
+
+        @Override
+        public Map<String, Map<String, Integer>> getCustomLabelMetrics()
+        {
+            Map<String, Map<String, Integer>> labelCounts = new HashMap<>();
+            for (CustomLabelProvider provider : getCustomLabelProviders())
+            {
+                labelCounts.put(provider.getName(), provider.getMetrics());
+            }
+            return labelCounts;
         }
     }
 }

--- a/api/src/org/labkey/api/settings/CustomLabelService.java
+++ b/api/src/org/labkey/api/settings/CustomLabelService.java
@@ -16,6 +16,7 @@
 package org.labkey.api.settings;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Container;
 import org.labkey.api.services.ServiceRegistry;
 
 import java.util.Collection;
@@ -41,6 +42,8 @@ public interface CustomLabelService
     Collection<CustomLabelProvider> getCustomLabelProviders();
 
     Map<String, Map<String, Integer>> getCustomLabelMetrics();
+
+    Map<String, Map<String, String>> getCustomLabels(Container container);
 
     class CustomLabelServiceImpl implements CustomLabelService
     {
@@ -74,6 +77,19 @@ public interface CustomLabelService
                 labelCounts.put(provider.getName(), provider.getMetrics());
             }
             return labelCounts;
+        }
+
+        @Override
+        public Map<String, Map<String, String>> getCustomLabels(Container container)
+        {
+            Map<String, Map<String, String>> moduleLabels = new HashMap<>();
+            for (CustomLabelProvider provider : getCustomLabelProviders())
+            {
+                Map<String, String> labels = provider.getCustomLabels(container);
+                if (labels != null)
+                    moduleLabels.put(provider.getName(), labels);
+            }
+            return moduleLabels;
         }
     }
 }

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2261,13 +2261,7 @@ public class PageFlowUtil
         CustomLabelService customLabelService = CustomLabelService.get();
         if (customLabelService != null)
         {
-            Map<String, Map<String, String>> moduleLabels = new HashMap<>();
-            for (CustomLabelProvider provider : customLabelService.getCustomLabelProviders())
-            {
-                Map<String, String> labels = provider.getCustomLabels(container);
-                if (labels != null)
-                    moduleLabels.put(provider.getName(), labels);
-            }
+            Map<String, Map<String, String>> moduleLabels = customLabelService.getCustomLabels(container);
             if (!moduleLabels.isEmpty())
                 json.put("labels", moduleLabels);
         }

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -2817,6 +2817,19 @@ public class CoreController extends SpringActionController
         }
     }
 
+    @RequiresPermission(ReadPermission.class)
+    public class GetCustomLabelsAction extends ReadOnlyApiAction<CustomLabelForm>
+    {
+        @Override
+        public Object execute(CustomLabelForm form, BindException errors)
+        {
+            ApiSimpleResponse response = new ApiSimpleResponse();
+            response.put("labels", CustomLabelService.get().getCustomLabels(getContainer()));
+            response.put("success", true);
+            return response;
+        }
+    }
+
     @RequiresPermission(AdminPermission.class)
     public class CustomLabelsAction extends MutatingApiAction<CustomLabelForm>
     {

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1162,6 +1162,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             cal.set(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), 1, 0, 0, 0);
             results.put("uniqueUserCountThisMonth", UserManager.getUniqueUsersCount(cal.getTime()));
             results.put("scriptEngines", LabKeyScriptEngineManager.get().getScriptEngineMetrics());
+            results.put("customLabels", CustomLabelService.get().getCustomLabelMetrics());
             return results;
         });
 


### PR DESCRIPTION
#### Rationale
CustomLabelService/Provider was previously created for supporting site level NLP label customization. This PR refactors the related function so it can be more widely used, both in LKS and apps. 

#### Related Pull Requests
* https://github.com/LabKey/labkey-ui-components/pull/1487
* https://github.com/LabKey/labkey-ui-premium/pull/406
* https://github.com/LabKey/platform/pull/5487
* https://github.com/LabKey/limsModules/pull/226
* https://github.com/LabKey/nlp/pull/241

#### Changes
- refactored custom label handling out of NLP into AbstractCustomLabelProvider
- new GetCustomLabels.api and CustomLabels.api to get and set custom labels
- added metric for site/project customLabel counts
