### PR TITLE
Overridable Role Impersonation

### DIFF
--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -398,7 +398,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
         _lastActivity = lastActivity;
     }
 
-    public void setImpersonationContext(ImpersonationContext impersonationContext)
+    void setImpersonationContext(ImpersonationContext impersonationContext)
     {
         _impersonationContext = impersonationContext;
     }

--- a/api/src/org/labkey/api/security/User.java
+++ b/api/src/org/labkey/api/security/User.java
@@ -398,7 +398,7 @@ public class User extends UserPrincipal implements Serializable, Cloneable, JSON
         _lastActivity = lastActivity;
     }
 
-    void setImpersonationContext(ImpersonationContext impersonationContext)
+    public void setImpersonationContext(ImpersonationContext impersonationContext)
     {
         _impersonationContext = impersonationContext;
     }

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -194,13 +194,13 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
             .filter(role -> !role.isPrivileged() || canImpersonatePrivilegedRoles);
     }
 
-    private static class RoleImpersonationContext extends AbstractImpersonationContext
+    public static class RoleImpersonationContext extends AbstractImpersonationContext
     {
         private final RoleSet _roles;
         private final String _cacheKey;
 
         @JsonCreator
-        private RoleImpersonationContext(
+        public RoleImpersonationContext(
                 @JsonProperty("_project") @Nullable Container project,
                 @JsonProperty("_adminUser") User adminUser,
                 @JsonProperty("_roles") RoleSet roles,
@@ -297,6 +297,11 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         {
             super.addMenu(menu, c, user, currentURL);
             RoleImpersonationContextFactory.addMenu(menu, "Adjust Impersonation");
+        }
+
+        public RoleSet getRoles()
+        {
+            return _roles;
         }
     }
 }

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -200,7 +200,7 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         private final String _cacheKey;
 
         @JsonCreator
-        public RoleImpersonationContext(
+        private RoleImpersonationContext(
                 @JsonProperty("_project") @Nullable Container project,
                 @JsonProperty("_adminUser") User adminUser,
                 @JsonProperty("_roles") RoleSet roles,


### PR DESCRIPTION
#### Rationale
SND uses non-container based permissions. These are tested, both manually and automated, using role impersonation. The recent change to role impersonation makes that testing not possible. This change allows the role impersonation context to be overridden.

#### Related Pull Requests
- https://github.com/LabKey/snd/pull/207

#### Changes
- Make RoleImpersonationContext public
- Make roles available in getter
