### PR TITLE
Issue 45594: Update lineage for run/result sample lookups

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -2119,8 +2119,8 @@ public abstract class AbstractAssayProvider implements AssayProvider
         ExpRun run,
         Map<String, Object> row,
         boolean isRunProperties,
-        @Nullable RemapCache cache,
-        @Nullable Map<Integer, ExpMaterial> materialsCache
+        @NotNull RemapCache cache,
+        @NotNull Map<Integer, ExpMaterial> materialsCache
     ) throws ValidationException
     {
         Domain domain = table.getDomain();
@@ -2151,7 +2151,7 @@ public abstract class AbstractAssayProvider implements AssayProvider
                     }
 
                     ExpSampleType sampleType = ExperimentService.get().getLookupSampleType(dp, container, user);
-                    ExpMaterial newInputMaterial = ExperimentService.get().resolveExpMaterial(container, user, entry.getValue(), sampleType, cache, materialsCache);
+                    ExpMaterial newInputMaterial = ExperimentService.get().findExpMaterial(container, user, entry.getValue(), sampleType, cache, materialsCache);
                     if (newInputMaterial != null)
                     {
                         // Prevent direct cycles

--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -2139,7 +2139,11 @@ public abstract class AbstractAssayProvider implements AssayProvider
             if (!isRunProperties || column instanceof PropertyColumn)
             {
                 DomainProperty dp = domain.getPropertyByURI(column.getPropertyURI());
-                if (dp != null && ExperimentService.get().isLookupToMaterials(dp))
+                if (dp == null)
+                    continue;
+
+                ExpSampleType sampleType = ExperimentService.get().getLookupSampleType(dp, container, user);
+                if (sampleType != null || ExperimentService.get().isLookupToMaterials(dp))
                 {
                     String inputRole = AssayService.get().getPropertyInputLineageRole(dp);
 
@@ -2150,7 +2154,6 @@ public abstract class AbstractAssayProvider implements AssayProvider
                             removedMaterialInputs.add(materialEntry.getKey().getRowId());
                     }
 
-                    ExpSampleType sampleType = ExperimentService.get().getLookupSampleType(dp, container, user);
                     ExpMaterial newInputMaterial = ExperimentService.get().findExpMaterial(container, user, entry.getValue(), sampleType, cache, materialsCache);
                     if (newInputMaterial != null)
                     {

--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -2141,13 +2141,12 @@ public abstract class AbstractAssayProvider implements AssayProvider
                 DomainProperty dp = domain.getPropertyByURI(column.getPropertyURI());
                 if (dp != null && ExperimentService.get().isLookupToMaterials(dp))
                 {
-                    String inputRole = AssayService.get().getInputRole(dp, false);
-                    String deprecatedInputRole = AssayService.get().getInputRole(dp, true);
+                    String inputRole = AssayService.get().getPropertyInputLineageRole(dp);
 
                     // Remove all material inputs with the same role
                     for (var materialEntry : run.getMaterialInputs().entrySet())
                     {
-                        if (inputRole.equalsIgnoreCase(materialEntry.getValue()) || deprecatedInputRole.equalsIgnoreCase(materialEntry.getValue()))
+                        if (inputRole.equalsIgnoreCase(materialEntry.getValue()))
                             removedMaterialInputs.add(materialEntry.getKey().getRowId());
                     }
 

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -661,17 +661,18 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
     /**
      * @param rowBasedInputMaterials the map of materials that are inputs to this run based on the data rows
      */
-    private DataIterator checkData(Container container,
-                                               User user,
-                                               TableInfo dataTable,
-                                               Domain dataDomain,
-                                               DataIterator rawData,
-                                               DataLoaderSettings settings,
-                                               ParticipantVisitResolver resolver,
-                                               Map<String, ExpMaterial> inputMaterials,
-                                               ContainerFilter containerFilter,
-                                               Map<ExpMaterial, String> rowBasedInputMaterials)
-            throws BatchValidationException
+    private DataIterator checkData(
+        Container container,
+        User user,
+        TableInfo dataTable,
+        Domain dataDomain,
+        DataIterator rawData,
+        DataLoaderSettings settings,
+        ParticipantVisitResolver resolver,
+        Map<String, ExpMaterial> inputMaterials,
+        ContainerFilter containerFilter,
+        Map<ExpMaterial, String> rowBasedInputMaterials
+    ) throws BatchValidationException
     {
         final ExperimentService exp = ExperimentService.get();
 
@@ -892,7 +893,6 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                                 errors.add(new PropertyValidationError(columnName + " must be a valid MV indicator.", columnName));
                             }
                         }
-
                     }
                     else
                     {
@@ -1105,7 +1105,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
 
     /** Wraps each map in a version that can be queried based on any of the aliases (name, property URI, import
-     * aliases, etc for a given property */
+     * aliases, etc.) for a given property */
     protected DataIterator convertPropertyNamesToURIs(DataIterator dataMaps, Domain domain)
     {
         // Get the mapping of different names to the set of domain properties

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -730,19 +730,15 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             }
             else
             {
-                ExpSampleType st = DefaultAssayRunCreator.getLookupSampleType(pd, container, user);
+                ExpSampleType st = ExperimentService.get().getLookupSampleType(pd, container, user);
                 if (st != null)
                 {
                     if (pd.getPropertyType().getJdbcType().isText())
-                    {
                         lookupToSampleTypeByName.put(pd, st);
-                    }
                     else
-                    {
                         lookupToSampleTypeById.put(pd, st);
-                    }
                 }
-                else if (DefaultAssayRunCreator.isLookupToMaterials(pd))
+                else if (ExperimentService.get().isLookupToMaterials(pd))
                 {
                     if (pd.getPropertyType().getJdbcType().isText())
                         lookupToAllSamplesByName.add(pd);
@@ -994,7 +990,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
                         if (material != null)
                         {
-                            rowBasedInputMaterials.putIfAbsent(material, pd.getName());
+                            rowBasedInputMaterials.putIfAbsent(material, AssayService.get().getInputRole(pd, false));
                             rowInputLSIDs.add(material.getLSID());
 
                             // If the lookup was defined with an explicit container, verify that the sample is in that container

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -990,7 +990,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
                         if (material != null)
                         {
-                            rowBasedInputMaterials.putIfAbsent(material, AssayService.get().getInputRole(pd, false));
+                            rowBasedInputMaterials.putIfAbsent(material, AssayService.get().getPropertyInputLineageRole(pd));
                             rowInputLSIDs.add(material.getLSID());
 
                             // If the lookup was defined with an explicit container, verify that the sample is in that container

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -963,7 +963,6 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                     if (o != null && (isSampleLookupById || isSampleLookupByName))
                     {
                         ExpSampleType byNameSS = isSampleLookupByName ? lookupToSampleTypeByName.get(pd) : lookupToSampleTypeById.get(pd);
-                        String ssName = byNameSS != null ? byNameSS.getName() : null;
                         Container lookupContainer = pd.getLookup().getContainer() != null ? pd.getLookup().getContainer() : container;
 
                         // Issue 47509: When samples have names that are numbers, they can be incorrectly interpreted as rowIds during the insert.
@@ -978,7 +977,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                             try
                             {
                                 if (material == null)
-                                    material = exp.findExpMaterial(lookupContainer, user, byNameSS, ssName, materialName, cache, materialCache);
+                                    material = exp.findExpMaterial(lookupContainer, user, materialName, byNameSS, cache, materialCache);
                             }
                             catch (ValidationException ve)
                             {

--- a/api/src/org/labkey/api/assay/AssayProvider.java
+++ b/api/src/org/labkey/api/assay/AssayProvider.java
@@ -23,6 +23,7 @@ import org.labkey.api.assay.actions.AssayRunUploadForm;
 import org.labkey.api.assay.pipeline.AssayRunAsyncContext;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.RemapCache;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Handler;
@@ -31,6 +32,7 @@ import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpExperiment;
+import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.IAssayDomainType;
@@ -379,11 +381,20 @@ public interface AssayProvider extends Handler<ExpProtocol>
     }
 
     /**
-     * Some assay implementations support experiment lineage representation of run property values.
-     * This can be called during the update of a run to ensure the associated lineage is updated when run property
-     * values change.
+     * Some assay implementations support experiment lineage representation of run/result property values.
+     * This can be called during the update of a run/result to ensure the associated lineage is updated when
+     * associated run/result property values change.
      */
-    default void updateRunPropertyLineage(Container container, User user, TableInfo runsTable, ExpRun run, Map<String, Object> row) throws ValidationException
+    default void updatePropertyLineage(
+        Container container,
+        User user,
+        TableInfo table,
+        ExpRun run,
+        Map<String, Object> row,
+        boolean isRunProperties,
+        @Nullable RemapCache cache,
+        @Nullable Map<Integer, ExpMaterial> materialsCache
+    ) throws ValidationException
     {
     }
 }

--- a/api/src/org/labkey/api/assay/AssayProvider.java
+++ b/api/src/org/labkey/api/assay/AssayProvider.java
@@ -23,6 +23,7 @@ import org.labkey.api.assay.actions.AssayRunUploadForm;
 import org.labkey.api.assay.pipeline.AssayRunAsyncContext;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Handler;
 import org.labkey.api.exp.Lsid;
@@ -64,13 +65,10 @@ import java.util.Set;
 
 /**
  * An AssayProvider is the main implementation point for participating in the overall assay framework. It provides
- * UI, data parsing, configuration, etc for distinct types of assay data. A full, custom AssayProvider implementation
+ * UI, data parsing, configuration, etc. for distinct types of assay data. A full, custom AssayProvider implementation
  * will rely on a variety of other implementation classes, but the AssayProvider is the coordinating point that
  * knows what those other classes are. A typical implementation approach is mix and match with custom and standard
  * implementations to hook in assay-specific customizations.
- *
- * User: brittp
- * Date: Jul 11, 2007
  */
 public interface AssayProvider extends Handler<ExpProtocol>
 {
@@ -105,7 +103,7 @@ public interface AssayProvider extends Handler<ExpProtocol>
 
     AssayRunCreator getRunCreator();
 
-    /** @return all of the legal data collectors that the user can choose from for the current import attempt */
+    /** @return all the legal data collectors that the user can choose from for the current import attempt */
     List<AssayDataCollector> getDataCollectors(Map<String, File> uploadedFiles, AssayRunUploadForm context);
 
     /**
@@ -114,7 +112,7 @@ public interface AssayProvider extends Handler<ExpProtocol>
      */
     String getName();
 
-    /** A user-facing short name for the assay provider. Typically matches the official name, but handy for renames */
+    /** A user-facing short name for the assay provider. Typically, matches the official name, but handy for renames */
     default String getLabel()
     {
         return getName();
@@ -364,7 +362,10 @@ public interface AssayProvider extends Handler<ExpProtocol>
      * @return the number of result rows loaded for the given designs, or null if not implemented
      * @param protocols all protocols for this assay provider
      */
-    default Long getResultRowCount(List<? extends ExpProtocol> protocols) { return null; }
+    default Long getResultRowCount(List<? extends ExpProtocol> protocols)
+    {
+        return null;
+    }
 
     void moveRuns(List<ExpRun> runs, Container targetContainer, User user, AbstractAssayProvider.AssayMoveData assayMoveData);
 
@@ -377,5 +378,12 @@ public interface AssayProvider extends Handler<ExpProtocol>
         return false;
     }
 
-
+    /**
+     * Some assay implementations support experiment lineage representation of run property values.
+     * This can be called during the update of a run to ensure the associated lineage is updated when run property
+     * values change.
+     */
+    default void updateRunPropertyLineage(Container container, User user, TableInfo runsTable, ExpRun run, Map<String, Object> row) throws ValidationException
+    {
+    }
 }

--- a/api/src/org/labkey/api/assay/AssayProvider.java
+++ b/api/src/org/labkey/api/assay/AssayProvider.java
@@ -392,8 +392,8 @@ public interface AssayProvider extends Handler<ExpProtocol>
         ExpRun run,
         Map<String, Object> row,
         boolean isRunProperties,
-        @Nullable RemapCache cache,
-        @Nullable Map<Integer, ExpMaterial> materialsCache
+        @NotNull RemapCache cache,
+        @NotNull Map<Integer, ExpMaterial> materialsCache
     ) throws ValidationException
     {
     }

--- a/api/src/org/labkey/api/assay/AssayRunUploadContextImpl.java
+++ b/api/src/org/labkey/api/assay/AssayRunUploadContextImpl.java
@@ -49,10 +49,6 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
-/**
- * User: kevink
- * Date: 12/18/13
- */
 public class AssayRunUploadContextImpl<ProviderType extends AssayProvider> implements AssayRunUploadContext<ProviderType>
 {
     private static final String FILE_INPUT_NAME = "file";
@@ -134,20 +130,13 @@ public class AssayRunUploadContextImpl<ProviderType extends AssayProvider> imple
 
     public static class Factory<ProviderType extends AssayProvider> extends AssayRunUploadContext.Factory<ProviderType, Factory<ProviderType>>
     {
-        public Factory(
-                @NotNull ExpProtocol protocol,
-                @NotNull ProviderType provider,
-                @NotNull ViewContext context)
+        public Factory(@NotNull ExpProtocol protocol, @NotNull ProviderType provider, @NotNull ViewContext context)
         {
             super(protocol, provider, context.getUser(), context.getContainer());
             setViewContext(context);
         }
 
-        public Factory(
-                @NotNull ExpProtocol protocol,
-                @NotNull ProviderType provider,
-                @NotNull User user,
-                @NotNull Container container)
+        public Factory(@NotNull ExpProtocol protocol, @NotNull ProviderType provider, @NotNull User user, @NotNull Container container)
         {
             super(protocol, provider, user, container);
         }
@@ -341,28 +330,28 @@ public class AssayRunUploadContextImpl<ProviderType extends AssayProvider> imple
 
     @NotNull
     @Override
-    public Map<? extends Object, String> getInputDatas()
+    public Map<?, String> getInputDatas()
     {
         return _inputDatas;
     }
 
     @NotNull
     @Override
-    public Map<? extends Object, String> getOutputDatas()
+    public Map<?, String> getOutputDatas()
     {
         return _outputDatas;
     }
 
     @NotNull
     @Override
-    public Map<? extends Object, String> getInputMaterials()
+    public Map<?, String> getInputMaterials()
     {
         return _inputMaterials;
     }
 
     @NotNull
     @Override
-    public Map<? extends Object, String> getOutputMaterials()
+    public Map<?, String> getOutputMaterials()
     {
         return _outputMaterials;
     }
@@ -459,6 +448,4 @@ public class AssayRunUploadContextImpl<ProviderType extends AssayProvider> imple
     {
         _autoFillDefaultResultColumns = autoFill;
     }
-
-
 }

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -30,6 +30,7 @@ import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
+import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.ExpRunTable;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.search.SearchService;
@@ -244,6 +245,8 @@ public interface AssayService
      */
     @NotNull Collection<Map<String, Object>> checkResults(Container container, User user, ExpProtocol protocol, ResultsCheckHelper checker);
     @NotNull <E> Collection<E> checkResults(Container container, User user, ExpProtocol protocol, ResultsCheckHelper checker, Class<E> clazz);
+
+    @NotNull String getInputRole(@NotNull DomainProperty dp, boolean useDeprecated);
 
     interface ResultsCheckHelper
     {

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -246,7 +246,8 @@ public interface AssayService
     @NotNull Collection<Map<String, Object>> checkResults(Container container, User user, ExpProtocol protocol, ResultsCheckHelper checker);
     @NotNull <E> Collection<E> checkResults(Container container, User user, ExpProtocol protocol, ResultsCheckHelper checker, Class<E> clazz);
 
-    @NotNull String getInputRole(@NotNull DomainProperty dp, boolean useDeprecated);
+    /** Returns the lineage "role" for an assay run/result property. */
+    @NotNull String getPropertyInputLineageRole(@NotNull DomainProperty dp);
 
     interface ResultsCheckHelper
     {

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -840,7 +840,7 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
         for (Map.Entry<?, String> entry : unresolved.entrySet())
         {
             Object sampleIdentifier = entry.getKey();
-            ExpMaterial material = ExperimentService.get().resolveExpMaterial(context.getContainer(), context.getUser(), sampleIdentifier, sampleType, cache, materialCache);
+            ExpMaterial material = ExperimentService.get().findExpMaterial(context.getContainer(), context.getUser(), sampleIdentifier, sampleType, cache, materialCache);
             if (material == null)
                 throw new ExperimentException("Unable to resolve sample: " + sampleIdentifier);
 

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -626,10 +626,8 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
                 continue;
 
             ExpSampleType st = ExperimentService.get().getLookupSampleType(dp, context.getContainer(), context.getUser());
-            if (st == null)
-                continue;
+            String role = AssayService.get().getPropertyInputLineageRole(dp);
 
-            String role = AssayService.get().getInputRole(dp, false);
             addMaterials(context, inputMaterials, Map.of(value, role), st, cache, materialCache);
         }
     }

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -622,12 +622,11 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
 
             // Lookup must point at "Samples.*", "exp.materials.*", or "exp.Materials"
             DomainProperty dp = entry.getKey();
-            if (!ExperimentService.get().isLookupToMaterials(dp))
+            ExpSampleType st = ExperimentService.get().getLookupSampleType(dp, context.getContainer(), context.getUser());
+            if (st == null && !ExperimentService.get().isLookupToMaterials(dp))
                 continue;
 
-            ExpSampleType st = ExperimentService.get().getLookupSampleType(dp, context.getContainer(), context.getUser());
             String role = AssayService.get().getPropertyInputLineageRole(dp);
-
             addMaterials(context, inputMaterials, Map.of(value, role), st, cache, materialCache);
         }
     }

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -302,8 +302,8 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
             resolveParticipantVisits(context, inputMaterials, inputDatas, outputMaterials, outputDatas, allProperties, resolverType);
 
             // Check for circular inputs/outputs
-            ExperimentService.get().checkForCycles(inputMaterials, outputMaterials.keySet());
-            ExperimentService.get().checkForCycles(inputDatas, outputDatas.keySet());
+            checkForCycles(inputMaterials, outputMaterials);
+            checkForCycles(inputDatas, outputDatas);
 
             // Create the batch, if needed
             if (batch == null)

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -50,7 +50,6 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.TabLoader;
 import org.labkey.api.security.User;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
@@ -254,7 +253,7 @@ public class NameGenerator
     private final Map<String, ExpDataClass> _dataClasses = new HashMap<>();
     private final Map<Integer, ExpMaterial> materialCache = new HashMap<>();
     private final Map<Integer, ExpData> dataCache = new HashMap<>();
-    private RemapCache renameCache;
+    private final RemapCache renameCache;
     private final Map<String, Map<String, Object>> objectPropertiesCache = new HashMap<>();
 
     private final Container _container;
@@ -1878,7 +1877,7 @@ public class NameGenerator
             try
             {
                 ExpRunItem parentObject = isMaterialParent ?
-                        ExperimentService.get().findExpMaterial(_container, _user, (ExpSampleType) parentObjectType, parentTypeName, parentName, renameCache, materialCache)
+                        ExperimentService.get().findExpMaterial(_container, _user, parentName, (ExpSampleType) parentObjectType, renameCache, materialCache)
                         : ExperimentService.get().findExpData(_container, _user, (ExpDataClass) parentObjectType, parentTypeName, parentName, renameCache, dataCache);
 
                 if (parentObject == null)

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -832,13 +832,13 @@ public class NameGenerator
         for (ExpObject dataType : dataTypes)
         {
             Domain domain = null;
-            if (dataType instanceof ExpSampleType)
+            if (dataType instanceof ExpSampleType sampleType)
             {
-                domain = ((ExpSampleType)dataType).getDomain();
+                domain = sampleType.getDomain();
             }
-            else if (dataType instanceof ExpDataClass)
+            else if (dataType instanceof ExpDataClass dataClass)
             {
-                domain = ((ExpDataClass)dataType).getDomain();
+                domain = dataClass.getDomain();
             }
             if (domain != null)
             {

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -18,6 +18,7 @@ import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.dataiterator.DetailedAuditLogDataIterator;
 import org.labkey.api.dataiterator.ListofMapsDataIterator;
 import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.exp.api.DataClassDomainKindProperties;
 import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpObject;
@@ -659,12 +660,13 @@ public class DataGenerator<T extends DataGenerator.Config>
         List<GWTPropertyDescriptor> props = new ArrayList<>();
         addDomainProperties(props, numFields);
 
-        ExperimentService service = ExperimentService.get();
-
         log.info(String.format("Creating Data Class '%s' with %d fields", dataClassName, numFields));
-        return service.createDataClass(_container, _user, dataClassName, "Custom data class with " + numFields + " fields",
-                props, List.of(), null,
-                namingPattern, null, category);
+        DataClassDomainKindProperties options = new DataClassDomainKindProperties();
+        options.setDescription("Custom data class with " + numFields + " fields");
+        options.setNameExpression(namingPattern);
+        options.setCategory(category);
+
+        return ExperimentService.get().createDataClass(_container, _user, dataClassName, options, props, List.of(), null, null);
     }
 
 

--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -2761,7 +2761,7 @@ public class OntologyManager
      * Insert or update an object property value.
      *
      * @param user The user inserting the property - currently only used for validating lookup values.
-     * @param container Insert the property value into the this container.
+     * @param container Insert the property value into this container.
      * @param pd The property descriptor.
      * @param lsid The object on which to attach the properties.
      * @param value The value to insert.

--- a/api/src/org/labkey/api/exp/api/ExpData.java
+++ b/api/src/org/labkey/api/exp/api/ExpData.java
@@ -31,7 +31,7 @@ import java.nio.file.Path;
 import java.sql.SQLException;
 
 /**
- * Represents a virtual experiment object. Typically a file on disk, but could be something pointed at by any URI including S3 objects.
+ * Represents a virtual experiment object. Typically, a file on disk, but could be something pointed at by any URI including S3 objects.
  */
 public interface ExpData extends ExpRunItem
 {

--- a/api/src/org/labkey/api/exp/api/ExpDataClass.java
+++ b/api/src/org/labkey/api/exp/api/ExpDataClass.java
@@ -32,9 +32,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * Category of {@link ExpData}, extended by a Domain with custom properties. Data version of an {@link ExpSampleType}
- * User: kevink
- * Date: 9/15/15
+ * Category of {@link ExpData}, extended by a Domain with custom properties. Data version of an {@link ExpSampleType}.
  */
 public interface ExpDataClass extends ExpObject
 {

--- a/api/src/org/labkey/api/exp/api/ExpProtocolApplication.java
+++ b/api/src/org/labkey/api/exp/api/ExpProtocolApplication.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * An individual step inside of an {@link ExpRun}, which can consume or produce {@link ExpData} or {@link ExpMaterial}
+ * An individual step inside an {@link ExpRun}, which can consume or produce {@link ExpData} or {@link ExpMaterial}
  */
 public interface ExpProtocolApplication extends ExpObject
 {

--- a/api/src/org/labkey/api/exp/api/ExpRun.java
+++ b/api/src/org/labkey/api/exp/api/ExpRun.java
@@ -72,19 +72,19 @@ public interface ExpRun extends ExpObject, Identifiable
     Map<? extends ExpData, String> getDataInputs();
 
     /**
-     * @return all of the materials objects marked as outputs of this run.
-     * This may be a subset of all of the materials that were created by the run if some were intermediate/transient.
+     * @return all the materials objects marked as outputs of this run.
+     * This may be a subset of all the materials that were created by the run if some were intermediate/transient.
      */
     List<ExpMaterial> getMaterialOutputs();
 
     /**
-     * @return all of the data objects marked as outputs of this run.
-     * This may be a subset of all of the files that were created by the run if some were intermediate/transient.
+     * @return all the data objects marked as outputs of this run.
+     * This may be a subset of all the files that were created by the run if some were intermediate/transient.
      */
     List<ExpData> getDataOutputs();
 
     /**
-     * @return all of the data objects referenced by this run,
+     * @return all the data objects referenced by this run,
      * including top-level inputs and outputs, as well as intermediate files
      */
     List<? extends ExpData> getAllDataUsedByRun();
@@ -92,11 +92,11 @@ public interface ExpRun extends ExpObject, Identifiable
 
     List<? extends ExpProtocolApplication> getProtocolApplications();
 
-    /** Get the protocol application that marks all of the inputs to the run as a whole */
-    ExpProtocolApplication getInputProtocolApplication();
+    /** Get the protocol application that marks all the inputs to the run as a whole */
+    @Nullable ExpProtocolApplication getInputProtocolApplication();
 
-    /** Get the protocol application that marks all of the outputs to the run as a whole */
-    ExpProtocolApplication getOutputProtocolApplication();
+    /** Get the protocol application that marks all the outputs to the run as a whole */
+    @Nullable ExpProtocolApplication getOutputProtocolApplication();
 
     void deleteProtocolApplications(User user);
 

--- a/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
@@ -17,7 +17,6 @@ package org.labkey.api.exp.api;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.apache.commons.beanutils.ConvertUtils;

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -319,7 +319,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     /**
      * Get a DataClass with name at a specific time.
      */
-    ExpDataClass getEffectiveDataClass(
+    @Nullable ExpDataClass getEffectiveDataClass(
         @NotNull Container definitionContainer,
         @NotNull User user,
         @NotNull String dataClassName,
@@ -343,15 +343,13 @@ public interface ExperimentService extends ExperimentRunTypeSource
     List<? extends ExpMaterial> getExpMaterials(Container container, User user, Collection<Integer> rowIds, @Nullable ExpSampleType sampleType);
 
     /* This version of createExpMaterial() takes name from lsid.getObjectId() */
-    ExpMaterial createExpMaterial(Container container, Lsid lsid);
+    @NotNull ExpMaterial createExpMaterial(Container container, Lsid lsid);
 
-    ExpMaterial createExpMaterial(Container container, String lsid, String name);
+    @NotNull ExpMaterial createExpMaterial(Container container, String lsid, String name);
 
-    @Nullable
-    ExpMaterial getExpMaterial(int rowId);
+    @Nullable ExpMaterial getExpMaterial(int rowId);
 
-    @Nullable
-    ExpMaterial getExpMaterial(int rowId, ContainerFilter containerFilter);
+    @Nullable ExpMaterial getExpMaterial(int rowId, ContainerFilter containerFilter);
 
     /**
      * Get material by rowId in this, project, or shared container and within the provided sample type.
@@ -361,7 +359,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
      * @param rowId           The sample rowId.
      * @param sampleType      Optional sample type that the sample must live in.
      */
-    ExpMaterial getExpMaterial(Container c, User u, int rowId, @Nullable ExpSampleType sampleType);
+    @Nullable ExpMaterial getExpMaterial(Container c, User u, int rowId, @Nullable ExpSampleType sampleType);
 
     @NotNull List<? extends ExpMaterial> getExpMaterials(Collection<Integer> rowIds);
 
@@ -369,31 +367,40 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     @Nullable ExpMaterial getExpMaterial(String lsid);
 
-    @Nullable ExpMaterial resolveExpMaterial(
-        Container container,
-        User user,
-        Object sampleIdentifier,
-        @Nullable ExpSampleType sampleType,
-        @Nullable RemapCache cache,
-        @Nullable Map<Integer, ExpMaterial> materialCache
-    ) throws ValidationException;
-
     /**
      * Looks in all the sample types visible from the given container for a single match with the specified name
      */
     @NotNull List<? extends ExpMaterial> getExpMaterialsByName(String name, @Nullable Container container, User user);
 
-    @Nullable ExpData findExpData(Container c, User user,
-                                  @NotNull ExpDataClass dataClass,
-                                  @NotNull String dataClassName, String dataName,
-                                  RemapCache cache, Map<Integer, ExpData> dataCache)
-            throws ValidationException;
+    @Nullable ExpData findExpData(
+        Container c,
+        User user,
+        @NotNull ExpDataClass dataClass,
+        @NotNull String dataClassName,
+        String dataName,
+        RemapCache cache,
+        Map<Integer, ExpData> dataCache
+    ) throws ValidationException;
 
-    @Nullable ExpMaterial findExpMaterial(Container c, User user,
-                                          ExpSampleType sampleType,
-                                          String sampleTypeName, String sampleName,
-                                          RemapCache cache, Map<Integer, ExpMaterial> materialCache)
-            throws ValidationException;
+    /**
+     * Attempts to resolve an ExpMaterial from an Object.
+     *
+     * @param container        The container in which to scope the resolution.
+     * @param user             The user that is attempting to resolve the material.
+     * @param sampleIdentifier An identifier object (ExpMaterial, Integer, String, etc.) that identifies an individual material.
+     * @param sampleType       An optional ExpSampleType in which to scope the resolution.
+     * @param cache            Caller-supplied remapping cache that remaps underlying queries for samples
+     * @param materialCache    Caller-supplied Map used to cache materials by rowId.
+     * @return The resolved ExpMaterial or null if the Object does not resolve to a material.
+     */
+    @Nullable ExpMaterial findExpMaterial(
+        Container container,
+        User user,
+        Object sampleIdentifier,
+        @Nullable ExpSampleType sampleType,
+        @NotNull RemapCache cache,
+        @NotNull Map<Integer, ExpMaterial> materialCache
+    ) throws ValidationException;
 
     ExpExperiment createHiddenRunGroup(Container container, User user, ExpRun... runs);
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -1107,8 +1107,6 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     boolean useStrictCounter();
 
-    void checkForCycles(Map<? extends ExpRunItem, String> inputs, Collection<? extends ExpRunItem> outputs) throws ValidationException;
-
     class XarExportOptions
     {
         String _lsidRelativizer = LSID_OPTION_FOLDER_RELATIVE;

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -42,6 +42,7 @@ import org.labkey.api.exp.ProtocolApplicationParameter;
 import org.labkey.api.exp.TemplateInfo;
 import org.labkey.api.exp.XarFormatException;
 import org.labkey.api.exp.XarSource;
+import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.ExpDataClassDataTable;
 import org.labkey.api.exp.query.ExpDataClassTable;
 import org.labkey.api.exp.query.ExpDataInputTable;
@@ -1106,6 +1107,15 @@ public interface ExperimentService extends ExperimentRunTypeSource
     void handleAssayNameChange(String newAssayName, String oldAssayName, AssayProvider provider, ExpProtocol protocol, User user, Container container);
 
     boolean useStrictCounter();
+
+    /**
+     * Returns the lookup ExpSampleType if the property has a lookup to samples.<SampleTypeName> or
+     * exp.materials.<SampleTypeName> and is an int or string.
+     */
+    @Nullable ExpSampleType getLookupSampleType(@NotNull DomainProperty dp, @NotNull Container container, @NotNull User user);
+
+    /** Returns true if the property has a lookup to exp.Materials and is an int or string. */
+    boolean isLookupToMaterials(DomainProperty dp);
 
     class XarExportOptions
     {

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -165,7 +165,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     List<? extends ExpRun> getExpRuns(Container container, @Nullable ExpProtocol parentProtocol, @Nullable ExpProtocol childProtocol, @NotNull Predicate<ExpRun> filterFn);
     
-    List<? extends ExpRun> getExpRuns( @Nullable SQLFragment filterSQL, @NotNull Predicate<ExpRun> filterFn, @NotNull Container container);
+    List<? extends ExpRun> getExpRuns(@Nullable SQLFragment filterSQL, @NotNull Predicate<ExpRun> filterFn, @NotNull Container container);
 
     List<? extends ExpRun> getExpRunsForJobId(int jobId);
 
@@ -252,34 +252,28 @@ public interface ExperimentService extends ExperimentRunTypeSource
     /**
      * Create a new DataClass with the provided domain properties and top level options.
      */
-    @Deprecated
-    ExpDataClass createDataClass(@NotNull Container c, @NotNull User u, @NotNull String name, String description,
-                                 List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, Integer sampleTypeId, String nameExpression,
-                                 @Nullable TemplateInfo templateInfo, @Nullable String category)
-            throws ExperimentException;
-
-    ExpDataClass createDataClass(@NotNull Container c, @NotNull User u, @NotNull String name, @Nullable DataClassDomainKindProperties options,
-                                 List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, @Nullable TemplateInfo templateInfo)
-            throws ExperimentException;
-
-    ExpDataClass createDataClass(@NotNull Container c, @NotNull User u, @NotNull String name, @Nullable DataClassDomainKindProperties options,
-                                 List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, @Nullable TemplateInfo templateInfo, @Nullable List<String> disabledSystemField)
-            throws ExperimentException;
-
-    /**
-     * Create a new DataClass with the provided domain properties and top level options.
-     */
-    ExpDataClass createDataClass(@NotNull Container c, @NotNull User u, @NotNull String name, @Nullable DataClassDomainKindProperties options,
-                                            List<GWTPropertyDescriptor> properties, List<GWTIndex> indices, @Nullable TemplateInfo templateInfo, @Nullable List<String> disabledSystemField, @Nullable Map<String, String> importAliases)
-            throws ExperimentException;
+    ExpDataClass createDataClass(
+        @NotNull Container c,
+        @NotNull User u,
+        @NotNull String name,
+        @Nullable DataClassDomainKindProperties options,
+        List<GWTPropertyDescriptor> properties,
+        List<GWTIndex> indices,
+        @Nullable TemplateInfo templateInfo,
+        @Nullable List<String> disabledSystemField
+    ) throws ExperimentException;
 
     /**
      * Update a DataClass with the provided domain properties and top level options.
      */
-    ValidationException updateDataClass(@NotNull Container c, @NotNull User u, @NotNull ExpDataClass dataClass,
-                                        @Nullable DataClassDomainKindProperties options,
-                                        GWTDomain<? extends GWTPropertyDescriptor> original,
-                                        GWTDomain<? extends GWTPropertyDescriptor> update);
+    ValidationException updateDataClass(
+        @NotNull Container c,
+        @NotNull User u,
+        @NotNull ExpDataClass dataClass,
+        @Nullable DataClassDomainKindProperties options,
+        GWTDomain<? extends GWTPropertyDescriptor> original,
+        GWTDomain<? extends GWTPropertyDescriptor> update
+    );
 
     /**
      * Get all DataClass definitions in the container.  If <code>includeOtherContainers</code> is true,
@@ -291,16 +285,6 @@ public interface ExperimentService extends ExperimentRunTypeSource
      * Get a DataClass by name within the definition container.
      */
     ExpDataClass getDataClass(@NotNull Container definitionContainer, @NotNull String dataClassName);
-
-    /**
-     * Get a DataClass with name at a specific time.
-     */
-    ExpDataClass getEffectiveDataClass(@NotNull Container definitionContainer, @NotNull User user, @NotNull String dataClassName, @NotNull Date effectiveDate, @Nullable ContainerFilter cf);
-
-    /**
-     * Get a ExpProtocol with name at a specific time.
-     */
-    ExpProtocol getEffectiveProtocol(Container container, User user, String schemaName, Date effectiveDate, ContainerFilter dataTypeCF);
 
     /**
      * Get a DataClass by name within scope -- current, project, and shared.
@@ -323,13 +307,29 @@ public interface ExperimentService extends ExperimentRunTypeSource
      * Get a DataClass by LSID.
      * NOTE: Prefer using one of the getDataClass methods that accept a Container and User for permission checking.
      */
-    ExpDataClass getDataClass(@NotNull String lsid);
+    @Nullable ExpDataClass getDataClass(@NotNull String lsid);
 
     /**
      * Get a DataClass by RowId
      * NOTE: Prefer using one of the getDataClass methods that accept a Container and User for permission checking.
      */
     ExpDataClass getDataClass(int rowId);
+
+    /**
+     * Get a DataClass with name at a specific time.
+     */
+    ExpDataClass getEffectiveDataClass(
+        @NotNull Container definitionContainer,
+        @NotNull User user,
+        @NotNull String dataClassName,
+        @NotNull Date effectiveDate,
+        @Nullable ContainerFilter cf
+    );
+
+    /**
+     * Get a ExpProtocol with name at a specific time.
+     */
+    ExpProtocol getEffectiveProtocol(Container container, User user, String schemaName, Date effectiveDate, ContainerFilter dataTypeCF);
 
     /**
      * Get materials by rowId in this, project, or shared container and within the provided sample type.
@@ -362,11 +362,20 @@ public interface ExperimentService extends ExperimentRunTypeSource
      */
     ExpMaterial getExpMaterial(Container c, User u, int rowId, @Nullable ExpSampleType sampleType);
 
-    @NotNull List<? extends ExpMaterial> getExpMaterials(Collection<Integer> rowids);
+    @NotNull List<? extends ExpMaterial> getExpMaterials(Collection<Integer> rowIds);
 
     @NotNull List<? extends ExpMaterial> getExpMaterialsByLsid(Collection<String> lsids);
 
     @Nullable ExpMaterial getExpMaterial(String lsid);
+
+    @Nullable ExpMaterial resolveExpMaterial(
+        Container container,
+        User user,
+        Object sampleIdentifier,
+        @Nullable ExpSampleType sampleType,
+        @Nullable RemapCache cache,
+        @Nullable Map<Integer, ExpMaterial> materialCache
+    ) throws ValidationException;
 
     /**
      * Looks in all the sample types visible from the given container for a single match with the specified name
@@ -387,7 +396,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     ExpExperiment createHiddenRunGroup(Container container, User user, ExpRun... runs);
 
-    ExpExperiment createExpExperiment(Container container, String name);
+    @NotNull ExpExperiment createExpExperiment(Container container, String name);
 
     @Nullable ExpExperiment getExpExperiment(int rowId);
 
@@ -397,7 +406,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     List<? extends ExpExperiment> getExperiments(Container container, User user, boolean includeOtherContainers, boolean includeBatches);
 
-    @Nullable ExpProtocol getExpProtocol(int rowid);
+    @Nullable ExpProtocol getExpProtocol(int rowId);
 
     @Nullable ExpProtocol getExpProtocol(String lsid);
 
@@ -798,7 +807,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     ExpProtocol insertSimpleProtocol(ExpProtocol baseProtocol, User user) throws ExperimentException;
 
     /**
-     * The run must be a instance of a protocol created with insertSimpleProtocol().
+     * The run must be an instance of a protocol created with insertSimpleProtocol().
      * The run must have at least one input and one output.
      *
      * @param run             ExperimentRun, populated with protocol, name, etc
@@ -1097,6 +1106,8 @@ public interface ExperimentService extends ExperimentRunTypeSource
     void handleAssayNameChange(String newAssayName, String oldAssayName, AssayProvider provider, ExpProtocol protocol, User user, Container container);
 
     boolean useStrictCounter();
+
+    void checkForCycles(Map<? extends ExpRunItem, String> inputs, Collection<? extends ExpRunItem> outputs) throws ValidationException;
 
     class XarExportOptions
     {

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -997,9 +997,11 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
                 // If the path is too long to store, bail out without creating an exp.data row
                 data.save(user);
             }
+
             return data;
         }
-        return  existingData;
+
+        return existingData;
     }
 
     // For security reasons, make sure the user hasn't tried to reference a file that's not under
@@ -1045,7 +1047,6 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
     /**
      * QUS instances that allow import of attachments through the AttachmentDataIterator should furnish a factory
      * implementation in order to resolve the attachment parent on incoming attachment files.
-     * @return
      */
     @Nullable
     protected AttachmentParentFactory getAttachmentParentFactory()
@@ -1085,7 +1086,6 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         }
         return result;
     }
-
 
     @TestWhen(TestWhen.When.BVT)
     public static class TestCase extends Assert

--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -158,12 +158,9 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
                         FieldKey pkFieldKey = new FieldKey(null, AbstractTsvAssayProvider.ROW_ID_COLUMN_NAME);
                         PropertyColumn.copyAttributes(_userSchema.getUser(), col, pd, schema.getContainer(), _userSchema.getSchemaPath(), getPublicName(), pkFieldKey, null, cf);
 
-                        if (ExperimentService.get().isLookupToMaterials(domainProperty))
-                        {
-                            ExpSampleType st = ExperimentService.get().getLookupSampleType(domainProperty, getContainer(), getUserSchema().getUser());
-                            if (st != null)
-                                col.setFk(new ExpSchema(_userSchema.getUser(), _userSchema.getContainer()).getMaterialIdForeignKey(st, domainProperty, getLookupContainerFilter()));
-                        }
+                        ExpSampleType st = ExperimentService.get().getLookupSampleType(domainProperty, getContainer(), getUserSchema().getUser());
+                        if (st != null || ExperimentService.get().isLookupToMaterials(domainProperty))
+                            col.setFk(new ExpSchema(_userSchema.getUser(), _userSchema.getContainer()).getMaterialIdForeignKey(st, domainProperty, getLookupContainerFilter()));
                     }
                     addColumn(col);
 

--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -83,10 +83,6 @@ import static org.labkey.api.data.Table.CREATED_COLUMN_NAME;
 import static org.labkey.api.data.Table.MODIFIED_BY_COLUMN_NAME;
 import static org.labkey.api.data.Table.MODIFIED_COLUMN_NAME;
 
-/**
- * User: jeckels
- * Date: Dec 14, 2010
- */
 public class AssayResultTable extends FilteredTable<AssayProtocolSchema> implements UpdateableTableInfo
 {
     protected final ExpProtocol _protocol;
@@ -131,7 +127,8 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
             }
             else if (baseColumn.isMvIndicatorColumn())
             {
-                col = null;     // skip and instead add AliasedColumn below
+                // skip and instead add AliasedColumn below
+                col = null;
             }
             else
             {

--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -158,9 +158,12 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
                         FieldKey pkFieldKey = new FieldKey(null, AbstractTsvAssayProvider.ROW_ID_COLUMN_NAME);
                         PropertyColumn.copyAttributes(_userSchema.getUser(), col, pd, schema.getContainer(), _userSchema.getSchemaPath(), getPublicName(), pkFieldKey, null, cf);
 
-                        ExpSampleType st = DefaultAssayRunCreator.getLookupSampleType(domainProperty, getContainer(), getUserSchema().getUser());
-                        if (st != null || DefaultAssayRunCreator.isLookupToMaterials(domainProperty))
-                            col.setFk(new ExpSchema(_userSchema.getUser(), _userSchema.getContainer()).getMaterialIdForeignKey(st, domainProperty, getLookupContainerFilter()));
+                        if (ExperimentService.get().isLookupToMaterials(domainProperty))
+                        {
+                            ExpSampleType st = ExperimentService.get().getLookupSampleType(domainProperty, getContainer(), getUserSchema().getUser());
+                            if (st != null)
+                                col.setFk(new ExpSchema(_userSchema.getUser(), _userSchema.getContainer()).getMaterialIdForeignKey(st, domainProperty, getLookupContainerFilter()));
+                        }
                     }
                     addColumn(col);
 

--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -17,16 +17,19 @@ package org.labkey.api.assay;
 
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtils;
+import org.apache.commons.collections4.map.LRUMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.RemapCache;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.OntologyObject;
 import org.labkey.api.exp.api.ExpData;
+import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ProvenanceService;
@@ -49,27 +52,27 @@ import java.util.Objects;
 
 import static org.labkey.api.dataiterator.DetailedAuditLogDataIterator.AuditConfigs.AuditUserComment;
 
-/**
- * User: jeckels
- * Date: 7/1/11
- */
 public class AssayResultUpdateService extends DefaultQueryUpdateService
 {
-    private final AssayProtocolSchema _schema;
+    private RemapCache _remapCache;
+    private Map<Integer, ExpMaterial> _materialsCache;
 
     public AssayResultUpdateService(AssayProtocolSchema schema, FilteredTable table)
     {
         super(table, table.getRealTable(), createMVMapping(schema.getProvider().getResultsDomain(schema.getProtocol())));
         if (!(table instanceof AssayResultTable))
             throw new IllegalArgumentException("Expected AssayResultTable");
-        _schema = schema;
     }
 
     @Override
-    protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, @Nullable Map<Enum, Object> configParameters) throws InvalidKeyException, ValidationException, QueryUpdateServiceException, SQLException
+    protected Map<String, Object> updateRow(
+        User user,
+        Container container,
+        Map<String, Object> row,
+        @NotNull Map<String, Object> oldRow,
+        @Nullable Map<Enum, Object> configParameters
+    ) throws InvalidKeyException, ValidationException, QueryUpdateServiceException, SQLException
     {
-        _schema.getProtocol();
-
         Map<String, Object> originalRow = getRow(user, container, oldRow);
         if (originalRow == null)
         {
@@ -111,6 +114,11 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
                 appendPropertyIfChanged(sb, col.getLabel(), oldValue, newValue);
             }
         }
+
+        AssayProvider assayProvider = AssayService.get().getProvider(run);
+        if (assayProvider != null)
+            assayProvider.updatePropertyLineage(container, user, getQueryTable(), run, updatedValues, false, getRemapCache(), getMaterialsCache());
+
         String userComment = configParameters == null ? null : (String) configParameters.get(AuditUserComment);
         ExperimentService.get().auditRunEvent(user, run.getProtocol(), run, null, sb.toString(), userComment);
 
@@ -216,5 +224,19 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
         sb.append(" to ");
         sb.append(newValue == null ? "blank" : "'" + newValue + "'");
         sb.append(".");
+    }
+
+    private RemapCache getRemapCache()
+    {
+        if (_remapCache == null)
+            _remapCache = new RemapCache();
+        return _remapCache;
+    }
+
+    private Map<Integer, ExpMaterial> getMaterialsCache()
+    {
+        if (_materialsCache == null)
+            _materialsCache = new LRUMap<>(1_000);
+        return _materialsCache;
     }
 }

--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -75,9 +75,7 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
     {
         Map<String, Object> originalRow = getRow(user, container, oldRow);
         if (originalRow == null)
-        {
             throw new InvalidKeyException("Could not find row");
-        }
 
         ExpRun run = getRun(originalRow, user, UpdatePermission.class);
 
@@ -89,7 +87,6 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
         convertTypes(user, container, row, getDbTable(), assayResultsRunDir);
 
         Map<String, Object> result = super.updateRow(user, container, row, oldRow, configParameters);
-
         Map<String, Object> updatedValues = getRow(user, container, oldRow);
 
         StringBuilder sb = new StringBuilder("Data row, id " + oldRow.get("RowId") + ", edited in " + run.getProtocol().getName() + ".");

--- a/assay/api-src/org/labkey/api/assay/DefaultAssaySaveHandler.java
+++ b/assay/api-src/org/labkey/api/assay/DefaultAssaySaveHandler.java
@@ -25,7 +25,6 @@ import org.json.JSONObject;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ExpDataFileConverter;
 import org.labkey.api.data.MvUtil;
-import org.labkey.api.dataiterator.AbstractMapDataIterator;
 import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.MvColumn;
@@ -182,13 +181,21 @@ public class DefaultAssaySaveHandler extends DefaultExperimentSaveHandler implem
     }
 
     @Override
-    protected ExpExperiment saveExperimentRun(ViewContext context, ExpProtocol protocol, ExpExperiment batch, ExpRun run,
-                                              JSONObject runJson, JSONArray dataArray, Map<ExpData, String> inputData,
-                                              Map<ExpData, String> outputData, Map<ExpMaterial, String> inputMaterial,
-                                              Map<ExpMaterial, String> outputMaterial) throws ExperimentException, ValidationException
+    protected ExpExperiment saveExperimentRun(
+        ViewContext context,
+        ExpProtocol protocol,
+        ExpExperiment batch,
+        ExpRun run,
+        JSONObject runJson,
+        JSONArray dataArray,
+        Map<ExpData, String> inputData,
+        Map<ExpData, String> outputData,
+        Map<ExpMaterial, String> inputMaterial,
+        Map<ExpMaterial, String> outputMaterial
+    ) throws ExperimentException, ValidationException
     {
         List<Map<String, Object>> dataRows = convertRunData(dataArray, run.getContainer(), protocol);
-        ExpData tsvData = DefaultAssayRunCreator.generateResultData(context.getUser(), run.getContainer(), getProvider(), dataRows, (Map)outputData, null);
+        ExpData tsvData = DefaultAssayRunCreator.generateResultData(context.getUser(), run.getContainer(), getProvider(), dataRows, (Map) outputData, null);
 
         // CONSIDER: Is this block still needed?
         // Try to find a data object to attach our data rows to
@@ -267,9 +274,16 @@ public class DefaultAssaySaveHandler extends DefaultExperimentSaveHandler implem
     }
 
     @Nullable
-    protected AssayRunUploadContext<?> createRunUploadContext(ViewContext context, ExpProtocol protocol, JSONObject runJsonObject, List<Map<String, Object>> dataRows,
-                                                           Map<ExpData, String> inputData, Map<ExpData, String> outputData,
-                                                           Map<ExpMaterial, String> inputMaterial, Map<ExpMaterial, String> outputMaterial)
+    protected AssayRunUploadContext<?> createRunUploadContext(
+        ViewContext context,
+        ExpProtocol protocol,
+        JSONObject runJsonObject,
+        List<Map<String, Object>> dataRows,
+        Map<ExpData, String> inputData,
+        Map<ExpData, String> outputData,
+        Map<ExpMaterial, String> inputMaterial,
+        Map<ExpMaterial, String> outputMaterial
+    )
     {
         if (dataRows != null)
         {

--- a/assay/api-src/org/labkey/api/assay/matrix/AbstractMatrixDataHandler.java
+++ b/assay/api-src/org/labkey/api/assay/matrix/AbstractMatrixDataHandler.java
@@ -195,7 +195,7 @@ public abstract class AbstractMatrixDataHandler extends AbstractExperimentDataHa
             ExpMaterial m;
             try
             {
-                m = ExperimentService.get().findExpMaterial(container, user, null, null, sampleName, cache, materialCache);
+                m = ExperimentService.get().findExpMaterial(container, user, sampleName, null, cache, materialCache);
             }
             catch (ValidationException e)
             {

--- a/assay/src/org/labkey/assay/AssayIntegrationTestCase.jsp
+++ b/assay/src/org/labkey/assay/AssayIntegrationTestCase.jsp
@@ -85,7 +85,6 @@
 <%@ page import="static org.labkey.api.files.FileContentService.UPLOADED_FILE" %>
 <%@ page import="static org.hamcrest.CoreMatchers.hasItem" %>
 <%@ page import="static org.hamcrest.CoreMatchers.not" %>
-<%@ page import="static java.util.Collections.emptySet" %>
 <%@ page import="org.labkey.api.exp.api.ExpSampleType" %>
 <%@ page import="org.labkey.api.exp.api.SampleTypeService" %>
 <%@ page import="static java.util.Collections.emptyList" %>
@@ -443,9 +442,7 @@
             Collections.emptyMap(),
             info,
             null,
-            false,
-            emptySet(),
-            emptySet()
+            false
         );
 
         // verify the material is an input and the file is an output

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -1135,8 +1135,11 @@ public class AssayManager implements AssayService
     }
 
     @Override
-    public @NotNull String getInputRole(@NotNull DomainProperty dp, boolean useDeprecated)
+    public @NotNull String getPropertyInputLineageRole(@NotNull DomainProperty dp)
     {
-        return useDeprecated ? dp.getName() : String.format("dp-%d", dp.getPropertyId());
+        // TODO: Issue 51038: This is not sufficiently unique across domains. Make unique and verify across folder export/import.
+        // The assay run and assay result may have properties that have the same name which will
+        // result in lineage inputs which we are unable to disambiguate when processing based on "role".
+        return dp.getName();
     }
 }

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -58,6 +58,7 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.ExpRunTable;
 import org.labkey.api.gwt.client.assay.model.GWTProtocol;
 import org.labkey.api.pipeline.PipeRoot;
@@ -1131,5 +1132,11 @@ public class AssayManager implements AssayService
             log.error(String.format("Assay provider not found for protocol : %s in folder : %s", protocol.getName(), container.getPath()));
 
         return null;
+    }
+
+    @Override
+    public @NotNull String getInputRole(@NotNull DomainProperty dp, boolean useDeprecated)
+    {
+        return useDeprecated ? dp.getName() : String.format("dp-%d", dp.getPropertyId());
     }
 }

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -1754,7 +1754,7 @@ public class ExpDataIterators
             if (sampleType == null)
                 throw new ValidationException("Invalid sample type: " + dataType);
 
-            aliquotParent = ExperimentService.get().findExpMaterial(c, user, sampleType, dataType, aliquotedFrom, cache, materialMap);
+            aliquotParent = ExperimentService.get().findExpMaterial(c, user, aliquotedFrom, sampleType, cache, materialMap);
 
             if (aliquotParent == null)
             {
@@ -1789,7 +1789,7 @@ public class ExpDataIterators
                     if (skipExistingAliquotParents)
                         continue;
 
-                    ExpMaterial sample = ExperimentService.get().findExpMaterial(c, user, null, null, entityName, cache, materialMap);
+                    ExpMaterial sample = ExperimentService.get().findExpMaterial(c, user, entityName, null, cache, materialMap);
                     if (sample != null)
                         parentMaterials.put(sample, sampleRole(sample));
                     else
@@ -1827,7 +1827,7 @@ public class ExpDataIterators
                         if (sampleType == null)
                             throw new ValidationException(String.format("Invalid import alias: parent SampleType [%1$s] does not exist or may have been deleted", namePart));
 
-                        ExpMaterial sample = ExperimentService.get().findExpMaterial(c, user, sampleType, namePart, entityName, cache, materialMap);
+                        ExpMaterial sample = ExperimentService.get().findExpMaterial(c, user, entityName, sampleType, cache, materialMap);
                         if (sample != null)
                             parentMaterials.put(sample, sampleRole(sample));
                         else
@@ -1843,7 +1843,7 @@ public class ExpDataIterators
 
                     if (!isEmptyEntity)
                     {
-                        ExpMaterial sample = ExperimentService.get().findExpMaterial(c, user, sampleType, namePart, entityName, cache, materialMap);
+                        ExpMaterial sample = ExperimentService.get().findExpMaterial(c, user, entityName, sampleType, cache, materialMap);
                         if (sample != null)
                         {
                             if (StringUtils.isEmpty(sample.getAliquotedFromLSID()))

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
@@ -31,6 +31,7 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.ExperimentException;
+import org.labkey.api.exp.api.DataClassDomainKindProperties;
 import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.query.ExpDataClassTable;
@@ -280,9 +281,13 @@ public class ExpDataClassTableImpl extends ExpTableImpl<ExpDataClassTable.Column
 
             try
             {
-                ExpDataClass dc = ExperimentService.get().createDataClass(c, user, name, description,
-                        Collections.emptyList(), Collections.emptyList(),
-                        materialSourceId, nameExpression, null, category);
+                DataClassDomainKindProperties options = new DataClassDomainKindProperties();
+                options.setDescription(description);
+                options.setNameExpression(nameExpression);
+                options.setSampleType(materialSourceId);
+                options.setCategory(category);
+
+                ExpDataClass dc = ExperimentService.get().createDataClass(c, user, name, options, Collections.emptyList(), Collections.emptyList(), null, null);
                 return new CaseInsensitiveHashMap(BeanUtils.describe(dc));
             }
             catch (ExperimentException | ReflectiveOperationException e)

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -97,7 +97,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
 
     static public List<ExpMaterialImpl> fromMaterials(Collection<Material> materials)
     {
-        return materials.stream().map(ExpMaterialImpl::new).collect(Collectors.toList());
+        return materials.stream().map(ExpMaterialImpl::new).toList();
     }
 
     // For serialization

--- a/experiment/src/org/labkey/experiment/api/ExpProtocolApplicationImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpProtocolApplicationImpl.java
@@ -51,7 +51,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<ProtocolApplication> implements ExpProtocolApplication
@@ -60,7 +59,6 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
     private List<ExpDataImpl> _inputDatas;
     private List<ExpMaterialImpl> _outputMaterials;
     private List<ExpDataImpl> _outputDatas;
-    private Map<String, String> _lsidMap;
 
     // For serialization
     protected ExpProtocolApplicationImpl() {}

--- a/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunImpl.java
@@ -469,13 +469,12 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
     }
 
     @Override
-    public ExpProtocolApplication getInputProtocolApplication()
+    public @Nullable ExpProtocolApplication getInputProtocolApplication()
     {
         return findProtocolApplication(ExpProtocol.ApplicationType.ExperimentRun);
     }
 
-    @Nullable
-    private ExpProtocolApplication findProtocolApplication(ExpProtocol.ApplicationType type)
+    private @Nullable ExpProtocolApplication findProtocolApplication(ExpProtocol.ApplicationType type)
     {
         for (ExpProtocolApplicationImpl expProtocolApplication : getProtocolApplications())
         {
@@ -488,7 +487,7 @@ public class ExpRunImpl extends ExpIdentifiableEntityImpl<ExperimentRun> impleme
     }
 
     @Override
-    public ExpProtocolApplication getOutputProtocolApplication()
+    public @Nullable ExpProtocolApplication getOutputProtocolApplication()
     {
         return findProtocolApplication(ExpProtocol.ApplicationType.ExperimentRunOutput);
     }

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -22,6 +22,9 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayFileWriter;
+import org.labkey.api.assay.AssayProvider;
+import org.labkey.api.assay.AssayService;
+import org.labkey.api.assay.DefaultAssayRunCreator;
 import org.labkey.api.attachments.SpringAttachmentFile;
 import org.labkey.api.collections.NamedObjectList;
 import org.labkey.api.data.*;
@@ -34,10 +37,12 @@ import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
+import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainKind;
+import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.ExpRunGroupMapTable;
 import org.labkey.api.exp.query.ExpRunTable;
 import org.labkey.api.exp.query.ExpSchema;
@@ -920,127 +925,138 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
         }
 
         @Override
-        protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, @Nullable Map<Enum, Object> configParameters) throws ValidationException, QueryUpdateServiceException
+        protected Map<String, Object> updateRow(
+            User user,
+            Container container,
+            Map<String, Object> row,
+            @NotNull Map<String, Object> oldRow,
+            @Nullable Map<Enum, Object> configParameters
+        ) throws ValidationException, QueryUpdateServiceException
         {
             ExpRunImpl run = getRun(oldRow);
-            if (run != null)
+            if (run == null)
+                return getRow(user, container, oldRow);
+
+            // Don't trust that they're trying to edit a run from the current container
+            if (!run.getContainer().hasPermission(user, UpdatePermission.class))
+                throw new UnauthorizedException("You do not have permission to edit a run in " + run.getContainer());
+
+            try
             {
-                // Don't trust that they're trying to edit a run from the current container
-                if (!run.getContainer().hasPermission(user, UpdatePermission.class))
+                StringBuilder auditComment = new StringBuilder("Run edited.");
+                for (Map.Entry<String, Object> entry : row.entrySet())
                 {
-                    throw new UnauthorizedException("You do not have permission to edit a run in " + run.getContainer());
-                }
+                    // Most fields in the hard table can't be modified, but there are a few
+                    final String columnName = entry.getKey();
+                    Object value = entry.getValue();
 
-                try
-                {
-                    StringBuilder sb = new StringBuilder("Run edited.");
-                    for (Map.Entry<String, Object> entry : row.entrySet())
+                    if (Column.Name.toString().equalsIgnoreCase(columnName))
                     {
-                        // Most fields in the hard table can't be modified, but there are a few
-                        Object value = entry.getValue();
-                        if (entry.getKey().equalsIgnoreCase(Column.Name.toString()))
-                        {
-                            String newName = value == null ? null : (String)ConvertUtils.convert(value.toString(), String.class);
-                            appendPropertyIfChanged(sb, "Name", run.getName(), newName);
-                            run.setName(newName);
-                        }
-                        else if (entry.getKey().equalsIgnoreCase(Column.Comments.toString()))
-                        {
-                            String newComment = value == null ? null : (String)ConvertUtils.convert(value.toString(), String.class);
-                            appendPropertyIfChanged(sb, "Comment", run.getComments(), newComment);
-                            run.setComments(newComment);
-                        }
-                        else if (entry.getKey().equalsIgnoreCase(Column.Flag.toString()))
-                        {
-                            String newFlag = value == null ? null : (String)ConvertUtils.convert(value.toString(), String.class);
-                            appendPropertyIfChanged(sb, "Flag", run.getComment(), newFlag);
-                            run.setComment(user, newFlag);
-                        }
-                        else if (entry.getKey().equalsIgnoreCase(Column.WorkflowTask.toString()))
-                        {
-                            Integer newWorkflowTaskId = value == null ? null : (Integer)ConvertUtils.convert(value.toString(), Integer.class);
-                            Integer oldWorkflowTaskID = null;
-                            if (run.getWorkflowTask() != null)
-                                oldWorkflowTaskID = run.getWorkflowTask().getRowId();
-
-                            appendPropertyIfChanged(sb, "WorkflowTask", oldWorkflowTaskID, newWorkflowTaskId);
-                            run.setWorkflowTaskId(newWorkflowTaskId);
-                        }
-
-                        // Also check for properties
-                        ColumnInfo col = getQueryTable().getColumn(entry.getKey());
-                        if (col instanceof PropertyColumn)
-                        {
-                            PropertyColumn propColumn = (PropertyColumn)col;
-                            PropertyDescriptor propertyDescriptor = propColumn.getPropertyDescriptor();
-                            Object oldValue = run.getProperty(propertyDescriptor);
-                            if (propertyDescriptor.getPropertyType() == PropertyType.FILE_LINK && (value instanceof MultipartFile || value instanceof SpringAttachmentFile))
-                            {
-                                value = saveFile(user, container, col.getName(), value, AssayFileWriter.DIR_NAME);
-                            }
-
-                            ForeignKey fk = col.getFk();
-                            if (fk != null && fk.allowImportByAlternateKey() && value != null)
-                            {
-                                try
-                                {
-                                    value = ConvertUtils.convert(String.valueOf(value), col.getJavaClass());
-                                }
-                                catch (ConversionException e)
-                                {
-                                    Container remapContainer = fk.getLookupContainer() != null ? fk.getLookupContainer() : container;
-                                    Object remappedValue = _cache.remap(SchemaKey.fromParts(fk.getLookupSchemaName()), fk.getLookupTableName(), user, remapContainer, ContainerFilter.Type.CurrentPlusProjectAndShared, String.valueOf(value));
-                                    if (remappedValue != null)
-                                        value = remappedValue;
-                                }
-                            }
-                            run.setProperty(user, propertyDescriptor, value);
-
-                            Object newValue = value;
-                            TableInfo fkTableInfo = fk != null ? fk.getLookupTableInfo() : null;
-                            String lookupColumnName = fk != null ? fk.getLookupColumnName() : null;
-                            ColumnInfo lookupColumn = fkTableInfo != null && lookupColumnName != null ? fkTableInfo.getColumn(lookupColumnName) : null;
-
-                            // Don't attempt type conversion if the lookup target isn't the PK column
-                            if (lookupColumn != null && lookupColumn.isKeyField())
-                            {
-                                // Do type conversion in case there's a mismatch in the lookup source and target columns
-                                Class<?> keyColumnType = lookupColumn.getJavaClass();
-                                if (newValue != null && !keyColumnType.isAssignableFrom(newValue.getClass()))
-                                {
-                                    newValue = ConvertUtils.convert(newValue.toString(), keyColumnType);
-                                }
-                                if (oldValue != null && !keyColumnType.isAssignableFrom(oldValue.getClass()))
-                                {
-                                    oldValue = ConvertUtils.convert(oldValue.toString(), keyColumnType);
-                                }
-                                Map<String, Object> oldLookupTarget = new TableSelector(fkTableInfo).getMap(oldValue);
-                                if (oldLookupTarget != null)
-                                {
-                                    oldValue = oldLookupTarget.get(fkTableInfo.getTitleColumn());
-                                }
-                                Map<String, Object> newLookupTarget = new TableSelector(fkTableInfo).getMap(newValue);
-                                if (newLookupTarget != null)
-                                {
-                                    newValue = newLookupTarget.get(fkTableInfo.getTitleColumn());
-                                }
-                            }
-                            appendPropertyIfChanged(sb, propertyDescriptor.getNonBlankCaption(), oldValue, newValue);
-                        }
+                        String newName = value == null ? null : (String)ConvertUtils.convert(value.toString(), String.class);
+                        appendPropertyIfChanged(auditComment, Column.Name.toString(), run.getName(), newName);
+                        run.setName(newName);
                     }
-                    run.save(user);
-                    String auditUserComment = configParameters == null ? null : (String) configParameters.get(DetailedAuditLogDataIterator.AuditConfigs.AuditUserComment);
-                    ExperimentServiceImpl.get().auditRunEvent(user, run.getProtocol(), run, null, sb.toString(), auditUserComment);
+                    else if (Column.Comments.toString().equalsIgnoreCase(columnName))
+                    {
+                        String newComment = value == null ? null : (String)ConvertUtils.convert(value.toString(), String.class);
+                        appendPropertyIfChanged(auditComment, Column.Comments.toString(), run.getComments(), newComment);
+                        run.setComments(newComment);
+                    }
+                    else if (Column.Flag.toString().equalsIgnoreCase(columnName))
+                    {
+                        String newFlag = value == null ? null : (String)ConvertUtils.convert(value.toString(), String.class);
+                        appendPropertyIfChanged(auditComment, Column.Flag.toString(), run.getComment(), newFlag);
+                        run.setComment(user, newFlag);
+                    }
+                    else if (Column.WorkflowTask.toString().equalsIgnoreCase(columnName))
+                    {
+                        Integer newWorkflowTaskId = value == null ? null : (Integer)ConvertUtils.convert(value.toString(), Integer.class);
+                        Integer oldWorkflowTaskID = null;
+                        if (run.getWorkflowTask() != null)
+                            oldWorkflowTaskID = run.getWorkflowTask().getRowId();
+
+                        appendPropertyIfChanged(auditComment, Column.WorkflowTask.toString(), oldWorkflowTaskID, newWorkflowTaskId);
+                        run.setWorkflowTaskId(newWorkflowTaskId);
+                    }
+
+                    // Also check for properties
+                    if (getQueryTable().getColumn(columnName) instanceof PropertyColumn col)
+                    {
+                        PropertyDescriptor propertyDescriptor = col.getPropertyDescriptor();
+                        Object oldValue = run.getProperty(propertyDescriptor);
+                        if (propertyDescriptor.getPropertyType() == PropertyType.FILE_LINK && (value instanceof MultipartFile || value instanceof SpringAttachmentFile))
+                        {
+                            value = saveFile(user, container, col.getName(), value, AssayFileWriter.DIR_NAME);
+                        }
+
+                        ForeignKey fk = col.getFk();
+                        if (fk != null && fk.allowImportByAlternateKey() && value != null)
+                        {
+                            try
+                            {
+                                value = ConvertUtils.convert(String.valueOf(value), col.getJavaClass());
+                            }
+                            catch (ConversionException e)
+                            {
+                                Container remapContainer = fk.getLookupContainer() != null ? fk.getLookupContainer() : container;
+                                Object remappedValue = _cache.remap(SchemaKey.fromParts(fk.getLookupSchemaName()), fk.getLookupTableName(), user, remapContainer, ContainerFilter.Type.CurrentPlusProjectAndShared, String.valueOf(value));
+                                if (remappedValue != null)
+                                    value = remappedValue;
+                            }
+                        }
+                        run.setProperty(user, propertyDescriptor, value);
+
+                        Object newValue = value;
+                        TableInfo fkTableInfo = fk != null ? fk.getLookupTableInfo() : null;
+                        String lookupColumnName = fk != null ? fk.getLookupColumnName() : null;
+                        ColumnInfo lookupColumn = fkTableInfo != null && lookupColumnName != null ? fkTableInfo.getColumn(lookupColumnName) : null;
+
+                        // Don't attempt type conversion if the lookup target isn't the PK column
+                        if (lookupColumn != null && lookupColumn.isKeyField())
+                        {
+                            // Do type conversion in case there's a mismatch in the lookup source and target columns
+                            Class<?> keyColumnType = lookupColumn.getJavaClass();
+                            if (newValue != null && !keyColumnType.isAssignableFrom(newValue.getClass()))
+                            {
+                                newValue = ConvertUtils.convert(newValue.toString(), keyColumnType);
+                            }
+                            if (oldValue != null && !keyColumnType.isAssignableFrom(oldValue.getClass()))
+                            {
+                                oldValue = ConvertUtils.convert(oldValue.toString(), keyColumnType);
+                            }
+                            Map<String, Object> oldLookupTarget = new TableSelector(fkTableInfo).getMap(oldValue);
+                            if (oldLookupTarget != null)
+                            {
+                                oldValue = oldLookupTarget.get(fkTableInfo.getTitleColumn());
+                            }
+                            Map<String, Object> newLookupTarget = new TableSelector(fkTableInfo).getMap(newValue);
+                            if (newLookupTarget != null)
+                            {
+                                newValue = newLookupTarget.get(fkTableInfo.getTitleColumn());
+                            }
+                        }
+                        appendPropertyIfChanged(auditComment, propertyDescriptor.getNonBlankCaption(), oldValue, newValue);
+                    }
                 }
-                catch (ConversionException e)
-                {
-                    throw new QueryUpdateServiceException("Unable to convert value " + e.getMessage());
-                }
-                catch (BatchValidationException e)
-                {
-                    throw new QueryUpdateServiceException(e);
-                }
+
+                AssayProvider assayProvider = AssayService.get().getProvider(run);
+                if (assayProvider != null)
+                    assayProvider.updateRunPropertyLineage(container, user, getQueryTable(), run, row);
+
+                run.save(user);
+
+                String auditUserComment = configParameters == null ? null : (String) configParameters.get(DetailedAuditLogDataIterator.AuditConfigs.AuditUserComment);
+                ExperimentServiceImpl.get().auditRunEvent(user, run.getProtocol(), run, null, auditComment.toString(), auditUserComment);
             }
+            catch (ConversionException e)
+            {
+                throw new QueryUpdateServiceException("Unable to convert value " + e.getMessage());
+            }
+            catch (BatchValidationException e)
+            {
+                throw new QueryUpdateServiceException(e);
+            }
+
             return getRow(user, container, oldRow);
         }
 
@@ -1058,7 +1074,7 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
             }
         }
 
-        private ExpRunImpl getRun(Map<String, Object> row)
+        private @Nullable ExpRunImpl getRun(Map<String, Object> row)
         {
             Object rowIdRaw = row.get(Column.RowId.toString());
             if (rowIdRaw != null)

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -9735,19 +9735,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
     }
 
-    @Override
-    public void checkForCycles(Map<? extends ExpRunItem, String> inputs, Collection<? extends ExpRunItem> outputs) throws ValidationException
-    {
-        for (ExpRunItem input : inputs.keySet())
-        {
-            if (outputs.contains(input))
-            {
-                String role = inputs.get(input);
-                throw new ValidationException("Circular input/output '" + input.getName() + "' with role '" + role + "'");
-            }
-        }
-    }
-
     public Map<String, Map<String, MissingFilesCheckInfo>> doMissingFilesCheck(User user, Container container, boolean trackMissingFiles) throws SQLException
     {
         if (container == null)

--- a/experiment/src/org/labkey/experiment/api/LineagePerfTest.java
+++ b/experiment/src/org/labkey/experiment/api/LineagePerfTest.java
@@ -351,7 +351,7 @@ public class LineagePerfTest extends Assert
             insertDataTimer.start();
             List<GWTPropertyDescriptor> props = new ArrayList<>();
             props.add(new GWTPropertyDescriptor("age", "int"));
-            final ExpDataClass dc = ExperimentService.get().createDataClass(_container, _user, "MyData", null, props, Collections.emptyList(), null);
+            final ExpDataClass dc = ExperimentService.get().createDataClass(_container, _user, "MyData", null, props, Collections.emptyList(), null, null);
             TableInfo dcTable = QueryService.get().getUserSchema(_user, _container, "exp.data").getTable("MyData");
             BatchValidationException errors = new BatchValidationException();
             List<Map<String, Object>> insertedDatas = dcTable.getUpdateService().insertRows(_user, _container, data, errors, null, null);

--- a/experiment/src/org/labkey/experiment/api/LineageTest.java
+++ b/experiment/src/org/labkey/experiment/api/LineageTest.java
@@ -150,10 +150,10 @@ public class LineageTest extends ExpProvisionedTableTestHelper
         List<GWTPropertyDescriptor> dcProps = new ArrayList<>();
         dcProps.add(new GWTPropertyDescriptor("age", "string"));
         final String firstDataClassName = "firstDataClass";
-        final ExpDataClassImpl firstDataClass = ExperimentServiceImpl.get().createDataClass(c, user, firstDataClassName, null, dcProps, emptyList(), null);
+        final ExpDataClassImpl firstDataClass = ExperimentServiceImpl.get().createDataClass(c, user, firstDataClassName, null, dcProps, emptyList(), null, null);
 
         final String secondDataClassName = "secondDataClass";
-        final ExpDataClassImpl secondDataClass = ExperimentServiceImpl.get().createDataClass(c, user, secondDataClassName, null, dcProps, emptyList(), null);
+        final ExpDataClassImpl secondDataClass = ExperimentServiceImpl.get().createDataClass(c, user, secondDataClassName, null, dcProps, emptyList(), null, null);
 
         // insert data class rows
         insertRows(c, Arrays.asList(new CaseInsensitiveHashMap<>(Collections.singletonMap("name", "jimbo"))), secondDataClassName);
@@ -342,7 +342,7 @@ public class LineageTest extends ExpProvisionedTableTestHelper
         List<GWTPropertyDescriptor> dcProps = new ArrayList<>();
         dcProps.add(new GWTPropertyDescriptor("age", "int"));
         final String myDataClassName = "MyData";
-        final ExpDataClassImpl myDataClass = ExperimentServiceImpl.get().createDataClass(c, user, myDataClassName, null, dcProps, emptyList(), null);
+        final ExpDataClassImpl myDataClass = ExperimentServiceImpl.get().createDataClass(c, user, myDataClassName, null, dcProps, emptyList(), null, null);
 
         // Import data and derive from "100"
         List<Map<String, Object>> rows = new ArrayList<>();
@@ -729,7 +729,7 @@ public class LineageTest extends ExpProvisionedTableTestHelper
         var dcProps = new ArrayList<GWTPropertyDescriptor>();
         dcProps.add(new GWTPropertyDescriptor("number", "int"));
         dcProps.add(new GWTPropertyDescriptor("position", "string"));
-        var dataClass = expSvc.createDataClass(c, user, dataClassName, null, dcProps, emptyList(), null);
+        var dataClass = expSvc.createDataClass(c, user, dataClassName, null, dcProps, emptyList(), null, null);
 
         // Create a Sample Type
         var sampleTypeName = "Games";

--- a/experiment/src/org/labkey/experiment/api/UniqueValueCounterTestCase.java
+++ b/experiment/src/org/labkey/experiment/api/UniqueValueCounterTestCase.java
@@ -22,6 +22,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.exp.api.DataClassDomainKindProperties;
 import org.labkey.api.exp.api.ExpDataClass;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.SampleTypeService;
@@ -242,9 +243,10 @@ public class UniqueValueCounterTestCase
         props.add(new GWTPropertyDescriptor("two", "int"));
         props.add(new GWTPropertyDescriptor("three", "int"));
 
-        final String nameExpression = "DC-${one}.${two}.${three}";
+        DataClassDomainKindProperties options = new DataClassDomainKindProperties();
+        options.setNameExpression("DC-${one}.${two}.${three}");
 
-        final ExpDataClass dc = ExperimentServiceImpl.get().createDataClass(c, user, dataClassName, null, props, emptyList(), null, nameExpression, null, null);
+        final ExpDataClass dc = ExperimentServiceImpl.get().createDataClass(c, user, dataClassName, options, props, emptyList(), null, null);
         assertNotNull(dc);
 
         UserSchema schema = QueryService.get().getUserSchema(user, c, SchemaKey.fromParts("exp", "data"));


### PR DESCRIPTION
#### Rationale
This addresses [Issue 45594](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=45594) by updating the lineage when assay run/result properties are mutated.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5755
- https://github.com/LabKey/limsModules/pull/563
- https://github.com/LabKey/provenance/pull/187
- https://github.com/LabKey/commonAssays/pull/788

#### Changes
- Process and modify lineage in `AbstractAssayProvider.updatePropertyLineage()`
- Update `ExperimentService.findExpMaterial()` to resolve from `Object` sample identifier.
- Introduce `AssayService.getPropertyInputLineageRole()` to centralize logic for "role" processing of assay property inputs
- Move `getLookupSampleType` and `isLookupToMaterials` utilities to `ExperimentService` from `DefaultAssayRunCreator`.
- Consolidate `ExperimentService.createDataClass` interface.