### PR TITLE
Plates: throw exception and resume indexing via rollback

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2421,6 +2421,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         try (DbScope.Transaction tx = ensureTransaction())
         {
             pausePlateIndexing();
+            tx.addCommitTask(this::resumePlateIndexing, DbScope.CommitTaskOption.POSTCOMMIT, DbScope.CommitTaskOption.POSTROLLBACK);
+
             List<Plate> platesAdded = new ArrayList<>();
 
             for (var plate : plates)
@@ -2433,15 +2435,9 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 platesAdded.add(createAndSavePlate(container, user, plateImpl, plateSetId, plate.data));
             }
 
-            tx.addCommitTask(this::resumePlateIndexing, DbScope.CommitTaskOption.POSTCOMMIT);
             tx.commit();
 
             return platesAdded;
-        }
-        catch (Exception e)
-        {
-            resumePlateIndexing();
-            throw UnexpectedException.wrap(e);
         }
     }
 


### PR DESCRIPTION
#### Rationale
This changes the pattern for exception handling when adding plates to a plate set to allow the exception to be thrown and resume indexing via commit task.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5697

#### Changes
- Remove wrapping of exception.
- Resume plate indexing via `CommitTaskOption.POSTROLLBACK`.
