### PR TITLE
Issue 49830: DataLoader.inferColumnInfo fall back to the known column class based on the columnInfoMap instead of defaulting to String

### DIFF
--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -322,6 +322,7 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
             for (int f = 0; f < nCols; f++)
             {
                 List<Class> classesToTest = new ArrayList<>(Arrays.asList(CONVERT_CLASSES));
+                Class knownColumnClass = null; // Issue 49830: if we know the column class based on the columnInfoMap, fall back to using that class instead of defaulting to String
 
                 int classIndex = -1;
                 //NOTE: this means we have a header row
@@ -334,11 +335,13 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
                         if (_columnInfoMap.containsKey(name))
                         {
                             //preferentially use this class if it matches
-                            classesToTest.add(0, _columnInfoMap.get(name).getJavaClass());
+                            knownColumnClass = _columnInfoMap.get(name).getJavaClass();
+                            classesToTest.add(0, knownColumnClass);
                         }
                         else if (renamedColumns.containsKey(name) && _columnInfoMap.containsKey(renamedColumns.get(name)))
                         {
-                            classesToTest.add(0, _columnInfoMap.get(renamedColumns.get(name)).getJavaClass());
+                            knownColumnClass = _columnInfoMap.get(renamedColumns.get(name)).getJavaClass();
+                            classesToTest.add(0, knownColumnClass);
                         }
                     }
                 }
@@ -374,7 +377,7 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
                         }
                     }
                 }
-                colDescs[f].clazz = classIndex == -1 ? String.class : classesToTest.get(classIndex);
+                colDescs[f].clazz = classIndex == -1 ? (knownColumnClass != null ? knownColumnClass : String.class) : classesToTest.get(classIndex);
             }
         }
 

--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -322,7 +322,7 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
             for (int f = 0; f < nCols; f++)
             {
                 List<Class> classesToTest = new ArrayList<>(Arrays.asList(CONVERT_CLASSES));
-                Class knownColumnClass = null; // Issue 49830: if we know the column class based on the columnInfoMap, fall back to using that class instead of defaulting to String
+                Class knownColumnClass = null; // Issue 49830: if we know the column class based on the columnInfoMap, use it instead of trying to infer the class based on the data
 
                 int classIndex = -1;
                 //NOTE: this means we have a header row
@@ -332,52 +332,49 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
                     {
                         String name = lineFields[0][f];
                         name = name.replaceAll("[\\t\\n\\r]+"," ");
+                        //preferentially use this class if it matches
                         if (_columnInfoMap.containsKey(name))
-                        {
-                            //preferentially use this class if it matches
                             knownColumnClass = _columnInfoMap.get(name).getJavaClass();
-                            classesToTest.add(0, knownColumnClass);
-                        }
                         else if (renamedColumns.containsKey(name) && _columnInfoMap.containsKey(renamedColumns.get(name)))
-                        {
                             knownColumnClass = _columnInfoMap.get(renamedColumns.get(name)).getJavaClass();
-                            classesToTest.add(0, knownColumnClass);
-                        }
                     }
                 }
 
-                for (int line = inferStartLine; line < numLines; line++)
+                if (knownColumnClass == null)
                 {
-                    if (f >= lineFields[line].length)
-                        continue;
-                    String field = lineFields[line][f];
-                    if (missingValueIndicators.contains(field))
+                    for (int line = inferStartLine; line < numLines; line++)
                     {
-                        colDescs[f].setMvEnabled(_mvIndicatorContainer);
-                        continue;
-                    }
-
-                    if ("".equals(field))
-                        continue;
-
-                    for (int c = Math.max(classIndex, 0); c < classesToTest.size(); c++)
-                    {
-                        //noinspection EmptyCatchBlock
-                        try
+                        if (f >= lineFields[line].length)
+                            continue;
+                        String field = lineFields[line][f];
+                        if (missingValueIndicators.contains(field))
                         {
-                            Object o = ConvertUtils.convert(field, classesToTest.get(c));
-                            //We found a type that works. If it is more general than
-                            //what we had before, we must use it.
-                            if (o != null && c > classIndex)
-                                classIndex = c;
-                            break;
+                            colDescs[f].setMvEnabled(_mvIndicatorContainer);
+                            continue;
                         }
-                        catch (Exception x)
+
+                        if ("".equals(field))
+                            continue;
+
+                        for (int c = Math.max(classIndex, 0); c < classesToTest.size(); c++)
                         {
+                            //noinspection EmptyCatchBlock
+                            try
+                            {
+                                Object o = ConvertUtils.convert(field, classesToTest.get(c));
+                                //We found a type that works. If it is more general than
+                                //what we had before, we must use it.
+                                if (o != null && c > classIndex)
+                                    classIndex = c;
+                                break;
+                            }
+                            catch (Exception x)
+                            {
+                            }
                         }
                     }
                 }
-                colDescs[f].clazz = classIndex == -1 ? (knownColumnClass != null ? knownColumnClass : String.class) : classesToTest.get(classIndex);
+                colDescs[f].clazz = knownColumnClass != null ? knownColumnClass : classIndex == -1 ? String.class : classesToTest.get(classIndex);
             }
         }
 


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49830

For a sample type with a file field type, the DataLoader.inferColumnInfo() will treat the incoming data as a String.class instead of File.class if it doesn't find any valid paths. Since we are passing in the known column types to the DataLoader in the sample type case, we can use that type instead of String (which will force File fields for sample types through the file converter).

#### Changes
- DataLoader.inferColumnInfo to use _columnInfoMap known column class if available
