### PR TITLE
enable the new experimental feature flag for the tests

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/VaccineProtocolTest.java
+++ b/study/test/src/org/labkey/test/tests/study/VaccineProtocolTest.java
@@ -29,6 +29,7 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldDefinition.ColumnType;
 import org.labkey.test.params.list.IntListDefinition;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.ExperimentalFeaturesHelper;
 import org.labkey.test.util.PortalHelper;
 
 import java.io.File;
@@ -50,6 +51,8 @@ public class VaccineProtocolTest extends BaseWebDriverTest
     @Test
     public void testSteps() throws Exception
     {
+        ExperimentalFeaturesHelper.enableExperimentalFeature(createDefaultConnection(), "GWTStudyDesign");
+
         _containerHelper.createProject(PROJECT_NAME, null);
         _containerHelper.createSubfolder(PROJECT_NAME, PROJECT_NAME, FOLDER_NAME, "None", null);
 
@@ -384,6 +387,7 @@ public class VaccineProtocolTest extends BaseWebDriverTest
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
+        ExperimentalFeaturesHelper.disableExperimentalFeature(createDefaultConnection(), "GWTStudyDesign");
         _containerHelper.deleteProject(getProjectName(), afterTest);
     }
 


### PR DESCRIPTION
#### Rationale
This recent [change](https://github.com/LabKey/platform/pull/5667) resulted in putting some vaccine protocol features behind an experimental flag. We'll need to enable the flag prior to running the tests.

#### Related Pull Requests
https://github.com/LabKey/customModules/pull/185

