### PR TITLE
Remove ClassTimeOut

### DIFF
--- a/study/test/src/org/labkey/test/tests/search/SearchSyntaxTest.java
+++ b/study/test/src/org/labkey/test/tests/search/SearchSyntaxTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import static org.junit.Assert.assertTrue;
 
 @Category({Daily.class, Search.class})
-@BaseWebDriverTest.ClassTimeout(minutes = 1)
 public class SearchSyntaxTest extends BaseWebDriverTest
 {
     @Test


### PR DESCRIPTION
#### Rationale
Unclear why a minute was selected as the time limit for this test. 
Removing the ClassTimeOut annotation allows the test to pass and does not show a significant increase in the overall test run time.

#### Related Pull Requests
- None

#### Changes
- Remove TimeOut annotation for the test class.
