### PR TITLE
Issue 49975: Lower and Upper bound lines are displayed incorrectly on qc plots

### DIFF
--- a/core/webapp/vis/src/plot.js
+++ b/core/webapp/vis/src/plot.js
@@ -2320,9 +2320,9 @@ boxPlot.render();
                             data: meanStdDevData,
                             aes: {
                                 error: function (row) {
-                                    return row[config.properties.mean];
+                                    return row.upperBound;
                                 },
-                                yLeft: 'upperBound'
+                                yLeft: config.properties.mean
                             }
                         });
                         config.layers.push(upperBoundLayer);

--- a/core/webapp/vis/src/utils.js
+++ b/core/webapp/vis/src/utils.js
@@ -27,6 +27,14 @@ if (!LABKEY.vis.PlotProperties) {
             StandardDeviation: 'stddev'
         }
     }
+    if (!LABKEY.vis.PlotProperties.Color) {
+        LABKEY.vis.PlotProperties.Color = {
+            Outlier: 'red',
+            Mean: 'darkgrey',
+            OneSD: 'green',
+            TwoSD: 'blue',
+        }
+    }
 }
 
 LABKEY.vis.makeLine = function(x1, y1, x2, y2){


### PR DESCRIPTION
#### Rationale
The upper bound layer for fixed deviation from mean is creating two lines. This PR fixes the issue.
This PR also fixes the bound lines that were shown incorrectly for percent of mean and standard deviation y axis scales for fixed value cuttoff and fixed deviation from mean metrics.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5323

#### Changes
- fix bound lines for fixed cutoff and for percent of mean & SD y axis scales
-  fix bound lines for fixed deviation and for percent of mean & SD y axis scales
- hide bound lines for fixed cuttoff for all series shown in a plot
