### PR TITLE
Stop looking for forbidden tomcat/lib jars

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -1280,35 +1280,6 @@ public class ModuleLoader implements MemTrackerListener
         return _tomcatVersion;
     }
 
-    public static @Nullable File getTomcatLib()
-    {
-        String classPath = System.getProperty("java.class.path", ".");
-
-        for (String path : StringUtils.split(classPath, File.pathSeparatorChar))
-        {
-            if (path.endsWith("/bin/bootstrap.jar"))
-            {
-                path = path.substring(0, path.length() - "/bin/bootstrap.jar".length());
-                if (new File(path, "lib").isDirectory())
-                    return new File(path, "lib");
-            }
-        }
-
-        String tomcat = System.getenv("CATALINA_HOME");
-
-        if (null == tomcat)
-            tomcat = System.getenv("TOMCAT_HOME");
-
-        if (null == tomcat)
-        {
-            _log.debug("Could not find CATALINA_HOME environment variable");
-            return null;
-        }
-
-        return new File(tomcat, "lib");
-    }
-
-
     /**
      * Initialize and update the Core module first. We want to change the core tables before we display pages, request
      * login, check permissions, or initialize any of the other modules.

--- a/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/mysql/MySqlDialectFactory.java
@@ -17,10 +17,9 @@
 package org.labkey.bigiron.mysql;
 
 import com.mysql.cj.jdbc.AbandonedConnectionCleanupThread;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.data.DbScope;
 import org.labkey.api.data.dialect.DatabaseNotSupportedException;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.SqlDialectFactory;
@@ -44,9 +43,6 @@ public class MySqlDialectFactory implements SqlDialectFactory
 
     public MySqlDialectFactory()
     {
-        // MySQL JDBC driver should not be present in <tomcat>/lib
-        DbScope.registerForbiddenTomcatFilenamePredicate(filename->filename.equalsIgnoreCase("mysql.jar"));
-
         // Terminate MySQL AbandonedConnectionCleanupThread at shutdown to avoid Tomcat logging IllegalStateException, Issue 42117
         ContextListener.addShutdownListener(new ShutdownListener()
         {

--- a/bigiron/src/org/labkey/bigiron/oracle/OracleDialectFactory.java
+++ b/bigiron/src/org/labkey/bigiron/oracle/OracleDialectFactory.java
@@ -16,12 +16,10 @@
 
 package org.labkey.bigiron.oracle;
 
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.data.DbScope;
 import org.labkey.api.data.dialect.AbstractDialectRetrievalTestCase;
 import org.labkey.api.data.dialect.DatabaseNotSupportedException;
 import org.labkey.api.data.dialect.JdbcHelperTest;
@@ -37,17 +35,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-/**
- * User: trent
- * Date: 6/10/11
- * Time: 3:40 PM
- */
 public class OracleDialectFactory implements SqlDialectFactory
 {
     public OracleDialectFactory()
     {
-        // Oracle JDBC driver should not be present in <tomcat>/lib
-        DbScope.registerForbiddenTomcatFilenamePredicate(filename-> StringUtils.startsWithIgnoreCase(filename, "ojdbc"));
     }
 
     private String getProductName()

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
-import org.labkey.api.data.DbScope;
 import org.labkey.api.data.dialect.AbstractDialectRetrievalTestCase;
 import org.labkey.api.data.dialect.DatabaseNotSupportedException;
 import org.labkey.api.data.dialect.JdbcHelperTest;
@@ -52,8 +51,6 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
 
     public PostgreSqlDialectFactory()
     {
-        // PostgreSQL JDBC driver should not be present in <tomcat>/lib
-        DbScope.registerForbiddenTomcatFilenamePredicate(filename->filename.equalsIgnoreCase("postgresql.jar"));
     }
 
     @Override

--- a/search/src/org/labkey/search/model/SavePaths.java
+++ b/search/src/org/labkey/search/model/SavePaths.java
@@ -173,7 +173,6 @@ public class SavePaths implements DavCrawler.SavePaths
         String valuePath = toPathString(path);
         String valueName = path.equals(Path.rootPath) ? "/" : path.getName();   // "" is treated like NULL
         Date valueNextCrawl = new Date();
-        Date valueLastCrawled = nullDate;
 
         DbSchema db = getSearchSchema();
         TableInfo coll = getSearchSchema().getTable("CrawlCollections");
@@ -190,7 +189,7 @@ public class SavePaths implements DavCrawler.SavePaths
             insert.add(valueName);
             insert.add(valuePath);
             insert.add(valueNextCrawl);
-            insert.add(valueLastCrawled);
+            insert.add(nullDate);
             // where
             insert.add(valueParent);
             insert.add(valueName);


### PR DESCRIPTION
#### Rationale
Checking for old jar files in tomcat/lib is no longer necessary plus the code doesn't work on embedded. Fix log4j 1.2 detection. Get rid of broken `getTomcatLib()` method.

#### Related Pull Requests
- https://github.com/LabKey/server/pull/867
