### PR TITLE
Fill PDFBox font cache proactively at startup to avoid test timeouts

### DIFF
--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -23,6 +23,8 @@ import jakarta.servlet.ServletRegistration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.pdmodel.font.FontMapper;
+import org.apache.pdfbox.pdmodel.font.FontMappers;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
@@ -170,6 +172,7 @@ import org.labkey.api.usageMetrics.UsageMetricsService;
 import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.JobRunner;
 import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.MothershipReport;
 import org.labkey.api.util.PageFlowUtil;
@@ -302,6 +305,8 @@ import org.quartz.SchedulerException;
 import org.quartz.impl.StdSchedulerFactory;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.ZonedDateTime;
@@ -1274,6 +1279,24 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         // ping, and then once every 24 hours.
         UsageReportingLevel.init();
         TempTableTracker.init();
+
+        // Loading the PDFBox font cache can be very slow on some agents; fill it proactively. Issue 50601
+        JobRunner.getDefault().execute(() -> {
+            try
+            {
+                long start = System.currentTimeMillis();
+                FontMapper mapper = FontMappers.instance();
+                Method method = mapper.getClass().getMethod("getProvider");
+                method.setAccessible(true);
+                method.invoke(mapper);
+                long duration = System.currentTimeMillis() - start;
+                LOG.info("Ensuring PDFBox on-disk font cache took {} seconds", Math.round(duration / 100.0) / 10.0);
+            }
+            catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e)
+            {
+                LOG.warn("Unable to initialize PDFBox font cache", e);
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
[PDF indexing is slow on first file after server startup on Windows](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50601)