### PR TITLE
Avoid inline script for ExtJS label tooltips

### DIFF
--- a/api/gwtsrc/org/labkey/api/gwt/client/ui/HelpPopup.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/ui/HelpPopup.java
@@ -42,28 +42,14 @@ public class HelpPopup extends InlineLabel
         _body = body;
 
         final String headerSize = PropertyUtil.getServerProperty("header1Size");
-        String text = "<a tabindex=\"-1\" href=\"javascript:void(0);\"><span class=\"labkey-help-pop-up\" style=\"font-size:" +
+        String text = "<a tabindex=\"-1\"><span class=\"labkey-help-pop-up\" style=\"font-size:" +
                 (headerSize == null ? "10pt" : headerSize) +
                 ";\"><sup>?</sup></span></a>";
         DOM.setInnerHTML(_element, text);
 
-        addMouseOverHandler(new MouseOverHandler()
-        {
-            @Override
-            public void onMouseOver(MouseOverEvent e)
-            {
-                showHelpDiv(_element, _title, _body);
-            }
-        });
+        addMouseOverHandler(e -> showHelpDiv(_element, _title, _body));
 
-        addMouseOutHandler(new MouseOutHandler()
-        {
-            @Override
-            public void onMouseOut(MouseOutEvent e)
-            {
-                hideHelpDiv();
-            }
-        });
+        addMouseOutHandler(e -> hideHelpDiv());
     }
 
     public void setBody(String body)

--- a/api/src/org/labkey/api/query/import.jsp
+++ b/api/src/org/labkey/api/query/import.jsp
@@ -345,12 +345,14 @@
                 preventMark: true,
                 fieldLabel: 'Import Options',
                 columns: 1,
-                helpPopup: LABKEY.Utils.encodeHtml(
+                helpPopup:
                         '<p>By default, import will insert new rows based on the data/file provided. The operation will fail ' +
                         'if there are existing row identifiers that match those being imported.</p>' +
-                        '<p>When \'Update ' + type + '\' is selected, data will be updated for matching row identifiers. When \'Allow new ' + type + ' during update\' is checked, new ' + type + ' will be created for any that do not match.' +
-                        ' Data will not be changed for any columns not in the imported data/file.</p>'
-                ),
+                        '<p>When \'Update ' + LABKEY.Utils.encodeHtml(type) +
+                        '\' is selected, data will be updated for matching row identifiers. When \'Allow new ' +
+                        LABKEY.Utils.encodeHtml(type) + ' during update\' is checked, new ' + LABKEY.Utils.encodeHtml(type) +
+                        ' will be created for any that do not match.' +
+                        ' Data will not be changed for any columns not in the imported data/file.</p>',
                 defaults: {
                     name: 'insertOptionUI'
                 },

--- a/api/webapp/clientapi/dom/Utils.js
+++ b/api/webapp/clientapi/dom/Utils.js
@@ -146,17 +146,21 @@ LABKEY.Utils = new function(impl, $) {
 
     // JavaScript version of PageFlowUtil.helpPopup(), returns html and callback to be invoked after element is inserted
     // into page. Useful for including LabKey-style help in Ext components.
-    impl.helpPopup = function(titleText, helpText)
+    impl.helpPopup = function(titleText, helpText, isHtml, autoRegisterDelay, zIndex)
     {
         const h = Ext4.util.Format.htmlEncode;
         const id = Ext4.id();
-        const html = '<a id="' + id + '" href="#" tabindex="-1" class="_helpPopup"><span class="labkey-help-pop-up">?</span></a>';
+        const html = '<a id="' + id + '" tabindex="-1" class="_helpPopup"><span class="labkey-help-pop-up">?</span></a>';
         const callback = function()
         {
-            LABKEY.Utils.attachEventHandler(id, "click", function() {return showHelpDivDelay(this, titleText, h(helpText), 'auto');});
-            LABKEY.Utils.attachEventHandler(id, "mouseover", function() {return showHelpDivDelay(this, titleText, h(helpText), 'auto');});
+            LABKEY.Utils.attachEventHandler(id, "click", function() {return showHelpDiv(this, titleText, isHtml ? helpText : h(helpText), 'auto', zIndex);});
+            LABKEY.Utils.attachEventHandler(id, "mouseover", function() {return showHelpDivDelay(this, titleText, isHtml ? helpText : h(helpText), 'auto', undefined, zIndex);});
             LABKEY.Utils.attachEventHandler(id, "mouseout", hideHelpDivDelay);
         };
+        if (autoRegisterDelay)
+        {
+            setTimeout(callback, autoRegisterDelay);
+        }
         return {"html":html, "callback":callback};
     };
 

--- a/api/webapp/clientapi/ext4/Util.js
+++ b/api/webapp/clientapi/ext4/Util.js
@@ -324,7 +324,7 @@
 
                 if (meta.friendlyType)
                     if (!(meta.lookup && meta.lookup['public'] !== false && meta.lookups !== false))
-``                        array.push(Ext4.util.Format.htmlEncode(meta.friendlyType));
+                        array.push(Ext4.util.Format.htmlEncode(meta.friendlyType));
 
                 if (meta.description)
                     array.push(Ext4.util.Format.htmlEncode(meta.description));

--- a/api/webapp/clientapi/ext4/Util.js
+++ b/api/webapp/clientapi/ext4/Util.js
@@ -324,7 +324,7 @@
 
                 if (meta.friendlyType)
                     if (!(meta.lookup && meta.lookup['public'] !== false && meta.lookups !== false))
-                        array.push(meta.friendlyType);
+``                        array.push(Ext4.util.Format.htmlEncode(meta.friendlyType));
 
                 if (meta.description)
                     array.push(Ext4.util.Format.htmlEncode(meta.description));

--- a/api/webapp/ext-4.2.1/ext-patches.js
+++ b/api/webapp/ext-4.2.1/ext-patches.js
@@ -166,8 +166,8 @@ Ext4.override(Ext4.form.field.Base, {
         '>',
         '{beforeLabelTextTpl}',
         '<tpl if="fieldLabel">{fieldLabel}{labelSeparator}</tpl>',
-        //NOTE: this line added.  this is sub-optimal, but afterLabelTpl uses a different path to populate tpl values
-        '<tpl if="helpPopup"><a tabindex="-1" href="javascript:void(0);" data-qtip="{helpPopup}"><span class="labkey-help-pop-up">?</span></a></tpl>',
+        // Use a very large zIndex so that the popup will render on top of any ExtJS windows/dialogs that may be open
+        '<tpl if="helpPopup">{[LABKEY.Utils.helpPopup(values.fieldLabel, values.helpPopup, true, 1, 50000).html]}</tpl>',
         '{afterLabelTextTpl}',
         '</label>',
         '{afterLabelTpl}',

--- a/api/webapp/ext-4.2.1/ext-patches.js
+++ b/api/webapp/ext-4.2.1/ext-patches.js
@@ -217,7 +217,9 @@ Ext4.override(Ext4.form.field.Base, {
         var data = this.callOverridden();
 
         //support a tooltip
-        data.helpPopupHtml = LABKEY.Utils.helpPopup(data.fieldLabel, this.helpPopup, true, 1, 50000).html;
+        if (this.helpPopup) {
+            data.helpPopupHtml = LABKEY.Utils.helpPopup(data.fieldLabel, this.helpPopup, true, 1, 50000).html;
+        }
 
         return data;
     }

--- a/api/webapp/ext-4.2.1/ext-patches.js
+++ b/api/webapp/ext-4.2.1/ext-patches.js
@@ -167,7 +167,7 @@ Ext4.override(Ext4.form.field.Base, {
         '{beforeLabelTextTpl}',
         '<tpl if="fieldLabel">{fieldLabel}{labelSeparator}</tpl>',
         // Use a very large zIndex so that the popup will render on top of any ExtJS windows/dialogs that may be open
-        '<tpl if="helpPopup">{[LABKEY.Utils.helpPopup(values.fieldLabel, values.helpPopup, true, 1, 50000).html]}</tpl>',
+        '<tpl if="helpPopupHtml">{helpPopupHtml}</tpl>',
         '{afterLabelTextTpl}',
         '</label>',
         '{afterLabelTpl}',
@@ -217,7 +217,7 @@ Ext4.override(Ext4.form.field.Base, {
         var data = this.callOverridden();
 
         //support a tooltip
-        data.helpPopup = this.helpPopup;
+        data.helpPopupHtml = LABKEY.Utils.helpPopup(data.fieldLabel, this.helpPopup, true, 1, 50000).html;
 
         return data;
     }

--- a/core/webapp/util.js
+++ b/core/webapp/util.js
@@ -47,13 +47,13 @@ function getHelpDiv()
     return _helpDiv;
 }
 
-function showHelpDivDelay(elem, titleText, bodyText, width, delay)
+function showHelpDivDelay(elem, titleText, bodyText, width, delay, zIndex)
 {
     // IE support
-    _showTimer = setTimeout(function() { showHelpDiv(elem, titleText, bodyText, width); }, delay ? delay : 400);
+    _showTimer = setTimeout(function() { showHelpDiv(elem, titleText, bodyText, width, zIndex); }, delay ? delay : 400);
 }
 
-function showHelpDiv(elem, titleText, bodyHtml, width)
+function showHelpDiv(elem, titleText, bodyHtml, width, zIndex)
 {
     var posLeft = 12;
     var posTop = 8;
@@ -88,7 +88,7 @@ function showHelpDiv(elem, titleText, bodyHtml, width)
     var pos = { left: bd.scrollLeft(), top: bd.scrollTop() };
     div.style.top = posTop + "px";
     div.style.display = "block";
-    div.style.zIndex = "1050";
+    div.style.zIndex = zIndex ? zIndex : "1050";
 
     var table = document.getElementById("helpDivTable");
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -725,9 +725,8 @@ public class ExperimentController extends SpringActionController
                     {
                         String editLink = updateURL.toString();
                         ActionButton updateButton = new ActionButton("Edit Type");
-                        updateButton.setURL("javascript:void(0)");
                         updateButton.setActionType(ActionButton.Action.SCRIPT);
-                        updateButton.setScript("javascript: if (window.confirm('This sample type is defined in the " + _sampleType.getContainer().getPath() + " folder. Would you still like to edit it?')) { window.location = '" + editLink + "' }");
+                        updateButton.setScript("if (window.confirm('This sample type is defined in the " + _sampleType.getContainer().getPath() + " folder. Would you still like to edit it?')) { window.location = '" + editLink + "' }");
                         detailsView.getDataRegion().getButtonBar(DataRegion.MODE_DETAILS).add(updateButton);
                     }
                     else
@@ -1088,9 +1087,8 @@ public class ExperimentController extends SpringActionController
                 else if (_dataClass.getContainer().hasPermission(getUser(), DesignDataClassPermission.class))
                 {
                     ActionButton updateButton = new ActionButton("Edit Data Class");
-                    updateButton.setURL("javascript:void(0)");
                     updateButton.setActionType(ActionButton.Action.SCRIPT);
-                    updateButton.setScript("javascript: if (window.confirm('This data class is defined in the " + _dataClass.getContainer().getPath() + " folder. Would you still like to edit it?')) { window.location = '" + updateURL + "' }");
+                    updateButton.setScript("if (window.confirm('This data class is defined in the " + _dataClass.getContainer().getPath() + " folder. Would you still like to edit it?')) { window.location = '" + updateURL + "' }");
                     updateButton.setPrimary(true);
                     bb.add(updateButton);
                 }

--- a/wiki/src/org/labkey/wiki/view/customizeWiki.jsp
+++ b/wiki/src/org/labkey/wiki/view/customizeWiki.jsp
@@ -110,7 +110,7 @@ function disableSubmit()
     var btn = document.getElementById("btnSubmit");
     btn.disabled = true;
     btn.className = "labkey-disabled-button primary";
-    btn.href = "javascript:return false;";
+    btn.href = "#";
 }
 
 function onSuccess(containerId, response)


### PR DESCRIPTION
#### Rationale
We can't use `href="javascript:void(0)"` with a strict CSP so we need a new strategy for ExtJS-based tooltips. And we want to show tooltips on top of all open ExtJS windows/dialogs.

#### Changes
- Use newer tooltip approach for ExtJS labels
- Fix some HTML encoding problems
