### PR TITLE
Exclude special "serverGuid" document from validation checks

### DIFF
--- a/search/src/org/labkey/search/model/IndexInspector.java
+++ b/search/src/org/labkey/search/model/IndexInspector.java
@@ -152,6 +152,10 @@ public class IndexInspector
 
                         if (titles.length != 1 || urls.length != 1 || uniqueIds.length != 1 || containerIds.length != 1)
                         {
+                            // Skip the special "serverGuid" doc
+                            if (doc.get("serverGuid") == null)
+                                continue;
+
                             throw new IOException("Incorrect number of term values found for document " + i);
                         }
 

--- a/search/src/org/labkey/search/model/IndexInspector.java
+++ b/search/src/org/labkey/search/model/IndexInspector.java
@@ -153,7 +153,7 @@ public class IndexInspector
                         if (titles.length != 1 || urls.length != 1 || uniqueIds.length != 1 || containerIds.length != 1)
                         {
                             // Skip the special "serverGuid" doc
-                            if (doc.get("serverGuid") == null)
+                            if (doc.get(LuceneSearchServiceImpl.SERVER_GUID_NAME) != null)
                                 continue;
 
                             throw new IOException("Incorrect number of term values found for document " + i);

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -406,7 +406,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         initializeIndex();
     }
 
-    private static final String SERVER_GUID_NAME = "ServerGuid";
+    public static final String SERVER_GUID_NAME = "ServerGuid";
 
     // The full-text search index is stored in the file system and the lastIndexed timestamp for most documents is
     // stored in the database. If the index and database get out-of-sync for any reason then documents will fail to


### PR DESCRIPTION
#### Rationale
Related PR added a "special" document to the Lucene index that doesn't conform to our usual rules. `IndexInspector` didn't get the memo, resulting in highly truncated index content exports.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5446