### PR TITLE
Ensure module properties are current on every startup

### DIFF
--- a/api/src/org/labkey/api/compliance/ComplianceService.java
+++ b/api/src/org/labkey/api/compliance/ComplianceService.java
@@ -34,10 +34,7 @@ import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewContext;
 
 /**
- * Created by davebradlee on 7/27/17.
- *
  * ComplianceService: ALL METHODS MUST CHECK IF ComplianceModule is enabled in container (if appropriate); callers don't check
- *
  */
 public interface ComplianceService
 {

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1591,7 +1591,7 @@ public class DbScope
                 }
                 catch (NamingException e)
                 {
-                    LOG.error("DataSources are not properly configured in " + AppProps.getInstance().getWebappConfigurationFilename() + ".", e);
+                    LOG.error("DataSources are not properly configured in {}.", AppProps.getInstance().getWebappConfigurationFilename(), e);
                 }
             }
 

--- a/api/src/org/labkey/api/data/DisplayColumn.java
+++ b/api/src/org/labkey/api/data/DisplayColumn.java
@@ -18,7 +18,6 @@ package org.labkey.api.data;
 
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -524,7 +523,7 @@ public abstract class DisplayColumn extends RenderColumn
             }
             catch (IllegalArgumentException e)
             {
-                LOG.warn("Unable to apply format to " + value.getClass().getName() + " value, likely a SQL type mismatch between XML metadata and actual ResultSet");
+                LOG.warn("Unable to apply format to {} value \"{}\" for column \"{}\", likely a SQL type mismatch between XML metadata and actual ResultSet", value.getClass().getName(), value, getName());
                 return ConvertUtils.convert(value);
             }
         }

--- a/api/src/org/labkey/api/data/dialect/SqlDialectFactory.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialectFactory.java
@@ -22,10 +22,6 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.Collection;
 
-/*
-* User: adam
-* Date: Nov 26, 2010
-*/
 public interface SqlDialectFactory
 {
     @Nullable SqlDialect createFromDriverClassName(String driverClassName);

--- a/api/src/org/labkey/api/data/dialect/SqlDialectNotSupportedException.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialectNotSupportedException.java
@@ -20,8 +20,8 @@ import org.labkey.api.util.ConfigurationException;
 
 public class SqlDialectNotSupportedException extends ConfigurationException
 {
-    SqlDialectNotSupportedException(String advice)
+    SqlDialectNotSupportedException(String message)
     {
-        super("JDBC database driver is not supported.", advice);
+        super(message);
     }
 }

--- a/api/src/org/labkey/api/module/ModuleContext.java
+++ b/api/src/org/labkey/api/module/ModuleContext.java
@@ -33,11 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-/**
- * User: migra
- * Date: Jul 19, 2005
- * Time: 1:16:28 PM
- */
 public class ModuleContext implements Cloneable
 {
     // ModuleContext fields are written by the main upgrade thread and read by request threads to show current

--- a/bigiron/src/org/labkey/bigiron/mysql/MySql56Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySql56Dialect.java
@@ -20,11 +20,6 @@ import org.labkey.api.collections.CsvSet;
 
 import java.util.Set;
 
-/**
- * User: adam
- * Date: 3/19/2014
- * Time: 7:49 AM
- */
 public class MySql56Dialect extends MySqlDialect
 {
     @NotNull

--- a/bigiron/src/org/labkey/bigiron/mysql/MySql57Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySql57Dialect.java
@@ -20,9 +20,6 @@ import org.labkey.api.collections.CsvSet;
 
 import java.util.Set;
 
-/**
- * Created by adam on 7/9/2016.
- */
 public class MySql57Dialect extends MySql56Dialect
 {
     @NotNull

--- a/bigiron/src/org/labkey/bigiron/mysql/MySql90Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySql90Dialect.java
@@ -15,7 +15,7 @@ public class MySql90Dialect extends MySql80Dialect
         Set<String> words = super.getReservedWords();
 
         words.removeAll(new CsvSet("master_bind, master_ssl_verify_server_cert"));
-        words.addAll(new CsvSet("intersect, parallel, tablesample"));
+        words.addAll(new CsvSet("parallel, qualify, tablesample"));
 
         return words;
     }

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -49,7 +49,6 @@ import org.labkey.api.audit.provider.FileSystemAuditProvider;
 import org.labkey.api.audit.provider.GroupAuditProvider;
 import org.labkey.api.audit.provider.ModulePropertiesAuditProvider;
 import org.labkey.api.cache.CacheManager;
-import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
@@ -68,14 +67,12 @@ import org.labkey.api.data.OutOfRangeDisplayColumn;
 import org.labkey.api.data.PropertySchema;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SchemaTableInfoFactory;
-import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TSVWriter;
 import org.labkey.api.data.TabContainerType;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.TempTableTracker;
 import org.labkey.api.data.TestSchema;
 import org.labkey.api.data.WorkbookContainerType;
@@ -107,7 +104,6 @@ import org.labkey.api.premium.AntiVirusProviderRegistry;
 import org.labkey.api.products.ProductRegistry;
 import org.labkey.api.qc.DataStateManager;
 import org.labkey.api.query.DefaultSchema;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
@@ -132,7 +128,6 @@ import org.labkey.api.security.DummyAntiVirusService;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.GroupManager;
 import org.labkey.api.security.LimitActiveUsersService;
-import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.MutableSecurityPolicy;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPointcutService;
@@ -142,7 +137,6 @@ import org.labkey.api.security.UserManager;
 import org.labkey.api.security.WikiTermsOfUseProvider;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.QCAnalystPermission;
-import org.labkey.api.security.roles.CanSeeAuditLogRole;
 import org.labkey.api.security.roles.NoPermissionsRole;
 import org.labkey.api.security.roles.PlatformDeveloperRole;
 import org.labkey.api.security.roles.ReaderRole;
@@ -1356,7 +1350,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     {
         return TabDisplayMode.DISPLAY_USER_PREFERENCE_DEFAULT;
     }
-
 
     @Override
     @NotNull

--- a/core/src/org/labkey/core/statistics/AnalyticsProviderRegistryImpl.java
+++ b/core/src/org/labkey/core/statistics/AnalyticsProviderRegistryImpl.java
@@ -60,9 +60,8 @@ public class AnalyticsProviderRegistryImpl implements AnalyticsProviderRegistry
         List<ColumnAnalyticsProvider> providers = new ArrayList<>();
         for (AnalyticsProvider registeredProvider : REGISTERED_PROVIDERS)
         {
-            if (registeredProvider instanceof ColumnAnalyticsProvider)
+            if (registeredProvider instanceof ColumnAnalyticsProvider colProvider)
             {
-                ColumnAnalyticsProvider colProvider = (ColumnAnalyticsProvider) registeredProvider;
                 if (columnInfo == null || colProvider.isApplicable(columnInfo))
                 {
                     providers.add(colProvider);
@@ -84,9 +83,8 @@ public class AnalyticsProviderRegistryImpl implements AnalyticsProviderRegistry
         List<QueryAnalyticsProvider> providers = new ArrayList<>();
         for (AnalyticsProvider registeredProvider : REGISTERED_PROVIDERS)
         {
-            if (registeredProvider instanceof QueryAnalyticsProvider)
+            if (registeredProvider instanceof QueryAnalyticsProvider queryProvider)
             {
-                QueryAnalyticsProvider queryProvider = (QueryAnalyticsProvider) registeredProvider;
                 if (settings == null || queryProvider.isApplicable(settings))
                 {
                     providers.add(queryProvider);

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -915,9 +915,9 @@ public class ExperimentModule extends SpringModule
 
     @Override
     @NotNull
-    public Set<String> getSchemaNames()
+    public Collection<String> getSchemaNames()
     {
-        return Set.of(
+        return List.of(
             ExpSchema.SCHEMA_NAME,
             DataClassDomainKind.PROVISIONED_SCHEMA_NAME,
             SampleTypeDomainKind.PROVISIONED_SCHEMA_NAME

--- a/issues/src/org/labkey/issue/IssuesModule.java
+++ b/issues/src/org/labkey/issue/IssuesModule.java
@@ -198,9 +198,9 @@ public class IssuesModule extends DefaultModule implements SearchService.Documen
 
     @Override
     @NotNull
-    public Set<String> getSchemaNames()
+    public List<String> getSchemaNames()
     {
-        return Set.of(
+        return List.of(
             IssuesSchema.getInstance().getSchemaName(),
             ISSUE_DEF_SCHEMA_NAME
         );


### PR DESCRIPTION
#### Rationale
A handful of unrelated improvements... see Changes section for details of each

#### Changes
- Previously, we updated the `core.Modules` table only when upgrades occurred, but these properties could change outside of an upgrade scenario (e.g., the schemas a module claims, https://github.com/LabKey/platform/pull/5760) . With this PR, we update module properties on every server startup, but only if they've changed vs. what's stored in the database. For consistency, we also sort the schema name list before saving and avoid `Set.of()` with multiple schema names since this method is aggressively non-deterministic.
- When encountering a display column formatting problem, provide more detailed logging so there's a chance we can determine which column is at fault
- Update MySQL reserved word list based on candidates added due to Snowflake
- Log the details when encountering an unsupported JDBC driver class names and product versions; logging "JDBC database driver is not supported" with no other details is unhelpful.
- Fix comments and warnings
