### PR TITLE
Add audit event for ELN custom label changes

### DIFF
--- a/api/src/org/labkey/api/settings/CustomLabelProvider.java
+++ b/api/src/org/labkey/api/settings/CustomLabelProvider.java
@@ -18,6 +18,7 @@ package org.labkey.api.settings;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.security.User;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,9 +31,9 @@ public interface CustomLabelProvider
      */
     Map<String, String> getCustomLabels(@Nullable Container container);
 
-    void resetLabels(@Nullable Container container);
+    void resetLabels(@Nullable Container container, @Nullable User auditUser);
 
-    void saveLabels(HashMap<String, String> updatedLabels, @Nullable Container container) throws ValidationException;
+    void saveLabels(HashMap<String, String> updatedLabels, @Nullable Container container, @Nullable User auditUser) throws ValidationException;
 
     String getName();
 

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -2856,14 +2856,14 @@ public class CoreController extends SpringActionController
             String mode = form.getMode();
             boolean isReset = "reset".equalsIgnoreCase(mode);
             if (isReset)
-                _customLabelProvider.resetLabels(getContainer());
+                _customLabelProvider.resetLabels(getContainer(), getUser());
             else
             {
                 try
                 {
                     HashMap<String, String> labels =
                             JsonUtil.DEFAULT_MAPPER.readValue(form.getLabelsJson(), HashMap.class);
-                    _customLabelProvider.saveLabels(labels, getContainer());
+                    _customLabelProvider.saveLabels(labels, getContainer(), getUser());
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
#### Rationale
We want to add audit events for when ELN labels are updated/reset. The events will be under "Site settings events", which is not currently exposed in the application. For 24.7, we will add the audit log. Exposing the event type in apps will be evaluated post 24.7.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5717
- https://github.com/LabKey/limsModules/pull/503

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
