### PR TITLE
50059: Audit column name casing changes

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -254,7 +254,9 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
                 }
 
                 updateIndices(domain, domainKind);
-                transaction.commit();
+                // Issue 50059, don't cache the DB schema table queried by updateIndices in order for the provisioned
+                // domain fields to be properly fixed up.
+                transaction.addCommitTask(() -> domainKind.invalidate(domain), DbScope.CommitTaskOption.POSTCOMMIT);
             }
             catch (ChangePropertyDescriptorException e)
             {

--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -257,6 +257,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
                 // Issue 50059, don't cache the DB schema table queried by updateIndices in order for the provisioned
                 // domain fields to be properly fixed up.
                 transaction.addCommitTask(() -> domainKind.invalidate(domain), DbScope.CommitTaskOption.POSTCOMMIT);
+                transaction.commit();
             }
             catch (ChangePropertyDescriptorException e)
             {


### PR DESCRIPTION
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50059)

#### Rationale
Because of the way we query for the provisioned storage tables in `AbstractAuditTypeProvider.udateIndices` we end up caching the `TableInfo` but the domain fields don't get fixed up they way they would ordinarily during typical construction. Maybe this is a bit heavy handed but one solution is to uncache the domain after initial startup in order for `StorageProvisionerImpl.fixupProvisionedDomain` to run normally.
