### PR TITLE
PlateMapExcelWriter: no longer refer to "Properties"

### DIFF
--- a/assay/api-src/org/labkey/api/assay/plate/PlateMapExcelWriter.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateMapExcelWriter.java
@@ -18,11 +18,9 @@ import org.labkey.api.data.Results;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.util.logging.LogHelper;
-import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 
 import java.io.IOException;
-import java.io.Writer;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
@@ -101,7 +99,8 @@ public class PlateMapExcelWriter extends ExcelWriter
         incrementRow();
     }
 
-    protected CellStyle getCellStyle(Workbook workbook, DisplayColumn dc) {
+    protected CellStyle getCellStyle(Workbook workbook, DisplayColumn dc)
+    {
         CellStyle cellStyle = _cellStyleMap.get(dc.getName());
 
         if (cellStyle == null)
@@ -222,7 +221,7 @@ public class PlateMapExcelWriter extends ExcelWriter
             else // CustomField view
             {
                 PlateCustomField customField = _plate.getCustomFields().get(sheetNumber - 2);
-                FieldKey fieldKey = FieldKey.fromParts("Properties", customField.getName());
+                FieldKey fieldKey = FieldKey.fromParts(customField.getName());
                 displayColumns = _displayColumns.stream().filter(dc -> dc.getColumnInfo().getFieldKey().equals(fieldKey)).toList();
             }
 
@@ -251,129 +250,6 @@ public class PlateMapExcelWriter extends ExcelWriter
                 setSheetName(customFields.get(sheetNum - 2).getName());
 
             renderNewSheet(workbook);
-        }
-    }
-
-    public class PlateMapDisplayColumn extends DisplayColumn
-    {
-        Class valueClass;
-
-        public PlateMapDisplayColumn(String name, Class valueClass)
-        {
-            this(name, name, valueClass);
-        }
-
-        public PlateMapDisplayColumn(String name, String caption, Class valueClass)
-        {
-            setName(name);
-            setCaption(caption);
-            this.valueClass = valueClass;
-        }
-
-        @Override
-        public Object getValue(RenderContext ctx)
-        {
-            //Ignore the context.
-//            return maps.get(currentRow).get(getName());
-            return null;
-        }
-
-        @Override
-        public Class getValueClass()
-        {
-            return valueClass;
-        }
-
-
-        //NOTE: Methods beyond here are unimplemented, just abstract in base class!
-        @Override
-        public void renderGridCellContents(RenderContext ctx, Writer out)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void renderDetailsCellContents(RenderContext ctx, Writer out)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void renderTitle(RenderContext ctx, Writer out)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public boolean isSortable()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isFilterable()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isEditable()
-        {
-            return false;
-        }
-
-        @Override
-        public void renderFilterOnClick(RenderContext ctx, Writer out)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void renderInputHtml(RenderContext ctx, Writer out, Object value)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void setURL(ActionURL url)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void setURL(String url)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public String getURL()
-        {
-            return null;
-        }
-
-        @Override
-        public String renderURL(RenderContext ctx)
-        {
-            return null;
-        }
-
-        @Override
-        public boolean isQueryColumn()
-        {
-            return false;
-        }
-
-        @Override
-        public ColumnInfo getColumnInfo()
-        {
-            return null;
-        }
-
-        @Override
-        public void render(RenderContext ctx, Writer out)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
         }
     }
 }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3195,7 +3195,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return new QueryView(userSchema, settings, null);
     }
 
-    public List<DisplayColumn> getPlateDisplayColumns(QueryView queryView)
+    private List<DisplayColumn> getPlateDisplayColumns(QueryView queryView)
     {
         // We have to use the display columns from the DataRegion returned from createDataView in order to get the
         // correct columns that we set via QuerySettings in getPlateQueryView, if we don't then we'll only get the

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -33,7 +33,7 @@ import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateCustomField;
 import org.labkey.api.assay.plate.PlateLayoutHandler;
-import org.labkey.api.assay.plate.PlateMapExcelWriter;
+import org.labkey.assay.plate.data.PlateMapExcelWriter;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateSetEdge;

--- a/assay/src/org/labkey/assay/plate/data/PlateMapExcelWriter.java
+++ b/assay/src/org/labkey/assay/plate/data/PlateMapExcelWriter.java
@@ -1,4 +1,4 @@
-package org.labkey.api.assay.plate;
+package org.labkey.assay.plate.data;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.poi.ss.usermodel.Cell;
@@ -7,6 +7,9 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateCustomField;
+import org.labkey.api.assay.plate.PositionImpl;
 import org.labkey.api.collections.ResultSetRowMapFactory;
 import org.labkey.api.collections.RowMap;
 import org.labkey.api.data.ColumnInfo;

--- a/assay/src/org/labkey/assay/plate/data/PlateMapExcelWriter.java
+++ b/assay/src/org/labkey/assay/plate/data/PlateMapExcelWriter.java
@@ -22,6 +22,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.HttpView;
+import org.labkey.assay.plate.query.WellTable;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -67,8 +68,8 @@ public class PlateMapExcelWriter extends ExcelWriter
             while (results.next())
             {
                 RowMap<Object> well = factory.getRowMap(results);
-                Integer row = (Integer) well.get("Row");
-                Integer col = (Integer) well.get("Col");
+                Integer row = (Integer) well.get(WellTable.Column.Row.name());
+                Integer col = (Integer) well.get(WellTable.Column.Col.name());
 
                 Map<Integer, RowMap<Object>> rowMap = _wellData.computeIfAbsent(row, k -> new HashMap<>());
 

--- a/assay/src/org/labkey/assay/plate/data/PlateMapExcelWriter.java
+++ b/assay/src/org/labkey/assay/plate/data/PlateMapExcelWriter.java
@@ -35,12 +35,8 @@ public class PlateMapExcelWriter extends ExcelWriter
     private static final Logger logger = LogHelper.getLogger(PlateMapExcelWriter.class, "Plate map export");
 
     private final Plate _plate;
-
     private final QueryView _queryView;
-
     private final List<DisplayColumn> _displayColumns;
-
-    private final Map<String, CellStyle> _cellStyleMap = new HashMap<>();
 
     // Map of Row label (A, B, etc.) to Column Data, which is a Map of Column Label (1, 2, etc.) to Well Data (Sample
     // ID, metadata column values)
@@ -101,24 +97,6 @@ public class PlateMapExcelWriter extends ExcelWriter
         }
 
         incrementRow();
-    }
-
-    protected CellStyle getCellStyle(Workbook workbook, DisplayColumn dc)
-    {
-        CellStyle cellStyle = _cellStyleMap.get(dc.getName());
-
-        if (cellStyle == null)
-        {
-            String formatString = dc.getExcelFormatString();
-
-            if (formatString == null)
-                formatString = dc.getFormatString();
-
-            cellStyle = ExcelCellUtils.createCellStyle(workbook, ExcelCellUtils.getSimpleType(dc), formatString);
-            _cellStyleMap.put(dc.getName(), cellStyle);
-        }
-
-        return cellStyle;
     }
 
     private String getDisplayColumnAlias(DisplayColumn displayColumn)


### PR DESCRIPTION
#### Rationale
This updates another usage of plate metadata fields that was referring to custom fields by the "Properties" prefix.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5637

#### Changes
- PlateMapExcelWriter: remove reference to "Properties"
- Move PlateMapExcelWriter to from api to assay package
- Use WellTable.Column constants
