### PR TITLE
Junit test for RoleSet serialization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -92,7 +92,6 @@ api/gwtsrc/org/labkey/api/gwt/client/ui/ImageButton.java -text
 api/gwtsrc/org/labkey/api/gwt/client/ui/LinkButton.java -text
 api/gwtsrc/org/labkey/api/gwt/client/ui/StringListBox.java -text
 api/gwtsrc/org/labkey/api/gwt/client/ui/TextBoxDialogBox.java -text
-api/gwtsrc/org/labkey/api/gwt/client/ui/VennDiagramView.java -text
 api/gwtsrc/org/labkey/api/gwt/client/ui/WebPartPanel.java -text
 api/gwtsrc/org/labkey/api/gwt/client/ui/WidgetUpdatable.java -text
 api/gwtsrc/org/labkey/api/gwt/client/ui/WindowUtil.java -text
@@ -342,7 +341,6 @@ api/src/org/labkey/api/cache/CacheStats.java -text
 api/src/org/labkey/api/cache/CacheTimeChooser.java -text
 api/src/org/labkey/api/cache/CacheType.java -text
 api/src/org/labkey/api/cache/CacheWrapper.java -text
-api/src/org/labkey/api/cache/DbCache.java -text
 api/src/org/labkey/api/cache/ehcache/EhCacheProvider.java -text
 api/src/org/labkey/api/cache/ehcache/EhSimpleCache.java -text
 api/src/org/labkey/api/cache/ehcache/SafeCacheManager.java -text
@@ -935,8 +933,6 @@ api/src/org/labkey/api/pipeline/WorkDirFactory.java -text
 api/src/org/labkey/api/pipeline/XMLBeanTaskFactoryFactory.java -text
 api/src/org/labkey/api/portal/ProjectUrls.java -text
 api/src/org/labkey/api/premium/AntiVirusService.java -text
-api/src/org/labkey/api/protein/ProteinService.java -text
-api/src/org/labkey/api/protein/ProteomicsModule.java -text
 api/src/org/labkey/api/qc/DataExchangeHandler.java -text
 api/src/org/labkey/api/qc/DataLoaderSettings.java -text
 api/src/org/labkey/api/qc/DataTransformer.java -text
@@ -1474,7 +1470,6 @@ api/src/org/labkey/api/view/PopupHelpView.java -text
 api/src/org/labkey/api/view/PopupMenu.java -text
 api/src/org/labkey/api/view/PopupMenuView.java -text
 api/src/org/labkey/api/view/PopupUserView.java -text
-api/src/org/labkey/api/view/ProteomicsWebPartFactory.java -text
 api/src/org/labkey/api/view/ReaderView.java -text
 api/src/org/labkey/api/view/RequestBasicAuthException.java -text
 api/src/org/labkey/api/view/ServletView.java -text
@@ -1576,7 +1571,6 @@ api/webapp/clientapi/ext4/data/Proxy.js -text
 api/webapp/clientapi/ext4/data/Reader.js -text
 api/webapp/clientapi/ext4/data/Store.js -text
 api/webapp/clientapi/ext4/Util.js -text
-api/webapp/ext-4.2.1/ext-patches.js -text
 api/webapp/ext-theme/blue/ext-all-debug.css -text
 api/webapp/ext-theme/brown/ext-all-debug.css -text
 api/webapp/ext-theme/harvest/ext-all-debug.css -text
@@ -1635,7 +1629,6 @@ assay/api-src/org/labkey/api/assay/nab/view/RunDetailsAction.java -text
 assay/api-src/org/labkey/api/assay/nab/view/RunDetailsHeaderView.java -text
 assay/api-src/org/labkey/api/assay/plate/AbstractPlateBasedAssayProvider.java -text
 assay/api-src/org/labkey/api/assay/plate/AbstractPlateReader.java -text
-assay/api-src/org/labkey/api/assay/plate/AbstractPlateTypeHandler.java -text
 assay/api-src/org/labkey/api/assay/plate/ExcelPlateReader.java -text
 assay/api-src/org/labkey/api/assay/plate/Plate.java -text
 assay/api-src/org/labkey/api/assay/plate/PlateBasedAssayProvider.java -text
@@ -1645,7 +1638,6 @@ assay/api-src/org/labkey/api/assay/plate/PlateReader.java -text
 assay/api-src/org/labkey/api/assay/plate/PlateSampleFilePropertyHelper.java -text
 assay/api-src/org/labkey/api/assay/plate/PlateSamplePropertyHelper.java -text
 assay/api-src/org/labkey/api/assay/plate/PlateService.java -text
-assay/api-src/org/labkey/api/assay/plate/PlateTypeHandler.java -text
 assay/api-src/org/labkey/api/assay/plate/PlateUtils.java -text
 assay/api-src/org/labkey/api/assay/plate/Position.java -text
 assay/api-src/org/labkey/api/assay/plate/PositionImpl.java -text
@@ -1654,9 +1646,6 @@ assay/api-src/org/labkey/api/assay/plate/Well.java -text
 assay/api-src/org/labkey/api/assay/plate/WellData.java -text
 assay/api-src/org/labkey/api/assay/plate/WellGroup.java -text
 assay/api-src/org/labkey/api/assay/query/RunListDetailsQueryView.java -text
-assay/gwtsrc/gwt/client/org/labkey/assay/designer/client/AssayImporter.java -text
-assay/gwtsrc/gwt/client/org/labkey/assay/designer/client/AssayImporterService.java -text
-assay/gwtsrc/gwt/client/org/labkey/assay/designer/client/AssayImporterServiceAsync.java -text
 assay/gwtsrc/gwt/client/org/labkey/plate/designer/client/GroupChangeListener.java -text
 assay/gwtsrc/gwt/client/org/labkey/plate/designer/client/GroupChangeListenerAdapter.java -text
 assay/gwtsrc/gwt/client/org/labkey/plate/designer/client/GroupTypePanel.java -text
@@ -1697,16 +1686,13 @@ assay/src/org/labkey/assay/actions/DeleteAction.java -text
 assay/src/org/labkey/assay/actions/DeleteProtocolAction.java -text
 assay/src/org/labkey/assay/actions/GetAssayBatchAction.java -text
 assay/src/org/labkey/assay/actions/GetProtocolAction.java -text
-assay/src/org/labkey/assay/actions/ImportAction.java -text
 assay/src/org/labkey/assay/actions/PipelineDataCollectorRedirectAction.java -text
 assay/src/org/labkey/assay/actions/SaveAssayBatchAction.java -text
 assay/src/org/labkey/assay/actions/SetDefaultValuesAssayAction.java -text
 assay/src/org/labkey/assay/actions/ShowSelectedDataAction.java -text
 assay/src/org/labkey/assay/actions/ShowSelectedRunsAction.java -text
 assay/src/org/labkey/assay/actions/TemplateAction.java -text
-assay/src/org/labkey/assay/actions/TsvImportAction.java -text
 assay/src/org/labkey/assay/AssayFolderType.java -text
-assay/src/org/labkey/assay/AssayImportServiceImpl.java -text
 assay/src/org/labkey/assay/AssayListPortalView.java -text
 assay/src/org/labkey/assay/AssayListQueryView.java -text
 assay/src/org/labkey/assay/AssayManager.java -text
@@ -1729,7 +1715,6 @@ assay/src/org/labkey/assay/plate/query/PlateSchema.java -text
 assay/src/org/labkey/assay/plate/query/PlateTable.java -text
 assay/src/org/labkey/assay/plate/query/WellGroupTable.java -text
 assay/src/org/labkey/assay/plate/view/copyTemplate.jsp -text
-assay/src/org/labkey/assay/plate/view/plateTemplateList.jsp -text
 assay/src/org/labkey/assay/plate/WellGroupCurveImpl.java -text
 assay/src/org/labkey/assay/plate/WellGroupImpl.java -text
 assay/src/org/labkey/assay/plate/WellImpl.java -text
@@ -2158,7 +2143,6 @@ experiment/src/org/labkey/experiment/FileLinkFileListener.java -text
 experiment/src/org/labkey/experiment/LineageGraphDisplayColumn.java -text
 experiment/src/org/labkey/experiment/MoveRunsBean.java -text
 experiment/src/org/labkey/experiment/moveRunsLocation.jsp -text
-experiment/src/org/labkey/experiment/NoPipelineRootSetView.java -text
 experiment/src/org/labkey/experiment/Parameters.jsp -text
 experiment/src/org/labkey/experiment/pipeline/ExperimentPipelineJob.java -text
 experiment/src/org/labkey/experiment/pipeline/ExperimentPipelineProvider.java -text
@@ -2734,7 +2718,6 @@ study/gwtsrc/gwt/client/org/labkey/study/designer/client/ScheduleGrid.java -text
 study/gwtsrc/gwt/client/org/labkey/study/designer/client/StudyDefinitionService.java -text
 study/gwtsrc/gwt/client/org/labkey/study/designer/client/StudyDefinitionServiceAsync.java -text
 study/gwtsrc/gwt/client/org/labkey/study/designer/client/VaccinePanel.java -text
-study/gwtsrc/gwt/public/org/labkey/study/designer/Designer.html -text
 study/gwtsrc/gwt/StudyApplication.gwt.xml -text
 study/module.properties -text
 study/resources/schemas/dbscripts/postgresql/study-create.sql -text

--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -132,6 +132,7 @@ import org.labkey.api.security.GroupManager;
 import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.NestedGroupsTest;
 import org.labkey.api.security.PasswordExpiration;
+import org.labkey.api.security.RoleSet;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.ValidEmail;
@@ -432,6 +433,7 @@ public class ApiModule extends CodeOnlyModule
             //RateLimiter.TestCase.class,
             ResultSetDataIterator.TestCase.class,
             ResultSetSelectorTestCase.class,
+            RoleSet.TestCase.class,
             RowTrackingResultSetWrapper.TestCase.class,
             SQLFragment.IntegrationTestCase.class,
             SecurityManager.TestCase.class,

--- a/api/src/org/labkey/api/annotations/Migrate.java
+++ b/api/src/org/labkey/api/annotations/Migrate.java
@@ -3,8 +3,7 @@ package org.labkey.api.annotations;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-// Used to tag classes & methods that should be migrated soon, e.g., those that are to be refactored into the specimen
-// or protein module
+// Used to tag classes & methods that should be migrated soon, e.g., those that should be moved from one module to another
 @Retention(RetentionPolicy.SOURCE)
 public @interface Migrate
 {

--- a/api/src/org/labkey/api/reports/ReportService.java
+++ b/api/src/org/labkey/api/reports/ReportService.java
@@ -45,10 +45,6 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 
-/**
- * User: Karl Lum
- * Date: Dec 21, 2007
- */
 public interface ReportService
 {
     // this logger is to enable all report loggers in the admin ui (org.labkey.api.reports.*)
@@ -108,20 +104,6 @@ public interface ReportService
     Report createReportInstance(ReportDescriptor descriptor);
 
     void deleteReport(ContainerUser context, Report report);
-
-    /**
-     * Note: almost all cases of saveReport will want to use the version that does not skip validation.
-     *       One example of where we skip validation is in the StudyUpgradeCode which has a method to fix report properties
-     *       across all reports in the database (regardless of user)
-     */
-    @Deprecated
-    int saveReport(ContainerUser context, String key, Report report, boolean skipValidation);
-
-    @Deprecated
-    default int saveReport(ContainerUser context, String key, Report report)
-    {
-        return saveReport(context, key, report, false);
-    }
 
     /**
      * Note: almost all cases of saveReport will want to use the version that does not skip validation.

--- a/api/src/org/labkey/api/reports/report/ReportIdentifier.java
+++ b/api/src/org/labkey/api/reports/report/ReportIdentifier.java
@@ -21,8 +21,6 @@ import org.labkey.api.writer.ContainerUser;
 
 /**
  * Uniquely identifies a report
- * User: Dave
- * Date: Dec 11, 2008
  */
 public interface ReportIdentifier
 {

--- a/api/src/org/labkey/api/security/RoleSet.java
+++ b/api/src/org/labkey/api/security/RoleSet.java
@@ -122,7 +122,7 @@ public class RoleSet
         }
     }
 
-    // Test Jackson serialization/deserialization of a RoleSet and a role-impersonating user
+    // Test Jackson serialization/deserialization of a couple RoleSets and role-impersonating users
     public static class TestCase extends Assert
     {
         @Test

--- a/api/src/org/labkey/api/security/RoleSet.java
+++ b/api/src/org/labkey/api/security/RoleSet.java
@@ -1,23 +1,43 @@
-package org.labkey.api.security.roles;
+package org.labkey.api.security;
 
 import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.type.WritableTypeId;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+import org.junit.Test;
+import org.labkey.api.data.Container;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.security.impersonation.RoleImpersonationContextFactory;
+import org.labkey.api.security.roles.CanSeeAuditLogRole;
+import org.labkey.api.security.roles.EditorRole;
+import org.labkey.api.security.roles.ProjectCreatorRole;
+import org.labkey.api.security.roles.ReaderRole;
+import org.labkey.api.security.roles.Role;
+import org.labkey.api.security.roles.RoleManager;
+import org.labkey.api.util.JunitUtil;
+import org.labkey.api.util.TestContext;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 // Wrapper that holds a set of Roles that need to be serialized/deserialized via JSON. I had hoped to instead create a
@@ -99,6 +119,51 @@ public class RoleSet
                     roles.add(role);
             }
             return new RoleSet(roles);
+        }
+    }
+
+    // Test Jackson serialization/deserialization of a RoleSet and a role-impersonating user
+    public static class TestCase extends Assert
+    {
+        @Test
+        public void testSerialization() throws JsonProcessingException
+        {
+            User adminUser = TestContext.get().getUser();
+
+            testImpersonateRoles(adminUser, null, ProjectCreatorRole.class, CanSeeAuditLogRole.class);
+            testImpersonateRoles(adminUser, JunitUtil.getTestContainer().getProject(), ReaderRole.class, EditorRole.class);
+        }
+
+        @SafeVarargs
+        private void testImpersonateRoles(User adminUser, @Nullable Container project, Class<? extends Role>... roleClasses) throws JsonProcessingException
+        {
+            User impersonatingUser = adminUser.cloneUser();
+            Set<Role> roles = Arrays.stream(roleClasses).map(RoleManager::getRole).collect(Collectors.toSet());
+
+            // Round-trip via the pipeline ObjectMapper, which serializes based on fields, not getters() (in contrast,
+            // our standard ObjectMapper's deserialization chokes because of User's *many* getters)
+            ObjectMapper mapper = PipelineJob.createObjectMapper();
+            ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
+
+            String json = writer.writeValueAsString(new RoleSet(roles));
+            RoleSet reconstitutedRoleSet = mapper.readValue(json, RoleSet.class);
+            assertEquals(roles, reconstitutedRoleSet.getRoles());
+
+            RoleImpersonationContextFactory factory = new RoleImpersonationContextFactory(project, adminUser, roles, Collections.emptySet(), null);
+            impersonatingUser.setImpersonationContext(factory.getImpersonationContext());
+
+            if (null == project)
+                assertEquals(roles, impersonatingUser.getSiteRoles().collect(Collectors.toSet()));
+            else
+                assertEquals(roles, impersonatingUser.getAssignedRoles(project).collect(Collectors.toSet()));
+
+            json = writer.writeValueAsString(impersonatingUser);
+            User reconstitutedUser = mapper.readValue(json, User.class);
+
+            if (null == project)
+                assertEquals(roles, reconstitutedUser.getSiteRoles().collect(Collectors.toSet()));
+            else
+                assertEquals(roles, reconstitutedUser.getAssignedRoles(project).collect(Collectors.toSet()));
         }
     }
 }

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -24,6 +24,7 @@ import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.PrincipalArray;
+import org.labkey.api.security.RoleSet;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.SecurityPolicyManager;
@@ -35,7 +36,6 @@ import org.labkey.api.security.permissions.CanImpersonateSiteRolesPermission;
 import org.labkey.api.security.roles.AbstractRootContainerRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
-import org.labkey.api.security.roles.RoleSet;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.ActionURL;
@@ -280,8 +280,8 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         @Override
         public Stream<Role> getSiteRoles(User user)
         {
-            // Return only site roles that are being impersonated
-            return super.getSiteRoles(user).filter(_roles::contains);
+            // Return the site roles that are being impersonated
+            return _roles.stream().filter(role->role instanceof AbstractRootContainerRole);
         }
 
         @Override

--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -43,7 +43,6 @@ public interface AppProps
     String SCOPE_EXPERIMENTAL_FEATURE = "ExperimentalFeature";
     String EXPERIMENTAL_JAVASCRIPT_MOTHERSHIP = "javascriptMothership";
     String EXPERIMENTAL_JAVASCRIPT_SERVER = "javascriptErrorServerLogging";
-    String EXPERIMENTAL_USER_FOLDERS = "userFolders";
     String EXPERIMENTAL_NO_GUESTS = "disableGuestAccount";
     String EXPERIMENTAL_BLOCKER = "blockMaliciousClients";
     String EXPERIMENTAL_RESOLVE_PROPERTY_URI_COLUMNS = "resolve-property-uri-columns";

--- a/query/src/org/labkey/query/reports/ReportServiceImpl.java
+++ b/query/src/org/labkey/query/reports/ReportServiceImpl.java
@@ -69,7 +69,6 @@ import org.labkey.api.reports.report.r.ModuleRReportDescriptor;
 import org.labkey.api.reports.report.r.RReportDescriptor;
 import org.labkey.api.reports.report.view.ReportUtil;
 import org.labkey.api.security.MutableSecurityPolicy;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
@@ -350,12 +349,6 @@ public class ReportServiceImpl extends AbstractContainerListener implements Repo
         }
     }
 
-    @Override @Deprecated /* use ReportIdentifier version saveReportEx */
-    public int saveReport(ContainerUser context, String key, Report report, boolean skipValidation)
-    {
-        return _saveDbReport(context, key, report, skipValidation).getRowId();
-    }
-
     @Override
     public void validateReportPermissions(ContainerUser context, Report report)
     {
@@ -469,12 +462,11 @@ public class ReportServiceImpl extends AbstractContainerListener implements Repo
 
     private ReportIdentifier _saveModuleReport(ContainerUser context, String key, Report report, boolean skipValidation)
     {
-        if (!(report.getDescriptor() instanceof ModuleReportDescriptor) || !(report.getDescriptor().getReportId() instanceof ModuleReportIdentifier))
+        if (!(report.getDescriptor() instanceof ModuleReportDescriptor descriptor) || !(report.getDescriptor().getReportId() instanceof ModuleReportIdentifier))
             throw new IllegalStateException("This should be a module report!");
 
         User user = context.getUser();
         Container c = context.getContainer();
-        ModuleReportDescriptor descriptor = (ModuleReportDescriptor)report.getDescriptor();
 
         report.beforeSave(context);
 

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -1753,9 +1753,9 @@ public class ReportsController extends SpringActionController
                 if (refreshDate != null)
                     descriptor.setRefreshDate(refreshDate);
 
-                int id = ReportService.get().saveReport(getViewContext(), getReportKey(report, form), report);
+                ReportIdentifier reportIdentifier = ReportService.get().saveReportEx(getViewContext(), getReportKey(report, form), report);
 
-                report = (R)ReportService.get().getReport(getContainer(), id);
+                report = (R)ReportService.get().getReport(getContainer(), reportIdentifier.getRowId());
 
                 afterReportSave(form, report);
 

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -268,7 +268,7 @@ public class ReportsController extends BaseStudyController
             {
                 final String key = ReportUtil.getReportQueryKey(report.getDescriptor());
 
-                int reportId = ReportService.get().saveReport(getViewContext(), key, report);
+                int reportId = ReportService.get().saveReportEx(getViewContext(), key, report).getRowId();
 
                 if (form.isRedirectToReport())
                 {
@@ -351,7 +351,7 @@ public class ReportsController extends BaseStudyController
             Report report = form.getReport(getViewContext());
             if (report != null)
             {
-                _savedReportId = ReportService.get().saveReport(getViewContext(), ReportUtil.getReportKey(form.getSchemaName(), form.getQueryName()), report);
+                _savedReportId = ReportService.get().saveReportEx(getViewContext(), ReportUtil.getReportKey(form.getSchemaName(), form.getQueryName()), report).getRowId();
                 return true;
             }
             return false;
@@ -1318,7 +1318,7 @@ public class ReportsController extends BaseStudyController
             String key = ReportUtil.getReportKey(form.getSchemaName(), form.getQueryName());
             Report report = getParticipantReport(form);
 
-            int rowId = ReportService.get().saveReport(getViewContext(), key, report);
+            int rowId = ReportService.get().saveReportEx(getViewContext(), key, report).getRowId();
             ReportIdentifier reportId = ReportService.get().getReportIdentifier(String.valueOf(rowId), getViewContext().getUser(), getViewContext().getContainer());
 
             response.put("success", true);
@@ -1498,8 +1498,7 @@ public class ReportsController extends BaseStudyController
             String key = ReportUtil.getReportKey(StudySchema.getInstance().getSchemaName(), null);
             Report report = getReport(form);
 
-            int rowId = ReportService.get().saveReport(getViewContext(), key, report);
-            ReportIdentifier reportId = ReportService.get().getReportIdentifier(String.valueOf(rowId), getViewContext().getUser(), getViewContext().getContainer());
+            ReportIdentifier reportId = ReportService.get().saveReportEx(getViewContext(), key, report);
 
             response.put("success", true);
             response.put("reportId", reportId);


### PR DESCRIPTION
#### Rationale
- Add tests for RoleSet and role-impersonating user serialization
- Fix `getSiteRoles()` while impersonating roles. Not generally used, but might as well correct its results for testing, debugging, etc.
- Migrate calls to `ReportService.saveReport()` method and remove it

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5607