### PR TITLE
Deprecate ACL-style perms in module HTML view files

### DIFF
--- a/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
+++ b/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
@@ -121,7 +121,7 @@ public class ModuleHtmlViewDefinition
                 _viewDef = viewDoc.getView();
                 if (null != _viewDef)
                 {
-                    calculatePermissions();
+                    calculatePermissions(r.toString());
                     // We will reload to pick up changes, so don't just keep adding to the same set of dependencies.
                     // Start over each time and flip the collection all at once.
                     addResources();
@@ -146,11 +146,12 @@ public class ModuleHtmlViewDefinition
         return ColumnInfo.labelFromName(name);
     }
 
-    protected void calculatePermissions()
+    protected void calculatePermissions(String resource)
     {
         PermissionsListType permsList = _viewDef.getPermissions();
         if (permsList != null && permsList.getPermissionArray() != null)
         {
+            _log.warn("The \"<permissions>\" element used in \"{}\" is deprecated and support will be removed in 24.11! Migrate uses to \"<permissionClasses>\".", resource);
             for (PermissionType permEntry : permsList.getPermissionArray())
             {
                 SimpleAction.PermissionEnum perm = SimpleAction.PermissionEnum.valueOf(permEntry.getName().toString());
@@ -159,7 +160,7 @@ public class ModuleHtmlViewDefinition
                     _requiresLogin = true;
                 else if (SimpleAction.PermissionEnum.none == perm)
                     _requiredPerms = perm.toInt();
-                else if (null != perm)
+                else
                     _requiredPerms |= perm.toInt();
             }
         }

--- a/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
@@ -33,11 +33,6 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 
-/*
-* User: adam
-* Date: Nov 26, 2010
-* Time: 10:11:46 PM
-*/
 public class MySqlDialectFactory implements SqlDialectFactory
 {
     private static final Logger _log = LogManager.getLogger(MySqlDialectFactory.class);
@@ -80,7 +75,7 @@ public class MySqlDialectFactory implements SqlDialectFactory
         return "com.mysql.cj.jdbc.Driver".equals(driverClassName) || "com.mysql.jdbc.Driver".equals(driverClassName) ? new MySqlDialect() : null;
     }
 
-    private final static String RECOMMENDED = getProductName() + " 8.0.x is the recommended version.";
+    private final static String RECOMMENDED = getProductName() + " 8.4.x is the recommended version.";
 
     @Override
     public @Nullable SqlDialect createFromMetadata(DatabaseMetaData md, boolean logWarnings, boolean primaryDataSource) throws SQLException, DatabaseNotSupportedException
@@ -95,8 +90,8 @@ public class MySqlDialectFactory implements SqlDialectFactory
         // Version 5.1 or greater is allowed...
         if (version >= 51)
         {
-            // ...but warn for anything greater than 8.0.x
-            if (logWarnings && version > 80)
+            // ...but warn for anything greater than 8.4.x
+            if (logWarnings && version > 84)
                 _log.warn("LabKey Server has not been tested against " + getProductName() + " version " + databaseProductVersion + ". " +  RECOMMENDED);
 
             if (version >= 80)


### PR DESCRIPTION
#### Rationale
In a couple releases, we want to eliminate old style bitmask perms in favor of permissions classes. The only place these are still provided to the system is in the `<permissions>` element of module HTML `.view.xml` files. For 24.7, just add a warning with a recommendation to migrate to the `<permissionClasses>` element. (Note that bitmask perms are *reported* by a few APIs, but we'll handle that separately.) 

Refactor `SimpleAction` permission checking to consolidate redundant checks and prep for (eventual) bitmask perm removal.

Bump up supported version of MySQL.