### PR TITLE
Plates: add indices on foreign key source columns

### DIFF
--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.008-24.009.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.008-24.009.sql
@@ -1,0 +1,2 @@
+-- Add index on assay.WellGroupPositions.WellId to improve performance of DELETE operation on assay.Well table.
+CREATE INDEX IX_WellGroupPositions_WellId ON assay.WellGroupPositions (WellId);

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.008-24.009.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.008-24.009.sql
@@ -1,2 +1,5 @@
+-- Add index on assay.Well.SampleId to improve performance of DELETE operation on exp.Material table.
+CREATE INDEX IX_Well_SampleId ON assay.Well (SampleId);
+
 -- Add index on assay.WellGroupPositions.WellId to improve performance of DELETE operation on assay.Well table.
 CREATE INDEX IX_WellGroupPositions_WellId ON assay.WellGroupPositions (WellId);

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.008-24.009.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.008-24.009.sql
@@ -1,0 +1,2 @@
+-- Add index on assay.WellGroupPositions.WellId to improve performance of DELETE operation on assay.Well table.
+CREATE INDEX IX_WellGroupPositions_WellId ON assay.WellGroupPositions (WellId);

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.008-24.009.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.008-24.009.sql
@@ -1,2 +1,5 @@
+-- Add index on assay.Well.SampleId to improve performance of DELETE operation on exp.Material table.
+CREATE INDEX IX_Well_SampleId ON assay.Well (SampleId);
+
 -- Add index on assay.WellGroupPositions.WellId to improve performance of DELETE operation on assay.Well table.
 CREATE INDEX IX_WellGroupPositions_WellId ON assay.WellGroupPositions (WellId);

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -116,7 +116,7 @@ public class AssayModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 24.008;
+        return 24.009;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We're [seeing degraded performance](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50531) when deleting plates. This introduces a couple of new database indices that index the source column for foreign keys declared in the assay schema. This improves performance of deleting plate wells and of deleting samples.

Took me a bit to slueth this one out but the key is in the triggers induced by the delete operation. Here is a resulting time it was taking to delete 384 assay.Well rows:

<img width="350" alt="image" src="https://github.com/LabKey/platform/assets/3926239/2de7c3e0-3de9-4522-a31a-07ebdc87ca57">

Same operation after adding the index on the assay.WellGroupPositions table:

<img width="350" alt="image" src="https://github.com/LabKey/platform/assets/3926239/dc75b1ff-ce37-4f51-a433-4bf7d68503dc">

#### Changes
- Add index on `assay.Well.SampleId` to improve performance of DELETE operation on `exp.Material` table.
- Add index on `assay.WellGroupPositions.WellId` to improve performance of DELETE operation on `assay.Well` table.
