### PR TITLE
Issue 50624: ETL pipeline job failure not moving job to ERROR

### DIFF
--- a/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
@@ -53,6 +53,7 @@ import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewBackgroundInfo;
+import org.springframework.dao.DataAccessResourceFailureException;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -244,7 +245,7 @@ public class PipelineStatusManager
             }
             return true;
         }
-        catch (ConfigurationException e)
+        catch (ConfigurationException | DataAccessResourceFailureException e)
         {
             // Issue 49822: Pipeline does not show a job as failed if DB fails
             JobStatusRetryJob.queue(job.getJobGUID(), () -> setStatusFile(job, user, status, info, allowInsert), e);


### PR DESCRIPTION
#### Rationale
49822 addressed a problem where pipeline jobs never moved to ERROR when there was a transient problem accessing the DB. Previously, we'd try to set the state but that would fail. We'd log the failure to set the state, but wouldn't retry later when the DB connection was restored.

The original failure condition was a failure to get a connection from the pool, which throws a ConfigurationException.

This second variant has slightly different timing. The code has grabbed a DB connection, but the attempt to update the row fails because the DB isn't responding.

#### Changes
- Handle both exception variants in the same way, queuing the job status setting for a retry