### PR TITLE
Fix study navigator filters when visit has no label

### DIFF
--- a/study/src/org/labkey/study/view/overview.jsp
+++ b/study/src/org/labkey/study/view/overview.jsp
@@ -79,6 +79,7 @@
     String subjectNoun = StudyService.get().getSubjectNounSingular(container);
     String qcUrlFilterKey = getQCUrlFilterKey(CompareType.EQUAL, DatasetQueryView.DATAREGION);
     String visitLabelUrlFilterKey = visitManager.getVisitLabelUrlFilterKey(container, DatasetQueryView.DATAREGION);
+    String visitLabelRowIdFilterKey = visitManager.getVisitRowIdUrlFilterKey(container, DatasetQueryView.DATAREGION);
 
     boolean showCohorts = CohortManager.getInstance().hasCohortMenu(container, user);
     Cohort selectedCohort = null;
@@ -186,14 +187,14 @@
             for (VisitStatistic v : bean.stats)
             {
         %><%=unsafe(slash)%><%
-            if (v == VisitStatistic.ParticipantCount)
-            {
+                if (v == VisitStatistic.ParticipantCount)
+                {
         %><%=h(visits.isEmpty() ? subjectNoun + " Count" : "All " + visitsLabel)%><%
-        }
-        else
-        {
+                }
+                else
+                {
         %><%=h(v.getDisplayString(study))%><%
-            }
+                }
                 slash = " / ";
             }
         %></td>
@@ -257,11 +258,11 @@
         </td>
     </tr>
     <%
+                }
+                prevCategory = category;
             }
-            prevCategory = category;
-        }
 
-        String datasetLabel = (dataset.getLabel() != null ? dataset.getLabel() : "" + dataset.getDatasetId());
+            String datasetLabel = (dataset.getLabel() != null ? dataset.getLabel() : "" + dataset.getDatasetId());
     %>
     <tr class="<%=getShadeRowClass(row)%>">
         <td align="center" style="font-weight:bold;" category="<%= h(dataset.getCategory()) %>"><%= h(datasetLabel) %><%
@@ -352,7 +353,10 @@
                 else if (userCanRead)
                 {
                     ActionURL datasetLink = new ActionURL(DatasetAction.class, container);
-                    datasetLink.addParameter(visitLabelUrlFilterKey, visit.getLabel());
+                    if (StringUtils.isBlank(visit.getLabel()))
+                        datasetLink.addParameter(visitLabelRowIdFilterKey, visit.getRowId());
+                    else
+                        datasetLink.addParameter(visitLabelUrlFilterKey, visit.getLabel());
                     datasetLink.addParameter(Dataset.DATASET_KEY, dataset.getDatasetId());
                     if (selectedCohort != null)
                         cohortFilter.addURLParameters(study, datasetLink, DatasetQueryView.DATAREGION);

--- a/study/src/org/labkey/study/visitmanager/VisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/VisitManager.java
@@ -16,6 +16,7 @@
 
 package org.labkey.study.visitmanager;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -757,7 +758,6 @@ public abstract class VisitManager
         return new SqlExecutor(study.getScope()).execute(sqlDelete);
     }
 
-
     StudyImpl getStudy()
     {
         return _study;
@@ -765,8 +765,18 @@ public abstract class VisitManager
 
     public String getVisitLabelUrlFilterKey(Container container, String dataRegionName)
     {
-        String participantVisitTableName = StudyService.get().getSubjectVisitTableName(container);
-        return new CompareType.CompareClause(FieldKey.fromParts(participantVisitTableName, "Visit", "Label"), CompareType.EQUAL, false).toURLParam( dataRegionName + ".").getKey();
+        return getVisitUrlFilterKey(container, dataRegionName, "Visit", "Label");
+    }
+
+    public String getVisitRowIdUrlFilterKey(Container container, String dataRegionName)
+    {
+        return getVisitUrlFilterKey(container, dataRegionName, "Visit");
+    }
+
+    private String getVisitUrlFilterKey(Container container, String dataRegionName, String... fieldKeyParts)
+    {
+        fieldKeyParts = ArrayUtils.insert(0, fieldKeyParts, StudyService.get().getSubjectVisitTableName(container));
+        return new CompareType.CompareClause(FieldKey.fromParts(fieldKeyParts), CompareType.EQUAL, "").toURLParam( dataRegionName + ".").getKey();
     }
 
     private static class ParticipantPurgeContextListener implements ShutdownListener


### PR DESCRIPTION
#### Rationale
In the related PR, study navigator started creating dataset links with a visit label URL filter instead of a one-off visitRowId parameter. This works great... except when the visit lacks a label. We now add a URL filter on the RowId in that case. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=44350

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5537