### PR TITLE
Issue 49989: "Show metric in plots, but don't identify outliers" should not display bound lines

### DIFF
--- a/core/webapp/vis/src/plot.js
+++ b/core/webapp/vis/src/plot.js
@@ -2215,7 +2215,9 @@ boxPlot.render();
                 config.layers = [];
 
                 if (config.properties.mean !== undefined) {
-                    if (config.properties.stdDev !== undefined && config.properties.boundType === LABKEY.vis.PlotProperties.BoundType.StandardDeviation) {
+                    if (config.properties.stdDev !== undefined &&
+                            config.properties.boundType === LABKEY.vis.PlotProperties.BoundType.StandardDeviation &&
+                            config.properties.showBoundLines) {
 
                         config.layers.push(new LABKEY.vis.Layer({
                             geom: new LABKEY.vis.Geom.ErrorBar({size: 1, color: 'red', dashed: true, width: barWidth, topOnly: true}),

--- a/core/webapp/vis/src/plot.js
+++ b/core/webapp/vis/src/plot.js
@@ -1744,6 +1744,8 @@ boxPlot.render();
                 config.properties.lowerBound = -3;
             }
         }
+        // default to true
+        config.properties.showBoundLines = config.properties.showBoundLines ?? true;
 
         // get a sorted array of the unique x-axis labels
         var uniqueXAxisKeys = {}, uniqueXAxisLabels = [];


### PR DESCRIPTION
#### Rationale
Check new plot config property to display bound lines

#### Related Pull Requests
- https://github.com/LabKey/targetedms/pull/896
