### PR TITLE
Stream runs from the ExpRuns table

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -91,6 +91,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
+import java.util.function.Predicate;
 
 import static org.labkey.api.exp.api.ExpDataClass.NEW_DATA_CLASS_ALIAS_VALUE;
 import static org.labkey.api.exp.api.SampleTypeService.NEW_SAMPLE_TYPE_ALIAS_VALUE;
@@ -159,6 +160,10 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     /** @return a list of ExpRuns ordered by the RowId */
     List<? extends ExpRun> getExpRuns(Container container, @Nullable ExpProtocol parentProtocol, @Nullable ExpProtocol childProtocol);
+
+    List<? extends ExpRun> getExpRuns(Container container, @Nullable ExpProtocol parentProtocol, @Nullable ExpProtocol childProtocol, @NotNull Predicate<ExpRun> filterFn);
+    
+    List<? extends ExpRun> getExpRuns(@NotNull Container container, @Nullable SQLFragment filterSQL, @NotNull Predicate<ExpRun> filterFn);
 
     List<? extends ExpRun> getExpRunsForJobId(int jobId);
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -164,7 +164,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     List<? extends ExpRun> getExpRuns(Container container, @Nullable ExpProtocol parentProtocol, @Nullable ExpProtocol childProtocol, @NotNull Predicate<ExpRun> filterFn);
     
-    List<? extends ExpRun> getExpRuns(@NotNull Container container, @Nullable SQLFragment filterSQL, @NotNull Predicate<ExpRun> filterFn);
+    List<? extends ExpRun> getExpRuns( @Nullable SQLFragment filterSQL, @NotNull Predicate<ExpRun> filterFn, @NotNull Container container);
 
     List<? extends ExpRun> getExpRunsForJobId(int jobId);
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -158,6 +158,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     ExpRun getExpRun(String lsid);
 
+    boolean hasExpRuns(Container container, @NotNull Predicate<ExpRun> filterFn);
     /** @return a list of ExpRuns ordered by the RowId */
     List<? extends ExpRun> getExpRuns(Container container, @Nullable ExpProtocol parentProtocol, @Nullable ExpProtocol childProtocol);
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -544,7 +544,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 + " WHERE ER.Container = ? ");
         sql.add(container.getId());
 
-        if (null != filterSQL)
+        if (null != filterSQL && !filterSQL.isEmpty())
             sql.append(" AND " ).append(filterSQL);
 
         sql.append(" ORDER BY ER.RowId ");

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -518,7 +518,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             sql.add(childProtocol.getLSID());
         }
 
-        return getExpRuns(container, sql, filterFn);
+        return getExpRuns(sql, filterFn, container);
     }
 
     @Override
@@ -537,7 +537,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public List<ExpRunImpl> getExpRuns(@NotNull Container container, @Nullable SQLFragment filterSQL, @NotNull Predicate<ExpRun> filterFn)
+    public List<ExpRunImpl> getExpRuns(@Nullable SQLFragment filterSQL, @NotNull Predicate<ExpRun> filterFn, @NotNull Container container)
     {
         SQLFragment sql = new SQLFragment(" SELECT ER.* "
                 + " FROM exp.ExperimentRun ER "

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -522,6 +522,21 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
+    public boolean hasExpRuns(Container container, @NotNull Predicate<ExpRun> filterFn)
+    {
+        SQLFragment sql = new SQLFragment(" SELECT ER.* "
+                + " FROM exp.ExperimentRun ER "
+                + " WHERE ER.Container = ? ");
+        sql.add(container.getId());
+
+        return new SqlSelector(getSchema(), sql)
+                .setJdbcCaching(false)
+                .stream(ExperimentRun.class)
+                .map(ExpRunImpl::new)
+                .anyMatch(filterFn);
+    }
+
+    @Override
     public List<ExpRunImpl> getExpRuns(@NotNull Container container, @Nullable SQLFragment filterSQL, @NotNull Predicate<ExpRun> filterFn)
     {
         SQLFragment sql = new SQLFragment(" SELECT ER.* "

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -25,7 +25,6 @@ import org.labkey.api.admin.FolderWriter;
 import org.labkey.api.admin.FolderWriterFactory;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.SQLFragment;
 import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -34,6 +33,7 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.api.writer.Writer;
 import org.labkey.experiment.XarExporter;
+import org.labkey.experiment.api.ExperimentServiceImpl;
 
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -116,13 +116,13 @@ public class FolderXarWriterFactory implements FolderWriterFactory
             // Also don't include recipe protocols; there's a separate folder writer and importer for the recipe module.
             // if an additional context has been furnished, filter out runs not included in this export
 
-            List<ExpRun> allRuns = (List<ExpRun>) ExperimentService.get().getExpRuns(c, null, null, this::runFilter);
+            List<? extends ExpRun> allRuns = ExperimentServiceImpl.get().getExpRuns(c, null, null, this::runFilter);
             // the smJobRuns can make reference to assay designs, so we will put all the SM Task and Protocols at the end to assure
             // the assay definitions have already been processed and can be resolved properly.
             List<ExpRun> reorderedRuns = allRuns.stream()
                     .filter((run -> !ExpProtocol.isSampleWorkflowProtocol(run.getProtocol().getLSID())))
                     .collect(Collectors.toList());
-            List<ExpRun> smJobRuns = allRuns.stream()
+            List<? extends ExpRun> smJobRuns = allRuns.stream()
                     .filter((run -> ExpProtocol.isSampleWorkflowProtocol(run.getProtocol().getLSID())))
                     .toList();
 

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -25,6 +25,7 @@ import org.labkey.api.admin.FolderWriter;
 import org.labkey.api.admin.FolderWriterFactory;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -102,14 +103,18 @@ public class FolderXarWriterFactory implements FolderWriterFactory
             // Don't include the sample derivation runs; we now have a separate exporter explicitly for sample types.
             // Also don't include recipe protocols; there's a separate folder writer and importer for the recipe module.
             // if an additional context has been furnished, filter out runs not included in this export
-            List<ExpRun> allRuns = ExperimentService.get().getExpRuns(c, null, null).stream()
-                    .filter(
+
+//            SQLFragment filter = new SQLFragment("ER.protocollsid NOT IN (").appendValue(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID).append(",")
+//                    .appendValue(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID).append(")");
+//            List<ExpRun> allRuns = ExperimentService.get().getExpRuns(c, filter, run ->
+//                    !"recipe".equalsIgnoreCase(run.getProtocol().getImplementationName()) && !"recipe".equalsIgnoreCase(run.getProtocol().getLSIDNamespacePrefix()));
+            
+            List<ExpRun> allRuns = (List<ExpRun>) ExperimentService.get().getExpRuns(c, null, null,
                         run -> !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID)
                                 && !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID)
                                 && !"recipe".equalsIgnoreCase(run.getProtocol().getImplementationName())
                                 && !"recipe".equalsIgnoreCase(run.getProtocol().getLSIDNamespacePrefix())
-                    )
-                    .collect(Collectors.toList());
+                    );
             // the smJobRuns can make reference to assay designs, so we will put all the SM Task and Protocols at the end to assure
             // the assay definitions have already been processed and can be resolved properly.
             List<ExpRun> reorderedRuns = allRuns.stream()

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -76,7 +76,7 @@ public class FolderXarWriterFactory implements FolderWriterFactory
             Set<Container> containers = ContainerManager.getAllChildren(c);
             for(Container container: containers)
             {
-                if (getProtocols(container).size() > 0 || getRuns(null, container).size() > 0)
+                if (!getProtocols(container).isEmpty() || hasRuns(container))
                 {
                     return true;
                 }
@@ -98,18 +98,25 @@ public class FolderXarWriterFactory implements FolderWriterFactory
             return children;
         }
 
-        private List<ExpRun> getRuns(@Nullable FolderExportContext ctx, Container c)
+        private boolean hasRuns(Container c)
+        {
+            return ExperimentService.get().hasExpRuns(c, this::runFilter);
+        }
+
+        private boolean runFilter(ExpRun run) {
+            return !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID)
+                    && !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID)
+                    && !"recipe".equalsIgnoreCase(run.getProtocol().getImplementationName())
+                    && !"recipe".equalsIgnoreCase(run.getProtocol().getLSIDNamespacePrefix());
+        }
+
+        private List<ExpRun> getRuns(Container c)
         {
             // Don't include the sample derivation runs; we now have a separate exporter explicitly for sample types.
             // Also don't include recipe protocols; there's a separate folder writer and importer for the recipe module.
             // if an additional context has been furnished, filter out runs not included in this export
 
-            List<ExpRun> allRuns = (List<ExpRun>) ExperimentService.get().getExpRuns(c, null, null,
-                        run -> !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID)
-                                && !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID)
-                                && !"recipe".equalsIgnoreCase(run.getProtocol().getImplementationName())
-                                && !"recipe".equalsIgnoreCase(run.getProtocol().getLSIDNamespacePrefix())
-                    );
+            List<ExpRun> allRuns = (List<ExpRun>) ExperimentService.get().getExpRuns(c, null, null, this::runFilter);
             // the smJobRuns can make reference to assay designs, so we will put all the SM Task and Protocols at the end to assure
             // the assay definitions have already been processed and can be resolved properly.
             List<ExpRun> reorderedRuns = allRuns.stream()
@@ -117,10 +124,10 @@ public class FolderXarWriterFactory implements FolderWriterFactory
                     .collect(Collectors.toList());
             List<ExpRun> smJobRuns = allRuns.stream()
                     .filter((run -> ExpProtocol.isSampleWorkflowProtocol(run.getProtocol().getLSID())))
-                    .collect(Collectors.toList());
+                    .toList();
+
             reorderedRuns.addAll(smJobRuns);
             return reorderedRuns;
-//            return allRuns;
         }
 
         private List<Integer> getProtocols(Container c)
@@ -168,7 +175,7 @@ public class FolderXarWriterFactory implements FolderWriterFactory
             selection.addProtocolIds(getProtocols(c));
 
             if (ctx.getDataTypes().contains(FolderArchiveDataTypes.EXPERIMENT_RUNS))
-                selection.addRuns(getRuns(ctx, c));
+                selection.addRuns(getRuns(c));
 
             ctx.getXml().addNewXar().setDir(XAR_DIRECTORY);
             VirtualFile xarDir = vf.getDir(XAR_DIRECTORY);

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -104,11 +104,6 @@ public class FolderXarWriterFactory implements FolderWriterFactory
             // Also don't include recipe protocols; there's a separate folder writer and importer for the recipe module.
             // if an additional context has been furnished, filter out runs not included in this export
 
-//            SQLFragment filter = new SQLFragment("ER.protocollsid NOT IN (").appendValue(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID).append(",")
-//                    .appendValue(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID).append(")");
-//            List<ExpRun> allRuns = ExperimentService.get().getExpRuns(c, filter, run ->
-//                    !"recipe".equalsIgnoreCase(run.getProtocol().getImplementationName()) && !"recipe".equalsIgnoreCase(run.getProtocol().getLSIDNamespacePrefix()));
-            
             List<ExpRun> allRuns = (List<ExpRun>) ExperimentService.get().getExpRuns(c, null, null,
                         run -> !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID)
                                 && !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID)


### PR DESCRIPTION
#### Rationale
Attempts to address [Issue 50850](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=50850) by preventing caching and streaming runs from the ExpRuns table.

#### Related Pull Requests
- https://github.com/LabKey/commonAssays/pull/782

#### Changes
- Added a new overload of getExpRuns and modified existing one to use it
