### PR TITLE
Remove credits for "Tomcat JAR files"

### DIFF
--- a/core/resources/credits/tomcat_jars.txt
+++ b/core/resources/credits/tomcat_jars.txt
@@ -1,5 +1,0 @@
-{table}
-Filename|Component|Version|Source|License|LabKey Dev|Purpose
-javax.activation.jar|Jakarta Activation™|1.2.2|{link:Eclipse|https://projects.eclipse.org/projects/ee4j.jaf}|{link:Eclipse Public License 2.0|https://www.eclipse.org/legal/epl-2.0/}|adam|Jakarta Mail and JAXB dependency
-mail.jar|Jakarta Mail™|1.6.7|{link:Eclipse|https://projects.eclipse.org/projects/ee4j.mail}|{link:Eclipse Public License 2.0|https://www.eclipse.org/legal/epl-2.0/}|adam|Send email from LabKey Server
-{table}

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1073,10 +1073,6 @@ public class AdminController extends SpringActionController
             modules.sort(Comparator.comparing(Module::getName, String.CASE_INSENSITIVE_ORDER));
 
             addCreditsViews(views, modules, "jars.txt", "JAR", null);
-
-            Module core = ModuleLoader.getInstance().getCoreModule();
-            addCreditsViews(views, Collections.singletonList(core), "tomcat_jars.txt", "Tomcat JAR", "JAR Files Installed in the <tomcat>/lib Directory"      /* No staging dir in production mode so skip error checking */);
-
             addCreditsViews(views, modules, "scripts.txt", "Script, Icon and Font");
             addCreditsViews(views, modules, "source.txt", "Java Source Code");
             addCreditsViews(views, modules, "executables.txt", "Executable");


### PR DESCRIPTION
#### Rationale
Now that we're embedded Tomcat only, we no longer copy jar files into the Tomcat lib directory