### PR TITLE
Plate: Reformat operations (cont'd)

### DIFF
--- a/assay/api-src/org/labkey/api/assay/plate/PlateSet.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateSet.java
@@ -21,6 +21,12 @@ public interface PlateSet
 
     boolean isArchived();
 
+    boolean isAssay();
+
+    boolean isPrimary();
+
+    boolean isStandalone();
+
     boolean isTemplate();
 
     List<Plate> getPlates();

--- a/assay/api-src/org/labkey/api/assay/plate/PlateType.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateType.java
@@ -2,6 +2,7 @@ package org.labkey.api.assay.plate;
 
 public interface PlateType
 {
+    boolean isArchived();
     Integer getRowId();
     String getDescription();
     Integer getRows();

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -1488,7 +1488,7 @@ public class PlateController extends SpringActionController
                 PlateSet plateSet = PlateManager.get().getPlateSet(getContainer(), form.getPlateSetId());
                 if (plateSet == null)
                     throw new NotFoundException("Unable to resolve Plate Set.");
-                if (plateSet.getType() != PlateSetType.assay)
+                if (!plateSet.isAssay())
                     throw new ValidationException("Instrument Instructions cannot be generated for non-Assay Plate Sets.");
 
                 ContainerFilter cf = ContainerFilter.Type.Current.create(getViewContext());

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3551,6 +3551,9 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         if (options.isPreview())
             return new ReformatResult(plateData, null, null, null);
 
+        if (plateData.isEmpty())
+            throw new ValidationException("This operation as configured does not create any plates.");
+
         Integer plateSetRowId;
         String plateSetName;
         List<Plate> newPlates;
@@ -3705,7 +3708,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 }
             }
 
-            plates.add(new PlateData(null, plateType.getRowId(), null, targetWellData));
+            if (!targetWellData.isEmpty())
+                plates.add(new PlateData(null, plateType.getRowId(), null, targetWellData));
         }
 
         return plates;

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3528,7 +3528,9 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             throw new ValidationException("An \"operation\" must be specified.");
 
         PlateSetImpl destinationPlateSet = getReformatDestinationPlateSet(container, options);
-        List<Plate> sourcePlates = getReformatSourcePlates(container, options);
+        Pair<PlateSet, List<Plate>> source = getReformatSourcePlates(container, options);
+        PlateSetImpl sourcePlateSet = (PlateSetImpl) source.first;
+        List<Plate> sourcePlates = source.second;
 
         PlateType targetPlateType = null;
         if (options.getTargetPlateTypeId() != null)
@@ -3562,7 +3564,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
         if (destinationPlateSet.isNew())
         {
-            PlateSet newPlateSet = createPlateSet(container, user, destinationPlateSet, plateData, options.getTargetPlateSet().getParentPlateSetId());
+            PlateSet newPlateSet = createPlateSet(container, user, destinationPlateSet, plateData, sourcePlateSet.getRowId());
             plateSetRowId = newPlateSet.getRowId();
             plateSetName = newPlateSet.getName();
             newPlates = newPlateSet.getPlates();
@@ -3644,7 +3646,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return plateSet;
     }
 
-    private List<Plate> getReformatSourcePlates(Container container, ReformatOptions options) throws ValidationException
+    private Pair<PlateSet, List<Plate>> getReformatSourcePlates(Container container, ReformatOptions options) throws ValidationException
     {
         List<Plate> sourcePlates = new ArrayList<>();
         PlateSet sourcePlateSet = null;
@@ -3666,7 +3668,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         if (sourcePlateSet != null && !container.equals(sourcePlateSet.getContainer()))
             throw new ValidationException(String.format("Plate set \"%s\" is not in the %s folder.", sourcePlateSet.getName(), container.getPath()));
 
-        return sourcePlates;
+        return Pair.of(sourcePlateSet, sourcePlates);
     }
 
     private @NotNull List<PlateData> hydratePlateDataFromWellLayout(

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -126,6 +126,7 @@ import org.labkey.assay.PlateController;
 import org.labkey.assay.TsvAssayProvider;
 import org.labkey.assay.plate.data.WellData;
 import org.labkey.assay.plate.layout.LayoutEngine;
+import org.labkey.assay.plate.layout.LayoutOperation;
 import org.labkey.assay.plate.layout.WellLayout;
 import org.labkey.assay.plate.model.PlateBean;
 import org.labkey.assay.plate.model.PlateSetAssays;
@@ -3546,7 +3547,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             ));
         }
 
-        List<PlateData> plateData = hydratePlateDataFromWellLayout(container, user, wellLayouts);
+        List<PlateData> plateData = hydratePlateDataFromWellLayout(container, user, wellLayouts, engine.getOperation());
 
         if (options.isPreview())
             return new ReformatResult(plateData, null, null, null);
@@ -3667,7 +3668,12 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return sourcePlates;
     }
 
-    private @NotNull List<PlateData> hydratePlateDataFromWellLayout(Container container, User user, List<WellLayout> wellLayouts)
+    private @NotNull List<PlateData> hydratePlateDataFromWellLayout(
+        Container container,
+        User user,
+        List<WellLayout> wellLayouts,
+        LayoutOperation operation
+    )
     {
         if (wellLayouts.isEmpty())
             return Collections.emptyList();
@@ -3708,7 +3714,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 }
             }
 
-            if (!targetWellData.isEmpty())
+            if (operation.produceEmptyPlates() || !targetWellData.isEmpty())
                 plates.add(new PlateData(null, plateType.getRowId(), null, targetWellData));
         }
 

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -24,6 +24,7 @@ import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.api.ExpMaterial;
+import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.SampleTypeService;
@@ -56,6 +57,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.api.exp.query.SamplesSchema.SCHEMA_SAMPLES;
 import static org.labkey.api.util.JunitUtil.deleteTestContainer;
 
 public final class PlateManagerTest
@@ -97,9 +99,8 @@ public final class PlateManagerTest
         // create sample type
         {
             List<GWTPropertyDescriptor> props = new ArrayList<>();
-            props.add(new GWTPropertyDescriptor("col1", "string"));
-            props.add(new GWTPropertyDescriptor("col2", "string"));
-            sampleType = SampleTypeService.get().createSampleType(container, user, "SampleType1", null, props, emptyList(), 0, -1, -1, -1, null, null);
+            props.add(new GWTPropertyDescriptor("name", "string"));
+            sampleType = SampleTypeService.get().createSampleType(container, user, "SampleType1", null, props, emptyList(), -1, -1, -1, -1, "PMT-${genId}", null);
         }
 
         // resolve plate types
@@ -582,14 +583,9 @@ public final class PlateManagerTest
     public void testGetInstrumentInstructions() throws Exception
     {
         // Arrange
-        ContainerFilter cf = ContainerFilter.Type.CurrentAndSubfolders.create(ContainerManager.getSharedContainer(), user);
-
-        final ExpMaterial sample1 = ExperimentService.get().createExpMaterial(container, sampleType.generateSampleLSID().setObjectId("sampleOne").toString(), "sampleOne");
-        sample1.setCpasType(sampleType.getLSID());
-        sample1.save(user);
-        final ExpMaterial sample2 = ExperimentService.get().createExpMaterial(container, sampleType.generateSampleLSID().setObjectId("sampleTwo").toString(), "sampleTwo");
-        sample2.setCpasType(sampleType.getLSID());
-        sample2.save(user);
+        List<ExpMaterial> samples = createSamples(2);
+        ExpMaterial sample1 = samples.get(0);
+        ExpMaterial sample2 = samples.get(1);
 
         List<Map<String, Object>> rows = List.of(
             CaseInsensitiveHashMap.of(
@@ -597,8 +593,8 @@ public final class PlateManagerTest
                 "sampleId", sample1.getRowId(),
                 "type", "SAMPLE",
                 "concentration", 2.25,
-                "barcode", "B1234")
-            ,
+                "barcode", "B1234"
+            ),
             CaseInsensitiveHashMap.of(
                 "wellLocation", "A2",
                 "sampleId", sample2.getRowId(),
@@ -608,19 +604,26 @@ public final class PlateManagerTest
             )
         );
         Plate plate = createPlate(PLATE_TYPE_96_WELLS, "myPlate", null, rows);
+        PlateSet plateSet = plate.getPlateSet();
+        assertNotNull(plateSet);
 
         // Act
-        List<FieldKey> includedMetadataCols = PlateManager.get().getMetadataColumns(plate.getPlateSet(), container, user, cf);
-        List<Object[]> result = PlateManager.get().getInstrumentInstructions(plate.getPlateSet().getRowId(), includedMetadataCols, container, user);
+        List<FieldKey> includedMetadataCols = PlateManager.get().getMetadataColumns(
+            plateSet,
+            container,
+            user,
+            ContainerFilter.Type.CurrentAndSubfolders.create(container, user)
+        );
+        List<Object[]> result = PlateManager.get().getInstrumentInstructions(plateSet.getRowId(), includedMetadataCols, container, user);
 
         // Assert
         Object[] row1 = result.get(0);
-        String[] valuesRow1 = new String[]{"myPlate", "A1", "96", "sampleOne", "B1234", "2.25"};
+        String[] valuesRow1 = new String[]{"myPlate", "A1", "96", sample1.getName(), "B1234", "2.25"};
         for (int i = 0; i < row1.length; i++)
             assertEquals(row1[i].toString(), valuesRow1[i]);
 
         Object[] row2 = result.get(1);
-        String[] valuesRow2 = new String[]{"myPlate", "A2", "96", "sampleTwo", "B5678", "1.25"};
+        String[] valuesRow2 = new String[]{"myPlate", "A2", "96", sample2.getName(), "B5678", "1.25"};
         for (int i = 0; i < row1.length; i++)
             assertEquals(row2[i].toString(), valuesRow2[i]);
     }
@@ -629,14 +632,11 @@ public final class PlateManagerTest
     public void testGetWorklist() throws Exception
     {
         // Arrange
-        ContainerFilter cf = ContainerFilter.Type.CurrentAndSubfolders.create(ContainerManager.getSharedContainer(), user);
+        ContainerFilter cf = ContainerFilter.Type.CurrentAndSubfolders.create(container, user);
 
-        final ExpMaterial sample1 = ExperimentService.get().createExpMaterial(container, sampleType.generateSampleLSID().setObjectId("sampleA").toString(), "sampleA");
-        sample1.setCpasType(sampleType.getLSID());
-        sample1.save(user);
-        final ExpMaterial sample2 = ExperimentService.get().createExpMaterial(container, sampleType.generateSampleLSID().setObjectId("sampleB").toString(), "sampleB");
-        sample2.setCpasType(sampleType.getLSID());
-        sample2.save(user);
+        List<ExpMaterial> samples = createSamples(2);
+        ExpMaterial sample1 = samples.get(0);
+        ExpMaterial sample2 = samples.get(1);
 
         List<Map<String, Object>> rows1 = List.of(
             CaseInsensitiveHashMap.of(
@@ -644,8 +644,8 @@ public final class PlateManagerTest
                 "sampleId", sample1.getRowId(),
                 "type", "SAMPLE",
                 "concentration", 2.25,
-                "barcode", "B1234")
-            ,
+                "barcode", "B1234"
+            ),
             CaseInsensitiveHashMap.of(
                 "wellLocation", "A2",
                 "sampleId", sample2.getRowId(),
@@ -682,17 +682,17 @@ public final class PlateManagerTest
 
         // Assert
         Object[] row1 = plateDataRows.get(0);
-        String[] valuesRow1 = new String[]{"myPlate1", "A1", "96", "sampleA", "B1234", "2.25", "myPlate2", "A2", "96"};
+        String[] valuesRow1 = new String[]{"myPlate1", "A1", "96", sample1.getName(), "B1234", "2.25", "myPlate2", "A2", "96"};
         for (int i = 0; i < row1.length; i++)
             assertEquals(row1[i].toString(), valuesRow1[i]);
 
         Object[] row2 = plateDataRows.get(1);
-        String[] valuesRow2 = new String[]{"myPlate1", "A2", "96", "sampleB", "B5678", "1.25", "myPlate2", "A1", "96"};
+        String[] valuesRow2 = new String[]{"myPlate1", "A2", "96", sample2.getName(), "B5678", "1.25", "myPlate2", "A1", "96"};
         for (int i = 0; i < row2.length; i++)
             assertEquals(row2[i].toString(), valuesRow2[i]);
 
         Object[] row3 = plateDataRows.get(2);
-        String[] valuesRow3 = new String[]{"myPlate1", "A2", "96", "sampleB", "B5678", "1.25", "myPlate2", "A3", "96"};
+        String[] valuesRow3 = new String[]{"myPlate1", "A2", "96", sample2.getName(), "B5678", "1.25", "myPlate2", "A3", "96"};
         for (int i = 0; i < row3.length; i++)
             assertEquals(row3[i].toString(), valuesRow3[i]);
     }
@@ -953,6 +953,168 @@ public final class PlateManagerTest
         }
     }
 
+    @Test
+    public void testReformatCompressByColumn() throws Exception
+    {
+        List<Integer> sampleRowIds = createSamples(6).stream().map(ExpObject::getRowId).sorted().toList();
+
+        // Arrange
+        List<Map<String, Object>> sourcePlateData = List.of(
+            CaseInsensitiveHashMap.of("wellLocation", "A1", "sampleId", sampleRowIds.get(0), "type", "SAMPLE"),
+            CaseInsensitiveHashMap.of("wellLocation", "H12", "sampleId", sampleRowIds.get(1), "type", "SAMPLE"),
+            CaseInsensitiveHashMap.of("wellLocation", "H13", "sampleId", sampleRowIds.get(2), "type", "SAMPLE"),
+            CaseInsensitiveHashMap.of("wellLocation", "I12", "sampleId", sampleRowIds.get(3), "type", "SAMPLE"),
+            CaseInsensitiveHashMap.of("wellLocation", "I13", "sampleId", sampleRowIds.get(4), "type", "SAMPLE"),
+            CaseInsensitiveHashMap.of("wellLocation", "P12", "barcode", "BC-P12"),
+            CaseInsensitiveHashMap.of("wellLocation", "P24", "sampleId", sampleRowIds.get(5), "type", "SAMPLE")
+        );
+        Plate sourcePlate = createPlate(PLATE_TYPE_384_WELLS, "Column compression source plate", null, sourcePlateData);
+        Integer targetPlateSetId = sourcePlate.getPlateSet().getRowId();
+
+        ReformatOptions options = new ReformatOptions()
+                .setOperation(ReformatOptions.ReformatOperation.columnCompression)
+                .setPlateRowIds(List.of(sourcePlate.getRowId()))
+                .setTargetPlateSet(new ReformatOptions.ReformatPlateSet().setRowId(targetPlateSetId))
+                .setTargetPlateTypeId(PLATE_TYPE_12_WELLS.getRowId())
+                .setPreview(true);
+
+        // Act (preview)
+        PlateManager.ReformatResult result = PlateManager.get().reformat(container, user, options);
+
+        // Assert
+        assertNotNull(result.previewData());
+        assertEquals("Expected column compress operation on a 384-well plate to generate 1 12-well plates.", 1, result.previewData().size());
+
+        List<Map<String, Object>> plateData = result.previewData().get(0).data();
+        assertEquals("Expected well P12 to be dropped as it does not include a sample.", sourcePlateData.size() - 1, plateData.size());
+
+        assertEquals(sampleRowIds.get(0), plateData.get(0).get("sampleId"));
+        assertEquals("A1", plateData.get(0).get("wellLocation"));
+        assertEquals(sampleRowIds.get(1), plateData.get(2).get("sampleId"));
+        assertEquals("B1", plateData.get(2).get("wellLocation"));
+        assertEquals(sampleRowIds.get(2), plateData.get(4).get("sampleId"));
+        assertEquals("C1", plateData.get(4).get("wellLocation"));
+        assertEquals(sampleRowIds.get(3), plateData.get(1).get("sampleId"));
+        assertEquals("A2", plateData.get(1).get("wellLocation"));
+        assertEquals(sampleRowIds.get(4), plateData.get(3).get("sampleId"));
+        assertEquals("B2", plateData.get(3).get("wellLocation"));
+        assertEquals(sampleRowIds.get(5), plateData.get(5).get("sampleId"));
+        assertEquals("C2", plateData.get(5).get("wellLocation"));
+
+        // Act (saved)
+        result = PlateManager.get().reformat(container, user, options.setPreview(false));
+
+        // Assert
+        assertNull(result.previewData());
+        assertEquals("Expected target plate set to be used", targetPlateSetId, result.plateSetRowId());
+        assertEquals(1, result.plateRowIds().size());
+
+        Plate newPlate = PlateManager.get().getPlate(container, result.plateRowIds().get(0));
+        assertNotNull(newPlate);
+        assertEquals(PLATE_TYPE_12_WELLS, newPlate.getPlateType());
+
+        try (var r = getPlateWellResults(newPlate.getRowId()))
+        {
+            while (r.next())
+            {
+                var sampleId = r.getInt(FieldKey.fromParts("sampleId"));
+                var wellPosition = r.getString(FieldKey.fromParts("position"));
+
+                switch (wellPosition)
+                {
+                    case "A1" -> assertEquals(sampleRowIds.get(0).intValue(), sampleId);
+                    case "A2" -> assertEquals(sampleRowIds.get(3).intValue(), sampleId);
+                    case "B1" -> assertEquals(sampleRowIds.get(1).intValue(), sampleId);
+                    case "B2" -> assertEquals(sampleRowIds.get(4).intValue(), sampleId);
+                    case "C1" -> assertEquals(sampleRowIds.get(2).intValue(), sampleId);
+                    case "C2" -> assertEquals(sampleRowIds.get(5).intValue(), sampleId);
+                    default -> assertEquals(0, sampleId);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testReformatCompressByRow() throws Exception
+    {
+        List<Integer> sampleRowIds = createSamples(6).stream().map(ExpObject::getRowId).sorted().toList();
+
+        // Arrange
+        List<Map<String, Object>> sourcePlateData = List.of(
+            CaseInsensitiveHashMap.of("wellLocation", "A1", "sampleId", sampleRowIds.get(0), "type", "SAMPLE"),
+            CaseInsensitiveHashMap.of("wellLocation", "H12", "sampleId", sampleRowIds.get(1), "type", "SAMPLE"),
+            CaseInsensitiveHashMap.of("wellLocation", "H13", "sampleId", sampleRowIds.get(2), "type", "SAMPLE"),
+            CaseInsensitiveHashMap.of("wellLocation", "I12", "sampleId", sampleRowIds.get(3), "type", "SAMPLE"),
+            CaseInsensitiveHashMap.of("wellLocation", "I13", "sampleId", sampleRowIds.get(4), "type", "SAMPLE"),
+            CaseInsensitiveHashMap.of("wellLocation", "P12", "barcode", "BC-P12"),
+            CaseInsensitiveHashMap.of("wellLocation", "P24", "sampleId", sampleRowIds.get(5), "type", "SAMPLE")
+        );
+        Plate sourcePlate = createPlate(PLATE_TYPE_384_WELLS, "Row compression source plate", null, sourcePlateData);
+        Integer targetPlateSetId = sourcePlate.getPlateSet().getRowId();
+
+        ReformatOptions options = new ReformatOptions()
+                .setOperation(ReformatOptions.ReformatOperation.rowCompression)
+                .setPlateRowIds(List.of(sourcePlate.getRowId()))
+                .setTargetPlateSet(new ReformatOptions.ReformatPlateSet().setRowId(targetPlateSetId))
+                .setTargetPlateTypeId(PLATE_TYPE_12_WELLS.getRowId())
+                .setPreview(true);
+
+        // Act (preview)
+        PlateManager.ReformatResult result = PlateManager.get().reformat(container, user, options);
+
+        // Assert
+        assertNotNull(result.previewData());
+        assertEquals("Expected row compress operation on a 384-well plate to generate 1 12-well plates.", 1, result.previewData().size());
+
+        List<Map<String, Object>> plateData = result.previewData().get(0).data();
+        assertEquals("Expected well P12 to be dropped as it does not include a sample.", sourcePlateData.size() - 1, plateData.size());
+
+        assertEquals(sampleRowIds.get(0), plateData.get(0).get("sampleId"));
+        assertEquals("A1", plateData.get(0).get("wellLocation"));
+        assertEquals(sampleRowIds.get(1), plateData.get(1).get("sampleId"));
+        assertEquals("A2", plateData.get(1).get("wellLocation"));
+        assertEquals(sampleRowIds.get(2), plateData.get(2).get("sampleId"));
+        assertEquals("A3", plateData.get(2).get("wellLocation"));
+        assertEquals(sampleRowIds.get(3), plateData.get(3).get("sampleId"));
+        assertEquals("A4", plateData.get(3).get("wellLocation"));
+        assertEquals(sampleRowIds.get(4), plateData.get(4).get("sampleId"));
+        assertEquals("B1", plateData.get(4).get("wellLocation"));
+        assertEquals(sampleRowIds.get(5), plateData.get(5).get("sampleId"));
+        assertEquals("B2", plateData.get(5).get("wellLocation"));
+
+        // Act (saved)
+        result = PlateManager.get().reformat(container, user, options.setPreview(false));
+
+        // Assert
+        assertNull(result.previewData());
+        assertEquals("Expected target plate set to be used", targetPlateSetId, result.plateSetRowId());
+        assertEquals(1, result.plateRowIds().size());
+
+        Plate newPlate = PlateManager.get().getPlate(container, result.plateRowIds().get(0));
+        assertNotNull(newPlate);
+        assertEquals(PLATE_TYPE_12_WELLS, newPlate.getPlateType());
+
+        try (var r = getPlateWellResults(newPlate.getRowId()))
+        {
+            while (r.next())
+            {
+                var sampleId = r.getInt(FieldKey.fromParts("sampleId"));
+                var wellPosition = r.getString(FieldKey.fromParts("position"));
+
+                switch (wellPosition)
+                {
+                    case "A1" -> assertEquals(sampleRowIds.get(0).intValue(), sampleId);
+                    case "A2" -> assertEquals(sampleRowIds.get(1).intValue(), sampleId);
+                    case "A3" -> assertEquals(sampleRowIds.get(2).intValue(), sampleId);
+                    case "A4" -> assertEquals(sampleRowIds.get(3).intValue(), sampleId);
+                    case "B1" -> assertEquals(sampleRowIds.get(4).intValue(), sampleId);
+                    case "B2" -> assertEquals(sampleRowIds.get(5).intValue(), sampleId);
+                    default -> assertEquals(0, sampleId);
+                }
+            }
+        }
+    }
+
     private Plate createPlate(@NotNull PlateType plateType) throws Exception
     {
         return createPlate(plateType, null, null, null);
@@ -967,6 +1129,24 @@ public final class PlateManagerTest
     {
         PlateImpl plate = new PlateImpl(container, plateName, plateType);
         return PlateManager.get().createAndSavePlate(container, user, plate, plateSetId, plateData);
+    }
+
+    private List<ExpMaterial> createSamples(int numSamples) throws Exception
+    {
+        List<Map<String, Object>> rows = new ArrayList<>();
+
+        for (int i = 0; i < numSamples; i++)
+            rows.add(CaseInsensitiveHashMap.of());
+
+        TableInfo table = QueryService.get().getUserSchema(user, container, SCHEMA_SAMPLES).getTable(sampleType.getName());
+
+        var errors = new BatchValidationException();
+        var insertedRows = table.getUpdateService().insertRows(user, container, rows, errors, null, null);
+        if (errors.hasErrors())
+            throw errors;
+
+        List<Integer> insertedRowIds = insertedRows.stream().map(row -> (Integer) row.get("RowId")).toList();
+        return new ArrayList<>(ExperimentService.get().getExpMaterials(insertedRowIds));
     }
 
     private @NotNull TableInfo getWellTable()

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -884,6 +884,8 @@ public final class PlateManagerTest
         List<Map<String, Object>> sourcePlateData = List.of(
             CaseInsensitiveHashMap.of("wellLocation", "A1", "barcode", "BC-A1"),
             CaseInsensitiveHashMap.of("wellLocation", "H12", "barcode", "BC-H12"),
+            CaseInsensitiveHashMap.of("wellLocation", "H13", "barcode", "BC-H13"),
+            CaseInsensitiveHashMap.of("wellLocation", "I12", "barcode", "BC-I12"),
             CaseInsensitiveHashMap.of("wellLocation", "I13", "barcode", "BC-I13"),
             CaseInsensitiveHashMap.of("wellLocation", "P24", "barcode", "BC-P24")
         );
@@ -930,9 +932,7 @@ public final class PlateManagerTest
                 {
                     var barcode = r.getString(FieldKey.fromParts("barcode"));
 
-                    if (i == 1 || i == 2)
-                        assertNull(barcode);
-                    else
+                    if (i == 0 || i == 3)
                     {
                         var wellPosition = r.getString(FieldKey.fromParts("position"));
                         if ("A1".equalsIgnoreCase(wellPosition))

--- a/assay/src/org/labkey/assay/plate/PlateSetImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetImpl.java
@@ -117,6 +117,27 @@ public class PlateSetImpl extends Entity implements PlateSet
     }
 
     @Override
+    @JsonIgnore
+    public boolean isAssay()
+    {
+        return PlateSetType.assay.equals(getType());
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isPrimary()
+    {
+        return PlateSetType.primary.equals(getType());
+    }
+
+    @Override
+    @JsonIgnore
+    public boolean isStandalone()
+    {
+        return getRootPlateSetId() == null && isAssay() && !isTemplate();
+    }
+
+    @Override
     public List<Plate> getPlates()
     {
         if (isNew())
@@ -175,12 +196,6 @@ public class PlateSetImpl extends Entity implements PlateSet
     public void setRootPlateSetId(Integer rootPlateSetId)
     {
         _rootPlateSetId = rootPlateSetId;
-    }
-
-    @JsonIgnore // TODO: Should probably just make this first class
-    public boolean isStandalone()
-    {
-        return getRootPlateSetId() == null && PlateSetType.assay.equals(getType()) && !isTemplate();
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/layout/ColumnCompressionOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/ColumnCompressionOperation.java
@@ -1,0 +1,73 @@
+package org.labkey.assay.plate.layout;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateType;
+import org.labkey.api.query.ValidationException;
+import org.labkey.assay.plate.model.ReformatOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ColumnCompressionOperation implements LayoutOperation
+{
+    @Override
+    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType)
+    {
+        List<WellLayout> layouts = new ArrayList<>();
+        WellLayout target = null;
+
+        int targetCols = targetPlateType.getColumns();
+        int targetRows = targetPlateType.getRows();
+
+        int targetColIdx = 0;
+        int targetRowIdx = 0;
+
+        for (Plate sourcePlate : sourcePlates)
+        {
+            int sourceRowId = sourcePlate.getRowId();
+            PlateType sourcePlateType = sourcePlate.getPlateType();
+
+            for (int r = 0; r < sourcePlateType.getRows(); r++)
+            {
+                for (int c = 0; c < sourcePlateType.getColumns(); c++)
+                {
+                    if (target == null)
+                        target = new WellLayout(targetPlateType);
+
+                    target.setWell(targetRowIdx, targetColIdx, sourceRowId, r, c);
+
+                    targetRowIdx++;
+                    if (targetRowIdx == targetRows)
+                    {
+                        targetRowIdx = 0;
+                        targetColIdx++;
+
+                        if (targetColIdx == targetCols)
+                        {
+                            layouts.add(target);
+                            target = null;
+                            targetColIdx = 0;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (target != null)
+            layouts.add(target);
+
+        return layouts;
+    }
+
+    @Override
+    public boolean requiresTargetPlateType()
+    {
+        return true;
+    }
+
+    @Override
+    public void validate(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType) throws ValidationException
+    {
+    }
+}

--- a/assay/src/org/labkey/assay/plate/layout/CompressionOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/CompressionOperation.java
@@ -48,6 +48,9 @@ public class CompressionOperation implements LayoutOperation
                     if (target == null)
                         target = new WellLayout(targetPlateType);
 
+                    if (sourcePlate.getWell(r, c).getSampleId() == null)
+                        continue;
+
                     target.setWell(targetRowIdx, targetColIdx, sourceRowId, r, c);
 
                     if (isColumnLayout)

--- a/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
+++ b/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
@@ -13,19 +13,23 @@ public class LayoutEngine
     private final ReformatOptions _options;
     private final List<Plate> _sourcePlates;
     private final PlateType _targetPlateType;
+    private final List<? extends PlateType> _allPlateTypes;
 
-    public LayoutEngine(ReformatOptions options, List<Plate> sourcePlates, PlateType targetPlateType)
+    public LayoutEngine(ReformatOptions options, List<Plate> sourcePlates, PlateType targetPlateType, List<? extends PlateType> allPlateTypes)
     {
         _operation = layoutOperationFactory(options);
         _options = options;
         _sourcePlates = sourcePlates;
         _targetPlateType = targetPlateType;
+        _allPlateTypes = allPlateTypes;
     }
 
     public List<WellLayout> run() throws ValidationException
     {
         if (_sourcePlates.isEmpty())
             throw new ValidationException("Invalid configuration. Source plates are required to run the layout engine.");
+
+        _operation.init(_options, _sourcePlates, _targetPlateType, _allPlateTypes);
 
         if (_operation.requiresTargetPlateType() && _targetPlateType == null)
             throw new ValidationException("A target plate type is required for this operation.");

--- a/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
+++ b/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
@@ -35,6 +35,11 @@ public class LayoutEngine
         return _operation.execute(_options, _sourcePlates, _targetPlateType);
     }
 
+    public LayoutOperation getOperation()
+    {
+        return _operation;
+    }
+
     private static LayoutOperation layoutOperationFactory(ReformatOptions reformatOptions)
     {
         return switch (reformatOptions.getOperation())

--- a/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
+++ b/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
@@ -34,8 +34,6 @@ public class LayoutEngine
         if (_operation.requiresTargetPlateType() && _targetPlateType == null)
             throw new ValidationException("A target plate type is required for this operation.");
 
-        _operation.validate(_options, _sourcePlates, _targetPlateType);
-
         return _operation.execute(_options, _sourcePlates, _targetPlateType);
     }
 

--- a/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
+++ b/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
@@ -39,6 +39,7 @@ public class LayoutEngine
     {
         return switch (reformatOptions.getOperation())
         {
+            case columnCompression -> new ColumnCompressionOperation();
             case quadrant -> new QuadrantOperation();
             case reverseQuadrant -> new ReverseQuadrantOperation();
             case stamp -> new StampOperation();

--- a/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
+++ b/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
@@ -39,9 +39,10 @@ public class LayoutEngine
     {
         return switch (reformatOptions.getOperation())
         {
-            case columnCompression -> new ColumnCompressionOperation();
+            case columnCompression -> new CompressionOperation(CompressionOperation.Layout.Column);
             case quadrant -> new QuadrantOperation();
             case reverseQuadrant -> new ReverseQuadrantOperation();
+            case rowCompression -> new CompressionOperation(CompressionOperation.Layout.Row);
             case stamp -> new StampOperation();
         };
     }

--- a/assay/src/org/labkey/assay/plate/layout/LayoutOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/LayoutOperation.java
@@ -16,6 +16,11 @@ public interface LayoutOperation
 
     List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType);
 
+    default boolean produceEmptyPlates()
+    {
+        return false;
+    }
+
     default boolean requiresTargetPlateType()
     {
         return false;

--- a/assay/src/org/labkey/assay/plate/layout/LayoutOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/LayoutOperation.java
@@ -12,7 +12,7 @@ public interface LayoutOperation
 {
     List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType);
 
-    default void init(ReformatOptions options, List<Plate> sourcePlates, PlateType targetPlateType, List<? extends PlateType> allPlateTypes) throws ValidationException
+    default void init(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, List<? extends PlateType> allPlateTypes) throws ValidationException
     {
     }
 
@@ -24,9 +24,5 @@ public interface LayoutOperation
     default boolean requiresTargetPlateType()
     {
         return false;
-    }
-
-    default void validate(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType) throws ValidationException
-    {
     }
 }

--- a/assay/src/org/labkey/assay/plate/layout/LayoutOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/LayoutOperation.java
@@ -10,11 +10,11 @@ import java.util.List;
 
 public interface LayoutOperation
 {
-    default void validate(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType) throws ValidationException
+    List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType);
+
+    default void init(ReformatOptions options, List<Plate> sourcePlates, PlateType targetPlateType, List<? extends PlateType> allPlateTypes) throws ValidationException
     {
     }
-
-    List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType);
 
     default boolean produceEmptyPlates()
     {
@@ -24,5 +24,9 @@ public interface LayoutOperation
     default boolean requiresTargetPlateType()
     {
         return false;
+    }
+
+    default void validate(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType) throws ValidationException
+    {
     }
 }

--- a/assay/src/org/labkey/assay/plate/layout/QuadrantOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/QuadrantOperation.java
@@ -62,7 +62,7 @@ public class QuadrantOperation implements LayoutOperation
     }
 
     @Override
-    public void init(ReformatOptions options, List<Plate> sourcePlates, PlateType targetPlateType, List<? extends PlateType> allPlateTypes) throws ValidationException
+    public void init(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, List<? extends PlateType> allPlateTypes) throws ValidationException
     {
         _sourcePlateType = getSourcePlateType(sourcePlates);
         _targetPlateType = getTargetPlateType(_sourcePlateType, allPlateTypes);

--- a/assay/src/org/labkey/assay/plate/layout/StampOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/StampOperation.java
@@ -30,4 +30,10 @@ public class StampOperation implements LayoutOperation
 
         return result;
     }
+
+    @Override
+    public boolean produceEmptyPlates()
+    {
+        return true;
+    }
 }

--- a/assay/src/org/labkey/assay/plate/model/ReformatOptions.java
+++ b/assay/src/org/labkey/assay/plate/model/ReformatOptions.java
@@ -8,6 +8,7 @@ public class ReformatOptions
 {
     public enum ReformatOperation
     {
+        columnCompression,
         quadrant,
         reverseQuadrant,
         stamp

--- a/assay/src/org/labkey/assay/plate/model/ReformatOptions.java
+++ b/assay/src/org/labkey/assay/plate/model/ReformatOptions.java
@@ -11,6 +11,7 @@ public class ReformatOptions
         columnCompression,
         quadrant,
         reverseQuadrant,
+        rowCompression,
         stamp
     }
 

--- a/assay/src/org/labkey/assay/plate/model/ReformatOptions.java
+++ b/assay/src/org/labkey/assay/plate/model/ReformatOptions.java
@@ -83,6 +83,7 @@ public class ReformatOptions
     private List<Integer> _plateRowIds;
     private String _plateSelectionKey;
     private Boolean _preview = false;
+    private Boolean _previewData = true;
     private ReformatPlateSet _targetPlateSet;
     private Integer _targetPlateTypeId;
 
@@ -128,6 +129,16 @@ public class ReformatOptions
     {
         _preview = preview;
         return this;
+    }
+
+    public Boolean isPreviewData()
+    {
+        return _previewData;
+    }
+
+    public void setPreviewData(Boolean previewData)
+    {
+        _previewData = previewData;
     }
 
     public ReformatPlateSet getTargetPlateSet()


### PR DESCRIPTION
#### Rationale
This adds new reformat operations and new options for the `plate-reformat.api` endpoint.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5645
- https://github.com/LabKey/labkey-ui-components/pull/1535
- https://github.com/LabKey/labkey-ui-premium/pull/472
- https://github.com/LabKey/platform/pull/5693
- https://github.com/LabKey/limsModules/pull/482

#### Changes
- Add new compression operations for compressing by row and compressing by column.
- Quadrant and reverse quadrant operations now resolve their target plate type based on the source type. User provided value for `targetPlateType` is ignored.
- Plate data hydration will now skip producing empty plates by default. Operations can opt-in to producing empty plates.
- `ReformatResult` response object now includes `plateCount` and `plateSetName`.
- New `previewData: boolean` option on the `plate-reformat.api` endpoint allows callers to opt-out of including preview data. This can be useful when the preview data is not needed.
