### PR TITLE
Misc 24.8 fixes and test cases

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -559,9 +559,12 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
         ExpSampleTypeImpl sampleType = (ExpSampleTypeImpl) getSampleType();
         Map<String,Object> uriMap = getProperties(sampleType);
         Map<PropertyDescriptor, Object> values = new HashMap<>();
-        for (DomainProperty pd : sampleType.getDomain().getProperties())
+        if (sampleType != null)
         {
-            values.put(pd.getPropertyDescriptor(), uriMap.get(pd.getPropertyURI()));
+            for (DomainProperty pd : sampleType.getDomain().getProperties())
+            {
+                values.put(pd.getPropertyDescriptor(), uriMap.get(pd.getPropertyURI()));
+            }
         }
         return values;
     }

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -1034,7 +1034,7 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
                 }
                 catch (ConversionException e)
                 {
-                    throw new ValidationException(e.getMessage());
+                    throw new QueryUpdateServiceException("Unable to convert value " + e.getMessage());
                 }
                 catch (BatchValidationException e)
                 {


### PR DESCRIPTION
#### Rationale
Issue [50409](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50409): NullPointerException in org.labkey.experiment.api.ExpMaterialImpl.getPropertyValues()
Issue [50388](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50388): Update uncategorized SqlException error to show conversion error when submitting string value to integer field

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5642
- https://github.com/LabKey/limsModules/pull/417

#### Changes
- ExpMaterialImpl.getPropertyValues() add null check for sampleType
- ExpRunTableImpl to throw QueryUpdateServiceException instead of ValidationException