### PR TITLE
Issue 50533: furnish server's timezone in server context

### DIFF
--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -44,7 +44,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -1609,6 +1608,11 @@ Parse:
         int date = fullDate.getDate();
 
         return new Date(year, month, date);
+    }
+
+    public static TimeZone getTimeZone()
+    {
+        return _timezoneDefault;
     }
 
     private final static Date ZERO_TIME = new Date(70, 0, 1, 0, 0, 0);

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2115,7 +2115,8 @@ public class PageFlowUtil
         }
     }
 
-    public static String documentToString(Document document) {
+    public static String documentToString(Document document)
+    {
         try
         {
             TransformerFactory tf = TransformerFactory.newInstance();
@@ -2160,6 +2161,7 @@ public class PageFlowUtil
         if (null != shared) // not good
             json.put("sharedContainer", shared.getName());
         json.put("hash", getServerSessionHash());
+        json.put("timezone", DateUtil.getTimeZone().getID());
 
         Container container = context.getContainer();
         User user = context.getUser();

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.53.2"
+        "@labkey/components": "3.53.3-fb-timezones.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -2421,9 +2421,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.34.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.0.tgz",
-      "integrity": "sha512-YSWDzkdK1ed+t7OtaFz9ZmCb2DEyVr7pdmZfVE7W0ZzBZHgfMiCUo9br0+g/dzqUXqxYBjuNgpJtbJhjObe2UQ=="
+      "version": "1.34.1-fb-timezones.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1-fb-timezones.0.tgz",
+      "integrity": "sha512-PicBTsRx+uBbiFjv+0Wive4Qz5y9fJGEihnKATMA2vHJkuneNLK6pHlufhiqVkfTRHTXsJL3RR/p1nqh71JuFw=="
     },
     "node_modules/@labkey/build": {
       "version": "7.3.0",
@@ -2462,11 +2462,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.53.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.2.tgz",
-      "integrity": "sha512-MsaANw+3OifaUAK1GN1/QmuPhecC/NKIiBpd58q+AeCXFlBS7I2jGCWNy6JbbYL7fORF7AZ7SVQsIjIdEcMfKw==",
+      "version": "3.53.3-fb-timezones.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.3-fb-timezones.0.tgz",
+      "integrity": "sha512-ES4MNyekJci1LCTZGinizv92WjuCNZ8MPIOAnrrHGoZRFAF/oBu/XKkIA8LeZlUjR+bo3aMgrVM3drqqxKQL4A==",
       "dependencies": {
-        "@labkey/api": "1.34.0",
+        "@labkey/api": "1.34.1-fb-timezones.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.53.3-fb-timezones.0"
+        "@labkey/components": "3.53.4"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -2421,9 +2421,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.34.1-fb-timezones.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1-fb-timezones.0.tgz",
-      "integrity": "sha512-PicBTsRx+uBbiFjv+0Wive4Qz5y9fJGEihnKATMA2vHJkuneNLK6pHlufhiqVkfTRHTXsJL3RR/p1nqh71JuFw=="
+      "version": "1.34.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1.tgz",
+      "integrity": "sha512-82dASLsBCq2IGecCIYNqFqbC1x/v/qIpH3rvd8e5S/VsFYjtAn9Xkd13DnDe0eO6+i0r54nSlIfLMtBCBKBchQ=="
     },
     "node_modules/@labkey/build": {
       "version": "7.3.0",
@@ -2462,11 +2462,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.53.3-fb-timezones.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.3-fb-timezones.0.tgz",
-      "integrity": "sha512-ES4MNyekJci1LCTZGinizv92WjuCNZ8MPIOAnrrHGoZRFAF/oBu/XKkIA8LeZlUjR+bo3aMgrVM3drqqxKQL4A==",
+      "version": "3.53.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.4.tgz",
+      "integrity": "sha512-MbaSzAvo9rBnq9UF9OH9BMODoqL8XDlgG9yTu7/IfY8jiqA4e1NpDD3r//Q9oF1KGF2Ie75K4cjCUkY0jdeSaQ==",
       "dependencies": {
-        "@labkey/api": "1.34.1-fb-timezones.0",
+        "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.53.2"
+    "@labkey/components": "3.53.3-fb-timezones.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "3.53.3-fb-timezones.0"
+    "@labkey/components": "3.53.4"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.53.3-fb-timezones.0",
+        "@labkey/components": "3.53.4",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3352,9 +3352,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.34.1-fb-timezones.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1-fb-timezones.0.tgz",
-      "integrity": "sha512-PicBTsRx+uBbiFjv+0Wive4Qz5y9fJGEihnKATMA2vHJkuneNLK6pHlufhiqVkfTRHTXsJL3RR/p1nqh71JuFw=="
+      "version": "1.34.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1.tgz",
+      "integrity": "sha512-82dASLsBCq2IGecCIYNqFqbC1x/v/qIpH3rvd8e5S/VsFYjtAn9Xkd13DnDe0eO6+i0r54nSlIfLMtBCBKBchQ=="
     },
     "node_modules/@labkey/build": {
       "version": "7.3.0",
@@ -3393,11 +3393,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.53.3-fb-timezones.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.3-fb-timezones.0.tgz",
-      "integrity": "sha512-ES4MNyekJci1LCTZGinizv92WjuCNZ8MPIOAnrrHGoZRFAF/oBu/XKkIA8LeZlUjR+bo3aMgrVM3drqqxKQL4A==",
+      "version": "3.53.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.4.tgz",
+      "integrity": "sha512-MbaSzAvo9rBnq9UF9OH9BMODoqL8XDlgG9yTu7/IfY8jiqA4e1NpDD3r//Q9oF1KGF2Ie75K4cjCUkY0jdeSaQ==",
       "dependencies": {
-        "@labkey/api": "1.34.1-fb-timezones.0",
+        "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.53.2",
+        "@labkey/components": "3.53.3-fb-timezones.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3352,9 +3352,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.34.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.0.tgz",
-      "integrity": "sha512-YSWDzkdK1ed+t7OtaFz9ZmCb2DEyVr7pdmZfVE7W0ZzBZHgfMiCUo9br0+g/dzqUXqxYBjuNgpJtbJhjObe2UQ=="
+      "version": "1.34.1-fb-timezones.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1-fb-timezones.0.tgz",
+      "integrity": "sha512-PicBTsRx+uBbiFjv+0Wive4Qz5y9fJGEihnKATMA2vHJkuneNLK6pHlufhiqVkfTRHTXsJL3RR/p1nqh71JuFw=="
     },
     "node_modules/@labkey/build": {
       "version": "7.3.0",
@@ -3393,11 +3393,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.53.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.2.tgz",
-      "integrity": "sha512-MsaANw+3OifaUAK1GN1/QmuPhecC/NKIiBpd58q+AeCXFlBS7I2jGCWNy6JbbYL7fORF7AZ7SVQsIjIdEcMfKw==",
+      "version": "3.53.3-fb-timezones.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.3-fb-timezones.0.tgz",
+      "integrity": "sha512-ES4MNyekJci1LCTZGinizv92WjuCNZ8MPIOAnrrHGoZRFAF/oBu/XKkIA8LeZlUjR+bo3aMgrVM3drqqxKQL4A==",
       "dependencies": {
-        "@labkey/api": "1.34.0",
+        "@labkey/api": "1.34.1-fb-timezones.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.53.3-fb-timezones.0",
+    "@labkey/components": "3.53.4",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "3.53.2",
+    "@labkey/components": "3.53.3-fb-timezones.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.53.3-fb-timezones.0"
+        "@labkey/components": "3.53.4"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -3200,9 +3200,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.34.1-fb-timezones.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1-fb-timezones.0.tgz",
-      "integrity": "sha512-PicBTsRx+uBbiFjv+0Wive4Qz5y9fJGEihnKATMA2vHJkuneNLK6pHlufhiqVkfTRHTXsJL3RR/p1nqh71JuFw=="
+      "version": "1.34.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1.tgz",
+      "integrity": "sha512-82dASLsBCq2IGecCIYNqFqbC1x/v/qIpH3rvd8e5S/VsFYjtAn9Xkd13DnDe0eO6+i0r54nSlIfLMtBCBKBchQ=="
     },
     "node_modules/@labkey/build": {
       "version": "7.3.0",
@@ -3241,11 +3241,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.53.3-fb-timezones.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.3-fb-timezones.0.tgz",
-      "integrity": "sha512-ES4MNyekJci1LCTZGinizv92WjuCNZ8MPIOAnrrHGoZRFAF/oBu/XKkIA8LeZlUjR+bo3aMgrVM3drqqxKQL4A==",
+      "version": "3.53.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.4.tgz",
+      "integrity": "sha512-MbaSzAvo9rBnq9UF9OH9BMODoqL8XDlgG9yTu7/IfY8jiqA4e1NpDD3r//Q9oF1KGF2Ie75K4cjCUkY0jdeSaQ==",
       "dependencies": {
-        "@labkey/api": "1.34.1-fb-timezones.0",
+        "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.53.2"
+        "@labkey/components": "3.53.3-fb-timezones.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -3200,9 +3200,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.34.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.0.tgz",
-      "integrity": "sha512-YSWDzkdK1ed+t7OtaFz9ZmCb2DEyVr7pdmZfVE7W0ZzBZHgfMiCUo9br0+g/dzqUXqxYBjuNgpJtbJhjObe2UQ=="
+      "version": "1.34.1-fb-timezones.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1-fb-timezones.0.tgz",
+      "integrity": "sha512-PicBTsRx+uBbiFjv+0Wive4Qz5y9fJGEihnKATMA2vHJkuneNLK6pHlufhiqVkfTRHTXsJL3RR/p1nqh71JuFw=="
     },
     "node_modules/@labkey/build": {
       "version": "7.3.0",
@@ -3241,11 +3241,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.53.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.2.tgz",
-      "integrity": "sha512-MsaANw+3OifaUAK1GN1/QmuPhecC/NKIiBpd58q+AeCXFlBS7I2jGCWNy6JbbYL7fORF7AZ7SVQsIjIdEcMfKw==",
+      "version": "3.53.3-fb-timezones.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.3-fb-timezones.0.tgz",
+      "integrity": "sha512-ES4MNyekJci1LCTZGinizv92WjuCNZ8MPIOAnrrHGoZRFAF/oBu/XKkIA8LeZlUjR+bo3aMgrVM3drqqxKQL4A==",
       "dependencies": {
-        "@labkey/api": "1.34.0",
+        "@labkey/api": "1.34.1-fb-timezones.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.53.3-fb-timezones.0"
+    "@labkey/components": "3.53.4"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "3.53.2"
+    "@labkey/components": "3.53.3-fb-timezones.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.53.3-fb-timezones.0"
+        "@labkey/components": "3.53.4"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -2601,9 +2601,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.34.1-fb-timezones.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1-fb-timezones.0.tgz",
-      "integrity": "sha512-PicBTsRx+uBbiFjv+0Wive4Qz5y9fJGEihnKATMA2vHJkuneNLK6pHlufhiqVkfTRHTXsJL3RR/p1nqh71JuFw=="
+      "version": "1.34.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1.tgz",
+      "integrity": "sha512-82dASLsBCq2IGecCIYNqFqbC1x/v/qIpH3rvd8e5S/VsFYjtAn9Xkd13DnDe0eO6+i0r54nSlIfLMtBCBKBchQ=="
     },
     "node_modules/@labkey/build": {
       "version": "7.3.0",
@@ -2642,11 +2642,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.53.3-fb-timezones.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.3-fb-timezones.0.tgz",
-      "integrity": "sha512-ES4MNyekJci1LCTZGinizv92WjuCNZ8MPIOAnrrHGoZRFAF/oBu/XKkIA8LeZlUjR+bo3aMgrVM3drqqxKQL4A==",
+      "version": "3.53.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.4.tgz",
+      "integrity": "sha512-MbaSzAvo9rBnq9UF9OH9BMODoqL8XDlgG9yTu7/IfY8jiqA4e1NpDD3r//Q9oF1KGF2Ie75K4cjCUkY0jdeSaQ==",
       "dependencies": {
-        "@labkey/api": "1.34.1-fb-timezones.0",
+        "@labkey/api": "1.34.1",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "3.53.2"
+        "@labkey/components": "3.53.3-fb-timezones.0"
       },
       "devDependencies": {
         "@labkey/build": "7.3.0",
@@ -2601,9 +2601,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.34.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.0.tgz",
-      "integrity": "sha512-YSWDzkdK1ed+t7OtaFz9ZmCb2DEyVr7pdmZfVE7W0ZzBZHgfMiCUo9br0+g/dzqUXqxYBjuNgpJtbJhjObe2UQ=="
+      "version": "1.34.1-fb-timezones.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.34.1-fb-timezones.0.tgz",
+      "integrity": "sha512-PicBTsRx+uBbiFjv+0Wive4Qz5y9fJGEihnKATMA2vHJkuneNLK6pHlufhiqVkfTRHTXsJL3RR/p1nqh71JuFw=="
     },
     "node_modules/@labkey/build": {
       "version": "7.3.0",
@@ -2642,11 +2642,11 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "3.53.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.2.tgz",
-      "integrity": "sha512-MsaANw+3OifaUAK1GN1/QmuPhecC/NKIiBpd58q+AeCXFlBS7I2jGCWNy6JbbYL7fORF7AZ7SVQsIjIdEcMfKw==",
+      "version": "3.53.3-fb-timezones.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-3.53.3-fb-timezones.0.tgz",
+      "integrity": "sha512-ES4MNyekJci1LCTZGinizv92WjuCNZ8MPIOAnrrHGoZRFAF/oBu/XKkIA8LeZlUjR+bo3aMgrVM3drqqxKQL4A==",
       "dependencies": {
-        "@labkey/api": "1.34.0",
+        "@labkey/api": "1.34.1-fb-timezones.0",
         "@testing-library/jest-dom": "~5.17.0",
         "@testing-library/react": "~12.1.5",
         "@testing-library/user-event": "~12.8.3",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.53.3-fb-timezones.0"
+    "@labkey/components": "3.53.4"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "3.53.2"
+    "@labkey/components": "3.53.3-fb-timezones.0"
   },
   "devDependencies": {
     "@labkey/build": "7.3.0",


### PR DESCRIPTION
#### Rationale
In support of [Issue 50533](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50533) the server's timezone configuration is now provided in the page's server context.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/177
- https://github.com/LabKey/labkey-ui-components/pull/1517
- https://github.com/LabKey/labkey-ui-premium/pull/444
- https://github.com/LabKey/limsModules/pull/375
- https://github.com/LabKey/platform/pull/5596

#### Changes
- Supply `"timezone"` in server context supplied to pages.
- Bump @labkey packages
