### PR TITLE
Issue 50543: 'Does Not Equal Any Of' conditional formatting not working

### DIFF
--- a/api/src/org/labkey/api/data/SimpleFilter.java
+++ b/api/src/org/labkey/api/data/SimpleFilter.java
@@ -825,10 +825,11 @@ public class SimpleFilter implements Filter
                 FilterClause compareClause = CompareType.EQUAL.createFilterClause(getFieldKeys().get(0), params);
                 if (compareClause.meetsCriteria(col, value))
                 {
-                    return true;
+                    var b = 1==1;
+                    return !_negated;
                 }
             }
-            return false;
+            return _negated;
         }
     }
 


### PR DESCRIPTION
#### Rationale
Like 'Does Not Contain Any Of`, conditional formats using 'Does Not Equal Any Of' need SimpleFilter.InClause to consider if it's being negated.

#### Changes
- Respect the negation flag for conditional formats too
