### PR TITLE
Issue 50842: Fix upper and lower bounds on qc plots

### DIFF
--- a/core/webapp/vis/src/plot.js
+++ b/core/webapp/vis/src/plot.js
@@ -1788,7 +1788,7 @@ boxPlot.render();
             // Convert values
             if (row[valProp] !== undefined) {
                 row.rawValue = row[valProp];
-                if (conversion === "percentDeviation") {
+                if (conversion === LABKEY.vis.PlotProperties.ValueConversion.PercentDeviation) {
                     row[valProp] = convertToPercentDeviation(row[valProp], row[meanProp]);
                 }
                 else {
@@ -1797,7 +1797,7 @@ boxPlot.render();
             }
             else if (row[valRightProp] !== undefined) {
                 row.rawValue = row[valRightProp];
-                if (conversion === "percentDeviation") {
+                if (conversion === LABKEY.vis.PlotProperties.ValueConversion.PercentDeviation) {
                     row[valRightProp] = convertToPercentDeviation(row[valRightProp], row[meanProp]);
                 }
                 else {
@@ -1812,12 +1812,12 @@ boxPlot.render();
             var maxValue, minValue;
             cushion = value > 1.0 ? 0.2 : 0.02;
             if (config.qcPlotType === LABKEY.vis.TrendingLinePlotType.MovingRange
-                    && config.properties.valueConversion === 'percentDeviation') {
+                    && config.properties.valueConversion === LABKEY.vis.PlotProperties.ValueConversion.PercentDeviation) {
                 maxValue = mean * LABKEY.vis.Stat.MOVING_RANGE_UPPER_LIMIT_WEIGHT;
                 minValue = mean;
             } else if (config.qcPlotType === LABKEY.vis.TrendingLinePlotType.LeveyJennings) {
                 if (config.properties.boundType === LABKEY.vis.PlotProperties.BoundType.StandardDeviation) {
-                    if (config.properties.valueConversion === 'standardDeviation') {
+                    if (config.properties.valueConversion === LABKEY.vis.PlotProperties.ValueConversion.StandardDeviation) {
                         maxValue = config.properties.upperBound + cushion;
                         minValue = config.properties.lowerBound - cushion;
                     }
@@ -1829,7 +1829,7 @@ boxPlot.render();
                 else if (config.properties.boundType === LABKEY.vis.PlotProperties.BoundType.MeanDeviation) {
                     maxValue = mean + config.properties.upperBound + cushion;
                     minValue = mean + config.properties.lowerBound - cushion;
-                    if (config.properties.valueConversion === 'percentDeviation') {
+                    if (config.properties.valueConversion === LABKEY.vis.PlotProperties.ValueConversion.PercentDeviation) {
                         // Multiplying by 10 to get the yAxisDomain[min & max] to be in the same range as the percent range
                         maxValue = mean + config.properties.upperBound * 10 + cushion;
                         minValue = mean + config.properties.lowerBound * 10 - cushion;
@@ -1954,7 +1954,7 @@ boxPlot.render();
                         row.lowerBound = config.properties.lowerBound + row[meanProp];
                     }
 
-                    if (config.properties.valueConversion === 'percentDeviation') {
+                    if (config.properties.valueConversion === LABKEY.vis.PlotProperties.ValueConversion.PercentDeviation) {
                         row.upperBound = convertToPercentDeviation(row.upperBound, row[meanProp]);
                         row.lowerBound = convertToPercentDeviation(row.lowerBound, row[meanProp]);
                         if (config.legendData && config.legendData.length > 0) {
@@ -1970,7 +1970,7 @@ boxPlot.render();
                             }
                         }
                     }
-                    else if (config.properties.valueConversion === 'standardDeviation') {
+                    else if (config.properties.valueConversion === LABKEY.vis.PlotProperties.ValueConversion.StandardDeviation) {
                         let isAbsolute = config.properties.boundType === LABKEY.vis.PlotProperties.BoundType.Absolute;
                         row.upperBound = convertToStandardDeviation(row.upperBound, row[meanProp], row[sdProp]);
                         row.lowerBound = convertToStandardDeviation(row.lowerBound, row[meanProp], row[sdProp]);
@@ -1997,11 +1997,11 @@ boxPlot.render();
                         }
                     }
                 }
-                if (config.properties.valueConversion === 'percentDeviation') {
+                if (config.properties.valueConversion === LABKEY.vis.PlotProperties.ValueConversion.PercentDeviation) {
                     row[sdProp] = convertToPercentDeviation(row[sdProp], row[meanProp]);
                     row[meanProp] = 100;
                 }
-                else if (config.properties.valueConversion === 'standardDeviation') {
+                else if (config.properties.valueConversion === LABKEY.vis.PlotProperties.ValueConversion.StandardDeviation) {
                     row[sdProp] = 1;
                     row[meanProp] = 0;
                 }
@@ -2273,7 +2273,7 @@ boxPlot.render();
 
                 if (config.properties.stdDev !== undefined &&
                         config.properties.boundType === LABKEY.vis.PlotProperties.BoundType.StandardDeviation &&
-                        (config.properties.showBoundLines || config.properties.valueConversion === 'standardDeviation')) {
+                        (config.properties.showBoundLines || config.properties.valueConversion === LABKEY.vis.PlotProperties.ValueConversion.StandardDeviation)) {
 
                     config.layers.push(new LABKEY.vis.Layer({
                         geom: new LABKEY.vis.Geom.ErrorBar({size: 1, color: LABKEY.vis.PlotProperties.Color.Outlier, dashed: true, width: barWidth, topOnly: true}),
@@ -2282,7 +2282,7 @@ boxPlot.render();
                             error: function (row) {
                                 return row[config.properties.stdDev] * config.properties.upperBound;
                             },
-                            yLeft: config.properties.combined ? "upperBound" : config.properties.mean
+                            yLeft: config.properties.combined ? LABKEY.vis.PlotProperties.BoundLabel.Upper : config.properties.mean
                         }
                     }));
                     config.layers.push(new LABKEY.vis.Layer({
@@ -2292,7 +2292,7 @@ boxPlot.render();
                             error: function (row) {
                                 return row[config.properties.stdDev] * config.properties.lowerBound;
                             },
-                            yLeft: config.properties.combined ? "lowerBound" : config.properties.mean
+                            yLeft: config.properties.combined ? LABKEY.vis.PlotProperties.BoundLabel.Lower : config.properties.mean
                         }
                     }));
                     if (config.properties.hideSDLines !== true) {
@@ -2339,8 +2339,8 @@ boxPlot.render();
                 if (config.properties.boundType === LABKEY.vis.PlotProperties.BoundType.Absolute) {
                     let isCombined = config.properties.combined;
                     let valueConversion = config.properties.valueConversion;
-                    let isValueConversionSD = valueConversion === 'standardDeviation';
-                    let isValueConversionPercentOfMean = valueConversion === 'percentDeviation';
+                    let isValueConversionSD = valueConversion === LABKEY.vis.PlotProperties.ValueConversion.StandardDeviation;
+                    let isValueConversionPercentOfMean = valueConversion === LABKEY.vis.PlotProperties.ValueConversion.PercentDeviation;
                     let showLines = true;
                     if (isCombined) {
                         if (isValueConversionSD || isValueConversionPercentOfMean) {
@@ -2362,7 +2362,7 @@ boxPlot.render();
                                     error: function (row) {
                                         return 0;
                                     },
-                                    yLeft: 'lowerBound'
+                                    yLeft: LABKEY.vis.PlotProperties.BoundLabel.Lower
                                 }
                             });
                             config.layers.push(lowerBoundLayer);
@@ -2381,7 +2381,7 @@ boxPlot.render();
                                     error: function (row) {
                                         return 0;
                                     },
-                                    yLeft: 'upperBound'
+                                    yLeft: LABKEY.vis.PlotProperties.BoundLabel.Upper
                                 }
                             });
                             config.layers.push(upperBoundLayer);
@@ -2405,7 +2405,7 @@ boxPlot.render();
                                 error: function (row) {
                                     return 0;
                                 },
-                                yLeft: 'lowerBound'
+                                yLeft: LABKEY.vis.PlotProperties.BoundLabel.Lower
                             }
                         });
                         config.layers.push(lowerBoundLayer);
@@ -2424,7 +2424,7 @@ boxPlot.render();
                                 error: function (row) {
                                     return 0;
                                 },
-                                yLeft: 'upperBound'
+                                yLeft: LABKEY.vis.PlotProperties.BoundLabel.Upper
                             }
                         });
                         config.layers.push(upperBoundLayer);
@@ -2444,7 +2444,7 @@ boxPlot.render();
                 config.layers = [range];
             }
             else if (config.qcPlotType === LABKEY.vis.TrendingLinePlotType.MovingRange) {
-                if (config.properties.valueConversion === "standardDeviation") {
+                if (config.properties.valueConversion === LABKEY.vis.PlotProperties.ValueConversion.StandardDeviation) {
                     config.layers = [];
                 }
                 else {

--- a/core/webapp/vis/src/utils.js
+++ b/core/webapp/vis/src/utils.js
@@ -35,6 +35,18 @@ if (!LABKEY.vis.PlotProperties) {
             TwoSD: 'blue',
         }
     }
+    if (!LABKEY.vis.PlotProperties.BoundLabel) {
+        LABKEY.vis.PlotProperties.BoundLabel = {
+            Upper: 'upperBound',
+            Lower: 'lowerBound'
+        }
+    }
+    if (!LABKEY.vis.PlotProperties.ValueConversion) {
+        LABKEY.vis.PlotProperties.ValueConversion = {
+            StandardDeviation: 'standardDeviation',
+            PercentDeviation: 'percentDeviation'
+        }
+    }
 }
 
 LABKEY.vis.makeLine = function(x1, y1, x2, y2){


### PR DESCRIPTION
#### Rationale
* Hide upper and lower bounds on the plot with a linear, log, and percent of mean scales for Levey-Jennings multi-series plots.
* Show the upper and lower bound lines for fixed cutoff value multi-series plots for linear & log but for SD & percent of mean * Hide the legend translation for SD for fixed cutoff value multi-series plots

#### Related Pull Requests
https://github.com/LabKey/targetedms/pull/933

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
