### PR TITLE
Convert usages of OverlayTrigger off of react-bootstrap

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.51.0"
+        "@labkey/components": "3.53.0-fb-overlayConverts.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -2462,9 +2462,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.51.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.51.0.tgz",
-      "integrity": "sha512-R+rfDIC8lgCf9oBDJKgHRvwRcA0NkD6tYzbkUBc9/WDOsURmnPiBk0nIn4nV1I3SSpi73Ne9d55YA3P8A+huQg==",
+      "version": "3.53.0-fb-overlayConverts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.0-fb-overlayConverts.0.tgz",
+      "integrity": "sha512-wy1QhWOJtJ64fiE6179kLsnTNXXBEwkLlGYFrZn7LgvmgNE9S2Fc0RQKFAuAKGGhRsjHauK3uod+OUeM3VKCpw==",
       "dependencies": {
         "@labkey/api": "1.34.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.53.0-fb-overlayConverts.0"
+        "@labkey/components": "3.53.1"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -2462,9 +2462,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.53.0-fb-overlayConverts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.0-fb-overlayConverts.0.tgz",
-      "integrity": "sha512-wy1QhWOJtJ64fiE6179kLsnTNXXBEwkLlGYFrZn7LgvmgNE9S2Fc0RQKFAuAKGGhRsjHauK3uod+OUeM3VKCpw==",
+      "version": "3.53.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.1.tgz",
+      "integrity": "sha512-M7F17y+pZt/59AlUGQkBms3QHnDmguM/S7eXbaNYV/8nHRe6FCOAfq4WSot1Wxwlaxj9xx/fmeeMsHCPoVa/Bg==",
       "dependencies": {
         "@labkey/api": "1.34.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.51.0"
+    "@labkey/components": "3.53.0-fb-overlayConverts.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.53.0-fb-overlayConverts.0"
+    "@labkey/components": "3.53.1"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.52.0",
+        "@labkey/components": "3.53.0-fb-overlayConverts.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3393,9 +3393,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.52.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.52.0.tgz",
-      "integrity": "sha512-lkQ+ZuZDot61Q5Amee6EnLL5YJU6YVlROD3zEvoXKDbqwcNGFg2q+yAaY4l+HrmR7qrPTAPMUX+MA4KjMKpEvQ==",
+      "version": "3.53.0-fb-overlayConverts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.0-fb-overlayConverts.0.tgz",
+      "integrity": "sha512-wy1QhWOJtJ64fiE6179kLsnTNXXBEwkLlGYFrZn7LgvmgNE9S2Fc0RQKFAuAKGGhRsjHauK3uod+OUeM3VKCpw==",
       "dependencies": {
         "@labkey/api": "1.34.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.53.0-fb-overlayConverts.0",
+        "@labkey/components": "3.53.1",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3393,9 +3393,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.53.0-fb-overlayConverts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.0-fb-overlayConverts.0.tgz",
-      "integrity": "sha512-wy1QhWOJtJ64fiE6179kLsnTNXXBEwkLlGYFrZn7LgvmgNE9S2Fc0RQKFAuAKGGhRsjHauK3uod+OUeM3VKCpw==",
+      "version": "3.53.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.1.tgz",
+      "integrity": "sha512-M7F17y+pZt/59AlUGQkBms3QHnDmguM/S7eXbaNYV/8nHRe6FCOAfq4WSot1Wxwlaxj9xx/fmeeMsHCPoVa/Bg==",
       "dependencies": {
         "@labkey/api": "1.34.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.52.0",
+    "@labkey/components": "3.53.0-fb-overlayConverts.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.53.0-fb-overlayConverts.0",
+    "@labkey/components": "3.53.1",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.52.0"
+        "@labkey/components": "3.53.0-fb-overlayConverts.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -3241,9 +3241,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.52.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.52.0.tgz",
-      "integrity": "sha512-lkQ+ZuZDot61Q5Amee6EnLL5YJU6YVlROD3zEvoXKDbqwcNGFg2q+yAaY4l+HrmR7qrPTAPMUX+MA4KjMKpEvQ==",
+      "version": "3.53.0-fb-overlayConverts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.0-fb-overlayConverts.0.tgz",
+      "integrity": "sha512-wy1QhWOJtJ64fiE6179kLsnTNXXBEwkLlGYFrZn7LgvmgNE9S2Fc0RQKFAuAKGGhRsjHauK3uod+OUeM3VKCpw==",
       "dependencies": {
         "@labkey/api": "1.34.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.53.0-fb-overlayConverts.0"
+        "@labkey/components": "3.53.1"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -3241,9 +3241,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.53.0-fb-overlayConverts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.0-fb-overlayConverts.0.tgz",
-      "integrity": "sha512-wy1QhWOJtJ64fiE6179kLsnTNXXBEwkLlGYFrZn7LgvmgNE9S2Fc0RQKFAuAKGGhRsjHauK3uod+OUeM3VKCpw==",
+      "version": "3.53.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.1.tgz",
+      "integrity": "sha512-M7F17y+pZt/59AlUGQkBms3QHnDmguM/S7eXbaNYV/8nHRe6FCOAfq4WSot1Wxwlaxj9xx/fmeeMsHCPoVa/Bg==",
       "dependencies": {
         "@labkey/api": "1.34.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.53.0-fb-overlayConverts.0"
+    "@labkey/components": "3.53.1"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.52.0"
+    "@labkey/components": "3.53.0-fb-overlayConverts.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.51.0"
+        "@labkey/components": "3.53.0-fb-overlayConverts.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -2642,9 +2642,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.51.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.51.0.tgz",
-      "integrity": "sha512-R+rfDIC8lgCf9oBDJKgHRvwRcA0NkD6tYzbkUBc9/WDOsURmnPiBk0nIn4nV1I3SSpi73Ne9d55YA3P8A+huQg==",
+      "version": "3.53.0-fb-overlayConverts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.0-fb-overlayConverts.0.tgz",
+      "integrity": "sha512-wy1QhWOJtJ64fiE6179kLsnTNXXBEwkLlGYFrZn7LgvmgNE9S2Fc0RQKFAuAKGGhRsjHauK3uod+OUeM3VKCpw==",
       "dependencies": {
         "@labkey/api": "1.34.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.53.0-fb-overlayConverts.0"
+        "@labkey/components": "3.53.1"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -2642,9 +2642,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.53.0-fb-overlayConverts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.0-fb-overlayConverts.0.tgz",
-      "integrity": "sha512-wy1QhWOJtJ64fiE6179kLsnTNXXBEwkLlGYFrZn7LgvmgNE9S2Fc0RQKFAuAKGGhRsjHauK3uod+OUeM3VKCpw==",
+      "version": "3.53.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.1.tgz",
+      "integrity": "sha512-M7F17y+pZt/59AlUGQkBms3QHnDmguM/S7eXbaNYV/8nHRe6FCOAfq4WSot1Wxwlaxj9xx/fmeeMsHCPoVa/Bg==",
       "dependencies": {
         "@labkey/api": "1.34.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.53.0-fb-overlayConverts.0"
+    "@labkey/components": "3.53.1"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.51.0"
+    "@labkey/components": "3.53.0-fb-overlayConverts.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/pipeline/src/org/labkey/pipeline/createPipelineTrigger.jsp
+++ b/pipeline/src/org/labkey/pipeline/createPipelineTrigger.jsp
@@ -25,11 +25,9 @@
 <%@ page import="java.util.function.Function" %>
 <%@ page import="java.util.stream.Collectors" %>
 <%@ page import="org.labkey.api.formSchema.FormSchema" %>
-<%@ page import="com.fasterxml.jackson.databind.ObjectMapper" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="org.labkey.api.util.UniqueID" %>
 <%@ page import="org.labkey.api.pipeline.trigger.PipelineTriggerRegistry" %>
-<%@ page import="org.labkey.api.util.JsonUtil" %>
 <%@ page import="org.labkey.api.util.JavaScriptFragment" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>


### PR DESCRIPTION
#### Rationale
As part of converting usages of components from the react-bootstrap packages, this PR converts several OverlayTrigger/Popover usages to the ui-components internal implementation.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1513

#### Changes
- update @labkey/components package version