### PR TITLE
ExperimentService: consolidate object fetch and deserialization logic

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -155,6 +155,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     List<? extends ExpRun> getExpRuns(Collection<Integer> rowIds);
 
+    @Nullable
     ExpRun getExpRun(String lsid);
 
     /** @return a list of ExpRuns ordered by the RowId */
@@ -182,8 +183,10 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     void syncRunEdges(Collection<ExpRun> runs);
 
+    @Nullable
     ExpData getExpData(int rowId);
 
+    @Nullable
     ExpData getExpData(String lsid);
 
     @NotNull
@@ -196,7 +199,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     List<? extends ExpData> getExpDatas(Collection<Integer> rowid);
 
     @NotNull
-    List<? extends ExpData> getExpDatas(ExpDataClass dataClass, Collection<Integer> rowIds);
+    List<? extends ExpData> getExpDatas(@NotNull ExpDataClass dataClass, Collection<Integer> rowIds);
 
     List<? extends ExpData> getExpDatas(Container container, @Nullable DataType type, @Nullable String name);
 
@@ -740,11 +743,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     void deleteAllExpObjInContainer(Container container, User user) throws ExperimentException;
 
-    void deleteExperimentRunsByRowIds(Container container, final User user, int... selectedRunIds);
+    void deleteExperimentRunsByRowIds(Container container, final User user, int... runRowIds);
 
-    void deleteExperimentRunsByRowIds(Container container, final User user, @Nullable String userComment, @NotNull Collection<Integer> selectedRunIds);
-
-    void deleteExpExperimentByRowId(Container container, User user, int experimentId);
+    void deleteExperimentRunsByRowIds(Container container, final User user, @Nullable String userComment, @NotNull Collection<Integer> runRowIds);
 
     void addExperimentListener(ExperimentListener listener);
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -746,6 +746,8 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     void deleteExperimentRunsByRowIds(Container container, final User user, @Nullable String userComment, @NotNull Collection<Integer> runRowIds);
 
+    void deleteExpExperimentByRowId(Container container, User user, int experimentId);
+
     void addExperimentListener(ExperimentListener listener);
 
     void clearCaches();

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -383,20 +383,19 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     ExpExperiment createExpExperiment(Container container, String name);
 
-    ExpExperiment getExpExperiment(int rowid);
+    @Nullable ExpExperiment getExpExperiment(int rowId);
 
-    ExpExperiment getExpExperiment(String lsid);
+    @Nullable ExpExperiment getExpExperiment(String lsid);
 
     List<? extends ExpExperiment> getExpExperiments(Collection<Integer> rowIds);
 
     List<? extends ExpExperiment> getExperiments(Container container, User user, boolean includeOtherContainers, boolean includeBatches);
 
-    ExpProtocol getExpProtocol(int rowid);
+    @Nullable ExpProtocol getExpProtocol(int rowid);
 
-    @Nullable
-    ExpProtocol getExpProtocol(String lsid);
+    @Nullable ExpProtocol getExpProtocol(String lsid);
 
-    ExpProtocol getExpProtocol(Container container, String name);
+    @Nullable ExpProtocol getExpProtocol(Container container, String name);
 
     ExpProtocol createExpProtocol(Container container, ExpProtocol.ApplicationType type, String name);
 

--- a/api/src/org/labkey/api/exp/query/ExpExperimentTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpExperimentTable.java
@@ -30,21 +30,23 @@ public interface ExpExperimentTable extends ExpTable<ExpExperimentTable.Column>
 
     enum Column
     {
-        RowId,
-        LSID,
-        Name,
-        Hypothesis,
-        Contact,
-        ExperimentDescriptionURL,
+        BatchProtocolId,
         Comments,
+        Contact,
         Created,
         CreatedBy,
+        ExperimentDescriptionURL,
+        FilePathRoot,
+        Folder,
+        Hypothesis,
+        JobId,
+        LSID,
         Modified,
         ModifiedBy,
-        RunCount,
-        Folder,
-        BatchProtocolId,
-        Properties
+        Name,
+        Properties,
+        RowId,
+        RunCount
     }
 
     MutableColumnInfo createRunCountColumn(String alias, ExpProtocol parentProtocol, ExpProtocol childProtocol);

--- a/experiment/src/org/labkey/experiment/api/ExpExperimentImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpExperimentImpl.java
@@ -262,7 +262,7 @@ public class ExpExperimentImpl extends ExpIdentifiableEntityImpl<Experiment> imp
     @Override
     public void delete(User user)
     {
-        ExperimentServiceImpl.get().deleteExperimentRunsByRowIds(getContainer(), user, getRowId());
+        ExperimentServiceImpl.get().deleteExpExperimentByRowId(getContainer(), user, getRowId());
     }
 
     public void setHidden(boolean hidden)

--- a/experiment/src/org/labkey/experiment/api/ExpExperimentImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpExperimentImpl.java
@@ -262,7 +262,7 @@ public class ExpExperimentImpl extends ExpIdentifiableEntityImpl<Experiment> imp
     @Override
     public void delete(User user)
     {
-        ExperimentServiceImpl.get().deleteExpExperimentByRowId(getContainer(), user, getRowId());
+        ExperimentServiceImpl.get().deleteExperimentRunsByRowIds(getContainer(), user, getRowId());
     }
 
     public void setHidden(boolean hidden)

--- a/experiment/src/org/labkey/experiment/api/ExpExperimentTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpExperimentTableImpl.java
@@ -191,11 +191,10 @@ public class ExpExperimentTableImpl extends ExpTableImpl<ExpExperimentTable.Colu
         addVocabularyDomains();
         addColumn(Column.Properties);
 
-        setTitleColumn("Name");
+        setTitleColumn(Column.Name.toString());
 
         DetailsURL detailsURL = new DetailsURL(new ActionURL(ExperimentController.DetailsAction.class, _userSchema.getContainer()), Collections.singletonMap("rowId", "RowId"));
         setDetailsURL(detailsURL);
-//        getColumn(Column.Name).setURL(detailsURL);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
@@ -540,7 +540,7 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
         final ExperimentServiceImpl svc = ExperimentServiceImpl.get();
         final SqlDialect dialect = svc.getSchema().getSqlDialect();
 
-        ExperimentServiceImpl.get().invalidateExperimentRun(getLSID());
+        svc.invalidateExperimentRun(getLSID());
 
         deleteProtocolApplicationProvenance();
 

--- a/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
@@ -36,7 +36,6 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.ExperimentRunType;
-import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.api.DataType;
 import org.labkey.api.exp.api.ExpData;
@@ -236,13 +235,7 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
     @Override
     public List<ExpDataImpl> getOutputDatas(@Nullable DataType type)
     {
-        SimpleFilter filter = new SimpleFilter();
-        filter.addCondition(FieldKey.fromParts("RunId"), getRowId());
-        if (type != null)
-        {
-            filter.addWhereClause(Lsid.namespaceFilter("LSID", type.getNamespacePrefix()), null);
-        }
-        return ExpDataImpl.fromDatas(new TableSelector(ExperimentServiceImpl.get().getTinfoData(), filter, null).getArrayList(Data.class));
+        return ExperimentServiceImpl.get().getOutputDatas(getRowId(), type);
     }
 
     @Override
@@ -649,7 +642,6 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
     {
         new SqlExecutor(getExpSchema()).execute("DELETE FROM exp.ProtocolApplication WHERE RunId = ?", getRowId());
     }
-
 
     private synchronized void ensureFullyPopulated()
     {

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -699,8 +699,7 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         if (cf != null)
             filter.addCondition(cf.createFilterClause(ExperimentServiceImpl.getExpSchema(), FieldKey.fromParts("Container")));
 
-        Sort sort = new Sort("Name");
-        return ExpMaterialImpl.fromMaterials(new TableSelector(ExperimentServiceImpl.get().getTinfoMaterial(), filter, sort).getArrayList(Material.class));
+        return ExperimentServiceImpl.get().getExpMaterials(filter, new Sort("Name"));
     }
 
     @Override
@@ -728,20 +727,12 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         if (cf != null)
             filter.addCondition(cf.createFilterClause(ExperimentServiceImpl.getExpSchema(), FieldKey.fromParts("Container")));
 
-        Material material = new TableSelector(ExperimentServiceImpl.get().getTinfoMaterial(), filter, null).getObject(Material.class);
-        if (material == null)
-            return null;
-        return new ExpMaterialImpl(material);
+        return ExperimentServiceImpl.get().getExpMaterial(filter);
     }
 
     private ExpMaterialImpl getSampleByObjectId(Integer objectId)
     {
-        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("ObjectId"), objectId);
-
-        Material material = new TableSelector(ExperimentServiceImpl.get().getTinfoMaterial(), filter, null).getObject(Material.class);
-        if (material == null)
-            return null;
-        return new ExpMaterialImpl(material);
+        return ExperimentServiceImpl.get().getExpMaterial(new SimpleFilter(FieldKey.fromParts("ObjectId"), objectId));
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -5469,6 +5469,21 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
     }
 
+    @Override
+    public void deleteExpExperimentByRowId(Container c, User user, int rowId)
+    {
+        if (!c.hasPermission(user, DeletePermission.class))
+        {
+            throw new IllegalStateException("Not permitted");
+        }
+
+        ExpExperimentImpl experiment = getExpExperiment(rowId);
+        if (experiment == null)
+            return;
+
+        deleteExpExperiment(c, user, experiment);
+    }
+
     // TODO: This should be refactored to support deletion of multiple ExpExperiments at one time
     private void deleteExpExperiment(Container c, User user, @NotNull ExpExperimentImpl experiment)
     {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1366,11 +1366,15 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     // Used when constructing a Protocol from XarReader where the protocol id is not set known
     public ExpMaterialProtocolInputImpl createMaterialProtocolInput(
-            @NotNull Container c,
-            @NotNull String name, int protocolId, boolean input,
-            @Nullable ExpSampleType sampleType,
-            @Nullable ExpProtocolInputCriteria criteria,
-            int minOccurs, @Nullable Integer maxOccurs)
+        @NotNull Container c,
+        @NotNull String name,
+        int protocolId,
+        boolean input,
+        @Nullable ExpSampleType sampleType,
+        @Nullable ExpProtocolInputCriteria criteria,
+        int minOccurs,
+        @Nullable Integer maxOccurs
+    )
     {
         MaterialProtocolInput obj = new MaterialProtocolInput();
         populateProtocolInput(obj, c, name, protocolId, input, criteria, minOccurs, maxOccurs);
@@ -1381,11 +1385,15 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     private void populateProtocolInput(
-            @NotNull AbstractProtocolInput obj,
-            @NotNull Container c,
-            @NotNull String name, int protocolId, boolean input,
-            @Nullable ExpProtocolInputCriteria criteria,
-            int minOccurs, @Nullable Integer maxOccurs)
+        @NotNull AbstractProtocolInput obj,
+        @NotNull Container c,
+        @NotNull String name,
+        int protocolId,
+        boolean input,
+        @Nullable ExpProtocolInputCriteria criteria,
+        int minOccurs,
+        @Nullable Integer maxOccurs
+    )
     {
         Objects.requireNonNull(name, "Name required");
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8811,7 +8811,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return excludedProjects;
     }
 
-
     private Set<Integer> _getContainerDataTypeExclusions(DataTypeForExclusion dataType, String excludedContainerId)
     {
         Set<Integer> excludedRowIds = new HashSet<>();

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1210,13 +1210,13 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public @Nullable ExpExperimentImpl getExpExperiment(int rowId)
     {
-        return getExpExperiment(new SimpleFilter(FieldKey.fromParts("RowId"), rowId));
+        return getExpExperiment(new SimpleFilter(FieldKey.fromParts(ExpExperimentTable.Column.RowId.name()), rowId));
     }
 
     @Override
     public ExpExperiment getExpExperiment(String lsid)
     {
-        return getExpExperiment(new SimpleFilter(FieldKey.fromParts("LSID"), lsid));
+        return getExpExperiment(new SimpleFilter(FieldKey.fromParts(ExpExperimentTable.Column.LSID.name()), lsid));
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -6215,8 +6215,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         int runId = expRun.getRowId();
         SimpleFilter filt = new SimpleFilter(FieldKey.fromParts("RunId"), runId);
-        Sort sort = new Sort("ActionSequence, RowId");
-        List<ExpProtocolApplicationImpl> protocolSteps = ExpProtocolApplicationImpl.fromProtocolApplications(new TableSelector(getTinfoProtocolApplication(), getTinfoProtocolApplication().getColumns(), filt, sort).getArrayList(ProtocolApplication.class));
+        List<ExpProtocolApplicationImpl> protocolSteps = ExpProtocolApplicationImpl.fromProtocolApplications(new TableSelector(getTinfoProtocolApplication(), getTinfoProtocolApplication().getColumns(), filt, new Sort("ActionSequence, RowId")).getArrayList(ProtocolApplication.class));
         expRun.setProtocolApplications(protocolSteps);
         final Map<Integer, ExpProtocolApplicationImpl> protStepMap = new HashMap<>(protocolSteps.size());
 
@@ -6241,7 +6240,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             mat.markAsPopulated(protApp);
         }
 
-        List<ExpDataImpl> datas = getExpDatas(filt, sort);
+        List<ExpDataImpl> datas = getExpDatas(filt, new Sort("RowId"));
         final Map<Integer, ExpDataImpl> runDataMap = new HashMap<>(datas.size());
 
         for (ExpDataImpl dat : datas)


### PR DESCRIPTION
#### Rationale
This consolidates logic in `ExperimentServiceImpl` for fetching a deserializing experiment objects from the database. There is a good amount of repeated and redundant logic/code in this service implementation and it makes it difficult to say how any one action performs its function. I've been able to consolidate logic for `Data`, `ExpData`, `ExpDataProtocolInput`,  `ExpExperiment`, `ExpMaterial`, `ExpProtocol`, `ExpProtocolInput`, `ExpRun`, and `ExperimentRun` and refactor the various incantations of fetching these objects to work via the same pattern for each.

#### Changes
- Add `SimpleFilter` parameter implementations of getters for `Data`, `ExpData`, `ExpExperiment`, `ExpMaterial`, and `ExpProtocol`
- Refactor usages around these implementations