### PR TITLE
Remove deprecated report designer method

### DIFF
--- a/api/src/org/labkey/api/module/SimpleFolderType.java
+++ b/api/src/org/labkey/api/module/SimpleFolderType.java
@@ -54,11 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * User: brittp
- * Date: Apr 19, 2010
- * Time: 4:20:27 PM
- */
 public class SimpleFolderType extends MultiPortalFolderType
 {
     private static final Logger LOG = LogHelper.getLogger(SimpleFolderType.class, "File-based folder types");
@@ -107,7 +102,7 @@ public class SimpleFolderType extends MultiPortalFolderType
             _folderTabs = createDefaultTab(type);
         }
 
-        if (_folderTabs.size() > 0)
+        if (!_folderTabs.isEmpty())
         {
             _defaultTab = _folderTabs.get(0);
             _folderTabs.get(0).setIsDefaultTab(true);

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -676,7 +676,7 @@ public class QueryView extends WebPartView<Object>
                 bean.setDataRegionName(getDataRegionName());
 
                 bean.setRedirectUrl(getReturnURL().getLocalURIString());
-                return ReportUtil.getRReportDesignerURL(_viewContext, bean);
+                return ReportUtil.getScriptReportDesignerURL(_viewContext, bean);
         }
         return ret;
     }

--- a/api/src/org/labkey/api/reports/report/view/DefaultReportUIProvider.java
+++ b/api/src/org/labkey/api/reports/report/view/DefaultReportUIProvider.java
@@ -83,7 +83,7 @@ public class DefaultReportUIProvider implements ReportService.UIProvider
         bean.setReportType(type);
         bean.setRedirectUrl(context.getActionURL().toString());
 
-        ActionURL designerURL = ReportUtil.getRReportDesignerURL(context, bean);
+        ActionURL designerURL = ReportUtil.getScriptReportDesignerURL(context, bean);
         designerURL = addForwardParams(designerURL, context, params);
 
         Report report = ReportService.get().createReportInstance(type);

--- a/api/src/org/labkey/api/reports/report/view/ReportUtil.java
+++ b/api/src/org/labkey/api/reports/report/view/ReportUtil.java
@@ -88,12 +88,6 @@ import java.util.regex.Pattern;
 
 public class ReportUtil
 {
-    @Deprecated // use getScriptReportDesignerURL instead
-    public static ActionURL getRReportDesignerURL(ViewContext context, ScriptReportBean bean)
-    {
-        return getScriptReportDesignerURL(context, bean);
-    }
-
     public static ActionURL getScriptReportDesignerURL(ViewContext context, ScriptReportBean bean)
     {
         ActionURL url = PageFlowUtil.urlProvider(ReportUrls.class).urlCreateScriptReport(context.getContainer());

--- a/core/resources/scripts/labkey/Security.js
+++ b/core/resources/scripts/labkey/Security.js
@@ -28,7 +28,7 @@ LABKEY.Security = new function()
     return {
 
         /**
-         * @deprecated Do not use this anymore! Use effectivePermissions instead.
+         * @deprecated Do not use this! Use effectivePermissions instead.
          */
         permissions : {
             read: 1,
@@ -1419,7 +1419,7 @@ LABKEY.Security = new function()
          */
         addGroupMembers : function(config)
         {
-            var params = {
+            const params = {
                 groupId: config.groupId,
                 principalIds: (LABKEY.Utils.isArray(config.principalIds) ? config.principalIds : [config.principalIds])
             };
@@ -1463,7 +1463,7 @@ LABKEY.Security = new function()
          */
         removeGroupMembers : function(config)
         {
-            var params = {
+            const params = {
                 groupId: config.groupId,
                 principalIds: (LABKEY.Utils.isArray(config.principalIds) ? config.principalIds : [config.principalIds])
             };
@@ -1507,7 +1507,7 @@ LABKEY.Security = new function()
          */
         createNewUser : function(config)
         {
-            var params = {
+            const params = {
                 email: config.email,
                 sendEmail: config.sendEmail,
                 optionalMessage: config.optionalMessage

--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -16,6 +16,10 @@
 
 package org.labkey.core.portal;
 
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -94,10 +98,6 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
-import jakarta.servlet.RequestDispatcher;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1581,7 +1581,7 @@ public class ProjectController extends SpringActionController
                 List<Map<String, Object>> children = getVisibleChildren(container, user, propertiesToSerialize, 0, form);
                 resultMap.put("children", children);
 
-                if (children.size() > 0)
+                if (!children.isEmpty())
                 {
                     // If user has permissions to at least one child container, then make sure that at least the
                     // parent name is shown (even if the user doesn't have permission in the parent container)

--- a/query/src/org/labkey/query/controllers/OlapController.java
+++ b/query/src/org/labkey/query/controllers/OlapController.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.query.controllers;
 
+import jakarta.servlet.http.HttpServletResponse;
 import mondrian.olap.Annotated;
 import mondrian.olap.Annotation;
 import mondrian.olap.MondrianException;
@@ -108,7 +109,6 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
-import jakarta.servlet.http.*;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -1138,7 +1138,7 @@ public class OlapController extends SpringActionController
             _cube = cube;
             return _cube;
         }
-        catch (SQLException|IOException x)
+        catch (SQLException x)
         {
             throw new ConfigurationException("Error getting mondrian connection", x);
         }

--- a/query/src/org/labkey/query/olap/BitSetQueryImpl.java
+++ b/query/src/org/labkey/query/olap/BitSetQueryImpl.java
@@ -1351,8 +1351,6 @@ public class BitSetQueryImpl
         return new MemberSetResult(set);
     }
 
-
-
     //
     // special optimized subset of query/mdx functionality
     // this method supports:
@@ -1370,10 +1368,10 @@ public class BitSetQueryImpl
             columnsExpr = processExpr(qq.onColumns);
         if (null != qq.onRows)
             rowsExpr = processExpr(qq.onRows);
-        if (null != qq.countFilters && qq.countFilters.arguments.size() > 0)
+        if (null != qq.countFilters && !qq.countFilters.arguments.isEmpty())
             countFilterExpr = processExpr(qq.countFilters);
 
-        if (null != qq.whereFilters && qq.whereFilters.arguments.size() > 0)
+        if (null != qq.whereFilters && !qq.whereFilters.arguments.isEmpty())
             whereFilterExpr = processExpr(qq.whereFilters);
 
         CellSet ret;

--- a/query/src/org/labkey/query/olap/ServerManager.java
+++ b/query/src/org/labkey/query/olap/ServerManager.java
@@ -222,9 +222,8 @@ public class ServerManager
         return ret;
     }
 
-
     public static Cube getCachedCube(@NotNull OlapSchemaDescriptor sd, OlapConnection conn, final Container c, final User user, String schemaName, String cubeName, BindException errors)
-            throws SQLException, IOException
+            throws SQLException
     {
         if (!sd.usesMondrian())
             return getCachedCubeRolap(sd, c, user, cubeName, null);
@@ -287,7 +286,7 @@ public class ServerManager
     }
 
     public static Cube getCachedCubeRolap(OlapSchemaDescriptor d, final Container c, final User user, String cubeName, @Nullable final UserSchema schema)
-            throws SQLException, IOException
+            throws SQLException
     {
         RolapCubeDef rolap = d.getRolapCubeDefinitionByName(cubeName);
 
@@ -494,7 +493,7 @@ public class ServerManager
             result = "Warming the " + cubeName + " in container " + fullContainerPath + " took: " + DateUtil.formatDuration(end - start);
             LOG.info(result);
         }
-        catch(Exception e)
+        catch (Exception e)
         {
             result = "Error trying to warm the " + cubeName + " in container " + c.getName();
             LOG.warn(result, e);
@@ -542,8 +541,6 @@ public class ServerManager
                 ref.decrement();
         }
     }
-
-
 
     /*
      * This is to support XmlaServlet, don't hang on to this for more than one request.  If you need to hold on

--- a/search/build.gradle
+++ b/search/build.gradle
@@ -280,8 +280,8 @@ dependencies {
             "XZ for Java",
             "tukaani.org",
             "https://tukaani.org/xz/java.html",
-            "public",
-            "https://tukaani.org/xz/java.html#Licensing",
+            "BSD Zero Clause",
+            "https://tukaani.org/xz/java.html#:~:text=Licensing",
             "Transitive dependency of commons-compress to support additional compression types for search"
         )
     )


### PR DESCRIPTION
#### Related Pull Requests
- https://github.com/LabKey/commonAssays/pull/784

#### Changes
- Use `getScriptReportDesignerURL()` and remove the deprecated method
- License change and link for Tukaani XZ
- Address some warnings
