### PR TITLE
Issue 50620: Slow file uploads to remote NFS file root

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -135,6 +135,7 @@ import org.labkey.api.security.PasswordExpiration;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.ValidEmail;
+import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.AppPropsTestCase;
 import org.labkey.api.settings.ExperimentalFeatureStartupListener;
@@ -191,6 +192,8 @@ public class ApiModule extends CodeOnlyModule
         AuthenticationManager.registerEncryptionMigrationHandler();
 
         LabKeyManagement.register(new StandardMBean(new OperationsMXBeanImpl(), OperationsMXBean.class, true), "Operations");
+
+        AdminConsole.addExperimentalFeatureFlag(FileStream.STAGE_FILE_UPLOADS, "Stage file uploads before moving to final destination", "When using a non-local file system, using a specific API that requires a locally staged copy of the file as the source can sometimes be significantly faster than streaming the uploaded file directly", false);
     }
 
     @NotNull


### PR DESCRIPTION
#### Rationale
Some remote file systems are incredibly slow unless we can use a FileChannel->FileChannel copy. After upgrading to Spring 6 and Tomcat 10 we're now getting a wrapped Channel that doesn't offer the same perf.

#### Changes
- Experimental feature (to be marked as Optional when it's merged forward) to copy to a staging file which we can then access via a FileChannel for the fast transfer