### PR TITLE
Fix lssues with react-bootstrap removal

### DIFF
--- a/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
+++ b/core/src/client/AuthenticationConfiguration/AuthenticationConfiguration.tsx
@@ -317,7 +317,7 @@ export class App extends PureComponent<{}, Partial<State>> {
                     actions={this.actions}
                 />
 
-                {dirty && <Alert>{UNSAVED_ALERT}</Alert>}
+                {dirty && <Alert bsStyle="info">{UNSAVED_ALERT}</Alert>}
                 {error && <Alert bsStyle="danger">{error}</Alert>}
 
                 {canEdit ? (


### PR DESCRIPTION
#### Rationale
My recent PRs that removed react-bootstrap updated the AuthenticationConfiguration component to use our internal Alert component, which has a different default for bsStyle.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/1982

#### Changes
- AuthenticationConfiguration: Fix bsStyle for unsaved alert