### PR TITLE
Issue 50543: 'Does Not Contain Any Of' conditional formatting doesn't apply

### DIFF
--- a/api/src/org/labkey/api/data/SimpleFilter.java
+++ b/api/src/org/labkey/api/data/SimpleFilter.java
@@ -962,10 +962,10 @@ public class SimpleFilter implements Filter
                 FilterClause compareClause = CompareType.CONTAINS.createFilterClause(getFieldKeys().get(0), params);
                 if (compareClause.meetsCriteria(col, value))
                 {
-                    return true;
+                    return !_negated;
                 }
             }
-            return false;
+            return _negated;
         }
     }
 


### PR DESCRIPTION
#### Rationale
`Does Not Contain Any Of` is applying conditional formatting the way as `Contains Any Of` does

#### Changes
- Check if we're negated or not when determining if the value meet the criteria