### PR TITLE
Issue 50701: Sample Manager: cycle of derivation dependencies error when importing samples

### DIFF
--- a/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
@@ -34,6 +34,8 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.UpdateableTableInfo;
 import org.labkey.api.data.validator.ColumnValidator;
 import org.labkey.api.data.validator.ColumnValidators;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DataIteratorUtil;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.OntologyObject;
@@ -44,6 +46,8 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.ValidatorContext;
+import org.labkey.api.reader.ColumnDescriptor;
+import org.labkey.api.reader.DataLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
@@ -54,6 +58,7 @@ import org.labkey.api.util.Pair;
 import org.labkey.api.view.UnauthorizedException;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -803,5 +808,24 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
         if (dp != null)
             return isAttachmentProperty(dp);
         return false;
+    }
+
+    protected void configureCrossFolderImport(DataIteratorBuilder rows, DataIteratorContext context) throws IOException
+    {
+        if (!context.getInsertOption().updateOnly && context.isCrossFolderImport() && rows instanceof DataLoader dataLoader)
+        {
+            boolean hasContainerField = false;
+            for (ColumnDescriptor columnDescriptor : dataLoader.getColumns())
+            {
+                String fieldName = columnDescriptor.getColumnName();
+                if (fieldName.equalsIgnoreCase("Container") || fieldName.equalsIgnoreCase("Folder"))
+                {
+                    hasContainerField = true;
+                    break;
+                }
+            }
+            if (!hasContainerField)
+                context.setCrossFolderImport(false);
+        }
     }
 }

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2728,6 +2728,8 @@ public class ExpDataIterators
 
             List<String> keys = new ArrayList<>();
             Set<String> allKeys = _typeFolderDataMap.keySet();
+            if (allKeys.size() == 1)
+                return allKeys;
             // if the parents referenced in the file are not samples that are potentially being created in this file, there is no dependency
             _idsPerType.forEach((typeName, ids) -> {
                 Set<String> parentIds = _parentIdsPerType.get(typeName);

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -1095,6 +1095,14 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         @Override
         public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
         {
+            try
+            {
+                configureCrossFolderImport(rows, context);
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
             return super.loadRows(user, container, rows, context, extraScriptContext);
         }
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
@@ -36,7 +36,6 @@
 <%@ page import="org.labkey.api.data.TableSelector" %>
 <%@ page import="org.labkey.api.data.dialect.SqlDialect" %>
 <%@ page import="org.labkey.api.dataiterator.DataIteratorContext" %>
-<%@ page import="org.labkey.api.dataiterator.ListofMapsDataIterator" %>
 <%@ page import="org.labkey.api.exp.ExperimentException" %>
 <%@ page import="org.labkey.api.exp.ObjectProperty" %>
 <%@ page import="org.labkey.api.exp.OntologyManager" %>
@@ -459,7 +458,7 @@ private void verifyAliasesViaSelectRows(String schemaName, String queryName, int
 private void testEmptyInsert(ExpDataClassImpl dataClass, TableInfo table, User user) throws Exception
 {
     List<Map<String, Object>> rows = new ArrayList<>();
-    ListofMapsDataIterator.Builder b = new ListofMapsDataIterator.Builder(new CaseInsensitiveHashSet("name", "flag", "alias", "aa"), rows);
+    MapLoader b = new MapLoader(rows);
 
     BatchValidationException errors = new BatchValidationException();
     int count = table.getUpdateService().importRows(user, c, b, errors, null, null);
@@ -1020,7 +1019,7 @@ public void testInsertOptionUpdate() throws Exception
     DataIteratorContext context = new DataIteratorContext();
     context.setInsertOption(QueryUpdateService.InsertOption.IMPORT);
 
-    var count = qus.loadRows(user, c, new ListofMapsDataIterator(rowsToAdd.get(0).keySet(), rowsToAdd), context, null);
+    var count = qus.loadRows(user, c, new MapLoader(rowsToAdd), context, null);
     assertFalse(context.getErrors().hasErrors());
     assertEquals(count,3);
 
@@ -1036,7 +1035,7 @@ public void testInsertOptionUpdate() throws Exception
     rowsToUpdate.add(CaseInsensitiveHashMap.of("name", "D-2", "prop", "b1", "DataInputs/DataClassWithImportOption", null));
 
     context.setInsertOption(QueryUpdateService.InsertOption.UPDATE);
-    count = qus.loadRows(user, c, new ListofMapsDataIterator(rowsToUpdate.get(0).keySet(), rowsToUpdate), context, null);
+    count = qus.loadRows(user, c, new MapLoader(rowsToUpdate), context, null);
 
     assertFalse(context.getErrors().hasErrors());
     assertEquals(count,3);

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
@@ -89,6 +89,7 @@
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.Set" %>
+<%@ page import="org.labkey.api.reader.MapLoader" %>
 
 <%@ page extends="org.labkey.api.jsp.JspTest.BVT" %>
 
@@ -683,7 +684,7 @@ public void testUpdateSomeParents() throws Exception
     rows.add(CaseInsensitiveHashMap.of("name", "C1", "MaterialInputs/Parent1Samples", "P1-1")); // change one parent but not the other
     rows.add(CaseInsensitiveHashMap.of("name", "C4", "MaterialInputs/Parent1Samples", null)); // remove one parent but not the other
 
-    svc.mergeRows(user, c, new ListofMapsDataIterator(rows.get(0).keySet(),rows), errors, null, null);
+    svc.mergeRows(user, c, new MapLoader(rows), errors, null, null);
     assertFalse(errors.hasErrors());
 
     ExpLineage lineage = ExperimentService.get().getLineage(c, user, C1, opts);
@@ -700,7 +701,7 @@ public void testUpdateSomeParents() throws Exception
     rows.add(CaseInsensitiveHashMap.of("name", "C4", "MaterialInputs/Parent1Samples", "P1-1", "MaterialInputs/Parent2Samples", "P2-1")); // change both parents
     rows.add(CaseInsensitiveHashMap.of("name", "C2", "MaterialInputs/Parent1Samples", "", "MaterialInputs/Parent2Samples", null)); // remove both parents
 
-    svc.mergeRows(user, c, new ListofMapsDataIterator(rows.get(0).keySet(),rows), errors, null, null);
+    svc.mergeRows(user, c, new MapLoader(rows), errors, null, null);
     assertFalse(errors.hasErrors());
 
     lineage = ExperimentService.get().getLineage(c, user, C2, opts);
@@ -1004,7 +1005,7 @@ public void testDetailedAuditLog() throws Exception
     // and since merge is a different code path...
     rows.clear(); errors.clear();
     rows.add(PageFlowUtil.mapInsensitive("Name", "A1", "Measure", "Merged", "Value", 3.0));
-    int count = qus.mergeRows(user, c, new ListofMapsDataIterator(null,rows), errors, config, null);
+    int count = qus.mergeRows(user, c, new MapLoader(rows), errors, config, null);
     assertEquals(1, count);
     // check audit log
     events = AuditLogService.get().getAuditEvents(c,user,SampleTimelineAuditEvent.EVENT_TYPE,f,new Sort("-RowId"));
@@ -1135,7 +1136,7 @@ public void testInsertOptionUpdate() throws Exception
 
     DataIteratorContext context = new DataIteratorContext();
     context.setInsertOption(QueryUpdateService.InsertOption.IMPORT);
-    var count = qus.loadRows(user, c, new ListofMapsDataIterator(rowsToAdd.get(0).keySet(), rowsToAdd), context, null);
+    var count = qus.loadRows(user, c, new MapLoader(rowsToAdd), context, null);
 
     assertFalse(context.getErrors().hasErrors());
     assertEquals(count,3);
@@ -1169,7 +1170,7 @@ public void testInsertOptionUpdate() throws Exception
     rowsToUpdate.add(CaseInsensitiveHashMap.of("name", "S-2", "intVal", 200));
 
     context.setInsertOption(QueryUpdateService.InsertOption.UPDATE);
-    count = qus.loadRows(user, c, new ListofMapsDataIterator(rowsToUpdate.get(0).keySet(), rowsToUpdate), context, null);
+    count = qus.loadRows(user, c, new MapLoader(rowsToUpdate), context, null);
 
     assertFalse(context.getErrors().hasErrors());
     assertEquals(count,3);
@@ -1195,7 +1196,7 @@ public void testInsertOptionUpdate() throws Exception
     // update a sample that doesn't exist should throw error
     rowsToUpdate = new ArrayList<>();
     rowsToUpdate.add(CaseInsensitiveHashMap.of("name", "S-1-absent", "intVal", 100));
-    qus.loadRows(user, c, new ListofMapsDataIterator(rowsToUpdate.get(0).keySet(), rowsToUpdate), context, null);
+    qus.loadRows(user, c, new MapLoader(rowsToUpdate), context, null);
     assertTrue(context.getErrors().hasErrors());
     String msg = context.getErrors().getRowErrors().size() > 0 ? context.getErrors().getRowErrors().get(0).toString() : "no message";
     assertTrue(msg.contains("Sample does not exist: S-1-absent."));
@@ -1206,7 +1207,7 @@ public void testInsertOptionUpdate() throws Exception
     Map<Enum, Object> auditOptions = new HashMap<>();
     auditOptions.put(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior, AuditBehaviorType.DETAILED);
     context.setConfigParameters(auditOptions);
-    qus.loadRows(user, c, new ListofMapsDataIterator(rowsToUpdate.get(0).keySet(), rowsToUpdate), context, null);
+    qus.loadRows(user, c, new MapLoader(rowsToUpdate), context, null);
     assertTrue(context.getErrors().hasErrors());
     msg = context.getErrors().getRowErrors().size() > 0 ? context.getErrors().getRowErrors().get(0).toString() : "no message";
     assertTrue(msg.contains("Sample does not exist: S-1-absent."));
@@ -1219,7 +1220,7 @@ public void testInsertOptionUpdate() throws Exception
 
     context = new DataIteratorContext();
     context.setInsertOption(QueryUpdateService.InsertOption.UPDATE);
-    qus.loadRows(user, c, new ListofMapsDataIterator(rowsToUpdate.get(0).keySet(), rowsToUpdate), context, null);
+    qus.loadRows(user, c, new MapLoader(rowsToUpdate), context, null);
     assertFalse(context.getErrors().hasErrors());
     assertEquals(count,3);
     rows = getSampleRows(sampleTypeName);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -410,6 +410,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                         columnDescriptor.name = SAMPLE_ALT_IMPORT_NAME_COLS.get(columnDescriptor.getColumnName());
                     }
                 }
+                configureCrossFolderImport(rows, context);
             }
         }
         catch (IOException e)

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4193,26 +4193,8 @@ public class ExperimentController extends SpringActionController
         {
             _context = createDataIteratorContext(_insertOption, getOptionParamsMap(), auditBehaviorType, auditUserComment, errors, null, getContainer());
 
-            if (_context.isCrossFolderImport())
-            {
-                if (!getContainer().hasProductProjects())
-                    _context.setCrossFolderImport(false);
-                else if (!_context.getInsertOption().updateOnly)
-                {
-                    ColumnDescriptor[] dataColumns = dl.getColumns();
-                    boolean hasContainerColumn = false;
-                    for (ColumnDescriptor dataColumn : dataColumns)
-                    {
-                        if (dataColumn.getColumnName().equalsIgnoreCase("container") || dataColumn.getColumnName().equalsIgnoreCase("folder"))
-                        {
-                            hasContainerColumn = true;
-                            break;
-                        }
-                    }
-                    if (!hasContainerColumn)
-                        _context.setCrossFolderImport(false);
-                }
-            }
+            if (_context.isCrossFolderImport() && !getContainer().hasProductProjects())
+                _context.setCrossFolderImport(false);
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
- Async import has crossFolder set to true always, even in the absence of 'Container' column. 
- When crossFolder import is true, the parent dependency check throws a false positive cycle detection error.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5612
- https://github.com/LabKey/limsModules/pull/392

#### Changes
- moves the 'Container' column check to a later point so it's done by in the sync and async code path. 
- avoid cycle detection error when sample type column is not provided
- use MapLoader instead of List so JUnit tests align closer with actual api action
