### PR TITLE
Migrate away from deprecated methods

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -16,6 +16,7 @@
 
 package org.labkey.announcements;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
@@ -133,7 +134,6 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -756,19 +756,16 @@ public class AnnouncementsController extends SpringActionController
         public SelectBuilder assignedToSelect;
     }
 
-
     private boolean hasEditorPerm(int groupId)
     {
         Role editorRole = RoleManager.getRole(EditorRole.class);
         Group group = SecurityManager.getGroup(groupId);
-        return null != group && SecurityManager.hasAllPermissions(null, getContainer().getPolicy(), group, editorRole.getPermissions(), Set.of());
+        return null != group && SecurityManager.hasAllPermissions(null, getContainer(), group, editorRole.getPermissions(), Set.of());
     }
-
 
     @RequiresAnyOf({InsertMessagePermission.class, InsertPermission.class})
     public abstract class BaseInsertAction extends FormViewAction<AnnouncementForm>
     {
-        private URLHelper _returnURL;
         protected HttpView _attachmentErrorView;
 
         protected abstract ModelAndView getInsertUpdateView(AnnouncementForm announcementForm, boolean reshow, BindException errors);
@@ -847,13 +844,12 @@ public class AnnouncementsController extends SpringActionController
             }
 
             _attachmentErrorView = AttachmentService.get().getErrorView(files, errors, returnURL);
-            _returnURL = returnURL;
 
             boolean success = (null == _attachmentErrorView);
 
             // Can't use getSuccessURL since this is a URLHelper, not an ActionURL
             if (success)
-                throw new RedirectException(_returnURL);
+                throw new RedirectException(returnURL);
 
             return false;
         }

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -493,12 +493,6 @@ public class Container implements Serializable, Comparable<Container>, Securable
         return SecurityManager.hasAllPermissions(logMsg, this, user, Set.of(perm), Set.of());
     }
 
-    @Override
-    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
-    {
-        return SecurityManager.hasAllPermissions(null, this, user, Set.of(perm), Set.of());
-    }
-
     public boolean hasPermission(String logMsg, @NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm, @Nullable Set<Role> contextualRoles)
     {
         return SecurityManager.hasAllPermissions(logMsg, this, user, Set.of(perm), contextualRoles);

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -36,13 +36,9 @@ import org.labkey.api.module.FolderType;
 import org.labkey.api.module.FolderTypeManager;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.pipeline.PipeRoot;
-import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.products.ProductRegistry;
 import org.labkey.api.query.QueryService;
-import org.labkey.api.reports.Report;
-import org.labkey.api.reports.ReportService;
 import org.labkey.api.security.HasPermission;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityManager;
@@ -485,7 +481,6 @@ public class Container implements Serializable, Comparable<Container>, Securable
         return project;
     }
 
-
     // Note: don't use the security policy directly unless you really have to... call hasPermission() or hasOneOf()
     // instead, to ensure proper behavior during impersonation.
     public @NotNull SecurityPolicy getPolicy()
@@ -493,53 +488,46 @@ public class Container implements Serializable, Comparable<Container>, Securable
         return SecurityPolicyManager.getPolicy(this);
     }
 
-
     public boolean hasPermission(String logMsg, @NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return SecurityManager.hasAllPermissions(logMsg, getPolicy(), user, Set.of(perm), Set.of());
+        return SecurityManager.hasAllPermissions(logMsg, this, user, Set.of(perm), Set.of());
     }
-
 
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return SecurityManager.hasAllPermissions(null, getPolicy(), user, Set.of(perm), Set.of());
+        return SecurityManager.hasAllPermissions(null, this, user, Set.of(perm), Set.of());
     }
-
 
     public boolean hasPermission(String logMsg, @NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm, @Nullable Set<Role> contextualRoles)
     {
-        return SecurityManager.hasAllPermissions(logMsg, getPolicy(), user, Set.of(perm), contextualRoles);
+        return SecurityManager.hasAllPermissions(logMsg, this, user, Set.of(perm), contextualRoles);
     }
-
 
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm, @Nullable Set<Role> contextualRoles)
     {
-        return SecurityManager.hasAllPermissions(null, getPolicy(), user, Set.of(perm), contextualRoles);
+        return SecurityManager.hasAllPermissions(null, this, user, Set.of(perm), contextualRoles);
     }
-
 
     public boolean hasPermissions(@NotNull UserPrincipal user, @NotNull Set<Class<? extends Permission>> permissions)
     {
-        return SecurityManager.hasAllPermissions(null, getPolicy(), user, permissions, Set.of());
+        return SecurityManager.hasAllPermissions(null, this, user, permissions, Set.of());
     }
 
     public boolean hasPermissions(@NotNull UserPrincipal user, @NotNull Set<Class<? extends Permission>> permissions, @Nullable Set<Role> contextualRoles)
     {
-        return SecurityManager.hasAllPermissions(null, getPolicy(), user, permissions, contextualRoles);
+        return SecurityManager.hasAllPermissions(null, this, user, permissions, contextualRoles);
     }
-
 
     public boolean hasOneOf(@NotNull UserPrincipal user, @NotNull Set<Class<? extends Permission>> perms)
     {
-        return SecurityManager.hasAnyPermissions(null, getPolicy(), user, perms, Set.of());
+        return SecurityManager.hasAnyPermissions(null, this, user, perms, Set.of());
     }
-
 
     @SafeVarargs
     public final boolean hasOneOf(@NotNull User user, @NotNull Class<? extends Permission>... perms)
     {
-        return SecurityManager.hasAnyPermissions(null, getPolicy(), user, new HashSet<>(Arrays.asList(perms)), Set.of());
+        return SecurityManager.hasAnyPermissions(null, this, user, new HashSet<>(Arrays.asList(perms)), Set.of());
     }
 
     public boolean isForbiddenProject(User user)

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1385,7 +1385,7 @@ public class ContainerManager
                 if (!f.isInFolderNav())
                     continue;
 
-                boolean hasPolicyRead = f.getPolicy().hasPermission(user, ReadPermission.class);
+                boolean hasPolicyRead = f.hasPermission(user, ReadPermission.class);
 
                 boolean skip = (
                         !hasPolicyRead ||
@@ -1446,7 +1446,7 @@ public class ContainerManager
                             for (Container p : ancestors)
                             {
                                 if (!permission.containsKey(p.getId()))
-                                    permission.put(p.getId(), p.getPolicy().hasPermission(user, ReadPermission.class));
+                                    permission.put(p.getId(), p.hasPermission(user, ReadPermission.class));
                                 boolean hasRead = permission.get(p.getId());
 
                                 if (p.equals(localRoot))
@@ -1465,7 +1465,7 @@ public class ContainerManager
                         {
                             hasAncestryRead = containersToRoot(f).stream().allMatch(p -> {
                                 if (!permission.containsKey(p.getId()))
-                                    permission.put(p.getId(), p.getPolicy().hasPermission(user, ReadPermission.class));
+                                    permission.put(p.getId(), p.hasPermission(user, ReadPermission.class));
                                 return permission.get(p.getId());
                             });
                         }
@@ -1517,7 +1517,7 @@ public class ContainerManager
                             else
                             {
                                 if (!permission.containsKey(missing.getId()))
-                                    permission.put(missing.getId(), missing.getPolicy().hasPermission(user, ReadPermission.class));
+                                    permission.put(missing.getId(), missing.hasPermission(user, ReadPermission.class));
 
                                 if (!permission.get(missing.getId()))
                                 {

--- a/api/src/org/labkey/api/files/view/FilesWebPart.java
+++ b/api/src/org/labkey/api/files/view/FilesWebPart.java
@@ -221,9 +221,7 @@ public class FilesWebPart extends JspView<FilesWebPart.FilesForm>
 
     protected void init()
     {
-        // Determine the security policy for this webpart
-        SecurityPolicy policy = SecurityPolicyManager.getPolicy(getSecurableResource());
-        getConfiguredForm(policy);
+        getConfiguredForm(getSecurableResource());
     }
 
 
@@ -234,8 +232,7 @@ public class FilesWebPart extends JspView<FilesWebPart.FilesForm>
             getModelBean().setAutoResize(b);
     }
 
-
-    protected List<FilesForm.actions> getConfiguredActions(SecurityPolicy policy)
+    protected List<FilesForm.actions> getConfiguredActions(SecurableResource resource)
     {
         List<FilesForm.actions> actions = new ArrayList<>();
         ViewContext context = getViewContext();
@@ -247,21 +244,21 @@ public class FilesWebPart extends JspView<FilesWebPart.FilesForm>
         actions.add(FilesForm.actions.refresh);
 
         // Actions not based on the current selection
-        if (policy.hasPermission(user, InsertPermission.class))
+        if (resource.hasPermission(user, InsertPermission.class))
             actions.add(FilesForm.actions.createDirectory);
 
         // Actions based on the current selection
         actions.add(FilesForm.actions.download);
-        if (policy.hasPermission(user, DeletePermission.class))
+        if (resource.hasPermission(user, DeletePermission.class))
             actions.add(FilesForm.actions.deletePath);
 
-        if (policy.hasPermission(user, UpdatePermission.class))
+        if (resource.hasPermission(user, UpdatePermission.class))
         {
             actions.add(FilesForm.actions.renamePath);
             actions.add(FilesForm.actions.movePath);
         }
 
-        if (policy.hasPermission(user, InsertPermission.class))
+        if (resource.hasPermission(user, InsertPermission.class))
         {
             actions.add(FilesForm.actions.editFileProps);
             if (!PremiumService.get().isFileUploadDisabled())
@@ -292,7 +289,7 @@ public class FilesWebPart extends JspView<FilesWebPart.FilesForm>
         return actions;
     }
 
-    protected FilesForm getConfiguredForm(SecurityPolicy policy)
+    protected FilesForm getConfiguredForm(SecurableResource resource)
     {
         FilesForm form = getModelBean();
         ViewContext context = getViewContext();
@@ -327,7 +324,7 @@ public class FilesWebPart extends JspView<FilesWebPart.FilesForm>
         form.setEnabled(!svc.isFileRootDisabled(rootContextContainer));
         form.setContentId("fileContent" + System.identityHashCode(this));
 
-        if (policy.hasPermission(user, InsertPermission.class))
+        if (resource.hasPermission(user, InsertPermission.class))
         {
             FilesAdminOptions options = svc.getAdminOptions(container);
             boolean expandUpload = BooleanUtils.toBooleanDefaultIfNull(options.getExpandFileUpload(), false);
@@ -350,7 +347,7 @@ public class FilesWebPart extends JspView<FilesWebPart.FilesForm>
             form.setRunEditors(editorMap);
         }
 
-        List<FilesForm.actions> actions = getConfiguredActions(policy);
+        List<FilesForm.actions> actions = getConfiguredActions(resource);
         form.setButtonConfig(actions.toArray(new FilesForm.actions[actions.size()]));
 
         return form;

--- a/api/src/org/labkey/api/reports/report/AbstractReport.java
+++ b/api/src/org/labkey/api/reports/report/AbstractReport.java
@@ -657,7 +657,7 @@ public abstract class AbstractReport implements Report, Cloneable // TODO: Remov
             if (!policy.isEmpty())
             {
                 // Issue 32103: even if custom SecurityPolicy present, the original creator/owner always has permissions
-                return policy.hasPermission(user, perm) || isOwner(user);
+                return descriptor.hasPermission(user, perm) || isOwner(user);
             }
             else
             {

--- a/api/src/org/labkey/api/security/SecurableResource.java
+++ b/api/src/org/labkey/api/security/SecurableResource.java
@@ -62,8 +62,7 @@ public interface SecurableResource extends HasPermission
     @Override
     default boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        SecurityPolicy policy = SecurityPolicyManager.getPolicy(this);
         return SecurityManager.hasAllPermissions(this.getClass().getName() + ":" + getResourceName(),
-                policy, user, Set.of(perm), Set.of());
+                this, user, Set.of(perm), Set.of());
     }
 }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3833,6 +3833,8 @@ public class SecurityManager
             Pair<ValidEmail, User> userAC  = new Pair<>(new ValidEmail("AC@localhost.test"), null);
             Pair<ValidEmail, User> userABC = new Pair<>(new ValidEmail("ABC@localhost.test"), null);
 
+            List<Role> createdRoles = new LinkedList<>();
+
             try
             {
                 // Create real users
@@ -3845,10 +3847,10 @@ public class SecurityManager
 
                 testFolder = ContainerManager.createContainer(parentFolder, "getusers_subfolder", testUser);
                 MutableSecurityPolicy policy = new MutableSecurityPolicy(testFolder);
-                addRoleAssignment(policy, userAB.getValue(), new RoleAB(), testUser);
-                addRoleAssignment(policy, userAC.getValue(), new RoleAC(), testUser);
-                addRoleAssignment(policy, userABC.getValue(), new RoleAB(), testUser);
-                addRoleAssignment(policy, userABC.getValue(), new RoleAC(), testUser);
+                createdRoles.add(addRoleAssignment(policy, userAB.getValue(), new RoleAB(), testUser));
+                createdRoles.add(addRoleAssignment(policy, userAC.getValue(), new RoleAC(), testUser));
+                createdRoles.add(addRoleAssignment(policy, userABC.getValue(), new RoleAB(), testUser));
+                createdRoles.add(addRoleAssignment(policy, userABC.getValue(), new RoleAC(), testUser));
 
                 var usersWithAll = new HashSet<>(getUsersWithPermissions(testFolder, Set.of(PermissionA.class)));
                 assertEquals(3, usersWithAll.size());
@@ -3876,6 +3878,8 @@ public class SecurityManager
             }
             finally
             {
+                createdRoles.forEach(RoleManager::unregisterRole);
+
                 for (var p : Arrays.asList(userAB, userAC, userABC))
                     if (null != p.getValue())
                         UserManager.deleteUser(p.getValue().getUserId());
@@ -3884,12 +3888,14 @@ public class SecurityManager
             }
         }
 
-        private void addRoleAssignment(MutableSecurityPolicy policy, UserPrincipal principal, Role role, User testUser)
+        private Role addRoleAssignment(MutableSecurityPolicy policy, UserPrincipal principal, Role role, User testUser)
         {
             if (!RoleManager.isPermissionRegistered((Class<? extends Permission>) role.getClass()))
                 RoleManager.registerRole(role, false);
             policy.addRoleAssignment(principal, role);
             SecurityPolicyManager.savePolicy(policy, testUser);
+
+            return role;
         }
     }
 
@@ -3909,25 +3915,25 @@ public class SecurityManager
         }
     }
 
-    static class PermissionA extends AbstractPermission implements Permission.TestPermission
+    public static class PermissionA extends AbstractPermission implements Permission.TestPermission
     {
-        PermissionA()
+        public PermissionA()
         {
             super("PermissionA","PermissionA");
         }
     }
 
-    static class PermissionB extends AbstractPermission implements Permission.TestPermission
+    public static class PermissionB extends AbstractPermission implements Permission.TestPermission
     {
-        PermissionB()
+        public PermissionB()
         {
             super("PermissionB","PermissionB");
         }
     }
 
-    static class PermissionC extends AbstractPermission implements Permission.TestPermission
+    public static class PermissionC extends AbstractPermission implements Permission.TestPermission
     {
-        PermissionC()
+        public PermissionC()
         {
             super("PermissionC","PermissionC");
         }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3208,6 +3208,7 @@ public class SecurityManager
         return validRecipients;
     }
 
+    @Deprecated // TODO: Migrate the three remaining callers
     public static boolean hasAllPermissions(@Nullable String logMsg, SecurityPolicy policy, UserPrincipal principal, Set<Class<? extends Permission>> perms, Set<Role> contextualRoles)
     {
         return hasPermissions(logMsg, policy, principal, perms, contextualRoles, HasPermissionOption.ALL);

--- a/api/src/org/labkey/api/security/SecurityPolicy.java
+++ b/api/src/org/labkey/api/security/SecurityPolicy.java
@@ -198,17 +198,6 @@ public class SecurityPolicy
         return _assignments.isEmpty();
     }
 
-
-    /**
-     * Callers outside this package should use SecurityManager.hasAllPermissions() or Container.hasPermission[s]() or SecurableResource.hasPermission().
-     * If you are modifying a SecurityPolicy you should use getOwnPermissions() or getAssignments()
-     */
-    @Deprecated
-    public boolean hasPermission(@NotNull UserPrincipal principal, @NotNull Class<? extends Permission> permission)
-    {
-        return SecurityManager.hasAllPermissions(null, this, principal, Set.of(permission), Set.of());
-    }
-
     // Throttle that limits warning logging to once per hour per permission class
     private static final Throttle<Class<? extends Permission>> NOT_REGISTERED_PERMISSION_THROTTLE = new Throttle<>("unregistered permissions", 100, CacheManager.HOUR, permission -> LOG.warn(permission + " is not registered!"));
 
@@ -346,7 +335,6 @@ public class SecurityPolicy
         return json;
     }
 
-
     /**
      * Create a map of the roleAssignments with the key as the role name and the value as a map
      * between the principalType and the list of UserPrincipals of that type assigned the particular role
@@ -377,7 +365,6 @@ public class SecurityPolicy
         }
         return assignmentsMap;
     }
-
 
     public boolean hasNonInheritedPermission(@NotNull UserPrincipal principal, Class<? extends Permission> perm)
     {

--- a/api/src/org/labkey/api/security/TestSecurityPolicy.java
+++ b/api/src/org/labkey/api/security/TestSecurityPolicy.java
@@ -1,0 +1,19 @@
+package org.labkey.api.security;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.security.permissions.Permission;
+
+// Normal permission checking operates on secure resources, but some unit tests need to update and interrogate
+// security policies directly. This class allows those tests to permission check directly on the policy.
+public class TestSecurityPolicy extends MutableSecurityPolicy
+{
+    public TestSecurityPolicy(@NotNull SecurableResource resource)
+    {
+        super(resource);
+    }
+
+    public boolean hasPermission(@NotNull UserPrincipal principal, @NotNull Class<? extends Permission> permission)
+    {
+        return getOwnPermissions(principal).contains(permission);
+    }
+}

--- a/api/src/org/labkey/api/security/permissions/Permission.java
+++ b/api/src/org/labkey/api/security/permissions/Permission.java
@@ -22,8 +22,6 @@ import org.labkey.api.security.roles.Role;
 /**
  * Represents a particular permission defined by a module. The most granular level of access that a user might be allowed.
  * Permissions are assigned to {@link org.labkey.api.security.UserPrincipal} via the assignment of {@link org.labkey.api.security.roles.Role}.
- * User: Dave
- * Date: Apr 9, 2009
  */
 public interface Permission extends Role
 {
@@ -33,7 +31,7 @@ public interface Permission extends Role
      */
     @Override
     @NotNull
-    public String getName();
+    String getName();
 
     /**
      * Returns a longer description for the permission suitable for a user interface.
@@ -41,7 +39,7 @@ public interface Permission extends Role
      */
     @Override
     @NotNull
-    public String getDescription();
+    String getDescription();
 
     /**
      * Returns a reference to the module in which this permission is defined.
@@ -49,7 +47,7 @@ public interface Permission extends Role
      */
     @Override
     @NotNull
-    public Module getSourceModule();
+    Module getSourceModule();
 
     interface TestPermission extends Permission {}
 }

--- a/api/src/org/labkey/api/view/Portal.java
+++ b/api/src/org/labkey/api/view/Portal.java
@@ -60,7 +60,6 @@ import org.labkey.api.module.SimpleWebPartFactory;
 import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.SecurityManager;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.Permission;
@@ -667,8 +666,7 @@ public class Portal implements ModuleChangeListener
 
                 if (permissionContainer != null && permission != null)
                 {
-                    SecurityPolicy policy = permissionContainer.getPolicy();
-                    hasPermission = SecurityManager.hasAllPermissions(part.getName(), policy, context.getUser(), Set.of(permission.getClass()), Set.of());
+                    hasPermission = SecurityManager.hasAllPermissions(part.getName(), permissionContainer, context.getUser(), Set.of(permission.getClass()), Set.of());
                 }
 
                 // If the permissionContainer is null, or the permission is missing, then we only show the webpart if

--- a/api/src/org/labkey/api/webdav/FileSystemResource.java
+++ b/api/src/org/labkey/api/webdav/FileSystemResource.java
@@ -128,8 +128,8 @@ public class FileSystemResource extends AbstractWebdavResource
 
         _files = new ArrayList<>(folder._files.size());
         _files.addAll(folder._files.stream()
-                .map(file -> new FileInfo(FileUtil.appendName(file.getFile(), name)))
-                .collect(Collectors.toList()));
+            .map(file -> new FileInfo(FileUtil.appendName(file.getFile(), name)))
+            .toList());
     }
 
     public FileSystemResource(Path path, File file, SecurityPolicy policy)

--- a/api/src/org/labkey/api/webdav/FileSystemResource.java
+++ b/api/src/org/labkey/api/webdav/FileSystemResource.java
@@ -78,7 +78,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  *  Base class for file-system based resources

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -620,15 +620,13 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
     {
         Container c = getContainer();
         User u = getUser();
-        SecurityPolicy policy = c.getPolicy();
-        return policy.hasPermission(u, DesignAssayPermission.class);
+        return c.hasPermission(u, DesignAssayPermission.class);
     }
 
     private boolean canUpdateTransformationScript()
     {
         Container c = getContainer();
         User u = getUser();
-        SecurityPolicy policy = c.getPolicy();
-        return policy.hasPermission(u, PlatformDeveloperPermission.class);
+        return c.hasPermission(u, PlatformDeveloperPermission.class);
     }
 }

--- a/core/src/org/labkey/core/admin/MenuViewFactory.java
+++ b/core/src/org/labkey/core/admin/MenuViewFactory.java
@@ -204,7 +204,7 @@ public class MenuViewFactory
             containersTemp = new ArrayList<>();
         }
 
-        if (!context.getContainer().getPolicy().hasPermission(user, AdminPermission.class))
+        if (!context.getContainer().hasPermission(user, AdminPermission.class))
         {
             // If user doesn't have Admin permission, don't show "_" containers
             List<Container> adjustedContainers = new ArrayList<>();

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -115,11 +115,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-/**
- * User: adam
- * Date: Jan 3, 2007
- * Time: 7:13:28 PM
- */
 public class AttachmentServiceImpl implements AttachmentService, ContainerManager.ContainerListener
 {
     private static final String UPLOAD_LOG = ".upload.log";
@@ -134,7 +129,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
     @Override
     public void download(HttpServletResponse response, AttachmentParent parent, String filename, @Nullable String alias, boolean inlineIfPossible) throws ServletException, IOException
     {
-        if (null == filename || 0 == filename.length())
+        if (null == filename || filename.isEmpty())
         {
             throw new NotFoundException();
         }
@@ -1718,7 +1713,8 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
         SecurityPolicy securityPolicy = attachmentParent.getSecurityPolicy();
         if (null != securityPolicy)
         {
-            if (null == user || !securityPolicy.hasPermission(user, ReadPermission.class))
+            // TODO: Temporary check... push SecurableResource into AttachmentParent (in place of SecurityPolicy) and call SR-based method
+            if (null == user || !SecurityManager.hasAllPermissions(null, securityPolicy, user, Set.of(ReadPermission.class), Set.of()))
                 throw new UnauthorizedException("User does not have permission to access this secure resource.");
         }
     }

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -798,7 +798,7 @@ public class SecurityApiActions
                 throw new IllegalArgumentException("No resource with the id '" + resourceId + "' was found in this container!");
 
             //ensure that user has admin permission on resource
-            if (!SecurityPolicyManager.getPolicy(resource).hasPermission(user, AdminPermission.class))
+            if (!resource.hasPermission(user, AdminPermission.class))
                 throw new IllegalArgumentException("You do not have permission to delete the security policy for this resource!");
 
             SecurityPolicyManager.deletePolicy(resource);

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -150,7 +150,7 @@ public class SecurityApiActions
             containerPerms.put("isInheritingPerms", container.isInheritedAcl());
             containerPerms.put("groups", getGroupPerms(container, policy, groups));
 
-            if(recurse && container.hasChildren())
+            if (recurse && container.hasChildren())
             {
                 List<Map<String, Object>> childPerms = new ArrayList<>();
                 for (Container child : container.getChildren())
@@ -192,7 +192,7 @@ public class SecurityApiActions
                 groupPerms.put("permissions", perms);
 
                 SecurityManager.PermissionSet role = SecurityManager.PermissionSet.findPermissionSet(perms);
-                if(null != role)
+                if (null != role)
                 {
                     groupPerms.put("role", role.toString());
                     groupPerms.put("roleLabel", role.getLabel());
@@ -332,7 +332,7 @@ public class SecurityApiActions
 
             //see if those match a given role name
             SecurityManager.PermissionSet role = SecurityManager.PermissionSet.findPermissionSet(perms);
-            if(null != role)
+            if (null != role)
             {
                 permsInfo.put("role", role.toString());
                 permsInfo.put("roleLabel", role.getLabel());
@@ -345,7 +345,7 @@ public class SecurityApiActions
 
             //effective roles
             List<String> effectiveRoles = new ArrayList<>();
-            for(Role effectiveRole : SecurityManager.getEffectiveRoles(policy,user))
+            for (Role effectiveRole : SecurityManager.getEffectiveRoles(policy,user))
             {
                 effectiveRoles.add(effectiveRole.getUniqueName());
             }
@@ -356,7 +356,7 @@ public class SecurityApiActions
             List<Group> groups = SecurityManager.getGroups(container, user);
             List<Map<String, Object>> groupsInfo = new ArrayList<>();
 
-            for(Group group : groups)
+            for (Group group : groups)
             {
                 Map<String, Object> groupInfo = new HashMap<>();
                 groupInfo.put("id", group.getUserId());
@@ -374,7 +374,7 @@ public class SecurityApiActions
 
                 //effective roles
                 List<String> groupEffectiveRoles = new ArrayList<>();
-                for(Role effectiveRole : SecurityManager.getEffectiveRoles(policy, group))
+                for (Role effectiveRole : SecurityManager.getEffectiveRoles(policy, group))
                 {
                     groupEffectiveRoles.add(effectiveRole.getUniqueName());
                 }
@@ -386,10 +386,10 @@ public class SecurityApiActions
             permsInfo.put("groups", groupsInfo);
 
             //recurse children if desired
-            if(recurse && container.hasChildren())
+            if (recurse && container.hasChildren())
             {
                 List<Map<String, Object>> childPerms = new ArrayList<>();
-                for(Container child : container.getChildren())
+                for (Container child : container.getChildren())
                 {
                     if (child.hasPermission(getUser(), ReadPermission.class))
                     {
@@ -459,14 +459,14 @@ public class SecurityApiActions
         {
             ArrayList<Map<String, Object>> rolesProps = new ArrayList<>();
 
-            for(Role role : RoleManager.getAllRoles())
+            for (Role role : RoleManager.getAllRoles())
             {
-                if(role.isAssignable())
+                if (role.isAssignable())
                     rolesProps.add(getRoleProps(role));
             }
 
             List<Map<String, Object>> permsProps = new ArrayList<>();
-            for(Permission perm : _allPermissions)
+            for (Permission perm : _allPermissions)
             {
                 permsProps.add(getPermissionProps(perm));
             }
@@ -487,7 +487,7 @@ public class SecurityApiActions
                 props.put("sourceModule", role.getSourceModule().getName());
 
             List<String> permissions = new ArrayList<>();
-            for(Class<? extends Permission> permClass : role.getPermissions())
+            for (Class<? extends Permission> permClass : role.getPermissions())
             {
                 Permission perm = RoleManager.getPermission(permClass);
                 _allPermissions.add(perm);
@@ -497,7 +497,7 @@ public class SecurityApiActions
             props.put("permissions", permissions);
 
             List<Integer> excludedPrincipals = new ArrayList<>();
-            for(UserPrincipal principal : role.getExcludedPrincipals())
+            for (UserPrincipal principal : role.getExcludedPrincipals())
             {
                 excludedPrincipals.add(principal.getUserId());
             }
@@ -610,7 +610,7 @@ public class SecurityApiActions
         protected List<Map<String, Object>> getChildrenProps(SecurableResource resource)
         {
             List<Map<String, Object>> childProps = new ArrayList<>();
-            for(SecurableResource child : resource.getChildResources(getUser()))
+            for (SecurableResource child : resource.getChildResources(getUser()))
             {
                 if (_includeSubfolders || !(child instanceof Container))
                     childProps.add(getResourceProps(child));

--- a/core/src/org/labkey/core/view/ShortURLServiceImpl.java
+++ b/core/src/org/labkey/core/view/ShortURLServiceImpl.java
@@ -90,8 +90,7 @@ public class ShortURLServiceImpl implements ShortURLService
     @Override
     public void deleteShortURL(@NotNull ShortURLRecord record, @NotNull User user) throws ValidationException
     {
-        SecurityPolicy policy = SecurityPolicyManager.getPolicy(record);
-        if (!policy.hasPermission(user, DeletePermission.class))
+        if (!record.hasPermission(user, DeletePermission.class))
         {
             throw new UnauthorizedException("You are not authorized to delete the short URL '" + record.getShortURL() + "'");
         }
@@ -152,8 +151,7 @@ public class ShortURLServiceImpl implements ShortURLService
         }
         else
         {
-            SecurityPolicy policy = SecurityPolicyManager.getPolicy(existingRecord);
-            if (!policy.hasPermission(user, UpdatePermission.class))
+            if (!existingRecord.hasPermission(user, UpdatePermission.class))
             {
                 throw new UnauthorizedException("You are not authorized to edit the short URL '" + shortURL + "'");
             }

--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -1115,7 +1115,7 @@ public class PipelineController extends SpringActionController
                 throw new NotFoundException();
 
             // check pipeline ACL
-            if (!SecurityPolicyManager.getPolicy(pipeRoot).hasPermission(getUser(), ReadPermission.class))
+            if (!pipeRoot.hasPermission(getUser(), ReadPermission.class))
                 throw new UnauthorizedException();
 
             File file = pipeRoot.resolvePath(form.getPath());

--- a/query/src/org/labkey/query/reports/ReportServiceImpl.java
+++ b/query/src/org/labkey/query/reports/ReportServiceImpl.java
@@ -145,8 +145,7 @@ public class ReportServiceImpl extends AbstractContainerListener implements Repo
             List<ReportDescriptor> ret = new ArrayList<>();
             for (Report report : ReportService.get().getReports(u, c))
             {
-                SecurityPolicy policy = SecurityPolicyManager.getPolicy(report.getDescriptor());
-                if (policy.hasPermission(u, AdminPermission.class))
+                if (report.getDescriptor().hasPermission(u, AdminPermission.class))
                     ret.add(report.getDescriptor());
             }
             return ret;

--- a/search/src/org/labkey/search/model/SecurityQuery.java
+++ b/search/src/org/labkey/search/model/SecurityQuery.java
@@ -37,8 +37,6 @@ import org.labkey.api.module.Module;
 import org.labkey.api.search.SearchScope;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityPolicy;
-import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.MultiPhaseCPUTimer.InvocationTimer;
@@ -51,11 +49,6 @@ import java.util.Set;
 
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 
-/*
-* User: adam
-* Date: Dec 16, 2009
-* Time: 1:36:39 PM
-*/
 class SecurityQuery extends Query
 {
     private final User _user;
@@ -176,8 +169,7 @@ class SecurityQuery extends Query
         if (null == canRead)
         {
             SecurableResource sr = new _SecurableResource(resourceId, _containerIds.get(containerId));
-            SecurityPolicy p = SecurityPolicyManager.getPolicy(sr);
-            canRead = p.hasPermission(_user, ReadPermission.class);
+            canRead = sr.hasPermission(_user, ReadPermission.class);
             _securableResourceIds.put(resourceId, canRead);
         }
 

--- a/study/src/org/labkey/study/StudyServiceImpl.java
+++ b/study/src/org/labkey/study/StudyServiceImpl.java
@@ -402,7 +402,7 @@ public class StudyServiceImpl implements StudyService, ContainerSecurableResourc
     {
         Study study = StudyManager.getInstance().getStudy(container);
 
-        if(null == study || !SecurityPolicyManager.getPolicy(container).hasPermission(user, ReadPermission.class))
+        if(null == study || !container.hasPermission(user, ReadPermission.class))
             return Collections.emptyList();
         else
             return Collections.singletonList(study);

--- a/study/src/org/labkey/study/model/GroupSecurityType.java
+++ b/study/src/org/labkey/study/model/GroupSecurityType.java
@@ -44,9 +44,8 @@ public enum GroupSecurityType
     public static GroupSecurityType getTypeForGroup(Group group, StudyImpl study)
     {
         boolean includeEditOption = study.getSecurityType() == SecurityType.ADVANCED_WRITE;
-        SecurityPolicy folderPolicy = study.getContainer().getPolicy();
         SecurityPolicy studyPolicy = SecurityPolicyManager.getPolicy(study);
-        boolean hasFolderRead = folderPolicy.hasPermission(group, ReadPermission.class);
+        boolean hasFolderRead = study.getContainer().hasPermission(group, ReadPermission.class); // TODO: Unused?
         boolean hasUpdatePerm = studyPolicy.hasNonInheritedPermission(group, UpdatePermission.class);
         boolean hasReadSomePerm = studyPolicy.hasNonInheritedPermission(group, ReadSomePermission.class);
         boolean hasReadAllPerm = (!hasUpdatePerm) && studyPolicy.hasNonInheritedPermission(group, ReadPermission.class);

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -2085,7 +2085,7 @@ public class StudyManager
         {
             // If we're not reading from a dataset for cohort definition,
             // we use the container's permission
-            return SecurityPolicyManager.getPolicy(container).hasPermission(user, ReadPermission.class);
+            return container.hasPermission(user, ReadPermission.class);
         }
 
         // Automatic cohort assignment -- can the user read the source dataset?

--- a/study/src/org/labkey/study/reports/ReportQueryViewFactory.java
+++ b/study/src/org/labkey/study/reports/ReportQueryViewFactory.java
@@ -113,7 +113,7 @@ public class ReportQueryViewFactory
         if (policy.isEmpty())
             return true;    // normal permission checking
 
-        if (!policy.hasPermission(user, perm))
+        if (!descriptor.hasPermission(user, perm))
             throw new UnauthorizedException();
 
         return false;   // user is OK, don't check permissions

--- a/study/src/org/labkey/study/security/study.jsp
+++ b/study/src/org/labkey/study/security/study.jsp
@@ -60,7 +60,6 @@ Any user with READ access to this folder may view some summary data. However, ac
             <th style="min-width:24px; text-align:center;">&nbsp;</th>
         </tr>
     <%
-    SecurityPolicy folderPolicy = getContainer().getPolicy();
     SecurityPolicy studyPolicy = SecurityPolicyManager.getPolicy(study);
     List<Group> groups = SecurityManager.getGroups(study.getContainer().getProject(), true);
     for (Group group : groups)
@@ -70,7 +69,7 @@ Any user with READ access to this folder may view some summary data. However, ac
         String name = group.getName();
         if (group.getUserId() == Group.groupUsers)
             name = "All site users";
-        boolean hasFolderRead = folderPolicy.hasPermission(group, ReadPermission.class);
+        boolean hasFolderRead = getContainer().hasPermission(group, ReadPermission.class);
         boolean hasUpdatePerm = studyPolicy.hasNonInheritedPermission(group, UpdatePermission.class);
         boolean hasReadSomePerm = studyPolicy.hasNonInheritedPermission(group, ReadSomePermission.class);
         boolean hasReadAllPerm = (!hasUpdatePerm) && studyPolicy.hasNonInheritedPermission(group, ReadPermission.class);

--- a/study/src/org/labkey/study/view/reportPermission.jsp
+++ b/study/src/org/labkey/study/view/reportPermission.jsp
@@ -56,7 +56,6 @@
 
     Study study = StudyManager.getInstance().getStudy(getContainer());
     Container c = study != null ? study.getContainer() : getContainer();
-    SecurityPolicy containerPolicy = c.getPolicy();
     SecurityPolicy reportPolicy = SecurityPolicyManager.getPolicy(bean.getDescriptor(), false);
 
     Container project = c.getProject();
@@ -157,8 +156,8 @@
             <%
             }
             //if (g.isAdministrators()) continue;
-            boolean checked = reportPolicy.hasPermission(g, ReadPermission.class) || g.isAdministrators();
-            boolean disabled = !containerPolicy.hasPermission(g, ReadPermission.class) || g.isAdministrators();
+            boolean checked = bean.getDescriptor().hasPermission(g, ReadPermission.class) || g.isAdministrators();
+            boolean disabled = !c.hasPermission(g, ReadPermission.class) || g.isAdministrators();
             %><tr class="labkey-row">
                 <td><font color=<%=unsafe(disabled ? "gray" : "black")%>><%=h(g.getName())%></font></td>
                 <td height="22" width="20" align="center"><input name=group value="<%=g.getUserId()%>" type=checkbox<%=checked(checked)%><%=disabled(disabled)%>></td>
@@ -166,7 +165,7 @@
         }
     %></table><%
 
-        if (projectGroups.size() > 0)
+        if (!projectGroups.isEmpty())
         {
             %><br/>
             <table class="labkey-data-region-legacy labkey-show-borders" style="width: 350px;">
@@ -176,8 +175,8 @@
                 </tr><%
             for (Group g : projectGroups)
             {
-                boolean checked = reportPolicy.hasPermission(g, ReadPermission.class);
-                boolean disabled = !containerPolicy.hasPermission(g, ReadPermission.class);
+                boolean checked = bean.getDescriptor().hasPermission(g, ReadPermission.class);
+                boolean disabled = !c.hasPermission(g, ReadPermission.class);
                 %><tr class="labkey-row">
                     <td><font color=<%=unsafe(disabled?"gray":"black")%>><%=h(g.getName())%></font></td>
                     <td height=22 width="20" align="center"><input name=group value="<%=g.getUserId()%>" type=checkbox<%=checked(checked)%><%=disabled(disabled)%>></td>
@@ -186,7 +185,7 @@
             %></table><%
         }
 
-        if (reportSharedUsers.size() > 0)
+        if (!reportSharedUsers.isEmpty())
         {
             %><br/>
             <table class="labkey-data-region-legacy labkey-show-borders" style="width: 350px;">
@@ -196,8 +195,8 @@
                 </tr><%
             for (User u : reportSharedUsers)
             {
-                boolean checked = reportPolicy.hasPermission(u, ReadPermission.class);
-                boolean disabled = !containerPolicy.hasPermission(u, ReadPermission.class);
+                boolean checked = bean.getDescriptor().hasPermission(u, ReadPermission.class);
+                boolean disabled = !c.hasPermission(u, ReadPermission.class);
                 %><tr class="labkey-row">
                     <td><font color=<%=unsafe(disabled?"gray":"black")%>><%=h(u.getName())%></font></td>
                     <td height=22 width="20" align="center"><input name=user value="<%=u.getUserId()%>" type=checkbox<%=checked(checked)%><%=disabled(disabled)%>></td>

--- a/wiki/src/org/labkey/wiki/BaseWikiPermissions.java
+++ b/wiki/src/org/labkey/wiki/BaseWikiPermissions.java
@@ -17,9 +17,6 @@
 package org.labkey.wiki;
 
 import org.labkey.api.data.Container;
-import org.labkey.api.security.SecurityManager;
-import org.labkey.api.security.SecurityPolicy;
-import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
@@ -36,23 +33,18 @@ import java.util.Set;
 
 /**
  * Encapsulates permission testing for wikis, handling the UPDATEOWN and DELETEOWN cases
- *
  * Extend this class to do other kinds of permission checking.
- *
- * User: Dave
- * Date: Nov 7, 2007
- * Time: 4:01:58 PM
  */
 public class BaseWikiPermissions
 {
     private final User _user;
-    private final SecurityPolicy _policy;
+    private final Container _container;
 
     public BaseWikiPermissions(User user, Container container)
     {
         assert(null != user && null != container);
         _user = user;
-        _policy = SecurityPolicyManager.getPolicy(container);
+        _container = container;
     }
 
     protected Set<Role> getContextualRoles(Wiki wiki)
@@ -65,38 +57,32 @@ public class BaseWikiPermissions
 
     public boolean allowRead()
     {
-        return SecurityManager.hasAllPermissions("wiki",
-                _policy, _user, Set.of(ReadPermission.class), Set.of());
+        return _container.hasPermission("wiki", _user, ReadPermission.class);
     }
 
     public boolean allowRead(Wiki wiki)
     {
-        return SecurityManager.hasAllPermissions("wiki: " + wiki.getName(),
-                _policy, _user, Set.of(ReadPermission.class), getContextualRoles(wiki));
+        return _container.hasPermission("wiki: " + wiki.getName(), _user, ReadPermission.class, getContextualRoles(wiki));
     }
 
     public boolean allowInsert()
     {
-        return SecurityManager.hasAllPermissions("wiki",
-                _policy, _user, Set.of(InsertPermission.class), Set.of());
+        return _container.hasPermission("wiki", _user, InsertPermission.class);
     }
 
     public boolean allowUpdate(Wiki wiki)
     {
-        return SecurityManager.hasAllPermissions("wiki: " + wiki.getName(),
-                _policy, _user, Set.of(UpdatePermission.class), getContextualRoles(wiki));
+        return _container.hasPermission("wiki: " + wiki.getName(), _user, UpdatePermission.class, getContextualRoles(wiki));
     }
 
     public boolean allowDelete(Wiki wiki)
     {
-        return SecurityManager.hasAllPermissions("wiki: " + wiki.getName(),
-                _policy, _user, Set.of(DeletePermission.class), getContextualRoles(wiki));
+        return _container.hasPermission("wiki: " + wiki.getName(), _user, DeletePermission.class, getContextualRoles(wiki));
     }
 
     public boolean allowAdmin()
     {
-        return SecurityManager.hasAllPermissions("wiki",
-                _policy, _user, Set.of(AdminPermission.class), Set.of());
+        return _container.hasPermission("wiki", _user, AdminPermission.class);
     }
 
     public boolean userIsCreator(Wiki wiki)


### PR DESCRIPTION
#### Rationale
`SecurityPolicy.hasPermission()` was deprecated several years ago; time to remove all callers and the method itself. This is prep for moving all permission checking on securable resources: https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=45251
