### PR TITLE
Issue 51021: WebSocket whoAmI failure to check for null _websocket before showing unavailable message

### DIFF
--- a/api/webapp/clientapi/dom/WebSocket.js
+++ b/api/webapp/clientapi/dom/WebSocket.js
@@ -120,8 +120,12 @@ LABKEY.WebSocket = new function ()
                     hideModal();
                 }
             }),
-            failure: function () {
-                setTimeout(showDisconnectedMessage, 1000);
+            failure: function (reason) {
+                setTimeout(function() {
+                    // Issue 51021: check for null _websocket before showing unavailable message as this can be triggered
+                    // in FF by having the API call aborted because of a page navigation
+                    if (_websocket === null) showDisconnectedMessage();
+                }, 1000);
             }
         });
     }


### PR DESCRIPTION
#### Rationale
See related PRs for previous changes related to issue https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51021
This PR adds in a null check so that if the whoAmI API call fails we check to see if the websocket connection is still available. If not, that is an indicator of "server unavailable". If the websocket is still available on the failure, then this is likely the "FF page navigation" case.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5789 

#### Changes
- check for null _websocket before showing unavailable message as this can be triggered (in FF by having the API call aborted because of a page navigation)
