### PR TITLE
Issue 51147: make exported folder archive available in file root

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -4846,7 +4846,7 @@ public class AdminController extends SpringActionController
 
     public enum ExportOption
     {
-        PipelineRootAsFiles("pipeline root as files")
+        PipelineRootAsFiles("file root as multiple files")
                 {
                     @Override
                     public ActionURL initiateExport(Container container, BindException errors, FolderWriterImpl writer, FolderExportContext ctx, HttpServletResponse response) throws Exception
@@ -4877,7 +4877,7 @@ public class AdminController extends SpringActionController
                     }
                 },
 
-        PipelineRootAsZip("pipeline root as a zip file")
+        PipelineRootAsZip("file root as a single zip file")
         {
             @Override
             public ActionURL initiateExport(Container container, BindException errors, FolderWriterImpl writer, FolderExportContext ctx, HttpServletResponse response) throws Exception

--- a/pipeline/src/org/labkey/pipeline/PipelineModule.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineModule.java
@@ -256,6 +256,8 @@ public class PipelineModule extends SpringModule implements ContainerManager.Con
             result.put("triggerCounts", triggerCounts);
             result.put("jmsType", PipelineService.get().getJmsType().toString());
 
+            result.put("pipelineRootCount", PipelineService.get().getAllPipelineRoots().size());
+
             return result;
         });
     }


### PR DESCRIPTION
#### Rationale
Servers almost exclusively use file roots.

#### Changes
- Update folder export options to refer to file root instead of pipeline root
- Metric to see which servers are using pipeline roots