### PR TITLE
Issue 51021: WebSocket to add window focus listener 

### DIFF
--- a/api/webapp/clientapi/dom/WebSocket.js
+++ b/api/webapp/clientapi/dom/WebSocket.js
@@ -35,6 +35,7 @@ LABKEY.WebSocket = new function ()
     var _websocket = null;
     var _callbacks = {};
     var _modalShowing = false;
+    var _shouldAddFocusListener = true;
 
     function openWebsocket() {
         if (_websocket !== null || !('WebSocket' in window)) return;
@@ -42,6 +43,15 @@ LABKEY.WebSocket = new function ()
         _websocket.onmessage = websocketOnMessage;
         _websocket.onclose = websocketOnClose;
         _websocket.onerror = websocketConnectionFailure;
+
+        // Issue 51021: Add a focus listener to check for session expiration when the user returns to the tab,
+        // this was done in the apps for issue 47024, but it should be done here for usages of WebSocket.js.
+        if (_shouldAddFocusListener) {
+            window.addEventListener('focus', function() {
+                checkForExpiredSession();
+            });
+            _shouldAddFocusListener = false;
+        }
     }
 
     function websocketConnectionFailure() {
@@ -64,7 +74,7 @@ LABKEY.WebSocket = new function ()
 
     function websocketOnClose(evt) {
         _websocket = null;
-        if (evt.wasClean) {
+        if (evt) {
             // first chance at handling the event goes to any registered callback listeners
             if (_callbacks[evt.code]) {
                 _callbacks[evt.code].forEach(function(cb){cb(evt)});
@@ -86,7 +96,9 @@ LABKEY.WebSocket = new function ()
             }
             else if (evt.code === CloseEventCode.ABNORMAL_CLOSURE) {
                 // 1006 abnormal close (e.g, server process died)
-                setTimeout(showDisconnectedMessage, 1000);
+                setTimeout(function() {
+                    showDisconnectedMessage(true);
+                }, 1000);
             }
             else if (evt.code === CloseEventCode.POLICY_VIOLATION) {
                 // Tomcat closes the websocket with "1008 Policy Violation" code when the session has expired.
@@ -119,8 +131,8 @@ LABKEY.WebSocket = new function ()
         });
     }
 
-    function showDisconnectedMessage() {
-        displayModal("Server Unavailable", "The server is currently unavailable. Please try reloading the page to continue.", false);
+    function showDisconnectedMessage(skipReopen) {
+        displayModal("Server Unavailable", "The server is currently unavailable. Please try reloading the page to continue.", false, skipReopen);
         // CONSIDER: Periodically attempt to reestablish connection until the server comes back up.
     }
 
@@ -167,8 +179,10 @@ LABKEY.WebSocket = new function ()
         _modalShowing = false;
     }
 
-    function displayModal(title, message, showReloadMessage) {
-        openWebsocket(); // re-establish the websocket connection for the new guest user session
+    function displayModal(title, message, showReloadMessage, skipReopen) {
+        if (!skipReopen) {
+            openWebsocket(); // re-establish the websocket connection for the new guest user session
+        }
 
         if (_modalShowing) return;
         _modalShowing = true;


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51021

We previously added code in the apps so that on browser window focus we do a whoAmI check via WebSocket. checkForExpiredSession() so that we can reliably show the session timeout / logout modal to the user. This PR moves that approach to the WebSocket.js file directly (note that I will remove the app specific code in develop).

#### Changes
- add window focus listener to help identify session timeout and user logout more consistently session timeout and user logout more consistently
