### PR TITLE
Issue 50549: resolve default well table columns

### DIFF
--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -56,8 +56,9 @@ import org.labkey.assay.plate.data.WellTriggerFactory;
 import org.labkey.assay.query.AssayDbSchema;
 
 import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -88,9 +89,9 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
         WellGroup
     }
 
-    private static final Set<FieldKey> defaultVisibleColumns = new LinkedHashSet<>();
+    private static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
     private static final Set<String> ignoredColumns = new CaseInsensitiveHashSet();
-    private final Map<FieldKey, ColumnInfo> _provisionedFieldMap = new HashMap<>();
+    private final Map<FieldKey, ColumnInfo> _provisionedFieldMap = new LinkedHashMap<>();
     private final boolean _allowInsertDelete;
 
     static
@@ -197,7 +198,6 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
                         continue;
 
                     FieldKey fieldKey = FieldKey.fromParts(Column.Properties.name(), column.getName());
-                    defaultVisibleColumns.add(fieldKey);
                     _provisionedFieldMap.put(fieldKey, column);
                 }
             }
@@ -301,7 +301,12 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
     @Override
     public List<FieldKey> getDefaultVisibleColumns()
     {
-        return defaultVisibleColumns.stream().toList();
+        List<FieldKey> visibleColumns = new ArrayList<>(defaultVisibleColumns);
+
+        for (var entry : _provisionedFieldMap.entrySet())
+            visibleColumns.add(entry.getKey());
+
+        return Collections.unmodifiableList(visibleColumns);
     }
 
 /*


### PR DESCRIPTION
#### Rationale
This addresses [Issue 50549](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50549) where a race condition could appear that resulted in the default visible columns being mutated while they were being streamed. This changes the approach to keep the the `defaultVisibleColumns` as a static list and then copy and add the non-static provisioned columns upon request for the visible columns.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5556 - Initial change introduced to fix Issue 50549 which resulted in this race condition

#### Changes
- Switch `defaultVisibleColumns` back to a `List`.
- Change `_provisionedFieldMap` to be backed by a `LinkedHashMap` to ensure iteration order.
- Update `getDefaultVisibleColumns()` implementation to coalesce `defaultVisibleColumns` and `_provisionedFieldMap` upon request.
