### PR TITLE
Increase timeout for TikaTestCase

### DIFF
--- a/api/src/org/labkey/api/test/TestTimeout.java
+++ b/api/src/org/labkey/api/test/TestTimeout.java
@@ -20,18 +20,13 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-/**
- * Timeout for server-side unit tests, in seconds
- * User: jeckels
- * Date: 1/14/13
- */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Inherited
 public @interface TestTimeout
 {
     /** One minute is our standard timeout */
-    public static final int DEFAULT = 60;
+    int DEFAULT = 60;
 
     int value() default DEFAULT;
 }

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -89,6 +89,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.settings.AppProps;
+import org.labkey.api.test.TestTimeout;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileStream;
@@ -1798,6 +1799,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         return _standardAnalyzer;
     }
 
+    @TestTimeout(120) // Initial load of PDF parser takes a minute on Windows (Started with Tika 2.9.2)
     public static class TikaTestCase extends Assert
     {
         @SuppressWarnings("ConstantConditions")

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -1826,6 +1826,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
 
             for (File file : sampledata.listFiles(File::isFile))
             {
+                _log.info("Attempting to parse: " + file.getName());
                 String docId = "testtika";
                 SimpleDocumentResource resource = new SimpleDocumentResource(new Path(file.getName()), docId, null, null, null, null, null);
                 ContentHandler handler = new BodyContentHandler(-1);


### PR DESCRIPTION
#### Rationale
[`LuceneSearchServiceImpl.TikaTestCase`](https://teamcity.labkey.org/test/-6448744520918666885?currentBuildTypeId=bt311&currentProjectId=LabkeyTrunk&expandTestHistoryChartSection=true&branch=%3Cdefault%3E) started taking over a minute to run on Windows when we upgraded Tika to 2.9.2.
There are two PDFs in the sample data used by this test; additional test logging shows that the first PDF takes over a minute to parse while the second PDF takes less than a second. Running the test locally shows a less extreme but still noticeable change between the first and second PDFs (6 seconds). Rerunning the test shows no slowdown for either PDF so this seems to be a problem only for the very first PDF indexed in the life of a server.

#### Related Pull Requests
- LabKey/server#794

#### Changes
- Increase timeout for `LuceneSearchServiceImpl.TikaTestCase`
