### PR TITLE
Issue 50203: Cancelling a running job for sample & data class import

### DIFF
--- a/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryImportPipelineJob;
 import org.labkey.api.query.QueryUpdateService;
 
 import java.util.HashMap;
@@ -49,6 +50,7 @@ public class DataIteratorContext
     boolean _verbose = false;
     boolean _supportAutoIncrementKey = false;
     boolean _allowImportLookupByAlternateKey = false;
+    QueryImportPipelineJob _backgroundJob = null;
     boolean _crossTypeImport = false;
     boolean _crossFolderImport = false;
     boolean _allowCreateStorage = false;
@@ -290,4 +292,20 @@ public class DataIteratorContext
     {
         _logger = logger;
     }
+
+    public boolean isBackgroundJob()
+    {
+        return _backgroundJob != null;
+    }
+
+    public void setBackgroundJob(QueryImportPipelineJob job)
+    {
+        _backgroundJob = job;
+    }
+
+    public QueryImportPipelineJob getBackgroundJob()
+    {
+        return _backgroundJob;
+    }
+
 }

--- a/api/src/org/labkey/api/dataiterator/QueryImportJobStatusCheckDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/QueryImportJobStatusCheckDataIterator.java
@@ -1,0 +1,84 @@
+package org.labkey.api.dataiterator;
+
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.pipeline.CancelledException;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryImportJobCancelledException;
+import org.labkey.api.query.QueryImportPipelineJob;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+// This is a pass-through iterator, it does not change any of the data, it only throws exceptions
+public class QueryImportJobStatusCheckDataIterator extends AbstractDataIterator
+{
+    final DataIterator _data;
+    final int _batchSize;
+    final QueryImportPipelineJob _job;
+    int _currentRow = -1;
+
+    public QueryImportJobStatusCheckDataIterator(DataIterator data, DataIteratorContext context, int batchSize)
+    {
+        super(context);
+        _data = data;
+        _job = context.getBackgroundJob();
+        _batchSize = batchSize > 0 ? batchSize : 1;
+    }
+
+    @Override
+    public int getColumnCount()
+    {
+        return _data.getColumnCount();
+    }
+
+    @Override
+    public ColumnInfo getColumnInfo(int i)
+    {
+        return _data.getColumnInfo(i);
+    }
+
+
+    @Override
+    public boolean next() throws BatchValidationException
+    {
+        if (!_data.next())
+            return false;
+
+        if ((_currentRow % _batchSize) == 0)
+        {
+            try
+            {
+                _job.setStatus(PipelineJob.TaskStatus.running);
+            }
+            catch (CancelledException e)
+            {
+                throw new QueryImportJobCancelledException();
+            }
+
+        }
+        _currentRow++;
+        return true;
+    }
+
+    @Override
+    public Object get(int i)
+    {
+        return _data.get(i);
+    }
+
+
+    @Override
+    public Supplier<Object> getSupplier(int i)
+    {
+        return _data.getSupplier(i);
+    }
+
+
+    @Override
+    public void close() throws IOException
+    {
+        _data.close();
+    }
+
+}

--- a/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
@@ -307,6 +307,9 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
             context.getDontUpdateColumnNames().addAll(unusedColNames);
         }
 
+        if (context.isBackgroundJob())
+            last = new QueryImportJobStatusCheckDataIterator(last, context, 1000);
+
         return LoggingDataIterator.wrap(ErrorIterator.wrap(last, context, false, setupError));
     }
 

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -788,6 +788,11 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
 
     public static DataIteratorContext createDataIteratorContext(QueryUpdateService.InsertOption insertOption, Map<Params, Boolean> optionParamsMap, @Nullable AuditBehaviorType auditBehaviorType, @Nullable String auditUserComment, BatchValidationException errors, @Nullable Logger logger, @Nullable Container container)
     {
+        return createDataIteratorContext(insertOption, optionParamsMap, auditBehaviorType, auditUserComment, errors, logger, container, null);
+    }
+
+    public static DataIteratorContext createDataIteratorContext(QueryUpdateService.InsertOption insertOption, Map<Params, Boolean> optionParamsMap, @Nullable AuditBehaviorType auditBehaviorType, @Nullable String auditUserComment, BatchValidationException errors, @Nullable Logger logger, @Nullable Container container, QueryImportPipelineJob importJob)
+    {
         boolean importLookupByAlternateKey = optionParamsMap.getOrDefault(AbstractQueryImportAction.Params.importLookupByAlternateKey, false);
         boolean importIdentity = optionParamsMap.getOrDefault(AbstractQueryImportAction.Params.importIdentity, false);
         boolean crossTypeImport = optionParamsMap.getOrDefault(AbstractQueryImportAction.Params.crossTypeImport, false);
@@ -796,6 +801,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         boolean useTransactionAuditCache = optionParamsMap.getOrDefault(Params.useTransactionAuditCache, false);
 
         DataIteratorContext context = new DataIteratorContext(errors);
+        context.setBackgroundJob(importJob);
         context.setInsertOption(insertOption);
         context.setAllowImportLookupByAlternateKey(importLookupByAlternateKey);
         if (auditBehaviorType != null)

--- a/api/src/org/labkey/api/query/QueryImportJobCancelledException.java
+++ b/api/src/org/labkey/api/query/QueryImportJobCancelledException.java
@@ -1,0 +1,7 @@
+package org.labkey.api.query;
+
+import org.labkey.api.pipeline.CancelledException;
+
+public class QueryImportJobCancelledException extends CancelledException
+{
+}

--- a/api/src/org/labkey/api/query/QueryImportPipelineJob.java
+++ b/api/src/org/labkey/api/query/QueryImportPipelineJob.java
@@ -306,6 +306,16 @@ public class QueryImportPipelineJob extends PipelineJob
                 notificationProvider.onJobSuccess(this, results);
             }
         }
+        catch (QueryImportJobCancelledException e)
+        {
+            // don't call error() as it would set import status to ERROR, instead of CANCELLED
+            // don't log exception stacktrace as it's not informative
+            if (getLogger() != null)
+                info("Import cancelled");
+
+            if (notificationProvider != null)
+                notificationProvider.onJobError(this, e.getMessage());
+        }
         catch (Exception e)
         {
             error("Import failed", e);
@@ -325,7 +335,7 @@ public class QueryImportPipelineJob extends PipelineJob
 
     private DataIteratorContext createDataIteratorContext(BatchValidationException errors, Container container)
     {
-        return AbstractQueryImportAction.createDataIteratorContext(_importContextBuilder.getInsertOption(), _importContextBuilder.getOptionParamsMap(), _importContextBuilder.getAuditBehaviorType(), _importContextBuilder.getAuditUserComment(), errors, getLogger(), container);
+        return AbstractQueryImportAction.createDataIteratorContext(_importContextBuilder.getInsertOption(), _importContextBuilder.getOptionParamsMap(), _importContextBuilder.getAuditBehaviorType(), _importContextBuilder.getAuditUserComment(), errors, getLogger(), container, this);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
status-cancelStatus.api sets the job status to Cancelling, which doesn't cancel the job is the job is already in RUNNING status. This PR modifies sample and dataclass async import process to check the job status every 1000 rows so a running job can be cancelled. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/482
- https://github.com/LabKey/platform/pull/5728
- https://github.com/LabKey/limsModules/pull/525

#### Changes
- added a new QueryImportJobStatusCheckDataIterator to check job status for every 1000 rows during async import
- Use a new QueryImportJobCancelledException to bypass setting job status to error in the case of a regular job cancellation
