### PR TITLE
Provide better error message when API authentication fails

### DIFF
--- a/api/src/org/labkey/api/action/ApiResponseWriter.java
+++ b/api/src/org/labkey/api/action/ApiResponseWriter.java
@@ -52,11 +52,10 @@ public abstract class ApiResponseWriter implements AutoCloseable
     private static final String RESPONSE_FORMAT_ATTRIBUTE = ApiResponseWriter.class.getName() + "$responseFormat";
 
     /*
-     * (MAB) This code defaults to using setting the response to SC_BAD_REQUEST
-     * when any error is encountered.  I think this is wrong.  Expected
-     * errors should be encoded in a normal JSON response and SC_OK.
+     * (MAB) This code defaults to setting the response to SC_BAD_REQUEST when any error is encountered. I think this
+     * is wrong. Expected errors should be encoded in a normal JSON response and SC_OK.
      *
-     * Also, this using SC_BAD_REQUEST means failed APIs get taggd by BlockListFilter
+     * Also, this using SC_BAD_REQUEST means failed APIs get tagged by BlockListFilter
      *
      * Allow new code to specify that SC_OK should be used for errors
      */
@@ -341,7 +340,7 @@ public abstract class ApiResponseWriter implements AutoCloseable
 
     /**
      * Even though the default exception handling is implemented here, we require that response.render()
-     * invokes this method in its own catch() block before endResponse().  This seems cleaner than coordinating
+     * invokes this method in its own catch() block before endResponse(). This seems cleaner than coordinating
      * to have render() not output matching { open and close } braces.
      *
      * @see ApiResponse#render(ApiResponseWriter) 

--- a/api/src/org/labkey/api/security/AuthFilter.java
+++ b/api/src/org/labkey/api/security/AuthFilter.java
@@ -31,6 +31,7 @@ import org.labkey.api.util.GUID;
 import org.labkey.api.util.HttpUtil;
 import org.labkey.api.util.HttpsUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewServlet;
 import org.labkey.api.view.template.PageConfig;
 
@@ -185,6 +186,11 @@ public class AuthFilter implements Filter
         catch (UnsupportedEncodingException uee)
         {
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST, uee.getMessage());
+            return;
+        }
+        catch (UnauthorizedException ue)
+        {
+            ExceptionUtil.handleException(req, resp, ue, ue.getMessage(), false);
             return;
         }
 

--- a/api/src/org/labkey/api/security/AuthFilter.java
+++ b/api/src/org/labkey/api/security/AuthFilter.java
@@ -16,6 +16,15 @@
 
 package org.labkey.api.security;
 
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.module.ModuleLoader;
@@ -35,15 +44,6 @@ import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewServlet;
 import org.labkey.api.view.template.PageConfig;
 
-import jakarta.servlet.Filter;
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.FilterConfig;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -1224,7 +1224,7 @@ public class AuthenticationManager
     // Attempts to authenticate using only LoginFormAuthenticationProviders (e.g., DbLogin, LDAP). This is for the case
     // where you have an id & password in hand and want to ignore SSO and other delegated authentication mechanisms that
     // rely on cookies, browser redirects, etc. Current usages include basic auth and a test case. Note that this will
-    // fail if any secondary authentication is enabled (e.g., Duo) unless an API key is passed.
+    // fail if any secondary authentication is enabled (e.g., TOTP, Duo) unless an API key is passed.
 
     // Throws UnauthorizedException if credentials are incorrect, user doesn't exist, user is inactive, or secondary
     // auth is enabled and an API key hasn't been used.

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.action.ApiResponseWriter;
+import org.labkey.api.action.ApiResponseWriter.Format;
 import org.labkey.api.action.LabKeyError;
 import org.labkey.api.action.LabKeyErrorWithHtml;
 import org.labkey.api.action.LabKeyErrorWithLink;
@@ -1241,9 +1242,13 @@ public class AuthenticationManager
         }
 
         // Basic auth has failed so send failure response in a format that APIs can consume
-        // TODO: Shouldn't our client APIs set the "respFormat" attribute? Java library doesn't...
+        // TODO: Shouldn't our client APIs set a default "respFormat" attribute? Java library doesn't...
         if (ApiResponseWriter.getResponseFormat(request, null) == null)
-            ApiResponseWriter.setResponseFormat(request, ApiResponseWriter.Format.JSON);
+        {
+            String respFormat = request.getParameter("respFormat");
+            Format format = StringUtils.contains(respFormat, "xml") ? Format.XML : Format.JSON;
+            ApiResponseWriter.setResponseFormat(request, format);
+        }
         String message = primaryResult.getMessage();
         throw new UnauthorizedException(message != null ? message : primaryResult.getStatusErrorMessage(DisplayLocation.API));
     }

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -119,6 +119,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.labkey.api.action.SpringActionController.ERROR_MSG;
+import static org.labkey.api.action.SpringActionController.RESPONSE_FORMAT_PARAMETER_NAME;
 import static org.labkey.api.security.AuthenticationProvider.FailureReason.complexity;
 import static org.labkey.api.security.AuthenticationProvider.FailureReason.expired;
 
@@ -1245,7 +1246,7 @@ public class AuthenticationManager
         // TODO: Shouldn't our client APIs set a default "respFormat" attribute? Java library doesn't...
         if (ApiResponseWriter.getResponseFormat(request, null) == null)
         {
-            String respFormat = request.getParameter("respFormat");
+            String respFormat = request.getParameter(RESPONSE_FORMAT_PARAMETER_NAME);
             Format format = StringUtils.contains(respFormat, "xml") ? Format.XML : Format.JSON;
             ApiResponseWriter.setResponseFormat(request, format);
         }

--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -825,7 +825,7 @@ public class ExceptionUtil
             if (isGET)
             {
                 // If user has not logged in or agreed to terms, not really unauthorized yet...
-                if (!isCSRFViolation && isGuest && type == UnauthorizedException.Type.redirectToLogin && !overrideBasicAuth)
+                if (!isCSRFViolation && isGuest && type == UnauthorizedException.Type.redirectToLogin && !overrideBasicAuth && HttpView.hasCurrentView())
                 {
                     // Issue 43307: If this is a locked project then just show the login page in the root. Register,
                     // forgot my password, profile update, password reset, etc. aren't going to work right in a locked

--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -816,7 +816,7 @@ public class ExceptionUtil
             // useful for when the page wants to handle 401s itself
             String headerHint = request.getHeader("X-ONUNAUTHORIZED");
 
-            boolean isGuest = user != null && user.isGuest();
+            boolean isGuest = user == null || user.isGuest();
             UnauthorizedException.Type type = uae.getType();
             boolean overrideBasicAuth = "UNAUTHORIZED".equals(headerHint);
             boolean isCSRFViolation = uae instanceof CSRFException;

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -335,7 +335,7 @@ public class LoginController extends SpringActionController
                     // Explicit test for valid email
                     ValidEmail email = new ValidEmail(form.getEmail());
 
-                    if (status.requiresRedirect())
+                    if (status.handleRedirect())
                     {
                         AuthenticationManager.setLoginReturnProperties(request, new LoginReturnProperties(result.getRedirectURL(), form.getUrlhash(), form.getSkipProfile()));
                     }


### PR DESCRIPTION
#### Rationale
We want API clients to receive more helpful guidance when authentication fails. For example, password expired vs. password doesn't meet complexity requirements vs. bad credentials. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50841

#### Changes
* If Basic authentication fails, return a JSON exception with user-appropriate details. Note: This is a behavior change; previously, no exception was returned, the server simply set up a guest session.
* `AuthenticationStatus` can now tailor error messages for web UI vs. API purposes. For example, returning a message to a piece of code that suggests checking the caps lock seems unhelpful.