### PR TITLE
Fix ClassCastException when entity type name is a number for cross-type import sample type is number

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2636,7 +2636,17 @@ public class ExpDataIterators
             else
             {
                 TypeData typeFolderData = null;
-                String typeName = _typeColIndex != null ? StringUtils.trim((String) get(_typeColIndex)) : _dataType.getName();
+                String typeName;
+                if (_typeColIndex != null)
+                {
+                    Object typeNameObj = String.valueOf(get(_typeColIndex));
+                    if (typeNameObj == null)
+                        typeName = null;
+                    else
+                        typeName = StringUtils.trim(String.valueOf(typeNameObj));
+                }
+                else
+                    typeName = _dataType.getName();
                 Container targetContainer = _container; // default to context container
 
                 if (StringUtils.isEmpty(typeName) && _isCrossType)

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2639,7 +2639,7 @@ public class ExpDataIterators
                 String typeName;
                 if (_typeColIndex != null)
                 {
-                    Object typeNameObj = String.valueOf(get(_typeColIndex));
+                    Object typeNameObj = get(_typeColIndex);
                     if (typeNameObj == null)
                         typeName = null;
                     else


### PR DESCRIPTION
#### Rationale
When the SampleType field is populated with only numbers (or, probably, only boolean values), we bring in the values as non-strings, so we need to not assume a string value is present in the file when processing the name

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/397

#### Changes
- Don't assume the string value.
