### PR TITLE
Allow 'PipeRoot.getWebdavURL' to return 'null'

### DIFF
--- a/pipeline/src/org/labkey/pipeline/api/PipeRootImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipeRootImpl.java
@@ -616,7 +616,6 @@ public class PipeRootImpl implements PipeRoot
     {
         String davName = _defaultRoot.getDavName();
         Container c = getContainer();
-        assert null != c;
         if (null == c)
             return null;
         return FilesWebPart.getRootPath(getContainer(), davName, _cloudStoreName);


### PR DESCRIPTION
#### Rationale
This `assert` caused a failure when the `FileContentDigestProvider` triggered during container deletion. Most callers of `PipeRootImpl.getWebdavURL` know how to handle a `null` return so I'm not sure what it's buying us.

```
java.lang.AssertionError: null
	at org.labkey.pipeline.api.PipeRootImpl.getWebdavURL(PipeRootImpl.java:619) ~[pipeline-24.7-SNAPSHOT.jar:?]
	at org.labkey.pipeline.PipelineWebdavProvider.addChildren(PipelineWebdavProvider.java:63) ~[pipeline-24.7-SNAPSHOT.jar:?]
	at org.labkey.api.webdav.AbstractWebdavResolver$AbstractWebFolderResource.getWebFoldersNames(AbstractWebdavResolver.java:254) ~[api-24.7-SNAPSHOT.jar:?]
	at org.labkey.api.webdav.WebdavResolverImpl$WebFolderResource.find(WebdavResolverImpl.java:198) ~[api-24.7-SNAPSHOT.jar:?]
	at org.labkey.api.webdav.AbstractWebdavResolver.lookupEx(AbstractWebdavResolver.java:58) ~[api-24.7-SNAPSHOT.jar:?]
	at org.labkey.core.webdav.ModuleStaticResolverImpl$SymbolicLink.lookupEx(ModuleStaticResolverImpl.java:709) ~[core-24.7-SNAPSHOT.jar:?]
	at org.labkey.core.webdav.ModuleStaticResolverImpl.resolve(ModuleStaticResolverImpl.java:196) ~[core-24.7-SNAPSHOT.jar:?]
	at org.labkey.core.webdav.ModuleStaticResolverImpl.lookupEx(ModuleStaticResolverImpl.java:162) ~[core-24.7-SNAPSHOT.jar:?]
	at org.labkey.api.webdav.WebdavResolver.lookup(WebdavResolver.java:53) ~[api-24.7-SNAPSHOT.jar:?]
	at org.labkey.filecontent.message.FileContentDigestProvider.sendDigest(FileContentDigestProvider.java:142) ~[filecontent-24.7-SNAPSHOT.jar:?]
	at org.labkey.filecontent.message.FileContentDigestProvider.sendDigestForAllContainers(FileContentDigestProvider.java:107) ~[filecontent-24.7-SNAPSHOT.jar:?]
	at org.labkey.api.message.digest.MessageDigest.lambda$sendMessageDigest$0(MessageDigest.java:84) ~[api-24.7-SNAPSHOT.jar:?]
```

#### Related Pull Requests
- N/A

#### Changes
- Remove `assert` from `PipeRoot.getWebdavURL`
