### PR TITLE
Pass and set SecurableResource instead of SecurityPolicy

### DIFF
--- a/api/src/org/labkey/api/attachments/AttachmentParent.java
+++ b/api/src/org/labkey/api/attachments/AttachmentParent.java
@@ -17,21 +17,10 @@
 package org.labkey.api.attachments;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.security.SecurityPolicy;
 
-/**
- * User: adam
- * Date: Jan 18, 2007
- * Time: 5:00:10 PM
- */
 public interface AttachmentParent
 {
     String getEntityId();
     String getContainerId();
     @NotNull AttachmentType getAttachmentType();
-
-    default SecurityPolicy getSecurityPolicy()
-    {
-        return null;
-    }
 }

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -1372,7 +1372,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
             if (includePermissions)
             {
                 containerProps.put("userPermissions", getPolicy().getPermsAsOldBitMask(user));
-                containerProps.put("effectivePermissions", SecurityManager.getPermissionNames(getPolicy(), user));
+                containerProps.put("effectivePermissions", SecurityManager.getPermissionNames(this, user));
             }
 
             if (includeStandardProps)

--- a/api/src/org/labkey/api/query/DefaultSchema.java
+++ b/api/src/org/labkey/api/query/DefaultSchema.java
@@ -45,7 +45,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * A schema, scoped to a particular container and user
- *
  * For performance a DefaultSchema caches resolved UserSchema objects. The DefaultSchema itself should not
  * be cached.  It should only be held onto for a short time (e.g. request or query scope).
  */
@@ -158,7 +157,7 @@ final public class DefaultSchema extends AbstractSchema implements QuerySchema.C
      */
     static public QuerySchema get(User user, Container container, String schemaPath)
     {
-        if (schemaPath == null || schemaPath.length() == 0)
+        if (schemaPath == null || schemaPath.isEmpty())
             return null;
 
         return get(user, container, SchemaKey.fromString(schemaPath));

--- a/api/src/org/labkey/api/reports/report/view/ReportUtil.java
+++ b/api/src/org/labkey/api/reports/report/view/ReportUtil.java
@@ -54,7 +54,6 @@ import org.labkey.api.resource.Resource;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.MutableSecurityPolicy;
 import org.labkey.api.security.SecurityManager;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
@@ -426,8 +425,7 @@ public class ReportUtil
 
         if (role != null)
         {
-            SecurityPolicy policy = container.getPolicy();
-            Set<Role> roles = SecurityManager.getEffectiveRoles(policy, user);
+            Set<Role> roles = SecurityManager.getEffectiveRoles(container, user);
 
             return roles.contains(role);
         }

--- a/api/src/org/labkey/api/resource/AbstractResource.java
+++ b/api/src/org/labkey/api/resource/AbstractResource.java
@@ -24,10 +24,6 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
 
-/**
- * User: kevink
- * Date: Mar 12, 2010 2:30:54 PM
- */
 abstract public class AbstractResource implements Resource
 {
     @NotNull

--- a/api/src/org/labkey/api/security/GroupManager.java
+++ b/api/src/org/labkey/api/security/GroupManager.java
@@ -463,7 +463,6 @@ public class GroupManager
             SecurityManager.addMember(_groupA, user);
             user = _testUser.cloneUser();
             assertTrue(policy.hasPermission(user, ReadPermission.class));
-            assertEquals(policy.getPermsAsOldBitMask(user), ACL.PERM_READ);
 
             assertFalse(policy.hasPermission(user, UpdatePermission.class));
             policy.addRoleAssignment(_groupB, AuthorRole.class);
@@ -471,7 +470,6 @@ public class GroupManager
             assertTrue(policy.hasPermission(_groupB, InsertPermission.class));
             assertFalse(policy.hasPermission(user, UpdatePermission.class));
             assertFalse(policy.hasPermission(user, InsertPermission.class));
-            assertEquals(policy.getPermsAsOldBitMask(user), ACL.PERM_READ);
 
             SecurityManager.addMember(_groupB, _groupA);
             user = _testUser.cloneUser();
@@ -479,35 +477,30 @@ public class GroupManager
             assertTrue(policy.hasPermission(_groupA, InsertPermission.class));
             assertFalse(policy.hasPermission(user, UpdatePermission.class));
             assertTrue(policy.hasPermission(user, InsertPermission.class));
-            assertEquals(policy.getPermsAsOldBitMask(user), ACL.PERM_READ | ACL.PERM_INSERT);
 
             policy.addRoleAssignment(user, EditorRole.class);
             assertFalse(policy.hasPermission(_groupA, UpdatePermission.class));
             assertFalse(policy.hasPermission(_groupB, UpdatePermission.class));
             assertTrue(policy.hasPermission(user, UpdatePermission.class));
             assertTrue(policy.hasPermission(user, DeletePermission.class));
-            assertEquals(policy.getPermsAsOldBitMask(user), ACL.PERM_READ | ACL.PERM_INSERT | ACL.PERM_UPDATE | ACL.PERM_DELETE);
 
             policy.clearAssignedRoles(user);
             assertFalse(policy.hasPermission(user, UpdatePermission.class));
             assertFalse(policy.hasPermission(user, DeletePermission.class));
             assertTrue(policy.hasPermission(user, InsertPermission.class));
             assertTrue(policy.hasPermission(user, ReadPermission.class));
-            assertEquals(policy.getPermsAsOldBitMask(user), ACL.PERM_READ | ACL.PERM_INSERT);
 
             SecurityManager.deleteMember(_groupB, _groupA);
             user = _testUser.cloneUser();
             assertFalse(policy.hasPermission(user, UpdatePermission.class));
             assertFalse(policy.hasPermission(user, InsertPermission.class));
             assertTrue(policy.hasPermission(user, ReadPermission.class));
-            assertEquals(policy.getPermsAsOldBitMask(user), ACL.PERM_READ);
 
             SecurityManager.deleteMember(_groupA, user);
             user = _testUser.cloneUser();
             assertFalse(policy.hasPermission(user, UpdatePermission.class));
             assertFalse(policy.hasPermission(user, InsertPermission.class));
             assertFalse(policy.hasPermission(user, ReadPermission.class));
-            assertEquals(policy.getPermsAsOldBitMask(user), ACL.PERM_NONE);
         }
 
         @Test

--- a/api/src/org/labkey/api/security/LimitedUser.java
+++ b/api/src/org/labkey/api/security/LimitedUser.java
@@ -128,18 +128,18 @@ public class LimitedUser extends ClonedUser
             testPermissions(ElevatedUser.ensureCanSeeAuditLogRole(c, ElevatedUser.getElevatedUser(new LimitedUser(user, ReaderRole.class), EditorRole.class)), 3, true, true, true, false, true);
 
             int groupCount = user.getGroups().size();
-            int roleCount = user.getAssignedRoles(c.getPolicy()).size();
+            int roleCount = user.getAssignedRoles(c).size();
             int siteRolesCount = user.getSiteRoles().size();
             User elevated = ElevatedUser.getElevatedUser(user);
             assertEquals(groupCount, elevated.getGroups().size());
-            assertEquals(roleCount, elevated.getAssignedRoles(c.getPolicy()).size());
+            assertEquals(roleCount, elevated.getAssignedRoles(c).size());
             assertEquals(siteRolesCount, elevated.getSiteRoles().size());
         }
 
         private void testPermissions(User user, int roleCount, boolean hasRead, boolean hasInsert, boolean hasUpdate, boolean hasAdmin, boolean hasCanSeeAuditLog)
         {
             Container c = JunitUtil.getTestContainer();
-            assertEquals(roleCount, user.getAssignedRoles(c.getPolicy()).size());
+            assertEquals(roleCount, user.getAssignedRoles(c).size());
             assertTrue(user.getSiteRoles().isEmpty());
             assertFalse(user.hasSiteAdminPermission());
             assertEquals(0, user.getGroups().stream().count());
@@ -166,8 +166,7 @@ public class LimitedUser extends ClonedUser
             String serialized = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(admin);
             User reconstitutedAdmin = mapper.readValue(serialized, User.class);
             assertEquals(admin, reconstitutedAdmin);
-            SecurityPolicy rootPolicy = ContainerManager.getRoot().getPolicy();
-            assertEquals(admin.getAssignedRoles(rootPolicy), reconstitutedAdmin.getAssignedRoles(rootPolicy));
+            assertEquals(admin.getAssignedRoles(ContainerManager.getRoot()), reconstitutedAdmin.getAssignedRoles(ContainerManager.getRoot()));
 
             // Serialize/deserialize search user
             User user = User.getSearchUser();

--- a/api/src/org/labkey/api/security/SecurityLogger.java
+++ b/api/src/org/labkey/api/security/SecurityLogger.java
@@ -47,11 +47,11 @@ public class SecurityLogger extends org.apache.logging.log4j.core.Logger
     }
 
 
-    public static void log(String msg, @Nullable UserPrincipal p, @Nullable SecurityPolicy sp, @Nullable Boolean result)
+    public static void log(String msg, @Nullable UserPrincipal p, @Nullable SecurableResource sr, @Nullable Boolean result)
     {
         String full = indentMsg(msg) +
                 (null==p?"":" " + p.getName()) +
-                (null==sp?"":" "+sp.getResourceClass() + "/" +sp.getResourceId()) +
+                (null==sr?"":" "+sr.getClass() + "/" +sr.getResourceId()) +
                 (null==result?"":result?" TRUE":" FALSE");
         instance.debug(full);
     }
@@ -106,8 +106,6 @@ public class SecurityLogger extends org.apache.logging.log4j.core.Logger
         super((LoggerContext) LogManager.getContext(), name, _log.getMessageFactory());
     }
 
-
-
     private static class ThreadSecurityContext
     {
         final User user;
@@ -119,10 +117,9 @@ public class SecurityLogger extends org.apache.logging.log4j.core.Logger
             this.user = user;
             this.description = desc;
             if (null != prev)
-            this.indent = prev.indent;
+                this.indent = prev.indent;
         }
     }
-
 
     static ThreadLocal<List<ThreadSecurityContext>> threadsecuritycontexts = new ThreadLocal<List<ThreadSecurityContext>>()
     {
@@ -135,7 +132,6 @@ public class SecurityLogger extends org.apache.logging.log4j.core.Logger
         }
     };
 
-
     private static Object indentMsg(Object msg)
     {
         List<ThreadSecurityContext> a = threadsecuritycontexts.get();
@@ -144,8 +140,6 @@ public class SecurityLogger extends org.apache.logging.log4j.core.Logger
             return msg;
         return StringUtils.repeat(' ', indent * 2) + String.valueOf(msg);
     }
-
-
 
     // LoggerWrapper
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3284,9 +3284,9 @@ public class SecurityManager
     }
 
     @NotNull
-    public static List<String> getPermissionNames(SecurityPolicy policy, @NotNull UserPrincipal principal)
+    public static List<String> getPermissionNames(SecurableResource resource, @NotNull UserPrincipal principal)
     {
-        Set<Class<? extends Permission>> perms = getPermissions(policy, principal, null);
+        Set<Class<? extends Permission>> perms = getPermissions(resource, principal, null);
         List<String> names = new ArrayList<>(perms.size());
         for (Class<? extends Permission> perm : perms)
         {

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3247,13 +3247,10 @@ public class SecurityManager
         if (null == resource || null == principal)
             return Set.of();
 
-        Container c = resource.getResourceContainer();
-        if (principal instanceof User user && c.isForbiddenProject(user))
+        if (principal instanceof User user && resource.getResourceContainer().isForbiddenProject(user))
             return Set.of();
 
-        SecurityPolicy policy = SecurityPolicyManager.getPolicy(resource);
-
-        Stream<Role> roles = principal.getAssignedRoles(policy).stream()
+        Stream<Role> roles = principal.getAssignedRoles(resource).stream()
             .filter(Objects::nonNull);
 
         if (null != contextualRoles && !contextualRoles.isEmpty())

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3208,7 +3208,7 @@ public class SecurityManager
         return validRecipients;
     }
 
-    @Deprecated // TODO: Migrate the three remaining callers
+    @Deprecated // TODO: Migrate two remaining callers in AbstractWebdavResource
     public static boolean hasAllPermissions(@Nullable String logMsg, SecurityPolicy policy, UserPrincipal principal, Set<Class<? extends Permission>> perms, Set<Role> contextualRoles)
     {
         return hasPermissions(logMsg, policy, principal, perms, contextualRoles, HasPermissionOption.ALL);
@@ -3234,7 +3234,7 @@ public class SecurityManager
      * object), locked projects, and contextual roles. This lets the SecurityPolicy object just handle its own ACL-like
      * functionality e.g. computing the permissions that it explicitly assigns (resolving roles and groups).
      */
-    @Deprecated // Migrate to the SecurableResource variant above
+    @Deprecated // TODO: dependent on AbstractWebdavResource migration (see above)
     private static boolean hasPermissions(@Nullable String logMsg, SecurityPolicy policy, UserPrincipal principal, Set<Class<? extends Permission>> permissions, Set<Role> contextualRoles, HasPermissionOption opt)
     {
         try
@@ -3259,7 +3259,7 @@ public class SecurityManager
         return getPermissions(SecurityPolicyManager.getPolicy(resource), principal, contextualRoles);
     }
 
-    @Deprecated
+    @Deprecated // TODO: dependent on AbstractWebdavResource migration
     public static Set<Class<? extends Permission>> getPermissions(SecurityPolicy policy, UserPrincipal principal, Set<Role> contextualRoles)
     {
         if (policy == null)
@@ -3298,9 +3298,8 @@ public class SecurityManager
     }
 
     /**
-     * Returns the roles the principal is playing, either due to
-     * direct assignment, or due to membership in a group that is
-     * assigned the role.
+     * Returns the roles the principal is playing, either due to direct assignment, or due to membership in a group
+     * that is assigned the role.
      * @param principal The principal
      * @return The roles this principal is playing
      */
@@ -3311,11 +3310,11 @@ public class SecurityManager
     }
 
     @NotNull
-    public static Set<Role> getEffectiveRoles(@NotNull SecurityPolicy policy, @NotNull UserPrincipal principal, boolean includeContextualRoles)
+    public static Set<Role> getEffectiveRoles(@NotNull SecurityPolicy policy, @NotNull UserPrincipal principal, boolean includeDirectlyAssignedRoles)
     {
         Set<Role> roles = policy.getRoles(principal.getGroups());
         roles.addAll(policy.getAssignedRoles(principal));
-        if (includeContextualRoles)
+        if (includeDirectlyAssignedRoles)
             roles.addAll(principal.getAssignedRoles(policy));
         return roles;
     }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3218,11 +3218,6 @@ public class SecurityManager
         return hasPermissions(logMsg, resource, principal, perms, contextualRoles, HasPermissionOption.ANY);
     }
 
-    /**
-     * This is a choke point for checking permissions. It handles SecurityPolicy permissions, impersonation (via User
-     * object), locked projects, and contextual roles. This lets the SecurityPolicy object just handle its own ACL-like
-     * functionality e.g. computing the permissions that it explicitly assigns (resolving roles and groups).
-     */
     private static boolean hasPermissions(@Nullable String logMsg, SecurableResource resource, UserPrincipal principal, Set<Class<? extends Permission>> permissions, Set<Role> contextualRoles, HasPermissionOption opt)
     {
         try
@@ -3242,6 +3237,11 @@ public class SecurityManager
         }
     }
 
+    /**
+     * This is a choke point for computing permissions. It handles SecurityPolicy permissions, impersonation (via User
+     * object), locked projects, and contextual roles. This lets the SecurityPolicy object just handle its own ACL-like
+     * functionality e.g. computing the permissions that it explicitly assigns (resolving roles and groups).
+     */
     public static Set<Class<? extends Permission>> getPermissions(SecurableResource resource, UserPrincipal principal, Set<Role> contextualRoles)
     {
         if (null == resource || null == principal)
@@ -3279,25 +3279,14 @@ public class SecurityManager
     }
 
     /**
-     * Returns the roles the principal is playing, either due to direct assignment, or due to membership in a group
-     * that is assigned the role.
+     * Returns the roles the principal is playing in this securable resource, either due to direct assignment or due
+     * to membership in a group that is assigned the role.
      * @param principal The principal
-     * @return The roles this principal is playing
+     * @return The roles this principal is playing in the securable resource
      */
-    @NotNull
-    public static Set<Role> getEffectiveRoles(@NotNull SecurityPolicy policy, @NotNull UserPrincipal principal)
+    public static Set<Role> getEffectiveRoles(@NotNull SecurableResource resource, @NotNull UserPrincipal principal)
     {
-        return getEffectiveRoles(policy, principal, true);
-    }
-
-    @NotNull
-    public static Set<Role> getEffectiveRoles(@NotNull SecurityPolicy policy, @NotNull UserPrincipal principal, boolean includeDirectlyAssignedRoles)
-    {
-        Set<Role> roles = policy.getRoles(principal.getGroups());
-        roles.addAll(policy.getAssignedRoles(principal));
-        if (includeDirectlyAssignedRoles)
-            roles.addAll(principal.getAssignedRoles(policy));
-        return roles;
+        return principal.getAssignedRoles(resource);
     }
 
     private enum HasPermissionOption

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3216,12 +3216,17 @@ public class SecurityManager
 
     public static boolean hasAllPermissions(@Nullable String logMsg, SecurableResource resource, UserPrincipal principal, Set<Class<? extends Permission>> perms, Set<Role> contextualRoles)
     {
-        return hasPermissions(logMsg, SecurityPolicyManager.getPolicy(resource), principal, perms, contextualRoles, HasPermissionOption.ALL);
+        return hasPermissions(logMsg, resource, principal, perms, contextualRoles, HasPermissionOption.ALL);
     }
 
     public static boolean hasAnyPermissions(@Nullable String logMsg, SecurableResource resource, UserPrincipal principal, Set<Class<? extends Permission>> perms, Set<Role> contextualRoles)
     {
-        return hasPermissions(logMsg, SecurityPolicyManager.getPolicy(resource), principal, perms, contextualRoles, HasPermissionOption.ANY);
+        return hasPermissions(logMsg, resource, principal, perms, contextualRoles, HasPermissionOption.ANY);
+    }
+
+    private static boolean hasPermissions(@Nullable String logMsg, SecurableResource resource, UserPrincipal principal, Set<Class<? extends Permission>> permissions, Set<Role> contextualRoles, HasPermissionOption opt)
+    {
+        return hasPermissions(logMsg, SecurityPolicyManager.getPolicy(resource), principal, permissions, contextualRoles, opt);
     }
 
     /**
@@ -3229,6 +3234,7 @@ public class SecurityManager
      * object), locked projects, and contextual roles. This lets the SecurityPolicy object just handle its own ACL-like
      * functionality e.g. computing the permissions that it explicitly assigns (resolving roles and groups).
      */
+    @Deprecated // Migrate to the SecurableResource variant above
     private static boolean hasPermissions(@Nullable String logMsg, SecurityPolicy policy, UserPrincipal principal, Set<Class<? extends Permission>> permissions, Set<Role> contextualRoles, HasPermissionOption opt)
     {
         try
@@ -3248,6 +3254,12 @@ public class SecurityManager
         }
     }
 
+    public static Set<Class<? extends Permission>> getPermissions(SecurableResource resource, UserPrincipal principal, Set<Role> contextualRoles)
+    {
+        return getPermissions(SecurityPolicyManager.getPolicy(resource), principal, contextualRoles);
+    }
+
+    @Deprecated
     public static Set<Class<? extends Permission>> getPermissions(SecurityPolicy policy, UserPrincipal principal, Set<Role> contextualRoles)
     {
         if (policy == null)

--- a/api/src/org/labkey/api/security/SecurityPolicy.java
+++ b/api/src/org/labkey/api/security/SecurityPolicy.java
@@ -224,6 +224,12 @@ public class SecurityPolicy
         return roles;
     }
 
+    /* Does not inspect any contextual roles, just the roles explicitly given by this SecurityPolicy */
+    public boolean hasRole(UserPrincipal principal, Class<? extends Role> roleClass)
+    {
+        return getRoles(principal.getGroups()).contains(RoleManager.getRole(roleClass));
+    }
+
     private void handleRoles(PrincipalArray principalArray, Consumer<Role> consumer)
     {
         List<Integer> principals = principalArray.getList();

--- a/api/src/org/labkey/api/security/SecurityPolicy.java
+++ b/api/src/org/labkey/api/security/SecurityPolicy.java
@@ -23,12 +23,7 @@ import org.json.JSONObject;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.cache.Throttle;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.security.permissions.AdminPermission;
-import org.labkey.api.security.permissions.DeletePermission;
-import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
 
@@ -256,30 +251,6 @@ public class SecurityPolicy
             else
                 ++principalsIdx;
         }
-    }
-
-    /**
-     * This is purely for backwards compatibility with HTTP APIs--Do not use for new code!
-     * @param principal the user/group
-     * @return old-style bitmask for basic permissions
-     */
-    @Deprecated // Use SecurityManager.getPermissions() instead.
-    public int getPermsAsOldBitMask(UserPrincipal principal)
-    {
-        int perms = 0;
-        Set<Class<? extends Permission>> permClasses = SecurityManager.getPermissions(this, principal, Set.of());
-        if (permClasses.contains(ReadPermission.class))
-            perms |= ACL.PERM_READ;
-        if (permClasses.contains(InsertPermission.class))
-            perms |= ACL.PERM_INSERT;
-        if (permClasses.contains(UpdatePermission.class))
-            perms |= ACL.PERM_UPDATE;
-        if (permClasses.contains(DeletePermission.class))
-            perms |= ACL.PERM_DELETE;
-        if (permClasses.contains(AdminPermission.class))
-            perms |= ACL.PERM_ADMIN;
-
-        return perms;
     }
 
     @Nullable

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -42,10 +42,8 @@ import org.labkey.api.security.permissions.PlatformDeveloperPermission;
 import org.labkey.api.security.permissions.SiteAdminPermission;
 import org.labkey.api.security.permissions.TrustedPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.security.roles.ApplicationAdminRole;
 import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.security.roles.Role;
-import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.security.roles.SiteAdminRole;
 import org.labkey.api.thumbnail.ThumbnailService;
 import org.labkey.api.util.GUID;
@@ -283,13 +281,6 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
     public boolean hasApplicationAdminPermission()
     {
         return hasRootPermission(ApplicationAdminPermission.class);
-    }
-
-    // NOTE: most callers should use hasApplicationAdminPermissionForPolicy() instead; only use this if you care specifically about the role itself
-    public boolean hasApplicationAdminForPolicy(SecurityPolicy policy)
-    {
-        Set<Role> assignedRoles = SecurityManager.getEffectiveRoles(policy,this, false);
-        return assignedRoles.contains(RoleManager.getRole(ApplicationAdminRole.class));
     }
 
     private static final Set<Class<? extends Permission>> TRUSTED_ANALYST = Set.of(AnalystPermission.class, TrustedPermission.class);

--- a/api/src/org/labkey/api/security/UserPrincipal.java
+++ b/api/src/org/labkey/api/security/UserPrincipal.java
@@ -98,7 +98,16 @@ public abstract class UserPrincipal implements Principal, Parameter.JdbcParamete
     public abstract PrincipalArray getGroups();
 
     /**
+     * @return the roles assigned to this principal in the provided securable resource
+     */
+    public Set<Role> getAssignedRoles(SecurableResource resource)
+    {
+        return getAssignedRoles(SecurityPolicyManager.getPolicy(resource));
+    }
+
+    /**
      * @return the roles assigned to this principal in the provided policy
+     * Outside callers should not use this. TODO: Make protected, or eliminate in favor of SecurableResource variant
      */
     public abstract Set<Role> getAssignedRoles(SecurityPolicy policy);
 

--- a/api/src/org/labkey/api/util/Path.java
+++ b/api/src/org/labkey/api/util/Path.java
@@ -32,20 +32,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.apache.commons.lang3.CharSetUtils.containsAny;
-
 /**
- * User: matthewb
- * Date: Nov 20, 2009
- * Time: 1:03:45 PM
- *
- * This object is used for parsing and manipulating parsed paths (folders, file paths, etc)
- *
- * NOTE: this is object is NOT attached to a filesystem.  It does NOT know the difference between a file
- * and a directory.  The isDirectory() property ONLY indicates that a parsed path originally ended with "/"
- *
- * Path could probably be subclassed, but I think wrapping is probably the way to go for added functionality
- *
+ * This object is used for parsing and manipulating parsed paths (folders, file paths, etc.)
+ * NOTE: this is object is NOT attached to a filesystem. It does NOT know the difference between a file
+ * and a directory. The isDirectory() property ONLY indicates that a parsed path originally ended with "/".
+ * Path could probably be subclassed, but I think wrapping is probably the way to go for added functionality.
  * CONSIDER: support "root"
  * This might be useful for handling webapp context path, or windows drive letter, etc.
  */
@@ -115,8 +106,8 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
     private static Collection<String> getNames(Iterable<java.nio.file.Path> it)
     {
         return StreamSupport.stream(it.spliterator(), false)
-                .map(java.nio.file.Path::toString)
-                .collect(Collectors.toList());
+            .map(java.nio.file.Path::toString)
+            .collect(Collectors.toList());
     }
 
 
@@ -179,18 +170,15 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return new Path(arr, arr.length, _abs(path), _dir(path));
     }
 
-
     protected Path createPath(String[] path, int length, boolean abs, boolean dir)
     {
         return new Path(path,length,abs,dir);
     }
 
-
     public boolean isAbsolute()
     {
         return _isAbsolute;
     }
-
 
     public boolean isDirectory()
     {
@@ -212,7 +200,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return _length - other._length;
     }
 
-
     public boolean endsWith(Path other)
     {
         if (other._length > _length)
@@ -225,7 +212,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         }
         return true;
     }
-
 
     public boolean equals(Object other)
     {
@@ -247,7 +233,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return true;
     }
 
-
     public boolean contains(String name)
     {
         for (int i=0 ; i<_length ; i++)
@@ -261,30 +246,25 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return contains(name.toString());
     }
 
-
     public String getName()
     {
         return _length == 0 ? "" : _path[_length-1];
     }
-
 
     public int size()
     {
         return _length;
     }
 
-
     public boolean isEmpty()
     {
         return 0 == _length;
     }
 
-
     public String get(int i)
     {
         return _path[i];
     }
-
 
     // like java.nio.Path
     public String getName(int i)
@@ -315,7 +295,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return new Path.Part(_path[_length-1]);
     }
 
-
     // like java.nio.Path
     public int getNameCount()
     {
@@ -334,18 +313,16 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return _parent.get();
     }
 
-
     public Path normalize()
     {
         for (int i = 0; i < _length; i++)
         {
             String s = _path[i];
-            if (s.length() == 0 || ".".equals(s) || "..".equals(s))
+            if (s.isEmpty() || ".".equals(s) || "..".equals(s))
                 return _normalize();
         }
         return this;
     }
-
 
     /**
      * CONSIDER: a version that allows a return path that starts with ../
@@ -378,7 +355,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return createPath(normal, next, isAbsolute(), isDirectory());
     }
 
-
     /**
      * Use only where 'this' is a directory
      */
@@ -410,7 +386,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return createPath(path, path.length, false, other.isDirectory());
     }
 
-
     /*
      * If other.isAbsolute() then return other.  Otherwise, return a new path by appending other to this path.
      *
@@ -430,7 +405,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return append(other);
     }
 
-
     /** same as resolve() but ignores isAbsolute() attribute */
     public Path append(Path other)
     {
@@ -444,7 +418,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
             ret._parent.set(this);
         return ret;
     }
-
 
     /** NOTE: do not pass in an unparsed path! use .append(Path.parse(path)) to append a path string */
     public Path append(String... names)
@@ -490,7 +463,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return ret;
     }
 
-
     public boolean startsWith(Path other)
     {
         if (other._length > _length)
@@ -503,7 +475,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         }
         return true;
     }
-
 
     public Path subpath(int begin, int end)
     {
@@ -531,7 +502,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return toString(null, null);
     }
 
-
     public String toString(String start, String end)
     {
         if (start == null)
@@ -553,13 +523,11 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return sb.toString();
     }
 
-
     @Override
     public int hashCode()
     {
         return _hash;
     }
-
 
     public String encode()
     {
@@ -587,24 +555,20 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return sb.toString();
     }
 
-
     protected int compareName(String a, String b)
     {
         return a.compareToIgnoreCase(b);
     }
-
 
     protected static String defaultDecodeName(String a)
     {
         return a;
     }
 
-
     protected static String defaultEncodeName(String a)
     {
         return a;
     }
-
 
     @Override
     @NotNull
@@ -613,7 +577,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         return new ArrayIterator<>(_path, 0, _length);
     }
 
-
     private void readObject(java.io.ObjectInputStream in)
             throws IOException, ClassNotFoundException
     {
@@ -621,12 +584,10 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
         _parent = new AtomicReference<>();
     }
 
-
     private static boolean _abs(String path)
     {
         return path.startsWith("/");
     }
-
 
     private static boolean _dir(String path)
     {
@@ -640,7 +601,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
     {
         return new Path.Part(name);
     }
-
 
     /**
      * Path.Part is just a wrapper for String.  It only indicates that this String came from a parsed Path, and
@@ -697,7 +657,6 @@ public class Path implements Serializable, Comparable<Path>, Iterable<String>
             return obj instanceof Part otherPart && this._name.equals(otherPart._name);
         }
     }
-
 
     public static class TestCase extends Assert
     {

--- a/api/src/org/labkey/api/webdav/AbstractWebdavResolver.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResolver.java
@@ -48,7 +48,7 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
         Path path = getRootPath().relativize(fullPath).normalize();
 
         WebdavResource root = getRoot();
-        if (path.size() == 0)
+        if (path.isEmpty())
             return new LookupResult(this,root);
 
         // start at the root and work down, to avoid lots of cache misses
@@ -173,7 +173,6 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
         }
     }
 
-
     public abstract class AbstractWebFolderResource extends AbstractWebdavResourceCollection implements WebdavResolver.WebFolder
     {
         protected WebdavResolver _resolver;
@@ -264,7 +263,6 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
             return _children;
         }
 
-
         @Override
         public boolean canCreateCollection(User user, boolean forCreate)
         {
@@ -296,7 +294,6 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
             return false;
         }
 
-
         @Override
         @NotNull
         public Collection<String> listNames()
@@ -308,7 +305,6 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
             Collections.sort(list);
             return list;
         }
-
     }
 
     public abstract class AbstractWebdavListener extends ContainerManager.AbstractContainerListener
@@ -373,20 +369,18 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
             }
         }
 
-
         Path getParentPath(Container c)
         {
             Path p = c.getParsedPath();
-            if (p.size() == 0)
+            if (p.isEmpty())
                 throw new IllegalArgumentException();
             return p.getParent();
         }
 
-
         Path resolveSibling(Container c, String name)
         {
             Path p = c.getParsedPath();
-            if (p.size() == 0)
+            if (p.isEmpty())
                 throw new IllegalArgumentException();
             return p.getParent().append(name);
         }

--- a/api/src/org/labkey/api/webdav/AbstractWebdavResolver.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResolver.java
@@ -186,7 +186,7 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
             _resolver = resolver;
             _c = c;
             _containerId = c.getId();
-            setPolicy(c.getPolicy());
+            setSecurableResource(c);
         }
 
         @Override

--- a/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
@@ -74,7 +74,6 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
 {
     private static final String FOLDER_FONT_CLS = "fa fa-folder-o";
 
-    private SecurityPolicy _policy;
     private SecurableResource _resource;
     private List<ExpData> _data = null;
 
@@ -339,13 +338,8 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
     @Deprecated
     protected SecurityPolicy getPolicy()
     {
-        return _resource != null ? SecurityPolicyManager.getPolicy(_resource) : _policy;
-    }
-
-    @Deprecated
-    protected void setPolicy(SecurityPolicy policy)
-    {
-        _policy = policy;
+        assert _resource != null;
+        return SecurityPolicyManager.getPolicy(_resource);
     }
 
     protected SecurableResource getSecurableResource()

--- a/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
@@ -35,8 +35,6 @@ import org.labkey.api.search.SearchService;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityLogger;
 import org.labkey.api.security.SecurityManager;
-import org.labkey.api.security.SecurityPolicy;
-import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
@@ -329,13 +327,6 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
         return true;
     }
 
-    @Deprecated
-    protected SecurityPolicy getPolicy()
-    {
-        assert _resource != null;
-        return SecurityPolicyManager.getPolicy(_resource);
-    }
-
     protected SecurableResource getSecurableResource()
     {
         return _resource;
@@ -357,6 +348,7 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
     @Override
     public boolean canRead(User user, boolean forRead)
     {
+        // TODO: This looks wrong
         if ("/".equals(getPath()))
             return true;
         try
@@ -380,14 +372,14 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
     {
         Set<Role> roles = user.equals(getCreatedBy()) ? RoleManager.roleSet(OwnerRole.class) : Set.of();
         return hasAccess(user) && !user.isGuest() &&
-                SecurityManager.hasAllPermissions(null, getPolicy(), user, Set.of(UpdatePermission.class), roles);
+                SecurityManager.hasAllPermissions(null, getSecurableResource(), user, Set.of(UpdatePermission.class), roles);
     }
 
     @Override
     public boolean canCreate(User user, boolean forCreate)
     {
         return hasAccess(user) && !user.isGuest() &&
-                SecurityManager.hasAllPermissions(null, getPolicy(), user, Set.of(InsertPermission.class), Set.of());
+                SecurityManager.hasAllPermissions(null, getSecurableResource(), user, Set.of(InsertPermission.class), Set.of());
     }
 
     @Override
@@ -419,7 +411,7 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
 
     public Set<Class<? extends Permission>> getPermissions(User user)
     {
-        return SecurityManager.getPermissions(getPolicy(), user, Set.of());
+        return SecurityManager.getPermissions(getSecurableResource(), user, Set.of());
     }
 
     @Override

--- a/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
@@ -183,7 +183,6 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
         return data.get(0).getModifiedBy();
     }
 
-
     @Override
     public void setLastIndexed(long indexed, long modified)
     {
@@ -219,7 +218,6 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
         return c(scheme + "://" + host + portStr, getLocalHref(context));
     }
 
-
     @Override
     @NotNull
     public String getLocalHref(ViewContext context)
@@ -231,7 +229,6 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
         return href;
     }
 
-
     @Override
     public String getExecuteHref(ViewContext context)
     {
@@ -239,7 +236,6 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
         path += (path.endsWith("/")?"":"/") + PageFlowUtil.encode(getPath().getName());
         return path;
     }
-
 
     @Override
     public String getIconHref()
@@ -291,7 +287,6 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
         return _etag;
     }
 
-
     @Override
     public String getETag()
     {
@@ -303,7 +298,6 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
     {
         return FileUtil.md5sum(getInputStream(user));
     }
-
 
     @Override
     public Map<String, ?> getProperties()
@@ -370,7 +364,7 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
             SecurityLogger.indent(getPath() + " AbstractWebdavResource.canRead()");
             if (!hasAccess(user))
             {
-                SecurityLogger.log("hasAccess()==false",user,null,false);
+                SecurityLogger.log("hasAccess()==false", user, null, false);
                 return false;
             }
             return getPermissions(user).contains(ReadPermission.class);
@@ -405,7 +399,7 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
     @Override
     public boolean canDelete(User user, boolean forDelete)
     {
-        return canDelete(user,forDelete,null);
+        return canDelete(user, forDelete, null);
     }
 
     @Override
@@ -447,7 +441,6 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
         return copyFrom(user, r.getFileStream(user));
     }
 
-
     @Override
     public void moveFrom(User user, WebdavResource src) throws IOException, DavException
     {
@@ -455,14 +448,12 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
         src.delete(user);
     }
 
-
     @Override
     @NotNull
     public Collection<WebdavResolver.History> getHistory()
     {
         return Collections.emptyList();
     }
-    
 
     @Override
     @NotNull
@@ -516,7 +507,7 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
         for (String name : names)
         {
             String bare = StringUtils.strip(name, "/");
-            if (bare.length() > 0)
+            if (!bare.isEmpty())
                 s.append("/").append(bare);
         }
         return s.toString();
@@ -575,7 +566,6 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
     {
         throw new UnsupportedOperationException();
     }
-
 
     //
     // SearchService

--- a/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
@@ -423,7 +423,6 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
         return perms.contains(UpdatePermission.class) || perms.contains(DeletePermission.class);
     }
 
-
     @Override
     public boolean canRename(User user, boolean forRename)
     {

--- a/api/src/org/labkey/api/webdav/AbstractWebdavResourceCollection.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResourceCollection.java
@@ -28,8 +28,6 @@ import java.util.List;
 
 /**
  * Convenience base class for WebDav entities that contain other collections or file-style resources.
- * User: matthewb
- * Date: Oct 22, 2008
  */
 public abstract class AbstractWebdavResourceCollection extends AbstractWebdavResource
 {
@@ -104,12 +102,5 @@ public abstract class AbstractWebdavResourceCollection extends AbstractWebdavRes
                 list.add(r);
         }
         return list;
-    }
-
-    @Override
-    @NotNull
-    public Collection<WebdavResolver.History> getHistory()
-    {
-        return Collections.emptyList();
     }
 }

--- a/api/src/org/labkey/api/webdav/FileSystemResource.java
+++ b/api/src/org/labkey/api/webdav/FileSystemResource.java
@@ -43,8 +43,6 @@ import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityLogger;
 import org.labkey.api.security.SecurityManager;
-import org.labkey.api.security.SecurityPolicy;
-import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.roles.CanSeeAuditLogRole;
@@ -112,16 +110,6 @@ public class FileSystemResource extends AbstractWebdavResource
         this(folder.append(name));
     }
 
-    @Deprecated // Down to one caller. TODO: Migrate
-    public FileSystemResource(WebdavResource folder, Path.Part name, File file, SecurityPolicy policy)
-    {
-        this(folder.getPath(), name);
-        _folder = folder;
-        _name = name.toString();
-        setPolicy(policy);
-        _files = Collections.singletonList(new FileInfo(FileUtil.getAbsoluteCaseSensitiveFile(file)));
-    }
-
     public FileSystemResource(WebdavResource folder, Path.Part name, File file, SecurableResource resource)
     {
         this(folder.getPath(), name);
@@ -169,23 +157,6 @@ public class FileSystemResource extends AbstractWebdavResource
     {
         super.setSecurableResource(resource);
         setSearchProperty(SearchService.PROPERTY.securableResourceId, null != resource ? resource.getResourceId() : null);
-    }
-
-    @Override
-    protected SecurityPolicy getPolicy()
-    {
-        SecurableResource resource = getSecurableResource();
-        return resource != null ? SecurityPolicyManager.getPolicy(resource) : _policy;
-    }
-
-    @Deprecated
-    private SecurityPolicy _policy;
-
-    @Deprecated
-    protected void setPolicy(SecurityPolicy policy)
-    {
-        _policy = policy;
-        setSearchProperty(SearchService.PROPERTY.securableResourceId, policy.getResourceId());
     }
 
     @Override
@@ -332,14 +303,12 @@ public class FileSystemResource extends AbstractWebdavResource
         }
     }
 
-
     @Override
     public void moveFrom(User user, WebdavResource src) throws IOException, DavException
     {
         super.moveFrom(user, src);
         resetMetadata();
     }
-
 
     private void resetMetadata()
     {
@@ -375,7 +344,6 @@ public class FileSystemResource extends AbstractWebdavResource
         return result;
     }
 
-
     @Override
     public Collection<WebdavResource> list()
     {
@@ -390,14 +358,12 @@ public class FileSystemResource extends AbstractWebdavResource
         return resources;
     }
 
-
     @Override
     public WebdavResource find(Path.Part name)
     {
         return new FileSystemResource(this, name);
     }
 
-    
     @Override
     public long getCreated()
     {

--- a/api/src/org/labkey/api/webdav/FileSystemResource.java
+++ b/api/src/org/labkey/api/webdav/FileSystemResource.java
@@ -40,6 +40,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.LimitedUser;
+import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityLogger;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
@@ -123,7 +124,7 @@ public class FileSystemResource extends AbstractWebdavResource
     {
         this(folder.getPath(), name);
         _folder = folder;
-        setPolicy(folder.getPolicy());
+        setSecurableResource(folder.getSecurableResource());
 
         _files = new ArrayList<>(folder._files.size());
         _files.addAll(folder._files.stream()
@@ -152,6 +153,12 @@ public class FileSystemResource extends AbstractWebdavResource
         return null==_folder ? null : _folder.getContainerId();
     }
 
+    @Override
+    protected void setSecurableResource(SecurableResource resource)
+    {
+        super.setSecurableResource(resource);
+        setSearchProperty(SearchService.PROPERTY.securableResourceId, resource.getResourceId());
+    }
 
     @Override
     protected void setPolicy(SecurityPolicy policy)

--- a/api/src/org/labkey/api/webdav/FileSystemResource.java
+++ b/api/src/org/labkey/api/webdav/FileSystemResource.java
@@ -142,14 +142,6 @@ public class FileSystemResource extends AbstractWebdavResource
             .toList());
     }
 
-    @Deprecated // Used only by tests. TODO: Migrate callers to SecurableResource variant
-    public FileSystemResource(Path path, File file, SecurityPolicy policy)
-    {
-        this(path);
-        _files = Collections.singletonList(new FileInfo(file));
-        setPolicy(policy);
-    }
-
     public FileSystemResource(Path path, File file, SecurableResource resource)
     {
         this(path);

--- a/api/src/org/labkey/api/webdav/FileSystemResource.java
+++ b/api/src/org/labkey/api/webdav/FileSystemResource.java
@@ -175,7 +175,7 @@ public class FileSystemResource extends AbstractWebdavResource
     protected void setSecurableResource(SecurableResource resource)
     {
         super.setSecurableResource(resource);
-        setSearchProperty(SearchService.PROPERTY.securableResourceId, resource.getResourceId());
+        setSearchProperty(SearchService.PROPERTY.securableResourceId, null != resource ? resource.getResourceId() : null);
     }
 
     @Override
@@ -184,7 +184,6 @@ public class FileSystemResource extends AbstractWebdavResource
         super.setPolicy(policy);
         setSearchProperty(SearchService.PROPERTY.securableResourceId, policy.getResourceId());
     }
-
 
     @Override
     public boolean exists()
@@ -197,7 +196,6 @@ public class FileSystemResource extends AbstractWebdavResource
 
         return getType() != FileType.notpresent;
     }
-
 
     private FileType getType()
     {
@@ -216,7 +214,6 @@ public class FileSystemResource extends AbstractWebdavResource
         return FileType.notpresent;
     }
 
-
     @Override
     public boolean isCollection()
     {
@@ -226,13 +223,11 @@ public class FileSystemResource extends AbstractWebdavResource
         return exists() && getPath().isDirectory();
     }
 
-
     @Override
     public boolean isFile()
     {
         return _files != null && getType() == FileType.file;
     }
-
 
     protected FileInfo getFileInfo()
     {
@@ -250,7 +245,6 @@ public class FileSystemResource extends AbstractWebdavResource
         return _files.get(0);
     }
 
-
     @Override
     public File getFile()
     {
@@ -259,7 +253,6 @@ public class FileSystemResource extends AbstractWebdavResource
             return null;
         return f.getFile();
     }
-
 
     @Override
     public FileStream getFileStream(User user) throws IOException
@@ -270,7 +263,6 @@ public class FileSystemResource extends AbstractWebdavResource
             return null;
         return new FileStream.FileFileStream(getFile());
     }
-
 
     @Override
     public InputStream getInputStream(User user) throws IOException

--- a/api/src/org/labkey/api/webdav/FileSystemResource.java
+++ b/api/src/org/labkey/api/webdav/FileSystemResource.java
@@ -44,6 +44,7 @@ import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityLogger;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.roles.CanSeeAuditLogRole;
@@ -171,9 +172,19 @@ public class FileSystemResource extends AbstractWebdavResource
     }
 
     @Override
+    protected SecurityPolicy getPolicy()
+    {
+        SecurableResource resource = getSecurableResource();
+        return resource != null ? SecurityPolicyManager.getPolicy(resource) : _policy;
+    }
+
+    @Deprecated
+    private SecurityPolicy _policy;
+
+    @Deprecated
     protected void setPolicy(SecurityPolicy policy)
     {
-        super.setPolicy(policy);
+        _policy = policy;
         setSearchProperty(SearchService.PROPERTY.securableResourceId, policy.getResourceId());
     }
 

--- a/api/src/org/labkey/api/webdav/FileSystemResource.java
+++ b/api/src/org/labkey/api/webdav/FileSystemResource.java
@@ -111,12 +111,22 @@ public class FileSystemResource extends AbstractWebdavResource
         this(folder.append(name));
     }
 
+    @Deprecated // Down to one caller. TODO: Migrate
     public FileSystemResource(WebdavResource folder, Path.Part name, File file, SecurityPolicy policy)
     {
         this(folder.getPath(), name);
         _folder = folder;
         _name = name.toString();
         setPolicy(policy);
+        _files = Collections.singletonList(new FileInfo(FileUtil.getAbsoluteCaseSensitiveFile(file)));
+    }
+
+    public FileSystemResource(WebdavResource folder, Path.Part name, File file, SecurableResource resource)
+    {
+        this(folder.getPath(), name);
+        _folder = folder;
+        _name = name.toString();
+        setSecurableResource(resource);
         _files = Collections.singletonList(new FileInfo(FileUtil.getAbsoluteCaseSensitiveFile(file)));
     }
 
@@ -132,11 +142,19 @@ public class FileSystemResource extends AbstractWebdavResource
             .toList());
     }
 
+    @Deprecated // Used only by tests. TODO: Migrate callers to SecurableResource variant
     public FileSystemResource(Path path, File file, SecurityPolicy policy)
     {
         this(path);
         _files = Collections.singletonList(new FileInfo(file));
         setPolicy(policy);
+    }
+
+    public FileSystemResource(Path path, File file, SecurableResource resource)
+    {
+        this(path);
+        _files = Collections.singletonList(new FileInfo(file));
+        setSecurableResource(resource);
     }
 
     @Override

--- a/api/src/org/labkey/api/webdav/WebdavResource.java
+++ b/api/src/org/labkey/api/webdav/WebdavResource.java
@@ -32,11 +32,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-/**
- * User: matthewb
- * Date: Apr 28, 2008
- * Time: 11:42:10 AM
- */
 public interface WebdavResource extends Resource
 {
     @Override

--- a/assay/src/org/labkey/assay/AssayFilesResourceProvider.java
+++ b/assay/src/org/labkey/assay/AssayFilesResourceProvider.java
@@ -4,7 +4,7 @@ import org.labkey.api.attachments.AttachmentDirectory;
 import org.labkey.api.data.Container;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.files.MissingRootDirectoryException;
-import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.ReadPermission;
@@ -74,7 +74,7 @@ public class AssayFilesResourceProvider implements WebdavService.Provider
                 if (!Files.exists(path))
                     return null;
 
-                return new AssayFilesResource(parent, Path.toPathPart(name), dir.getFileSystemDirectory(), c.getPolicy());
+                return new AssayFilesResource(parent, Path.toPathPart(name), dir.getFileSystemDirectory(), c);
             }
         }
         catch (MissingRootDirectoryException e)
@@ -93,9 +93,9 @@ public class AssayFilesResourceProvider implements WebdavService.Provider
 
     static class AssayFilesResource extends FileSystemResource
     {
-        public AssayFilesResource(WebdavResource folder, Path.Part name, File file, SecurityPolicy policy)
+        public AssayFilesResource(WebdavResource folder, Path.Part name, File file, SecurableResource resource)
         {
-            super(folder, name, file, policy);
+            super(folder, name, file, resource);
         }
 
         public AssayFilesResource(FileSystemResource folder, Path.Part relativePath)

--- a/core/src/org/labkey/core/admin/sitevalidation/SiteValidationJob.java
+++ b/core/src/org/labkey/core/admin/sitevalidation/SiteValidationJob.java
@@ -30,7 +30,7 @@ public class SiteValidationJob extends PipelineJob
     public SiteValidationJob(ViewBackgroundInfo info, PipeRoot pipeRoot, SiteValidationForm form)
     {
         super("SiteValidation", info, pipeRoot);
-        setLogFile(new File(pipeRoot.getLogDirectory(), FileUtil.makeFileNameWithTimestamp("site_validation", "log")).toPath());
+        setLogFile(FileUtil.appendName(pipeRoot.getLogDirectory(), FileUtil.makeFileNameWithTimestamp("site_validation", "log")).toPath());
         _form = form;
     }
 
@@ -59,7 +59,7 @@ public class SiteValidationJob extends PipelineJob
         JspTemplate<SiteValidationForm> template = new JspTemplate<>("/org/labkey/core/admin/sitevalidation/siteValidation.jsp", _form);
         ViewContext context = new ViewContext(getInfo());
         template.setViewContext(context);
-        File results = new File(getPipeRoot().getLogDirectory(), getResultsFileName());
+        File results = FileUtil.appendName(getPipeRoot().getLogDirectory(), getResultsFileName());
 
         try (PrintWriter out = new PrintWriter(results, StringUtilsLabKey.DEFAULT_CHARSET))
         {
@@ -71,7 +71,7 @@ public class SiteValidationJob extends PipelineJob
             finalStatus = TaskStatus.error;
         }
 
-        info("Site validation complete");
+        info("Site validation complete. Click the \"Data\" button to see the results.");
         setStatus(finalStatus);
     }
 

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -184,7 +184,7 @@ public class SecurityApiActions
                 groupPerms.put("isSystemGroup", group.isSystemGroup());
                 groupPerms.put("isProjectGroup", group.isProjectGroup());
 
-                int perms = container.getPolicy().getPermsAsOldBitMask(group);
+                int perms = container.getPermsAsOldBitMask(group);
                 groupPerms.put("permissions", perms);
 
                 SecurityManager.PermissionSet role = SecurityManager.PermissionSet.findPermissionSet(perms);
@@ -322,8 +322,7 @@ public class SecurityApiActions
             permsInfo.put("path", container.getPath());
 
             //add user's effective permissions
-            SecurityPolicy policy = container.getPolicy();
-            int perms = policy.getPermsAsOldBitMask(user);
+            int perms = container.getPermsAsOldBitMask(user);
             permsInfo.put("permissions", perms);
 
             //see if those match a given role name
@@ -341,7 +340,7 @@ public class SecurityApiActions
 
             //effective roles
             List<String> effectiveRoles = new ArrayList<>();
-            for (Role effectiveRole : SecurityManager.getEffectiveRoles(policy,user))
+            for (Role effectiveRole : SecurityManager.getEffectiveRoles(container.getPolicy(), user))
             {
                 effectiveRoles.add(effectiveRole.getUniqueName());
             }
@@ -358,7 +357,7 @@ public class SecurityApiActions
                 groupInfo.put("id", group.getUserId());
                 groupInfo.put("name", SecurityManager.getDisambiguatedGroupName(group));
 
-                int groupPerms = policy.getPermsAsOldBitMask(group);
+                int groupPerms = container.getPermsAsOldBitMask(group);
                 groupInfo.put("permissions", groupPerms);
 
                 SecurityManager.PermissionSet groupRole = SecurityManager.PermissionSet.findPermissionSet(groupPerms);
@@ -370,7 +369,7 @@ public class SecurityApiActions
 
                 //effective roles
                 List<String> groupEffectiveRoles = new ArrayList<>();
-                for (Role effectiveRole : SecurityManager.getEffectiveRoles(policy, group))
+                for (Role effectiveRole : SecurityManager.getEffectiveRoles(container.getPolicy(), group))
                 {
                     groupEffectiveRoles.add(effectiveRole.getUniqueName());
                 }

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -64,6 +64,7 @@ import org.labkey.api.security.permissions.SeeGroupDetailsPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.permissions.UpdateUserPermission;
 import org.labkey.api.security.permissions.UserManagementPermission;
+import org.labkey.api.security.roles.ApplicationAdminRole;
 import org.labkey.api.security.roles.FolderAdminRole;
 import org.labkey.api.security.roles.ProjectAdminRole;
 import org.labkey.api.security.roles.ReaderRole;
@@ -195,7 +196,7 @@ public class SecurityApiActions
                 }
 
                 //add effective roles array
-                Set<Role> effectiveRoles = SecurityManager.getEffectiveRoles(container.getPolicy(), group);
+                Set<Role> effectiveRoles = SecurityManager.getEffectiveRoles(container, group);
                 ArrayList<String> effectiveRoleList = new ArrayList<>();
                 for (Role effectiveRole : effectiveRoles)
                 {
@@ -340,7 +341,7 @@ public class SecurityApiActions
 
             //effective roles
             List<String> effectiveRoles = new ArrayList<>();
-            for (Role effectiveRole : SecurityManager.getEffectiveRoles(container.getPolicy(), user))
+            for (Role effectiveRole : SecurityManager.getEffectiveRoles(container, user))
             {
                 effectiveRoles.add(effectiveRole.getUniqueName());
             }
@@ -369,7 +370,7 @@ public class SecurityApiActions
 
                 //effective roles
                 List<String> groupEffectiveRoles = new ArrayList<>();
-                for (Role effectiveRole : SecurityManager.getEffectiveRoles(container.getPolicy(), group))
+                for (Role effectiveRole : SecurityManager.getEffectiveRoles(container, group))
                 {
                     groupEffectiveRoles.add(effectiveRole.getUniqueName());
                 }
@@ -741,7 +742,7 @@ public class SecurityApiActions
 
             //if root container permissions update, check for app admin removal
             if (container.isRoot() && resourceId.equals(container.getId()) && user.hasApplicationAdminPermission() && !user.hasSiteAdminPermission()
-                    && !user.hasApplicationAdminForPolicy(policy) && !form.isConfirm())
+                    && !policy.hasRole(user, ApplicationAdminRole.class) && !form.isConfirm())
             {
                 Map<String, Object> props = new HashMap<>();
                 props.put("success", false);

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.core.security;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -150,8 +152,6 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.servlet.ModelAndView;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
@@ -2277,8 +2277,7 @@ public class SecurityController extends SpringActionController
             {
                 user = UserManager.getUser(user.getUserId()); // the cache from UserManager.getUsers might not have the updated groups list
                 Map<String, List<Group>> userAccessGroups = new TreeMap<>();
-                SecurityPolicy policy = SecurityPolicyManager.getPolicy(getContainer());
-                Set<Role> effectiveRoles = SecurityManager.getEffectiveRoles(policy, user);
+                Set<Role> effectiveRoles = SecurityManager.getEffectiveRoles(getContainer(), user);
                 effectiveRoles.remove(RoleManager.getRole(NoPermissionsRole.class)); //ignore no perms
                 for (Role role : effectiveRoles)
                 {
@@ -2287,7 +2286,7 @@ public class SecurityController extends SpringActionController
 
                 if (!effectiveRoles.isEmpty())
                 {
-                    fillUserAccessGroups(user, groups, policy, effectiveRoles, userAccessGroups);
+                    fillUserAccessGroups(user, groups, getContainer().getPolicy(), effectiveRoles, userAccessGroups);
                 }
 
                 if (showAll || !userAccessGroups.isEmpty())

--- a/core/src/org/labkey/core/user/SecurityAccessView.java
+++ b/core/src/org/labkey/core/user/SecurityAccessView.java
@@ -22,7 +22,6 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ContainerType;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurityManager;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.roles.NoPermissionsRole;
@@ -105,8 +104,7 @@ public class SecurityAccessView extends VBox
             if (!child.isContainerFor(ContainerType.DataType.permissions))
                 continue;
 
-            SecurityPolicy policy = child.getPolicy();
-            Collection<Role> allRoles = SecurityManager.getEffectiveRoles(policy, _principal);
+            Collection<Role> allRoles = SecurityManager.getEffectiveRoles(child, _principal);
             allRoles.remove(RoleManager.getRole(NoPermissionsRole.class)); //ignore no perms
 
             List<Role> roles = new ArrayList<>();
@@ -136,7 +134,7 @@ public class SecurityAccessView extends VBox
             {
                 Container project = child.getProject();
                 List<Group> groups = _projectGroupCache.computeIfAbsent(project, k -> SecurityManager.getGroups(project, true));
-                SecurityController.fillUserAccessGroups(_principal, groups, policy, roles, childAccessGroups);
+                SecurityController.fillUserAccessGroups(_principal, groups, child.getPolicy(), roles, childAccessGroups);
             }
 
             if (_showAll || !roles.isEmpty())

--- a/core/src/org/labkey/core/user/SecurityAccessView.java
+++ b/core/src/org/labkey/core/user/SecurityAccessView.java
@@ -106,7 +106,7 @@ public class SecurityAccessView extends VBox
                 continue;
 
             SecurityPolicy policy = child.getPolicy();
-            Collection<Role> allRoles = SecurityManager.getEffectiveRoles(policy,_principal);
+            Collection<Role> allRoles = SecurityManager.getEffectiveRoles(policy, _principal);
             allRoles.remove(RoleManager.getRole(NoPermissionsRole.class)); //ignore no perms
 
             List<Role> roles = new ArrayList<>();

--- a/core/src/org/labkey/core/webdav/UserResolverImpl.java
+++ b/core/src/org/labkey/core/webdav/UserResolverImpl.java
@@ -203,7 +203,6 @@ public class UserResolverImpl extends AbstractWebdavResolver
             return new FileSystemResource(this, Path.toPathPart(user.getName()), fileRoot, p);
         }
 
-
         @Override
         public Set<Class<? extends Permission>> getPermissions(User user)
         {

--- a/core/src/org/labkey/core/webdav/UserResolverImpl.java
+++ b/core/src/org/labkey/core/webdav/UserResolverImpl.java
@@ -67,14 +67,7 @@ public class UserResolverImpl extends AbstractWebdavResolver
     {
         if (null == _root)
         {
-            _root = new UsersCollectionResource(getRootPath(), this)
-            {
-                @Override
-                public boolean canList(User user, boolean forRead)
-                {
-                    return true;
-                }
-            };
+            _root = new UsersCollectionResource(getRootPath(), this);
         }
         return _root;
     }
@@ -97,10 +90,7 @@ public class UserResolverImpl extends AbstractWebdavResolver
         return "users";
     }
 
-    /**
-     * Created by iansigmon on 6/20/16.
-     */
-    public class UsersCollectionResource extends AbstractWebdavResourceCollection
+    public static class UsersCollectionResource extends AbstractWebdavResourceCollection
     {
         public static final String USERS_LINK = "/_users/";
 

--- a/core/src/org/labkey/core/webdav/UserResolverImpl.java
+++ b/core/src/org/labkey/core/webdav/UserResolverImpl.java
@@ -17,13 +17,9 @@ package org.labkey.core.webdav;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.security.RoleAssignment;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.Permission;
-import org.labkey.api.security.roles.EditorRole;
-import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.Result;
 import org.labkey.api.view.HttpView;
@@ -34,16 +30,11 @@ import org.labkey.api.webdav.WebdavResolver;
 import org.labkey.api.webdav.WebdavResource;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
-/**
- * Created by iansigmon on 6/20/16.
- */
 public class UserResolverImpl extends AbstractWebdavResolver
 {
     private static final UserResolverImpl _instance = new UserResolverImpl(Path.parse(UsersCollectionResource.USERS_LINK));
@@ -181,16 +172,8 @@ public class UserResolverImpl extends AbstractWebdavResolver
             if (!r.success() || !r.get().isDirectory())
                 return null;
             File fileRoot = r.get();
-            SecurityPolicy p = new SecurityPolicy
-            (
-                user.getEntityId(),
-                User.class.getName(),
-                ContainerManager.getRoot().getId(),
-                Arrays.asList(new RoleAssignment(user.getEntityId(), user, RoleManager.getRole(EditorRole.class))),
-                new Date()
-            );
 
-            return new FileSystemResource(this, Path.toPathPart(user.getName()), fileRoot, p);
+            return new FileSystemResource(this, Path.toPathPart(user.getName()), fileRoot, ContainerManager.getForId(getContainerId()));
         }
 
         @Override

--- a/core/src/org/labkey/core/webdav/WebFilesResolverImpl.java
+++ b/core/src/org/labkey/core/webdav/WebFilesResolverImpl.java
@@ -386,7 +386,7 @@ public class WebFilesResolverImpl extends AbstractWebdavResolver implements File
                                     {
                                         if (!FileUtil.hasCloudScheme(p))
                                         {
-                                            return new FileSystemResource(this, Path.toPathPart(name), p.toFile(), parentContainer.getPolicy());
+                                            return new FileSystemResource(this, Path.toPathPart(name), p.toFile(), parentContainer);
                                         }
                                         else if (isCloudRoot)
                                         {
@@ -418,7 +418,7 @@ public class WebFilesResolverImpl extends AbstractWebdavResolver implements File
                 {
                     if (!FileUtil.hasCloudScheme(fileRootFile))
                     {
-                        FileSystemResource fileRootResource = new FileSystemResource(this, Path.toPathPart(FileContentService.FILES_LINK), fileRootFile.toFile(), parentContainer.getPolicy());
+                        FileSystemResource fileRootResource = new FileSystemResource(this, Path.toPathPart(FileContentService.FILES_LINK), fileRootFile.toFile(), parentContainer);
                         if (child.toString().equals(FileContentService.FILES_LINK))
                             return fileRootResource;
                         return new FileSystemResource(fileRootResource, child);

--- a/experiment/src/org/labkey/experiment/ScriptsResourceProvider.java
+++ b/experiment/src/org/labkey/experiment/ScriptsResourceProvider.java
@@ -6,7 +6,7 @@ import org.labkey.api.attachments.AttachmentDirectory;
 import org.labkey.api.data.Container;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.files.MissingRootDirectoryException;
-import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.NetworkDrive;
@@ -69,7 +69,7 @@ public class ScriptsResourceProvider implements WebdavService.Provider
             AttachmentDirectory dir = service.getMappedAttachmentDirectory(c, FileContentService.ContentType.scripts, false);
             if (dir != null)
             {
-                return new ScriptsResource(parent, Path.toPathPart(name), dir.getFileSystemDirectory(), c.getPolicy());
+                return new ScriptsResource(parent, Path.toPathPart(name), dir.getFileSystemDirectory(), c);
             }
         }
         catch (MissingRootDirectoryException e)
@@ -88,14 +88,14 @@ public class ScriptsResourceProvider implements WebdavService.Provider
 
     static class ScriptsResource extends FileSystemResource
     {
-        public ScriptsResource(WebdavResource folder, Path.Part name, File file, SecurityPolicy policy)
+        public ScriptsResource(WebdavResource folder, Path.Part name, File file, SecurableResource resource)
         {
-            super(folder, name, file, policy);
+            super(folder, name, file, resource);
         }
 
         public ScriptsResource(FileSystemResource folder, Path.Part relativePath)
         {
-            super(folder,relativePath);
+            super(folder, relativePath);
         }
 
         @Override

--- a/filecontent/src/org/labkey/filecontent/FileWebdavProvider.java
+++ b/filecontent/src/org/labkey/filecontent/FileWebdavProvider.java
@@ -25,7 +25,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.files.MissingRootDirectoryException;
-import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.FileUtil;
@@ -116,7 +116,7 @@ public class FileWebdavProvider implements WebdavService.Provider
                 AttachmentDirectory dir = service.getMappedAttachmentDirectory(c, false);
                 if (dir != null)
                 {
-                    return new _FilesResource(parent, Path.toPathPart(name), dir.getFileSystemDirectory(), c.getPolicy());
+                    return new _FilesResource(parent, Path.toPathPart(name), dir.getFileSystemDirectory(), c);
                 }
             }
             catch (MissingRootDirectoryException e)
@@ -130,9 +130,9 @@ public class FileWebdavProvider implements WebdavService.Provider
 
     static class _FilesResource extends FileSystemResource
     {
-        public _FilesResource(WebdavResource folder, Path.Part name, File file, SecurityPolicy policy)
+        public _FilesResource(WebdavResource folder, Path.Part name, File file, SecurableResource resource)
         {
-            super(folder, name, file, policy);
+            super(folder, name, file, resource);
         }
 
         public _FilesResource(FileSystemResource folder, Path.Part name)

--- a/filecontent/src/org/labkey/filecontent/FileWebdavProvider.java
+++ b/filecontent/src/org/labkey/filecontent/FileWebdavProvider.java
@@ -166,7 +166,6 @@ public class FileWebdavProvider implements WebdavService.Provider
         }
     }
 
-
     static class _FilesetsFolder extends AbstractWebdavResourceCollection
     {
         Container _c;

--- a/filecontent/src/org/labkey/filecontent/FileWebdavProvider.java
+++ b/filecontent/src/org/labkey/filecontent/FileWebdavProvider.java
@@ -177,7 +177,7 @@ public class FileWebdavProvider implements WebdavService.Provider
         {
             super(folder, FileContentService.FILE_SETS_LINK);
             _c = c;
-            setPolicy(_c.getPolicy());
+            setSecurableResource(_c);
             
             FileContentService svc = FileContentService.get();
             for (AttachmentDirectory dir : svc.getRegisteredDirectories(_c))

--- a/pipeline/src/org/labkey/pipeline/PipelineWebdavProvider.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineWebdavProvider.java
@@ -117,7 +117,7 @@ public class PipelineWebdavProvider implements WebdavService.Provider
         @Override
         protected boolean hasAccess(User user)
         {
-            return user.hasRootPermission(AdminOperationsPermission.class) || !SecurityManager.getPermissions(c.getPolicy(), user, Set.of()).isEmpty();
+            return user.hasRootPermission(AdminOperationsPermission.class) || !SecurityManager.getPermissions(c, user, Set.of()).isEmpty();
         }
 
         @Override

--- a/pipeline/src/org/labkey/pipeline/PipelineWebdavProvider.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineWebdavProvider.java
@@ -23,7 +23,6 @@ import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.SecurityManager;
-import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.util.PageFlowUtil;
@@ -98,7 +97,7 @@ public class PipelineWebdavProvider implements WebdavService.Provider
             this.c = c;
             _containerId = c.getId();
             _shouldIndex = root.isSearchable();
-            setPolicy(SecurityPolicyManager.getPolicy(root));
+            setSecurableResource(root);
 
             _files = new ArrayList<>();
             for (File file : root.getRootPaths())

--- a/query/src/org/labkey/query/QueryWebdavProvider.java
+++ b/query/src/org/labkey/query/QueryWebdavProvider.java
@@ -49,11 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * User: matthewb
- * Date: Feb 4, 2009
- * Time: 11:17:57 AM
- */
 public class QueryWebdavProvider implements WebdavService.Provider
 {
 	final String QUERY_NAME = "@query";
@@ -91,7 +86,7 @@ public class QueryWebdavProvider implements WebdavService.Provider
 		{
 			super(parent.getPath(), QUERY_NAME);
 			_c = parent.getContainer();
-			setPolicy(_c.getPolicy());
+			setSecurableResource(_c);
 		}
 		
 		@Override
@@ -148,7 +143,7 @@ public class QueryWebdavProvider implements WebdavService.Provider
 		{
 			super(parent.getPath(), schemaName);
 			_parent = parent;
-			setPolicy(_parent._c.getPolicy());
+			setSecurableResource(_parent._c);
 		}
 		
 		@Override
@@ -204,7 +199,7 @@ public class QueryWebdavProvider implements WebdavService.Provider
 		{
 			super(parent.getPath(), query.getName() + ".sql");
 			_parent = parent;
-			setPolicy(_parent._parent._c.getPolicy());
+			setSecurableResource(_parent._parent._c);
 			_q = query;
 			if (_q instanceof QueryDefinitionImpl)
 				_qdef = ((QueryDefinitionImpl)_q).getQueryDef();

--- a/query/src/org/labkey/query/reports/ReportWebdavProvider.java
+++ b/query/src/org/labkey/query/reports/ReportWebdavProvider.java
@@ -89,7 +89,7 @@ public class ReportWebdavProvider implements WebdavService.Provider
         {
             super(parent.getPath(), VIEW_NAME);
             _c = c;
-            setPolicy(c.getPolicy());
+            setSecurableResource(c);
         }
 
         @Override
@@ -154,7 +154,7 @@ public class ReportWebdavProvider implements WebdavService.Provider
             super(folder.getPath(), report.getDescriptor().getReportName() + ".xml");
             _report = report;
             _c = folder._c;
-            setPolicy(folder._c.getPolicy());
+            setSecurableResource(folder._c);
             _folder = folder;
         }
 

--- a/search/src/org/labkey/search/model/CrawlerTest.java
+++ b/search/src/org/labkey/search/model/CrawlerTest.java
@@ -21,14 +21,11 @@ import org.junit.Test;
 import org.labkey.api.data.Container;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.security.MutableSecurityPolicy;
 import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
-import org.labkey.api.security.UserManager;
-import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
 import org.labkey.api.webdav.FileSystemResource;
@@ -48,7 +45,7 @@ public class CrawlerTest extends Assert
     public void test()
     {
         DavCrawler cr = new DavCrawler();
-        cr.setResolver(new TestResolver(ModuleLoader.getInstance().getCoreModule().getExplodedPath()));
+        cr.setResolver(new TestResolver(ModuleLoader.getInstance().getCoreModule().getExplodedPath(), JunitUtil.getTestContainer()));
         cr.startFull(Path.rootPath, true);
     }
 
@@ -57,16 +54,13 @@ public class CrawlerTest extends Assert
     //
     class TestResolver implements WebdavResolver, SecurableResource
     {
-        final File _base;
-        final SecurityPolicy _policy;
+        private final File _base;
+        private final Container _c;
 
-        TestResolver(File f)
+        TestResolver(File f, Container c)
         {
             _base = f;
-            MutableSecurityPolicy policy = new MutableSecurityPolicy(this);
-            policy.addRoleAssignment(UserManager.getGuestUser(), ReaderRole.class);
-            policy.addRoleAssignment(User.getSearchUser(), ReaderRole.class);
-            _policy = policy;
+            _c = c;
         }
         
         @Override
@@ -84,7 +78,7 @@ public class CrawlerTest extends Assert
         @Override
         public WebdavResource lookup(Path path)
         {
-            return new FileSystemResource(path, FileUtil.appendPath(_base, path), _policy);
+            return new FileSystemResource(path, FileUtil.appendPath(_base, path), _c);
         }
 
         @Override
@@ -140,7 +134,7 @@ public class CrawlerTest extends Assert
         @NotNull
         public Container getResourceContainer()
         {
-            return null;
+            return _c;
         }
 
         @Override

--- a/search/src/org/labkey/search/model/CrawlerTest.java
+++ b/search/src/org/labkey/search/model/CrawlerTest.java
@@ -27,6 +27,7 @@ import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.roles.ReaderRole;
+import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
@@ -41,29 +42,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-/**
- * User: matthewb
- * Date: Dec 12, 2009
- * Time: 3:51:51 PM
- */
 public class CrawlerTest extends Assert
 {
-
     @Test
     public void test()
     {
         DavCrawler cr = new DavCrawler();
         cr.setResolver(new TestResolver(ModuleLoader.getInstance().getCoreModule().getExplodedPath()));
         cr.startFull(Path.rootPath, true);
-
-        long start = System.currentTimeMillis();
     }
 
-    
     //
     // TEST
     //
-
     class TestResolver implements WebdavResolver, SecurableResource
     {
         final File _base;
@@ -93,7 +84,7 @@ public class CrawlerTest extends Assert
         @Override
         public WebdavResource lookup(Path path)
         {
-            return new FileSystemResource(path, new File(_base, path.toString()), _policy);
+            return new FileSystemResource(path, FileUtil.appendPath(_base, path), _policy);
         }
 
         @Override
@@ -109,7 +100,7 @@ public class CrawlerTest extends Assert
         }
 
         // SecurableResource
-        String _guid = GUID.makeGUID();
+        private final String _guid = GUID.makeGUID();
 
         @Override
         @NotNull
@@ -166,7 +157,6 @@ public class CrawlerTest extends Assert
         }
     }
 
-
     class TestSavePaths implements DavCrawler.SavePaths
     {
         Map<Path, Pair<Date,Date>> collections = new HashMap<>();
@@ -221,14 +211,12 @@ public class CrawlerTest extends Assert
             return ret;
         }
 
-
         @Override
         public Date getNextCrawl()
         {
             return new Date(System.currentTimeMillis());
         }
         
-
         @Override
         public synchronized Map<String, DavCrawler.ResourceInfo> getFiles(Path path)
         {

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -2003,20 +2003,9 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         @SuppressWarnings("unused")
         public void testTika()
         {
-            File root = new File("c:\\");
-            Predicate<WebdavResource> fileFilter = webdavResource -> StringUtils.endsWithIgnoreCase(webdavResource.getName(), ".chm");
-
-            MutableSecurityPolicy policy = new MutableSecurityPolicy(_c);
-            policy.addRoleAssignment(User.getSearchUser(), ReaderRole.class);
-            FileSystemResource rootResource = new FileSystemResource(Path.parse(root.getAbsolutePath()), root, policy)
-            {
-                @Override
-                public String getContainerId()
-                {
-                    return _c.getId();
-                }
-            };
-
+            File root = new File("c:\\temp");
+            Predicate<WebdavResource> fileFilter = webdavResource -> StringUtils.endsWithIgnoreCase(webdavResource.getName(), ".txt");
+            FileSystemResource rootResource = new FileSystemResource(Path.parse(root.getAbsolutePath()), root, _c);
             traverse(rootResource, fileFilter);
         }
 

--- a/study/src/org/labkey/study/view/datasetDetails.jsp
+++ b/study/src/org/labkey/study/view/datasetDetails.jsp
@@ -70,7 +70,7 @@
     String schemaName = datasetTable.getSchema().getQuerySchemaName();
 
     StudyImpl study = StudyManager.getInstance().getStudy(c);
-    Set<Class<? extends Permission>> permissions = SecurityManager.getPermissions(c.getPolicy(), user, Set.of());
+    Set<Class<? extends Permission>> permissions = SecurityManager.getPermissions(c, user, Set.of());
 
     // is definition inherited
     boolean isDatasetInherited = dataset.isInherited();

--- a/wiki/src/org/labkey/wiki/WikiWebdavProvider.java
+++ b/wiki/src/org/labkey/wiki/WikiWebdavProvider.java
@@ -28,7 +28,6 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.module.Module;
 import org.labkey.api.search.SearchService;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.Permission;
@@ -125,7 +124,7 @@ public class WikiWebdavProvider implements WebdavService.Provider
             super(parent.getPath(), WIKI_NAME);
             _c = c;
             _containerId = _c.getId();
-            setPolicy(c.getPolicy());
+            setSecurableResource(c);
         }
 
         @Override
@@ -217,7 +216,7 @@ public class WikiWebdavProvider implements WebdavService.Provider
         {
             super(parent.getPath(), WikiWriterFactory.WIKIS_FILENAME);
             _parent = parent;
-            setPolicy(parent._c.getPolicy());
+            setSecurableResource(parent._c);
         }
 
         @Override
@@ -322,7 +321,7 @@ public class WikiWebdavProvider implements WebdavService.Provider
             super(folder.getPath(), name);
             _c = folder._c;
             _containerId = _c.getId();
-            setPolicy(_c.getPolicy());
+            setSecurableResource(_c);
             _wiki = WikiSelectManager.getWiki(_c, name);
             if (null != _wiki)
                 _attachments = AttachmentService.get().getAttachmentResource(getPath(), _wiki.getAttachmentParent());
@@ -440,7 +439,7 @@ public class WikiWebdavProvider implements WebdavService.Provider
         WikiPageResource(WikiFolder folder, Wiki wiki, String docName)
         {
             super(folder.getPath(), docName);
-            init(folder._c, wiki.getName(), wiki.getEntityId(), folder, folder._c.getPolicy(), new HashMap<>());
+            init(folder._c, wiki.getName(), wiki.getEntityId(), folder, new HashMap<>());
 
             _wiki = wiki;
             WikiVersion v = getWikiVersion();
@@ -458,21 +457,21 @@ public class WikiWebdavProvider implements WebdavService.Provider
         WikiPageResource(Container c, String name, String entityId, String body, WikiRendererType rendererType, Map<String, Object> m)
         {
             super(new Path("wiki", c.getId(), name));
-            init(c, name, entityId, null, c.getPolicy(), m);
+            init(c, name, entityId, null, m);
 
             _type = rendererType;
             setBody(body);
         }
 
 
-        private void init(Container c, String name, String entityId, WikiFolder folder, SecurityPolicy policy, Map<String, Object> properties)
+        private void init(Container c, String name, String entityId, WikiFolder folder, Map<String, Object> properties)
         {
             _c = c;
             _containerId = _c.getId();
             _name = name;
             _entityId = entityId;
             _folder = folder;
-            setPolicy(policy);
+            setSecurableResource(c);
             _properties = properties;
             _properties.put(SearchService.PROPERTY.categories.toString(), WikiManager.searchCategory.getName());
         }


### PR DESCRIPTION
#### Rationale
We want low-level permission checking to operate on `SecurableResource`, which means we need to pass them around instead of `SecurityPolicy`. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=45251

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5575