### PR TITLE
excludeGuests() and excludeUsers() consistency

### DIFF
--- a/api/src/org/labkey/api/security/roles/AbstractRole.java
+++ b/api/src/org/labkey/api/security/roles/AbstractRole.java
@@ -25,6 +25,7 @@ import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurableResource;
+import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
@@ -173,7 +174,12 @@ public abstract class AbstractRole implements Role
     protected void excludeGuests()
     {
         addExcludedPrincipal(User.guest);
-        addExcludedPrincipal(org.labkey.api.security.SecurityManager.getGroup(Group.groupGuests));
+        addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
+    }
+
+    protected void excludeUsers()
+    {
+        addExcludedPrincipal(SecurityManager.getGroup(Group.groupUsers));
     }
 
     @Nullable

--- a/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ApplicationAdminRole.java
@@ -15,8 +15,6 @@
  */
 package org.labkey.api.security.roles;
 
-import org.labkey.api.security.Group;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.AddUserPermission;
 import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.security.permissions.CanImpersonateSiteRolesPermission;
@@ -56,8 +54,7 @@ public class ApplicationAdminRole extends AbstractRootContainerRole implements A
             PERMISSIONS
         );
 
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupUsers));
+        excludeUsers();
     }
 
     @Override

--- a/api/src/org/labkey/api/security/roles/CanSeeAuditLogRole.java
+++ b/api/src/org/labkey/api/security/roles/CanSeeAuditLogRole.java
@@ -16,8 +16,6 @@
 package org.labkey.api.security.roles;
 
 import org.labkey.api.audit.permissions.CanSeeAuditLogPermission;
-import org.labkey.api.security.Group;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.SeeUserDetailsPermission;
 
 public class CanSeeAuditLogRole extends AbstractRootContainerRole
@@ -25,9 +23,8 @@ public class CanSeeAuditLogRole extends AbstractRootContainerRole
     public CanSeeAuditLogRole()
     {
         super("See Audit Log Events", "Allows non-administrators to view audit log events",
-                CanSeeAuditLogPermission.class,
-                SeeUserDetailsPermission.class);
-
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
+            CanSeeAuditLogPermission.class,
+            SeeUserDetailsPermission.class
+        );
     }
 }

--- a/api/src/org/labkey/api/security/roles/EmailNonUsersRole.java
+++ b/api/src/org/labkey/api/security/roles/EmailNonUsersRole.java
@@ -15,21 +15,12 @@
  */
 package org.labkey.api.security.roles;
 
-import org.labkey.api.security.Group;
-import org.labkey.api.security.SecurityManager;
-
-/*
-* User: adam
-* Date: Jan 22, 2010
-* Time: 1:22:04 PM
-*/
 public class EmailNonUsersRole extends AbstractRootContainerRole
 {
     public EmailNonUsersRole()
     {
         super("Email Non-Users", "Allows users to send emails to addresses that are not associated with LabKey Server accounts.  Use caution when enabling this if you have self-sign-on enabled.",
-                EmailNonUsersPermission.class);
-
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
+            EmailNonUsersPermission.class
+        );
     }
 }

--- a/api/src/org/labkey/api/security/roles/FolderAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/FolderAdminRole.java
@@ -27,19 +27,14 @@ import org.labkey.api.security.permissions.Permission;
 import java.util.Arrays;
 import java.util.Collection;
 
-/*
-* User: Dave
-* Date: Apr 28, 2009
-* Time: 10:16:08 AM
-*/
 public class FolderAdminRole extends AbstractRole implements AdminRoleListener
 {
     // Most permissions are assigned to all admin roles automatically, and shouldn't be added to this list
     static Collection<Class<? extends Permission>> PERMISSIONS = Arrays.asList(
         AdminPermission.class,
-        FolderExportPermission.class,
         DesignDataClassPermission.class,
-        DesignSampleTypePermission.class
+        DesignSampleTypePermission.class,
+        FolderExportPermission.class
     );
 
     public FolderAdminRole()

--- a/api/src/org/labkey/api/security/roles/FolderAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/FolderAdminRole.java
@@ -17,9 +17,7 @@ package org.labkey.api.security.roles;
 
 import org.labkey.api.admin.FolderExportPermission;
 import org.labkey.api.data.Container;
-import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DesignDataClassPermission;
@@ -52,7 +50,7 @@ public class FolderAdminRole extends AbstractRole implements AdminRoleListener
         );
 
         excludeGuests();
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupUsers));
+        excludeUsers();
     }
 
     @Override

--- a/api/src/org/labkey/api/security/roles/ImpersonatingTroubleshooterRole.java
+++ b/api/src/org/labkey/api/security/roles/ImpersonatingTroubleshooterRole.java
@@ -1,7 +1,5 @@
 package org.labkey.api.security.roles;
 
-import org.labkey.api.security.Group;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.CanImpersonatePrivilegedSiteRolesPermission;
 import org.labkey.api.security.permissions.CanImpersonateSiteRolesPermission;
 import org.labkey.api.security.permissions.ExemptFromAccountDisablingPermission;
@@ -20,7 +18,7 @@ public class ImpersonatingTroubleshooterRole extends AbstractRootContainerRole
                 ExemptFromAccountDisablingPermission.class
             )
         );
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupUsers));
+        excludeUsers();
     }
 
     @Override

--- a/api/src/org/labkey/api/security/roles/PlatformDeveloperRole.java
+++ b/api/src/org/labkey/api/security/roles/PlatformDeveloperRole.java
@@ -15,8 +15,6 @@
  */
 package org.labkey.api.security.roles;
 
-import org.labkey.api.security.Group;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.AnalystPermission;
 import org.labkey.api.security.permissions.BrowserDeveloperPermission;
 import org.labkey.api.security.permissions.EditModuleResourcesPermission;
@@ -43,8 +41,6 @@ public class PlatformDeveloperRole extends AbstractRootContainerRole
         super("Platform Developer", "Allows developers to write and deploy code outside the LabKey security framework.",
             PERMISSIONS
         );
-
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
     }
 
     @Override

--- a/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
@@ -23,11 +23,6 @@ import org.labkey.api.security.permissions.Permission;
 
 import java.util.Collections;
 
-/*
-* User: Dave
-* Date: Apr 28, 2009
-* Time: 10:13:55 AM
-*/
 public class ProjectAdminRole extends AbstractRole implements AdminRoleListener
 {
     public ProjectAdminRole()

--- a/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
+++ b/api/src/org/labkey/api/security/roles/ProjectAdminRole.java
@@ -16,9 +16,7 @@
 package org.labkey.api.security.roles;
 
 import org.labkey.api.data.Container;
-import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.AddUserPermission;
 import org.labkey.api.security.permissions.Permission;
@@ -41,7 +39,7 @@ public class ProjectAdminRole extends AbstractRole implements AdminRoleListener
         );
 
         excludeGuests();
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupUsers));
+        excludeUsers();
     }
 
     @Override

--- a/api/src/org/labkey/api/security/roles/ProjectCreatorRole.java
+++ b/api/src/org/labkey/api/security/roles/ProjectCreatorRole.java
@@ -1,7 +1,5 @@
 package org.labkey.api.security.roles;
 
-import org.labkey.api.security.Group;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.CreateProjectPermission;
 
 public class ProjectCreatorRole extends AbstractRootContainerRole
@@ -15,7 +13,6 @@ public class ProjectCreatorRole extends AbstractRootContainerRole
             CreateProjectPermission.class
         );
 
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupUsers));
+        excludeUsers();
     }
 }

--- a/api/src/org/labkey/api/security/roles/SeeFilePathsRole.java
+++ b/api/src/org/labkey/api/security/roles/SeeFilePathsRole.java
@@ -15,19 +15,12 @@
  */
 package org.labkey.api.security.roles;
 
-import org.labkey.api.security.Group;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.webdav.permissions.SeeFilePathsPermission;
 
-/**
- * Created by davebradlee on 10/10/17.
- */
 public class SeeFilePathsRole extends AbstractRootContainerRole
 {
     public SeeFilePathsRole()
     {
         super("See Absolute File Paths", "Allows users to see absolute file paths.", SeeFilePathsPermission.class);
-
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
     }
 }

--- a/api/src/org/labkey/api/security/roles/SeeUserAndGroupDetailsRole.java
+++ b/api/src/org/labkey/api/security/roles/SeeUserAndGroupDetailsRole.java
@@ -16,8 +16,6 @@
 package org.labkey.api.security.roles;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.security.Group;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.SeeGroupDetailsPermission;
 import org.labkey.api.security.permissions.SeeUserDetailsPermission;
 
@@ -36,9 +34,9 @@ public class SeeUserAndGroupDetailsRole extends AbstractRootContainerRole
     public SeeUserAndGroupDetailsRole()
     {
         super(NAME, "Allows viewing email addresses and contact information of other users as well as information about security groups.",
-                SeeUserDetailsPermission.class, SeeGroupDetailsPermission.class);
-
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
+            SeeUserDetailsPermission.class,
+            SeeGroupDetailsPermission.class
+        );
     }
 
     @Override

--- a/api/src/org/labkey/api/security/roles/SeeUserAndGroupDetailsRole.java
+++ b/api/src/org/labkey/api/security/roles/SeeUserAndGroupDetailsRole.java
@@ -22,11 +22,6 @@ import org.labkey.api.security.permissions.SeeUserDetailsPermission;
 import java.util.Collection;
 import java.util.Collections;
 
-/*
-* User: adam
-* Date: Jan 22, 2010
-* Time: 1:22:04 PM
-*/
 public class SeeUserAndGroupDetailsRole extends AbstractRootContainerRole
 {
     public static final String NAME = "See User and Group Details";

--- a/api/src/org/labkey/api/security/roles/TroubleshooterRole.java
+++ b/api/src/org/labkey/api/security/roles/TroubleshooterRole.java
@@ -16,8 +16,6 @@
 package org.labkey.api.security.roles;
 
 import org.labkey.api.audit.permissions.CanSeeAuditLogPermission;
-import org.labkey.api.security.Group;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.SeeUserDetailsPermission;
 import org.labkey.api.security.permissions.TroubleshooterPermission;
@@ -36,6 +34,5 @@ public class TroubleshooterRole extends AbstractRootContainerRole
     public TroubleshooterRole()
     {
         super("Troubleshooter", "Troubleshooters may view administration settings but may not change them.", PERMISSIONS);
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupUsers));
     }
 }

--- a/specimen/src/org/labkey/specimen/security/roles/SpecimenCoordinatorRole.java
+++ b/specimen/src/org/labkey/specimen/security/roles/SpecimenCoordinatorRole.java
@@ -16,8 +16,6 @@
 package org.labkey.specimen.security.roles;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.security.Group;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.permissions.EditSharedViewPermission;
 import org.labkey.api.specimen.security.permissions.EditSpecimenDataPermission;
 import org.labkey.api.specimen.security.permissions.ManageRequestSettingsPermission;
@@ -36,11 +34,6 @@ import org.labkey.specimen.security.permissions.SetSpecimenCommentsPermission;
 import java.util.Collection;
 import java.util.Set;
 
-/*
-* User: Dave
-* Date: May 13, 2009
-* Time: 3:16:54 PM
-*/
 public class SpecimenCoordinatorRole extends AbstractSpecimenRole
 {
     public SpecimenCoordinatorRole()
@@ -63,8 +56,8 @@ public class SpecimenCoordinatorRole extends AbstractSpecimenRole
             RequestSpecimensPermission.class,
             SetSpecimenCommentsPermission.class
         );
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupUsers));
+        excludeGuests();
+        excludeUsers();
     }
 
     @Override

--- a/specimen/src/org/labkey/specimen/security/roles/SpecimenRequesterRole.java
+++ b/specimen/src/org/labkey/specimen/security/roles/SpecimenRequesterRole.java
@@ -16,8 +16,6 @@
 package org.labkey.specimen.security.roles;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.security.Group;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.specimen.security.permissions.RequestSpecimensPermission;
 
 import java.util.Collection;
@@ -34,8 +32,9 @@ public class SpecimenRequesterRole extends AbstractSpecimenRole
     {
         super("Specimen Requester",
                 "Specimen Requesters may request specimen vials.",
-                RequestSpecimensPermission.class);
-        addExcludedPrincipal(SecurityManager.getGroup(Group.groupGuests));
+            RequestSpecimensPermission.class
+        );
+        excludeGuests();
     }
 
     @Override

--- a/specimen/src/org/labkey/specimen/security/roles/SpecimenRequesterRole.java
+++ b/specimen/src/org/labkey/specimen/security/roles/SpecimenRequesterRole.java
@@ -21,17 +21,12 @@ import org.labkey.api.specimen.security.permissions.RequestSpecimensPermission;
 import java.util.Collection;
 import java.util.Set;
 
-/*
-* User: Dave
-* Date: May 18, 2009
-* Time: 2:23:42 PM
-*/
 public class SpecimenRequesterRole extends AbstractSpecimenRole
 {
     public SpecimenRequesterRole()
     {
         super("Specimen Requester",
-                "Specimen Requesters may request specimen vials.",
+            "Specimen Requesters may request specimen vials.",
             RequestSpecimensPermission.class
         );
         excludeGuests();


### PR DESCRIPTION
#### Rationale
All site roles (classes extending `AbstractRootContainerRole`) exclude guests by default, so there's no reason for individual roles to `excludeGuests()`. While we're at it, add similar helper method `excludeUsers()` and use these helpers consistently.
