### PR TITLE
Fix encoding for MiniProfiler init script

### DIFF
--- a/api/src/org/labkey/api/miniprofiler/MiniProfiler.java
+++ b/api/src/org/labkey/api/miniprofiler/MiniProfiler.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.miniprofiler;
 
+import jakarta.servlet.ServletContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.Cache;
@@ -27,12 +28,12 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.util.JavaScriptFragment;
 import org.labkey.api.util.MemTracker;
+import org.labkey.api.util.SafeToRender;
 import org.labkey.api.util.SafeToRenderEnum;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.ViewServlet;
 
-import jakarta.servlet.ServletContext;
 import java.security.Principal;
 import java.util.Map;
 import java.util.Set;
@@ -151,12 +152,11 @@ public class MiniProfiler
         SETTINGS_CACHE.remove(user);
     }
 
-    public static JavaScriptFragment renderInitScript(@NotNull User user, long currentId, Set<Long> ids, String version)
+    public static SafeToRender renderInitScript(@NotNull User user, long currentId, Set<Long> ids, String version)
     {
         Settings settings = getSettings(user);
 
-        return JavaScriptFragment.unsafe(
-            HttpView.currentPageConfig().getScriptTagStart().toString() +
+        JavaScriptFragment initFragment = JavaScriptFragment.unsafe(
             "LABKEY.internal.MiniProfiler.init({\n" +
             "  currentId:" + currentId + ",\n" +
             "  ids:" + ids + ",\n" +
@@ -171,9 +171,9 @@ public class MiniProfiler
             "  toggleShortcut:" + jsString(settings.getToggleShortcut() != null ? settings.getToggleShortcut() : "") + ",\n" +
             "  startHidden:" + settings.isStartHidden() + ",\n" +
             "  startMinimized:" + settings.isStartMinimized() + "\n" +
-            "});\n" +
-            "</script>\n"
+            "});"
         );
+        return HttpView.currentPageConfig().buildScriptTagBlock(initFragment);
     }
 
     public static void addObject(Object object)

--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -16,6 +16,8 @@
 
 package org.labkey.api.view.template;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
@@ -32,6 +34,8 @@ import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.JavaScriptFragment;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.SafeToRender;
+import org.labkey.api.util.SafeToRenderBuilder;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.UniqueID;
 import org.labkey.api.util.logging.LogHelper;
@@ -43,8 +47,6 @@ import org.labkey.api.view.ViewService;
 import org.labkey.api.view.ViewServlet;
 import org.springframework.web.servlet.ModelAndView;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
@@ -594,8 +596,20 @@ public class PageConfig
     public HtmlString getScriptTagStart()
     {
         HtmlString nonce = getScriptNonce();
-        return HtmlStringBuilder.of(HtmlString.unsafe("\n<script type=\"text/javascript\" nonce=\"")).append(nonce).unsafeAppend("\">").getHtmlString();
+        return HtmlStringBuilder.of(HtmlString.unsafe("\n<script type=\"text/javascript\" nonce=\"")).append(nonce).unsafeAppend("\">\n").getHtmlString();
     }
+
+
+    public SafeToRender buildScriptTagBlock(JavaScriptFragment javaScriptFragment)
+    {
+        SafeToRenderBuilder scriptBuilder = SafeToRenderBuilder.of();
+        scriptBuilder.append(HttpView.currentPageConfig().getScriptTagStart());
+        scriptBuilder.append(HtmlString.unsafe("\n"));
+        scriptBuilder.append(javaScriptFragment);
+        scriptBuilder.append(HtmlString.unsafe("\n</script>\n"));
+        return scriptBuilder.getSafeToRender();
+    }
+
 
 
     private void _addHandler(EventHandler eh)

--- a/api/src/org/labkey/api/view/template/PageConfig.java
+++ b/api/src/org/labkey/api/view/template/PageConfig.java
@@ -596,7 +596,7 @@ public class PageConfig
     public HtmlString getScriptTagStart()
     {
         HtmlString nonce = getScriptNonce();
-        return HtmlStringBuilder.of(HtmlString.unsafe("\n<script type=\"text/javascript\" nonce=\"")).append(nonce).unsafeAppend("\">\n").getHtmlString();
+        return HtmlStringBuilder.of(HtmlString.unsafe("\n<script type=\"text/javascript\" nonce=\"")).append(nonce).unsafeAppend("\">").getHtmlString();
     }
 
 


### PR DESCRIPTION
#### Rationale
`MiniProfiler.renderInitScript` attempts to include the script tag as a part of a JavaScript fragment. This is no longer allowed and causes the tag to be left unclosed, totally breaking the page.
I'm adding a new `buildScriptTagBlock` method to the `PageConfig` that properly encodes the HTML and JavaScript portions separately and makes sure the script tag starts and ends correctly.

#### Related Pull Requests
- #5108 

#### Changes
- Fix encoding for MiniProfiler init script
