### PR TITLE
Avoid ClassCastException when supplied value isn't numeric

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -1165,8 +1165,8 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                         if (material == null)
                             material = exp.findExpMaterial(lookupContainer, user, byNameSS, ssName, materialName, cache, materialCache);
                     }
-                    else
-                        material = materialCache.computeIfAbsent((Integer)o, (id) -> exp.getExpMaterial(id, containerFilter));
+                    else if (o instanceof Number n)
+                        material = materialCache.computeIfAbsent(n.intValue(), (id) -> exp.getExpMaterial(id, containerFilter));
 
                     if (material != null)
                     {


### PR DESCRIPTION
#### Rationale
```
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Integer (java.lang.String and java.lang.Integer are in module java.base of loader 'bootstrap')
	at org.labkey.api.assay.AbstractAssayTsvDataHandler.checkData(AbstractAssayTsvDataHandler.java:1185)
	at org.labkey.api.assay.AbstractAssayTsvDataHandler.importRows(AbstractAssayTsvDataHandler.java:566)
	at org.labkey.api.assay.AbstractAssayTsvDataHandler.importFile(AbstractAssayTsvDataHandler.java:156)
	at org.labkey.api.assay.DefaultAssayRunCreator.importStandardResultData(DefaultAssayRunCreator.java:547)
	at org.labkey.api.assay.DefaultAssayRunCreator.importResultData(DefaultAssayRunCreator.java:565)
	at org.labkey.api.assay.DefaultAssayRunCreator.saveExperimentRun(DefaultAssayRunCreator.java:375)
	at org.labkey.api.assay.DefaultAssayRunCreator.saveExperimentRun(DefaultAssayRunCreator.java:165)
	at org.labkey.assay.actions.ImportRunApiAction.execute(ImportRunApiAction.java:314)
	at org.labkey.assay.actions.ImportRunApiAction.execute(ImportRunApiAction.java:85)
	at org.labkey.api.action.BaseApiAction.handlePost(BaseApiAction.java:239)
```

https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=37683

#### Changes
- Don't assume that the user has supplied integer values when attempting to resolve samples during assay import