### PR TITLE
Issue 49830: Update inferColumnInfo to force fields of type File to use ExpDataFileConverter

### DIFF
--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -322,6 +322,7 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
             for (int f = 0; f < nCols; f++)
             {
                 List<Class> classesToTest = new ArrayList<>(Arrays.asList(CONVERT_CLASSES));
+                Class knownColumnClass = null;
 
                 int classIndex = -1;
                 //NOTE: this means we have a header row
@@ -334,13 +335,22 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
                         if (_columnInfoMap.containsKey(name))
                         {
                             //preferentially use this class if it matches
-                            classesToTest.add(0, _columnInfoMap.get(name).getJavaClass());
+                            knownColumnClass = _columnInfoMap.get(name).getJavaClass();
+                            classesToTest.add(0, knownColumnClass);
                         }
                         else if (renamedColumns.containsKey(name) && _columnInfoMap.containsKey(renamedColumns.get(name)))
                         {
-                            classesToTest.add(0, _columnInfoMap.get(renamedColumns.get(name)).getJavaClass());
+                            knownColumnClass = _columnInfoMap.get(renamedColumns.get(name)).getJavaClass();
+                            classesToTest.add(0, knownColumnClass);
                         }
                     }
+                }
+
+                // Issue 49830: if we know the column class is File based on the columnInfoMap, use it instead of trying to infer the class based on the data
+                if (File.class.equals(knownColumnClass))
+                {
+                    colDescs[f].clazz = knownColumnClass;
+                    continue;
                 }
 
                 for (int line = inferStartLine; line < numLines; line++)


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=49830

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5368
- https://github.com/LabKey/testAutomation/pull/1980

#### Changes
- DataLoader.inferColumnInfo to use _columnInfoMap for columns we know are of type File
