### PR TITLE
Fix check for transform scripts

### DIFF
--- a/api/src/org/labkey/api/settings/ProductConfiguration.java
+++ b/api/src/org/labkey/api/settings/ProductConfiguration.java
@@ -34,6 +34,7 @@ public class ProductConfiguration extends AbstractWriteableSettingsGroup impleme
         else
             config.storeStringValue(PROPERTY_NAME, productKey);
         config.save();
+        ProductRegistry.clearProductFeatureSetCache();
     }
 
     private static ProductConfiguration getWritableConfig()

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": " 4.4.0"
+        "@labkey/components": "  4.4.2-enabledTransformScripts.0"
       },
       "devDependencies": {
         "@labkey/build": "7.4.0",
@@ -2516,9 +2516,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "4.4.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.0.tgz",
-      "integrity": "sha512-fC1zUVGYIEdlqSjDRN/37OFxCmScn8FZPj2qPSw5McTcF9awmlEFgjxjBOJU7wZQuvwY9PwF9HTGbC5ZVi0PZQ==",
+      "version": "4.4.2-enabledTransformScripts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.2-enabledTransformScripts.0.tgz",
+      "integrity": "sha512-w6m48kzdDsrLjRQEKPXagQLvZvx5oKfefmv1EqwVLuFngOFhd8aSjFHwGbvNhMJAjWjdo7wLr89sOxHvsttm5A==",
       "dependencies": {
         "@labkey/api": "1.35.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "  4.4.2-enabledTransformScripts.0"
+        "@labkey/components": "  4.4.2"
       },
       "devDependencies": {
         "@labkey/build": "7.4.0",
@@ -2516,9 +2516,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "4.4.2-enabledTransformScripts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.2-enabledTransformScripts.0.tgz",
-      "integrity": "sha512-w6m48kzdDsrLjRQEKPXagQLvZvx5oKfefmv1EqwVLuFngOFhd8aSjFHwGbvNhMJAjWjdo7wLr89sOxHvsttm5A==",
+      "version": "4.4.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.2.tgz",
+      "integrity": "sha512-b9uJPR5YXH3BK90uZkfQHEZcRCGdVo52IZOQrdL7ZKhrU0h5L+Hqqq/fwmhzfRqC9O+WB+AxS9WI87Avx59CAA==",
       "dependencies": {
         "@labkey/api": "1.35.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": " 4.4.0"
+    "@labkey/components": "  4.4.2-enabledTransformScripts.0"
   },
   "devDependencies": {
     "@labkey/build": "7.4.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "  4.4.2-enabledTransformScripts.0"
+    "@labkey/components": "  4.4.2"
   },
   "devDependencies": {
     "@labkey/build": "7.4.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": " 4.4.0",
+        "@labkey/components": "  4.4.2-enabledTransformScripts.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3440,9 +3440,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "4.4.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.0.tgz",
-      "integrity": "sha512-fC1zUVGYIEdlqSjDRN/37OFxCmScn8FZPj2qPSw5McTcF9awmlEFgjxjBOJU7wZQuvwY9PwF9HTGbC5ZVi0PZQ==",
+      "version": "4.4.2-enabledTransformScripts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.2-enabledTransformScripts.0.tgz",
+      "integrity": "sha512-w6m48kzdDsrLjRQEKPXagQLvZvx5oKfefmv1EqwVLuFngOFhd8aSjFHwGbvNhMJAjWjdo7wLr89sOxHvsttm5A==",
       "dependencies": {
         "@labkey/api": "1.35.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "  4.4.2-enabledTransformScripts.0",
+        "@labkey/components": "  4.4.2",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3440,9 +3440,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "4.4.2-enabledTransformScripts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.2-enabledTransformScripts.0.tgz",
-      "integrity": "sha512-w6m48kzdDsrLjRQEKPXagQLvZvx5oKfefmv1EqwVLuFngOFhd8aSjFHwGbvNhMJAjWjdo7wLr89sOxHvsttm5A==",
+      "version": "4.4.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.2.tgz",
+      "integrity": "sha512-b9uJPR5YXH3BK90uZkfQHEZcRCGdVo52IZOQrdL7ZKhrU0h5L+Hqqq/fwmhzfRqC9O+WB+AxS9WI87Avx59CAA==",
       "dependencies": {
         "@labkey/api": "1.35.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "  4.4.2-enabledTransformScripts.0",
+    "@labkey/components": "  4.4.2",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": " 4.4.0",
+    "@labkey/components": "  4.4.2-enabledTransformScripts.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/src/org/labkey/core/admin/productConfiguration.jsp
+++ b/core/src/org/labkey/core/admin/productConfiguration.jsp
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 %>
-<%@ page import="org.labkey.api.settings.AdminConsole" %>
-<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
-<%@ page import="org.labkey.core.admin.AdminController" %>
 <%@ page import="org.labkey.api.products.Product" %>
 <%@ page import="org.labkey.api.products.ProductRegistry" %>
+<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.labkey.core.admin.AdminController" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": " 4.4.0"
+        "@labkey/components": "  4.4.2-enabledTransformScripts.0"
       },
       "devDependencies": {
         "@labkey/build": "7.4.0",
@@ -3243,9 +3243,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "4.4.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.0.tgz",
-      "integrity": "sha512-fC1zUVGYIEdlqSjDRN/37OFxCmScn8FZPj2qPSw5McTcF9awmlEFgjxjBOJU7wZQuvwY9PwF9HTGbC5ZVi0PZQ==",
+      "version": "4.4.2-enabledTransformScripts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.2-enabledTransformScripts.0.tgz",
+      "integrity": "sha512-w6m48kzdDsrLjRQEKPXagQLvZvx5oKfefmv1EqwVLuFngOFhd8aSjFHwGbvNhMJAjWjdo7wLr89sOxHvsttm5A==",
       "dependencies": {
         "@labkey/api": "1.35.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "  4.4.2-enabledTransformScripts.0"
+        "@labkey/components": "  4.4.2"
       },
       "devDependencies": {
         "@labkey/build": "7.4.0",
@@ -3243,9 +3243,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "4.4.2-enabledTransformScripts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.2-enabledTransformScripts.0.tgz",
-      "integrity": "sha512-w6m48kzdDsrLjRQEKPXagQLvZvx5oKfefmv1EqwVLuFngOFhd8aSjFHwGbvNhMJAjWjdo7wLr89sOxHvsttm5A==",
+      "version": "4.4.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.2.tgz",
+      "integrity": "sha512-b9uJPR5YXH3BK90uZkfQHEZcRCGdVo52IZOQrdL7ZKhrU0h5L+Hqqq/fwmhzfRqC9O+WB+AxS9WI87Avx59CAA==",
       "dependencies": {
         "@labkey/api": "1.35.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "  4.4.2-enabledTransformScripts.0"
+    "@labkey/components": "  4.4.2"
   },
   "devDependencies": {
     "@labkey/build": "7.4.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": " 4.4.0"
+    "@labkey/components": "  4.4.2-enabledTransformScripts.0"
   },
   "devDependencies": {
     "@labkey/build": "7.4.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": " 4.4.0"
+        "@labkey/components": "  4.4.2-enabledTransformScripts.0"
       },
       "devDependencies": {
         "@labkey/build": "7.4.0",
@@ -2689,9 +2689,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "4.4.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.0.tgz",
-      "integrity": "sha512-fC1zUVGYIEdlqSjDRN/37OFxCmScn8FZPj2qPSw5McTcF9awmlEFgjxjBOJU7wZQuvwY9PwF9HTGbC5ZVi0PZQ==",
+      "version": "4.4.2-enabledTransformScripts.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.2-enabledTransformScripts.0.tgz",
+      "integrity": "sha512-w6m48kzdDsrLjRQEKPXagQLvZvx5oKfefmv1EqwVLuFngOFhd8aSjFHwGbvNhMJAjWjdo7wLr89sOxHvsttm5A==",
       "dependencies": {
         "@labkey/api": "1.35.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "  4.4.2-enabledTransformScripts.0"
+        "@labkey/components": "  4.4.2"
       },
       "devDependencies": {
         "@labkey/build": "7.4.0",
@@ -2689,9 +2689,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "4.4.2-enabledTransformScripts.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.2-enabledTransformScripts.0.tgz",
-      "integrity": "sha512-w6m48kzdDsrLjRQEKPXagQLvZvx5oKfefmv1EqwVLuFngOFhd8aSjFHwGbvNhMJAjWjdo7wLr89sOxHvsttm5A==",
+      "version": "4.4.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-4.4.2.tgz",
+      "integrity": "sha512-b9uJPR5YXH3BK90uZkfQHEZcRCGdVo52IZOQrdL7ZKhrU0h5L+Hqqq/fwmhzfRqC9O+WB+AxS9WI87Avx59CAA==",
       "dependencies": {
         "@labkey/api": "1.35.0",
         "@testing-library/jest-dom": "~5.17.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": " 4.4.0"
+    "@labkey/components": "  4.4.2-enabledTransformScripts.0"
   },
   "devDependencies": {
     "@labkey/build": "7.4.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "  4.4.2-enabledTransformScripts.0"
+    "@labkey/components": "  4.4.2"
   },
   "devDependencies": {
     "@labkey/build": "7.4.0",


### PR DESCRIPTION
#### Rationale
Transform scripts should be enabled for LKS Community and Starter, but not for LKSM Starter or Professional. The original implementation assumed it should not be enabled for LKS Community.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1544
- #5716 

#### Changes
- package updates
