### PR TITLE
Deprecate support for SQL Server 2014

### DIFF
--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -94,8 +94,8 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
 
         if (logWarnings)
         {
-            // Extract the SQL Server year from the enum name and include it in warning messages
-            String displayVersion = ssv.name().substring(11) + " (" + databaseProductVersion + ")";
+            // Display product year and numeric version in warning messages
+            String displayVersion = ssv.getYear() + " (" + databaseProductVersion + ")";
 
             // It's an old version being used as an external data source... we allow this but still warn to encourage upgrades
             if (!ssv.isAllowedAsPrimaryDataSource())

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -94,21 +94,26 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
 
         if (logWarnings)
         {
-            // It's an old version being used as an external schema... we allow this but still warn to encourage upgrades
+            // Extract the SQL Server year from the enum name and include it in warning messages
+            String displayVersion = ssv.name().substring(11) + " (" + databaseProductVersion + ")";
+
+            // It's an old version being used as an external data source... we allow this but still warn to encourage upgrades
             if (!ssv.isAllowedAsPrimaryDataSource())
             {
-                LOG.warn(getStandardWarningMessage("no longer supports", databaseProductVersion));
+                LOG.warn(getStandardWarningMessage("no longer supports", displayVersion));
             }
-
-            if (!ssv.isTested())
+            else
             {
-                LOG.warn(getStandardWarningMessage("has not been tested against", databaseProductVersion));
-            }
-            else if (ssv.isDeprecated())
-            {
-                String deprecationWarning = getStandardWarningMessage("no longer supports", databaseProductVersion);
-                LOG.warn(deprecationWarning);
-                dialect.setAdminWarning(HtmlString.of(deprecationWarning));
+                if (!ssv.isTested())
+                {
+                    LOG.warn(getStandardWarningMessage("has not been tested against", displayVersion));
+                }
+                else if (ssv.isDeprecated())
+                {
+                    String deprecationWarning = getStandardWarningMessage("no longer supports", displayVersion);
+                    LOG.warn(deprecationWarning);
+                    dialect.setAdminWarning(HtmlString.of(deprecationWarning));
+                }
             }
         }
 
@@ -117,7 +122,7 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
 
     public static String getStandardWarningMessage(String warning, String databaseProductVersion)
     {
-        return "LabKey Server " + warning + " " + PRODUCT_NAME + " version " + databaseProductVersion + ". " + RECOMMENDED;
+        return "LabKey Server " + warning + " " + PRODUCT_NAME + " " + databaseProductVersion + ". " + RECOMMENDED;
     }
 
     @Override
@@ -173,6 +178,18 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
 
             // >= 16.0 should result in MicrosoftSqlServer2022Dialect
             good("Microsoft SQL Server", 16.0, 18.0, "", null, driverName, MicrosoftSqlServer2022Dialect.class);
+
+            MicrosoftSqlServerDialectFactory factory = new MicrosoftSqlServerDialectFactory();
+
+            for (int i = 120; i < 170; i += 10)
+            {
+                factory.getDialect(i, "primary DB test", true, true);
+            }
+
+            for (int i = 100; i < 170; i += 10)
+            {
+                factory.getDialect(i, "external data source test", true, false);
+            }
         }
     }
 

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -178,18 +178,6 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
 
             // >= 16.0 should result in MicrosoftSqlServer2022Dialect
             good("Microsoft SQL Server", 16.0, 18.0, "", null, driverName, MicrosoftSqlServer2022Dialect.class);
-
-            MicrosoftSqlServerDialectFactory factory = new MicrosoftSqlServerDialectFactory();
-
-            for (int i = 120; i < 170; i += 10)
-            {
-                factory.getDialect(i, "primary DB test", true, true);
-            }
-
-            for (int i = 100; i < 170; i += 10)
-            {
-                factory.getDialect(i, "external data source test", true, false);
-            }
         }
     }
 

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerVersion.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerVersion.java
@@ -22,9 +22,9 @@ public enum MicrosoftSqlServerVersion
 
     // We support 2014 and higher as the primary data source, but allow 2012/2008/2008R2 as an external data source
     SQL_SERVER_UNSUPPORTED(Integer.MIN_VALUE, true, false, false, null),
-    SQL_SERVER_2008(100, false, true, false, MicrosoftSqlServer2008R2Dialect::new),
-    SQL_SERVER_2012(110, false, true, false, MicrosoftSqlServer2012Dialect::new),
-    SQL_SERVER_2014(120, false, true, true, MicrosoftSqlServer2014Dialect::new),
+    SQL_SERVER_2008(100, true, true, false, MicrosoftSqlServer2008R2Dialect::new),
+    SQL_SERVER_2012(110, true, true, false, MicrosoftSqlServer2012Dialect::new),
+    SQL_SERVER_2014(120, true, true, true, MicrosoftSqlServer2014Dialect::new),
     SQL_SERVER_2016(130, false, true, true, MicrosoftSqlServer2016Dialect::new),
     SQL_SERVER_2017(140, false, true, true, MicrosoftSqlServer2017Dialect::new),
     SQL_SERVER_2019(150, false, true, true, MicrosoftSqlServer2019Dialect::new),

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerVersion.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerVersion.java
@@ -20,30 +20,37 @@ public enum MicrosoftSqlServerVersion
         - http://sqlserverbuilds.blogspot.se/
      */
 
-    // We support 2014 and higher as the primary data source, but allow 2012/2008/2008R2 as an external data source
-    SQL_SERVER_UNSUPPORTED(Integer.MIN_VALUE, true, false, false, null),
-    SQL_SERVER_2008(100, true, true, false, MicrosoftSqlServer2008R2Dialect::new),
-    SQL_SERVER_2012(110, true, true, false, MicrosoftSqlServer2012Dialect::new),
-    SQL_SERVER_2014(120, true, true, true, MicrosoftSqlServer2014Dialect::new),
-    SQL_SERVER_2016(130, false, true, true, MicrosoftSqlServer2016Dialect::new),
-    SQL_SERVER_2017(140, false, true, true, MicrosoftSqlServer2017Dialect::new),
-    SQL_SERVER_2019(150, false, true, true, MicrosoftSqlServer2019Dialect::new),
-    SQL_SERVER_2022(160, false, true, true, MicrosoftSqlServer2022Dialect::new),
-    SQL_SERVER_FUTURE(170, false, false, true, MicrosoftSqlServer2022Dialect::new);
+    // We support 2014 and higher as the primary data source, but allow 2008+ as an external data source
+    SQL_SERVER_UNSUPPORTED(Integer.MIN_VALUE, "Unknown", true, false, false, null),
+    SQL_SERVER_2008(100, "2008", true, true, false, MicrosoftSqlServer2008R2Dialect::new),
+    SQL_SERVER_2012(110, "2012", true, true, false, MicrosoftSqlServer2012Dialect::new),
+    SQL_SERVER_2014(120, "2014", true, true, true, MicrosoftSqlServer2014Dialect::new),
+    SQL_SERVER_2016(130, "2016", false, true, true, MicrosoftSqlServer2016Dialect::new),
+    SQL_SERVER_2017(140, "2017", false, true, true, MicrosoftSqlServer2017Dialect::new),
+    SQL_SERVER_2019(150, "2019", false, true, true, MicrosoftSqlServer2019Dialect::new),
+    SQL_SERVER_2022(160, "2022", false, true, true, MicrosoftSqlServer2022Dialect::new),
+    SQL_SERVER_FUTURE(170, "Unknown", false, false, true, MicrosoftSqlServer2022Dialect::new);
 
     private final int _version;
+    private final String _year;
     private final boolean _deprecated;
     private final boolean _tested;
     private final boolean _allowedAsPrimaryDataSource;
     private final Supplier<? extends MicrosoftSqlServer2008R2Dialect> _dialectFactory;
 
-    MicrosoftSqlServerVersion(int version, boolean deprecated, boolean tested, boolean allowedAsPrimaryDataSource, Supplier<? extends MicrosoftSqlServer2008R2Dialect> dialectFactory)
+    MicrosoftSqlServerVersion(int version, String year, boolean deprecated, boolean tested, boolean allowedAsPrimaryDataSource, Supplier<? extends MicrosoftSqlServer2008R2Dialect> dialectFactory)
     {
         _version = version;
+        _year = year;
         _deprecated = deprecated;
         _tested = tested;
         _allowedAsPrimaryDataSource = allowedAsPrimaryDataSource;
         _dialectFactory = dialectFactory;
+    }
+
+    public String getYear()
+    {
+        return _year;
     }
 
     // Should LabKey warn administrators that support for this SQL Server version will be removed soon?


### PR DESCRIPTION
#### Rationale
SQL Server 2014 will reach "end of support (EOS)" next month, so deprecate our support. Also, improve warning messages.