### PR TITLE
Reinstate support for DROP * IF EXISTS on MS SQL Server

### DIFF
--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -332,17 +332,11 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
         }
     }
 
-    private static final Pattern DROP_IF_EXISTS = Pattern.compile(
-        "drop(aggregate|assembly|database|default|function|index|procedure|role|rule|schema|securitypolicy|sequence|synonym|table|trigger|type|user|view)ifexists"
-    );
-
     @Override
     protected void checkSqlScript(String lowerNoComments, String lowerNoCommentsNoWhiteSpace, Collection<String> errors)
     {
         if (lowerNoComments.startsWith("use ") || lowerNoComments.contains("\nuse "))
             errors.add("USE statements are prohibited");
-        if (DROP_IF_EXISTS.matcher(lowerNoCommentsNoWhiteSpace).find())
-            errors.add("DROP xxx IF EXISTS statements are prohibited since they're not supported until SQL Server 2016. Instead, use EXEC core.fn_dropifexists.");
     }
 
     private enum ReselectType {INSERT, UPDATE, OTHER}
@@ -367,7 +361,6 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
 
         return _addReselect(sql, columnName, hasDbTriggers, proposedVariable);
     }
-
 
     public String _addReselect(SQLFragment sql, String columnName, boolean useOutputIntoTableVar, @Nullable String proposedVariable)
     {

--- a/core/resources/schemas/dbscripts/sqlserver/core-24.003-24.004.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-24.003-24.004.sql
@@ -1,1 +1,1 @@
-EXEC core.fn_dropifexists 'PrincipalRelations', 'core', 'TABLE', NULL
+DROP TABLE IF EXISTS core.PrincipalRelations;

--- a/core/resources/schemas/dbscripts/sqlserver/core-drop.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-drop.sql
@@ -14,10 +14,5 @@
  * limitations under the License.
  */
 
--- DROP all views (current and obsolete)
-
--- NOTE: Don't remove any of these drop statements, even if we stop re-creating the view in *-create.sql. Drop statements must
--- remain in place so we can correctly upgrade from older versions, which we commit to for two years after each release.
-
-EXEC core.fn_dropifexists 'ActiveUsers', 'core', 'VIEW', NULL;
-EXEC core.fn_dropifexists 'Users', 'core', 'VIEW', NULL;
+DROP VIEW IF EXISTS core.ActiveUsers;
+DROP VIEW IF EXISTS core.Users;

--- a/core/resources/schemas/dbscripts/sqlserver/test-drop.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/test-drop.sql
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
--- DROP all views (current and obsolete)
-
--- NOTE: Don't remove any of these drop statements, even if we stop re-creating the view in *-create.sql. Drop statements must
--- remain in place so we can correctly upgrade from older versions, which we commit to for two years after each release.
-
--- dropifexists() doesn't like table names with special characters
-IF OBJECT_ID('test.a$b', 'V') IS NOT NULL
-    DROP VIEW test."a$b";
-IF OBJECT_ID('test.a_b', 'V') IS NOT NULL
-    DROP VIEW test."a_b";
-IF OBJECT_ID('test.a%b', 'V') IS NOT NULL
-    DROP VIEW test."a%b";
-IF OBJECT_ID('test.a\b', 'V') IS NOT NULL
-    DROP VIEW test."a\b";
+DROP VIEW IF EXISTS test."a$b";
+DROP VIEW IF EXISTS test."a_b";
+DROP VIEW IF EXISTS test."a%b";
+DROP VIEW IF EXISTS test."a\b";


### PR DESCRIPTION
#### Rationale
Now that we've removed support for SQL Server 2014, we can start using `DROP TABLE IF EXISTS ...`, `DROP VIEW IF EXISTS ...`, etc.

Allow the `DROP * IF EXISTS ...` syntax and use it in a few scripts.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5569