### PR TITLE
Plate: prevent mutations via query

### DIFF
--- a/assay/resources/schemas/assay.xml
+++ b/assay/resources/schemas/assay.xml
@@ -41,6 +41,7 @@
           <fkTable>PlateSet</fkTable>
           <fkDbSchema>assay</fkDbSchema>
         </fk>
+        <shownInUpdateView>false</shownInUpdateView>
       </column>
       <column columnName="PlateType">
         <description>The plate type of this plate.</description>
@@ -49,6 +50,7 @@
           <fkTable>PlateType</fkTable>
           <fkDbSchema>assay</fkDbSchema>
         </fk>
+        <shownInUpdateView>false</shownInUpdateView>
       </column>
       <column columnName="CreatedBy">
         <datatype>int</datatype>
@@ -100,6 +102,7 @@
       </column>
       <column columnName="AssayType">
         <description>A text label of the plate assay type ("NAb", for example).</description>
+        <shownInUpdateView>false</shownInUpdateView>
       </column>
       <column columnName="Archived">
         <isHidden>true</isHidden>

--- a/assay/resources/schemas/assay.xml
+++ b/assay/resources/schemas/assay.xml
@@ -133,14 +133,19 @@
       <column columnName="Created"/>
       <column columnName="ModifiedBy"/>
       <column columnName="Modified"/>
-      <column columnName="Archived"/>
-      <column columnName="Type"/>
+      <column columnName="Archived">
+        <isUserEditable>false</isUserEditable>
+      </column>
+      <column columnName="Type">
+        <isUserEditable>false</isUserEditable>
+      </column>
       <column columnName="PrimaryPlateSetId">
         <description>
           The nearest parent "primary" plate set in this plate set's lineage. When blank it means the plate set does
           not participate in a lineage (a.k.a. stand-alone plate set).
         </description>
         <isHidden>true</isHidden>
+        <isUserEditable>false</isUserEditable>
       </column>
       <column columnName="RootPlateSetId">
         <description>
@@ -149,6 +154,7 @@
           (a.k.a stand-alone plate set). For top-level "primary" plate sets this will always refer to itself.
         </description>
         <isHidden>true</isHidden>
+        <isUserEditable>false</isUserEditable>
       </column>
       <column columnName="Template">
         <isHidden>true</isHidden>

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1466,9 +1466,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
     private @NotNull QueryUpdateService getPlateUpdateService(Container container, User user)
     {
-        UserSchema schema = getPlateUserSchema(container, user);
-        TableInfo tableInfo = schema.getTableOrThrow(PlateTable.NAME);
-        QueryUpdateService qus = tableInfo.getUpdateService();
+        TableInfo table = PlateSchema.getPlateTable(container, user, null);
+        QueryUpdateService qus = table.getUpdateService();
         if (qus == null)
             throw new IllegalStateException("Unable to resolve QueryUpdateService for Plates.");
 

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1476,9 +1476,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
     private @NotNull QueryUpdateService getPlateSetUpdateService(Container container, User user)
     {
-        UserSchema schema = getPlateUserSchema(container, user);
-        TableInfo tableInfo = schema.getTableOrThrow(PlateSetTable.NAME);
-        QueryUpdateService qus = tableInfo.getUpdateService();
+        TableInfo table = PlateSchema.getPlateSetTable(container, user, null);
+        QueryUpdateService qus = table.getUpdateService();
         if (qus == null)
             throw new IllegalStateException("Unable to resolve QueryUpdateService for PlateSets.");
 

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1464,50 +1464,37 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return AssayDbSchema.getInstance().getTableInfoPlate();
     }
 
-    private @NotNull QueryUpdateService getPlateUpdateService(Container container, User user)
+    private @NotNull TableInfo getWellTable(Container container, User user)
     {
-        TableInfo table = PlateSchema.getPlateTable(container, user, null);
+        return getPlateUserSchema(container, user).getTableOrThrow(WellTable.NAME);
+    }
+
+    private @NotNull QueryUpdateService requiredUpdateService(@NotNull TableInfo table)
+    {
         QueryUpdateService qus = table.getUpdateService();
         if (qus == null)
-            throw new IllegalStateException("Unable to resolve QueryUpdateService for Plates.");
-
+            throw new IllegalStateException(String.format("Unable to resolve QueryUpdateService for %s.", table.getName()));
         return qus;
+    }
+
+    private @NotNull QueryUpdateService getPlateUpdateService(Container container, User user)
+    {
+        return requiredUpdateService(PlateSchema.getPlateTable(container, user, null));
     }
 
     private @NotNull QueryUpdateService getPlateSetUpdateService(Container container, User user)
     {
-        TableInfo table = PlateSchema.getPlateSetTable(container, user, null);
-        QueryUpdateService qus = table.getUpdateService();
-        if (qus == null)
-            throw new IllegalStateException("Unable to resolve QueryUpdateService for PlateSets.");
-
-        return qus;
+        return requiredUpdateService(PlateSchema.getPlateSetTable(container, user, null));
     }
 
     private @NotNull QueryUpdateService getWellGroupUpdateService(Container container, User user)
     {
-        UserSchema schema = getPlateUserSchema(container, user);
-        TableInfo tableInfo = schema.getTableOrThrow(WellGroupTable.NAME);
-        QueryUpdateService qus = tableInfo.getUpdateService();
-        if (qus == null)
-            throw new IllegalStateException("Unable to resolve QueryUpdateService for Well Groups.");
-
-        return qus;
-    }
-
-    private @NotNull TableInfo getWellTable(Container container, User user)
-    {
-        return PlateSchema.getWellTable(container, user, null);
+        return requiredUpdateService(PlateSchema.getWellGroupTable(container, user, null));
     }
 
     private @NotNull QueryUpdateService getWellUpdateService(Container container, User user)
     {
-        TableInfo tableInfo = getWellTable(container, user);
-        QueryUpdateService qus = tableInfo.getUpdateService();
-        if (qus == null)
-            throw new IllegalStateException("Unable to resolve QueryUpdateService for Wells.");
-
-        return qus;
+        return requiredUpdateService(PlateSchema.getWellTable(container, user, null));
     }
 
     private static class PlateLsidHandler implements LsidManager.LsidHandler<Plate>

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -692,14 +692,14 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         {
             for (Plate plate : plateSet.getPlates(user))
             {
-                if (plate.getName().equalsIgnoreCase(name))
+                if (plate.getName() != null && plate.getName().equalsIgnoreCase(name))
                     return true;
             }
             return false;
         }
 
         Plate plate = getPlateByName(c, name);
-        return plate != null && plate.getName().equals(name);
+        return plate != null && plate.getName() != null && plate.getName().equals(name);
     }
 
     public boolean isDuplicatePlateTemplateName(Container container, String name)

--- a/assay/src/org/labkey/assay/plate/query/PlateSchema.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSchema.java
@@ -70,7 +70,7 @@ public class PlateSchema extends SimpleUserSchema
         if (PlateSetTable.NAME.equalsIgnoreCase(name))
             return new PlateSetTable(this, cf, false).init();
         if (PlateTypeTable.NAME.equalsIgnoreCase(name))
-            return new PlateTypeTable(this, cf).init();
+            return new PlateTypeTable(this, cf, false).init();
         if (HitTable.NAME.equalsIgnoreCase(name))
             return new HitTable(this, cf, false).init();
         if (WellGroupTable.NAME.equalsIgnoreCase(name))

--- a/assay/src/org/labkey/assay/plate/query/PlateSchema.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSchema.java
@@ -68,7 +68,7 @@ public class PlateSchema extends SimpleUserSchema
         if (WellTable.NAME.equalsIgnoreCase(name))
             return new WellTable(this, cf, false).init();
         if (PlateSetTable.NAME.equalsIgnoreCase(name))
-            return new PlateSetTable(this, cf).init();
+            return new PlateSetTable(this, cf, false).init();
         if (PlateTypeTable.NAME.equalsIgnoreCase(name))
             return new PlateTypeTable(this, cf).init();
         if (HitTable.NAME.equalsIgnoreCase(name))
@@ -85,6 +85,12 @@ public class PlateSchema extends SimpleUserSchema
             return new WellGroupTypeTable(this);
 
         return null;
+    }
+
+    public static TableInfo getPlateSetTable(Container container, User user, @Nullable ContainerFilter cf)
+    {
+        PlateSchema plateSchema = new PlateSchema(user, container);
+        return new PlateSetTable(plateSchema, cf, true).init();
     }
 
     public static TableInfo getPlateTable(Container container, User user, @Nullable ContainerFilter cf)

--- a/assay/src/org/labkey/assay/plate/query/PlateSchema.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSchema.java
@@ -64,7 +64,7 @@ public class PlateSchema extends SimpleUserSchema
     public TableInfo createTable(String name, ContainerFilter cf)
     {
         if (PlateTable.NAME.equalsIgnoreCase(name))
-            return new PlateTable(this, cf).init();
+            return new PlateTable(this, cf, false).init();
         if (WellTable.NAME.equalsIgnoreCase(name))
             return new WellTable(this, cf, false).init();
         if (PlateSetTable.NAME.equalsIgnoreCase(name))
@@ -85,6 +85,12 @@ public class PlateSchema extends SimpleUserSchema
             return new WellGroupTypeTable(this);
 
         return null;
+    }
+
+    public static TableInfo getPlateTable(Container container, User user, @Nullable ContainerFilter cf)
+    {
+        PlateSchema plateSchema = new PlateSchema(user, container);
+        return new PlateTable(plateSchema, cf, true).init();
     }
 
     public static TableInfo getWellTable(Container container, User user, @Nullable ContainerFilter cf)

--- a/assay/src/org/labkey/assay/plate/query/PlateSchema.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSchema.java
@@ -74,7 +74,7 @@ public class PlateSchema extends SimpleUserSchema
         if (HitTable.NAME.equalsIgnoreCase(name))
             return new HitTable(this, cf, false).init();
         if (WellGroupTable.NAME.equalsIgnoreCase(name))
-            return new WellGroupTable(this, cf).init();
+            return new WellGroupTable(this, cf, false).init();
         if (WellTable.WELL_PROPERTIES_TABLE.equalsIgnoreCase(name))
         {
             Domain domain = PlateManager.get().getPlateMetadataDomain(getContainer(), getUser());
@@ -97,6 +97,12 @@ public class PlateSchema extends SimpleUserSchema
     {
         PlateSchema plateSchema = new PlateSchema(user, container);
         return new PlateTable(plateSchema, cf, true).init();
+    }
+
+    public static TableInfo getWellGroupTable(Container container, User user, @Nullable ContainerFilter cf)
+    {
+        PlateSchema plateSchema = new PlateSchema(user, container);
+        return new WellGroupTable(plateSchema, cf, true).init();
     }
 
     public static TableInfo getWellTable(Container container, User user, @Nullable ContainerFilter cf)

--- a/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
@@ -1,5 +1,6 @@
 package org.labkey.assay.plate.query;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateSet;
@@ -31,6 +32,9 @@ import org.labkey.api.query.RowIdForeignKey;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.security.permissions.Permission;
 import org.labkey.assay.plate.PlateManager;
 import org.labkey.assay.query.AssayDbSchema;
 
@@ -46,6 +50,7 @@ public class PlateSetTable extends SimpleUserSchema.SimpleTable<UserSchema>
 {
     public static final String NAME = "PlateSet";
     private static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
+    private final boolean _allowInsert;
 
     static
     {
@@ -60,9 +65,10 @@ public class PlateSetTable extends SimpleUserSchema.SimpleTable<UserSchema>
         defaultVisibleColumns.add(FieldKey.fromParts("ModifiedBy"));
     }
 
-    public PlateSetTable(PlateSchema schema, @Nullable ContainerFilter cf)
+    public PlateSetTable(PlateSchema schema, @Nullable ContainerFilter cf, boolean allowInsert)
     {
         super(schema, AssayDbSchema.getInstance().getTableInfoPlateSet(), cf);
+        _allowInsert = allowInsert;
         setTitleColumn("Name");
     }
 
@@ -120,6 +126,14 @@ public class PlateSetTable extends SimpleUserSchema.SimpleTable<UserSchema>
     public List<FieldKey> getDefaultVisibleColumns()
     {
         return defaultVisibleColumns;
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        if (!_allowInsert && InsertPermission.class.equals(perm))
+            return false;
+        return super.hasPermission(user, perm);
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/query/PlateTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTable.java
@@ -17,6 +17,7 @@
 package org.labkey.assay.plate.query;
 
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.plate.Plate;
@@ -276,7 +277,7 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
             if (row.containsKey("Name"))
             {
                 String oldName = (String) oldRow.get("Name");
-                String newName = (String) row.get("Name");
+                String newName = StringUtils.trimToNull((String) row.get("Name"));
                 if (newName != null && !newName.equals(oldName))
                 {
                     if (plate.isTemplate() && PlateManager.get().isDuplicatePlateTemplateName(container, newName))
@@ -284,6 +285,10 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
                     if (PlateManager.get().isDuplicatePlateName(container, user, newName, plate.getPlateSet()))
                         throw new QueryUpdateServiceException("Plate with name : " + newName + " already exists.");
                 }
+
+                // Do not allow empty string as the name. Fallback to PlateId.
+                if (newName == null)
+                    row.put("Name", plate.getPlateId());
             }
 
             Map<String, Object> newRow = super.updateRow(user, container, row, oldRow, configParameters);

--- a/assay/src/org/labkey/assay/plate/query/PlateTypeTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTypeTable.java
@@ -1,10 +1,16 @@
 package org.labkey.assay.plate.query;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.DeletePermission;
+import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.assay.query.AssayDbSchema;
 
 import java.util.ArrayList;
@@ -12,6 +18,7 @@ import java.util.List;
 
 public class PlateTypeTable extends SimpleUserSchema.SimpleTable<UserSchema>
 {
+    public static final String NAME = "PlateType";
     private static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
 
     static
@@ -20,8 +27,6 @@ public class PlateTypeTable extends SimpleUserSchema.SimpleTable<UserSchema>
         defaultVisibleColumns.add(FieldKey.fromParts("Rows"));
         defaultVisibleColumns.add(FieldKey.fromParts("Columns"));
     }
-
-    public static final String NAME = "PlateType";
 
     public PlateTypeTable(PlateSchema schema, @Nullable ContainerFilter cf)
     {
@@ -33,5 +38,13 @@ public class PlateTypeTable extends SimpleUserSchema.SimpleTable<UserSchema>
     public List<FieldKey> getDefaultVisibleColumns()
     {
         return defaultVisibleColumns;
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        if (InsertPermission.class.equals(perm) || UpdatePermission.class.equals(perm) || DeletePermission.class.equals(perm))
+            return false;
+        return super.hasPermission(user, perm);
     }
 }

--- a/assay/src/org/labkey/assay/plate/query/PlateTypeTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTypeTable.java
@@ -20,6 +20,7 @@ public class PlateTypeTable extends SimpleUserSchema.SimpleTable<UserSchema>
 {
     public static final String NAME = "PlateType";
     private static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
+    boolean _allowInsertUpdateDelete;
 
     static
     {
@@ -28,9 +29,10 @@ public class PlateTypeTable extends SimpleUserSchema.SimpleTable<UserSchema>
         defaultVisibleColumns.add(FieldKey.fromParts("Columns"));
     }
 
-    public PlateTypeTable(PlateSchema schema, @Nullable ContainerFilter cf)
+    public PlateTypeTable(PlateSchema schema, @Nullable ContainerFilter cf, boolean allowInsertUpdateDelete)
     {
         super(schema, AssayDbSchema.getInstance().getTableInfoPlateType(), cf);
+        _allowInsertUpdateDelete = allowInsertUpdateDelete;
         setTitleColumn("Description");
     }
 
@@ -43,7 +45,7 @@ public class PlateTypeTable extends SimpleUserSchema.SimpleTable<UserSchema>
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        if (InsertPermission.class.equals(perm) || UpdatePermission.class.equals(perm) || DeletePermission.class.equals(perm))
+        if (!_allowInsertUpdateDelete && (InsertPermission.class.equals(perm) || UpdatePermission.class.equals(perm) || DeletePermission.class.equals(perm)))
             return false;
         return super.hasPermission(user, perm);
     }

--- a/assay/src/org/labkey/assay/plate/query/WellGroupTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellGroupTable.java
@@ -16,6 +16,7 @@
 
 package org.labkey.assay.plate.query;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.WellGroup;
@@ -51,6 +52,11 @@ import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.DeletePermission;
+import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.assay.plate.PlateCache;
 import org.labkey.assay.plate.PlateManager;
 import org.labkey.assay.query.AssayDbSchema;
@@ -67,6 +73,7 @@ public class WellGroupTable extends SimpleUserSchema.SimpleTable<UserSchema>
 {
     public static final String NAME = "WellGroup";
     private static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
+    boolean _allowInsertUpdateDelete;
 
     static
     {
@@ -75,9 +82,10 @@ public class WellGroupTable extends SimpleUserSchema.SimpleTable<UserSchema>
         defaultVisibleColumns.add(FieldKey.fromParts("TypeName"));
     }
 
-    public WellGroupTable(PlateSchema schema, ContainerFilter cf)
+    public WellGroupTable(PlateSchema schema, ContainerFilter cf, boolean allowInsertUpdateDelete)
     {
         super(schema, AssayDbSchema.getInstance().getTableInfoWellGroup(), cf);
+        _allowInsertUpdateDelete = allowInsertUpdateDelete;
         setTitleColumn("Name");
     }
 
@@ -118,6 +126,14 @@ public class WellGroupTable extends SimpleUserSchema.SimpleTable<UserSchema>
         col.setFk(new PropertyForeignKey(getUserSchema(), getContainerFilter(), map));
 
         return col;
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        if (!_allowInsertUpdateDelete && (InsertPermission.class.equals(perm) || UpdatePermission.class.equals(perm) || DeletePermission.class.equals(perm)))
+            return false;
+        return super.hasPermission(user, perm);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
This addresses [Issue 50658](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50658) as well as prevents various mutation operations on plate tables where we only want these being updated via controlled interfaces.

#### Changes
- Utilize `trimToNull` to prevent insertion of empty plate names. This addresses Issue 50658.
- Explicitly suppress query mutation of the plate, plate set, plate type and well group tables.
- Expose getters on `PlateSchema` that furnish mutation-supported tables.