### PR TITLE
Add metric to track custom Log4J configs

### DIFF
--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1123,6 +1123,12 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             String labkeyContextPath = AppProps.getInstance().getContextPath();
             results.put("webappContextPath", labkeyContextPath);
             results.put("embeddedTomcat", AppProps.getInstance().isEmbeddedTomcat());
+            boolean customLog4JConfig = false;
+            if (ModuleLoader.getServletContext() != null)
+            {
+                customLog4JConfig = Boolean.parseBoolean(ModuleLoader.getServletContext().getInitParameter("org.labkey.customLog4JConfig"));
+            }
+            results.put("customLog4JConfig", customLog4JConfig);
             results.put("runtimeMode", AppProps.getInstance().isDevMode() ? "development" : "production");
             Set<String> deployedApps = new HashSet<>(CoreWarningProvider.collectAllDeployedApps());
             deployedApps.remove(labkeyContextPath);


### PR DESCRIPTION
#### Rationale
We want to be more proactive in coordinating edits to `log4j2.xml` configs for on-premise and cloud deployments

#### Related Pull Requests
- https://github.com/LabKey/server/pull/817

#### Changes
* New `modules.Core.customLog4JConfig` metric to capture whether a custom config file is being used
