### PR TITLE
Action and test for response.sendError(int, String)

### DIFF
--- a/devtools/src/org/labkey/devtools/TestController.java
+++ b/devtools/src/org/labkey/devtools/TestController.java
@@ -16,6 +16,7 @@
 
 package org.labkey.devtools;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.FormArrayList;
@@ -57,6 +58,7 @@ import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.Controller;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -83,12 +85,7 @@ import static org.labkey.api.util.HttpUtil.Method.PUT;
 import static org.labkey.api.util.PageFlowUtil.filter;
 
 /**
- * User: matthewb
- * Date: Sep 6, 2007
- * Time: 8:55:54 AM
- *
- * This controller is for testing the controller framework including
- *
+ * This controller is for testing the controller framework including:
  *  actions
  *  jsp
  *  tags
@@ -99,6 +96,7 @@ import static org.labkey.api.util.PageFlowUtil.filter;
 public class TestController extends SpringActionController
 {
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(TestController.class);
+
     public static final String NAME = "test";
 
     public TestController()
@@ -1113,8 +1111,8 @@ public class TestController extends SpringActionController
         }
     }
 
-
-    /* This action is broken at the moment.  However, pivot.jsp and resources/olap/specimen.xml
+    /*
+     * This action is broken at the moment. However, pivot.jsp and resources/olap/specimen.xml
      * show how the olap APIs should work on the client side.
      */
     @RequiresSiteAdmin
@@ -1132,4 +1130,25 @@ public class TestController extends SpringActionController
         }
     }
 
+    /**
+     * We expect {@code response.sendError()} to send the message in the response, but this wasn't happening by default
+     * on embedded Tomcat distributions. This simple action provides a straightforward test. See Issue 51110 and
+     * {@code SendErrorTest}.
+     */
+    @RequiresSiteAdmin
+    public static class SendErrorAction extends SimpleViewAction<Object>
+    {
+        @Override
+        public ModelAndView getView(Object o, BindException errors) throws IOException
+        {
+            HttpServletResponse response = getViewContext().getResponse();
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "This is a very bad request!");
+            return null;
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+        }
+    }
 }

--- a/devtools/test/src/org/labkey/test/tests/devtools/SendErrorTest.java
+++ b/devtools/test/src/org/labkey/test/tests/devtools/SendErrorTest.java
@@ -1,0 +1,67 @@
+package org.labkey.test.tests.devtools;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.CommandResponse;
+import org.labkey.remoteapi.GetCommand;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.categories.Base;
+import org.labkey.test.categories.DRT;
+import org.labkey.test.categories.Daily;
+import org.labkey.test.categories.Git;
+import org.labkey.test.categories.Hosting;
+import org.labkey.test.categories.Smoke;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.fail;
+
+/**
+ * We expect {@code response.sendError(statusCode, message)} to send the provided message in the response, but this
+ * wasn't happening by default on embedded Tomcat distributions. This simple test verifies the fix. See Issue 51110.
+ */
+@Category({Base.class, DRT.class, Daily.class, Git.class, Hosting.class, Smoke.class})
+public class SendErrorTest extends BaseWebDriverTest
+{
+    @Override
+    protected String getProjectName()
+    {
+        return null;
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return List.of("DeveloperTools");
+    }
+
+    @Test
+    public void testSendError() throws IOException
+    {
+        SendErrorCommand sendErrorCommand = new SendErrorCommand();
+        final CommandResponse response;
+        try
+        {
+            response = sendErrorCommand.execute(WebTestHelper.getRemoteApiConnection(), "/");
+            fail("Expected execute() to throw a CommandException but succeeded with: " + response.getText());
+        }
+        catch (CommandException e)
+        {
+            checker().verifyThat("Response status code", e.getStatusCode(), equalTo(400));
+            checker().verifyThat("Response text", e.getResponseText(), containsString("This is a very bad request!"));
+        }
+    }
+
+    private static class SendErrorCommand extends GetCommand<CommandResponse>
+    {
+        protected SendErrorCommand()
+        {
+            super("test", "sendError");
+        }
+    }
+}


### PR DESCRIPTION
#### Rationale
HttpServletResponse.sendError(statusCode, message) has been failing to send the message by default on embedded Tomcat distributions. `MyStudiesRegistrationTest` noticed, but an explicit action and test will be a more prominent canary in our coal mine.

Actual fix is in the related PR

#### Related Pull Requests
- https://github.com/LabKey/server/pull/868