### PR TITLE
Plates: insert well data upon creation

### DIFF
--- a/assay/api-src/org/labkey/api/assay/dilution/DilutionManager.java
+++ b/assay/api-src/org/labkey/api/assay/dilution/DilutionManager.java
@@ -41,7 +41,6 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.security.User;
-import org.labkey.api.assay.plate.PlateService;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -118,8 +117,6 @@ public class DilutionManager
         // Delete the rows in NASpecimen hat match those runIdFilter
         TableInfo nabTableInfo = getSchema().getTable(NAB_SPECIMEN_TABLE_NAME);
         Table.delete(nabTableInfo, runIdFilter);
-
-        PlateService.get().deleteAllPlateData(container);
     }
 
     public int insertNabSpecimenRow(User user, Map<String, Object> fields)

--- a/assay/api-src/org/labkey/api/assay/plate/PlateService.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateService.java
@@ -215,13 +215,6 @@ public interface PlateService
     Position createPosition(Container container, int row, int column);
 
     /**
-     * Deletes all plate and template data from the specified container.
-     * Typically used only when a container is deleted.
-     * @param container The container from which to delete all plate data.
-     */
-    void deleteAllPlateData(Container container);
-
-    /**
      * Deletes a single plate object.
      * @param container The object's container.
      * @param rowid The row id of the plate object to be deleted.

--- a/assay/api-src/org/labkey/api/assay/plate/PlateUtils.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateUtils.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 
@@ -406,6 +407,20 @@ public class PlateUtils
         public int getCol()
         {
             return _col;
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (obj instanceof Location loc)
+                return loc.getRow() == getRow() && loc.getCol() == getCol();
+            return false;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(_row, _col);
         }
     }
 

--- a/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
+++ b/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
@@ -42,7 +42,7 @@ import static org.labkey.assay.plate.PlateManager.CreatePlateSetPlate;
 public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.Config>
 {
     private static final int MAX_LINEAGE_DEPTH = 10;
-    private static final int MAX_PLATESETS_PER_LEVEL = 10;
+    private static final int MAX_PLATE_SETS_PER_LEVEL = 10;
     private PlateType _plateType;
     private int _plateSetsCreated = 0;
     private final List<String> _wellProperties = new ArrayList<>();
@@ -127,15 +127,15 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
             return false;
         }
 
-        if ((config.getPrimaryPlateSetsPerLevel() + config.getAssayPlateSetsPerLevel()) > MAX_PLATESETS_PER_LEVEL)
+        if ((config.getPrimaryPlateSetsPerLevel() + config.getAssayPlateSetsPerLevel()) > MAX_PLATE_SETS_PER_LEVEL)
         {
-            _log.error(String.format("The max number of plate sets per level cannot exceed %d", MAX_PLATESETS_PER_LEVEL));
+            _log.error(String.format("The max number of plate sets per level cannot exceed %d", MAX_PLATE_SETS_PER_LEVEL));
             return false;
         }
 
         if (config.getMinCustomProperties() > config.getMaxCustomProperties())
         {
-            _log.error(String.format("The max number of plate sets per level cannot exceed %d", MAX_PLATESETS_PER_LEVEL));
+            _log.error(String.format("The max number of plate sets per level cannot exceed %d", MAX_PLATE_SETS_PER_LEVEL));
             return false;
         }
 
@@ -258,7 +258,7 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
                     Position position = PlateManager.get().createPosition(getContainer(), row, col);
                     Map<String, Object> rowMap = new HashMap<>();
 
-                    rowMap.put("wellLocation", position.getDescription());
+                    rowMap.put(WellTable.WELL_LOCATION, position.getDescription());
                     rowMap.put(WellTable.Column.Type.name(), WellGroup.Type.SAMPLE.name());
                     rowMap.put(WellTable.Column.SampleId.name(), ids.get(sampleIdx++));
 

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -8,7 +8,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.labkey.api.assay.AssayProtocolSchema;
@@ -1033,11 +1032,6 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 
             container = JunitUtil.getTestContainer();
             user = TestContext.get().getUser();
-        }
-
-        @After
-        public void cleanup()
-        {
         }
 
         @Test

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -80,6 +80,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.labkey.api.assay.AssayResultDomainKind.WELL_LSID_COLUMN_NAME;
 
@@ -1026,69 +1027,71 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         private static User user;
 
         @BeforeClass
-        public static void setupTest()
+        public static void setup()
         {
+            JunitUtil.deleteTestContainer();
+
             container = JunitUtil.getTestContainer();
             user = TestContext.get().getUser();
-
-            PlateService.get().deleteAllPlateData(container);
         }
 
         @After
-        public void cleanupTest()
+        public void cleanup()
         {
-            PlateManager.get().deleteAllPlateData(container);
         }
 
         @Test
         public void testGridAnnotations() throws Exception
         {
-            // create a plate set
-            PlateSetImpl plateSet = new PlateSetImpl();
             PlateType plateType = PlateManager.get().getPlateType(8, 12);
+            assertNotNull("Expected 8x12 plate type to resolve", plateType);
+
             List<PlateManager.CreatePlateSetPlate> plates = List.of(
-                    new PlateManager.CreatePlateSetPlate(null, plateType.getRowId(), null, Collections.emptyList()),
-                    new PlateManager.CreatePlateSetPlate(null, plateType.getRowId(), null, Collections.emptyList())
+                new PlateManager.CreatePlateSetPlate(null, plateType.getRowId(), null, Collections.emptyList()),
+                new PlateManager.CreatePlateSetPlate(null, plateType.getRowId(), null, Collections.emptyList())
             );
-            plateSet = PlateManager.get().createPlateSet(container, user, plateSet, plates, null);
-            List<Plate> platesetPlates = PlateManager.get().getPlatesForPlateSet(plateSet);
+
+            PlateSet plateSet = PlateManager.get().createPlateSet(container, user, new PlateSetImpl(), plates, null);
+            List<Plate> plateSetPlates = PlateManager.get().getPlatesForPlateSet(plateSet);
+            assertEquals("Expected two plates to be created.", 2, plateSetPlates.size());
+            Plate plate = plateSetPlates.get(0);
 
             PlateGridInfo gridInfo = new PlateGridInfo(
-                    new PlateUtils.GridInfo(new double[8][12], List.of(platesetPlates.get(0).getPlateId())),
+                    new PlateUtils.GridInfo(new double[8][12], List.of(plate.getPlateId())),
                     plateSet);
-            assertEquals("Expected plate to resolve on annotation", platesetPlates.get(0).getRowId(), gridInfo.getPlate().getRowId());
+            assertEquals("Expected plate to resolve on annotation", plate.getRowId(), gridInfo.getPlate().getRowId());
 
             gridInfo = new PlateGridInfo(
-                    new PlateUtils.GridInfo(new double[8][12], List.of(platesetPlates.get(0).getName())),
+                    new PlateUtils.GridInfo(new double[8][12], List.of(plate.getName())),
                     plateSet);
-            assertEquals("Expected plate to resolve on annotation", platesetPlates.get(0).getRowId(), gridInfo.getPlate().getRowId());
+            assertEquals("Expected plate to resolve on annotation", plate.getRowId(), gridInfo.getPlate().getRowId());
 
             gridInfo = new PlateGridInfo(
-                    new PlateUtils.GridInfo(new double[8][12], List.of(platesetPlates.get(0).getRowId().toString())),
+                    new PlateUtils.GridInfo(new double[8][12], List.of(plate.getRowId().toString())),
                     plateSet);
-            assertEquals("Expected plate to resolve on annotation", platesetPlates.get(0).getRowId(), gridInfo.getPlate().getRowId());
+            assertEquals("Expected plate to resolve on annotation", plate.getRowId(), gridInfo.getPlate().getRowId());
 
             // test for multiple annotations
             gridInfo = new PlateGridInfo(
-                    new PlateUtils.GridInfo(new double[8][12], List.of(platesetPlates.get(0).getPlateId(), "Density")),
+                    new PlateUtils.GridInfo(new double[8][12], List.of(plate.getPlateId(), "Density")),
                     plateSet);
             assertNull("Expected plate to not resolve on annotation without a prefix", gridInfo.getPlate());
             assertNull("Expected measure to not resolve on annotation without a prefix", gridInfo.getMeasureName());
 
             gridInfo = new PlateGridInfo(
-                    new PlateUtils.GridInfo(new double[8][12], List.of("PLATE:" + platesetPlates.get(0).getPlateId(), "Density")),
+                    new PlateUtils.GridInfo(new double[8][12], List.of("PLATE:" + plate.getPlateId(), "Density")),
                     plateSet);
-            assertEquals("Expected plate to resolve on annotation with a prefix", platesetPlates.get(0).getRowId(), gridInfo.getPlate().getRowId());
+            assertEquals("Expected plate to resolve on annotation with a prefix", plate.getRowId(), gridInfo.getPlate().getRowId());
             assertNull("Expected measure to not resolve on annotation without a prefix", gridInfo.getMeasureName());
 
             gridInfo = new PlateGridInfo(
-                    new PlateUtils.GridInfo(new double[8][12], List.of("plate:" + platesetPlates.get(0).getPlateId(), "MEASURE : Density")),
+                    new PlateUtils.GridInfo(new double[8][12], List.of("plate:" + plate.getPlateId(), "MEASURE : Density")),
                     plateSet);
-            assertEquals("Expected plate to resolve on annotation with a prefix", platesetPlates.get(0).getRowId(), gridInfo.getPlate().getRowId());
+            assertEquals("Expected plate to resolve on annotation with a prefix", plate.getRowId(), gridInfo.getPlate().getRowId());
             assertEquals("Expected measure to resolve on annotation with a prefix", "Density", gridInfo.getMeasureName());
 
             gridInfo = new PlateGridInfo(
-                    new PlateUtils.GridInfo(new double[8][12], List.of(platesetPlates.get(0).getPlateId(), "measure : Density")),
+                    new PlateUtils.GridInfo(new double[8][12], List.of(plate.getPlateId(), "measure : Density")),
                     plateSet);
             assertNull("Expected plate to not resolve on annotation without a prefix", gridInfo.getPlate());
             assertEquals("Expected measure to resolve on annotation with a prefix", "Density", gridInfo.getMeasureName());

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -152,6 +152,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static org.labkey.api.assay.plate.PlateSet.MAX_PLATES;
+import static org.labkey.assay.plate.query.WellTable.WELL_LOCATION;
 
 public class PlateManager implements PlateService, AssayListener, ExperimentListener
 {
@@ -327,7 +328,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         // resolve columns and set any custom fields associated with the plate
         for (Map<String, Object> dataRow : data)
         {
-            if (dataRow.containsKey("wellLocation"))
+            if (dataRow.containsKey(WELL_LOCATION))
             {
                 for (String colName : dataRow.keySet())
                 {
@@ -774,9 +775,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     @Override
     public int save(Container container, User user, Plate plate) throws Exception
     {
-        if (plate instanceof PlateImpl plateTemplate)
-            return save(container, user, plateTemplate, null);
-        throw new IllegalArgumentException("Only plate instances created by the plate service can be saved.");
+        return save(container, user, plate, null);
     }
 
     private int save(Container container, User user, Plate plate, @Nullable List<Map<String, Object>> wellData) throws Exception
@@ -1110,16 +1109,16 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             WellTable.Column.Properties.name(),
             WellTable.Column.Row.name(),
             WellTable.Column.RowId.name(),
-            "WellLocation"
+            WELL_LOCATION
         );
 
         Map<String, Map<String, Object>> wellDataMap = new HashMap<>();
 
         for (var wellDataRow : rawWellData)
         {
-            if (wellDataRow.containsKey("wellLocation"))
+            if (wellDataRow.containsKey(WELL_LOCATION))
             {
-                var wellLocation = StringUtils.trimToNull(String.valueOf(wellDataRow.get("wellLocation")));
+                var wellLocation = StringUtils.trimToNull(String.valueOf(wellDataRow.get(WELL_LOCATION)));
                 if (wellLocation == null)
                     continue;
 
@@ -2929,7 +2928,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 wellSampleDataForPlate.add(CaseInsensitiveHashMap.of(
                     WellTable.Column.SampleId.name(), sampleIds.get(sampleIdsCounter),
                     WellTable.Column.Type.name(), WellGroup.Type.SAMPLE.name(),
-                    "WellLocation", createPosition(c, rowIdx, colIdx).getDescription()
+                    WELL_LOCATION, createPosition(c, rowIdx, colIdx).getDescription()
                 ));
                 sampleIdsCounter++;
             }
@@ -2975,7 +2974,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             {
                 data.add(CaseInsensitiveHashMap.of(
                     WellTable.Column.Type.name(), WellGroup.Type.SAMPLE.name(),
-                    "WellLocation", createPosition(container, rowIdx, colIdx).getDescription()
+                    WELL_LOCATION, createPosition(container, rowIdx, colIdx).getDescription()
                 ));
             }
         }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -326,8 +326,10 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             metadataFields = metadataTable.getColumns().stream().map(ColumnInfo::getFieldKey).collect(Collectors.toSet());
 
         // resolve columns and set any custom fields associated with the plate
-        for (Map<String, Object> dataRow : data)
+        for (Map<String, Object> dataMap : data)
         {
+            var dataRow = new CaseInsensitiveHashMap<>(dataMap);
+
             if (dataRow.containsKey(WELL_LOCATION))
             {
                 for (String colName : dataRow.keySet())

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -37,7 +37,6 @@ import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateSetEdge;
 import org.labkey.api.assay.plate.PlateSetType;
 import org.labkey.api.assay.plate.PlateType;
-import org.labkey.api.assay.plate.PlateUtils;
 import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.PositionImpl;
 import org.labkey.api.assay.plate.Well;
@@ -280,12 +279,12 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 ((PlateImpl) plate).setPlateSet(plateSet);
             }
 
-            int plateRowId = save(container, user, plate);
+            int plateRowId = save(container, user, plate, data);
             plate = getPlate(container, plateRowId);
             if (plate == null)
                 throw new IllegalStateException("Unexpected failure. Failed to retrieve plate after save (pre-commit).");
 
-            saveWellData(container, user, plate, data);
+            deriveCustomFieldsFromWellData(container, user, plate, data);
 
             tx.commit();
 
@@ -305,7 +304,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         }
     }
 
-    private void saveWellData(
+    private void deriveCustomFieldsFromWellData(
         @NotNull Container container,
         @NotNull User user,
         @NotNull Plate plate,
@@ -317,9 +316,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         if (data == null || data.isEmpty())
             return;
 
-        QueryUpdateService qus = getWellUpdateService(container, user);
         TableInfo wellTable = getWellTable(container, user);
-        BatchValidationException errors = new BatchValidationException();
         Set<PlateCustomField> customFields = new HashSet<>();
 
         TableInfo metadataTable = getPlateMetadataTable(container, user);
@@ -328,38 +325,20 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             metadataFields = metadataTable.getColumns().stream().map(ColumnInfo::getFieldKey).collect(Collectors.toSet());
 
         // resolve columns and set any custom fields associated with the plate
-        List<Map<String, Object>> rows = new ArrayList<>();
         for (Map<String, Object> dataRow : data)
         {
             if (dataRow.containsKey("wellLocation"))
             {
-                PlateUtils.Location loc = PlateUtils.parseLocation(String.valueOf(dataRow.get("wellLocation")));
-                Well well = plate.getWell(loc.getRow(), loc.getCol());
-                Map<String, Object> row = new CaseInsensitiveHashMap<>(dataRow);
-                row.put("rowId", well.getRowId());
-                rows.add(row);
-
                 for (String colName : dataRow.keySet())
                 {
                     ColumnInfo col = wellTable.getColumn(FieldKey.fromParts(colName));
                     if (col != null && metadataFields.contains(col.getFieldKey()))
                     {
-                        PlateCustomField customField = new PlateCustomField(col.getPropertyURI());
-                        customFields.add(customField);
+                        customFields.add(new PlateCustomField(col.getPropertyURI()));
                     }
                 }
             }
-            else
-            {
-                // should we fail or just log?
-                LOG.error("Unable to add well data for plate: " + plate.getName() + " each data row must contain a wellLocation field.");
-            }
         }
-
-        // update the well table
-        qus.updateRows(user, container, rows, null, errors, null, null);
-        if (errors.hasErrors())
-            throw errors;
 
         // add custom fields to the plate
         if (!customFields.isEmpty())
@@ -796,7 +775,14 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     public int save(Container container, User user, Plate plate) throws Exception
     {
         if (plate instanceof PlateImpl plateTemplate)
-            return savePlateImpl(container, user, plateTemplate);
+            return save(container, user, plateTemplate, null);
+        throw new IllegalArgumentException("Only plate instances created by the plate service can be saved.");
+    }
+
+    private int save(Container container, User user, Plate plate, @Nullable List<Map<String, Object>> wellData) throws Exception
+    {
+        if (plate instanceof PlateImpl plateTemplate)
+            return savePlateImpl(container, user, plateTemplate, false, wellData);
         throw new IllegalArgumentException("Only plate instances created by the plate service can be saved.");
     }
 
@@ -925,12 +911,23 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return AssayDbSchema.getInstance().getSchema().getScope().ensureTransaction(locks);
     }
 
-    private int savePlateImpl(Container container, User user, PlateImpl plate) throws Exception
+    private int savePlateImpl(Container container, User user, @NotNull PlateImpl plate) throws Exception
     {
         return savePlateImpl(container, user, plate, false);
     }
 
-    private int savePlateImpl(Container container, User user, PlateImpl plate, boolean isCopy) throws Exception
+    private int savePlateImpl(Container container, User user, @NotNull PlateImpl plate, boolean isCopy) throws Exception
+    {
+        return savePlateImpl(container, user, plate, isCopy, null);
+    }
+
+    private int savePlateImpl(
+        Container container,
+        User user,
+        @NotNull PlateImpl plate,
+        boolean isCopy,
+        @Nullable List<Map<String, Object>> wellData
+    ) throws Exception
     {
         boolean updateExisting = plate.getRowId() != null;
 
@@ -1028,6 +1025,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             {
                 QueryUpdateService wellQus = getWellUpdateService(container, user);
                 List<Map<String, Object>> wellRows = new ArrayList<>();
+                Map<String, Map<String, Object>> wellDataMap = getWellDataMap(wellData);
+
                 for (int row = 0; row < plate.getRows(); row++)
                 {
                     for (int col = 0; col < plate.getColumns(); col++)
@@ -1038,9 +1037,19 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                             throw new IllegalStateException("Attempting to create a new plate but there are existing wells associated with it.");
 
                         position.setPlateId(plateId);
-                        wellRows.add(factory.toMap(position, new ArrayListMap<>()));
+                        Map<String, Object> wellRow = factory.toMap(position, new CaseInsensitiveHashMap<>());
+
+                        if (wellDataMap.containsKey(position.getDescription()))
+                        {
+                            wellDataMap.get(position.getDescription()).forEach(
+                                (key, value) -> wellRow.merge(key, value, (v1, v2) -> v1)
+                            );
+                        }
+
+                        wellRows.add(wellRow);
                     }
                 }
+
                 BatchValidationException wellErrors = new BatchValidationException();
                 insertedRows = wellQus.insertRows(user, container, wellRows, wellErrors, null, extraScriptContext);
                 if (wellErrors.hasErrors())
@@ -1085,6 +1094,58 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
             return plateId;
         }
+    }
+
+    private @NotNull Map<String, Map<String, Object>> getWellDataMap(@Nullable List<Map<String, Object>> rawWellData)
+    {
+        if (rawWellData == null || rawWellData.isEmpty())
+            return Collections.emptyMap();
+
+        Set<String> keywords = CaseInsensitiveHashSet.of(
+            WellTable.Column.Col.name(),
+            WellTable.Column.Container.name(),
+            WellTable.Column.Lsid.name(),
+            WellTable.Column.PlateId.name(),
+            WellTable.Column.Position.name(),
+            WellTable.Column.Properties.name(),
+            WellTable.Column.Row.name(),
+            WellTable.Column.RowId.name(),
+            "WellLocation"
+        );
+
+        Map<String, Map<String, Object>> wellDataMap = new HashMap<>();
+
+        for (var wellDataRow : rawWellData)
+        {
+            if (wellDataRow.containsKey("wellLocation"))
+            {
+                var wellLocation = StringUtils.trimToNull(String.valueOf(wellDataRow.get("wellLocation")));
+                if (wellLocation == null)
+                    continue;
+
+                var safeWellRow = new CaseInsensitiveHashMap<>();
+                for (var entry : wellDataRow.entrySet())
+                {
+                    if (StringUtils.trimToNull(entry.getKey()) == null || entry.getValue() == null)
+                        continue;
+
+                    var key = entry.getKey();
+                    var customFieldPrefix = WellTable.Column.Properties.name().toLowerCase() + "/";
+                    if (key.toLowerCase().startsWith(customFieldPrefix))
+                        key = key.substring(customFieldPrefix.length());
+
+                    if (StringUtils.trimToNull(key) != null && keywords.contains(key))
+                        continue;
+
+                    safeWellRow.put(key, entry.getValue());
+                }
+
+                if (!safeWellRow.isEmpty())
+                    wellDataMap.put(wellLocation, safeWellRow);
+            }
+        }
+
+        return wellDataMap;
     }
 
     // return a list of wellId and wellGroupId pairs
@@ -1283,7 +1344,6 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 " WHERE wellId IN (SELECT rowId FROM " + schema.getTableInfoWell() + " WHERE plateId=?)", plate.getRowId());
     }
 
-    @Override
     public void deleteAllPlateData(Container container)
     {
         try (DbScope.Transaction tx = ensureTransaction())
@@ -3327,7 +3387,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             {
                 switch (wellGroup.getType())
                 {
-                    case NEGATIVE_CONTROL, POSITIVE_CONTROL, SAMPLE -> validateWellGroup(plate, wellGroup);
+                    case CONTROL, NEGATIVE_CONTROL, POSITIVE_CONTROL, SAMPLE -> validateWellGroup(plate, wellGroup);
                     default -> throw new ValidationException(
                         String.format(
                             "Well Group Type \"%s\" is not supported for assay type \"%s\" plates.",

--- a/assay/src/org/labkey/assay/plate/data/WellData.java
+++ b/assay/src/org/labkey/assay/plate/data/WellData.java
@@ -27,7 +27,7 @@ public class WellData
     {
         Map<String, Object> data = new CaseInsensitiveHashMap<>();
         if (_position != null)
-            data.put("WellLocation", _position);
+            data.put(WellTable.WELL_LOCATION, _position);
         if (_sampleId != null)
             data.put(WellTable.Column.SampleId.name(), _sampleId);
         if (_type != null)

--- a/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
@@ -105,12 +105,17 @@ public class WellTriggerFactory implements TriggerFactory
             Map<String, Object> extraContext
         )
         {
-            // Skip computing well groups when this is a plate copy or save operation
-            if (isCopyOperation(extraContext) || isSaveOperation(extraContext))
+            // Skip computing well groups when this is a plate copy operation
+            if (isCopyOperation(extraContext))
                 return;
 
             var hasSampleChange = hasSampleChange(newRow);
             var hasTypeGroupChange = hasTypeGroupChange(newRow);
+
+            // If this is an insertion (newRow != null && oldRow == null),
+            // then verify further to ignore when type and group are present but are set to null.
+            if (hasTypeGroupChange && oldRow == null)
+                hasTypeGroupChange = newRow.get(WellTable.Column.Type.name()) != null || newRow.get(WellTable.Column.WellGroup.name()) != null;
 
             if (!hasSampleChange && !hasTypeGroupChange)
                 return;

--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -56,8 +56,8 @@ import org.labkey.assay.plate.data.WellTriggerFactory;
 import org.labkey.assay.query.AssayDbSchema;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -88,7 +88,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
         WellGroup
     }
 
-    private static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
+    private static final Set<FieldKey> defaultVisibleColumns = new LinkedHashSet<>();
     private static final Set<String> ignoredColumns = new CaseInsensitiveHashSet();
     private final Map<FieldKey, ColumnInfo> _provisionedFieldMap = new HashMap<>();
     private final boolean _allowInsertDelete;
@@ -301,7 +301,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
     @Override
     public List<FieldKey> getDefaultVisibleColumns()
     {
-        return defaultVisibleColumns;
+        return defaultVisibleColumns.stream().toList();
     }
 
 /*

--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -68,6 +68,7 @@ import static org.labkey.api.query.ExprColumn.STR_TABLE_ALIAS;
 public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
 {
     public static final String NAME = "Well";
+    public static final String WELL_LOCATION = "WellLocation";
     public static final String WELL_PROPERTIES_TABLE = "WellProperties";
 
     public enum Column


### PR DESCRIPTION
#### Rationale
 Improves performance of plate creation by eliminating second pass update of wells.

#### Changes
- Refactor `PlateManager.savePlateImpl()` to optionally process additional well data when inserting new wells.
- Refactor `PlateManager.saveWellData()` to process just the derivation of custom metadata columns from well data. Renamed to `PlateManager.deriveCustomFieldsFromWellData()`. Done for backwards compatibility. This may go away in the near future if we move to sourcing visible fields by Plate Set rather than by Plate.
- Factor out all usages of `PlateManager.deleteAllPlateData()` outside of container delete. This also stops us from duplicately calling delete all plate data on the same container from the `DilutionManager`. Remove from public service interface.