### PR TITLE
Move the GWT study protocol editor under an experimental feature flag

### DIFF
--- a/api/src/org/labkey/api/study/Study.java
+++ b/api/src/org/labkey/api/study/Study.java
@@ -36,6 +36,8 @@ import java.util.Map;
  */
 public interface Study extends StudyEntity
 {
+    public static final String GWT_STUDY_DESIGN = "GWTStudyDesign";
+
     String getShortName();
 
     List<? extends Visit> getVisits(Visit.Order order);

--- a/study/gwtsrc/gwt/client/org/labkey/study/designer/client/Designer.java
+++ b/study/gwtsrc/gwt/client/org/labkey/study/designer/client/Designer.java
@@ -259,7 +259,7 @@ public class Designer implements EntryPoint
             }
         }
 
-        if (null != panelName && "assays".equals(panelName.toLowerCase()) && "true".equals(PropertyUtil.getServerProperty("canAdmin")))
+        if (null != panelName && "assays".equals(panelName.toLowerCase()) && "true".equals(PropertyUtil.getServerProperty("canAdmin")) && canEdit)
         {
             if (definition.getAssaySchedule().getAssays().size() > 0)
             {

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -67,6 +67,7 @@ import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.settings.AdminConsole;
+import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.specimen.SpecimenSampleTypeDomainKind;
 import org.labkey.api.specimen.model.AdditiveTypeDomainKind;
 import org.labkey.api.specimen.model.DerivativeTypeDomainKind;
@@ -418,6 +419,14 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
                 "Merging of dataset that uses server-managed third key (such as GUID or auto RowId) is not officially supported. Unexpected outcome might be experienced when merge is performed.",
                 false);
 
+        AdminConsole.addExperimentalFeatureFlag(Study.GWT_STUDY_DESIGN,
+                "Vaccine Study Protocol Editor",
+                "The study protocol editor (accessed from the Vaccine Study Protocols webpart) has been deprecated and protocol " +
+                        "information will be shown in a read only mode. The edit button can be shown by enabling this feature, " +
+                        "but this capability will be removed permanently in a future release. " +
+                        "Please create any new study protocols in the format as defined by the \"Manage Study Products\" link on the study Manage tab.",
+                false);
+
         ReportAndDatasetChangeDigestProvider.get().addNotificationInfoProvider(new DatasetNotificationInfoProvider());
 
         AdminLinkManager.getInstance().addListener((adminNavTree, container, user) -> {
@@ -692,7 +701,19 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
         @Override
         public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
         {
-            return new StudyDesignsWebPart(portalCtx, true);
+            if (ExperimentalFeatureService.get().isFeatureEnabled(Study.GWT_STUDY_DESIGN))
+                return new StudyDesignsWebPart(portalCtx, true);
+            else
+                return null;
+        }
+
+        @Override
+        public boolean isAvailable(Container c, String scope, String location)
+        {
+            if (ExperimentalFeatureService.get().isFeatureEnabled(Study.GWT_STUDY_DESIGN))
+                return super.isAvailable(c, scope, location);
+            else
+                return false;
         }
     }
 

--- a/study/src/org/labkey/study/controllers/designer/DesignerController.java
+++ b/study/src/org/labkey/study/controllers/designer/DesignerController.java
@@ -49,6 +49,7 @@ import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.specimen.SpecimenMigrationService;
 import org.labkey.api.study.MapArrayExcelWriter;
 import org.labkey.api.study.Study;
@@ -243,7 +244,7 @@ public class DesignerController extends SpringActionController
                 }
                 params.put("revision", Integer.toString(revision));
                 params.put("edit", getViewContext().hasPermission(UpdatePermission.class) && form.isEdit() ? "true" : "false");
-                boolean canEdit = getViewContext().hasPermission(UpdatePermission.class);
+                boolean canEdit = ExperimentalFeatureService.get().isFeatureEnabled(Study.GWT_STUDY_DESIGN) && getViewContext().hasPermission(UpdatePermission.class);
                 params.put("canEdit",  Boolean.toString(canEdit));
                 boolean canAdmin = getViewContext().hasPermission(AdminPermission.class);
                 params.put("canAdmin", Boolean.toString(canAdmin));

--- a/study/src/org/labkey/study/view/vaccineStudy.jsp
+++ b/study/src/org/labkey/study/view/vaccineStudy.jsp
@@ -56,7 +56,7 @@
 
     params.put("revision", Integer.toString(revInteger));
     params.put("edit", context.hasPermission(UpdatePermission.class) && bean.isEditMode() ? "true" : "false");
-    boolean canEdit = ExperimentalFeatureService.get().isFeatureEnabled(Study.GWT_STUDY_DESIGN) && getViewContext().hasPermission(UpdatePermission.class);
+    boolean canEdit = ExperimentalFeatureService.get().isFeatureEnabled(Study.GWT_STUDY_DESIGN) && context.hasPermission(UpdatePermission.class);
     params.put("canEdit",  Boolean.toString(canEdit));
     //Can't create repository from web part
     params.put("canCreateRepository", Boolean.FALSE.toString());

--- a/study/src/org/labkey/study/view/vaccineStudy.jsp
+++ b/study/src/org/labkey/study/view/vaccineStudy.jsp
@@ -18,6 +18,8 @@
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.security.permissions.AdminPermission" %>
 <%@ page import="org.labkey.api.security.permissions.UpdatePermission" %>
+<%@ page import="org.labkey.api.settings.ExperimentalFeatureService" %>
+<%@ page import="org.labkey.api.study.Study" %>
 <%@ page import="org.labkey.api.study.Visit" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.NotFoundException" %>
@@ -54,7 +56,7 @@
 
     params.put("revision", Integer.toString(revInteger));
     params.put("edit", context.hasPermission(UpdatePermission.class) && bean.isEditMode() ? "true" : "false");
-    boolean canEdit = context.hasPermission(UpdatePermission.class);
+    boolean canEdit = ExperimentalFeatureService.get().isFeatureEnabled(Study.GWT_STUDY_DESIGN) && getViewContext().hasPermission(UpdatePermission.class);
     params.put("canEdit",  Boolean.toString(canEdit));
     //Can't create repository from web part
     params.put("canCreateRepository", Boolean.FALSE.toString());


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49860)

This puts legacy GWT-based study protocol editor/designer under an experimental feature flag. The flag will result in any existing designs being put in a read only mode.

#### Changes
- Don't render the Vaccine Study Protocols webpart
- Remove the edit button from the various views of the XML protocol:
  - Study Protocol Summary webpart
  - Vaccine Design tab 
  - Immunizations tab
  - Assays tab