### PR TITLE
NavTrail: write ancestors regardless of if breadcrumb existed previously

### DIFF
--- a/api/webapp/clientapi/dom/NavTrail.js
+++ b/api/webapp/clientapi/dom/NavTrail.js
@@ -45,14 +45,11 @@ LABKEY.NavTrail.setTrail("People View", [{url: ancestorURL, title: "API Example"
         {
             var elem = document.querySelector('.lk-body-title');
             var folderLinkElem = document.querySelector('.lk-body-title-folder-outer');
-            if (elem)
-            {
+            if (elem) {
                 var newTrail = '';
                 var newTitle = '<h3 style="display: inline-block;">' + (encode !== false ? LABKEY.Utils.encodeHtml(currentPageTitle) : currentPageTitle) + '</h3>';
 
-                var trailEl = elem.querySelector('.breadcrumb');
-                if (trailEl && ancestors)
-                {
+                if (ancestors) {
                     newTrail = '<ol class="breadcrumb">';
                     for (var i=0; i < ancestors.length; i++)
                     {
@@ -71,8 +68,9 @@ LABKEY.NavTrail.setTrail("People View", [{url: ancestorURL, title: "API Example"
 
                 elem.innerHTML = newTrail + newTitle;
             }
-            if (!removeFolderLink && folderLinkElem)
+            if (!removeFolderLink && folderLinkElem) {
                 elem.appendChild(folderLinkElem);
+            }
 
             //set document title:
             //<currentPageTitle>: <container path>


### PR DESCRIPTION
#### Rationale
This simplifies the logic a bit for client-side `NavTrail` rendering by not requiring that a `.breadcrumb` element be present when attempting to add links into the bread crumb trail.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5792
- https://github.com/LabKey/limsModules/pull/596

#### Changes
- Remove check for preexisting `.breadcrumb` element.
