### PR TITLE
include module supplied query metadata when editing XML metadata

### DIFF
--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -2363,7 +2363,7 @@ public class QueryServiceImpl implements QueryService
         }
     }
 
-    private QueryDef findMetadataOverrideInDatabase(UserSchema schema, String tableName, boolean customQuery)
+    public QueryDef findMetadataOverrideInDatabase(UserSchema schema, String tableName, boolean customQuery)
     {
         String schemaName = schema.getSchemaPath().toString();
         Container container = schema.getContainer();
@@ -2406,7 +2406,7 @@ public class QueryServiceImpl implements QueryService
     }
 
     // Look for file-based definitions in modules
-    private @Nullable QueryDef findMetadataOverrideInModules(@NotNull UserSchema schema, @NotNull String tableName, boolean allModules, @Nullable Path dir)
+    public @Nullable QueryDef findMetadataOverrideInModules(@NotNull UserSchema schema, @NotNull String tableName, boolean allModules, @Nullable Path dir)
     {
         if (dir == null)
         {


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50362)

It was thought that initially this was a regression but after some investigation it appears that the related issue may have always been a problem. For Biologics in particular there are a number of data classes that apply module scoped query metadata. This was not getting applied to the `rawTableInfo` for the table being edited so comparisons to the incoming XML metadata would be inaccurate resulting in the related issue.

Unfortunately there isn't a direct way to create a table with some (but not all) metadata applied. This means we need to look at the list of `QueryDefinition` objects returned by the `QueryServiceImpl`. This returns a mix of module resource and definitions saved to the database. The first entry without a `rowId` distinguishes a module supplied definition (if present).

@labkey-nicka I'm happy to target this for `24.9.0` or `24.10.0` depending on perceived need and level of risk. Adding @cnathe since he recently changed some of this code in support of calculated columns.