### PR TITLE
Issue 50730: resolve data class table titles as displayValue

### DIFF
--- a/api/src/org/labkey/api/exp/api/FilterProtocolInputCriteria.java
+++ b/api/src/org/labkey/api/exp/api/FilterProtocolInputCriteria.java
@@ -83,24 +83,22 @@ public class FilterProtocolInputCriteria extends AbstractProtocolInputCriteria
     public List<? extends ExpRunItem> findMatching(@NotNull ExpProtocolInput protocolInput, @NotNull User user, @NotNull Container c)
     {
         TableInfo table = null;
-        if (protocolInput instanceof ExpDataProtocolInput)
+        if (protocolInput instanceof ExpDataProtocolInput dpi)
         {
-            ExpDataProtocolInput dpi = (ExpDataProtocolInput)protocolInput;
             ExpDataClass dc = dpi.getType();
             if (dc != null)
             {
-                UserSchema schema = QueryService.get().getUserSchema(user, c, SchemaKey.fromParts(ExpSchema.SCHEMA_NAME, ExpSchema.NestedSchemas.data.toString()));
+                UserSchema schema = QueryService.get().getUserSchema(user, c, ExpSchema.SCHEMA_EXP_DATA);
                 table = schema.getTable(dc.getName());
             }
             else
             {
-                UserSchema schema = QueryService.get().getUserSchema(user, c, SchemaKey.fromParts(ExpSchema.SCHEMA_NAME));
+                UserSchema schema = QueryService.get().getUserSchema(user, c, ExpSchema.SCHEMA_EXP);
                 table = schema.getTable(ExpSchema.TableType.Data.toString());
             }
         }
-        else if (protocolInput instanceof ExpMaterialProtocolInput)
+        else if (protocolInput instanceof ExpMaterialProtocolInput mpi)
         {
-            ExpMaterialProtocolInput mpi = (ExpMaterialProtocolInput)protocolInput;
             ExpSampleType st = mpi.getType();
             if (st != null)
             {
@@ -109,7 +107,7 @@ public class FilterProtocolInputCriteria extends AbstractProtocolInputCriteria
             }
             else
             {
-                UserSchema schema = QueryService.get().getUserSchema(user, c, SchemaKey.fromParts(ExpSchema.SCHEMA_NAME));
+                UserSchema schema = QueryService.get().getUserSchema(user, c, ExpSchema.SCHEMA_EXP);
                 table = schema.getTable(ExpSchema.TableType.Materials.toString());
             }
         }

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -69,6 +69,8 @@ public class ExpSchema extends AbstractExpSchema
 
     public static final SchemaKey SCHEMA_EXP = SchemaKey.fromParts(ExpSchema.SCHEMA_NAME);
     public static final SchemaKey SCHEMA_EXP_DATA = SchemaKey.fromString(SCHEMA_EXP, ExpSchema.NestedSchemas.data.name());
+    public static final SchemaKey SCHEMA_EXP_MATERIALS = SchemaKey.fromString(SCHEMA_EXP, ExpSchema.NestedSchemas.materials.name());
+
     private static final Set<String> ADDITIONAL_SOURCES_AUDIT_FIELDS = new CaseInsensitiveHashSet("Name");
 
     public enum NestedSchemas

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -6204,8 +6204,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         // Delete sequences (genId and the unique counters)
         DbSequenceManager.deleteLike(c, ExpDataClassImpl.SEQUENCE_PREFIX, dataClass.getRowId(), getExpSchema().getSqlDialect());
 
-        SchemaKey expDataSchema = SchemaKey.fromParts(ExpSchema.SCHEMA_NAME, ExpSchema.NestedSchemas.data.toString());
-        QueryService.get().fireQueryDeleted(user, c, null, expDataSchema, singleton(dataClass.getName()));
+        QueryService.get().fireQueryDeleted(user, c, null, ExpSchema.SCHEMA_EXP_DATA, singleton(dataClass.getName()));
 
         // remove DataClass from search index
         SearchService ss = SearchService.get();

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -1129,11 +1129,11 @@ public class ExperimentController extends SpringActionController
 
         private QueryView getDataClassContentsView(BindException errors)
         {
-            ExpSchema expSchema = new ExpSchema(getUser(), getContainer());
-            UserSchema dataClassSchema = (UserSchema) expSchema.getSchema(ExpSchema.NestedSchemas.data.toString());
+            UserSchema dataClassSchema = QueryService.get().getUserSchema(getUser(), getContainer(), ExpSchema.SCHEMA_EXP_DATA);
             QuerySettings settings = dataClassSchema.getSettings(getViewContext(), QueryView.DATAREGIONNAME_DEFAULT, _dataClass.getName());
-            return new QueryView(dataClassSchema, settings, errors){
 
+            return new QueryView(dataClassSchema, settings, errors)
+            {
                 @Override
                 public @NotNull LinkedHashSet<ClientDependency> getClientDependencies()
                 {
@@ -3636,13 +3636,13 @@ public class ExperimentController extends SpringActionController
                 if (dc == null)
                 {
                     // Reference to exp.Data table
-                    schemaKey = SchemaKey.fromParts(ExpSchema.SCHEMA_NAME);
+                    schemaKey = ExpSchema.SCHEMA_EXP;
                     queryName = ExpSchema.TableType.Data.name();
                 }
                 else
                 {
                     // Reference to exp.data.<DataClass> table
-                    schemaKey = SchemaKey.fromParts(ExpSchema.SCHEMA_NAME, ExpSchema.NestedSchemas.data.name());
+                    schemaKey = ExpSchema.SCHEMA_EXP_DATA;
                     queryName = dc.getName();
                 }
 


### PR DESCRIPTION
#### Rationale
This addresses [Issue 50730](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50730) by having the server furnish the title of the table as the `displayValue` via `selectRows` for the `exp.DataClasses.Name` column.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1522
- https://github.com/LabKey/limsModules/pull/410
- https://github.com/LabKey/platform/pull/5634

#### Changes
- Add display column factory for the `exp.DataClasses.Name` column to resolve the table title
- Use `SchemaKey` constants declared by `ExpSchema`
