### PR TITLE
Update description for Materials Name field

### DIFF
--- a/experiment/resources/schemas/exp.xml
+++ b/experiment/resources/schemas/exp.xml
@@ -259,7 +259,7 @@
           <description>Contains a life sciences identifier for this sample</description>
       </column>
       <column columnName="Name">
-          <description>Contains a short description for this sample</description>
+          <description>Contains a short name for this sample</description>
       </column>
       <column columnName="Description">
           <description>Contains a description for this sample</description>


### PR DESCRIPTION
#### Rationale
The description for Materials name is not accurate.

#### Changes
- Update the description
