### PR TITLE
Handle unknown modules on every startup

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -1833,9 +1833,10 @@ public class ModuleLoader implements MemTrackerListener
     {
         setUpgradeState(UpgradeState.UpgradeComplete);
 
+        handleUnknownModules();
+
         if (performedUpgrade)
         {
-            handleUnknownModules();
             updateModuleProperties();
         }
 


### PR DESCRIPTION
#### Rationale
Modules can disappear in new server versions that don't include module upgrades (e.g., 24.7.2 --> 24.7.3 update). We want modules to uninstall themselves in this case as well.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5786