### PR TITLE
Issue 50804: LKSM: Importing samples across folders with "User defined IDs" off errors unexpectedly

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -338,7 +338,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
             context.setDataSource((String) extraScriptContext.get(DataIteratorUtil.DATA_SOURCE));
         }
 
-        boolean skipTriggers = context.getConfigParameterBoolean(ConfigParameters.SkipTriggers) || context.isCrossTypeImport();
+        boolean skipTriggers = context.getConfigParameterBoolean(ConfigParameters.SkipTriggers) || context.isCrossTypeImport() || context.isCrossFolderImport();
         boolean hasTableScript = hasTableScript(container);
         TriggerDataBuilderHelper helper = new TriggerDataBuilderHelper(getQueryTable(), container, user, extraScriptContext, context.getInsertOption().useImportAliases);
         if (!skipTriggers)


### PR DESCRIPTION
#### Rationale
We want to skip the set of operations (evaluate name expression, increment sample counts, etc) done as part of preTriggerDataIterator for cross folder import, just like how we skip it for cross sample type import. 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5662
- https://github.com/LabKey/limsModules/pull/450

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
