### PR TITLE
Remove support for remote login API and ACLs

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -143,6 +143,7 @@ import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.AppPropsTestCase;
 import org.labkey.api.settings.LookAndFeelProperties;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.settings.OptionalFeatureStartupListener;
 import org.labkey.api.settings.WriteableLookAndFeelProperties;
 import org.labkey.api.util.ChecksumUtil;
@@ -196,6 +197,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.EnumSet.allOf;
+import static org.labkey.api.security.ACL.RESTORE_USE_OF_ACLS;
 import static org.labkey.api.settings.LookAndFeelProperties.Properties.applicationMenuDisplayMode;
 import static org.labkey.api.settings.SiteSettingsProperties.allowApiKeys;
 import static org.labkey.api.settings.SiteSettingsProperties.allowSessionKeys;
@@ -225,6 +227,10 @@ public class ApiModule extends CodeOnlyModule
         LabKeyManagement.register(new StandardMBean(new OperationsMXBeanImpl(), OperationsMXBean.class, true), "Operations");
 
         AdminConsole.addExperimentalFeatureFlag(FileStream.STAGE_FILE_UPLOADS, "Stage file uploads before moving to final destination", "When using a non-local file system, using a specific API that requires a locally staged copy of the file as the source can sometimes be significantly faster than streaming the uploaded file directly", false);
+        AdminConsole.addOptionalFeatureFlag(new AdminConsole.OptionalFeatureFlag(RESTORE_USE_OF_ACLS,
+            "Restore ability to use deprecated bitmask-based permissions",
+            "If enabled, module HTML view metadata (.view.xml) files with \"<permission name='read'>\"-type elements will be accepted and specific API responses will include user permissions as integer bitmasks. This option and all support for bitmask based permissions will be removed in LabKey Server v24.12.",
+            false, false, OptionalFeatureService.FeatureType.Deprecated));
     }
 
     @NotNull

--- a/api/src/org/labkey/api/action/ApiUsageException.java
+++ b/api/src/org/labkey/api/action/ApiUsageException.java
@@ -20,8 +20,6 @@ import org.labkey.api.util.SkipMothershipLogging;
 /**
  * Signals the client API caller that they somehow made an invalid request. These errors are not reported to the
  * mothership.
- * User: jeckels
- * Date: Oct 5, 2010
  */
 public class ApiUsageException extends RuntimeException implements SkipMothershipLogging
 {

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -58,6 +58,7 @@ import org.labkey.api.security.roles.Role;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.LookAndFeelProperties;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.settings.ProductFeature;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.util.ContainerContext;
@@ -1398,7 +1399,10 @@ public class Container implements Serializable, Comparable<Container>, Securable
 
             if (includePermissions)
             {
-                containerProps.put("userPermissions", getPermsAsOldBitMask(user));
+                if (OptionalFeatureService.get().isFeatureEnabled(ACL.RESTORE_USE_OF_ACLS))
+                {
+                    containerProps.put("userPermissions", getPermsAsOldBitMask(user));
+                }
                 containerProps.put("effectivePermissions", SecurityManager.getPermissionNames(this, user));
             }
 

--- a/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
+++ b/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
@@ -190,7 +190,7 @@ public class ModuleHtmlViewDefinition
             if (allowAcls)
                 _log.warn("The \"<permissions>\" element used in \"{}\" is deprecated and support will be removed in LabKey Server 24.12! Migrate uses to \"<requiresPermissions>\", \"<requiresNoPermission>\", or \"<requiresLogin>\".", resource);
             else
-                throw new ViewDefinitionException("The \"<permissions>\" element is no longer supported. Migrate uses to \"<requiresPermissions>\", \"<requiresNoPermission>\", or \"<requiresLogin>\".");
+                throw new ViewDefinitionException("The \"<permissions>\" element is no longer supported. Migrate uses to \"<requiresPermissions>\", \"<requiresNoPermission>\", or \"<requiresLogin>\". Site administrators can turn on a deprecated feature flag to temporarily restore support and ease migration of existing .view.xml files.");
 
             for (PermissionType permEntry : permsList.getPermissionArray())
             {

--- a/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
+++ b/api/src/org/labkey/api/module/ModuleHtmlViewDefinition.java
@@ -31,6 +31,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.MinorConfigurationException;
@@ -156,19 +157,48 @@ public class ModuleHtmlViewDefinition
         return ColumnInfo.labelFromName(name);
     }
 
+    private enum PermissionEnum
+    {
+        login(0),
+        read(ACL.PERM_READ),
+        insert(ACL.PERM_INSERT),
+        update(ACL.PERM_UPDATE),
+        delete(ACL.PERM_DELETE),
+        admin(ACL.PERM_ADMIN),
+        none(ACL.PERM_NONE);
+
+        private final int _value;
+
+        PermissionEnum(int value)
+        {
+            _value = value;
+        }
+
+        private int toInt()
+        {
+            return _value;
+        }
+    }
+
     protected void calculatePermissions(String resource) throws ViewDefinitionException
     {
+        boolean allowAcls = OptionalFeatureService.get().isFeatureEnabled(ACL.RESTORE_USE_OF_ACLS);
+
         PermissionsListType permsList = _viewDef.getPermissions();
         if (permsList != null && permsList.getPermissionArray() != null)
         {
-            _log.warn("The \"<permissions>\" element used in \"{}\" is deprecated and support will be removed in LabKey Server 24.8! Migrate uses to \"<requiresPermissions>\", \"<requiresNoPermission>\", or \"<requiresLogin>\".", resource);
+            if (allowAcls)
+                _log.warn("The \"<permissions>\" element used in \"{}\" is deprecated and support will be removed in LabKey Server 24.12! Migrate uses to \"<requiresPermissions>\", \"<requiresNoPermission>\", or \"<requiresLogin>\".", resource);
+            else
+                throw new ViewDefinitionException("The \"<permissions>\" element is no longer supported. Migrate uses to \"<requiresPermissions>\", \"<requiresNoPermission>\", or \"<requiresLogin>\".");
+
             for (PermissionType permEntry : permsList.getPermissionArray())
             {
-                SimpleAction.PermissionEnum perm = SimpleAction.PermissionEnum.valueOf(permEntry.getName().toString());
+                PermissionEnum perm = PermissionEnum.valueOf(permEntry.getName().toString());
 
-                if (SimpleAction.PermissionEnum.login == perm)
+                if (PermissionEnum.login == perm)
                     _requiresLogin = true;
-                else if (SimpleAction.PermissionEnum.none == perm)
+                else if (PermissionEnum.none == perm)
                     _requiredPerms = perm.toInt();
                 else
                     _requiredPerms |= perm.toInt();
@@ -183,7 +213,7 @@ public class ModuleHtmlViewDefinition
             // <permissionClasses> and <requiresPermissions> are synonyms, so add all permission classes from both.
             // For now, allow but warn for empty <permissionClasses> element; throw for empty <requiresPermissions> element.
             if (_viewDef.isSetPermissionClasses())
-                addPermissionClasses(_viewDef.getPermissionClasses(), resource, false);
+                addPermissionClasses(_viewDef.getPermissionClasses(), resource, !allowAcls);
 
             if (_viewDef.isSetRequiresPermissions())
                 addPermissionClasses(_viewDef.getRequiresPermissions(), resource, true);
@@ -196,7 +226,7 @@ public class ModuleHtmlViewDefinition
         else
         {
             // No permissions case: for now, clear out old-style perms as well
-            _requiredPerms = SimpleAction.PermissionEnum.none.toInt();
+            _requiredPerms = PermissionEnum.none.toInt();
         }
 
         if (_viewDef.isSetRequiresLogin())
@@ -324,50 +354,101 @@ public class ModuleHtmlViewDefinition
         @Test
         public void testPermissions()
         {
-            testPermissions(null, ACL.PERM_READ, Set.of(), false); // No .view.xml file -> read
-            testPermissions("", ACL.PERM_READ, Set.of(ReadPermission.class), false); // No permission elements -> read
-            testPermissions("<requiresLogin/>", ACL.PERM_READ, Set.of(ReadPermission.class), true); // read + login
-            testPermissions("<requiresNoPermission/>", ACL.PERM_NONE, Set.of(), false); // no permissions
-            testPermissions("""
-                <requiresNoPermission/>
-                <requiresLogin/>""", ACL.PERM_NONE, Set.of(), true); // just login required
-            testPermissions("<permissionClasses/>", ACL.PERM_READ, Set.of(), false); // allow empty element for now
-            testPermissions("""
-                <permissionClasses>
-                    <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-                </permissionClasses>""", ACL.PERM_READ, Set.of(ReadPermission.class), false);
-            testPermissions("""
-                <permissionClasses>
-                    <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-                </permissionClasses>
-                <requiresLogin/>""", ACL.PERM_READ, Set.of(ReadPermission.class), true);
-            testPermissions("""
-                <permissionClasses>
-                    <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-                </permissionClasses>""", ACL.PERM_READ, Set.of(InsertPermission.class), false);
-            testPermissions("""
-                <permissionClasses>
-                    <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-                    <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
-                </permissionClasses>""", ACL.PERM_READ, Set.of(InsertPermission.class, UpdatePermission.class), false);
-            testPermissions("""
-                <requiresPermissions>
-                    <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-                </requiresPermissions>""", ACL.PERM_READ, Set.of(ReadPermission.class), false);
-            testPermissions("""
-                <requiresPermissions>
-                    <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-                </requiresPermissions>
-                <requiresLogin/>""", ACL.PERM_READ, Set.of(ReadPermission.class), true);
-            testPermissions("""
-                <requiresPermissions>
-                    <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-                </requiresPermissions>""", ACL.PERM_READ, Set.of(InsertPermission.class), false);
-            testPermissions("""
-                <requiresPermissions>
-                    <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-                    <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
-                </requiresPermissions>""", ACL.PERM_READ, Set.of(InsertPermission.class, UpdatePermission.class), false);
+            if (OptionalFeatureService.get().isFeatureEnabled(ACL.RESTORE_USE_OF_ACLS))
+            {
+                testPermissions(null, ACL.PERM_READ, Set.of(), false); // No .view.xml file -> read
+                testPermissions("", ACL.PERM_READ, Set.of(ReadPermission.class), false); // No permission elements -> read
+                testPermissions("<requiresLogin/>", ACL.PERM_READ, Set.of(ReadPermission.class), true); // read + login
+                testPermissions("<requiresNoPermission/>", ACL.PERM_NONE, Set.of(), false); // no permissions
+                testPermissions("""
+                    <requiresNoPermission/>
+                    <requiresLogin/>""", ACL.PERM_NONE, Set.of(), true); // just login required
+                testPermissions("<permissionClasses/>", ACL.PERM_READ, Set.of(), false); // allow empty element for now
+                testPermissions("""
+                    <permissionClasses>
+                        <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                    </permissionClasses>""", ACL.PERM_READ, Set.of(ReadPermission.class), false);
+                testPermissions("""
+                    <permissionClasses>
+                        <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                    </permissionClasses>
+                    <requiresLogin/>""", ACL.PERM_READ, Set.of(ReadPermission.class), true);
+                testPermissions("""
+                    <permissionClasses>
+                        <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
+                    </permissionClasses>""", ACL.PERM_READ, Set.of(InsertPermission.class), false);
+                testPermissions("""
+                    <permissionClasses>
+                        <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
+                        <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
+                    </permissionClasses>""", ACL.PERM_READ, Set.of(InsertPermission.class, UpdatePermission.class), false);
+                testPermissions("""
+                    <requiresPermissions>
+                        <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                    </requiresPermissions>""", ACL.PERM_READ, Set.of(ReadPermission.class), false);
+                testPermissions("""
+                    <requiresPermissions>
+                        <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                    </requiresPermissions>
+                    <requiresLogin/>""", ACL.PERM_READ, Set.of(ReadPermission.class), true);
+                testPermissions("""
+                    <requiresPermissions>
+                        <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
+                    </requiresPermissions>""", ACL.PERM_READ, Set.of(InsertPermission.class), false);
+                testPermissions("""
+                    <requiresPermissions>
+                        <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
+                        <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
+                    </requiresPermissions>""", ACL.PERM_READ, Set.of(InsertPermission.class, UpdatePermission.class), false);
+            }
+            else
+            {
+                testPermissions(null, Set.of(), false); // No .view.xml file -> read
+                testPermissions("", Set.of(ReadPermission.class), false); // No permission elements -> read
+                testPermissions("<requiresLogin/>", Set.of(ReadPermission.class), true); // read + login
+                testPermissions("<requiresNoPermission/>", Set.of(), false); // no permissions
+                testPermissions("""
+                    <requiresNoPermission/>
+                    <requiresLogin/>""", Set.of(), true); // just login required
+                testPermissions("""
+                    <permissionClasses>
+                        <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                    </permissionClasses>""", Set.of(ReadPermission.class), false);
+                testPermissions("""
+                    <permissionClasses>
+                        <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                    </permissionClasses>
+                    <requiresLogin/>""", Set.of(ReadPermission.class), true);
+                testPermissions("""
+                    <permissionClasses>
+                        <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
+                    </permissionClasses>""", Set.of(InsertPermission.class), false);
+                testPermissions("""
+                    <permissionClasses>
+                        <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
+                        <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
+                    </permissionClasses>""", Set.of(InsertPermission.class, UpdatePermission.class), false);
+                testPermissions("""
+                    <requiresPermissions>
+                        <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                    </requiresPermissions>""", Set.of(ReadPermission.class), false);
+                testPermissions("""
+                    <requiresPermissions>
+                        <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
+                    </requiresPermissions>
+                    <requiresLogin/>""", Set.of(ReadPermission.class), true);
+                testPermissions("""
+                    <requiresPermissions>
+                        <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
+                    </requiresPermissions>""", Set.of(InsertPermission.class), false);
+                testPermissions("""
+                    <requiresPermissions>
+                        <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
+                        <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
+                    </requiresPermissions>""", Set.of(InsertPermission.class, UpdatePermission.class), false);
+
+                testBadPermissions("<permissionClasses/>", "Empty permissions class lists are not allowed");
+            }
 
             testBadPermissions("<requiresPermissions/>", "Empty permissions class lists are not allowed");
             testBadPermissions("""
@@ -381,6 +462,14 @@ public class ModuleHtmlViewDefinition
         {
             ModuleHtmlViewDefinition def = new ModuleHtmlViewDefinition("test.html", HtmlString.of("Success!"), permissions != null ? getViewXmlResource(permissions) : null, true);
             assertEquals(expectedPerms, def.getRequiredPerms());
+            assertEquals(expectedPermissionClasses, def.getRequiredPermissionClasses());
+            assertEquals(expectedLogin, def.isRequiresLogin());
+            assertEquals("Success!", def.getHtml().toText());
+        }
+
+        private void testPermissions(@Nullable String permissions, Set<Class<? extends Permission>> expectedPermissionClasses, boolean expectedLogin)
+        {
+            ModuleHtmlViewDefinition def = new ModuleHtmlViewDefinition("test.html", HtmlString.of("Success!"), permissions != null ? getViewXmlResource(permissions) : null, true);
             assertEquals(expectedPermissionClasses, def.getRequiredPermissionClasses());
             assertEquals(expectedLogin, def.isRequiresLogin());
             assertEquals("Success!", def.getHtml().toText());

--- a/api/src/org/labkey/api/module/ModuleXml.java
+++ b/api/src/org/labkey/api/module/ModuleXml.java
@@ -70,7 +70,7 @@ public class ModuleXml
                 }
                 catch (XmlValidationException e)
                 {
-                    LOG.error("Module XML file failed validation for module: " + module.getName() + ". Error: " + e.getDetails());
+                    LOG.error("Module XML file failed validation for module: {}. Error: {}", module.getName(), e.getDetails());
                 }
             }
 
@@ -122,7 +122,7 @@ public class ModuleXml
                                 editPermissions.add(permClass);
                         }
 
-                        if (editPermissions.size() > 0)
+                        if (!editPermissions.isEmpty())
                             mp.setEditPermissions(editPermissions);
                     }
 
@@ -139,7 +139,7 @@ public class ModuleXml
                     moduleName -> {
                         if (module.getName().equalsIgnoreCase(moduleName))
                         {
-                            LOG.error("Module " + module.getName() + " lists itself as a dependency in its module.xml!");
+                            LOG.error("Module {} lists itself as a dependency in its module.xml!", module.getName());
                             return false;
                         }
 

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -473,19 +473,15 @@ public class QueryView extends WebPartView<Object>
 
     protected StringExpression urlExpr(QueryAction action)
     {
-        StringExpression expr = null;
-
-        // NOTE: details/update URL may not get picked up from TableInfo if subclass overrides createTable()
-        // but that case should use QueryView.setDetailsURL/setUpdateURL() anyway
-        switch (action)
+        StringExpression expr = switch (action)
         {
-            case detailsQueryRow:
-                expr = _detailsURL;
-                break;
-            case updateQueryRow:
-                expr = _updateURL;
-                break;
-        }
+            case detailsQueryRow -> _detailsURL;
+            case updateQueryRow -> _updateURL;
+            default -> null;
+
+            // NOTE: details/update URL may not get picked up from TableInfo if subclass overrides createTable()
+            // but that case should use QueryView.setDetailsURL/setUpdateURL() anyway
+        };
 
         if (null == expr)
             expr = getQueryDef().urlExpr(action, _schema.getContainer());
@@ -584,7 +580,7 @@ public class QueryView extends WebPartView<Object>
         // determine if the sort/filter originated from QuerySettings or from a user applied sort/filter.
         getSettings().getBaseFilter().applyToURL(ret, DATAREGIONNAME_DEFAULT);
 
-        if (getSettings().getBaseSort().getSortList().size() > 0)
+        if (!getSettings().getBaseSort().getSortList().isEmpty())
             getSettings().getBaseSort().applyToURL(ret, DATAREGIONNAME_DEFAULT, true);
 
         switch (action)

--- a/api/src/org/labkey/api/reports/Report.java
+++ b/api/src/org/labkey/api/reports/Report.java
@@ -43,11 +43,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-/**
- * User: Mark Igra
- * Date: May 10, 2006
- * Time: 1:01:50 PM
- */
 public interface Report extends AttachmentParent, ThumbnailProvider
 {
     String SHARE_REPORT_TYPE = "Report.ShareReport";

--- a/api/src/org/labkey/api/reports/report/ReportUrls.java
+++ b/api/src/org/labkey/api/reports/report/ReportUrls.java
@@ -27,10 +27,6 @@ import org.labkey.api.view.ViewContext;
 
 import java.util.Map;
 
-/**
- * User: Karl Lum
- * Date: Feb 29, 2008
- */
 public interface ReportUrls extends UrlProvider
 {
     ActionURL urlDownloadData(Container c);

--- a/api/src/org/labkey/api/reports/report/view/ReportUtil.java
+++ b/api/src/org/labkey/api/reports/report/view/ReportUtil.java
@@ -79,34 +79,19 @@ import org.labkey.api.view.TabStripView;
 import org.labkey.api.view.ViewContext;
 import org.springframework.validation.Errors;
 
-import javax.imageio.ImageIO;
 import javax.script.ScriptEngine;
-import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-/**
- * User: Karl Lum
- * Date: Apr 20, 2007
- */
 public class ReportUtil
 {
-    public static final String FORWARD_URL = "forwardUrl";
-
     @Deprecated // use getScriptReportDesignerURL instead
     public static ActionURL getRReportDesignerURL(ViewContext context, ScriptReportBean bean)
     {
-        ActionURL url = PageFlowUtil.urlProvider(ReportUrls.class).urlCreateScriptReport(context.getContainer());
-        url.addParameters(context.getActionURL().getParameters());
-        url.replaceParameter(TabStripView.TAB_PARAM, ScriptReport.TAB_SOURCE);
-
-        return _getChartDesignerURL(url, bean);
+        return getScriptReportDesignerURL(context, bean);
     }
 
     public static ActionURL getScriptReportDesignerURL(ViewContext context, ScriptReportBean bean)
@@ -116,13 +101,13 @@ public class ReportUtil
         url.replaceParameter(ScriptReportDescriptor.Prop.scriptExtension.name(), bean.getScriptExtension());
         url.replaceParameter(TabStripView.TAB_PARAM, ScriptReport.TAB_SOURCE);
 
-        // issue 18390, don't want reportId on the create report action
+        // issue 18390, don't want reportId on the "create" action
         url.deleteParameter(ReportDescriptor.Prop.reportId);
 
         return _getChartDesignerURL(url, bean);
     }
 
-    protected static ActionURL _getChartDesignerURL(ActionURL url, ReportDesignBean bean)
+    protected static ActionURL _getChartDesignerURL(ActionURL url, ReportDesignBean<?> bean)
     {
         url.replaceParameter("reportType", bean.getReportType());
         if (bean.getSchemaName() != null)
@@ -316,35 +301,9 @@ public class ReportUtil
         return parts;
     }
 
-
-    public static void renderErrorImage(OutputStream outputStream, Report r, String errorMessage) throws IOException
-    {
-        int width = 640;
-        int height = 480;
-
-        renderErrorImage(outputStream, width, height, errorMessage);
-    }
-
-    public static void renderErrorImage(OutputStream outputStream, int width, int height, String errorMessage) throws IOException
-    {
-        if (errorMessage == null)
-        {
-            errorMessage = "ERROR";
-        }
-        BufferedImage bi = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-        Graphics2D g = bi.createGraphics();
-        g.setColor(Color.white);
-        g.fillRect(0, 0, width, height);
-        g.setColor(Color.black);
-        g.drawString(errorMessage, (width - g.getFontMetrics().stringWidth(errorMessage)) / 2, (height - g.getFontMetrics().getHeight()) / 2);
-        ImageIO.write(bi, "png", outputStream);
-        outputStream.flush();
-    }
-
     public static List<Report> getReportsIncludingInherited(Container c, User user, @Nullable String reportKey)
     {
-        List<Report> reports = new ArrayList<>();
-        reports.addAll(ReportService.get().getReports(user, c, reportKey));
+        List<Report> reports = new ArrayList<>(ReportService.get().getReports(user, c, reportKey));
 
         while (!c.isRoot())
         {

--- a/api/src/org/labkey/api/reports/report/view/ScriptReportBean.java
+++ b/api/src/org/labkey/api/reports/report/view/ScriptReportBean.java
@@ -18,11 +18,6 @@ package org.labkey.api.reports.report.view;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.reports.report.ScriptReport;
 
-/*
-* User: Karl Lum
-* Date: Dec 29, 2008
-* Time: 3:35:00 PM
-*/
 public class ScriptReportBean extends ReportDesignBean<ScriptReport>
 {
     protected boolean _runInBackground;

--- a/api/src/org/labkey/api/security/ACL.java
+++ b/api/src/org/labkey/api/security/ACL.java
@@ -22,6 +22,8 @@ package org.labkey.api.security;
 @Deprecated
 public class ACL implements Cloneable
 {
+    public static final String RESTORE_USE_OF_ACLS = "restoreUseOfAcls";
+
     public static final int PERM_NONE = 0x00000000;
 
     /** {@link org.labkey.api.security.permissions.ReadPermission} */

--- a/api/src/org/labkey/api/settings/OptionalFeatureService.java
+++ b/api/src/org/labkey/api/settings/OptionalFeatureService.java
@@ -86,8 +86,7 @@ public interface OptionalFeatureService
                     """
                     <strong>WARNING</strong>:
                     Experimental features may change, break, or disappear at any time.
-                    We make absolutely no guarantees about what may happen if you turn on these experimental
-                    features. Enabling or disabling some features will require a restart of the server.
+                    We make absolutely no guarantee about what will happen if you turn on any experimental feature.
                     """
                 );
             }

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2014Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2014Dialect.java
@@ -15,11 +15,6 @@
  */
 package org.labkey.bigiron.mssql;
 
-/**
- * User: adam
- * Date: 4/10/2014
- * Time: 6:59 PM
- */
 public class MicrosoftSqlServer2014Dialect extends MicrosoftSqlServer2012Dialect
 {
 }

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerDialectFactory.java
@@ -38,11 +38,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
-/*
-* User: adam
-* Date: Nov 26, 2010
-* Time: 9:51:40 PM
-*/
 public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
 {
     private static final Logger LOG = LogHelper.getLogger(MicrosoftSqlServerDialectFactory.class, "Warnings about SQL Server versions");
@@ -78,7 +73,7 @@ public class MicrosoftSqlServerDialectFactory implements SqlDialectFactory
         String driverName = md.getDriverName();
 
         if (!driverName.startsWith("Microsoft"))
-            LOG.warn("LabKey Server has not been tested against " + driverName + ". Instead, we recommend configuring the Microsoft SQL Server JDBC Driver, which is distributed with LabKey Server.");
+            LOG.warn("LabKey Server has not been tested against {}. Instead, we recommend configuring the Microsoft SQL Server JDBC Driver, which is distributed with LabKey Server.", driverName);
 
         return dialect;
     }

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerVersion.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerVersion.java
@@ -24,7 +24,7 @@ public enum MicrosoftSqlServerVersion
     SQL_SERVER_UNSUPPORTED(Integer.MIN_VALUE, "Unknown", true, false, false, null),
     SQL_SERVER_2008(100, "2008", true, true, false, MicrosoftSqlServer2008R2Dialect::new),
     SQL_SERVER_2012(110, "2012", true, true, false, MicrosoftSqlServer2012Dialect::new),
-    SQL_SERVER_2014(120, "2014", true, true, true, MicrosoftSqlServer2014Dialect::new),
+    SQL_SERVER_2014(120, "2014", true, true, false, MicrosoftSqlServer2014Dialect::new),
     SQL_SERVER_2016(130, "2016", false, true, true, MicrosoftSqlServer2016Dialect::new),
     SQL_SERVER_2017(140, "2017", false, true, true, MicrosoftSqlServer2017Dialect::new),
     SQL_SERVER_2019(150, "2019", false, true, true, MicrosoftSqlServer2019Dialect::new),

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerVersion.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServerVersion.java
@@ -91,11 +91,15 @@ public enum MicrosoftSqlServerVersion
         @Test
         public void test()
         {
-            // Good
+            // Good for external data sources; bad for primary data source
             test(100, false, SQL_SERVER_2008);
+            test(100, true, SQL_SERVER_UNSUPPORTED);
             test(110, false, SQL_SERVER_2012);
-            test(120, true, SQL_SERVER_2014);
+            test(110, true, SQL_SERVER_UNSUPPORTED);
             test(120, false, SQL_SERVER_2014);
+            test(120, true, SQL_SERVER_UNSUPPORTED);
+
+            // Good for primary and external data sources
             test(130, true, SQL_SERVER_2016);
             test(130, false, SQL_SERVER_2016);
             test(140, true, SQL_SERVER_2017);

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -334,6 +334,7 @@ import static org.labkey.api.settings.StashedStartupProperties.siteAvailableEmai
 import static org.labkey.api.settings.StashedStartupProperties.siteAvailableEmailMessage;
 import static org.labkey.api.settings.StashedStartupProperties.siteAvailableEmailSubject;
 import static org.labkey.api.util.MothershipReport.EXPERIMENTAL_LOCAL_MARKETING_UPDATE;
+import static org.labkey.core.login.LoginController.REMOTE_LOGIN_FEATURE_FLAG;
 import static org.labkey.filters.ContentSecurityPolicyFilter.FEATURE_FLAG_DISABLE_ENFORCE_CSP;
 
 public class CoreModule extends SpringModule implements SearchService.DocumentProvider
@@ -1083,36 +1084,38 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         }
 
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_JAVASCRIPT_MOTHERSHIP,
-                "Client-side Exception Logging To Mothership",
-                "Report unhandled JavaScript exceptions to mothership.",
-                false);
+            "Client-side Exception Logging To Mothership",
+            "Report unhandled JavaScript exceptions to mothership.",
+            false);
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_JAVASCRIPT_SERVER,
-                "Client-side Exception Logging To Server",
-                "Report unhandled JavaScript exceptions to the server log.",
-                false);
+            "Client-side Exception Logging To Server",
+            "Report unhandled JavaScript exceptions to the server log.",
+            false);
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_NO_GUESTS,
-                "No Guest Account",
-                "Disable the guest account",
-                false);
+            "No Guest Account",
+            "Disable the guest account",
+            false);
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_BLOCKER,
-                "Block malicious clients",
-                "Reject requests from clients that appear malicious. Turn this feature off if you want to run a security scanner.",
-                false);
-        AdminConsole.addOptionalFeatureFlag(new OptionalFeatureFlag(EXPERIMENTAL_LOCAL_MARKETING_UPDATE,
-                "Self test marketing updates", "Test marketing updates from this local server (requires the mothership module).", false, true, FeatureType.Experimental));
+            "Block malicious clients",
+            "Reject requests from clients that appear malicious. Turn this feature off if you want to run a security scanner.",
+            false);
         AdminConsole.addExperimentalFeatureFlag(FEATURE_FLAG_DISABLE_ENFORCE_CSP,
-                "Disable enforce Content Security Policy",
-                "Stop sending the " + ContentSecurityPolicyFilter.ContentSecurityPolicyType.Enforce.getHeaderName() + " header to browsers, " +
-                "but continue sending the " + ContentSecurityPolicyFilter.ContentSecurityPolicyType.Report.getHeaderName() + " header. " +
-                "This turns off an important layer of security for the entire site, so use it as a last resort only on a temporary basis " +
-                "(e.g., if an enforce CSP breaks critical functionality).",
-                false);
+            "Disable enforce Content Security Policy",
+            "Stop sending the " + ContentSecurityPolicyFilter.ContentSecurityPolicyType.Enforce.getHeaderName() + " header to browsers, " +
+            "but continue sending the " + ContentSecurityPolicyFilter.ContentSecurityPolicyType.Report.getHeaderName() + " header. " +
+            "This turns off an important layer of security for the entire site, so use it as a last resort only on a temporary basis " +
+            "(e.g., if an enforce CSP breaks critical functionality).",
+            false);
 
+        AdminConsole.addOptionalFeatureFlag(new OptionalFeatureFlag(EXPERIMENTAL_LOCAL_MARKETING_UPDATE,
+            "Self test marketing updates", "Test marketing updates from this local server (requires the mothership module).", false, true, FeatureType.Experimental));
         OptionalFeatureService.get().addFeatureListener(EXPERIMENTAL_LOCAL_MARKETING_UPDATE, (feature, enabled) -> {
             // update the timer task when this setting changes
             MothershipReport.setSelfTestMarketingUpdates(enabled);
             UsageReportingLevel.reportNow();
         });
+
+        AdminConsole.addOptionalFeatureFlag(new OptionalFeatureFlag(REMOTE_LOGIN_FEATURE_FLAG, "Restore ability to use the deprecated Remote Login API", "This option and all support for the Remote Login API will be removed in LabKey Server v24.12.", false, false, FeatureType.Deprecated));
 
         if (null != PropertyService.get())
         {

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -2230,7 +2230,7 @@ public class LoginController extends SpringActionController
         if (OptionalFeatureService.get().isFeatureEnabled(REMOTE_LOGIN_FEATURE_FLAG))
             _log.warn("The Remote Login API has been deprecated and will be removed in LabKey Server 24.12! Migrate uses to the CAS identity provider.");
         else
-            throw new ApiUsageException("The Remote Login API has been removed. Migrate uses to the CAS identity provider.");
+            throw new ApiUsageException("The Remote Login API has been removed. Migrate uses to the CAS identity provider. Site administrators can turn on a deprecated feature flag to temporarily restore support and ease migration.");
     }
 
     @SuppressWarnings("unused")

--- a/query/src/org/labkey/query/reports/ReportServiceImpl.java
+++ b/query/src/org/labkey/query/reports/ReportServiceImpl.java
@@ -216,7 +216,7 @@ public class ReportServiceImpl extends AbstractContainerListener implements Repo
             throw new IllegalArgumentException("Invalid report instance");
 
         if (null != _reports.putIfAbsent(report.getType(), report.getClass()))
-            _log.warn("Report type : " + report.getType() + " has previously been registered.");
+            _log.warn("Report type : {} has previously been registered.", report.getType());
     }
 
     @Override
@@ -677,7 +677,7 @@ public class ReportServiceImpl extends AbstractContainerListener implements Repo
         {
             inheritable = inheritable.stream()
                 .filter(report -> reportKey.equals(report.getDescriptor().getReportKey()))
-                .collect(Collectors.toList());
+                .toList();
         }
 
         List<Report> reportsList = new ArrayList<>(inheritable);
@@ -787,9 +787,7 @@ public class ReportServiceImpl extends AbstractContainerListener implements Repo
 
             if (null != claimingProvider)
             {
-                String iconClass = claimingProvider.getIconCls(report);  // may be null if report does not support CSS icons
-
-                return iconClass;
+                return claimingProvider.getIconCls(report);
             }
 
             for (UIProvider provider : _uiProviders)

--- a/query/src/org/labkey/query/reports/view/ReportUIProvider.java
+++ b/query/src/org/labkey/query/reports/view/ReportUIProvider.java
@@ -79,7 +79,7 @@ public class ReportUIProvider extends DefaultReportUIProvider
     }
 
     /**
-     * Add report creation to UI's that aren't associated with a query (manage views, data views)
+     * Add report creation to UIs that aren't associated with a query (manage views, data views)
      */
     @Override
     public List<ReportService.DesignerInfo> getDesignerInfo(ViewContext context)

--- a/study/src/org/labkey/study/DataspaceStudyFolderType.java
+++ b/study/src/org/labkey/study/DataspaceStudyFolderType.java
@@ -53,7 +53,7 @@ public class DataspaceStudyFolderType extends StudyFolderType
             if (container.isProject())
             {
                 study.setShareDatasetDefinitions(Boolean.TRUE);
-                // NOTE: consider setShareVisitDefincitons(Boolean.TRUE);
+                // NOTE: consider setShareVisitDefinitions(Boolean.TRUE);
             }
             StudyManager.getInstance().createStudy(user, study);
         }

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -200,6 +200,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
 
+import static org.labkey.study.reports.ExternalReport.ENABLE_EXTERNAL_REPORT;
 
 public class StudyModule extends SpringModule implements SearchService.DocumentProvider
 {
@@ -366,7 +367,8 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
         AuditLogService.get().registerAuditType(new ParticipantGroupAuditProvider());
 
         ReportService.get().registerReport(new StudyQueryReport());
-        ReportService.get().registerReport(new ExternalReport());
+        if (OptionalFeatureService.get().isFeatureEnabled(ENABLE_EXTERNAL_REPORT))
+            ReportService.get().registerReport(new ExternalReport());
         ReportService.get().registerReport(new CrosstabReport());
         ReportService.get().registerReport(new StudyCrosstabReport());
         ReportService.get().registerReport(new StudyRReport());
@@ -407,25 +409,30 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
         DatasetDefinition.cleanupOrphanedDatasetDomains();
 
         AdminConsole.addExperimentalFeatureFlag(StudyQuerySchema.EXPERIMENTAL_STUDY_SUBSCHEMAS, "Use sub-schemas in Study",
-                "Separate study tables into three groups 'datasets', 'specimens', and 'design'", false);
+            "Separate study tables into three groups 'datasets', 'specimens', and 'design'", false);
 
         AdminConsole.addExperimentalFeatureFlag(DatasetQueryView.EXPERIMENTAL_LINKED_DATASET_CHECK,
-                "Assay linked to study consistency check",
-                "Flags rows in assay linked datasets where the subject and timepoint may be different from the source assay.",
-                false);
+            "Assay linked to study consistency check",
+            "Flags rows in assay linked datasets where the subject and timepoint may be different from the source assay.",
+            false);
 
         AdminConsole.addExperimentalFeatureFlag(DatasetQueryView.EXPERIMENTAL_ALLOW_MERGE_WITH_MANAGED_KEYS,
-                "Allow merge of study dataset that uses server-managed additional key fields",
-                "Merging of dataset that uses server-managed third key (such as GUID or auto RowId) is not officially supported. Unexpected outcome might be experienced when merge is performed.",
-                false);
+            "Allow merge of study dataset that uses server-managed additional key fields",
+            "Merging of dataset that uses server-managed third key (such as GUID or auto RowId) is not officially supported. Unexpected outcome might be experienced when merge is performed.",
+            false);
 
         AdminConsole.addExperimentalFeatureFlag(Study.GWT_STUDY_DESIGN,
-                "Vaccine Study Protocol Editor",
-                "The study protocol editor (accessed from the Vaccine Study Protocols webpart) has been deprecated and protocol " +
-                        "information will be shown in a read only mode. The edit button can be shown by enabling this feature, " +
-                        "but this capability will be removed permanently in a future release. " +
-                        "Please create any new study protocols in the format as defined by the \"Manage Study Products\" link on the study Manage tab.",
-                false);
+            "Vaccine Study Protocol Editor",
+            "The study protocol editor (accessed from the Vaccine Study Protocols webpart) has been deprecated and protocol " +
+            "information will be shown in a read only mode. The edit button can be shown by enabling this feature, " +
+            "but this capability will be removed permanently in a future release. " +
+            "Please create any new study protocols in the format as defined by the \"Manage Study Products\" link on the study Manage tab.",
+            false);
+
+        AdminConsole.addOptionalFeatureFlag(new AdminConsole.OptionalFeatureFlag(ENABLE_EXTERNAL_REPORT,
+            "Restore support for deprecated advanced reports",
+            "This option and all support for advanced reports will be removed in LabKey Server v24.12.",
+            true, false, OptionalFeatureService.FeatureType.Deprecated));
 
         ReportAndDatasetChangeDigestProvider.get().addNotificationInfoProvider(new DatasetNotificationInfoProvider());
 

--- a/study/src/org/labkey/study/reports/ExternalReport.java
+++ b/study/src/org/labkey/study/reports/ExternalReport.java
@@ -61,13 +61,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-/**
- * User: migra
- * Date: Mar 9, 2006
- * Time: 11:21:04 AM
- */
 public class ExternalReport extends AbstractReport
 {
+    public static final String ENABLE_EXTERNAL_REPORT = "enableExternalReport";
     public static final String TYPE = "Study.externalReport";
 
     private RecomputeWhen recomputeWhen = RecomputeWhen.Always;

--- a/study/src/org/labkey/study/reports/StudyReportUIProvider.java
+++ b/study/src/org/labkey/study/reports/StudyReportUIProvider.java
@@ -26,6 +26,7 @@ import org.labkey.api.reports.report.view.ReportUtil;
 import org.labkey.api.reports.report.view.ScriptReportBean;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.reports.CrosstabReport;
 import org.labkey.api.util.URLHelper;
@@ -41,15 +42,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/*
- * User: Karl Lum
- * Date: May 16, 2008
- * Time: 5:19:28 PM
- */
 public class StudyReportUIProvider extends DefaultReportUIProvider
 {
-    private static Map<String, String> _typeToIconMap = new HashMap<>();
-    private static Map<String, String> _typeToIconClsMap = new HashMap<>();
+    private static final Map<String, String> _typeToIconMap = new HashMap<>();
+    private static final Map<String, String> _typeToIconClsMap = new HashMap<>();
 
     static
     {
@@ -83,7 +79,7 @@ public class StudyReportUIProvider extends DefaultReportUIProvider
     };
 
     /**
-     * Add report creation to UI's that aren't associated with a query (manage views, data views)
+     * Add report creation to UIs that aren't associated with a query (manage views, data views)
      */
     @Override
     public List<ReportService.DesignerInfo> getDesignerInfo(ViewContext context)
@@ -162,13 +158,16 @@ public class StudyReportUIProvider extends DefaultReportUIProvider
                         _getIconPath(StudyRReport.TYPE), ReportService.DesignerType.DEFAULT, _getIconCls(StudyRReport.TYPE)));
             }
 
-            // external report - keep in sync with ExternalReportAction permissions checks
-            if (context.getContainer().hasPermission(context.getUser(), InsertPermission.class) && context.getUser().isPlatformDeveloper())
+            if (OptionalFeatureService.get().isFeatureEnabled(ExternalReport.ENABLE_EXTERNAL_REPORT))
             {
-                ActionURL buttonURL = context.getActionURL().clone();
-                buttonURL.setAction(ReportsController.ExternalReportAction.class);
-                designers.add(new DesignerInfoImpl(ExternalReport.TYPE, "Advanced Report", "An External Command Report",
-                        buttonURL, _getIconPath(ExternalReport.TYPE), ReportService.DesignerType.DEFAULT, _getIconCls(ExternalReport.TYPE)));
+                // external report - keep in sync with ExternalReportAction permissions checks
+                if (context.getContainer().hasPermission(context.getUser(), InsertPermission.class) && context.getUser().isPlatformDeveloper())
+                {
+                    ActionURL buttonURL = context.getActionURL().clone();
+                    buttonURL.setAction(ReportsController.ExternalReportAction.class);
+                    designers.add(new DesignerInfoImpl(ExternalReport.TYPE, "Advanced Report", "An External Command Report",
+                            buttonURL, _getIconPath(ExternalReport.TYPE), ReportService.DesignerType.DEFAULT, _getIconCls(ExternalReport.TYPE)));
+                }
             }
         }
         else


### PR DESCRIPTION
#### Rationale
Some features are going away

#### Changes
- Remove support for:
  - `<permissions>` element in `.view.xml` files
  - APIs returning ACLs (bitmask-based permissions)
  - Remote Login API
  - Advanced reports
  - SQL Server 2014
