### PR TITLE
Allow SQL dialects to enforce identifier name limitations

### DIFF
--- a/api/src/org/labkey/api/data/dialect/SimpleSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SimpleSqlDialect.java
@@ -441,6 +441,13 @@ public abstract class SimpleSqlDialect extends SqlDialect
     {
         return false;
     }
+
+    @Override
+    public boolean supportsNativeGreatestAndLeast()
+    {
+        return false;
+    }
+
     // The following methods should never be called on a simple dialect.
 
     @Override
@@ -545,11 +552,5 @@ public abstract class SimpleSqlDialect extends SqlDialect
     public String translateParameterName(String name, boolean dialectSpecific)
     {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean supportsNativeGreatestAndLeast()
-    {
-        return false;
     }
 }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -867,12 +867,17 @@ public abstract class SqlDialect
     // If necessary, quote identifier
     public String makeLegalIdentifier(String id)
     {
+        id = makeLegalIdentifierName(id);
         if (shouldQuoteIdentifier(id))
             return quoteIdentifier(id);
         else
             return id;
     }
 
+    public String makeLegalIdentifierName(String id)
+    {
+        return id;
+    }
 
     // Escape quotes and quote the identifier  // TODO: Move to DialectStringHandler?
     public String quoteIdentifier(String id)

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -867,7 +867,6 @@ public abstract class SqlDialect
     // If necessary, quote identifier
     public String makeLegalIdentifier(String id)
     {
-        id = makeLegalIdentifierName(id);
         if (shouldQuoteIdentifier(id))
             return quoteIdentifier(id);
         else

--- a/api/src/org/labkey/api/query/AliasManager.java
+++ b/api/src/org/labkey/api/query/AliasManager.java
@@ -175,7 +175,9 @@ public class AliasManager
             ret = ret + "_";
         int length = ret.length();
         if (0 == length)
-            return "X_";
+            ret = "X_";
+        if (dialect != null)
+            ret = dialect.makeLegalIdentifierName(ret);
         // we use 28 here because Oracle has a limit or 30 characters, and that is likely the shortest restriction
         int maxLength = useLegacyMaxLength ? 40 : (dialect == null ? 28 : dialect.getIdentifierMaxLength());
         if (reserveCount > 0)

--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -178,6 +178,16 @@ public class StringUtilsLabKey
         return false;
     }
 
+    // Does the string have ANY lower-case letters?
+    public static boolean containsLowerCase(String s)
+    {
+        for (char ch : s.toCharArray())
+            if (Character.isLowerCase(ch))
+                return true;
+
+        return false;
+    }
+
 
     public static boolean isText(String s)
     {


### PR DESCRIPTION
#### Rationale
Snowflake only allows all-caps field and table identifiers. Need to add a way for SQL dialects to enforce identifier name limitations. This change fixed the errors I was having with PIVOT queries and expression columns in LabKey SQL.
It also makes LabKey SQL not be as strict about column alias casing when querying Snowflake.

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/30

#### Changes
- Allow SQL dialects to enforce identifier name limitations
