### PR TITLE
Push SecurableResource into ImpersonationContext methods

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -1074,7 +1074,11 @@ public class ModuleLoader implements MemTrackerListener
         }
 
         for (String e : excludeSet)
-            includedModules.remove(e);
+        {
+            Module module = includedModules.remove(e);
+            if (module != null)
+                _log.info("Excluding module {} since it was specified in the exclude startup property", module.getName());
+        }
 
         return new ArrayList<>(includedModules.values());
     }

--- a/api/src/org/labkey/api/reports/report/view/ReportUtil.java
+++ b/api/src/org/labkey/api/reports/report/view/ReportUtil.java
@@ -425,9 +425,7 @@ public class ReportUtil
 
         if (role != null)
         {
-            Set<Role> roles = SecurityManager.getEffectiveRoles(container, user);
-
-            return roles.contains(role);
+            return SecurityManager.getEffectiveRoles(container, user).anyMatch(r -> r.equals(role));
         }
         return false;
     }

--- a/api/src/org/labkey/api/security/Group.java
+++ b/api/src/org/labkey/api/security/Group.java
@@ -19,7 +19,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.roles.Role;
 
-import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * A group may be scoped to either the entire server or a specific project. It is a collection of users and/or
@@ -127,9 +127,10 @@ public class Group extends UserPrincipal
     }
 
     @Override
-    public Set<Role> getAssignedRoles(SecurityPolicy policy)
+    public Stream<Role> getAssignedRoles(SecurableResource resource)
     {
-        return policy.getRoles(getGroups());
+        SecurityPolicy policy = SecurityPolicyManager.getPolicy(resource);
+        return policy.getRoles(getGroups()).stream();
     }
 
     @Override

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3255,7 +3255,7 @@ public class SecurityManager
         if (principal instanceof User user && resource.getResourceContainer().isForbiddenProject(user))
             return Set.of();
 
-        Stream<Role> roles = principal.getAssignedRoles(resource).stream()
+        Stream<Role> roles = principal.getAssignedRoles(resource)
             .filter(Objects::nonNull);
 
         if (null != contextualRoles && !contextualRoles.isEmpty())
@@ -3295,7 +3295,7 @@ public class SecurityManager
      */
     public static Set<Role> getEffectiveRoles(@NotNull SecurableResource resource, @NotNull UserPrincipal principal)
     {
-        return principal.getAssignedRoles(resource);
+        return principal.getAssignedRoles(resource).collect(Collectors.toSet());
     }
 
     private enum HasPermissionOption
@@ -3539,9 +3539,10 @@ public class SecurityManager
                 }
 
                 @Override
-                public Set<Role> getAssignedRoles(SecurityPolicy policy)
+                public Stream<Role> getAssignedRoles(SecurableResource resource)
                 {
-                    return policy.getRoles(getGroups());
+                    SecurityPolicy policy = SecurityPolicyManager.getPolicy(resource);
+                    return policy.getRoles(getGroups()).stream();
                 }
 
                 @Override

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3293,9 +3293,9 @@ public class SecurityManager
      * @param principal The principal
      * @return The roles this principal is playing in the securable resource
      */
-    public static Set<Role> getEffectiveRoles(@NotNull SecurableResource resource, @NotNull UserPrincipal principal)
+    public static Stream<Role> getEffectiveRoles(@NotNull SecurableResource resource, @NotNull UserPrincipal principal)
     {
-        return principal.getAssignedRoles(resource).collect(Collectors.toSet());
+        return principal.getAssignedRoles(resource);
     }
 
     private enum HasPermissionOption

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -53,6 +53,7 @@ import org.labkey.api.view.ActionURL;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Represents a user in the LabKey system, typically tied to a specific individual, but see {@link GuestUser} for a
@@ -117,9 +118,9 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
 
         @Override
         @JsonIgnore
-        public Set<Role> getAssignedRoles(SecurityPolicy policy)
+        public Stream<Role> getAssignedRoles(SecurableResource resource)
         {
-            return super.getAssignedRoles(policy);
+            return super.getAssignedRoles(resource);
         }
     }
 
@@ -344,9 +345,9 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
     }
 
     @Override
-    public Set<Role> getAssignedRoles(SecurityPolicy policy)
+    public Stream<Role> getAssignedRoles(SecurableResource resource)
     {
-        return _impersonationContext.getAssignedRoles(this, policy);
+        return _impersonationContext.getAssignedRoles(this, resource);
     }
 
     public JSONObject getUserProps()
@@ -354,7 +355,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
         return User.getUserProps(this);
     }
 
-    public Set<Role> getSiteRoles()
+    public final Stream<Role> getSiteRoles()
     {
         return _impersonationContext.getSiteRoles(this);
     }

--- a/api/src/org/labkey/api/security/UserPrincipal.java
+++ b/api/src/org/labkey/api/security/UserPrincipal.java
@@ -25,7 +25,7 @@ import org.labkey.api.security.roles.Role;
 
 import java.io.Serializable;
 import java.security.Principal;
-import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * A user-oriented principal within the system. This encompasses both {@link User}s and {@link Group}s (of groups and users).
@@ -100,16 +100,7 @@ public abstract class UserPrincipal implements Principal, Parameter.JdbcParamete
     /**
      * @return the roles assigned to this principal in the provided securable resource
      */
-    public Set<Role> getAssignedRoles(SecurableResource resource)
-    {
-        return getAssignedRoles(SecurityPolicyManager.getPolicy(resource));
-    }
-
-    /**
-     * @return the roles assigned to this principal in the provided policy
-     * Outside callers should not use this. TODO: Make protected, or eliminate in favor of SecurableResource variant
-     */
-    public abstract Set<Role> getAssignedRoles(SecurityPolicy policy);
+    public abstract Stream<Role> getAssignedRoles(SecurableResource resource);
 
     public abstract boolean isInGroup(int group);
 

--- a/api/src/org/labkey/api/security/impersonation/AbstractImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/AbstractImpersonationContext.java
@@ -26,7 +26,7 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 
-import java.util.Set;
+import java.util.stream.Stream;
 
 public abstract class AbstractImpersonationContext implements ImpersonationContext
 {
@@ -85,10 +85,10 @@ public abstract class AbstractImpersonationContext implements ImpersonationConte
     /**
      * @return A set of roles with the privileged roles filtered out if the impersonating admin user isn't allowed them
      */
-    protected Set<Role> getFilteredRoles(Set<Role> roles)
+    protected Stream<Role> getFilteredRoles(Stream<Role> roles)
     {
         if (getAdminUser() != null && !getAdminUser().hasRootPermission(CanImpersonatePrivilegedSiteRolesPermission.class))
-            roles.removeIf(Role::isPrivileged);
+            return roles.filter(role -> !role.isPrivileged());
 
         return roles;
     }

--- a/api/src/org/labkey/api/security/impersonation/DisallowPrivilegedRolesContext.java
+++ b/api/src/org/labkey/api/security/impersonation/DisallowPrivilegedRolesContext.java
@@ -19,11 +19,11 @@ package org.labkey.api.security.impersonation;
   A "not impersonating" context that filters out privileged site roles (i.e., Site Admin, Platform Developer)
  */
 
-import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.User;
 import org.labkey.api.security.roles.Role;
 
-import java.util.Set;
+import java.util.stream.Stream;
 
 public class DisallowPrivilegedRolesContext extends NotImpersonatingContext
 {
@@ -45,11 +45,8 @@ public class DisallowPrivilegedRolesContext extends NotImpersonatingContext
     }
 
     @Override
-    public Set<Role> getAssignedRoles(User user, SecurityPolicy policy)
+    public Stream<Role> getAssignedRoles(User user, SecurableResource resource)
     {
-        Set<Role> roles = super.getAssignedRoles(user, policy);
-        roles.removeIf(Role::isPrivileged);
-
-        return roles;
+        return super.getAssignedRoles(user, resource).filter(role -> !role.isPrivileged());
     }
 }

--- a/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
@@ -18,6 +18,7 @@ package org.labkey.api.security.impersonation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.servlet.http.HttpServletRequest;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.Container;
@@ -25,8 +26,8 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.GroupMembershipCache;
 import org.labkey.api.security.PrincipalArray;
+import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityManager;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.AdminPermission;
@@ -36,11 +37,10 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Used to indicate that a user is impersonating a specific group (site or project), and is not operating as their
@@ -232,9 +232,9 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
         }
 
         @Override
-        public Set<Role> getAssignedRoles(User user, SecurityPolicy policy)
+        public Stream<Role> getAssignedRoles(User user, SecurableResource resource)
         {
-            return getFilteredRoles(super.getAssignedRoles(user, policy));
+            return getFilteredRoles(super.getAssignedRoles(user, resource));
         }
     }
 }

--- a/api/src/org/labkey/api/security/impersonation/ImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/ImpersonationContext.java
@@ -60,7 +60,7 @@ public interface ImpersonationContext extends Serializable
     {
         Stream<Role> roles = getSiteRoles(user);
         SecurityPolicy policy = SecurityPolicyManager.getPolicy(resource);
-        return Streams.concat(roles, policy.getRoles(user.getGroups()).stream());
+        return Streams.concat(roles, policy.getRoles(user.getGroups()).stream()).distinct();
     }
 
     /**

--- a/api/src/org/labkey/api/security/impersonation/ImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/ImpersonationContext.java
@@ -15,11 +15,14 @@
  */
 package org.labkey.api.security.impersonation;
 
+import com.google.common.collect.Streams;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.PrincipalArray;
+import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.roles.NoPermissionsRole;
@@ -50,21 +53,21 @@ public interface ImpersonationContext extends Serializable
     PrincipalArray getGroups(User user);
 
     /**
-     * @return The roles assigned to this user in the provided policy as well as the root. The roles may be modified
-     * and/or filtered by the impersonation context.
+     * @return The roles assigned to this user in the provided resource's policy as well as the root. The roles may be
+     * modified and/or filtered by the impersonation context.
      */
-    default Set<Role> getAssignedRoles(User user, SecurityPolicy policy)
+    default Stream<Role> getAssignedRoles(User user, SecurableResource resource)
     {
-        Set<Role> roles = getSiteRoles(user);
-        roles.addAll(policy.getRoles(user.getGroups()));
-        return roles;
+        Stream<Role> roles = getSiteRoles(user);
+        SecurityPolicy policy = SecurityPolicyManager.getPolicy(resource);
+        return Streams.concat(roles, policy.getRoles(user.getGroups()).stream());
     }
 
     /**
      * @return The roles assigned to this user in the root. The roles may be modified and/or filtered by the
      * impersonation context.
      */
-    default Set<Role> getSiteRoles(User user)
+    default Stream<Role> getSiteRoles(User user)
     {
         Container root = ContainerManager.getRoot();
         SecurityPolicy policy = root.getPolicy();
@@ -73,7 +76,7 @@ public interface ImpersonationContext extends Serializable
         for (Role role : roles)
             assert role.isApplicable(policy, root);
 
-        return roles;
+        return roles.stream();
     }
 
     ImpersonationContextFactory getFactory();

--- a/api/src/org/labkey/api/security/impersonation/ReadOnlyImpersonatingContext.java
+++ b/api/src/org/labkey/api/security/impersonation/ReadOnlyImpersonatingContext.java
@@ -1,7 +1,7 @@
 package org.labkey.api.security.impersonation;
 
 import org.labkey.api.data.Container;
-import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AllowedForReadOnlyUser;
 import org.labkey.api.security.permissions.Permission;
@@ -9,7 +9,6 @@ import org.labkey.api.security.roles.Role;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 
-import java.util.Set;
 import java.util.stream.Stream;
 
 public class ReadOnlyImpersonatingContext extends NotImpersonatingContext
@@ -22,11 +21,9 @@ public class ReadOnlyImpersonatingContext extends NotImpersonatingContext
     }
 
     @Override
-    public Set<Role> getAssignedRoles(User user, SecurityPolicy policy)
+    public Stream<Role> getAssignedRoles(User user, SecurableResource resource)
     {
-        var ret = super.getAssignedRoles(user, policy);
-        ret.removeIf(Role::isPrivileged);
-        return ret;
+        return super.getAssignedRoles(user, resource).filter(role -> !role.isPrivileged());
     }
 
     @Override

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -165,7 +165,6 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         return UserManager.getUser(_adminUserId);
     }
 
-
     @Override
     public void stopImpersonating(HttpServletRequest request)
     {
@@ -204,7 +203,7 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
 
     private static class RoleImpersonationContext extends AbstractImpersonationContext
     {
-        /** Hold on to the role names and not the Roles themselves for serialization purposes. See issue #15660 */
+        /** Hold on to the role names and not the Roles themselves for serialization purposes. See Issue #15660 */
         // TODO: Hold only Set<Role> and use custom serialization, see below
         private final Set<String> _roleNames;
         private transient Set<Role> _roles;
@@ -310,7 +309,9 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         @Override
         public Stream<Role> getAssignedRoles(User user, SecurableResource resource)
         {
-            return getRoles().stream(); // No filtering - we trust verifyPermissions to validate that the admin is allowed to impersonate the specified roles
+            // No filtering - we trust verifyPermissions to validate that the admin is allowed to impersonate the
+            // specified roles. See Issue #50248 to understand the Container check.
+            return resource instanceof Container ? getRoles().stream() : Stream.empty();
         }
 
         @Override

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -18,12 +18,13 @@ package org.labkey.api.security.impersonation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.collections4.CollectionUtils;
+import jakarta.servlet.http.HttpServletRequest;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.PrincipalArray;
+import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
@@ -40,7 +41,6 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -301,16 +301,16 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         }
 
         @Override
-        public Set<Role> getSiteRoles(User user)
+        public Stream<Role> getSiteRoles(User user)
         {
             // Return only site roles that are being impersonated
-            return new HashSet<>(CollectionUtils.intersection(super.getSiteRoles(user), getRoles()));
+            return super.getSiteRoles(user).filter(role -> getRoles().contains(role));
         }
 
         @Override
-        public Set<Role> getAssignedRoles(User user, SecurityPolicy policy)
+        public Stream<Role> getAssignedRoles(User user, SecurableResource resource)
         {
-            return getRoles(); // No filtering - we trust verifyPermissions to validate that the admin is allowed to impersonate the specified roles
+            return getRoles().stream(); // No filtering - we trust verifyPermissions to validate that the admin is allowed to impersonate the specified roles
         }
 
         @Override

--- a/api/src/org/labkey/api/security/impersonation/UserImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/UserImpersonationContextFactory.java
@@ -18,14 +18,15 @@ package org.labkey.api.security.impersonation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.servlet.http.HttpServletRequest;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.GroupManager;
 import org.labkey.api.security.PrincipalArray;
+import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityManager;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.permissions.AdminPermission;
@@ -36,10 +37,9 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Context representing that a user is impersonating another user, and should not be treated as their normal self.
@@ -220,9 +220,9 @@ public class UserImpersonationContextFactory extends AbstractImpersonationContex
         }
 
         @Override
-        public Set<Role> getAssignedRoles(User user, SecurityPolicy policy)
+        public Stream<Role> getAssignedRoles(User user, SecurableResource resource)
         {
-            return getFilteredRoles(super.getAssignedRoles(user, policy));
+            return getFilteredRoles(super.getAssignedRoles(user, resource));
         }
     }
 }

--- a/api/src/org/labkey/api/security/impersonation/WrappedImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/WrappedImpersonationContext.java
@@ -88,7 +88,7 @@ public class WrappedImpersonationContext implements ImpersonationContext
     @Override
     public Stream<Role> getAssignedRoles(User user, SecurableResource resource)
     {
-        return Streams.concat(_additionalRoles.stream(), _delegate.getAssignedRoles(user, resource));
+        return Streams.concat(_additionalRoles.stream(), _delegate.getAssignedRoles(user, resource)).distinct();
     }
 
     @Override

--- a/api/src/org/labkey/api/security/impersonation/WrappedImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/WrappedImpersonationContext.java
@@ -15,17 +15,17 @@
  */
 package org.labkey.api.security.impersonation;
 
+import com.google.common.collect.Streams;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.PrincipalArray;
-import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -86,11 +86,9 @@ public class WrappedImpersonationContext implements ImpersonationContext
     }
 
     @Override
-    public Set<Role> getAssignedRoles(User user, SecurityPolicy policy)
+    public Stream<Role> getAssignedRoles(User user, SecurableResource resource)
     {
-        Set<Role> ret = new HashSet<>(_additionalRoles);
-        ret.addAll(_delegate.getAssignedRoles(user, policy));
-        return ret;
+        return Streams.concat(_additionalRoles.stream(), _delegate.getAssignedRoles(user, resource));
     }
 
     @Override

--- a/api/src/org/labkey/api/security/roles/RoleSet.java
+++ b/api/src/org/labkey/api/security/roles/RoleSet.java
@@ -1,0 +1,104 @@
+package org.labkey.api.security.roles;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.WritableTypeId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+// Wrapper that holds a set of Roles that need to be serialized/deserialized via JSON. I had hoped to instead create a
+// custom serializer/deserializer for our singleton Roles, but Jackson doesn't seem to support this pattern.
+@JsonSerialize(using = RoleSet.RoleSetSerializer.class)
+@JsonDeserialize(using = RoleSet.RoleSetDeserializer.class)
+public class RoleSet
+{
+    private final Set<Role> _roles;
+
+    public RoleSet(Collection<Role> roles)
+    {
+        _roles = Set.copyOf(roles);
+    }
+
+    public Set<Role> getRoles()
+    {
+        return _roles;
+    }
+
+    public boolean isEmpty()
+    {
+        return _roles.isEmpty();
+    }
+
+    public boolean contains(Role role)
+    {
+        return _roles.contains(role);
+    }
+
+    public Stream<Role> stream()
+    {
+        return _roles.stream();
+    }
+
+    public static class RoleSetSerializer extends StdSerializer<RoleSet>
+    {
+        @SuppressWarnings("unused")
+        public RoleSetSerializer()
+        {
+            super(RoleSet.class);
+        }
+
+        @Override
+        public void serialize(RoleSet roleSet, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException
+        {
+            jsonGenerator.writeFieldName("roles");
+            String[] roleNames = roleSet.getRoles().stream().map(Role::getUniqueName).toArray(String[]::new);
+            jsonGenerator.writeArray(roleNames, 0, roleNames.length);
+        }
+
+        @Override
+        public void serializeWithType(RoleSet roleSet, JsonGenerator gen, SerializerProvider serializers, TypeSerializer typeSer) throws IOException
+        {
+            WritableTypeId typeIdDef = typeSer.writeTypePrefix(gen, typeSer.typeId(roleSet, JsonToken.START_OBJECT));
+            serialize(roleSet, gen, serializers);
+            typeSer.writeTypeSuffix(gen, typeIdDef);
+        }
+    }
+
+    public static class RoleSetDeserializer extends StdDeserializer<RoleSet>
+    {
+        @SuppressWarnings("unused")
+        public RoleSetDeserializer()
+        {
+            super(RoleSet.class);
+        }
+
+        @Override
+        public RoleSet deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JacksonException
+        {
+            Set<Role> roles = new HashSet<>();
+            JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+            for (JsonNode jsonNode : node.get("roles"))
+            {
+                String roleName = jsonNode.textValue();
+                Role role = RoleManager.getRole(roleName);
+                if (role != null)
+                    roles.add(role);
+            }
+            return new RoleSet(roles);
+        }
+    }
+}

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -195,13 +195,8 @@ public class SecurityApiActions
                     groupPerms.put("roleLabel", role.getLabel());
                 }
 
-                //add effective roles array
-                Set<Role> effectiveRoles = SecurityManager.getEffectiveRoles(container, group);
-                ArrayList<String> effectiveRoleList = new ArrayList<>();
-                for (Role effectiveRole : effectiveRoles)
-                {
-                    effectiveRoleList.add(effectiveRole.getUniqueName());
-                }
+                //add effective roles
+                List<String> effectiveRoleList = SecurityManager.getEffectiveRoles(container, group).map(Role::getUniqueName).toList();
                 groupPerms.put("roles", effectiveRoleList);
                 groupPerms.put("effectivePermissions", SecurityManager.getPermissionNames(container, group));
 
@@ -340,11 +335,7 @@ public class SecurityApiActions
             }
 
             //effective roles
-            List<String> effectiveRoles = new ArrayList<>();
-            for (Role effectiveRole : SecurityManager.getEffectiveRoles(container, user))
-            {
-                effectiveRoles.add(effectiveRole.getUniqueName());
-            }
+            List<String> effectiveRoles = SecurityManager.getEffectiveRoles(container, user).map(Role::getUniqueName).toList();
             permsInfo.put("roles", effectiveRoles);
             permsInfo.put("effectivePermissions", SecurityManager.getPermissionNames(container, user));
 
@@ -369,11 +360,7 @@ public class SecurityApiActions
                 }
 
                 //effective roles
-                List<String> groupEffectiveRoles = new ArrayList<>();
-                for (Role effectiveRole : SecurityManager.getEffectiveRoles(container, group))
-                {
-                    groupEffectiveRoles.add(effectiveRole.getUniqueName());
-                }
+                List<String> groupEffectiveRoles = SecurityManager.getEffectiveRoles(container, group).map(Role::getUniqueName).toList();
                 groupInfo.put("roles", groupEffectiveRoles);
                 groupInfo.put("effectivePermissions", SecurityManager.getPermissionNames(container, group));
 

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -2277,8 +2277,10 @@ public class SecurityController extends SpringActionController
             {
                 user = UserManager.getUser(user.getUserId()); // the cache from UserManager.getUsers might not have the updated groups list
                 Map<String, List<Group>> userAccessGroups = new TreeMap<>();
-                Set<Role> effectiveRoles = SecurityManager.getEffectiveRoles(getContainer(), user);
-                effectiveRoles.remove(RoleManager.getRole(NoPermissionsRole.class)); //ignore no perms
+                Set<Role> effectiveRoles = SecurityManager.getEffectiveRoles(getContainer(), user)
+                    .filter(role -> !(role instanceof NoPermissionsRole))
+                    .collect(Collectors.toSet());
+
                 for (Role role : effectiveRoles)
                 {
                     userAccessGroups.put(role.getName(), new ArrayList<>());

--- a/core/src/org/labkey/core/user/SecurityAccessView.java
+++ b/core/src/org/labkey/core/user/SecurityAccessView.java
@@ -35,7 +35,6 @@ import org.labkey.core.user.UserController.AccessDetail;
 import org.labkey.core.user.UserController.AccessDetailRow;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 // TODO: Reconcile with FolderAccessAction as well
 // TODO: Move AccessDetail, FolderAccessForm, AccessDetail into this class
@@ -104,8 +104,9 @@ public class SecurityAccessView extends VBox
             if (!child.isContainerFor(ContainerType.DataType.permissions))
                 continue;
 
-            Collection<Role> allRoles = SecurityManager.getEffectiveRoles(child, _principal);
-            allRoles.remove(RoleManager.getRole(NoPermissionsRole.class)); //ignore no perms
+            Set<Role> allRoles = SecurityManager.getEffectiveRoles(child, _principal)
+                .filter(role -> role instanceof NoPermissionsRole)
+                .collect(Collectors.toSet());
 
             List<Role> roles = new ArrayList<>();
             if (filterSiteRoles)

--- a/core/src/org/labkey/core/user/SecurityAccessView.java
+++ b/core/src/org/labkey/core/user/SecurityAccessView.java
@@ -105,7 +105,7 @@ public class SecurityAccessView extends VBox
                 continue;
 
             Set<Role> allRoles = SecurityManager.getEffectiveRoles(child, _principal)
-                .filter(role -> role instanceof NoPermissionsRole)
+                .filter(role -> !(role instanceof NoPermissionsRole))
                 .collect(Collectors.toSet());
 
             List<Role> roles = new ArrayList<>();

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -2991,7 +2991,7 @@ public class UserController extends SpringActionController
         public ApiResponse execute(Object object, BindException errors)
         {
             ImpersonationContext context = authorizeImpersonateRoles();
-            Set<Role> impersonationRoles = context.isImpersonating() ? context.getAssignedRoles(getUser(), getContainer().getPolicy()) : Collections.emptySet();
+            Set<Role> impersonationRoles = context.isImpersonating() ? context.getAssignedRoles(getUser(), getContainer()).collect(Collectors.toSet()) : Collections.emptySet();
 
             User user = context.isImpersonating() ? context.getAdminUser() : getUser();
             ApiSimpleResponse response = new ApiSimpleResponse();
@@ -3056,7 +3056,7 @@ public class UserController extends SpringActionController
         public String impersonate(ImpersonateRolesForm form)
         {
             ImpersonationContext context = authorizeImpersonateRoles();
-            Set<Role> currentImpersonationRoles = context.isImpersonating() ? context.getAssignedRoles(getUser(), getContainer().getPolicy()) : Collections.emptySet();
+            Set<Role> currentImpersonationRoles = context.isImpersonating() ? context.getAssignedRoles(getUser(), getContainer()).collect(Collectors.toSet()) : Collections.emptySet();
 
             String[] roleNames = form.getRoleNames();
 

--- a/query/src/org/labkey/query/LinkedSchema.java
+++ b/query/src/org/labkey/query/LinkedSchema.java
@@ -68,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class LinkedSchema extends ExternalSchema
 {
@@ -605,7 +606,7 @@ public class LinkedSchema extends ExternalSchema
         }
 
         @Override
-        public Set<Role> getAssignedRoles(SecurableResource resource)
+        public Stream<Role> getAssignedRoles(SecurableResource resource)
         {
             // If the resource is allowed (current container or current study) then return the ReaderRole that's set on the LimitedUser
             if (_allowedResourceIds.contains(resource.getResourceId()))
@@ -614,7 +615,7 @@ public class LinkedSchema extends ExternalSchema
             }
 
             // For all other containers and studies, no permissions
-            return Collections.emptySet();
+            return Stream.empty();
         }
     }
 }


### PR DESCRIPTION
#### Rationale
Last meter of the `SecurableResource` -> `SecurityPolicy` work. `getAssignedRoles()`, `getSiteRoles()`, and `getEffectiveRoles()` all take a SecurableResource now. They also return `Stream<Role>` to avoid interim `Set` and `Stream` creation in most permissions code paths.

Introduce `RoleSet` and use it to serialize role impersonation context in a sane manner.

Address https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=50248

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5577