### PR TITLE
DomainKind.supportsPhiLevel property

### DIFF
--- a/api/gwtsrc/org/labkey/api/gwt/client/model/GWTDomain.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/model/GWTDomain.java
@@ -74,6 +74,8 @@ public class GWTDomain<FieldType extends GWTPropertyDescriptor> implements IsSer
     private String templateDescription=null; // null if no template
     private String instructions = null;
 
+    private boolean supportsPhiLevel = false;
+
     public GWTDomain()
     {
     }
@@ -101,6 +103,7 @@ public class GWTDomain<FieldType extends GWTPropertyDescriptor> implements IsSer
         this.defaultValueOptions = src.defaultValueOptions;
         this.defaultValuesURL = src.defaultValuesURL;
         this.provisioned = src.isProvisioned();
+        this.supportsPhiLevel = src.supportsPhiLevel;
 
         if (src.indices != null)
         {
@@ -525,4 +528,13 @@ public class GWTDomain<FieldType extends GWTPropertyDescriptor> implements IsSer
         this.provisioned = value;
     }
 
+    public boolean isSupportsPhiLevel()
+    {
+        return supportsPhiLevel;
+    }
+
+    public void setSupportsPhiLevel(boolean supportsPhiLevel)
+    {
+        this.supportsPhiLevel = supportsPhiLevel;
+    }
 }

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
@@ -663,6 +664,6 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
     @Override
     public boolean supportsPhiLevel()
     {
-        return true;
+        return ComplianceService.get().isComplianceSupported();
     }
 }

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -659,4 +659,10 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
 
         return false;
     }
+
+    @Override
+    public boolean supportsPhiLevel()
+    {
+        return true;
+    }
 }

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -406,4 +406,9 @@ abstract public class DomainKind<T>  implements Handler<String>
     {
         return true;
     }
+
+    public boolean supportsPhiLevel()
+    {
+        return false;
+    }
 }

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -387,6 +387,7 @@ public class DomainUtil
             gwtDomain.setAllowUniqueConstraintProperties(kind.allowUniqueConstraintProperties());
             gwtDomain.setShowDefaultValueSettings(kind.showDefaultValueSettings());
             gwtDomain.setInstructions(kind.getDomainEditorInstructions());
+            gwtDomain.setSupportsPhiLevel(kind.supportsPhiLevel());
         }
         return gwtDomain;
     }

--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -660,4 +660,10 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
     {
         return new FieldKey(null, "Folder");
     }
+
+    @Override
+    public boolean supportTableRules()
+    {
+        return super.supportTableRules();
+    }
 }

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchema;
@@ -474,6 +475,6 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
     @Override
     public boolean supportsPhiLevel()
     {
-        return true;
+        return ComplianceService.get().isComplianceSupported();
     }
 }

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -470,4 +470,10 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
     {
         return true;
     }
+
+    @Override
+    public boolean supportsPhiLevel()
+    {
+        return true;
+    }
 }

--- a/filecontent/src/org/labkey/filecontent/FilePropertiesDomainKind.java
+++ b/filecontent/src/org/labkey/filecontent/FilePropertiesDomainKind.java
@@ -16,6 +16,7 @@
 package org.labkey.filecontent;
 
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.api.ExperimentUrls;
@@ -126,6 +127,6 @@ public class FilePropertiesDomainKind extends BaseAbstractDomainKind
     @Override
     public boolean supportsPhiLevel()
     {
-        return true;
+        return ComplianceService.get().isComplianceSupported();
     }
 }

--- a/filecontent/src/org/labkey/filecontent/FilePropertiesDomainKind.java
+++ b/filecontent/src/org/labkey/filecontent/FilePropertiesDomainKind.java
@@ -122,4 +122,10 @@ public class FilePropertiesDomainKind extends BaseAbstractDomainKind
     {
         return DefaultValueType.FIXED_EDITABLE;
     }
+
+    @Override
+    public boolean supportsPhiLevel()
+    {
+        return true;
+    }
 }

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -22,6 +22,7 @@ import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
@@ -731,6 +732,6 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
     @Override
     public boolean supportsPhiLevel()
     {
-        return true;
+        return ComplianceService.get().isComplianceSupported();
     }
 }

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -727,4 +727,10 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
     {
         var props = getBaseProperties(d);
     }
+
+    @Override
+    public boolean supportsPhiLevel()
+    {
+        return true;
+    }
 }

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -806,4 +806,10 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
             }
         }
     }
+
+    @Override
+    public boolean supportsPhiLevel()
+    {
+        return true;
+    }
 }

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -20,6 +20,7 @@ import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.ApiUsageException;
+import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
@@ -810,6 +811,6 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
     @Override
     public boolean supportsPhiLevel()
     {
-        return true;
+        return ComplianceService.get().isComplianceSupported();
     }
 }


### PR DESCRIPTION
#### Rationale
This is returned by property-getDomainDetails.api for use by the domain designer.

https://github.com/LabKey/platform/issues/5599

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
