### PR TITLE
Fix metrics test failures due to quoted queryName in sql

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -1124,7 +1124,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     /** Returns true if the property has a lookup to exp.Materials and is an int or string. */
     boolean isLookupToMaterials(DomainProperty dp);
 
-    void registerNameExpressionType(String dataType, TableInfo tableInfo, String nameExpressionCol);
+    void registerNameExpressionType(String dataType, String schemaName, String queryname, String nameExpressionCol);
 
     Map<String, Object> getNameExpressionMetrics();
 

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -225,9 +225,9 @@ public class ExperimentModule extends SpringModule
 
         ExperimentService.get().registerExperimentDataHandler(new DefaultExperimentDataHandler());
         ExperimentService.get().registerProtocolInputCriteria(new FilterProtocolInputCriteria.Factory());
-        ExperimentService.get().registerNameExpressionType("sampletype", ExperimentService.get().getTinfoSampleType(), "nameexpression");
-        ExperimentService.get().registerNameExpressionType("aliquots", ExperimentService.get().getTinfoSampleType(), "aliquotnameexpression");
-        ExperimentService.get().registerNameExpressionType("dataclass", ExperimentService.get().getTinfoDataClass(), "nameexpression");
+        ExperimentService.get().registerNameExpressionType("sampletype", "exp", "MaterialSource", "nameexpression");
+        ExperimentService.get().registerNameExpressionType("aliquots", "exp", "MaterialSource", "aliquotnameexpression");
+        ExperimentService.get().registerNameExpressionType("dataclass", "exp", "DataClass", "nameexpression");
 
         AdminConsole.addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_RESOLVE_PROPERTY_URI_COLUMNS, "Resolve property URIs as columns on experiment tables",
                 "If a column is not found on an experiment table, attempt to resolve the column name as a Property URI and add it as a property column", false);

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -9162,9 +9162,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public void registerNameExpressionType(String dataType, TableInfo tableInfo, String nameExpressionCol)
+    public void registerNameExpressionType(String dataType, String schemaName, String queryName, String nameExpressionCol)
     {
-        _nameExpressionTypes.add(new NameExpressionType(dataType, tableInfo, nameExpressionCol));
+        _nameExpressionTypes.add(new NameExpressionType(dataType, schemaName, queryName, nameExpressionCol));
     }
 
     @Override
@@ -9174,17 +9174,17 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         for (NameExpressionType nameExpressionType : _nameExpressionTypes)
         {
-            TableInfo tableInfo = nameExpressionType.tableInfo;
             Map<String, Object> typeMetrics = new HashMap<>();
-            DbSchema schema = tableInfo.getSchema();
             SQLFragment sql = new SQLFragment("SELECT ")
                     .append(nameExpressionType.nameExpressionCol)
                     .append(" FROM ")
-                    .append(tableInfo)
+                    .append(nameExpressionType.schemaName)
+                    .append(".")
+                    .append(nameExpressionType.queryName)
                     .append(" WHERE ")
                     .append(nameExpressionType.nameExpressionCol)
                     .append(" IS NOT NULL");
-            List<String> nameExpressionStrs = new SqlSelector(schema, sql).getArrayList(String.class);
+            List<String> nameExpressionStrs = new SqlSelector(ExperimentService.get().getSchema(), sql).getArrayList(String.class);
 
             Map<String, Long> substitutionMetrics = new HashMap<>();
             for (NameGenerator.SubstitutionValue substitutionValue : NameGenerator.SubstitutionValue.values())
@@ -10342,7 +10342,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
     }
 
-    private record NameExpressionType(String dataType, TableInfo tableInfo, String nameExpressionCol)
+    private record NameExpressionType(String dataType, String schemaName, String queryName, String nameExpressionCol)
     {
     }
 }


### PR DESCRIPTION
#### Rationale
For unknown reason, the sample type tableInfo (ExperimentService.getTinfoSampleType) produced exp."MaterialSource" when appended as sql fragment on some Teamcity instances. This results in table not found error. as the actual table name is likely "materialsource". 

This PR modifies the metrics util for naming patterns to take schema and query name as inputs, instead of tableInfo, to avoid the problematic quotes. 

[InProductMessagingTest.testSetMarketingMessage](https://teamcity.labkey.org/viewLog.html?buildId=3157060&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId4271799274862982904), [InProductMessagingTest.testMarketingMessageAppearsForGuest](https://teamcity.labkey.org/viewLog.html?buildId=3157060&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId8527624581545126454), [InProductMessagingTest.testMarketingMessageAppearsForAuthor](https://teamcity.labkey.org/viewLog.html?buildId=3157060&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId-5567586386025024959), [MothershipReportTest.testForwardedRequest](https://teamcity.labkey.org/viewLog.html?buildId=3157060&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId-4263590430038755300), [MothershipReportTest.testJsonMetrics](https://teamcity.labkey.org/viewLog.html?buildId=3157060&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId-888750332093462015), [MothershipReportTest.testServerHostName](https://teamcity.labkey.org/viewLog.html?buildId=3157060&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId-3892690952565497465), [MothershipReportTest.testTopLevelItems](https://teamcity.labkey.org/viewLog.html?buildId=3157060&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId8463883017390958291)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5791
- https://github.com/LabKey/limsModules/pull/595

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
