### PR TITLE
Sync ancestor nodes for multiple runs all at once

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -497,6 +497,26 @@ public class ClosureQueryHelper
         recomputeFromSeeds(selectSeedsSql, true);
     }
 
+    private static void recomputeMaterialAncestorsForRuns(Collection<Integer> runIds)
+    {
+        var tx = getScope().getCurrentTransaction();
+        if (null != tx)
+        {
+            tx.addCommitTask(() -> recomputeMaterialAncestorsForRuns(runIds), DbScope.CommitTaskOption.POSTCOMMIT);
+            return;
+        }
+
+        SQLFragment selectSeedsSql = new SQLFragment()
+                .append("SELECT m.RowId, m.ObjectId, 'm' AS ObjectType FROM exp.material m\n")
+                .append("INNER JOIN exp.MaterialInput mi ON m.rowId = mi.materialId\n")
+                .append("INNER JOIN exp.ProtocolApplication pa ON mi.TargetApplicationId = pa.RowId\n")
+                .append("WHERE pa.RunId ");
+        getScope().getSqlDialect().appendInClauseSql(selectSeedsSql, runIds);
+        selectSeedsSql
+                .append(" AND pa.CpasType = ").appendValue(ExperimentRunOutput);
+        recomputeFromSeeds(selectSeedsSql, true);
+    }
+
     public static void recomputeDataObjectAncestors(int rowId)
     {
         var tx = getScope().getCurrentTransaction();
@@ -529,6 +549,32 @@ public class ClosureQueryHelper
                 .append(" AND d.cpasType = ? ").add(sourceTypeLsid)
                 .append(" AND pa.CpasType = ").appendValue(ExperimentRunOutput);
         recomputeFromSeeds(selectSeedsSql, false);
+    }
+
+    private static void recomputeDataAncestorsForRuns(Collection<Integer> runIds)
+    {
+        var tx = getScope().getCurrentTransaction();
+        if (null != tx)
+        {
+            tx.addCommitTask(() -> recomputeDataAncestorsForRuns(runIds), DbScope.CommitTaskOption.POSTCOMMIT);
+            return;
+        }
+
+        SQLFragment selectSeedsSql = new SQLFragment()
+                .append("SELECT d.RowId, d.ObjectId, 'd' AS ObjectType FROM exp.data d\n")
+                .append("INNER JOIN exp.DataInput di ON d.rowId = di.dataId\n")
+                .append("INNER JOIN exp.ProtocolApplication pa ON di.TargetApplicationId = pa.RowId\n")
+                .append("WHERE pa.RunId ");
+        getScope().getSqlDialect().appendInClauseSql(selectSeedsSql, runIds);
+        selectSeedsSql
+                .append(" AND pa.CpasType = ").appendValue(ExperimentRunOutput);
+        recomputeFromSeeds(selectSeedsSql, false);
+    }
+
+    public static void recomputeAncestorsForRuns(Collection<Integer> runIds)
+    {
+        recomputeDataAncestorsForRuns(runIds);
+        recomputeMaterialAncestorsForRuns(runIds);
     }
 
     private static DbScope getScope()

--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -573,6 +573,9 @@ public class ClosureQueryHelper
 
     public static void recomputeAncestorsForRuns(Collection<Integer> runIds)
     {
+        if (runIds.isEmpty())
+            return;
+
         recomputeDataAncestorsForRuns(runIds);
         recomputeMaterialAncestorsForRuns(runIds);
     }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -3415,8 +3415,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         final String runLsid;
         final Container runContainer;
         boolean deleteFirst = true;
-        boolean verifyEdgesNoInsert=false;
-        boolean doIncrementalClosureInvalidation =true;
+        boolean verifyEdgesNoInsert = false;
+        boolean doIncrementalClosureInvalidation = true;
 
         SyncRunEdges(ExpRun run)
         {
@@ -7278,9 +7278,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             {
                 new SyncRunEdges(er.getExpObject())
                         .deleteFirst(false)
+                        .doIncrementalClosureInvalidation(false) // do this update all at once below
                         .verifyEdgesNoInsert(false)
                         .sync(cpasTypeToObjectId);
             }
+            ClosureQueryHelper.recomputeAncestorsForRuns(runLsidToRowId.values().stream().map(IdentifiableEntity::getRowId).toList());
         }
 
         private void initAliquotRootsCache(List<ProtocolAppRecord> protAppRecords)


### PR DESCRIPTION
#### Rationale
When we create many derivatives or aliquots at once, it makes more sense to batch the ancestor updates all together rather than do each run individually.  We've seen some degradation in our UI performance tests after the Ancestor implementation was updated. Locally, things perform much better with these changes.

#### Related Pull Requests
- #5508 

#### Changes
- Add method to `ClosureQueryHelper` to recompute ancestors for a set of runs.
