### PR TITLE
Issue 50781: LKSM: File fields in Sample Types sometimes showing as Text Fields

### DIFF
--- a/experiment/src/org/labkey/experiment/FileLinkFileListener.java
+++ b/experiment/src/org/labkey/experiment/FileLinkFileListener.java
@@ -187,6 +187,8 @@ public class FileLinkFileListener implements FileListener
             String storageSchemaName = row.get("StorageSchemaName").toString();
             DbSchema schema = DbSchema.get(storageSchemaName, DbSchemaType.Provisioned);
             Domain domain = PropertyService.get().getDomain((Integer) row.get("DomainId"));
+            // Issue 50781: LKSM: File fields in Sample Types sometimes showing as Text Fields
+            // Don't use schema.getTable(storageTableName);
             TableInfo tableInfo = StorageProvisioner.get().getSchemaTableInfo(domain);
             if (tableInfo != null)
             {

--- a/experiment/src/org/labkey/experiment/FileLinkFileListener.java
+++ b/experiment/src/org/labkey/experiment/FileLinkFileListener.java
@@ -181,8 +181,10 @@ public class FileLinkFileListener implements FileListener
 
         new SqlSelector(OntologyManager.getExpSchema(), sql).forEachMap(row -> {
             // Find the DbSchema/TableInfo/ColumnInfo for the FileLink column
-            DbSchema schema = DbSchema.get(row.get("StorageSchemaName").toString(), DbSchemaType.Provisioned);
-            TableInfo tableInfo = schema.getTable(row.get("StorageTableName").toString());
+            String storageSchemaName = row.get("StorageSchemaName").toString();
+            String storageTableName = row.get("StorageTableName").toString();
+            DbSchema schema = DbSchema.get(storageSchemaName, DbSchemaType.Provisioned);
+            TableInfo tableInfo = schema.getTable(storageTableName);
             if (tableInfo != null)
             {
                 String containerId = row.get("Container").toString();
@@ -191,6 +193,8 @@ public class FileLinkFileListener implements FileListener
                 {
                     block.exec(schema, tableInfo, pathCol, containerId);
                 }
+                // Issue 50781: LKSM: File fields in Sample Types sometimes showing as Text Fields
+                schema.getScope().invalidateTable(storageSchemaName, storageTableName, DbSchemaType.Provisioned);
             }
         });
     }

--- a/experiment/src/org/labkey/experiment/FileLinkFileListener.java
+++ b/experiment/src/org/labkey/experiment/FileLinkFileListener.java
@@ -183,19 +183,26 @@ public class FileLinkFileListener implements FileListener
             // Find the DbSchema/TableInfo/ColumnInfo for the FileLink column
             String storageSchemaName = row.get("StorageSchemaName").toString();
             String storageTableName = row.get("StorageTableName").toString();
-            DbSchema schema = DbSchema.get(storageSchemaName, DbSchemaType.Provisioned);
-            TableInfo tableInfo = schema.getTable(storageTableName);
-            if (tableInfo != null)
+            try
             {
-                String containerId = row.get("Container").toString();
-                ColumnInfo pathCol = tableInfo.getColumn(row.get("Name").toString());
-                if (pathCol != null && containerId != null)
+                DbSchema schema = DbSchema.get(storageSchemaName, DbSchemaType.Provisioned);
+                TableInfo tableInfo = schema.getTable(storageTableName);
+                if (tableInfo != null)
                 {
-                    block.exec(schema, tableInfo, pathCol, containerId);
+                    String containerId = row.get("Container").toString();
+                    ColumnInfo pathCol = tableInfo.getColumn(row.get("Name").toString());
+                    if (pathCol != null && containerId != null)
+                    {
+                        block.exec(schema, tableInfo, pathCol, containerId);
+                    }
                 }
-                // Issue 50781: LKSM: File fields in Sample Types sometimes showing as Text Fields
-                schema.getScope().invalidateTable(storageSchemaName, storageTableName, DbSchemaType.Provisioned);
             }
+            finally
+            {
+                // Issue 50781: LKSM: File fields in Sample Types sometimes showing as Text Fields
+                OntologyManager.getExpSchema().getScope().invalidateTable(storageSchemaName, storageTableName, DbSchemaType.Provisioned);
+            }
+
         });
     }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -2031,12 +2031,19 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                     if (updatedFile != null)
                     {
                         FileFieldRenameData renameData = new FileFieldRenameData(sampleType, sample.getName(), fileProp.getName(), new File(sourceFileName), updatedFile);
-                        fileService.fireFileMoveEvent(renameData.sourceFile, renameData.targetFile, user, targetContainer);
                         sampleFileRenames.putIfAbsent(sample.getRowId(), new ArrayList<>());
                         List<FileFieldRenameData> fieldRenameData = sampleFileRenames.get(sample.getRowId());
                         fieldRenameData.add(renameData);
                     }
                 }
+        }
+
+        // TODO, support batch fireFileMoveEvent to avoid excessive FileLinkFileListener.hardTableFileLinkColumns calls
+        for (int sampleId: sampleFileRenames.keySet())
+        {
+            List<FileFieldRenameData> fieldRenameRecords = sampleFileRenames.get(sampleId);
+            for (FileFieldRenameData renameData : fieldRenameRecords)
+                fileService.fireFileMoveEvent(renameData.sourceFile, renameData.targetFile, user, targetContainer);
         }
 
         return sampleFileRenames;


### PR DESCRIPTION
#### Rationale
The file metrics query iterate though provisioned tables containsing filelink columns. In doing so, a "provisioned" table tableinfo that lacks the full domain descriptor info for the datatype is generated and got put in the cache for the schema/table and later gets used. This PR switches to use StorageProvisioner.get().getSchemaTableInfo(domain) to get the fixed up tableinfo with the correct domain.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
