### PR TITLE
Issue 51021: Remove websocket check for Abnormal Closure event and rely on checkForExpiredSession() instead

### DIFF
--- a/api/webapp/clientapi/dom/WebSocket.js
+++ b/api/webapp/clientapi/dom/WebSocket.js
@@ -94,12 +94,6 @@ LABKEY.WebSocket = new function ()
                 // 1001 sent when server is shutdown normally (AND on page reload in FireFox, but that one doesn't have a reason)
                 setTimeout(showDisconnectedMessage, 1000);
             }
-            else if (evt.code === CloseEventCode.ABNORMAL_CLOSURE) {
-                // 1006 abnormal close (e.g, server process died)
-                setTimeout(function() {
-                    showDisconnectedMessage(true);
-                }, 1000);
-            }
             else if (evt.code === CloseEventCode.POLICY_VIOLATION) {
                 // Tomcat closes the websocket with "1008 Policy Violation" code when the session has expired.
                 // evt.reason === "This connection was established under an authenticated HTTP session that has ended."
@@ -122,6 +116,7 @@ LABKEY.WebSocket = new function ()
                 if (LABKEY.user.id !== response.id && !LABKEY.user.isGuest) {
                     displayModal("Session Expired", 'Your session has expired.', true);
                 } else {
+                    openWebsocket(); // re-establish the websocket connection, if not already open
                     hideModal();
                 }
             }),
@@ -164,8 +159,6 @@ LABKEY.WebSocket = new function ()
     }
 
     function hideModal() {
-        openWebsocket(); // re-establish the websocket connection for the new user session
-
         toggleBackgroundBlurred(false);
 
         var modal = $('#lk-utils-modal');


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51021

The related PR add a browser focus listener to help check more reliably if a user's session had expired. We discovered that the AWS load balancer has a connection idle timeout setting which also results in an Abnormal Closure websocket event. The related PR change was now inadvertently showing the "Server Unavailable" message because of this. This PR removes the check for the Abnormal Closure event and instead relies on the "checkForExpiredSession on browser focus" check to catch this server unavailable case.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5767

#### Changes
- WebSocket.js update to remove check for Abnormal Closure 1006 event code
