### PR TITLE
Misc 24.7 fixes (issues 50710, 50715, 50672)

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -572,7 +572,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
                                 .setAuditBehaviorType(behaviorType)
                                 .setAuditUserComment(_auditUserComment)
                                 .setOptionParamsMap(getOptionParamsMap())
-                                .setHasLineageColumns(hasLineageColumns())
+                                .setAllowLineageColumns(allowLineageColumns())
                                 .setJobDescription(getQueryImportDescription())
                                 .setJobNotificationProvider(getQueryImportJobNotificationProviderName());
 
@@ -641,10 +641,10 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
 
     protected void configureLoader(DataLoader loader) throws IOException
     {
-        configureLoader(loader, _target, getRenamedColumns(), hasLineageColumns());
+        configureLoader(loader, _target, getRenamedColumns(), allowLineageColumns());
     }
 
-    public static void configureLoader(DataLoader loader, @Nullable TableInfo target, @Nullable Map<String, String> renamedColumns, boolean includeLineageColumns) throws IOException
+    public static void configureLoader(DataLoader loader, @Nullable TableInfo target, @Nullable Map<String, String> renamedColumns, boolean allowLineageColumns) throws IOException
     {
         //apply known columns so loader can do better type conversion
         if (loader != null && target != null)
@@ -664,7 +664,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
 
         // Issue 40302: Unable to use samples or data class with integer like names as material or data input
         // treat lineage columns as string values
-        if (loader != null && includeLineageColumns)
+        if (loader != null && allowLineageColumns)
         {
             ColumnDescriptor[] cols = loader.getColumns();
             for (ColumnDescriptor col : cols)
@@ -684,7 +684,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
 
     }
 
-    protected boolean hasLineageColumns()
+    protected boolean allowLineageColumns()
     {
         return false;
     }

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -673,7 +673,8 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
                 if (name.startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase() + "/") ||
                     name.startsWith(ExpMaterial.MATERIAL_OUTPUT_CHILD.toLowerCase() + "/") ||
                     name.startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase() + "/") ||
-                    name.startsWith(ExpData.DATA_OUTPUT_CHILD.toLowerCase() + "/"))
+                    name.startsWith(ExpData.DATA_OUTPUT_CHILD.toLowerCase() + "/") ||
+                    name.equalsIgnoreCase("Name") /* Issue 50710: Treat "Name" column as a string value for sample or data class import */)
                 {
                     col.clazz = String.class;
                     col.converter = TabLoader.noopConverter;

--- a/api/src/org/labkey/api/query/QueryImportPipelineJob.java
+++ b/api/src/org/labkey/api/query/QueryImportPipelineJob.java
@@ -56,7 +56,7 @@ public class QueryImportPipelineJob extends PipelineJob
         QueryUpdateService.InsertOption _insertOption= QueryUpdateService.InsertOption.INSERT;
         AuditBehaviorType _auditBehaviorType = null;
         String _auditUserComment = null;
-        boolean _hasLineageColumns = false;
+        boolean _allowLineageColumns = false;
         Map<AbstractQueryImportAction.Params, Boolean> _optionParamsMap = new HashMap<>();
 
         String _jobDescription;
@@ -118,9 +118,9 @@ public class QueryImportPipelineJob extends PipelineJob
             return _optionParamsMap;
         }
 
-        public boolean isHasLineageColumns()
+        public boolean allowLineageColumns()
         {
-            return _hasLineageColumns;
+            return _allowLineageColumns;
         }
 
         public String getJobDescription()
@@ -198,9 +198,9 @@ public class QueryImportPipelineJob extends PipelineJob
             return this;
         }
 
-        public QueryImportAsyncContextBuilder setHasLineageColumns(boolean hasLineageColumns)
+        public QueryImportAsyncContextBuilder setAllowLineageColumns(boolean allowLineageColumns)
         {
-            _hasLineageColumns = hasLineageColumns;
+            _allowLineageColumns = allowLineageColumns;
             return this;
         }
 
@@ -271,7 +271,7 @@ public class QueryImportPipelineJob extends PipelineJob
 
             loader = DataLoader.get().createLoader(_importContextBuilder.getPrimaryFile(), _importContextBuilder.getFileContentType(), _importContextBuilder.isHasColumnHeaders(), null, null);
 
-            AbstractQueryImportAction.configureLoader(loader, target, _importContextBuilder.getRenamedColumns(), _importContextBuilder.isHasLineageColumns());
+            AbstractQueryImportAction.configureLoader(loader, target, _importContextBuilder.getRenamedColumns(), _importContextBuilder.allowLineageColumns());
 
             TransactionAuditProvider.TransactionAuditEvent auditEvent = null;
 

--- a/api/src/org/labkey/api/study/assay/FileLinkDisplayColumn.java
+++ b/api/src/org/labkey/api/study/assay/FileLinkDisplayColumn.java
@@ -166,6 +166,7 @@ public class FileLinkDisplayColumn extends AbstractFileDisplayColumn
             sb.append("&pk=${");
             sb.append(pkFieldKey);
             sb.append("}");
+            sb.append("&modified=${Modified}");
             if (AS_ATTACHMENT_FORMAT.equalsIgnoreCase(col.getFormat()))
             {
                 sb.append("&inline=false");
@@ -233,6 +234,7 @@ public class FileLinkDisplayColumn extends AbstractFileDisplayColumn
     public void addQueryFieldKeys(Set<FieldKey> keys)
     {
         super.addQueryFieldKeys(keys);
+        keys.add(FieldKey.fromParts("Modified"));
         if (_pkFieldKey != null)
             keys.add(_pkFieldKey);
         if (_objectURIFieldKey != null)

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -872,7 +872,7 @@ public class DomainImpl implements Domain
         for (DomainProperty prop: uniqueIdProps)
         {
             // Issue 50715: quote column names with spaces for update statement
-            sql.append(separator).append(dialect.getColumnSelectName(prop.getName())).append(" = ?").add(new Parameter(prop.getName(), prop.getJdbcType()));
+            sql.append(separator).append(prop.getPropertyDescriptor().getLegalSelectName(dialect)).append(" = ?").add(new Parameter(prop.getName(), prop.getJdbcType()));
             separator = ",";
         }
         sql.append(" WHERE ");

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4250,7 +4250,7 @@ public class ExperimentController extends SpringActionController
         }
 
         @Override
-        protected boolean hasLineageColumns()
+        protected boolean allowLineageColumns()
         {
             return true;
         }


### PR DESCRIPTION
#### Rationale
- Issue [50710](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50710): DataLoader converter to treat "Name" column as a string value for sample or data class import
- Issue [50715](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50715): Unique ID column population to quote column names with spaces for update statement
- Issue [50672](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50672): FileLinkDisplayColumn to include modified date in url so app thumbnails are updated

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1521

#### Changes
- query import configureLoader to treat "Name" similar to lineage columns for converter (i.e. force as String)
- FileLinkDisplayColumn to add modified date to URL to prevent browser cache issues on update
- DomainImpl to use getLegalSelectName() in unique ID update statement
