### PR TITLE
Adjust permissions for Troubleshooters

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -11477,7 +11477,7 @@ public class AdminController extends SpringActionController
         }
     }
 
-    @RequiresPermission(AdminPermission.class)
+    @RequiresPermission(TroubleshooterPermission.class)
     public class ViewUsageStatistics extends SimpleViewAction<Object>
     {
         @Override


### PR DESCRIPTION
#### Rationale
Troubleshooters should be able to view metrics information and shouldn't be able to invoke expensive tests on data sources. We also should check for read permissions in folders with external schemas before linking to them.
