### PR TITLE
Add modal for customizing a view for use in tool tips and drop downs.

### DIFF
--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -1023,7 +1023,9 @@ public class QueryManager
                 "namedViews", new SqlSelector(CoreSchema.getInstance().getSchema(),
                         "SELECT COUNT(*) FROM query.customview C WHERE " + schemaClause + " AND C.flags < 2 AND C.name IS NOT NULL").getObject(Long.class), // possibly inheritable, no hidden, not snapshot
                 "shared", new SqlSelector(CoreSchema.getInstance().getSchema(),
-                        "SELECT COUNT(*) FROM query.customview C WHERE " + schemaClause + " AND C.customviewowner IS NULL").getObject(Long.class)
+                        "SELECT COUNT(*) FROM query.customview C WHERE " + schemaClause + " AND C.customviewowner IS NULL").getObject(Long.class),
+                "identifyingFieldsViews", new SqlSelector(CoreSchema.getInstance().getSchema(),
+                        "SELECT COUNT(*) FROM query.customview C WHERE " + schemaClause + " AND C.name = '~~identifyingfields~~'").getObject(Long.class)
         );
     }
 


### PR DESCRIPTION
#### Rationale
This is the first in a series of stories for adding the ability for users to customize the fields of sample types and source types that appear in dropdowns and on tool tips for storage grids and ELNs. This is being done using a hidden customized view, which allows us to reuse much of the customizer components that already exist.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1551
- https://github.com/LabKey/labkey-ui-premium/pull/492
- https://github.com/LabKey/limsModules/pull/574

#### Changes
- Add metric to count the number of types that have customized the identifying fields
