### PR TITLE
Issues 50584 & 50461: Make ExpirationDate recognized for sample type and restrict field RunId for samples and data classes

### DIFF
--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -126,6 +126,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         RESERVED_NAMES.add("Sample ID");
         RESERVED_NAMES.add("Status");
         RESERVED_NAMES.add("Amount");
+        RESERVED_NAMES.add("RunId"); // Issue 50461
         RESERVED_NAMES.addAll(InventoryService.INVENTORY_STATUS_COLUMN_NAMES);
         RESERVED_NAMES.addAll(InventoryService.INVENTORY_STATUS_COLUMN_LABELS);
 

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -105,6 +105,7 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
         RESERVED_NAMES = new CaseInsensitiveHashSet(BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()));
         RESERVED_NAMES.addAll(Arrays.asList(ExpDataClassDataTable.Column.values()).stream().map(ExpDataClassDataTable.Column::name).collect(Collectors.toList()));
         RESERVED_NAMES.add("Container");
+        RESERVED_NAMES.add("RunId"); // Issue 50461
 
         FOREIGN_KEYS = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(
                 // NOTE: We join to exp.data using LSID instead of rowid for insert performance -- we will generate

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -182,6 +182,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         SAMPLE_ALT_IMPORT_NAME_COLS = new CaseInsensitiveHashMap<>();
         SAMPLE_ALT_IMPORT_NAME_COLS.put("SampleId", "Name");
         SAMPLE_ALT_IMPORT_NAME_COLS.put("Sample Id", "Name");
+        SAMPLE_ALT_IMPORT_NAME_COLS.put("ExpirationDate", "MaterialExpDate");
     }
 
     public enum Options


### PR DESCRIPTION
#### Rationale
- Issue [50584](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50584)
- Issue [50461](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50461)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/378

#### Changes
- Add `RunId` to list of reserved fields for both sample types and data classes
- Add renaming mapping for "ExpirationDate" to "MaterialExpDate" ("Expiration Date" already gets mapped because it is the field label)