### PR TITLE
Make PrincipalArray immutable

### DIFF
--- a/api/src/org/labkey/api/security/PrincipalArray.java
+++ b/api/src/org/labkey/api/security/PrincipalArray.java
@@ -1,7 +1,6 @@
 package org.labkey.api.security;
 
 import com.google.common.primitives.Ints;
-import org.apache.commons.collections4.iterators.ArrayIterator;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -12,69 +11,67 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /*
-    Simple wrapper that limits the ability to mutate the int[] and ensures it's sorted, searched efficiently, etc.
+    Immutable wrapper that manages a list of principal IDs, ensuring it's sorted, searched efficiently, etc.
     Can represent a group's membership list OR user's list of group memberships.
  */
 public class PrincipalArray implements Iterable<Integer>
 {
     private static final PrincipalArray EMPTY_PRINCIPAL_ARRAY = new PrincipalArray(Collections.emptyList());
 
-    private final int[] _principals; // Always sorted
+    // The set of principal IDs is fixed at construction time, so sort it and hold it in both array and list form
+    // for convenience and performance.
+    private final int[] _array;
+    private final List<Integer> _list;
 
     public PrincipalArray(Collection<Integer> principals)
     {
-        _principals = new int[principals.size()];
+        _array = new int[principals.size()];
         int i = 0;
-        for (int group : principals)
-            _principals[i++] = group;
-        Arrays.sort(_principals);
+        for (int principal : principals)
+            _array[i++] = principal;
+        Arrays.sort(_array);
+        _list = Ints.asList(_array);
     }
 
     // Needed for pipeline deserialization
     public PrincipalArray()
     {
-        _principals = null;
+        _array = null;
+        _list = null;
     }
 
     public boolean contains(int groupId)
     {
-        return Arrays.binarySearch(_principals, groupId) >= 0;
+        return Arrays.binarySearch(_array, groupId) >= 0;
     }
 
-    // Package private: for now, security classes can access underlying int[] for performance
-    int[] getPrincipals()
-    {
-        return _principals;
-    }
-
-    // Preferred method for accessing the principal IDs
     public Stream<Integer> stream()
     {
-        return Arrays.stream(_principals).boxed();
+        return _list.stream();
     }
 
     @Override
     public String toString()
     {
-        return "PrincipalArray" + Arrays.toString(_principals);
+        return "PrincipalArray" + Arrays.toString(_array);
     }
 
     public int size()
     {
-        return _principals.length;
+        return _list.size();
     }
 
     @NotNull
     @Override
     public Iterator<Integer> iterator()
     {
-        return new ArrayIterator<>(_principals);
+        return _list.iterator();
     }
 
-    // Returns an immutable list that wraps the principals array
+    // Returns an immutable list of principals
     public List<Integer> getList()
     {
-        return Ints.asList(_principals);
+        return _list;
     }
 
     public static PrincipalArray getEmptyPrincipalArray()

--- a/api/src/org/labkey/api/security/PrincipalArray.java
+++ b/api/src/org/labkey/api/security/PrincipalArray.java
@@ -30,7 +30,7 @@ public class PrincipalArray implements Iterable<Integer>
         for (int principal : principals)
             _array[i++] = principal;
         Arrays.sort(_array);
-        _list = Ints.asList(_array);
+        _list = Collections.unmodifiableList(Ints.asList(_array));
     }
 
     // Needed for pipeline deserialization

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1359,7 +1359,7 @@ public class SecurityManager
     }
 
     // Used only in the case of email change... current email address might be invalid
-    public static boolean loginExists(String email)
+    static boolean loginExists(String email)
     {
         return (null != getPasswordHash(email));
     }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1359,7 +1359,7 @@ public class SecurityManager
     }
 
     // Used only in the case of email change... current email address might be invalid
-    static boolean loginExists(String email)
+    public static boolean loginExists(String email)
     {
         return (null != getPasswordHash(email));
     }
@@ -1894,13 +1894,7 @@ public class SecurityManager
                 // group always returned empty set. Allow a special case of returning real set if explicitly requested.
                 if (next.isUsers() && returnSiteUsers)
                 {
-                    List<Integer> userIds = UserManager.getUserIds();
-                    int[] ids = new int[userIds.size()];
-                    for (int i = 0; i < userIds.size(); i++)
-                    {
-                        ids[i] = userIds.get(i);
-                    }
-                    addMembers(members, ids, memberType);
+                    addMembers(members, UserManager.getUserIds(), memberType);
                 }
                 else
                 {
@@ -1915,19 +1909,17 @@ public class SecurityManager
         return members;
     }
 
-    private static <P extends UserPrincipal> void addMembers(Collection<P> principals, int[] ids, MemberType<P> memberType)
+    private static <P extends UserPrincipal> void addMembers(Collection<P> principals, List<Integer> ids, MemberType<P> memberType)
     {
-        for (int id : ids)
-        {
-            P principal = memberType.getPrincipal(id);
-            if (null != principal)
-                principals.add(principal);
-        }
+        ids.stream()
+            .map(memberType::getPrincipal)
+            .filter(Objects::nonNull)
+            .forEach(principals::add);
     }
 
     private static <P extends UserPrincipal> void addMembers(Collection<P> principals, PrincipalArray members, MemberType<P> memberType)
     {
-        addMembers(principals, members.getPrincipals(), memberType);
+        addMembers(principals, members.getList(), memberType);
     }
 
     // get the list of group members that do not need to be direct members because they are a member of a member group (i.e. groups-in-groups)


### PR DESCRIPTION
#### Rationale
Caching and stashing immutable classes is strongly preferred. `PrincipalArray` previously exposed its array of principal IDs to other security classes. None of that code has been changing the array recently, but that wasn't obvious and, regardless, it's dangerous and unnecessary. This PR converts callers to use an immutable list of principal IDs and removes external access to the array.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5490
