### PR TITLE
Fix deriving from parent sample containing comma

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -666,7 +666,8 @@ public class NameGenerator
 
             // Issue 44841: The names of the parents may include commas, so we parse the set of parent names
             // using TabLoader instead of just splitting on the comma.
-            try (TabLoader tabLoader = new TabLoader(tsvWriter.quoteValue(valueStr)))
+            String quotedStr = (valueStr).contains(",") ? valueStr : tsvWriter.quoteValue(valueStr); // if value contains comma, no need to quote again
+            try (TabLoader tabLoader = new TabLoader(quotedStr))
             {
                 tabLoader.setDelimiterCharacter(',');
                 tabLoader.setUnescapeBackslashes(false);


### PR DESCRIPTION
#### Rationale
When a sample name contains comma, we require that the name be supplied in quotes. there is no need to double quote on the server when trying to parse it using tsv loader.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5762
- https://github.com/LabKey/testAutomation/pull/2020

- https://github.com/LabKey/labkey-ui-components/pull/1548
- https://github.com/LabKey/platform/pull/5732
- https://github.com/LabKey/testAutomation/pull/2007
- https://github.com/LabKey/limsModules/pull/537

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
