### PR TITLE
Support MySQL server version 9.0.0

### DIFF
--- a/bigiron/src/org/labkey/bigiron/mysql/MySql90Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySql90Dialect.java
@@ -1,0 +1,22 @@
+package org.labkey.bigiron.mysql;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.collections.CsvSet;
+
+import java.util.Set;
+
+public class MySql90Dialect extends MySql80Dialect
+{
+    @NotNull
+    @Override
+    protected Set<String> getReservedWords()
+    {
+        // Update reserved words for MySQL 9.0
+        Set<String> words = super.getReservedWords();
+
+        words.removeAll(new CsvSet("master_bind, master_ssl_verify_server_cert"));
+        words.addAll(new CsvSet("intersect, parallel, tablesample"));
+
+        return words;
+    }
+}

--- a/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
@@ -75,7 +75,7 @@ public class MySqlDialectFactory implements SqlDialectFactory
         return "com.mysql.cj.jdbc.Driver".equals(driverClassName) || "com.mysql.jdbc.Driver".equals(driverClassName) ? new MySqlDialect() : null;
     }
 
-    private final static String RECOMMENDED = getProductName() + " 8.4.x is the recommended version.";
+    private final static String RECOMMENDED = getProductName() + " 9.0.x is the recommended version.";
 
     @Override
     public @Nullable SqlDialect createFromMetadata(DatabaseMetaData md, boolean logWarnings, boolean primaryDataSource) throws SQLException, DatabaseNotSupportedException
@@ -90,9 +90,12 @@ public class MySqlDialectFactory implements SqlDialectFactory
         // Version 5.1 or greater is allowed...
         if (version >= 51)
         {
-            // ...but warn for anything greater than 8.4.x
-            if (logWarnings && version > 84)
+            // ...but warn for anything greater than 9.0.x
+            if (logWarnings && version > 90)
                 _log.warn("LabKey Server has not been tested against " + getProductName() + " version " + databaseProductVersion + ". " +  RECOMMENDED);
+
+            if (version >= 90)
+                return new MySql90Dialect();
 
             if (version >= 80)
                 return new MySql80Dialect();


### PR DESCRIPTION
#### Rationale
MySQL server 9.0.0 released recently. LabKey seems to support it just fine with a couple minor changes.