### PR TITLE
Plates: move custom fields from plate to plate set

### DIFF
--- a/assay/resources/schemas/assay.xml
+++ b/assay/resources/schemas/assay.xml
@@ -111,10 +111,10 @@
       </column>
     </columns>
   </table>
-  <table tableName="PlateProperty" tableDbType="TABLE">
+  <table tableName="PlateSetProperty" tableDbType="TABLE">
     <columns>
       <column columnName="RowId"/>
-      <column columnName="PlateId"/>
+      <column columnName="PlateSetId"/>
       <column columnName="PropertyURI"/>
       <column columnName="PropertyId"/>
     </columns>

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.011-24.012.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.011-24.012.sql
@@ -1,3 +1,4 @@
+-- Specify plate metadata columns on the plate set rather than the individual plates
 CREATE TABLE assay.PlateSetProperty
 (
     RowId SERIAL,

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.011-24.012.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.011-24.012.sql
@@ -7,8 +7,8 @@ CREATE TABLE assay.PlateSetProperty
 
     CONSTRAINT PK_PlateSetProperty PRIMARY KEY (RowId),
     CONSTRAINT UQ_PlateSetProperty_PlateSetId_PropertyId UNIQUE (PlateSetId, PropertyId),
-    CONSTRAINT FK_PlateSetProperty_PlateSetId FOREIGN KEY (PlateSetId) REFERENCES assay.PlateSet(RowId),
-    CONSTRAINT FK_PlateSetProperty_PropertyId FOREIGN KEY (PropertyId) REFERENCES exp.PropertyDescriptor(PropertyId)
+    CONSTRAINT FK_PlateSetProperty_PlateSetId FOREIGN KEY (PlateSetId) REFERENCES assay.PlateSet(RowId) ON DELETE CASCADE,
+    CONSTRAINT FK_PlateSetProperty_PropertyId FOREIGN KEY (PropertyId) REFERENCES exp.PropertyDescriptor(PropertyId) ON DELETE CASCADE
 );
 
 INSERT INTO assay.PlateSetProperty (PlateSetId, PropertyId, PropertyURI)

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.011-24.012.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.011-24.012.sql
@@ -1,0 +1,24 @@
+CREATE TABLE assay.PlateSetProperty
+(
+    RowId SERIAL,
+    PlateSetId INT NOT NULL,
+    PropertyId INT NOT NULL,
+    PropertyURI VARCHAR(300) NOT NULL,
+
+    CONSTRAINT PK_PlateSetProperty PRIMARY KEY (RowId),
+    CONSTRAINT UQ_PlateSetProperty_PlateSetId_PropertyId UNIQUE (PlateSetId, PropertyId),
+    CONSTRAINT FK_PlateSetProperty_PlateSetId FOREIGN KEY (PlateSetId) REFERENCES assay.PlateSet(RowId),
+    CONSTRAINT FK_PlateSetProperty_PropertyId FOREIGN KEY (PropertyId) REFERENCES exp.PropertyDescriptor(PropertyId)
+);
+
+INSERT INTO assay.PlateSetProperty (PlateSetId, PropertyId, PropertyURI)
+SELECT
+    PL.PlateSet AS PlateSetId,
+    PP.PropertyId,
+    PP.PropertyURI
+FROM assay.PlateProperty AS PP
+INNER JOIN assay.Plate AS PL ON PP.PlateId = PL.RowId
+GROUP BY PlateSetId, PropertyId, PropertyURI
+ORDER BY PlateSetId, PropertyId;
+
+-- DROP TABLE assay.PlateProperty;

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.011-24.012.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.011-24.012.sql
@@ -7,8 +7,8 @@ CREATE TABLE assay.PlateSetProperty
 
     CONSTRAINT PK_PlateSetProperty PRIMARY KEY (RowId),
     CONSTRAINT UQ_PlateSetProperty_PlateSetId_PropertyId UNIQUE (PlateSetId, PropertyId),
-    CONSTRAINT FK_PlateSetProperty_PlateSetId FOREIGN KEY (PlateSetId) REFERENCES assay.PlateSet(RowId),
-    CONSTRAINT FK_PlateSetProperty_PropertyId FOREIGN KEY (PropertyId) REFERENCES exp.PropertyDescriptor(PropertyId)
+    CONSTRAINT FK_PlateSetProperty_PlateSetId FOREIGN KEY (PlateSetId) REFERENCES assay.PlateSet(RowId) ON DELETE CASCADE,
+    CONSTRAINT FK_PlateSetProperty_PropertyId FOREIGN KEY (PropertyId) REFERENCES exp.PropertyDescriptor(PropertyId) ON DELETE CASCADE
 );
 
 INSERT INTO assay.PlateSetProperty (PlateSetId, PropertyId, PropertyURI)

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.011-24.012.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.011-24.012.sql
@@ -1,9 +1,9 @@
 CREATE TABLE assay.PlateSetProperty
 (
-    RowId SERIAL,
+    RowId INT IDENTITY(1,1),
     PlateSetId INT NOT NULL,
     PropertyId INT NOT NULL,
-    PropertyURI VARCHAR(300) NOT NULL,
+    PropertyURI NVARCHAR(300) NOT NULL,
 
     CONSTRAINT PK_PlateSetProperty PRIMARY KEY (RowId),
     CONSTRAINT UQ_PlateSetProperty_PlateSetId_PropertyId UNIQUE (PlateSetId, PropertyId),
@@ -18,7 +18,8 @@ SELECT
     PP.PropertyURI
 FROM assay.PlateProperty AS PP
 INNER JOIN assay.Plate AS PL ON PP.PlateId = PL.RowId
-GROUP BY PlateSetId, PropertyId, PropertyURI
+GROUP BY PL.PlateSet, PP.PropertyId, PP.PropertyURI
 ORDER BY PlateSetId, PropertyId;
 
 DROP TABLE assay.PlateProperty;
+GO

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.011-24.012.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.011-24.012.sql
@@ -1,3 +1,4 @@
+-- Specify plate metadata columns on the plate set rather than the individual plates
 CREATE TABLE assay.PlateSetProperty
 (
     RowId INT IDENTITY(1,1),

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -117,7 +117,7 @@ public class AssayModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 24.011;
+        return 24.012;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -382,7 +382,7 @@ public class AssayUpgradeCode implements UpgradeCode
         try (DbScope.Transaction tx = scope.ensureTransaction())
         {
             // just truncate the plate to custom property mappings
-            Table.truncate(AssayDbSchema.getInstance().getTableInfoPlateProperty());
+            Table.truncate(AssayDbSchema.getInstance().getSchema().getTable("PlateProperty"));
             List<Container> biologicsFolders = new ArrayList<>();
 
             for (Container container : ContainerManager.getAllChildren(ContainerManager.getRoot()))

--- a/assay/src/org/labkey/assay/plate/PlateCache.java
+++ b/assay/src/org/labkey/assay/plate/PlateCache.java
@@ -204,6 +204,7 @@ public class PlateCache
     public static void uncache(Container c, PlateSet plateSet)
     {
         // TODO: Feels like this could end up caching a bunch of a plates that were not cached just to uncache them.
+        // Consider introducing plate set caching and moving custom field modeling to plate sets
         getPlatesForPlateSet(c, plateSet.getRowId()).forEach(plate -> uncache(c, plate));
     }
 

--- a/assay/src/org/labkey/assay/plate/PlateCache.java
+++ b/assay/src/org/labkey/assay/plate/PlateCache.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.cache.CacheManager;
@@ -198,6 +199,12 @@ public class PlateCache
 
         if (_loader._containerPlateMap.containsKey(c))
             _loader._containerPlateMap.get(c).remove(plate);
+    }
+
+    public static void uncache(Container c, PlateSet plateSet)
+    {
+        // TODO: Feels like this could end up caching a bunch of a plates that were not cached just to uncache them.
+        getPlatesForPlateSet(c, plateSet.getRowId()).forEach(plate -> uncache(c, plate));
     }
 
     public static void clearCache()

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1309,8 +1309,6 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         final AssayDbSchema schema = AssayDbSchema.getInstance();
         final SqlDialect sqlDialect = schema.getSchema().getSqlDialect();
 
-        // assay.PlateSetProperty rows are deleted via ON DELETE CASCADE when the plate set is deleted.
-
         // delete PlateSetEdge relationships
         {
             SQLFragment sql = new SQLFragment("DELETE FROM ").append(schema.getTableInfoPlateSetEdge())
@@ -1333,6 +1331,9 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                     .append(" SET RootPlateSetId = NULL WHERE RootPlateSetId ").appendInClause(plateSetIds, sqlDialect);
             new SqlExecutor(schema.getSchema()).execute(sql);
         }
+
+        // The following tables are cleaned up via ON DELETE CASCADE when a plate set is deleted:
+        // - assay.PlateSetProperty
     }
 
     private void deleteWellGroups(Container container, User user, List<Integer> wellGroupRowIds) throws Exception

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1309,20 +1309,14 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         final AssayDbSchema schema = AssayDbSchema.getInstance();
         final SqlDialect sqlDialect = schema.getSchema().getSqlDialect();
 
+        // assay.PlateSetProperty rows are deleted via ON DELETE CASCADE when the plate set is deleted.
+
         // delete PlateSetEdge relationships
         {
             SQLFragment sql = new SQLFragment("DELETE FROM ").append(schema.getTableInfoPlateSetEdge())
                     .append(" WHERE FromPlateSetId ").appendInClause(plateSetIds, sqlDialect)
                     .append(" OR ToPlateSetId ").appendInClause(plateSetIds, sqlDialect)
                     .append(" OR RootPlateSetId ").appendInClause(plateSetIds, sqlDialect);
-            new SqlExecutor(schema.getSchema()).execute(sql);
-        }
-
-        // delete PlateSetProperty mappings
-        {
-            SQLFragment sql = new SQLFragment("DELETE FROM ")
-                    .append(schema.getTableInfoPlateSetProperty(), "")
-                    .append(" WHERE PlateSetId ").appendInClause(plateSetIds, sqlDialect);
             new SqlExecutor(schema.getSchema()).execute(sql);
         }
 

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -405,17 +405,6 @@ public final class PlateManagerTest
         // assign custom fields to the plate
         assertEquals("Expected custom fields to be added to the plate", 7, PlateManager.get().addFields(container, user, plateId, fields).size());
 
-        // verification when adding custom fields to the plate
-        try
-        {
-            PlateManager.get().addFields(container, user, plateId, fields);
-            fail("Expected a validation error when adding existing fields");
-        }
-        catch (IllegalArgumentException e)
-        {
-            assertEquals("Expected validation exception", "Failed to add plate custom fields. Custom field \"Amount\" already is associated with this plate.", e.getMessage());
-        }
-
         // remove amount and amountUnits metadata fields
         fields = PlateManager.get().removeFields(container, user, plateId, List.of(fields.get(0), fields.get(1)));
         assertEquals("Expected 5 plate custom fields", 5, fields.size());

--- a/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
@@ -203,7 +203,7 @@ public class PlateSetTable extends SimpleUserSchema.SimpleTable<UserSchema>
         ) throws QueryUpdateServiceException, SQLException, InvalidKeyException
         {
             // ensure the plate set is empty
-            Integer plateSetId = (Integer)oldRowMap.get("RowId");
+            Integer plateSetId = (Integer) oldRowMap.get("RowId");
             PlateSet plateSet = PlateManager.get().getPlateSet(container, plateSetId);
             if (plateSet == null)
                 throw new QueryUpdateServiceException(String.format("Plate set could not be found for ID : %d", plateSetId));

--- a/assay/src/org/labkey/assay/query/AssayDbSchema.java
+++ b/assay/src/org/labkey/assay/query/AssayDbSchema.java
@@ -54,9 +54,9 @@ public class AssayDbSchema
         return getSchema().getTable("WellGroupPositions");
     }
 
-    public TableInfo getTableInfoPlateProperty()
+    public TableInfo getTableInfoPlateSetProperty()
     {
-        return getSchema().getTable("PlateProperty");
+        return getSchema().getTable("PlateSetProperty");
     }
 
     public TableInfo getTableInfoPlateSet()


### PR DESCRIPTION
#### Rationale
This moves server-side implementation of custom fields to be declared on a plate set instead of on each plate individually. I have not changed the API so it still accepts a `plateId` from which is resolves the plate set. This leaves the current UX intact.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/605

#### Changes
- Create and hydrate a new `assay.PlateSetProperty` table from the pre-existing `assay.PlateProperty` table.
- Update queries mutating custom fields to resolve to/from the plate set.
- Drop the `assay.PlateProperty` table.
- Fix [Issue 50161](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50161) by deleting `assay.PlateSetProperty` rows via `ON DELETE CASCADE`.
