### PR TITLE
Use correct domain kind for test list

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/VaccineProtocolTest.java
+++ b/study/test/src/org/labkey/test/tests/study/VaccineProtocolTest.java
@@ -27,7 +27,7 @@ import org.labkey.test.pages.DesignerController.DesignerTester;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
-import org.labkey.test.params.list.VarListDefinition;
+import org.labkey.test.params.list.IntListDefinition;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.PortalHelper;
 
@@ -167,9 +167,9 @@ public class VaccineProtocolTest extends BaseWebDriverTest
 
         portalHelper.addWebPart("Lists");
 
-        new VarListDefinition(LIST_NAME)
+        new IntListDefinition(LIST_NAME)
                 .setFields(List.of(
-                        new FieldDefinition("Key", FieldDefinition.ColumnType.Integer),
+                        new FieldDefinition("Key", ColumnType.Integer),
                         new FieldDefinition("Value", ColumnType.String).setDescription("Vaccine Value")))
                 .create(createDefaultConnection(), getProjectName() + "/" + FOLDER_NAME + "/" + STUDY_FOLDER);
 


### PR DESCRIPTION
#### Rationale
I used the wrong list definition type for this test list. SQL server actually throws an error if you give a `VarList` an Integer key.

#### Related Pull Requests
- LabKey/testAutomation#1947

#### Changes
- Use `IntListDefinition` to create test list
