### PR TITLE
Issue 50939: Mutation event used in DataRegion removed from browsers

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -4115,7 +4115,8 @@ if (!LABKEY.DataRegions) {
             timeout,
             locked = false,
             lastLeft = 0,
-            pos = [ 0, 0, 0, 0 ];
+            pos = [ 0, 0, 0, 0 ],
+            domObserver = null;
 
         // init
         var floatRow = headerRow
@@ -4183,8 +4184,11 @@ if (!LABKEY.DataRegions) {
                     .unbind('load', domTask)
                     .unbind('resize', resizeTask)
                     .unbind('scroll', onScroll);
-            $(document)
-                    .unbind('DOMNodeInserted', domTask);
+
+            if (domObserver) {
+                domObserver.disconnect();
+                domObserver = null;
+            }
         };
 
         /**
@@ -4300,8 +4304,12 @@ if (!LABKEY.DataRegions) {
                 .one('load', domTask)
                 .on('resize', resizeTask)
                 .on('scroll', onScroll);
-        $(document)
-                .on('DOMNodeInserted', domTask); // Issue 13121
+
+        domObserver = new MutationObserver(mutationList =>
+                mutationList.filter(m => m.type === 'childList').forEach(m => {
+                    m.addedNodes.forEach(domTask);
+                }));
+        domObserver.observe(document,{childList: true, subtree: true}); // Issue 13121, 50939
 
         // ensure that resize/scroll fire at the end of initialization
         domTask();


### PR DESCRIPTION
#### Rationale
Chrome and Firefox have dropped support for a collection of DOM listeners. We rely on one of them to make sure that LKS-rendered grids lock their column headers correctly.

#### Changes
- Backport the switch to a MutationObserver