### PR TITLE
Allow authentication and email change with an invalid address

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -243,9 +243,13 @@ public class AuthenticationManager
     }
 
     // Ignores domain == "*"
-    public static boolean isLdapOrSsoEmail(ValidEmail email)
+    public static boolean isLdapOrSsoEmail(ValidEmail validEmail)
     {
-        String emailAddress = email.getEmailAddress();
+        return isLdapOrSsoEmail(validEmail.getEmailAddress());
+    }
+
+    public static boolean isLdapOrSsoEmail(String emailAddress)
+    {
         return AuthenticationConfigurationCache.getActiveDomains().stream()
             .anyMatch(domain->StringUtils.endsWithIgnoreCase(emailAddress, "@" + domain));
     }
@@ -1026,45 +1030,57 @@ public class AuthenticationManager
     @NotNull
     public static PrimaryAuthenticationResult finalizePrimaryAuthentication(HttpServletRequest request, AuthenticationResponse response)
     {
-        ValidEmail email = response.getValidEmail();
-        User user;
+        User user = response.getUser();
+        final String emailAddress;
 
-        try
+        if (null != user)
         {
-            user = UserManager.getUser(email);
+            // Authentication provider set a User, so 1) the user exists and 2) the user's email address may be invalid
+            emailAddress = user.getEmail();
+        }
+        else
+        {
+            ValidEmail email = response.getValidEmail();
+            emailAddress = email.getEmailAddress();
 
-            // If user is authenticated but doesn't exist in our system...
-            if (null == user)
+            try
             {
-                // ...are we configured to allow auto-creation?
-                if (isAutoCreateAccountsEnabled())
+                user = UserManager.getUser(email);
+
+                // If user is authenticated but doesn't exist in our system...
+                if (null == user)
                 {
-                    // Yes: add user to the database
-                    SecurityManager.NewUserStatus bean = SecurityManager.addUser(email, null, false);
-                    user = bean.getUser();
-                    UserManager.addToUserHistory(user, user.getEmail() + " authenticated successfully and was added to the system automatically.");
-                }
-                else
-                {
-                    // No: log that we're not permitted to create accounts automatically
-                    addAuditEvent(User.guest, request, "User " + email + " successfully authenticated via " + response.getSuccessDetails() + ", but login failed because account creation is disabled.");
-                    return new PrimaryAuthenticationResult(AuthenticationStatus.UserCreationNotAllowed);
+                    // ...are we configured to allow auto-creation?
+                    if (isAutoCreateAccountsEnabled())
+                    {
+                        // Yes: add user to the database
+                        SecurityManager.NewUserStatus bean = SecurityManager.addUser(email, null, false);
+                        user = bean.getUser();
+                        UserManager.addToUserHistory(user, user.getEmail() + " authenticated successfully and was added to the system automatically.");
+                    }
+                    else
+                    {
+                        // No: log that we're not permitted to create accounts automatically
+                        addAuditEvent(User.guest, request, "User " + email + " successfully authenticated via " + response.getSuccessDetails() + ", but login failed because account creation is disabled.");
+                        return new PrimaryAuthenticationResult(AuthenticationStatus.UserCreationNotAllowed);
+                    }
                 }
             }
-            UserManager.updateLogin(user);
-        }
-        catch (SecurityManager.UserManagementException e)
-        {
-            // "User limit" exception is expected. Log other exceptions.
-            if (!e.getMessage().startsWith("User limit has been reached"))
+            catch (SecurityManager.UserManagementException e)
             {
-                // Make sure we record any unexpected problems during user creation; one goal is to help track down cause of #20712
-                ExceptionUtil.decorateException(e, ExceptionUtil.ExceptionInfo.ExtraMessage, email.getEmailAddress(), true);
-                ExceptionUtil.logExceptionToMothership(request, e);
-            }
+                // "User limit" exception is expected. Log other exceptions.
+                if (!e.getMessage().startsWith("User limit has been reached"))
+                {
+                    // Make sure we record any unexpected problems during user creation; one goal is to help track down cause of #20712
+                    ExceptionUtil.decorateException(e, ExceptionUtil.ExceptionInfo.ExtraMessage, email.getEmailAddress(), true);
+                    ExceptionUtil.logExceptionToMothership(request, e);
+                }
 
-            return new PrimaryAuthenticationResult(AuthenticationStatus.UserCreationError);
+                return new PrimaryAuthenticationResult(AuthenticationStatus.UserCreationError);
+            }
         }
+
+        UserManager.updateLogin(user);
 
         if (!user.isActive())
         {
@@ -1072,11 +1088,10 @@ public class AuthenticationManager
             return new PrimaryAuthenticationResult(AuthenticationStatus.InactiveUser);
         }
 
-        addAuditEvent(user, request, email + " " + UserManager.UserAuditEvent.LOGGED_IN + " successfully via " + response.getSuccessDetails() + ".");
+        addAuditEvent(user, request, emailAddress + " " + UserManager.UserAuditEvent.LOGGED_IN + " successfully via " + response.getSuccessDetails() + ".");
 
         return new PrimaryAuthenticationResult(user, response);
     }
-
 
     // limit one bad login per second averaged out over 60sec
     private static final Cache<Integer, RateLimiter> addrLimiter = CacheManager.getCache(1001, TimeUnit.MINUTES.toMillis(5), "Login limiter");
@@ -1086,12 +1101,10 @@ public class AuthenticationManager
     private static final CacheLoader<Integer, RateLimiter> pwdLoader = (key, request) -> new RateLimiter("Pwd limiter: " + key, new Rate(20, TimeUnit.MINUTES));
     private static final CacheLoader<Integer, RateLimiter> userLoader = (key, request) -> new RateLimiter("User limiter: " + key, new Rate(20, TimeUnit.MINUTES));
 
-
     private static Integer _toKey(String s)
     {
         return null==s ? 0 : s.toLowerCase().hashCode() % 1000;
     }
-
 
     private static PrimaryAuthenticationResult _beforeAuthenticate(HttpServletRequest request, String id, String pwd)
     {

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -236,7 +236,7 @@ public class AuthenticationManager
         return builder.getHtmlString();
     }
 
-    @Deprecated // Left behind for backwards compatibility. Remove once mGAP adjusts usages.
+    @Deprecated // Left behind for backwards compatibility. Remove once mGAP & mcc adjust usages.
     public static boolean isLdapEmail(ValidEmail email)
     {
         return isLdapOrSsoEmail(email);

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1013,7 +1013,6 @@ public class SecurityManager
         }
     }
 
-
     public static class UserManagementException extends Exception
     {
         private final String _email;
@@ -1337,8 +1336,8 @@ public class SecurityManager
         return getPasswordHash(email.getEmailAddress());
     }
 
-    // Look up email in Logins table and return the corresponding password hash
-    private static String getPasswordHash(String email)
+    // For internal use only, plus database login and change email workflows, where existing email could be invalid.
+    public static String getPasswordHash(String email)
     {
         SqlSelector selector = new SqlSelector(core.getSchema(), new SQLFragment("SELECT Crypt FROM " + core.getTableInfoLogins() + " WHERE Email = ?", email));
         return selector.getObject(String.class);
@@ -1358,7 +1357,7 @@ public class SecurityManager
             return Crypt.MD5.matches(password, hash);
     }
 
-    // Used only in the case of email change... current email address might be invalid
+    // Used in the case of set password or email change... current email address might be invalid
     public static boolean loginExists(String email)
     {
         return (null != getPasswordHash(email));
@@ -3333,7 +3332,6 @@ public class SecurityManager
 
         abstract boolean accept(Set<Class<? extends Permission>> granted, Set<Class<? extends Permission>> required);
     }
-
 
     public static class TestCase extends Assert
     {

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1336,7 +1336,7 @@ public class SecurityManager
         return getPasswordHash(email.getEmailAddress());
     }
 
-    // For internal use only, plus database login and change email workflows, where existing email could be invalid.
+    // For internal use only, plus database login and change email workflows, where existing email address could be invalid (i.e., non-conforming according to RFC 822)
     public static String getPasswordHash(String email)
     {
         SqlSelector selector = new SqlSelector(core.getSchema(), new SQLFragment("SELECT Crypt FROM " + core.getTableInfoLogins() + " WHERE Email = ?", email));
@@ -1357,7 +1357,7 @@ public class SecurityManager
             return Crypt.MD5.matches(password, hash);
     }
 
-    // Used in the case of set password or email change... current email address might be invalid
+    // Used in the case of set password or email change... current email address could be invalid (i.e., non-conforming according to RFC 822)
     public static boolean loginExists(String email)
     {
         return (null != getPasswordHash(email));

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1359,7 +1359,7 @@ public class SecurityManager
     }
 
     // Used only in the case of email change... current email address might be invalid
-    static boolean loginExists(String email)
+    public static boolean loginExists(String email)
     {
         return (null != getPasswordHash(email));
     }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -941,6 +941,12 @@ public class SecurityManager
         return (null == getVerification(email));
     }
 
+    // Test if user has been verified for database authentication. Use only when email address could be invalid ().
+    public static boolean isVerified(String email)
+    {
+        return (null == getVerification(email));
+    }
+
     public static boolean verify(ValidEmail email, String verification)
     {
         String dbVerification = getVerification(email);
@@ -956,7 +962,12 @@ public class SecurityManager
 
     public static String getVerification(ValidEmail email)
     {
-        return new SqlSelector(core.getSchema(), "SELECT Verification FROM " + core.getTableInfoLogins() + " WHERE Email = ?", email.getEmailAddress()).getObject(String.class);
+        return getVerification(email.getEmailAddress());
+    }
+
+    private static String getVerification(String email)
+    {
+        return new SqlSelector(core.getSchema(), "SELECT Verification FROM " + core.getTableInfoLogins() + " WHERE Email = ?", email).getObject(String.class);
     }
 
     public static class NewUserStatus
@@ -1336,7 +1347,7 @@ public class SecurityManager
         return getPasswordHash(email.getEmailAddress());
     }
 
-    // For internal use only, plus database login and change email workflows, where existing email address could be invalid (i.e., non-conforming according to RFC 822)
+    // For internal use only, plus database login and change email workflows, where existing email address could be invalid (i.e., non-conforming per RFC 822)
     public static String getPasswordHash(String email)
     {
         SqlSelector selector = new SqlSelector(core.getSchema(), new SQLFragment("SELECT Crypt FROM " + core.getTableInfoLogins() + " WHERE Email = ?", email));
@@ -1357,7 +1368,7 @@ public class SecurityManager
             return Crypt.MD5.matches(password, hash);
     }
 
-    // Used in the case of set password or email change... current email address could be invalid (i.e., non-conforming according to RFC 822)
+    // Used in the case of set password or email change... current email address could be invalid (i.e., non-conforming per RFC 822)
     public static boolean loginExists(String email)
     {
         return (null != getPasswordHash(email));

--- a/api/src/org/labkey/api/security/UserCache.java
+++ b/api/src/org/labkey/api/security/UserCache.java
@@ -62,7 +62,6 @@ class UserCache
         return null != user ? user.cloneUser() : null;
     }
 
-
     // Return a new copy of the User with this email address, or null if user doesn't exist
     static @Nullable User getUser(ValidEmail email)
     {
@@ -72,7 +71,6 @@ class UserCache
         return null != user ? user.cloneUser() : null;
     }
 
-
     // Return a new copy of the User with this display name, or null if user doesn't exist
     static @Nullable User getUser(String displayName)
     {
@@ -81,7 +79,6 @@ class UserCache
         // these should really be readonly
         return null != user ? user.cloneUser() : null;
     }
-
 
     // Returns a deep copy of the active users list, allowing callers to interrogate user permissions without affecting
     // cached users. Collection is ordered by email... maybe it should be ordered by display name?

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -70,6 +70,7 @@ import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.AjaxCompletion;
 import org.labkey.api.view.HttpView;
+import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewContext;
 
 import jakarta.servlet.http.HttpSession;
@@ -270,7 +271,6 @@ public class UserManager
         return errors;
     }
 
-
     public static List<Throwable> fireUserPropertiesChanged(int userid)
     {
         List<UserListener> list = getListeners();
@@ -338,12 +338,10 @@ public class UserManager
         return UserCache.getUser(userId);
     }
 
-
     public static @Nullable User getUser(ValidEmail email)
     {
         return UserCache.getUser(email);
     }
-
 
     public static @Nullable User getUserByDisplayName(String displayName)
     {
@@ -368,7 +366,6 @@ public class UserManager
         }
     }
 
-
     private static void removeRecentUser(User user)
     {
         synchronized(RECENT_USERS)
@@ -382,7 +379,6 @@ public class UserManager
     {
         return new SqlSelector(CORE.getSchema(), new SQLFragment("SELECT COUNT(*) FROM " + CORE.getTableInfoUsersData() + " WHERE LastLogin >= ?", since)).getObject(Integer.class);
     }
-
 
     private static final Comparator<Pair<String, Long>> RECENT_USER_COMPARATOR = Comparator.comparing(Pair<String, Long>::getValue).thenComparing(Pair::getKey);
 
@@ -552,20 +548,17 @@ public class UserManager
         return User.guest;
     }
 
-
     // Return display name if user id != null and user exists, otherwise return null
     public static String getDisplayName(Integer userId, User currentUser)
     {
         return getDisplayName(userId, false, currentUser);
     }
 
-
     // If userIdIfDeleted = true, then return "<userId>" if user doesn't exist
     public static String getDisplayNameOrUserId(Integer userId, User currentUser)
     {
         return getDisplayName(userId, true, currentUser);
     }
-
 
     private static String getDisplayName(Integer userId, boolean userIdIfDeleted, User currentUser)
     {
@@ -587,7 +580,6 @@ public class UserManager
 
         return user.getDisplayName(currentUser);
     }
-
 
     public static String getEmailForId(Integer userId)
     {
@@ -681,8 +673,7 @@ public class UserManager
         }
         catch (RuntimeException ignored){}
 
-        UserAuditEvent event = new UserAuditEvent(c.getId(), message, principal);
-        AuditLogService.get().addEvent(user, event);
+        addAuditEvent(user, c, principal, message);
     }
 
     public static boolean hasUsers()
@@ -792,32 +783,32 @@ public class UserManager
         addToUserHistory(toUpdate, "Contact information for " + toUpdate.getEmail() + " was updated");
     }
 
-    public static void requestEmailChange(int userId, String currentEmail, String requestedEmail, String verificationToken, User currentUser) throws UserManagementException
+    public static void requestEmailChange(User userToChange, ValidEmail requestedEmail, String verificationToken, User currentUser) throws UserManagementException
     {
-        if (SecurityManager.loginExists(currentEmail))
+        if (SecurityManager.loginExists(userToChange.getEmail()))
         {
             DbScope scope = CORE.getSchema().getScope();
             try (Transaction transaction = scope.ensureTransaction())
             {
                 Instant timeoutDate = Instant.now().plus(VERIFICATION_EMAIL_TIMEOUT, ChronoUnit.MINUTES);
                 SqlExecutor executor = new SqlExecutor(CORE.getSchema());
-                int rows = executor.execute("UPDATE " + CORE.getTableInfoLogins() + " SET RequestedEmail=?, Verification=?, VerificationTimeout=? WHERE Email=?",
-                        requestedEmail, verificationToken, Date.from(timeoutDate), currentEmail);
+                int rows = executor.execute("UPDATE " + CORE.getTableInfoLogins() + " SET RequestedEmail = ?, Verification = ?, VerificationTimeout = ? WHERE Email = ?",
+                        requestedEmail.getEmailAddress(), verificationToken, Date.from(timeoutDate), userToChange.getEmail());
                 if (1 != rows)
                     throw new UserManagementException(requestedEmail, "Unexpected number of rows returned when setting verification: " + rows);
-                addToUserHistory(getUser(userId), currentUser + " requested email address change from " + currentEmail + " to " + requestedEmail +
+                addToUserHistory(userToChange, currentUser + " requested email address change from " + userToChange.getEmail() + " to " + requestedEmail +
                         " with token '" + verificationToken + "' and timeout date '" + Date.from(timeoutDate) + "'.");
                 transaction.commit();
             }
         }
     }
 
-    public static void changeEmail(boolean isAdmin, int userId, String oldEmail, String newEmail, String verificationToken, User currentUser)
+    public static void changeEmail(User currentUser, User userToChange, boolean isAdmin, String newEmail, String verificationToken)
             throws UserManagementException, ValidEmail.InvalidEmailException
     {
         // make sure these emails are valid, and also have been processed (like changing to lowercase)
 
-        oldEmail = new ValidEmail(oldEmail).getEmailAddress();
+        String oldEmail = userToChange.getEmail();
         newEmail = new ValidEmail(newEmail).getEmailAddress();
 
         DbScope scope = CORE.getSchema().getScope();
@@ -833,24 +824,23 @@ public class UserManager
             }
 
             SqlExecutor executor = new SqlExecutor(CORE.getSchema());
-            int rows = executor.execute("UPDATE " + CORE.getTableInfoPrincipals() + " SET Name=? WHERE UserId=?", newEmail, userId);
+            int rows = executor.execute("UPDATE " + CORE.getTableInfoPrincipals() + " SET Name = ? WHERE UserId = ?", newEmail, userToChange.getUserId());
             if (1 != rows)
                 throw new UserManagementException(oldEmail, "Unexpected number of rows returned when setting new name: " + rows);
 
-            executor.execute("UPDATE " + CORE.getTableInfoLogins() + " SET Email=? WHERE Email=?", newEmail, oldEmail);  // won't update if non-LabKey-managed, because there is no data here
+            executor.execute("UPDATE " + CORE.getTableInfoLogins() + " SET Email = ? WHERE Email = ?", newEmail, oldEmail);  // won't update if non-LabKey-managed, because there is no data here
             if (isAdmin)
             {
-                addToUserHistory(getUser(userId), "Admin " + currentUser + " changed an email address from " + oldEmail + " to " + newEmail + ".");
+                addToUserHistory(userToChange, "Admin " + currentUser + " changed an email address from " + oldEmail + " to " + newEmail + ".");
             }
             else
             {
-                addToUserHistory(getUser(userId), currentUser + " changed their email address from " + oldEmail + " to " + newEmail + " with token '" + verificationToken + "'.");
+                addToUserHistory(userToChange, currentUser + " changed their email address from " + oldEmail + " to " + newEmail + " with token '" + verificationToken + "'.");
             }
-            User userToBeEdited = getUser(userId);
 
-            if (userToBeEdited.getDisplayName(userToBeEdited).equals(oldEmail))
+            if (userToChange.getDisplayName(userToChange).equals(oldEmail))
             {
-                rows = executor.execute("UPDATE " + CORE.getTableInfoUsersData() + " SET DisplayName=? WHERE UserId=?", newEmail, userId);
+                rows = executor.execute("UPDATE " + CORE.getTableInfoUsersData() + " SET DisplayName = ? WHERE UserId = ?", newEmail, userToChange.getUserId());
                 if (1 != rows)
                     throw new UserManagementException(oldEmail, "Unexpected number of rows returned when setting new display name: " + rows);
             }
@@ -893,11 +883,21 @@ public class UserManager
         private String _verification;
         private Date _verificationTimeout;
 
+        public @NotNull User getUserToChange()
+        {
+            // Current email could be invalid, so can't use ValidEmail here. See Issue #50188.
+            return getUsers(true).stream()
+                .filter(user -> user.getEmail().equals(_email))
+                .findAny()
+                .orElseThrow(() -> new NotFoundException("User with email '" + _email + "' not found."));
+        }
+
         public String getEmail()
         {
             return _email;
         }
 
+        @SuppressWarnings("unused")
         public void setEmail(String email)
         {
             _email = email;
@@ -908,6 +908,7 @@ public class UserManager
             return _requestedEmail;
         }
 
+        @SuppressWarnings("unused")
         public void setRequestedEmail(String requestedEmail)
         {
             _requestedEmail = requestedEmail;
@@ -918,6 +919,7 @@ public class UserManager
             return _verification;
         }
 
+        @SuppressWarnings("unused")
         public void setVerification(String verification)
         {
             _verification = verification;
@@ -928,6 +930,7 @@ public class UserManager
             return _verificationTimeout;
         }
 
+        @SuppressWarnings("unused")
         public void setVerificationTimeout(Date verificationTimeout)
         {
             _verificationTimeout = verificationTimeout;
@@ -1062,14 +1065,6 @@ public class UserManager
     }
 
     /**
-     *  Get completions from list of all site users
-     */
-    public static List<AjaxCompletion> getAjaxCompletions(User currentUser, Container c)
-    {
-        return getAjaxCompletions(getActiveUsers(), currentUser, c);
-    }
-
-    /**
      * Returns the ajax completion objects for the specified groups and users.
      */
     public static List<AjaxCompletion> getAjaxCompletions(Collection<Group> groups, Collection<User> users, User currentUser, Container c)
@@ -1197,9 +1192,9 @@ public class UserManager
     }
 
     /**
-     * Parse a string of delimited email addresses and/or display names into a delimited string of
-     * corresponding userIds. Inputs which did not resolve to a current active user are preserved in the output.
-     * @param theList Any combination of email addresses and display names, delimited with semi-colons or new line characters
+     * Parse a string of delimited email addresses and/or display names into a delimited string of corresponding
+     * userIds. Inputs which did not resolve to a current active user are preserved in the output.
+     * @param theList Any combination of email addresses and display names, delimited with semicolons or new line characters
      * @return Semi-colon delimited string of corresponding userIds. Unresolvable inputs are preserved.
      */
     public static String parseUserListInput(String theList)
@@ -1245,7 +1240,7 @@ public class UserManager
     /**
      * Return the HTML tag for the user details page of the displayedUserId.
      * @param container The current container
-     * @param currentUser The current logged in user
+     * @param currentUser The current logged-in user
      * @param displayedUserId The user id of the url we want to navigate to
      * @return The HTML string to navigate to the displayedUserId's user details page
      */

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -342,15 +342,6 @@ public class UserManager
         return UserCache.getUser(email);
     }
 
-    // Use only for database login when existing email is invalid
-    public static @Nullable User getUser(String email)
-    {
-        return getUsers(true).stream()
-            .filter(user -> user.getEmail().equals(email))
-            .findAny()
-            .orElse(null);
-    }
-
     public static @Nullable User getUserByDisplayName(String displayName)
     {
         return UserCache.getUser(displayName);
@@ -852,9 +843,9 @@ public class UserManager
                     throw new UserManagementException(oldEmail, "Unexpected number of rows returned when setting new display name: " + rows);
             }
 
-            if (SecurityManager.loginExists(newEmail))
+            ValidEmail validNewEmail = new ValidEmail(newEmail);
+            if (SecurityManager.loginExists(validNewEmail))
             {
-                ValidEmail validNewEmail = new ValidEmail(newEmail);
                 SecurityManager.setVerification(validNewEmail, null);  // so we don't let user use this link again
             }
 

--- a/api/src/org/labkey/api/security/ValidEmail.java
+++ b/api/src/org/labkey/api/security/ValidEmail.java
@@ -40,7 +40,7 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * Represents an email address that is known to be valid according to RFC 822. Will automatically append
+ * Represents an email address that is known to be valid per RFC 822. Will automatically append
  * the default email domain from {@link AppProps} and do other normalization if needed.
  */
 public class ValidEmail

--- a/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
+++ b/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
@@ -125,7 +125,10 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
             {
                 // This invalid email address might be in the database. If so, attempt to authenticate; if not, throw.
                 hash = SecurityManager.getPasswordHash(id);
-                user = UserManager.getUser(id);
+                user = UserManager.getUsers(true).stream()
+                    .filter(u -> u.getEmail().equals(id))
+                    .findAny()
+                    .orElse(null);
                 if (null == hash || null == user)
                     throw e;
             }

--- a/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
+++ b/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
@@ -31,6 +31,7 @@ import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.ValidEmail;
+import org.labkey.api.security.ValidEmail.InvalidEmailException;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.StandardStartupPropertyHandler;
 import org.labkey.api.settings.StartupPropertyEntry;
@@ -95,7 +96,7 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
 
     @Override
     // id and password will not be blank (not null, not empty, not whitespace only)
-    public @NotNull AuthenticationResponse authenticate(DbLoginConfiguration configuration, @NotNull String id, @NotNull String password, URLHelper returnURL) throws ValidEmail.InvalidEmailException
+    public @NotNull AuthenticationResponse authenticate(DbLoginConfiguration configuration, @NotNull String id, @NotNull String password, URLHelper returnURL) throws InvalidEmailException
     {
         // Check for API key first
         if (API_KEY.equals(id))
@@ -109,12 +110,25 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
         }
         else
         {
-            ValidEmail email = new ValidEmail(id);
-            String hash = SecurityManager.getPasswordHash(email);
-            User user = UserManager.getUser(email);
+            String hash;
+            User user;
 
-            if (null == hash || null == user)
-                return AuthenticationResponse.createFailureResponse(configuration, FailureReason.userDoesNotExist);
+            try
+            {
+                ValidEmail email = new ValidEmail(id);
+                hash = SecurityManager.getPasswordHash(email);
+                user = UserManager.getUser(email);
+                if (null == hash || null == user)
+                    return AuthenticationResponse.createFailureResponse(configuration, FailureReason.userDoesNotExist);
+            }
+            catch (InvalidEmailException e)
+            {
+                // This invalid email address might be in the database. If so, attempt to authenticate; if not, throw.
+                hash = SecurityManager.getPasswordHash(id);
+                user = UserManager.getUser(id);
+                if (null == hash || null == user)
+                    throw e;
+            }
 
             if (!SecurityManager.matchPassword(password, hash))
                 return AuthenticationResponse.createFailureResponse(configuration, FailureReason.badPassword);
@@ -132,15 +146,16 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
                 else
                 {
                     PasswordExpiration expiration = configuration.getExpiration();
+                    User user2 = user;
 
-                    if (expiration.hasExpired(() -> SecurityManager.getLastChanged(user)))
+                    if (expiration.hasExpired(() -> SecurityManager.getLastChanged(user2)))
                     {
                         return getChangePasswordResponse(configuration, user, returnURL, FailureReason.expired);
                     }
                 }
             }
 
-            return AuthenticationResponse.createSuccessResponse(configuration, email);
+            return AuthenticationResponse.createSuccessResponse(configuration, user);
         }
     }
 

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1748,12 +1748,12 @@ public class LoginController extends SpringActionController
         boolean isVerified = SecurityManager.verify(email, verification);
 
         User user = UserManager.getUser(email);
-        LoginController.checkVerificationErrors(isVerified, user, email, verification, errors);
+        LoginController.checkVerificationErrors(isVerified, user, email.getEmailAddress(), verification, errors);
 
         return isVerified && !errors.hasErrors();
     }
 
-    public static void checkVerificationErrors(boolean isVerified, User user, ValidEmail email, String verification, Errors errors)
+    public static void checkVerificationErrors(boolean isVerified, User user, String email, String verification, Errors errors)
     {
         if (isVerified)
         {
@@ -1772,12 +1772,10 @@ public class LoginController extends SpringActionController
             if (!SecurityManager.loginExists(email))
             {
                 if (AuthenticationManager.isLdapOrSsoEmail(email))
-                    errors.reject("setPassword", "Your account will authenticate using LDAP and you do not need to set a separate password.");
+                    errors.reject("setPassword", "You can authenticate your account using LDAP/SSO and you do not need to set a separate password.");
                 else
                     errors.reject("setPassword", "This email address is not associated with an account. Make sure you've copied the entire link into your browser's address bar.");
             }
-            else if (SecurityManager.isVerified(email))
-                errors.reject("setPassword", "This email address has already been verified.");
             else if (null == verification || verification.length() < SecurityManager.tempPasswordLength)
                 errors.reject("setPassword", "Make sure you've copied the entire link into your browser's address bar.");
             else

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1755,7 +1755,7 @@ public class LoginController extends SpringActionController
 
     public static void checkVerificationErrors(boolean isVerified, User user, ValidEmail email, String verification, Errors errors)
     {
-        if(isVerified)
+        if (isVerified)
         {
             if (user == null)
             {

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -328,7 +328,7 @@ public class LoginController extends SpringActionController
                 String defaultDomain = ValidEmail.getDefaultDomain();
                 StringBuilder sb = new StringBuilder();
                 sb.append("Please sign in using your full email address, for example: ");
-                if (defaultDomain.length() > 0)
+                if (!defaultDomain.isEmpty())
                 {
                     sb.append("employee@");
                     sb.append(defaultDomain);
@@ -2765,7 +2765,7 @@ public class LoginController extends SpringActionController
                 }
             }
 
-            // If user doesn't exist (initial user case) or email is invalid pass in a fake user to filter the email address
+            // If user doesn't exist (initial user case) or email is invalid, pass in a fake user to filter the email address
             if (null == user)
                 user = new User(form.getEmail(), -9999);
 

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1776,6 +1776,8 @@ public class LoginController extends SpringActionController
                 else
                     errors.reject("setPassword", "This email address is not associated with an account. Make sure you've copied the entire link into your browser's address bar.");
             }
+            else if (SecurityManager.isVerified(email))
+                errors.reject("setPassword", "This email address has already been verified.");
             else if (null == verification || verification.length() < SecurityManager.tempPasswordLength)
                 errors.reject("setPassword", "Make sure you've copied the entire link into your browser's address bar.");
             else

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -1342,7 +1342,7 @@ public class UserController extends SpringActionController
 
         public String getAccess()
         {
-            if (null == _accessGroups || _accessGroups.size() == 0)
+            if (null == _accessGroups || _accessGroups.isEmpty())
                 return "";
 
             String sep = "";
@@ -1373,7 +1373,7 @@ public class UserController extends SpringActionController
 
         public List<Group> getGroups()
         {
-            if (null == _accessGroups || _accessGroups.size() == 0)
+            if (null == _accessGroups || _accessGroups.isEmpty())
                 return Collections.emptyList();
 
             List<Group> allGroups = new ArrayList<>();
@@ -1540,7 +1540,6 @@ public class UserController extends SpringActionController
         }
     }
 
-
     public static void addUserDetailsNavTrail(Container c, User currentUser, NavTree root, @Nullable ActionURL userDetailsUrl)
     {
         if (c.isRoot())
@@ -1559,7 +1558,6 @@ public class UserController extends SpringActionController
         else
             root.addChild("User Details", userDetailsUrl);
     }
-
 
     @RequiresLogin
     public class DetailsAction extends SimpleViewAction<UserQueryForm>
@@ -1588,7 +1586,7 @@ public class UserController extends SpringActionController
             // don't let a non-site admin manage certain parts of a site-admin's account
             boolean canManageDetailsUser = currentUser.hasSiteAdminPermission() || !detailsUser.hasSiteAdminPermission();
             String detailsEmail = detailsUser.getEmail();
-            boolean loginExists = SecurityManager.loginExists(detailsEmail);
+            boolean loginExists = SecurityManager.loginExists(detailsEmail); // Note: Not using ValidEmail variant since existing address could be invalid
 
             UserSchema schema = form.getSchema();
             if (schema == null)
@@ -1882,6 +1880,7 @@ public class UserController extends SpringActionController
                 form._userToChange = getModifiableUser(form.getUserId());  // Push validated user into form for JSP
             }
 
+            // Consider: create a separate "change password from verification link in an email" action (and JSP?)
             if (form.getIsFromVerifiedLink())
             {
                 User loggedInUser = getUser();

--- a/core/src/org/labkey/core/user/changeEmail.jsp
+++ b/core/src/org/labkey/core/user/changeEmail.jsp
@@ -38,7 +38,7 @@
     UserForm form = me.getModelBean();
     ActionURL cancelURL = urlFor(DetailsAction.class).addParameter("userId", form.getUserId());
     boolean canUpdateUser = getUser().hasRootPermission(UpdateUserPermission.class);
-    String currentEmail = form.getUser().getEmail();
+    String currentEmail = form.getUserToChange().getEmail();
 
     if (form.getIsChangeEmailRequest())
     {
@@ -88,7 +88,7 @@
     else if (form.getIsVerified())
     {
 %>
-        <p>Email change from <%=h(form.getOldEmail())%> to <%=h(form.getRequestedEmail())%> was successful. An email has been sent to the old address for security purposes.</p>
+        <p>Email change from <%=h(currentEmail)%> to <%=h(form.getRequestedEmail())%> was successful. An email has been sent to the old address for security purposes.</p>
         <%= button("Done").href(cancelURL) %>
 <%
     }

--- a/core/src/org/labkey/core/user/changeEmail.jsp
+++ b/core/src/org/labkey/core/user/changeEmail.jsp
@@ -88,7 +88,7 @@
     else if (form.getIsVerified())
     {
 %>
-        <p>Email change from <%=h(currentEmail)%> to <%=h(form.getRequestedEmail())%> was successful. An email has been sent to the old address for security purposes.</p>
+        <p>Email change from <%=h(currentEmail)%> to <%=h(form.getRequestedEmail())%> was successful.<% if (form.isSentCourtesyEmail()) {%> An email has been sent to the old address for security purposes.<%}%></p>
         <%= button("Done").href(cancelURL) %>
 <%
     }


### PR DESCRIPTION
#### Rationale
Users can end up with invalid email addresses saved in their accounts. Overly aggressive validation blocks 1) admins from changing these to valid addresses and 2) users from logging in and executing the self-change workflow. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=50188

Also, rewrite the validation code for self-serve email changes.