### PR TITLE
Plates: add integration tests for plate schema tables

### DIFF
--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -83,6 +83,7 @@ import org.labkey.assay.plate.PlateMetadataDomainKind;
 import org.labkey.assay.plate.PlateMetricsProvider;
 import org.labkey.assay.plate.TsvPlateLayoutHandler;
 import org.labkey.assay.plate.query.PlateSchema;
+import org.labkey.assay.plate.query.PlateSchemaTest;
 import org.labkey.assay.query.AssayDbSchema;
 import org.labkey.assay.query.AssaySchemaImpl;
 import org.labkey.assay.security.AssayDesignerRole;
@@ -316,7 +317,9 @@ public class AssayModule extends SpringModule
     public @NotNull Set<Class> getIntegrationTests()
     {
         return Set.of(
-            ModuleAssayCache.TestCase.class
+            ModuleAssayCache.TestCase.class,
+            PlateManagerTest.class,
+            PlateSchemaTest.class
         );
     }
 
@@ -335,7 +338,6 @@ public class AssayModule extends SpringModule
             TsvAssayProvider.TestCase.class,
             AssaySchemaImpl.TestCase.class,
             AssayProviderSchema.TestCase.class,
-            PlateManagerTest.class,
             PositionImpl.TestCase.class,
             PlateImpl.TestCase.class,
             PlateUtils.TestCase.class,

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1453,7 +1453,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return _plateLayoutHandlers.get(plateTypeName);
     }
     
-    private UserSchema getPlateUserSchema(Container container, User user)
+    public UserSchema getPlateUserSchema(Container container, User user)
     {
         return QueryService.get().getUserSchema(user, container, PlateSchema.SCHEMA_NAME);
     }
@@ -1462,6 +1462,16 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     public TableInfo getPlateTableInfo()
     {
         return AssayDbSchema.getInstance().getTableInfoPlate();
+    }
+
+    public @NotNull TableInfo getPlateTable(Container container, User user)
+    {
+        return getPlateTable(container, user, null);
+    }
+
+    public @NotNull TableInfo getPlateTable(Container container, User user, @Nullable ContainerFilter cf)
+    {
+        return getPlateUserSchema(container, user).getTableOrThrow(PlateTable.NAME, cf);
     }
 
     private @NotNull TableInfo getWellTable(Container container, User user)
@@ -2830,8 +2840,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         Map<Integer, List<Integer>> protocolPlateSets = new HashMap<>();
         Map<Integer, PlateSet> plateSets = lineage.getPlateSetAndDescendents(plateSetId);
         plateSetAssays.setPlateSets(plateSets);
-        UserSchema schema = getPlateUserSchema(container, user);
-        TableInfo plateTable = schema.getTableOrThrow(PlateTable.NAME, cf);
+        TableInfo plateTable = getPlateTable(container, user, cf);
         List<ExpProtocol> protocols = AssayService.get().getAssayProtocols(container, provider)
                 .stream().filter(provider::isPlateMetadataEnabled).toList();
 

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -102,7 +102,7 @@ public final class PlateManagerTest
     }
 
     @Test
-    public void createPlateTemplate() throws Exception
+    public void testCreatePlateTemplate() throws Exception
     {
         //
         // INSERT
@@ -495,7 +495,7 @@ public final class PlateManagerTest
     }
 
     @Test
-    public void getWellSampleData()
+    public void testGetWellSampleData()
     {
         // Act
         List<Integer> sampleIds = List.of(0, 3, 5, 8, 10, 11, 12, 13, 15, 17, 19);
@@ -533,7 +533,7 @@ public final class PlateManagerTest
     }
 
     @Test
-    public void getInstrumentInstructions() throws Exception
+    public void testGetInstrumentInstructions() throws Exception
     {
         // Arrange
         ContainerFilter cf = ContainerFilter.Type.CurrentAndSubfolders.create(ContainerManager.getSharedContainer(), user);
@@ -584,7 +584,7 @@ public final class PlateManagerTest
     }
 
     @Test
-    public void getWorklist() throws Exception
+    public void testGetWorklist() throws Exception
     {
         // Arrange
         ContainerFilter cf = ContainerFilter.Type.CurrentAndSubfolders.create(ContainerManager.getSharedContainer(), user);

--- a/assay/src/org/labkey/assay/plate/query/PlateSchemaTest.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSchemaTest.java
@@ -1,0 +1,155 @@
+package org.labkey.assay.plate.query;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateType;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QueryUpdateServiceException;
+import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.DeletePermission;
+import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.util.JunitUtil;
+import org.labkey.api.util.TestContext;
+import org.labkey.assay.plate.PlateImpl;
+import org.labkey.assay.plate.PlateManager;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+public final class PlateSchemaTest
+{
+    private static Container container;
+    private static User user;
+    private static PlateType PLATE_TYPE_12_WELL;
+
+    @BeforeClass
+    public static void setupTest()
+    {
+        deleteTestContainer();
+
+        container = JunitUtil.getTestContainer();
+        user = TestContext.get().getUser();
+
+        PLATE_TYPE_12_WELL = PlateManager.get().getPlateType(3, 4);
+        assertNotNull("12-well plate type was not found", PLATE_TYPE_12_WELL);
+    }
+
+    @AfterClass
+    public static void cleanup()
+    {
+        deleteTestContainer();
+        container = null;
+        user = null;
+    }
+
+    private static void deleteTestContainer()
+    {
+        JunitUtil.deleteTestContainer();
+    }
+
+    @Test
+    public void testPlateRenaming() throws Exception
+    {
+        Plate plate = PlateManager.get().createAndSavePlate(container, user, new PlateImpl(container, null, PLATE_TYPE_12_WELL), null, null);
+        assertEquals("A null plate \"Name\" is expected to result in a plate with the \"Name\" being set to the \"PlateId\".", plate.getPlateId(), plate.getName());
+
+        // Issue 50658: Clearing plate name should reset the plate name to equal the PlateId
+        String nonEmptyName = "Non-Empty Plate Name";
+        plate = updatePlate(plateRow(plate, PlateTable.Column.Name, nonEmptyName));
+        assertEquals("Name not set as expected.", nonEmptyName, plate.getName());
+
+        plate = updatePlate(plateRow(plate, PlateTable.Column.Name, ""));
+        assertEquals("Setting \"Name\" to an empty value is expected to reset name to the value of \"PlateId\".", plate.getPlateId(), plate.getName());
+    }
+
+    private CaseInsensitiveHashMap<Object> plateRow(Plate plate, @Nullable PlateTable.Column column, @Nullable Object value)
+    {
+        var row = new CaseInsensitiveHashMap<>();
+        row.put(PlateTable.Column.RowId.name(), plate.getRowId());
+        if (column != null)
+            row.put(column.name(), value);
+        return row;
+    }
+
+    @Test
+    public void testPlateUpdates() throws Exception
+    {
+        Plate plate = PlateManager.get().createAndSavePlate(container, user, new PlateImpl(container, null, PLATE_TYPE_12_WELL), null, null);
+
+        // Verify updating AssayType is not allowed
+        {
+            var row = plateRow(plate, PlateTable.Column.AssayType, "Regular");
+            assertThrows(String.format("Expected attempted update of the %s column to fail.", PlateTable.Column.AssayType.name()), QueryUpdateServiceException.class, () -> updatePlate(row));
+        }
+
+        // Verify updating PlateSet is not allowed
+        {
+            var row = plateRow(plate, PlateTable.Column.PlateSet, 12);
+            assertThrows(String.format("Expected attempted update of the %s column to fail.", PlateTable.Column.PlateSet.name()), QueryUpdateServiceException.class, () -> updatePlate(row));
+        }
+
+        // Verify updating PlateType is not allowed
+        {
+            var row = plateRow(plate, PlateTable.Column.PlateType, 4);
+            assertThrows(String.format("Expected attempted update of the %s column to fail.", PlateTable.Column.PlateType.name()), QueryUpdateServiceException.class, () -> updatePlate(row));
+        }
+    }
+
+    @Test
+    public void testTablePermissions()
+    {
+        verifyTablePermissions(HitTable.NAME, false, false, true);
+        verifyTablePermissions(PlateSetTable.NAME, false, true, true);
+        verifyTablePermissions(PlateTable.NAME, false, true, true);
+        verifyTablePermissions(PlateTypeTable.NAME, false, false, false);
+        verifyTablePermissions(WellGroupTable.NAME, false, false, false);
+        verifyTablePermissions(WellTable.NAME, false, true, false);
+    }
+
+    private void verifyTablePermissions(String tableName, boolean allowInsert, boolean allowUpdate, boolean allowDelete)
+    {
+        UserSchema schema = QueryService.get().getUserSchema(user, container, PlateSchema.SCHEMA_NAME);
+        TableInfo table = schema.getTableOrThrow(tableName);
+
+        assertEquals(String.format("Insert permissions set incorrectly for \"%s\" table.", table.getName()), allowInsert, table.hasPermission(user, InsertPermission.class));
+        assertEquals(String.format("Update permissions set incorrectly for \"%s\" table.", table.getName()), allowUpdate, table.hasPermission(user, UpdatePermission.class));
+        assertEquals(String.format("Delete permissions set incorrectly for \"%s\" table.", table.getName()), allowDelete, table.hasPermission(user, DeletePermission.class));
+    }
+
+    private @NotNull Plate getPlate(int rowId)
+    {
+        Plate plate = PlateManager.get().getPlate(container, rowId);
+        assertNotNull(String.format("Unable to get plate with RowId (%d)", rowId), plate);
+        return plate;
+    }
+
+    private @NotNull Plate updatePlate(CaseInsensitiveHashMap<Object> row) throws Exception
+    {
+        var errors = new BatchValidationException();
+        var plateRows = PlateManager.get().getPlateTable(container, user)
+                .getUpdateService()
+                .updateRows(user, container, Arrays.asList(row), null, errors, null, null);
+
+        assertFalse("Expected no errors", errors.hasErrors());
+        assertEquals("Expected a single row", 1, plateRows.size());
+
+        var plateRow = plateRows.get(0);
+        var plateRowId = (int) plateRow.get(PlateTable.Column.RowId.name());
+
+        return getPlate(plateRowId);
+    }
+}

--- a/assay/src/org/labkey/assay/plate/query/PlateTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateTable.java
@@ -86,8 +86,12 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
         Archived,
         AssayType,
         Container,
+        Created,
+        CreatedBy,
         Description,
         Lsid,
+        Modified,
+        ModifiedBy,
         Name,
         PlateId,
         PlateSet,
@@ -106,10 +110,10 @@ public class PlateTable extends SimpleUserSchema.SimpleTable<UserSchema>
         defaultVisibleColumns.add(FieldKey.fromParts(Column.PlateSet.name()));
         defaultVisibleColumns.add(FieldKey.fromParts(Column.AssayType.name()));
         defaultVisibleColumns.add(FieldKey.fromParts(Column.WellsFilled.name()));
-        defaultVisibleColumns.add(FieldKey.fromParts("Created"));
-        defaultVisibleColumns.add(FieldKey.fromParts("CreatedBy"));
-        defaultVisibleColumns.add(FieldKey.fromParts("Modified"));
-        defaultVisibleColumns.add(FieldKey.fromParts("ModifiedBy"));
+        defaultVisibleColumns.add(FieldKey.fromParts(Column.Created.name()));
+        defaultVisibleColumns.add(FieldKey.fromParts(Column.CreatedBy.name()));
+        defaultVisibleColumns.add(FieldKey.fromParts(Column.Modified.name()));
+        defaultVisibleColumns.add(FieldKey.fromParts(Column.ModifiedBy.name()));
     }
 
     public PlateTable(PlateSchema schema, @Nullable ContainerFilter cf, boolean allowInsert)

--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -31,6 +31,7 @@ import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.query.AliasedColumn;
 import org.labkey.api.query.BatchValidationException;
@@ -293,7 +294,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
         {
             columnInfo.setFk(QueryForeignKey.from(getUserSchema(), getContainerFilter())
                     .schema(ExpSchema.SCHEMA_NAME, getContainer())
-                    .to("Materials", "RowId", "Name"));
+                    .to(ExpSchema.TableType.Materials.name(), ExpMaterialTable.Column.RowId.name(), ExpMaterialTable.Column.Name.name()));
         }
         return columnInfo;
     }


### PR DESCRIPTION
#### Rationale
This adds integration test coverage for various cases in our plate schema tables. 

#### Changes
- Add `PlateSchemaTest` with new test case coverage
- Add regression coverage for [Issue 50658](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50658)
- Migrate a couple of more constants
