### PR TITLE
Metrics for remote login actions

### DIFF
--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -64,6 +64,7 @@ import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.settings.WriteableLookAndFeelProperties;
+import org.labkey.api.usageMetrics.SimpleMetricsService;
 import org.labkey.api.util.CSRFUtil;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.HelpTopic;
@@ -90,6 +91,7 @@ import org.labkey.api.view.WebPartView;
 import org.labkey.api.view.template.PageConfig;
 import org.labkey.api.wiki.WikiRendererType;
 import org.labkey.api.wiki.WikiRenderingService;
+import org.labkey.core.CoreModule;
 import org.labkey.core.admin.AdminController;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
@@ -2194,6 +2196,8 @@ public class LoginController extends SpringActionController
         }
     }
 
+    private static final String REMOTE_LOGIN_FEATURE_AREA = "remoteLoginInvocations";
+
     @SuppressWarnings("unused")
     @RequiresLogin
     public static class CreateTokenAction extends SimpleViewAction<TokenAuthenticationForm>
@@ -2217,6 +2221,7 @@ public class LoginController extends SpringActionController
             returnUrl.addParameter("labkeyEmail", user.getEmail());
 
             getViewContext().getResponse().sendRedirect(returnUrl.getURIString());
+            SimpleMetricsService.get().increment(CoreModule.CORE_MODULE_NAME, REMOTE_LOGIN_FEATURE_AREA, "create");
             return null;
         }
 
@@ -2270,7 +2275,7 @@ public class LoginController extends SpringActionController
             }
 
             response.flushBuffer();
-
+            SimpleMetricsService.get().increment(CoreModule.CORE_MODULE_NAME, REMOTE_LOGIN_FEATURE_AREA, "verify");
             return null;
         }
 
@@ -2292,6 +2297,7 @@ public class LoginController extends SpringActionController
             if (null != form.getLabkeyToken())
                 TokenAuthenticationManager.get().invalidateKey(form.getLabkeyToken());
             URLHelper returnUrl = form.getValidReturnUrl();
+            SimpleMetricsService.get().increment(CoreModule.CORE_MODULE_NAME, REMOTE_LOGIN_FEATURE_AREA, "invalidate");
             if (null != returnUrl)
                 return returnUrl;
             return AppProps.getInstance().getHomePageActionURL();


### PR DESCRIPTION
#### Rationale
Adds remote login action invocation counts to the `core` module metrics:

```
"remoteLoginInvocations" : {
  "create" : 6,
  "verify" : 4,
  "invalidate" : 2
}
```