### PR TITLE
Issue 50896: Fix population of ancestors when samples are in different containers

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-24.002-24.003.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-24.002-24.003.sql
@@ -7,8 +7,6 @@ CREATE TABLE exp.MaterialAncestors
     CONSTRAINT FK_MaterialAncestors_MaterialId FOREIGN KEY (RowId) REFERENCES exp.Material (RowId) ON DELETE CASCADE
 );
 
-SELECT core.executeJavaUpgradeCode('populateMaterialAncestors');
-
 CREATE UNIQUE INDEX UQ_MaterialAncestors_AncestorTypeId_RowId ON exp.MaterialAncestors (AncestorTypeId, RowId);
 CREATE INDEX IDX_MaterialAncestors_AncestorTypeId_RowId_AncestorRowId ON exp.MaterialAncestors (AncestorTypeId, RowId, AncestorRowId);
 
@@ -21,8 +19,6 @@ CREATE TABLE exp.DataAncestors
 
     CONSTRAINT FK_DataAncestors_DataId FOREIGN KEY (RowId) REFERENCES exp.Data (RowId) ON DELETE CASCADE
 );
-
-SELECT core.executeJavaUpgradeCode('populateDataAncestors');
 
 CREATE UNIQUE INDEX UQ_DataAncestors_AncestorTypeId_RowId ON exp.DataAncestors (AncestorTypeId, RowId);
 CREATE INDEX IDX_DataAncestors_AncestorTypeId_RowId_AncestorRowId ON exp.DataAncestors (AncestorTypeId, RowId, AncestorRowId);

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-24.005-24.006.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-24.005-24.006.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('repopulateAncestors');

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-24.002-24.003.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-24.002-24.003.sql
@@ -1,32 +1,24 @@
 CREATE TABLE exp.MaterialAncestors
 (
     RowId INT NOT NULL,
---     TypeId INT NOT NULL,
     AncestorRowId INT NOT NULL,
     AncestorTypeId VARCHAR(11),
 
     CONSTRAINT FK_MaterialAncestors_MaterialId FOREIGN KEY (RowId) REFERENCES exp.Material (RowId) ON DELETE CASCADE
 );
 
-EXEC core.executeJavaUpgradeCode 'populateMaterialAncestors';
-
 CREATE UNIQUE INDEX UQ_MaterialAncestors_AncestorTypeId_RowId ON exp.MaterialAncestors (AncestorTypeId, RowId);
 CREATE INDEX IDX_MaterialAncestors_AncestorTypeId_RowId_AncestorRowId ON exp.MaterialAncestors (AncestorTypeId, RowId, AncestorRowId);
--- CREATE INDEX IDX_MaterialAncestors_TypeId_RowId_AncestorRowId ON exp.MaterialAncestors (TypeId, RowId, AncestorRowId);
 
 CREATE TABLE exp.DataAncestors
 (
     RowId INT NOT NULL,
---     TypeId INT NOT NULL,
     AncestorRowId INT NOT NULL,
     AncestorTypeId VARCHAR(11),
 
     CONSTRAINT FK_DataAncestors_DataId FOREIGN KEY (RowId) REFERENCES exp.Data (RowId) ON DELETE CASCADE
 );
 
-EXEC core.executeJavaUpgradeCode 'populateDataAncestors';
-
 CREATE UNIQUE INDEX UQ_DataAncestors_AncestorTypeId_RowId ON exp.DataAncestors (AncestorTypeId, RowId);
 CREATE INDEX IDX_DataAncestors_AncestorTypeId_RowId_AncestorRowId ON exp.DataAncestors (AncestorTypeId, RowId, AncestorRowId);
--- CREATE INDEX IDX_DataAncestors_TypeId_RowId_AncestorRowId ON exp.DataAncestors (TypeId, RowId, AncestorRowId);
 

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-24.005-24.006.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-24.005-24.006.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'repopulateAncestors';

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -176,7 +176,7 @@ public class ExperimentModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 24.005;
+        return 24.006;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -390,7 +390,7 @@ public class ExperimentUpgradeCode implements UpgradeCode
         }
     }
 
-    // called from exp-24.004-24.005.sql
+    // called from exp-24.005-24.006.sql
     public static void repopulateAncestors(ModuleContext context)
     {
         if (context.isNewInstall())

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -324,28 +324,6 @@ public class ExperimentUpgradeCode implements UpgradeCode
         }
     }
 
-    /**
-     * Called from exp-24.002-24.003.sql
-     */
-    public static void populateMaterialAncestors(ModuleContext context)
-    {
-        if (context.isNewInstall())
-            return;
-
-        ClosureQueryHelper.populateMaterialAncestors(LOG);
-    }
-
-    /**
-     * Called from exp-24.002-24.003.sql
-     */
-    public static void populateDataAncestors(ModuleContext context)
-    {
-        if (context.isNewInstall())
-            return;
-
-        ClosureQueryHelper.populateDataAncestors(LOG);
-    }
-
     // called from exp-24.003-24.004.sql
     public static void addMissingSampleTypeIdsForSampleTimelineAudit(ModuleContext context)
     {

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -411,4 +411,13 @@ public class ExperimentUpgradeCode implements UpgradeCode
             transaction.commit();
         }
     }
+
+    // called from exp-24.004-24.005.sql
+    public static void repopulateAncestors(ModuleContext context)
+    {
+        if (context.isNewInstall())
+            return;
+
+        ClosureQueryHelper.truncateAndRecreate(LOG);
+    }
 }

--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -369,20 +369,20 @@ public class ClosureQueryHelper
         DbSchema schema = ExperimentService.get().getSchema();
 
         ContainerManager.getAllChildren(ContainerManager.getRoot()).forEach(
-                container -> {
-                    int totalRows = 0;
-                    logger.info("Adding rows to exp.materialAncestors from sample types in container " + container.getPath());
-                    for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(container, null, false))
-                    {
-                        logger.debug("   Adding rows from samples in sampleType " + sampleType.getName());
-                        SQLFragment from = new SQLFragment(" FROM exp.material WHERE materialSourceId = ?").add(sampleType.getRowId());
-                        SQLFragment sql = ClosureQueryHelper.selectAndInsertSql(schema.getSqlDialect(), from, null, "INSERT INTO exp.materialAncestors (RowId, AncestorRowId, AncestorTypeId) ");
-                        int numRows = new SqlExecutor(schema.getScope()).execute(sql);
-                        totalRows += numRows;
-                        logger.debug("    Added " + numRows + " rows for data class " + sampleType.getName());
-                    }
-                    logger.info("Added " + totalRows + " rows for sample types in container " + container.getPath());
+            container -> {
+                int totalRows = 0;
+                logger.info("Adding rows to exp.materialAncestors from sample types in container " + container.getPath());
+                for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(container, null, false))
+                {
+                    logger.debug("   Adding rows from samples in sampleType " + sampleType.getName());
+                    SQLFragment from = new SQLFragment(" FROM exp.material WHERE materialSourceId = ?").add(sampleType.getRowId());
+                    SQLFragment sql = ClosureQueryHelper.selectAndInsertSql(schema.getSqlDialect(), from, null, "INSERT INTO exp.materialAncestors (RowId, AncestorRowId, AncestorTypeId) ");
+                    int numRows = new SqlExecutor(schema.getScope()).execute(sql);
+                    totalRows += numRows;
+                    logger.debug("    Added " + numRows + " rows for data class " + sampleType.getName());
                 }
+                logger.info("Added " + totalRows + " rows for sample types in container " + container.getPath());
+            }
         );
         logger.info("Finished populating exp.materialAncestors");
     }

--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -370,16 +370,18 @@ public class ClosureQueryHelper
 
         ContainerManager.getAllChildren(ContainerManager.getRoot()).forEach(
                 container -> {
-                    logger.info("Adding rows to exp.materialAncestors from samples in container " + container.getPath());
-                    SampleTypeService.get().getSampleTypes(container, null, false).forEach(
-                            sampleType -> {
-                                logger.debug("   Adding rows from samples in sampleType " + sampleType.getName() + " in container " + container.getPath());
-                                SQLFragment from = new SQLFragment(" FROM exp.material WHERE container = ?").add(container.getEntityId())
-                                        .append(" AND materialSourceId = ?").add(sampleType.getRowId());
-                                SQLFragment sql = ClosureQueryHelper.selectAndInsertSql(schema.getSqlDialect(), from, null, "INSERT INTO exp.materialAncestors (RowId, AncestorRowId, AncestorTypeId) ");
-                                new SqlExecutor(schema.getScope()).execute(sql);
-                            }
-                    );
+                    int totalRows = 0;
+                    logger.info("Adding rows to exp.materialAncestors from sample types in container " + container.getPath());
+                    for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(container, null, false))
+                    {
+                        logger.debug("   Adding rows from samples in sampleType " + sampleType.getName());
+                        SQLFragment from = new SQLFragment(" FROM exp.material WHERE materialSourceId = ?").add(sampleType.getRowId());
+                        SQLFragment sql = ClosureQueryHelper.selectAndInsertSql(schema.getSqlDialect(), from, null, "INSERT INTO exp.materialAncestors (RowId, AncestorRowId, AncestorTypeId) ");
+                        int numRows = new SqlExecutor(schema.getScope()).execute(sql);
+                        totalRows += numRows;
+                        logger.debug("    Added " + numRows + " rows for data class " + sampleType.getName());
+                    }
+                    logger.info("Added " + totalRows + " rows for sample types in container " + container.getPath());
                 }
         );
         logger.info("Finished populating exp.materialAncestors");
@@ -390,24 +392,31 @@ public class ClosureQueryHelper
         DbSchema schema = ExperimentService.get().getSchema();
 
         ContainerManager.getAllChildren(ContainerManager.getRoot()).forEach(
-                container -> {
-                    logger.info("Adding rows to exp.dataAncestors from data objects in container " + container.getPath());
-                    ExperimentService.get().getDataClasses(container, null, false).forEach(
-                            dataClass -> {
-                                logger.debug("    Adding rows to exp.dataAncestors from data class " + dataClass.getName() + " in container " + container.getPath());
-                                SQLFragment from = new SQLFragment(" FROM exp.data WHERE container = ?").add(container.getEntityId())
-                                        .append(" AND classId = ?").add(dataClass.getRowId());
-                                SQLFragment sql = ClosureQueryHelper.selectAndInsertSql(schema.getSqlDialect(), from, null,
-                                        "INSERT INTO exp.dataAncestors (RowId, AncestorRowId, AncestorTypeId) ");
-                                new SqlExecutor(schema.getScope()).execute(sql);
-                            }
-                    );
+            container -> {
+                int totalRows = 0;
+                logger.info("Adding rows to exp.dataAncestors from data classes in container " + container.getPath());
+                for (ExpDataClass dataClass : ExperimentService.get().getDataClasses(container, null, false))
+                {
+                    logger.debug("   Adding rows to exp.dataAncestors from data class " + dataClass.getName());
+                    SQLFragment from = new SQLFragment(" FROM exp.data WHERE classId = ?").add(dataClass.getRowId());
+                    SQLFragment sql = ClosureQueryHelper.selectAndInsertSql(schema.getSqlDialect(), from, null,
+                            "INSERT INTO exp.dataAncestors (RowId, AncestorRowId, AncestorTypeId) ");
+                    int numRows = new SqlExecutor(schema.getScope()).execute(sql);
+                    totalRows += numRows;
+                    logger.debug("    Added " + numRows + " rows for data class " + dataClass.getName());
                 }
+                logger.info("Added " + totalRows + " rows for data classes in container " + container.getPath());
+            }
         );
         logger.info("Finished populating exp.dataAncestors");
     }
 
     public static void truncateAndRecreate()
+    {
+        truncateAndRecreate(logger);
+    }
+
+    public static void truncateAndRecreate(Logger logger)
     {
         try (DbScope.Transaction transaction = ExperimentService.get().getSchema().getScope().ensureTransaction())
         {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -3704,7 +3704,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 LOG.debug("Rebuilt all run-based edges: " + timing.getDuration() + " ms");
             }
         }
-        ClosureQueryHelper.truncateAndRecreate();
+        ClosureQueryHelper.truncateAndRecreate(LOG);
     }
 
     public void verifyRunEdges(ExpRun run)


### PR DESCRIPTION
#### Rationale
The code to populate the ancestors table was chunking up the updates by sample type and container but the logic is flawed and picks up only the samples in the container where the sample type is defined. 

This adds an upgrade script to rerun the populate task with repaired logic. Since there are currently no additional upgrade scripts on develop, this seems safe to do at this juncture.

#### Related Pull Requests
- #5508 

#### Changes
- Fix logic for chunking up the ancestor table inserts
- Add upgrade script to repopulate the ancestor tables  
