### PR TITLE
51040: AssayModule does not claim the "assaywell" schema

### DIFF
--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -20,6 +20,7 @@ import jakarta.servlet.ServletContext;
 import org.apache.commons.collections4.Factory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AbstractTsvAssayProvider;
 import org.labkey.api.assay.AssayBatchDomainKind;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayProviderSchema;
@@ -306,7 +307,10 @@ public class AssayModule extends SpringModule
     @NotNull
     public Set<String> getProvisionedSchemaNames()
     {
-        return PageFlowUtil.set("assayresult");
+        return Set.of(
+            AbstractTsvAssayProvider.ASSAY_SCHEMA_NAME,
+            PlateMetadataDomainKind.PROVISIONED_SCHEMA_NAME
+        );
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/PlateMetadataDomainKind.java
+++ b/assay/src/org/labkey/assay/plate/PlateMetadataDomainKind.java
@@ -44,7 +44,7 @@ public class PlateMetadataDomainKind extends BaseAbstractDomainKind
     private static final Set<String> MANDATORY_PROPS;
     private static final Set<PropertyStorageSpec.Index> INDEXES;
     private static final List<PropertyStorageSpec> REQUIRED_PROPS;
-    private static final String PROVISIONED_SCHEMA_NAME = "assaywell";
+    public static final String PROVISIONED_SCHEMA_NAME = "assaywell";
 
     public enum Column
     {


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51040)

I did some research and we still do need this provisioned schema (for assay well metadata). I ended up adding it to the set of  provisioned schema names.
