### PR TITLE
Add @SkipScriptIfSchemaExists annotation for SQL upgrade scripts

### DIFF
--- a/api/src/org/labkey/api/annotations/RemoveIn21_7.java
+++ b/api/src/org/labkey/api/annotations/RemoveIn21_7.java
@@ -1,9 +1,0 @@
-package org.labkey.api.annotations;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
-@Retention(RetentionPolicy.SOURCE)
-public @interface RemoveIn21_7
-{
-}

--- a/api/src/org/labkey/api/data/DbSchema.java
+++ b/api/src/org/labkey/api/data/DbSchema.java
@@ -182,10 +182,14 @@ public class DbSchema
 //        return type.createDbSchema(scope, metaDataName, module);
     }
 
+    public boolean existsInDatabase()
+    {
+        return SchemaNameCache.get().getSchemaNameMap(getScope()).containsKey(getName());
+    }
 
     /**
-     * Queries JDBC meta data to retrieve the list of tables in this schema, ignoring any temp tables.
-     * Returns a case-insensitive map of table names to canonical (meta data) names.
+     * Queries JDBC metadata to retrieve the list of tables in this schema, ignoring any temp tables.
+     * Returns a case-insensitive map of table names to canonical (metadata) names.
      *
      * Note: Do not call this unless you really know what you're doing! You should probably be calling DbSchema.getTables()
      * instead, to ensure you get the cached version.
@@ -218,7 +222,7 @@ public class DbSchema
     }
 
 
-    // Base class that pulls table meta data from the database, based on a supplied table pattern. This lets us share
+    // Base class that pulls table metadata from the database, based on a supplied table pattern. This lets us share
     // code between schema load (when we capture just the table names for all tables) and table load (when we capture
     // all properties of just a single table). We want consistent transaction, exception, and filtering behavior in
     // both cases.

--- a/api/src/org/labkey/api/data/SqlScriptRunner.java
+++ b/api/src/org/labkey/api/data/SqlScriptRunner.java
@@ -66,10 +66,9 @@ public class SqlScriptRunner
         }
     }
 
-    // Throws SQLException only if getRunScripts() fails -- script failures are handled more gracefully
     public void runScripts(Module module, List<SqlScript> scripts) throws SqlScriptException
     {
-        _log.info("Running " + scripts.toString());
+        _log.info("Running {}", scripts.toString());
 
         synchronized(SCRIPT_LOCK)
         {
@@ -90,7 +89,7 @@ public class SqlScriptRunner
             }
         }
 
-        // Clear caches to invalidate previously loaded meta data (upgrade scripts we just ran may have changed them)
+        // Clear caches to invalidate previously loaded metadata (upgrade scripts we just ran may have changed them)
         // and invalidate potentially stale objects that have been cached.
         CacheManager.clearAllKnownCaches();
 

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -2217,16 +2217,53 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
             }
             else
             {
-                // RETURNS TABLE AS RETURN ( ... )
-                if (!"RETURNS".equalsIgnoreCase(tokens[idx - 1]))
+                // Currently supporting two RETURNS TABLE options:
+                // - RETURNS TABLE AS RETURN ( ... )
+                // - RETURNS @returnTableName TABLE ( ... ) AS BEGIN ... END
+                if (!"RETURNS".equalsIgnoreCase(tokens[idx - 1]) && !"RETURNS".equalsIgnoreCase(tokens[idx - 2]))
                     return Collections.singleton("Stored procedure definition " + procedureName + " doesn't seem to have a RETURNS keyword in the right spot");
 
-                skipToSet = PARENS;
-                firstToken = Token.OPEN_PAREN;
-                idx = skipToToken(tokens, idx + 1, new CaseInsensitiveHashSet("("));
+                // Skip optional TABLE definition after TABLE AS RETURN
+                if (tokens[idx + 1].equals("("))
+                {
+                    int open = 1;
+                    idx = idx + 2;
+                    while (open > 0 && idx < tokens.length)
+                    {
+                        String token = tokens[idx];
+                        if (token.equals("("))
+                            open++;
+                        else if (token.equals(")"))
+                            open--;
+                        idx++;
+                    }
 
-                if (-1 == idx)
-                    return Collections.singleton("Stored procedure definition " + procedureName + " doesn't have an opening (");
+                    if (idx == tokens.length)
+                        return Collections.singleton("Stored procedure definition " + procedureName + " TABLE declaration doesn't have a closing )");
+
+                    idx = assertNextTokens(tokens, idx, "AS BEGIN");
+                }
+                else
+                {
+                    idx = assertNextTokens(tokens, idx, "TABLE AS RETURN (");
+                }
+            }
+
+            if ("BEGIN".equalsIgnoreCase(tokens[idx]))
+            {
+                // BEGIN ... END
+                firstToken = Token.BEGIN;
+                skipToSet = BEGIN_END;
+            }
+            else if ("(".equals(tokens[idx]))
+            {
+                // ( ... )
+                firstToken = Token.OPEN_PAREN;
+                skipToSet = PARENS;
+            }
+            else
+            {
+                return Collections.singleton("Stored procedure definition " + procedureName + " doesn't have an opening BEGIN or (");
             }
 
             Stack<Token> stack = new Stack<>();
@@ -2261,6 +2298,15 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         }
 
         return Collections.emptyList();
+    }
+
+    private int assertNextTokens(String[] tokens, int idx, String expected)
+    {
+        for (String token : expected.split(" "))
+            if (!token.equalsIgnoreCase(tokens[idx++]))
+                throw new IllegalArgumentException("Unexpected tokens before stored procedure definition");
+
+        return idx - 1; // Stay on the last token
     }
 
     private final static CaseInsensitiveHashSet CREATE = new CaseInsensitiveHashSet("CREATE", "ALTER");

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -332,19 +332,12 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         }
     }
 
-    private static final Pattern DROP_IF_EXISTS = Pattern.compile(
-        "drop(aggregate|assembly|database|default|function|index|procedure|role|rule|schema|securitypolicy|sequence|synonym|table|trigger|type|user|view)ifexists"
-    );
-
     @Override
     protected void checkSqlScript(String lowerNoComments, String lowerNoCommentsNoWhiteSpace, Collection<String> errors)
     {
         if (lowerNoComments.startsWith("use ") || lowerNoComments.contains("\nuse "))
             errors.add("USE statements are prohibited");
-        if (DROP_IF_EXISTS.matcher(lowerNoCommentsNoWhiteSpace).find())
-            errors.add("DROP xxx IF EXISTS statements are prohibited since they're not supported on SQL Server 2012. Instead, use EXEC core.fn_dropifexists.");
     }
-
 
     private enum ReselectType {INSERT, UPDATE, OTHER}
 
@@ -368,7 +361,6 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
 
         return _addReselect(sql, columnName, hasDbTriggers, proposedVariable);
     }
-
 
     public String _addReselect(SQLFragment sql, String columnName, boolean useOutputIntoTableVar, @Nullable String proposedVariable)
     {

--- a/core/resources/schemas/dbscripts/sqlserver/core-24.003-24.004.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-24.003-24.004.sql
@@ -1,1 +1,1 @@
-EXEC core.fn_dropifexists 'PrincipalRelations', 'core', 'TABLE', NULL
+DROP TABLE IF EXISTS core.PrincipalRelations;

--- a/core/resources/schemas/dbscripts/sqlserver/core-drop.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-drop.sql
@@ -19,5 +19,5 @@
 -- NOTE: Don't remove any of these drop statements, even if we stop re-creating the view in *-create.sql. Drop statements must
 -- remain in place so we can correctly upgrade from older versions, which we commit to for two years after each release.
 
-EXEC core.fn_dropifexists 'ActiveUsers', 'core', 'VIEW', NULL;
-EXEC core.fn_dropifexists 'Users', 'core', 'VIEW', NULL;
+DROP VIEW IF EXISTS core.ActiveUsers;
+DROP VIEW IF EXISTS core.Users;

--- a/core/resources/schemas/dbscripts/sqlserver/test-drop.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/test-drop.sql
@@ -19,17 +19,7 @@
 -- NOTE: Don't remove any of these drop statements, even if we stop re-creating the view in *-create.sql. Drop statements must
 -- remain in place so we can correctly upgrade from older versions, which we commit to for two years after each release.
 
-EXEC core.fn_dropifexists 'TestTable3', 'test', 'VIEW', NULL;
-EXEC core.fn_dropifexists 'Containers2', 'test', 'VIEW', NULL;
-EXEC core.fn_dropifexists 'ContainerAliases2', 'test', 'VIEW', NULL;
-EXEC core.fn_dropifexists 'Users2', 'test', 'VIEW', NULL;
-
--- dropifexists() doesn't like table names with special characters
-IF OBJECT_ID('test.a$b', 'V') IS NOT NULL
-    DROP VIEW test."a$b";
-IF OBJECT_ID('test.a_b', 'V') IS NOT NULL
-    DROP VIEW test."a_b";
-IF OBJECT_ID('test.a%b', 'V') IS NOT NULL
-    DROP VIEW test."a%b";
-IF OBJECT_ID('test.a\b', 'V') IS NOT NULL
-    DROP VIEW test."a\b";
+DROP VIEW IF EXISTS test."a$b";
+DROP VIEW IF EXISTS test."a_b";
+DROP VIEW IF EXISTS test."a%b";
+DROP VIEW IF EXISTS test."a\b";


### PR DESCRIPTION
#### Rationale
When moving schema ownership from one module to another, we've found it's best to construct the "new" scripts so they execute statements conditionally (e.g., if schema exists) and re-run those scripts in the new context (module name, script names). Conditionalizing a large and complex script can be difficult, though, especially on SQL Server (which effectively requires conditionalizing every GO-separated block).

- Add a simple script-level annotation, `@SkipScriptIfSchemaExists`, that, if present, prevents the script runner from executing any statements if the schema already exists in the database. This will be used to ease moving the `prot` schema scripts from - MS2 to the Protein module.
- Improve parsing for SQL Server stored procedure definitions that use syntax like: `RETURNS @someTableName TABLE AS BEGIN ... END`
- Allow `DROP * IF EXISTS` syntax on SQL Server