### PR TITLE
Issue 50964: Save Incomplete Disabled Authentication Configurations

### DIFF
--- a/api/src/org/labkey/api/security/SaveConfigurationForm.java
+++ b/api/src/org/labkey/api/security/SaveConfigurationForm.java
@@ -8,6 +8,7 @@ import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.ConfigurationException;
 
 import java.util.Map;
+import java.util.Objects;
 
 public abstract class SaveConfigurationForm
 {
@@ -78,7 +79,7 @@ public abstract class SaveConfigurationForm
     public final @Nullable String getProperties()
     {
         Map<String, Object> map = getPropertyMap();
-        assert map.containsKey("domain") ? map.get("domain").equals(getDomain()) : (map.containsKey("Domain") ? map.get("Domain").equals(getDomain()) : null == getDomain()) : "Inconsistency between getDomain() and map.get(\"domain\")";
+        assert Objects.equals(map.get("domain"), getDomain());
         return map.isEmpty() ? null : new JSONObject(map).toString();
     }
 

--- a/core/src/client/components/DynamicConfigurationModal.tsx
+++ b/core/src/client/components/DynamicConfigurationModal.tsx
@@ -91,6 +91,10 @@ export default class DynamicConfigurationModal extends PureComponent<Props, Part
     };
 
     areRequiredFieldsEmpty = (): boolean => {
+        if (!this.state.fieldValues.enabled) {
+            return false;
+        }
+
         // Array of all required fields
         const requiredFields = this.props.modalType.settingsFields.reduce((accum, current) => {
             if (current.required) {

--- a/core/src/client/components/DynamicConfigurationModal.tsx
+++ b/core/src/client/components/DynamicConfigurationModal.tsx
@@ -91,6 +91,7 @@ export default class DynamicConfigurationModal extends PureComponent<Props, Part
     };
 
     areRequiredFieldsEmpty = (): boolean => {
+        // Issue 50964: Save incomplete disabled authentication configurations
         if (!this.state.fieldValues.enabled) {
             return false;
         }


### PR DESCRIPTION
#### Rationale
See issue [here](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=50964).

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/32

#### Changes
- If auth config is disabled, bypass warning of empty required fields upon save attempt
