### PR TITLE
Issue 50488: Pre-register this data source's SQL error codes in Spring to prevent deadlocks

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -53,6 +53,7 @@ import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.data.xml.TablesDocument;
 import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.jdbc.support.SQLErrorCodesFactory;
 
 import javax.naming.Binding;
 import javax.naming.Context;
@@ -549,6 +550,9 @@ public class DbScope
             _provisionedTableCache = new SchemaTableInfoCache(this, true);
             _rds = _dialect.isRds(this);
             _escape = dbmd.getSearchStringEscape();
+
+            // Issue 50488: Pre-register this data source's SQL error codes in Spring to prevent deadlocks
+            SQLErrorCodesFactory.getInstance().registerDatabase(dataSource.getDataSource(), _databaseProductName);
         }
     }
 


### PR DESCRIPTION
#### Rationale
This seeks to address [Issue 50488](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50488) by pre-registering LabKey data sources into Spring's `SQLErrorCodesFactory` error codes caching. By doing so we avoid Spring attempting to connect to the database upon an error which can result in deadlocks if the error code factory is unable to get a connection.

#### Changes
- Call `SQLErrorCodesFactory.getInstance().registerDatabase()` during `DbScope` construction after the first connection has been established.
