### PR TITLE
Update FileLinkMetricsMaintenanceTask to include metric info for valid file paths broken down by type (i.e. schema name)

### DIFF
--- a/experiment/src/org/labkey/experiment/FileLinkMetricsMaintenanceTask.java
+++ b/experiment/src/org/labkey/experiment/FileLinkMetricsMaintenanceTask.java
@@ -26,7 +26,7 @@ public class FileLinkMetricsMaintenanceTask implements SystemMaintenance.Mainten
     @Override
     public String getDescription()
     {
-        return "Task to calculate metrics for missing files for File fields.";
+        return "Task to calculate metrics for valid and missing files for File fields";
     }
 
     @Override
@@ -55,22 +55,30 @@ public class FileLinkMetricsMaintenanceTask implements SystemMaintenance.Mainten
     {
         try
         {
-            Map<String, Map<String, Set<String>>> results = ExperimentServiceImpl.get().doMissingFilesCheck(getTaskUser(), ContainerManager.getRoot());
+            Map<String, Map<String, MissingFilesCheckInfo>> results = ExperimentServiceImpl.get().doMissingFilesCheck(getTaskUser(), ContainerManager.getRoot(), false);
             Map<String, Object> missingFilesMetrics = new HashMap<>();
             missingFilesMetrics.put("Run time", new Date());
             Map<String, Object> metrics = new HashMap<>();
             metrics.put(NAME, missingFilesMetrics);
-            long totalCount = 0;
+            long missingFilesCount = 0;
+            Map<String, Long> validFilesCount = new HashMap<>();
             if (null != results)
             {
                 for (String containerId : results.keySet())
                 {
-                    Map<String, Set<String>> missingFiles = results.get(containerId);
-                    for (String source : missingFiles.keySet())
-                        totalCount += missingFiles.get(source).size();
+                    Map<String, MissingFilesCheckInfo> info = results.get(containerId);
+                    for (String source : info.keySet())
+                    {
+                        missingFilesCount += info.get(source).getMissingFilesCount();
+
+                        String schemaName = source.substring(0, source.indexOf('.')); // e.g. 'assayresults.c9043290_test'
+                        long schemaValidFilesCount = validFilesCount.getOrDefault(schemaName, 0L);
+                        validFilesCount.put(schemaName, schemaValidFilesCount + info.get(source).getValidFilesCount());
+                    }
                 }
             }
-            missingFilesMetrics.put("Missing files count", totalCount);
+            missingFilesMetrics.put("Missing files count", missingFilesCount);
+            missingFilesMetrics.put("Valid files count", validFilesCount);
             FileLinkMetricsProvider.getInstance().updateMetrics(metrics);
         }
         catch (Exception e)
@@ -86,7 +94,7 @@ public class FileLinkMetricsMaintenanceTask implements SystemMaintenance.Mainten
                     @Override
                     public String getDescription()
                     {
-                        return "Enable the system maintenance task to calculate metrics for missing files for File fields.";
+                        return "Enable the system maintenance task to calculate metrics for valid and missing files for File fields.";
                     }
                 }
     }

--- a/experiment/src/org/labkey/experiment/FileLinkMetricsMaintenanceTask.java
+++ b/experiment/src/org/labkey/experiment/FileLinkMetricsMaintenanceTask.java
@@ -71,7 +71,10 @@ public class FileLinkMetricsMaintenanceTask implements SystemMaintenance.Mainten
                     {
                         missingFilesCount += info.get(source).getMissingFilesCount();
 
-                        String schemaName = source.substring(0, source.indexOf('.')); // e.g. 'assayresults.c9043290_test'
+                        // e.g. 'assayresults.c9043290_test'
+                        // note that files from the assay batch and run fields will have "exp" as the schema name here
+                        String schemaName = source.substring(0, source.indexOf('.'));
+
                         long schemaValidFilesCount = validFilesCount.getOrDefault(schemaName, 0L);
                         validFilesCount.put(schemaName, schemaValidFilesCount + info.get(source).getValidFilesCount());
                     }

--- a/experiment/src/org/labkey/experiment/MissingFilesCheckInfo.java
+++ b/experiment/src/org/labkey/experiment/MissingFilesCheckInfo.java
@@ -1,0 +1,53 @@
+package org.labkey.experiment;
+
+import org.json.JSONObject;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class MissingFilesCheckInfo
+{
+    long _missingFilesCount = 0;
+    long _validFilesCount = 0;
+    Set<String> _missingFilePaths = new HashSet<>();
+
+    public MissingFilesCheckInfo()
+    {}
+
+    public long getMissingFilesCount()
+    {
+        return _missingFilesCount;
+    }
+
+    public long getValidFilesCount()
+    {
+        return _validFilesCount;
+    }
+
+    public Set<String> getMissingFilePaths()
+    {
+        return _missingFilePaths;
+    }
+
+    public void addMissingFile(String path, boolean trackMissingFiles)
+    {
+        _missingFilesCount++;
+        if (trackMissingFiles)
+            _missingFilePaths.add(path);
+    }
+
+    public void incrementValidFilesCount()
+    {
+        _validFilesCount++;
+    }
+
+    public JSONObject toJSON()
+    {
+        JSONObject json = new JSONObject();
+        json.put("missingFilesCount", _missingFilesCount);
+        json.put("validFilesCount", _validFilesCount);
+        if (!_missingFilePaths.isEmpty())
+            json.put("missingFilePaths", _missingFilePaths);
+        return json;
+    }
+}

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -9726,9 +9726,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             selectSql = unionSql;
         else
             selectSql = new SQLFragment("SELECT * FROM (").append(unionSql).append(") WHERE Container ").appendInClause(cf.getIds(), CoreSchema.getInstance().getSchema().getSqlDialect());
-        final int MAX_MISSING_COUNT = 1000;
+        final int MAX_MISSING_COUNT = 1_000;
+        final int MAX_ROWS = 100_000;
         int missingCount = 0;
-        try (ResultSet rs = new SqlSelector(CoreSchema.getInstance().getSchema(), selectSql).getResultSet(false))
+        try (ResultSet rs = new SqlSelector(CoreSchema.getInstance().getSchema(), selectSql).setMaxRows(MAX_ROWS).getResultSet(false))
         {
             while (rs.next())
             {

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -7911,9 +7911,19 @@ public class ExperimentController extends SpringActionController
         @Override
         public Object execute(Object o, BindException errors) throws Exception
         {
+            Map<String, Map<String, MissingFilesCheckInfo>> info = ExperimentServiceImpl.get().doMissingFilesCheck(getUser(), getContainer(), true);
+            JSONObject results = new JSONObject();
+            for (String containerId : info.keySet())
+            {
+                JSONObject containerResults = new JSONObject();
+                for (String sourceName : info.get(containerId).keySet())
+                    containerResults.put(sourceName, info.get(containerId).get(sourceName).toJSON());
+                results.put(containerId, containerResults);
+            }
+
             ApiSimpleResponse response = new ApiSimpleResponse();
             response.put("success", true);
-            response.put("result", ExperimentServiceImpl.get().doMissingFilesCheck(getUser(), getContainer()));
+            response.put("result", results);
             return response;
         }
     }


### PR DESCRIPTION
#### Rationale
The related PR added support for a better app user experience for assay imports that includes File fields at the results domain. With that, we want to track a metric counting the valid file paths for these fields. This PR adds that to the existing FileLinkMetricsMaintenanceTask which was already setup to check for missing file paths.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5533

#### Changes
- Update FileLinkMetricsMaintenanceTask to include metric info for valid file paths broken down by type (i.e. schema name)
- doMissingFilesCheck to only track paths for the per container action (otherwise just tracking counts)
