### PR TITLE
Issue 43374: Workaround for webDavUrl encoding problem

### DIFF
--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -1161,7 +1161,8 @@ public class PipelineController extends SpringActionController
             ApiSimpleResponse resp = new ApiSimpleResponse();
             PipeRoot root = PipelineService.get().findPipelineRoot(getContainer());
             resp.put("containerPath", null != root ? root.getContainer().getPath() : null);
-            resp.put("webDavURL", null != root ? FileUtil.encodeForURL(root.getWebdavURL()) : null);
+            // Hack as temporary workaround for issue 43374
+            resp.put("webDavURL", null != root ? FileUtil.encodeForURL(root.getWebdavURL().replace("%25", "%").replace("%2B", "+")) : null);
             return resp;
         }
     }


### PR DESCRIPTION
#### Rationale
Our WebDav URL encoding is very inconsistent. This fixes a problem in `pipeline-getPipelineContainer.api` where `%` and `+` in container names are double-encoded in the URL returned.

Longer term, and much more invasively, we need to centralize the encoding and return `URL` objects from methods like `PipeRoot.getWebdavURL()`. But that will require changes to JavaScript and other code which make assumptions that certain characters are encoded but others aren't.

#### Changes
- Decode `%25` and `%2B` before encoding the whole URL