### PR TITLE
Plate: Source plates from plate templates

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.46.0"
+        "@labkey/components": "3.46.6-fb-plate-template-deux.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -2462,9 +2462,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.46.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.46.0.tgz",
-      "integrity": "sha512-7j1fyEXc4pHmbqNkhrx0nTXr+EyY4QZNmkDWRtkTPd2BI45An1PbNA3FLzTGXvD6Gft3z9gk8bcongJnAPt2vQ==",
+      "version": "3.46.6-fb-plate-template-deux.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.46.6-fb-plate-template-deux.0.tgz",
+      "integrity": "sha512-zW+uVWPzZ7MWpQ+/WF0dPSn0+Qj0lQAj9myajbo3FkQntOzvbjICGMnUjf829ydBLW+qJGzau9u9ZFQWQwoKKg==",
       "dependencies": {
         "@labkey/api": "1.33.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.46.6-fb-plate-template-deux.0"
+        "@labkey/components": "3.47.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -2462,9 +2462,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.46.6-fb-plate-template-deux.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.46.6-fb-plate-template-deux.0.tgz",
-      "integrity": "sha512-zW+uVWPzZ7MWpQ+/WF0dPSn0+Qj0lQAj9myajbo3FkQntOzvbjICGMnUjf829ydBLW+qJGzau9u9ZFQWQwoKKg==",
+      "version": "3.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.47.0.tgz",
+      "integrity": "sha512-qxEZKddnN39VLn800RudYh3x9hIMZjIMepfApahVaZ35RFVP5K7S5bb6dy+M0HnQWDOgIvCul3twGBpNK92zag==",
       "dependencies": {
         "@labkey/api": "1.33.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.46.6-fb-plate-template-deux.0"
+    "@labkey/components": "3.47.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.46.0"
+    "@labkey/components": "3.46.6-fb-plate-template-deux.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -1092,7 +1092,7 @@ public class PlateController extends SpringActionController
                         errors.reject(ERROR_REQUIRED, "Specifying a \"selectionKey\" is required for this configuration.");
                         return null;
                     }
-                    plates = PlateManager.get().getPlateData(getContainer(), getUser(), selectionKey, form.getPlates());
+                    plates = PlateManager.get().reArrayFromSelection(getContainer(), getUser(), selectionKey, form.getPlates());
                 }
                 else if (form.isDefaultCase())
                     plates = form.getPlates();

--- a/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
+++ b/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
@@ -272,7 +272,7 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
                     rows.add(rowMap);
                 }
             }
-            plates.add(new CreatePlateSetPlate(null, _plateType.getRowId(), rows));
+            plates.add(new CreatePlateSetPlate(null, _plateType.getRowId(), null, rows));
         }
         _plateSetsCreated++;
         return PlateManager.get().createPlateSet(getContainer(), getUser(), plateSet, plates, parentPlateSet != null ? parentPlateSet.getRowId() : null);

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -1047,8 +1047,8 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             PlateSetImpl plateSet = new PlateSetImpl();
             PlateType plateType = PlateManager.get().getPlateType(8, 12);
             List<PlateManager.CreatePlateSetPlate> plates = List.of(
-                    new PlateManager.CreatePlateSetPlate(null, plateType.getRowId(), Collections.emptyList()),
-                    new PlateManager.CreatePlateSetPlate(null, plateType.getRowId(), Collections.emptyList())
+                    new PlateManager.CreatePlateSetPlate(null, plateType.getRowId(), null, Collections.emptyList()),
+                    new PlateManager.CreatePlateSetPlate(null, plateType.getRowId(), null, Collections.emptyList())
             );
             plateSet = PlateManager.get().createPlateSet(container, user, plateSet, plates, null);
             List<Plate> platesetPlates = PlateManager.get().getPlatesForPlateSet(plateSet);

--- a/assay/src/org/labkey/assay/plate/PlateImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateImpl.java
@@ -62,7 +62,7 @@ import static org.junit.Assert.assertTrue;
 public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
 {
     private boolean _archived;
-    private String _assayType;
+    private String _assayType = TsvPlateLayoutHandler.TYPE;
     private long _created;
     private int _createdBy;
     private List<PlateCustomField> _customFields = Collections.emptyList();
@@ -94,14 +94,15 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     {
         super(container);
         _name = StringUtils.trimToNull(name);
-        _assayType = assayType;
+        if (StringUtils.trimToNull(assayType) != null)
+            _assayType = assayType;
         _dataFileId = GUID.makeGUID();
         _plateType = plateType;
     }
 
     public PlateImpl(Container container, String name, @NotNull PlateType plateType)
     {
-        this(container, name, TsvPlateLayoutHandler.TYPE, plateType);
+        this(container, name, null, plateType);
     }
 
     public PlateImpl(@NotNull PlateImpl plate, double[][] wellValues, boolean[][] excluded, int runId, int plateNumber)

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2854,7 +2854,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return Pair.of(sampleIdsCounter, wellSampleDataForPlate);
     }
 
-    public List<CreatePlateSetPlate> preparePlateData(Container container, User user, List<CreatePlateSetPlate> plates)
+    /** Prepares the plate data for plates that specify a "templateId". */
+    public List<CreatePlateSetPlate> preparePlateData(Container container, User user, Collection<CreatePlateSetPlate> plates)
     {
         if (plates == null || plates.isEmpty())
             return Collections.emptyList();
@@ -2879,6 +2880,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return plateData;
     }
 
+    /** Prepares the plate data for a plate template created from a plate type. */
     public List<Map<String, Object>> prepareEmptyPlateTemplateData(Container container, @NotNull PlateType plateType)
     {
         List<Map<String, Object>> data = new ArrayList<>();
@@ -2897,8 +2899,10 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return data;
     }
 
-    // This is a re-array operation, so take the plate sources and apply the selected samples according to each
-    // plate's layout.
+    /**
+     * This is a re-array operation, so take the plate sources and apply the selected samples
+     * according to each plate's layout.
+     */
     public List<CreatePlateSetPlate> reArrayFromSelection(
         Container container,
         User user,

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -41,10 +41,9 @@ import org.labkey.assay.plate.query.WellTable;
 import org.labkey.assay.query.AssayDbSchema;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
@@ -263,9 +262,9 @@ public final class PlateManagerTest
 
         // Act
         PlateSet plateSet = PlateManager.get().createPlateSet(container, user, plateSetImpl, List.of(
-                new PlateManager.CreatePlateSetPlate("testAccessPlateByIdentifiersFirst", plateType.getRowId(), null),
-                new PlateManager.CreatePlateSetPlate("testAccessPlateByIdentifiersSecond", plateType.getRowId(), null),
-                new PlateManager.CreatePlateSetPlate("testAccessPlateByIdentifiersThird", plateType.getRowId(), null)
+                new PlateManager.CreatePlateSetPlate("testAccessPlateByIdentifiersFirst", plateType.getRowId(), null, null),
+                new PlateManager.CreatePlateSetPlate("testAccessPlateByIdentifiersSecond", plateType.getRowId(), null, null),
+                new PlateManager.CreatePlateSetPlate("testAccessPlateByIdentifiersThird", plateType.getRowId(), null, null)
         ), null);
 
         // Assert
@@ -499,17 +498,17 @@ public final class PlateManagerTest
     public void getWellSampleData()
     {
         // Act
-        int[] sampleIdsSorted = new int[]{0, 3, 5, 8, 10, 11, 12, 13, 15, 17, 19};
-        Pair<Integer, List<Map<String, Object>>> wellSampleDataFilledFull = PlateManager.get().getWellSampleData(sampleIdsSorted, 2, 3, 0, container);
-        Pair<Integer, List<Map<String, Object>>> wellSampleDataFilledPartial = PlateManager.get().getWellSampleData(sampleIdsSorted, 2, 3, 6, container);
+        List<Integer> sampleIds = List.of(0, 3, 5, 8, 10, 11, 12, 13, 15, 17, 19);
+        Pair<Integer, List<Map<String, Object>>> wellSampleDataFilledFull = PlateManager.get().getWellSampleData(container, sampleIds, 2, 3, 0);
+        Pair<Integer, List<Map<String, Object>>> wellSampleDataFilledPartial = PlateManager.get().getWellSampleData(container, sampleIds, 2, 3, 6);
 
         // Assert
         assertEquals(wellSampleDataFilledFull.first, 6, 0);
-        ArrayList<String> wellLocations = new ArrayList<>(Arrays.asList("A1", "A2", "A3", "B1", "B2", "B3"));
+        List<String> wellLocations = List.of("A1", "A2", "A3", "B1", "B2", "B3");
         for (int i = 0; i < wellSampleDataFilledFull.second.size(); i++)
         {
             Map<String, Object> well = wellSampleDataFilledFull.second.get(i);
-            assertEquals(well.get("sampleId"), sampleIdsSorted[i]);
+            assertEquals(well.get("sampleId"), sampleIds.get(i));
             assertEquals(well.get("wellLocation"), wellLocations.get(i));
         }
 
@@ -517,14 +516,14 @@ public final class PlateManagerTest
         for (int i = 0; i < wellSampleDataFilledPartial.second.size(); i++)
         {
             Map<String, Object> well = wellSampleDataFilledPartial.second.get(i);
-            assertEquals(well.get("sampleId"), sampleIdsSorted[i + 6]);
+            assertEquals(well.get("sampleId"), sampleIds.get(i + 6));
             assertEquals(well.get("wellLocation"), wellLocations.get(i));
         }
 
         // Act
         try
         {
-            PlateManager.get().getWellSampleData(new int[]{}, 2, 3, 0, container);
+            PlateManager.get().getWellSampleData(container, Collections.emptyList(), 2, 3, 0);
         }
         // Assert
         catch (IllegalArgumentException e)

--- a/assay/src/org/labkey/assay/plate/PlateSetImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetImpl.java
@@ -187,6 +187,12 @@ public class PlateSetImpl extends Entity implements PlateSet
         _rootPlateSetId = rootPlateSetId;
     }
 
+    @JsonIgnore // TODO: Should probably just make this first class
+    public boolean isStandalone()
+    {
+        return getRootPlateSetId() == null && PlateSetType.assay.equals(getType()) && !isTemplate();
+    }
+
     @Override
     public boolean isTemplate()
     {

--- a/assay/src/org/labkey/assay/plate/data/WellData.java
+++ b/assay/src/org/labkey/assay/plate/data/WellData.java
@@ -1,0 +1,136 @@
+package org.labkey.assay.plate.data;
+
+import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.assay.plate.query.WellTable;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class WellData
+{
+    private Integer _col;
+    private String _lsid;
+    private Map<String, Object> _metadata;
+    private String _position;
+    private Integer _row;
+    private Integer _rowId;
+    private Integer _sampleId;
+    private WellGroup.Type _type;
+    private String _wellGroup;
+
+    public WellData()
+    {
+    }
+
+    public Map<String, Object> getData()
+    {
+        Map<String, Object> data = new CaseInsensitiveHashMap<>();
+        if (_position != null)
+            data.put("WellLocation", _position);
+        if (_sampleId != null)
+            data.put(WellTable.Column.SampleId.name(), _sampleId);
+        if (_type != null)
+            data.put(WellTable.Column.Type.name(), _type.name());
+        if (_wellGroup != null)
+            data.put(WellTable.Column.WellGroup.name(), _wellGroup);
+
+        for (var entry : getMetadata().entrySet())
+        {
+            if (entry.getValue() != null)
+                data.put(WellTable.Column.Properties.name() + "/" + entry.getKey(), entry.getValue());
+        }
+
+        return data;
+    }
+
+    public Integer getCol()
+    {
+        return _col;
+    }
+
+    public void setCol(Integer col)
+    {
+        _col = col;
+    }
+
+    public String getLsid()
+    {
+        return _lsid;
+    }
+
+    public void setLsid(String lsid)
+    {
+        _lsid = lsid;
+    }
+
+    public Map<String, Object> getMetadata()
+    {
+        return _metadata == null ? Collections.emptyMap() : _metadata;
+    }
+
+    public void setMetadata(Map<String, Object> metadata)
+    {
+        _metadata = metadata;
+    }
+
+    public String getPosition()
+    {
+        return _position;
+    }
+
+    public void setPosition(String position)
+    {
+        _position = position;
+    }
+
+    public Integer getRow()
+    {
+        return _row;
+    }
+
+    public void setRow(Integer row)
+    {
+        _row = row;
+    }
+
+    public Integer getRowId()
+    {
+        return _rowId;
+    }
+
+    public void setRowId(Integer rowId)
+    {
+        _rowId = rowId;
+    }
+
+    public Integer getSampleId()
+    {
+        return _sampleId;
+    }
+
+    public void setSampleId(Integer sampleId)
+    {
+        _sampleId = sampleId;
+    }
+
+    public WellGroup.Type getType()
+    {
+        return _type;
+    }
+
+    public void setType(WellGroup.Type type)
+    {
+        _type = type;
+    }
+
+    public String getWellGroup()
+    {
+        return _wellGroup;
+    }
+
+    public void setWellGroup(String wellGroup)
+    {
+        _wellGroup = wellGroup;
+    }
+}

--- a/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
@@ -150,9 +150,9 @@ public class WellTriggerFactory implements TriggerFactory
                     if (StringUtils.trimToNull(type) == null)
                         type = "";
                 }
-                if (newRow.containsKey(WellTable.Column.Group.name()))
+                if (newRow.containsKey(WellTable.Column.WellGroup.name()))
                 {
-                    group = (String) newRow.get(WellTable.Column.Group.name());
+                    group = (String) newRow.get(WellTable.Column.WellGroup.name());
                     if (StringUtils.trimToNull(group) == null)
                         group = "";
                 }
@@ -170,7 +170,7 @@ public class WellTriggerFactory implements TriggerFactory
 
         private boolean hasTypeGroupChange(@Nullable Map<String, Object> row)
         {
-            return row != null && (row.containsKey(WellTable.Column.Type.name()) || row.containsKey(WellTable.Column.Group.name()));
+            return row != null && (row.containsKey(WellTable.Column.Type.name()) || row.containsKey(WellTable.Column.WellGroup.name()));
         }
 
         private boolean isCopyOperation(Map<String, Object> extraContext)

--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -79,7 +79,6 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
         Col,
         Container,
         Dilution,
-        Group,
         Lsid,
         PlateId,
         Position,
@@ -89,6 +88,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
         SampleId,
         Type,
         Value,
+        WellGroup
     }
 
     private static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
@@ -120,13 +120,13 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
     public void addColumns()
     {
         super.addColumns();
-        addGroupColumn();
+        addWellGroupColumn();
         addPositionColumn();
         addPropertiesColumn();
         addTypeColumn();
     }
 
-    private void addGroupColumn()
+    private void addWellGroupColumn()
     {
         SQLFragment groupSql = new SQLFragment("SELECT WG.Name FROM ")
                 .append(AssayDbSchema.getInstance().getTableInfoWellGroupPositions(), "WGP")
@@ -143,7 +143,8 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
         // we do not support having multiple values. Here we limit the query to return a single result.
         groupSql = new SQLFragment("(").append(getSqlDialect().limitRows(groupSql, 1)).append(")");
 
-        var column = new ExprColumn(this, FieldKey.fromParts(Column.Group.name()), groupSql, JdbcType.VARCHAR);
+        var column = new ExprColumn(this, FieldKey.fromParts(Column.WellGroup.name()), groupSql, JdbcType.VARCHAR);
+        column.setLabel("Group");
         column.setUserEditable(true);
         column.setShownInInsertView(true);
         addColumn(column);

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.46.6-fb-plate-template-deux.0",
+        "@labkey/components": "3.47.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3393,9 +3393,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.46.6-fb-plate-template-deux.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.46.6-fb-plate-template-deux.0.tgz",
-      "integrity": "sha512-zW+uVWPzZ7MWpQ+/WF0dPSn0+Qj0lQAj9myajbo3FkQntOzvbjICGMnUjf829ydBLW+qJGzau9u9ZFQWQwoKKg==",
+      "version": "3.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.47.0.tgz",
+      "integrity": "sha512-qxEZKddnN39VLn800RudYh3x9hIMZjIMepfApahVaZ35RFVP5K7S5bb6dy+M0HnQWDOgIvCul3twGBpNK92zag==",
       "dependencies": {
         "@labkey/api": "1.33.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.46.0",
+        "@labkey/components": "3.46.6-fb-plate-template-deux.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3393,9 +3393,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.46.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.46.0.tgz",
-      "integrity": "sha512-7j1fyEXc4pHmbqNkhrx0nTXr+EyY4QZNmkDWRtkTPd2BI45An1PbNA3FLzTGXvD6Gft3z9gk8bcongJnAPt2vQ==",
+      "version": "3.46.6-fb-plate-template-deux.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.46.6-fb-plate-template-deux.0.tgz",
+      "integrity": "sha512-zW+uVWPzZ7MWpQ+/WF0dPSn0+Qj0lQAj9myajbo3FkQntOzvbjICGMnUjf829ydBLW+qJGzau9u9ZFQWQwoKKg==",
       "dependencies": {
         "@labkey/api": "1.33.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.46.0",
+    "@labkey/components": "3.46.6-fb-plate-template-deux.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.46.6-fb-plate-template-deux.0",
+    "@labkey/components": "3.47.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.46.6-fb-plate-template-deux.0"
+        "@labkey/components": "3.47.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -3241,9 +3241,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.46.6-fb-plate-template-deux.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.46.6-fb-plate-template-deux.0.tgz",
-      "integrity": "sha512-zW+uVWPzZ7MWpQ+/WF0dPSn0+Qj0lQAj9myajbo3FkQntOzvbjICGMnUjf829ydBLW+qJGzau9u9ZFQWQwoKKg==",
+      "version": "3.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.47.0.tgz",
+      "integrity": "sha512-qxEZKddnN39VLn800RudYh3x9hIMZjIMepfApahVaZ35RFVP5K7S5bb6dy+M0HnQWDOgIvCul3twGBpNK92zag==",
       "dependencies": {
         "@labkey/api": "1.33.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.46.0"
+        "@labkey/components": "3.46.6-fb-plate-template-deux.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -3241,9 +3241,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.46.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.46.0.tgz",
-      "integrity": "sha512-7j1fyEXc4pHmbqNkhrx0nTXr+EyY4QZNmkDWRtkTPd2BI45An1PbNA3FLzTGXvD6Gft3z9gk8bcongJnAPt2vQ==",
+      "version": "3.46.6-fb-plate-template-deux.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.46.6-fb-plate-template-deux.0.tgz",
+      "integrity": "sha512-zW+uVWPzZ7MWpQ+/WF0dPSn0+Qj0lQAj9myajbo3FkQntOzvbjICGMnUjf829ydBLW+qJGzau9u9ZFQWQwoKKg==",
       "dependencies": {
         "@labkey/api": "1.33.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.46.0"
+    "@labkey/components": "3.46.6-fb-plate-template-deux.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.46.6-fb-plate-template-deux.0"
+    "@labkey/components": "3.47.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.46.0"
+        "@labkey/components": "3.46.6-fb-plate-template-deux.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -2642,9 +2642,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.46.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.46.0.tgz",
-      "integrity": "sha512-7j1fyEXc4pHmbqNkhrx0nTXr+EyY4QZNmkDWRtkTPd2BI45An1PbNA3FLzTGXvD6Gft3z9gk8bcongJnAPt2vQ==",
+      "version": "3.46.6-fb-plate-template-deux.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.46.6-fb-plate-template-deux.0.tgz",
+      "integrity": "sha512-zW+uVWPzZ7MWpQ+/WF0dPSn0+Qj0lQAj9myajbo3FkQntOzvbjICGMnUjf829ydBLW+qJGzau9u9ZFQWQwoKKg==",
       "dependencies": {
         "@labkey/api": "1.33.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.46.6-fb-plate-template-deux.0"
+        "@labkey/components": "3.47.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -2642,9 +2642,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.46.6-fb-plate-template-deux.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.46.6-fb-plate-template-deux.0.tgz",
-      "integrity": "sha512-zW+uVWPzZ7MWpQ+/WF0dPSn0+Qj0lQAj9myajbo3FkQntOzvbjICGMnUjf829ydBLW+qJGzau9u9ZFQWQwoKKg==",
+      "version": "3.47.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.47.0.tgz",
+      "integrity": "sha512-qxEZKddnN39VLn800RudYh3x9hIMZjIMepfApahVaZ35RFVP5K7S5bb6dy+M0HnQWDOgIvCul3twGBpNK92zag==",
       "dependencies": {
         "@labkey/api": "1.33.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.46.6-fb-plate-template-deux.0"
+    "@labkey/components": "3.47.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.46.0"
+    "@labkey/components": "3.46.6-fb-plate-template-deux.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",


### PR DESCRIPTION
#### Rationale
Introduces capability to source a plate from a plate template. These scenarios include:

- Sourcing of a set of plates via `plate-createPlateSet.api`. This includes re-plating, re-array, and custom plate construction.
- Sourcing of a plate via `plate-createPlate.api`.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1502
- https://github.com/LabKey/labkey-ui-premium/pull/421
- https://github.com/LabKey/platform/pull/5535
- https://github.com/LabKey/limsModules/pull/304

#### Changes
- Support specifying a "templateId" within a `CreatePlateSetPlate`
- Support replating a plate set as an explicit operation. Plates now copied via `copyPlate()`
- Re-array from with a selection of samples into a new plate set. These plates can be sourced from plate types and plate templates.
- Introduce `WellData` model to encapsulate all data within a well. Handles database deserialization and generation of query row data.
- Rename `Plate.Well.Group` column to `Plate.Well.WellGroup` to avoid conflicting with "GROUP" keyword in SQL (was making it so we had to do extra work to serialize).