### PR TITLE
Issue 50766: Remove use of TreeMap, which prevents run inputs with the same names

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2757,9 +2757,6 @@ public class ExpDataIterators
                 }
             });
 
-            if (keys.isEmpty())
-                return keys;
-
             boolean hasCycle = false;
             while (keys.size() != allKeys.size() && !hasCycle)
             {

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2757,7 +2757,10 @@ public class ExpDataIterators
                 }
             });
 
-            boolean hasCycle = keys.isEmpty();
+            if (keys.isEmpty())
+                return keys;
+
+            boolean hasCycle = false;
             while (keys.size() != allKeys.size() && !hasCycle)
             {
                 Set<String> addedTypeNames = new HashSet<>();

--- a/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
@@ -652,10 +652,6 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
             Collections.sort(_materialOutputs);
             Collections.sort(_dataOutputs);
 
-            _materialInputs = new TreeMap<>(_materialInputs);
-
-            _dataInputs = new TreeMap<>(_dataInputs);
-
             for (ExpProtocolApplicationImpl step : _protocolSteps)
             {
                 Collections.sort(step.getInputDatas());


### PR DESCRIPTION
#### Rationale
Issue [50766](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50766) Though having samples and data class objects with the same names in different types seems like it would be uncommon, we do allow it. However, for the TreeMap used to sort these input when "fully populating" the run, if the comparison of two keys results in a value of 0, only one of them can be in the map.  First attempt is to remove the use of the `TreeMap` and see what breaks. If for some reason, we need these values to be sorted, I'll update the comparator to use the rowId in addition to the name.
 

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Remove use of `TreeMap` in `ExpRunIimp.ensureFullyPopulated` method
- Better logic in `getImportOrderTypeKeys` when there are no cross-type keys
