### PR TITLE
Reduce role/permission log warnings

### DIFF
--- a/api/src/org/labkey/api/security/roles/RoleConverter.java
+++ b/api/src/org/labkey/api/security/roles/RoleConverter.java
@@ -16,30 +16,15 @@
 package org.labkey.api.security.roles;
 
 import org.apache.commons.beanutils.Converter;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-/*
-* User: Dave
-* Date: Apr 23, 2009
-* Time: 4:28:20 PM
-*/
 public class RoleConverter implements Converter
 {
-    private static final Logger _log = LogManager.getLogger(RoleConverter.class);
-
     @Override
     public Object convert(Class type, Object value)
     {
-        if(null == value || !type.equals(Role.class) || !(value instanceof String))
+        if (null == value || !type.equals(Role.class) || !(value instanceof String))
             return null;
         else
-        {
-            Role role = RoleManager.getRole((String) value);
-            if(null == role)
-                _log.warn("Unable to resolve role name '" + value + "'! This role may no longer exist, or has not been registered with RoleManger.register().");
-            
-            return role;
-        }
+            return RoleManager.getRole((String) value); // Note: getRole() logs a warning for unknown roles, so no need to do so here
     }
 }


### PR DESCRIPTION
#### Rationale
`RoleManager` and `RoleConverter` log warnings every time they encounter an unknown role. This can result in an excessive number of warnings on development machines where roles are often set in test folders, their corresponding modules often come & go, and the indexer & other processes reference security policies that hold these missing roles.

RoleConverter logging is completely redundant since it calls a RoleManager method that logs, so remove that. RoleManager logging is now throttled to one warning per day per each unique message.
