### PR TITLE
Fix group membership cache invalidation

### DIFF
--- a/api/src/org/labkey/api/cache/BlockingCache.java
+++ b/api/src/org/labkey/api/cache/BlockingCache.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.DeadlockPreventingException;
 import org.labkey.api.util.DebugInfoDumper;
 import org.labkey.api.util.Filter;
@@ -270,6 +271,7 @@ public class BlockingCache<K, V> implements Cache<K, V>
         return new BlockingCache<>(_cache.createTemporaryCache(), _loader, _timeout);
     }
 
+    @TestWhen(TestWhen.When.BVT)
     public static class BlockingCacheTest extends Assert
     {
         private Cache<Integer, Wrapper<Integer>> _cache;

--- a/api/src/org/labkey/api/data/AbstractForeignKey.java
+++ b/api/src/org/labkey/api/data/AbstractForeignKey.java
@@ -55,8 +55,6 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Convenience base class for {@link ForeignKey} implementors.
- * User: kevink
- * Date: Nov 29, 2007 5:30:26 PM
  */
 public abstract class AbstractForeignKey implements ForeignKey, Cloneable
 {

--- a/api/src/org/labkey/api/files/FileSystemWatcherImpl.java
+++ b/api/src/org/labkey/api/files/FileSystemWatcherImpl.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.labkey.api.cloud.CloudWatchService;
 import org.labkey.api.cloud.CloudWatcherConfig;
 import org.labkey.api.collections.ConcurrentHashSet;
+import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileUtil;
@@ -70,10 +71,6 @@ import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
  *
  * This class is thread-safe, for both listener registration and event invocation. Implementations of FileSystemDirectoryListener
  * must be thread-safe. Listener methods must return quickly since they are all invoked by a single thread.
- *
- * User: adam
- * Date: 9/14/13
- * Time: 11:07 AM
  */
 public class FileSystemWatcherImpl implements FileSystemWatcher
 {
@@ -469,6 +466,7 @@ public class FileSystemWatcherImpl implements FileSystemWatcher
         }
     }
 
+    @TestWhen(TestWhen.When.BVT)
     public static class TestCase extends Assert
     {
         @Test

--- a/api/src/org/labkey/api/security/GroupCache.java
+++ b/api/src/org/labkey/api/security/GroupCache.java
@@ -22,11 +22,6 @@ import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlSelector;
 
-/**
- * User: adam
- * Date: 10/15/11
- * Time: 10:09 AM
- */
 public class GroupCache
 {
     private static final CoreSchema CORE = CoreSchema.getInstance();
@@ -37,21 +32,13 @@ public class GroupCache
         return selector.getObject(Group.class);
     });
 
-
     static @Nullable Group get(int groupId)
     {
         return CACHE.get(groupId);
     }
 
-
     static void uncache(int groupId)
     {
         CACHE.remove(groupId);
-    }
-
-
-    static void uncacheAll()
-    {
-        CACHE.clear();
     }
 }

--- a/api/src/org/labkey/api/security/GroupManager.java
+++ b/api/src/org/labkey/api/security/GroupManager.java
@@ -439,7 +439,7 @@ public class GroupManager
                 SecurityManager.deleteGroup(groupId);
                 assertNull(SecurityManager.getGroupId(project, name, false));
 
-                // Test that delete and cache clearing is correct
+                // Test that cache clearing after group delete is correct
                 PrincipalArray memberships = GroupManager.getAllGroupsForPrincipal(TestContext.get().getUser());
                 assertFalse("getAllGroupsForPrincipal() returned " + memberships + ", which contains the just-deleted group: " + groupId + "!", memberships.contains(groupId));
                 List<UserPrincipal> unknownPrincipals = memberships.stream()

--- a/api/src/org/labkey/api/security/GroupManager.java
+++ b/api/src/org/labkey/api/security/GroupManager.java
@@ -66,6 +66,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class GroupManager
@@ -426,10 +427,27 @@ public class GroupManager
 
             Container project = JunitUtil.getTestContainer().getProject();
 
-            if (null != SecurityManager.getGroupId(project, "a", false))
-                SecurityManager.deleteGroup(SecurityManager.getGroupId(project, "a"));
-            if (null != SecurityManager.getGroupId(project, "b", false))
-                SecurityManager.deleteGroup(SecurityManager.getGroupId(project, "b"));
+            deleteGroup(project, "a");
+            deleteGroup(project, "b");
+        }
+
+        private void deleteGroup(Container project, String name)
+        {
+            Integer groupId = SecurityManager.getGroupId(project, name, false);
+            if (null != groupId)
+            {
+                SecurityManager.deleteGroup(groupId);
+                assertNull(SecurityManager.getGroupId(project, name, false));
+
+                // Test that delete and cache clearing is correct
+                PrincipalArray memberships = GroupManager.getAllGroupsForPrincipal(TestContext.get().getUser());
+                assertFalse("getAllGroupsForPrincipal() returned " + memberships + ", which contains the just-deleted group: " + groupId + "!", memberships.contains(groupId));
+                List<UserPrincipal> unknownPrincipals = memberships.stream()
+                    .map(SecurityManager::getPrincipal)
+                    .filter(Objects::isNull)
+                    .toList();
+                assertTrue("getAllGroupsForPrincipal() returned " + memberships + ", which contains unknown principal(s): " + unknownPrincipals, unknownPrincipals.isEmpty());
+            }
         }
 
         @Test

--- a/api/src/org/labkey/api/security/GroupMembershipCache.java
+++ b/api/src/org/labkey/api/security/GroupMembershipCache.java
@@ -92,7 +92,8 @@ public class GroupMembershipCache
     {
         // very slight overkill
         uncache(group);
-        uncache(principal);
+        if (!group.equals(principal))
+            uncache(principal);
 
         // invalidate all computed group lists (getAllGroups())
         if (principal instanceof Group)

--- a/api/src/org/labkey/api/security/GroupMembershipCache.java
+++ b/api/src/org/labkey/api/security/GroupMembershipCache.java
@@ -96,7 +96,10 @@ public class GroupMembershipCache
 
         // invalidate all computed group lists (getAllGroups())
         if (principal instanceof Group)
+        {
             CACHE.removeUsingFilter(new Cache.StringPrefixFilter(ALL_GROUP_MEMBERSHIPS_PREFIX));
+            CACHE.removeUsingFilter(new Cache.StringPrefixFilter(IMMEDIATE_GROUP_MEMBERSHIPS_PREFIX));
+        }
     }
 
     private static void uncache(UserPrincipal principal)

--- a/api/src/org/labkey/api/security/LimitedUser.java
+++ b/api/src/org/labkey/api/security/LimitedUser.java
@@ -127,11 +127,11 @@ public class LimitedUser extends ClonedUser
             testPermissions(ElevatedUser.ensureCanSeeAuditLogRole(c, new LimitedUser(user, ReaderRole.class)), 2, true, false, false, false, true);
             testPermissions(ElevatedUser.ensureCanSeeAuditLogRole(c, ElevatedUser.getElevatedUser(new LimitedUser(user, ReaderRole.class), EditorRole.class)), 3, true, true, true, false, true);
 
-            int groupCount = (int)user.getGroups().stream().count();
+            int groupCount = user.getGroups().size();
             int roleCount = user.getAssignedRoles(c.getPolicy()).size();
             int siteRolesCount = user.getSiteRoles().size();
             User elevated = ElevatedUser.getElevatedUser(user);
-            assertEquals(groupCount, elevated.getGroups().stream().count());
+            assertEquals(groupCount, elevated.getGroups().size());
             assertEquals(roleCount, elevated.getAssignedRoles(c.getPolicy()).size());
             assertEquals(siteRolesCount, elevated.getSiteRoles().size());
         }

--- a/api/src/org/labkey/api/security/MemberType.java
+++ b/api/src/org/labkey/api/security/MemberType.java
@@ -17,12 +17,6 @@ package org.labkey.api.security;
 
 import org.jetbrains.annotations.Nullable;
 
-/**
- * User: adam
- * Date: 11/12/12
- * Time: 8:30 AM
- */
-
 // This is a "generic enum"... it was a true enum (SecurityManager.GroupMemberType), but the interface / implementation approach
 // better supports generics and cleans up getGroupMembers(), getAllGroupMembers(), etc. Standard enums don't support generics.
 
@@ -31,43 +25,23 @@ public interface MemberType<P extends UserPrincipal>
 {
     @Nullable P getPrincipal(int id);
 
-    static MemberType<Group> GROUPS = new MemberType<Group>() {
-        @Override
-        public Group getPrincipal(int id)
-        {
-            return SecurityManager.getGroup(id);
-        }
-    };
+    MemberType<Group> GROUPS = SecurityManager::getGroup;
 
-    static MemberType<User> ACTIVE_AND_INACTIVE_USERS = new MemberType<User>() {
-        @Override
-        public User getPrincipal(int id)
-        {
-            return UserManager.getUser(id);
-        }
-    };
+    MemberType<User> ACTIVE_AND_INACTIVE_USERS = UserManager::getUser;
 
-    static MemberType<User> ACTIVE_USERS = new MemberType<User>() {
-        @Override
-        public User getPrincipal(int id)
-        {
-            User user = UserManager.getUser(id);
+    MemberType<User> ACTIVE_USERS = id -> {
+        User user = UserManager.getUser(id);
 
-            return (null != user && user.isActive() ? user : null);
-        }
+        return (null != user && user.isActive() ? user : null);
     };
 
     // All groups and all users (including inactive)
-    static MemberType<UserPrincipal> ALL_GROUPS_AND_USERS = new MemberType<UserPrincipal>() {
-        @Override
-        public UserPrincipal getPrincipal(int id)
-        {
-            User user = ACTIVE_AND_INACTIVE_USERS.getPrincipal(id);
+    MemberType<UserPrincipal> ALL_GROUPS_AND_USERS = id -> {
+        User user = ACTIVE_AND_INACTIVE_USERS.getPrincipal(id);
 
-            if (null != user)
-                return user;
+        if (null != user)
+            return user;
 
-            return GROUPS.getPrincipal(id);
-        }
+        return GROUPS.getPrincipal(id);
     };
 }

--- a/api/src/org/labkey/api/security/PrincipalArray.java
+++ b/api/src/org/labkey/api/security/PrincipalArray.java
@@ -1,15 +1,21 @@
 package org.labkey.api.security;
 
+import com.google.common.primitives.Ints;
+import org.apache.commons.collections4.iterators.ArrayIterator;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 import java.util.stream.Stream;
 
 /*
     Simple wrapper that limits the ability to mutate the int[] and ensures it's sorted, searched efficiently, etc.
     Can represent a group's membership list OR user's list of group memberships.
  */
-public class PrincipalArray
+public class PrincipalArray implements Iterable<Integer>
 {
     private static final PrincipalArray EMPTY_PRINCIPAL_ARRAY = new PrincipalArray(Collections.emptyList());
 
@@ -47,14 +53,32 @@ public class PrincipalArray
         return Arrays.stream(_principals).boxed();
     }
 
-    public static PrincipalArray getEmptyPrincipalArray()
-    {
-        return EMPTY_PRINCIPAL_ARRAY;
-    }
-
     @Override
     public String toString()
     {
         return "PrincipalArray" + Arrays.toString(_principals);
+    }
+
+    public int size()
+    {
+        return _principals.length;
+    }
+
+    @NotNull
+    @Override
+    public Iterator<Integer> iterator()
+    {
+        return new ArrayIterator<>(_principals);
+    }
+
+    // Returns an immutable list that wraps the principals array
+    public List<Integer> getList()
+    {
+        return Ints.asList(_principals);
+    }
+
+    public static PrincipalArray getEmptyPrincipalArray()
+    {
+        return EMPTY_PRINCIPAL_ARRAY;
     }
 }

--- a/api/src/org/labkey/api/security/ProjectAndSiteGroupsCache.java
+++ b/api/src/org/labkey/api/security/ProjectAndSiteGroupsCache.java
@@ -31,12 +31,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * User: adam
- * Date: 3/27/12
- * Time: 4:45 PM
- */
-
 // Caches the list of groups in each project plus the site group list
 public class ProjectAndSiteGroupsCache
 {
@@ -56,7 +50,6 @@ public class ProjectAndSiteGroupsCache
 
         return Collections.unmodifiableCollection(new SqlSelector(CORE.getSchema(), sql).getCollection(Integer.class));
     };
-
 
     static @NotNull List<Group> getProjectGroups(Container project, boolean includeSiteGroups)
     {
@@ -79,7 +72,6 @@ public class ProjectAndSiteGroupsCache
         return Collections.unmodifiableList(groups);
     }
 
-
     static @NotNull List<Group> getSiteGroups()
     {
         Collection<Integer> siteGroupIds = getSiteGroupIds();
@@ -88,7 +80,6 @@ public class ProjectAndSiteGroupsCache
 
         return Collections.unmodifiableList(groups);
     }
-
 
     private static void addAll(List<Group> groups, Collection<Integer> ids)
     {
@@ -101,12 +92,10 @@ public class ProjectAndSiteGroupsCache
         }
     }
 
-
     private static @NotNull Collection<Integer> getSiteGroupIds()
     {
         return CACHE.get(ContainerManager.getRoot(), null, GROUP_LIST_LOADER);
     }
-
 
     static void uncache(Container c)
     {

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1498,7 +1498,7 @@ public class SecurityManager
                 ProjectAndSiteGroupsCache.uncache(c);
                 // 20329 SecurityPolicy cache still has the role assignments for deleted groups.
                 SecurityPolicyManager.notifyPolicyChanges(resources);
-                // Need to invalidate all computed group lists. This isn't quite right, but it gets the job done.
+                // Invalidate all computed group lists
                 GroupMembershipCache.handleGroupChange(group, group);
             }, CommitTaskOption.IMMEDIATE, CommitTaskOption.POSTCOMMIT, CommitTaskOption.POSTROLLBACK);
 

--- a/api/src/org/labkey/api/security/SecurityPolicy.java
+++ b/api/src/org/labkey/api/security/SecurityPolicy.java
@@ -201,7 +201,6 @@ public class SecurityPolicy
     /**
      * Callers outside this package should use SecurityManager.hasAllPermissions() or Container.hasPermission[s]() or SecurableResource.hasPermission().
      * If you are modifying a SecurityPolicy you should use getOwnPermissions() or getAssignments()
-     *
      */
     @Deprecated
     public boolean hasPermission(@NotNull UserPrincipal principal, @NotNull Class<? extends Permission> permission)

--- a/api/src/org/labkey/api/util/TestContext.java
+++ b/api/src/org/labkey/api/util/TestContext.java
@@ -15,24 +15,19 @@
  */
 package org.labkey.api.util;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.labkey.api.security.User;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 
-/**
- * User: mbellew
- * Date: Feb 24, 2004
- * Time: 12:31:33 PM
- */
 public class TestContext
 {
-    private static ThreadLocal<TestContext> local = new ThreadLocal<>();
+    private static final ThreadLocal<TestContext> local = new ThreadLocal<>();
+
+    private final ArrayList<CPUTimer> _perfResults = new ArrayList<>();
 
     private HttpServletRequest _request;
     private User _user;
-    ArrayList<CPUTimer> _perfResults = new ArrayList<>();
-
 
     public static TestContext get()
     {
@@ -47,24 +42,20 @@ public class TestContext
         local.set(t);
     }
 
-
     public User getUser()
     {
         return _user;
     }
-
 
     void setUser(User user)
     {
         _user = user;
     }
 
-
     public HttpServletRequest getRequest()
     {
         return _request;
     }
-
 
     public void setRequest(HttpServletRequest request)
     {

--- a/experiment/src/org/labkey/experiment/api/ExperimentStressTest.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentStressTest.java
@@ -18,6 +18,7 @@ import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.security.User;
+import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.TestContext;
 
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
 
 import static org.labkey.api.exp.api.ExperimentService.QueryOptions.SkipBulkRemapCache;
 
+@TestWhen(TestWhen.When.BVT)
 public class ExperimentStressTest
 {
     private static final Logger LOG = LogManager.getLogger(ExperimentStressTest.class);

--- a/experiment/src/org/labkey/experiment/api/LineageTest.java
+++ b/experiment/src/org/labkey/experiment/api/LineageTest.java
@@ -53,6 +53,7 @@ import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.reader.MapLoader;
 import org.labkey.api.security.User;
+import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.view.ActionURL;
@@ -82,6 +83,7 @@ import static org.junit.Assert.fail;
 import static org.labkey.api.exp.api.ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_NAME;
 import static org.labkey.api.exp.api.ExperimentService.SAMPLE_DERIVATION_PROTOCOL_NAME;
 
+@TestWhen(TestWhen.When.BVT)
 public class LineageTest extends ExpProvisionedTableTestHelper
 {
     Container c;

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -30,10 +30,29 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.collections.Sets;
-import org.labkey.api.data.*;
+import org.labkey.api.data.BaseColumnInfo;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.DatabaseTableType;
+import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbSchemaType;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DbScope.SchemaTableOptions;
 import org.labkey.api.data.DbScope.Transaction;
+import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.MVDisplayColumnFactory;
+import org.labkey.api.data.ParameterMapStatement;
+import org.labkey.api.data.PropertyStorageSpec;
+import org.labkey.api.data.RuntimeSQLException;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SchemaTableInfo;
+import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.TableChange;
 import org.labkey.api.data.TableChange.ChangeType;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.UpdateableTableInfo;
+import org.labkey.api.data.VirtualTable;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
@@ -60,6 +79,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.test.TestTimeout;
+import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.CPUTimer;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.GUID;
@@ -1547,6 +1567,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
     }
 
     @TestTimeout(120)
+    @TestWhen(TestWhen.When.BVT)
     public static class TestCase extends Assert
     {
         private final Container container = JunitUtil.getTestContainer();

--- a/pipeline/src/org/labkey/pipeline/cluster/ClusterStartup.java
+++ b/pipeline/src/org/labkey/pipeline/cluster/ClusterStartup.java
@@ -27,11 +27,11 @@ import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.reader.Readers;
+import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
 import org.labkey.pipeline.AbstractPipelineStartup;
 import org.labkey.pipeline.mule.test.DummyPipelineJob;
@@ -51,8 +51,6 @@ import java.util.concurrent.TimeUnit;
 /**
  * Entry point for pipeline jobs that are invoked on a cluster node. After completion of the job, the process
  * should exit with a zero exit code in the case of success.
- * User: jeckels
- * Date: Apr 8, 2008
  */
 public class ClusterStartup extends AbstractPipelineStartup
 {
@@ -161,6 +159,7 @@ public class ClusterStartup extends AbstractPipelineStartup
         //System.exit(0);
     }
 
+    @TestWhen(TestWhen.When.BVT)
     public static class TestCase
     {
         private File _tempDir;


### PR DESCRIPTION
#### Rationale
Repeated runs of the DRT suite failed, pointing out an issue with group membership cache invalidation. Fix this and improve the test to fail faster.

Repeated runs also failed due to discrepancies between the `deleteGroups()` and `deleteGroup()` implementations. (The latter didn't invalidate most of the caches.) deleteGroups() now simply iterates the groups and calls deleteGroup() on each, for consistency.

Enhance `PrincipalArray` with more convenience methods to reduce use of internal array.

Move some long-running tests (>10s) from DRT to BVT.