### PR TITLE
AssayAPITest and AssayResultsFileWriter fixes for assay results files updates

### DIFF
--- a/api/src/org/labkey/api/assay/AssayResultsFileWriter.java
+++ b/api/src/org/labkey/api/assay/AssayResultsFileWriter.java
@@ -185,8 +185,7 @@ public class AssayResultsFileWriter<ContextType extends AssayRunUploadContext<? 
         @Test
         public void testGetRunResultsFileDir()
         {
-            String dir = getRunResultsFileDir(_protocol, _run);
-            String[] tokens = dir.split(File.separator);
+            String[] tokens = getRunResultsFileDir(_protocol, _run).split("/\\\\");
             assertEquals("AssayId_123", tokens[0]);
             assertEquals("RunId_456", tokens[1]);
         }
@@ -194,8 +193,7 @@ public class AssayResultsFileWriter<ContextType extends AssayRunUploadContext<? 
         @Test
         public void testGetPipelineResultsFileDir()
         {
-            String dir = getPipelineResultsFileDir(_protocol, "789");
-            String[] tokens = dir.split(File.separator);
+            String[] tokens = getPipelineResultsFileDir(_protocol, "789").split("/\\\\");
             assertEquals("AssayId_123", tokens[0]);
             assertEquals("Job_789", tokens[1]);
         }

--- a/api/src/org/labkey/api/assay/AssayResultsFileWriter.java
+++ b/api/src/org/labkey/api/assay/AssayResultsFileWriter.java
@@ -38,9 +38,9 @@ public class AssayResultsFileWriter<ContextType extends AssayRunUploadContext<? 
         _pipelineJobGUID = pipelineJobGUID;
     }
 
-    public static String getRunResultsFileDir(ExpRun run)
+    public static String getRunResultsFileDir(ExpProtocol protocol, ExpRun run)
     {
-        return "AssayId_" + run.getProtocol().getRowId() + File.separator + "RunId_" + run.getRowId();
+        return "AssayId_" + protocol.getRowId() + File.separator + "RunId_" + run.getRowId();
     }
 
     public static String getPipelineResultsFileDir(ExpProtocol protocol, String pipelineJobGUID)
@@ -50,7 +50,7 @@ public class AssayResultsFileWriter<ContextType extends AssayRunUploadContext<? 
 
     public static Path getAssayFilesDirectoryPath(ExpRun run)
     {
-        String resultsFilePath = getRunResultsFileDir(run);
+        String resultsFilePath = getRunResultsFileDir(run.getProtocol(), run);
         return getAssayFilesDirectoryPath(run.getContainer(), resultsFilePath);
     }
 
@@ -99,7 +99,7 @@ public class AssayResultsFileWriter<ContextType extends AssayRunUploadContext<? 
 
     private String getFileTargetDirName()
     {
-        return _run != null ? getRunResultsFileDir(_run) : getPipelineResultsFileDir(_protocol, _pipelineJobGUID);
+        return _run != null ? getRunResultsFileDir(_protocol, _run) : getPipelineResultsFileDir(_protocol, _pipelineJobGUID);
     }
 
     public void cleanupPostedFiles(Container container, boolean deleteIfEmptyOnly) throws ExperimentException

--- a/api/src/org/labkey/api/assay/AssayResultsFileWriter.java
+++ b/api/src/org/labkey/api/assay/AssayResultsFileWriter.java
@@ -185,13 +185,19 @@ public class AssayResultsFileWriter<ContextType extends AssayRunUploadContext<? 
         @Test
         public void testGetRunResultsFileDir()
         {
-            assertEquals("AssayId_123/RunId_456", getRunResultsFileDir(_run));
+            String dir = getRunResultsFileDir(_protocol, _run);
+            String[] tokens = dir.split(File.separator);
+            assertEquals("AssayId_123", tokens[0]);
+            assertEquals("RunId_456", tokens[1]);
         }
 
         @Test
         public void testGetPipelineResultsFileDir()
         {
-            assertEquals("AssayId_123/Job_789", getPipelineResultsFileDir(_protocol, "789"));
+            String dir = getPipelineResultsFileDir(_protocol, "789");
+            String[] tokens = dir.split(File.separator);
+            assertEquals("AssayId_123", tokens[0]);
+            assertEquals("Job_789", tokens[1]);
         }
 
         @Test

--- a/api/src/org/labkey/api/assay/AssayResultsFileWriter.java
+++ b/api/src/org/labkey/api/assay/AssayResultsFileWriter.java
@@ -185,7 +185,8 @@ public class AssayResultsFileWriter<ContextType extends AssayRunUploadContext<? 
         @Test
         public void testGetRunResultsFileDir()
         {
-            String[] tokens = getRunResultsFileDir(_protocol, _run).split("/\\\\");
+            String dir = getRunResultsFileDir(_protocol, _run);
+            String[] tokens = dir.contains("/") ? dir.split("/") : dir.split("\\\\");
             assertEquals("AssayId_123", tokens[0]);
             assertEquals("RunId_456", tokens[1]);
         }
@@ -193,7 +194,8 @@ public class AssayResultsFileWriter<ContextType extends AssayRunUploadContext<? 
         @Test
         public void testGetPipelineResultsFileDir()
         {
-            String[] tokens = getPipelineResultsFileDir(_protocol, "789").split("/\\\\");
+            String dir = getPipelineResultsFileDir(_protocol, "789");
+            String[] tokens = dir.contains("/") ? dir.split("/") : dir.split("\\\\");
             assertEquals("AssayId_123", tokens[0]);
             assertEquals("Job_789", tokens[1]);
         }


### PR DESCRIPTION
#### Rationale
Fixing test failures that came up after the merge of the changes for the assay results files updates.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5533

#### Changes
- AssayAPITest fix for exception when accessing run.getProtocol() after connection is closed
- AssayResultsFileWriter junit fix for file separator differences
