### PR TITLE
Issue 50324: Assure runs are deleted when all output data objects are deleted

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -1521,7 +1521,8 @@ public class ExpDataIterators
 
         List<ExpData> dataOutputs = existingDerivationRun.getDataOutputs();
         List<ExpMaterial> materialOutputs = existingDerivationRun.getMaterialOutputs();
-        if (dataOutputs.isEmpty() && (materialOutputs.isEmpty() || (materialOutputs.size() == 1 && materialOutputs.contains(runItem))))
+        if ((dataOutputs.isEmpty() && (materialOutputs.isEmpty() || (materialOutputs.size() == 1 && materialOutputs.contains(runItem))))
+           || (materialOutputs.isEmpty() && dataOutputs.size() == 1 && dataOutputs.contains(runItem)))
         {
             LOG.debug("Run item '" + runItem.getName() + "' has existing source derivation run '" + existingDerivationRun.getRowId() + "' -- run has no other outputs, deleting run");
             // if run has no other outputs, delete the run completely


### PR DESCRIPTION
#### Rationale
Issue [50324](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50324)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/230

#### Changes
- Update `clearRunItemSourceRun` to also check for all output data objects having been removed without any sample outputs in the mix.