### PR TITLE
Deprecate XML schema elements for removal

### DIFF
--- a/api/schemas/view.xsd
+++ b/api/schemas/view.xsd
@@ -12,7 +12,11 @@
 
     <xsd:complexType name="viewType">
         <xsd:sequence>
-            <xsd:element name="permissions" type="vw:permissionsListType" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="permissions" type="vw:permissionsListType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Deprecated: Use &lt;requiresPermissions>, &lt;requiresNoPermission/>, and &lt;requiresLogin/> elements instead of &lt;permissions>. All support for &lt;permissions> will be removed in LabKey Server v24.12.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
             <!-- <permissionClasses> and <requiresPermissions> are synonyms -->
             <xsd:element name="permissionClasses" type="vw:permissionClassListType" minOccurs="0" maxOccurs="1"/>
             <xsd:element name="requiresPermissions" type="vw:permissionClassListType" minOccurs="0" maxOccurs="1"/>
@@ -34,8 +38,15 @@
     </xsd:complexType>
 
     <xsd:complexType name="permissionsListType">
+        <xsd:annotation>
+            <xsd:documentation>Deprecated: Use &lt;requiresPermissions> and &lt;permissionClass> elements instead of &lt;permissions> and &lt;permission>. All support for &lt;permissions> and &lt;permission> will be removed in LabKey Server v24.12.</xsd:documentation>
+        </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="permission" type="vw:permissionType" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="permission" type="vw:permissionType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Deprecated: Use &lt;requiresPermissions> and &lt;permissionClass> elements instead of &lt;permissions> and &lt;permission>. All support for &lt;permissions> and &lt;permission> will be removed in LabKey Server v24.12.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
         </xsd:sequence>
     </xsd:complexType>
 
@@ -46,6 +57,9 @@
     </xsd:complexType>
 
     <xsd:complexType name="permissionType">
+        <xsd:annotation>
+            <xsd:documentation>Deprecated: Use &lt;requiresPermissions> and &lt;permissionClass> elements instead of &lt;permissions> and &lt;permission>. All support for &lt;permissions> and &lt;permission> will be removed in LabKey Server v24.12.</xsd:documentation>
+        </xsd:annotation>
         <xsd:attribute name="name" type="vw:permissionEnum"/>
     </xsd:complexType>
 
@@ -54,6 +68,9 @@
     </xsd:complexType>
 
     <xsd:simpleType name="permissionEnum">
+        <xsd:annotation>
+            <xsd:documentation>Deprecated: Use &lt;requiresPermissions> and &lt;permissionClass> elements instead of &lt;permissions> and &lt;permission>. All support for &lt;permissions> and &lt;permission> will be removed in LabKey Server v24.12.</xsd:documentation>
+        </xsd:annotation>
         <xsd:restriction base="xsd:string">
             <xsd:enumeration value="login"/>
             <xsd:enumeration value="read"/>


### PR DESCRIPTION
#### Rationale
Several `.view.xml` elements and types were deprecated in v24.7.x and, if used, produce warnings in the log. Annotate these elements in the XML schema with documentation deprecation warnings. These warnings show up in the XSD documentation and in IntelliJ when the deprecated elements are used.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5701