### PR TITLE
Fix template folder permission check

### DIFF
--- a/core/src/org/labkey/core/admin/importFolder.jsp
+++ b/core/src/org/labkey/core/admin/importFolder.jsp
@@ -312,9 +312,10 @@
         };
 
         const getTemplateFolders = function(data) {
-            // add the container itself to the templateFolder object if it is not the root and the user has admin perm to it
-            // and if it is not a workbook or container tab folder
-            if (data.path !== "/" && LABKEY.Security.hasEffectivePermission(data.effectivePermissions, LABKEY.Security.effectivePermissions.admin)
+            // add the container itself to the templateFolder object if it is not the root, it has effectivePermissions,
+            // (note that getContainers.api includes effectivePermissions only if the user has read in that container),
+            // effectivePermissions includes admin perm, and it is not a workbook or container tab folder
+            if (data.path !== "/" && data.effectivePermissions && LABKEY.Security.hasEffectivePermission(data.effectivePermissions, LABKEY.Security.effectivePermissions.admin)
                     && !data.isWorkbook && !data.isContainerTab) {
                 templateFolders.push([data.id, data.path]);
             }


### PR DESCRIPTION
#### Rationale
`AdvancedImportOptionsTest.testImportToMultipleFolders()` started failing after switching `importFolder.jsp` to use `hasEffectivePermission()` and `data.effectivePermissions`. Turns out `getContainers.api` includes the effectivePermissions property only if the user has read permission in that container, so we need to check that it's defined.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5718
