### PR TITLE
Issue 45594: Add null check on resolved column

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -2136,7 +2136,7 @@ public abstract class AbstractAssayProvider implements AssayProvider
         {
             ColumnInfo column = table.getColumn(entry.getKey());
 
-            if (!isRunProperties || column instanceof PropertyColumn)
+            if (column != null && (!isRunProperties || column instanceof PropertyColumn))
             {
                 DomainProperty dp = domain.getPropertyByURI(column.getPropertyURI());
                 if (dp == null)


### PR DESCRIPTION
#### Rationale
Need to check for column resolution for null when updating property lineage from assay sample lookups. This addresses test failures in `AssayExportImportTest`.

#### Related Pull Requests
- #5755

#### Changes
- Add null check
