### PR TITLE
PlateSetExport: update lookup resolution

### DIFF
--- a/assay/api-src/org/labkey/api/assay/plate/PlateSet.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateSet.java
@@ -23,7 +23,7 @@ public interface PlateSet
 
     boolean isTemplate();
 
-    List<Plate> getPlates(User user);
+    List<Plate> getPlates();
 
     PlateSetType getType();
 }

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -42,7 +42,6 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.module.ModuleContext;
-import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;

--- a/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
+++ b/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
@@ -331,7 +331,7 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
     {
         // create a row for every plate in the plate set
         List<Map<String, Object>> data = new ArrayList<>();
-        for (Plate plate : plateSet.getPlates(getUser()))
+        for (Plate plate : plateSet.getPlates())
         {
             for (int row=0; row < _plateType.getRows(); row++)
             {

--- a/assay/src/org/labkey/assay/plate/PlateCache.java
+++ b/assay/src/org/labkey/assay/plate/PlateCache.java
@@ -155,9 +155,9 @@ public class PlateCache
         return getPlates(c, null);
     }
 
-    public static @NotNull List<Plate> getPlatesForPlateSet(Container c, Integer plateSetId)
+    public static @NotNull List<Plate> getPlatesForPlateSet(Container c, Integer plateSetRowId)
     {
-        return getPlates(c, new SimpleFilter(FieldKey.fromParts(PlateTable.Column.PlateSet.name()), plateSetId));
+        return getPlates(c, new SimpleFilter(FieldKey.fromParts(PlateTable.Column.PlateSet.name()), plateSetRowId));
     }
 
     public static @NotNull List<Plate> getPlateTemplates(Container c)

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -328,7 +328,7 @@ public final class PlateManagerTest
 
         // Assert
         assertTrue("Expected plateSet to have been persisted and provided with a rowId", plateSet.getRowId() > 0);
-        List<Plate> plates = plateSet.getPlates(user);
+        List<Plate> plates = plateSet.getPlates();
         assertEquals("Expected plateSet to have 3 plates", 3, plates.size());
 
         // verify access via plate rowId

--- a/assay/src/org/labkey/assay/plate/PlateSetExport.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetExport.java
@@ -88,7 +88,7 @@ public class PlateSetExport
 
         List<ColumnDescriptor> metadataColumns = includedMetadataCols
                 .stream()
-                .map(fk -> new ColumnDescriptor(fk.getParts().size() > 2 ? fk.getParent().getCaption() : fk.getCaption()))
+                .map(fk -> new ColumnDescriptor(fk.getParts().size() > 1 ? fk.getParent().getCaption() : fk.getCaption()))
                 .toList();
 
         baseColumns.addAll(metadataColumns);
@@ -111,11 +111,11 @@ public class PlateSetExport
         // Where the data rows contain the key's sample
         try (Results rs = QueryService.get().select(wellTable, getWellColumns(wellTable, destinationIncludedMetadataCols), new SimpleFilter(FKMap.get(PLATE_SET_ID_COL), destinationPlateSetId), new Sort(ROW_ID_COL)))
         {
-            while (rs.next()) {
+            while (rs.next())
+            {
                 String sampleId = rs.getString(FKMap.get(SAMPLE_ID_COL));
-                if (sampleId == null) {
+                if (sampleId == null)
                     continue;
-                }
 
                 sampleIdToDestinationRow.computeIfAbsent(sampleId, key -> new ArrayList<>())
                         .add(getDataRow(PlateSetExport.DESTINATION, rs, destinationIncludedMetadataCols));

--- a/assay/src/org/labkey/assay/plate/PlateSetImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetImpl.java
@@ -7,18 +7,12 @@ import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateSetType;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.Entity;
 import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableSelector;
-import org.labkey.api.query.FieldKey;
-import org.labkey.api.security.User;
 import org.labkey.assay.query.AssayDbSchema;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -123,16 +117,12 @@ public class PlateSetImpl extends Entity implements PlateSet
     }
 
     @Override
-    public List<Plate> getPlates(User user)
+    public List<Plate> getPlates()
     {
-        ContainerFilter cf = PlateManager.get().getPlateContainerFilter(null, getContainer(), user);
-        List<Plate> plates = new ArrayList<>();
-        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("PlateSet"), _rowId);
-        new TableSelector(AssayDbSchema.getInstance().getTableInfoPlate(), Collections.singleton("RowId"), filter, null).forEach(Integer.class, plateId -> {
-            plates.add(PlateCache.getPlate(cf, plateId));
-        });
+        if (isNew())
+            return Collections.emptyList();
 
-        return plates;
+        return PlateCache.getPlatesForPlateSet(getContainer(), getRowId());
     }
 
     @JsonProperty("plateCount")

--- a/assay/src/org/labkey/assay/plate/model/PlateTypeBean.java
+++ b/assay/src/org/labkey/assay/plate/model/PlateTypeBean.java
@@ -1,5 +1,6 @@
 package org.labkey.assay.plate.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.labkey.api.assay.plate.PlateType;
 
@@ -80,6 +81,7 @@ public class PlateTypeBean implements PlateType
         _archived = archived;
     }
 
+    @JsonIgnore
     @Override
     public Integer getWellCount()
     {

--- a/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
@@ -208,7 +208,7 @@ public class PlateSetTable extends SimpleUserSchema.SimpleTable<UserSchema>
             if (plateSet == null)
                 throw new QueryUpdateServiceException(String.format("Plate set could not be found for ID : %d", plateSetId));
 
-            List<Plate> plates = plateSet.getPlates(user);
+            List<Plate> plates = plateSet.getPlates();
             if (!plates.isEmpty())
                 throw new QueryUpdateServiceException(String.format("Plate set has %d plates associated with it and cannot be deleted.", plates.size()));
 


### PR DESCRIPTION
#### Rationale
With the removal of the "Properties/" prefix from plate well metadata we need to update plate set export to refer to single level lookups.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/423
- https://github.com/LabKey/platform/pull/5637

#### Changes
- Decrement field key size constraint in `PlateSetExport` to match lookups on the well table.
- Consolidate implementation of `PlateCache.getPlates()` variants.
