### PR TITLE
Eliminate 'javascript:' hrefs

### DIFF
--- a/core/webapp/WebPartPermissionsPanel.js
+++ b/core/webapp/WebPartPermissionsPanel.js
@@ -268,33 +268,14 @@ Ext4.define('LABKEY.Portal.WebPartPermissionsPanel', {
                 jsonData: requestObj,
                 scope: this,
                 success: function(response){
-                    var json = Ext4.JSON.decode(response.responseText);
-                    this.replaceHREF(json.permission, requestObj.containerPath);
                     this.close();
+                    location.reload();
                 },
                 failure: function(response){
                     var json = Ext4.JSON.decode(response.responseText);
                 }
             });
 
-        },
-
-        replaceHREF: function(perm, path){
-            // Only wrap in quotes if not null
-            if(path != null){
-                path = "'" + Ext4.htmlEncode(path) + "'";
-            }
-
-            var query = Ext4.query('#permissions_'+this.webPartId),
-                href =  "javascript:(function(){Ext4.create('LABKEY.Portal.WebPartPermissionsPanel', {" +
-                        "webPartId: '" + this.webPartId + "'," +
-                        "permission: '" + perm + "'," +
-                        "containerPath: " + path +
-                        "}).show();}())";
-
-            if(query.length > 0){
-                query[0].setAttribute('href', href);
-            }
         },
 
         handleCancel: function(){

--- a/core/webapp/dropzone/dropzone.js
+++ b/core/webapp/dropzone/dropzone.js
@@ -135,7 +135,6 @@
       acceptedMimeTypes: null,
       autoProcessQueue: true,
       autoQueue: true,
-      addRemoveLinks: false,
       previewsContainer: null,
       capture: null,
       dictDefaultMessage: "Drop files here to upload",
@@ -261,10 +260,6 @@
           for (_j = 0, _len1 = _ref1.length; _j < _len1; _j++) {
             node = _ref1[_j];
             node.innerHTML = this.filesize(file.size);
-          }
-          if (this.options.addRemoveLinks) {
-            file._removeLink = Dropzone.createElement("<a class=\"dz-remove\" href=\"javascript:undefined;\" data-dz-remove>" + this.options.dictRemoveFile + "</a>");
-            file.previewElement.appendChild(file._removeLink);
           }
           removeFileEvent = (function(_this) {
             return function(e) {


### PR DESCRIPTION
#### Rationale
To support a Content Security Policy that prohibits inline script we need to get rid of `javascript:` hrefs.

#### Changes
- Delete unused option in dropzone to eliminate the use of a `javascript:` href
- Refresh the page to have the web part permissions update correctly. The user may no longer see the web part, and the attempt to refresh the config for subsequent reships of the dialog hadn't been working anyway.
