### PR TITLE
Plate: Respect target plate set name/description in reformat

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3684,8 +3684,14 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         {
             plateSet = new PlateSetImpl();
             plateSet.setType(targetPlateSetOptions.getType());
-            if (StringUtils.trimToNull(targetPlateSetOptions.getDescription()) != null)
-                plateSet.setDescription(targetPlateSetOptions.getDescription());
+
+            String plateSetName = StringUtils.trimToNull(targetPlateSetOptions.getName());
+            if (plateSetName != null)
+                plateSet.setName(plateSetName);
+
+            String description = StringUtils.trimToNull(targetPlateSetOptions.getDescription());
+            if (description != null)
+                plateSet.setDescription(description);
         }
 
         return plateSet;


### PR DESCRIPTION
#### Rationale
Fixes reformatting creation of a new plate set to respect user specified plate set name and description.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/488
- https://github.com/LabKey/limsModules/pull/546
- https://github.com/LabKey/platform/pull/5744

#### Changes
- Respect name and description from target plate set during reformatting
