### PR TITLE
Add and rework module HTML view metadata (*.view.xml) elements

### DIFF
--- a/api/schemas/view.xsd
+++ b/api/schemas/view.xsd
@@ -13,7 +13,11 @@
     <xsd:complexType name="viewType">
         <xsd:sequence>
             <xsd:element name="permissions" type="vw:permissionsListType" minOccurs="0" maxOccurs="1"/>
+            <!-- <permissionClasses> and <requiresPermissions> are synonyms -->
             <xsd:element name="permissionClasses" type="vw:permissionClassListType" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="requiresPermissions" type="vw:permissionClassListType" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="requiresNoPermission" type="xsd:string" fixed="" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="requiresLogin" type="xsd:string" fixed="" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="dependencies" type="vw:dependenciesType" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="requiredModuleContext" type="cl:moduleContextType" minOccurs="0" maxOccurs="1"/>
         </xsd:sequence>

--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -95,7 +95,6 @@ import org.labkey.api.exp.api.ExperimentJSONConverter;
 import org.labkey.api.exp.property.DomainTemplateGroup;
 import org.labkey.api.files.FileSystemWatcherImpl;
 import org.labkey.api.iterator.MarkableIterator;
-import org.labkey.api.iterator.ValidatingDataRowIterator;
 import org.labkey.api.iterator.ValidatingDataRowIteratorTestCase;
 import org.labkey.api.markdown.MarkdownService;
 import org.labkey.api.mbean.LabKeyManagement;
@@ -106,6 +105,7 @@ import org.labkey.api.module.JavaVersion;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.ModuleDependencySorter;
 import org.labkey.api.module.ModuleHtmlView;
+import org.labkey.api.module.ModuleHtmlViewDefinition;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.ModuleLoader.StartupPropertyStartupListener;
 import org.labkey.api.module.ModuleXml;
@@ -393,6 +393,7 @@ public class ApiModule extends CodeOnlyModule
             MemTracker.TestCase.class,
             ModuleContext.TestCase.class,
             ModuleDependencySorter.TestCase.class,
+            ModuleHtmlViewDefinition.TestCase.class,
             MultiValuedRenderContext.TestCase.class,
             NameGenerator.TestCase.class,
             NumberUtilsLabKey.TestCase.class,

--- a/api/src/org/labkey/api/module/ModuleHtmlView.java
+++ b/api/src/org/labkey/api/module/ModuleHtmlView.java
@@ -113,7 +113,7 @@ public class ModuleHtmlView extends HtmlView
 
     public ModuleHtmlView(Module module, String name, HtmlString body)
     {
-        this(new ModuleHtmlViewDefinition(name, body), module, null);
+        this(new ModuleHtmlViewDefinition(name, body, null, true), module, null);
     }
 
 

--- a/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
+++ b/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
@@ -316,7 +316,9 @@ public class ModuleHtmlViewDefinition
 
     public static class TestCase extends Assert
     {
-        private static final String HEADER = "<view xmlns=\"http://labkey.org/data/xml/view\" title=\"Test view.xml file\" frame=\"portal\">\n";
+        private static final String HEADER = """
+            <view xmlns="http://labkey.org/data/xml/view" title="Test view.xml file" frame="portal">
+            """;
         private static final String FOOTER = "\n</view>";
 
         @Test
@@ -326,19 +328,53 @@ public class ModuleHtmlViewDefinition
             testPermissions("", ACL.PERM_READ, Set.of(ReadPermission.class), false); // No permission elements -> read
             testPermissions("<requiresLogin/>", ACL.PERM_READ, Set.of(ReadPermission.class), true); // read + login
             testPermissions("<requiresNoPermission/>", ACL.PERM_NONE, Set.of(), false); // no permissions
-            testPermissions("<requiresNoPermission/>\n<requiresLogin/>", ACL.PERM_NONE, Set.of(), true); // just login required
+            testPermissions("""
+                <requiresNoPermission/>
+                <requiresLogin/>""", ACL.PERM_NONE, Set.of(), true); // just login required
             testPermissions("<permissionClasses/>", ACL.PERM_READ, Set.of(), false); // allow empty element for now
-            testPermissions("<permissionClasses>\n<permissionClass name=\"org.labkey.api.security.permissions.ReadPermission\"/>\n</permissionClasses>", ACL.PERM_READ, Set.of(ReadPermission.class), false);
-            testPermissions("<permissionClasses>\n<permissionClass name=\"org.labkey.api.security.permissions.ReadPermission\"/>\n</permissionClasses>\n<requiresLogin/>", ACL.PERM_READ, Set.of(ReadPermission.class), true);
-            testPermissions("<permissionClasses>\n<permissionClass name=\"org.labkey.api.security.permissions.InsertPermission\"/>\n</permissionClasses>", ACL.PERM_READ, Set.of(InsertPermission.class), false);
-            testPermissions("<permissionClasses>\n<permissionClass name=\"org.labkey.api.security.permissions.InsertPermission\"/>\n<permissionClass name=\"org.labkey.api.security.permissions.UpdatePermission\"/>\n</permissionClasses>", ACL.PERM_READ, Set.of(InsertPermission.class, UpdatePermission.class), false);
-            testPermissions("<requiresPermissions>\n<permissionClass name=\"org.labkey.api.security.permissions.ReadPermission\"/>\n</requiresPermissions>", ACL.PERM_READ, Set.of(ReadPermission.class), false);
-            testPermissions("<requiresPermissions>\n<permissionClass name=\"org.labkey.api.security.permissions.ReadPermission\"/>\n</requiresPermissions>\n<requiresLogin/>", ACL.PERM_READ, Set.of(ReadPermission.class), true);
-            testPermissions("<requiresPermissions>\n<permissionClass name=\"org.labkey.api.security.permissions.InsertPermission\"/>\n</requiresPermissions>", ACL.PERM_READ, Set.of(InsertPermission.class), false);
-            testPermissions("<requiresPermissions>\n<permissionClass name=\"org.labkey.api.security.permissions.InsertPermission\"/>\n<permissionClass name=\"org.labkey.api.security.permissions.UpdatePermission\"/>\n</requiresPermissions>", ACL.PERM_READ, Set.of(InsertPermission.class, UpdatePermission.class), false);
+            testPermissions("""
+                <permissionClasses>
+                    <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                </permissionClasses>""", ACL.PERM_READ, Set.of(ReadPermission.class), false);
+            testPermissions("""
+                <permissionClasses>
+                    <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                </permissionClasses>
+                <requiresLogin/>""", ACL.PERM_READ, Set.of(ReadPermission.class), true);
+            testPermissions("""
+                <permissionClasses>
+                    <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
+                </permissionClasses>""", ACL.PERM_READ, Set.of(InsertPermission.class), false);
+            testPermissions("""
+                <permissionClasses>
+                    <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
+                    <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
+                </permissionClasses>""", ACL.PERM_READ, Set.of(InsertPermission.class, UpdatePermission.class), false);
+            testPermissions("""
+                <requiresPermissions>
+                    <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                </requiresPermissions>""", ACL.PERM_READ, Set.of(ReadPermission.class), false);
+            testPermissions("""
+                <requiresPermissions>
+                    <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                </requiresPermissions>
+                <requiresLogin/>""", ACL.PERM_READ, Set.of(ReadPermission.class), true);
+            testPermissions("""
+                <requiresPermissions>
+                    <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
+                </requiresPermissions>""", ACL.PERM_READ, Set.of(InsertPermission.class), false);
+            testPermissions("""
+                <requiresPermissions>
+                    <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
+                    <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
+                </requiresPermissions>""", ACL.PERM_READ, Set.of(InsertPermission.class, UpdatePermission.class), false);
 
             testBadPermissions("<requiresPermissions/>", "Empty permissions class lists are not allowed");
-            testBadPermissions("<requiresPermissions>\n<permissionClass name=\"org.labkey.api.security.permissions.ReadPermission\"/>\n</requiresPermissions>\n<requiresNoPermission/>", "The <requiresNoPermission/> element can't be specified along with other permission elements");
+            testBadPermissions("""
+                <requiresPermissions>
+                    <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                </requiresPermissions>
+                <requiresNoPermission/>""", "The <requiresNoPermission/> element can't be specified along with other permission elements");
         }
 
         private void testPermissions(@Nullable String permissions, int expectedPerms, Set<Class<? extends Permission>> expectedPermissionClasses, boolean expectedLogin)

--- a/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
+++ b/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
@@ -58,8 +58,8 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 /**
- * Metadata for a file-based html view in a module, supplied by a .view.xml file in a module's ./resources/views directory.
- * This is separate from ModuleHtmlView so that it can be cached.
+ * Metadata for a file-based html view in a module, typically supplied by a .view.xml file in a module's
+ * ./resources/views directory. This is separate from ModuleHtmlView so that it can be cached.
  */
 public class ModuleHtmlViewDefinition
 {
@@ -161,7 +161,7 @@ public class ModuleHtmlViewDefinition
         PermissionsListType permsList = _viewDef.getPermissions();
         if (permsList != null && permsList.getPermissionArray() != null)
         {
-            _log.warn("The \"<permissions>\" element used in \"{}\" is deprecated and support will be removed in LabKey Server 24.8! Migrate uses to \"<requiresPermissions>\", \"<requiresNoPermissions>\", or \"<requiresLogin>\".", resource);
+            _log.warn("The \"<permissions>\" element used in \"{}\" is deprecated and support will be removed in LabKey Server 24.8! Migrate uses to \"<requiresPermissions>\", \"<requiresNoPermission>\", or \"<requiresLogin>\".", resource);
             for (PermissionType permEntry : permsList.getPermissionArray())
             {
                 SimpleAction.PermissionEnum perm = SimpleAction.PermissionEnum.valueOf(permEntry.getName().toString());
@@ -178,7 +178,7 @@ public class ModuleHtmlViewDefinition
         if (_viewDef.isSetPermissionClasses() || _viewDef.isSetRequiresPermissions())
         {
             if (_viewDef.isSetRequiresNoPermission())
-                throw new ViewDefinitionException("The <requiresNoPermissions/> element can't be specified along with other permission elements");
+                throw new ViewDefinitionException("The <requiresNoPermission/> element can't be specified along with other permission elements");
 
             // <permissionClasses> and <requiresPermissions> are synonyms, so add all permission classes from both.
             // For now, allow but warn for empty <permissionClasses> element; throw for empty <requiresPermissions> element.
@@ -338,7 +338,7 @@ public class ModuleHtmlViewDefinition
             testPermissions("<requiresPermissions>\n<permissionClass name=\"org.labkey.api.security.permissions.InsertPermission\"/>\n<permissionClass name=\"org.labkey.api.security.permissions.UpdatePermission\"/>\n</requiresPermissions>", ACL.PERM_READ, Set.of(InsertPermission.class, UpdatePermission.class), false);
 
             testBadPermissions("<requiresPermissions/>", "Empty permissions class lists are not allowed");
-            testBadPermissions("<requiresPermissions>\n<permissionClass name=\"org.labkey.api.security.permissions.ReadPermission\"/>\n</requiresPermissions>\n<requiresNoPermission/>", "The <requiresNoPermissions/> element can't be specified along with other permission elements");
+            testBadPermissions("<requiresPermissions>\n<permissionClass name=\"org.labkey.api.security.permissions.ReadPermission\"/>\n</requiresPermissions>\n<requiresNoPermission/>", "The <requiresNoPermission/> element can't be specified along with other permission elements");
         }
 
         private void testPermissions(@Nullable String permissions, int expectedPerms, Set<Class<? extends Permission>> expectedPermissionClasses, boolean expectedLogin)

--- a/api/src/org/labkey/api/resource/TestResource.java
+++ b/api/src/org/labkey/api/resource/TestResource.java
@@ -1,0 +1,37 @@
+package org.labkey.api.resource;
+
+import org.apache.commons.io.IOUtils;
+import org.labkey.api.util.Path;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class TestResource extends AbstractResource
+{
+    private final String _contents;
+
+    public TestResource(String name, String contents)
+    {
+        super(new Path(name), null);
+        _contents = contents;
+    }
+
+    @Override
+    public boolean exists()
+    {
+        return true;
+    }
+
+    @Override
+    public Resource parent()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException
+    {
+        return IOUtils.toInputStream(_contents, StandardCharsets.UTF_8);
+    }
+}

--- a/api/src/org/labkey/api/resource/TestResource.java
+++ b/api/src/org/labkey/api/resource/TestResource.java
@@ -2,11 +2,12 @@ package org.labkey.api.resource;
 
 import org.apache.commons.io.IOUtils;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.StringUtilsLabKey;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
+// Minimal Resource for testing purposes
 public class TestResource extends AbstractResource
 {
     private final String _contents;
@@ -32,6 +33,6 @@ public class TestResource extends AbstractResource
     @Override
     public InputStream getInputStream() throws IOException
     {
-        return IOUtils.toInputStream(_contents, StandardCharsets.UTF_8);
+        return IOUtils.toInputStream(_contents, StringUtilsLabKey.DEFAULT_CHARSET);
     }
 }


### PR DESCRIPTION
#### Rationale
We've deprecated and plan to remove bitmask-based permissions. This means we need non-bitmask alternatives to the "none" and "login" bitmask options in `.view.xml` files.

Note that, for 24.7.x, we're warning but still allowing `<permissions>` elements and empty `<permissionClasses>` elements. In 24.8.0, those will be disallowed (but could be re-instated by enabling a deprecated feature flag).

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5632

#### Changes
- Add `<requiresNoPermission/>` and `<requiresLogin/>` elements. Wire them up.
- Add `<requiresPermissions>` element as a synonym for `<permissionClasses>`.
- Add junit test to verify all current options and key non-options.
