### PR TITLE
Initial Plate set cache

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1860,21 +1860,14 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 LOG.warn(String.format("clearCache: failed to resolve container for plate with rowId %d with containerId %s.", rowId, containerId));
                 continue;
             }
-
-            Plate plate = PlateCache.getPlate(c, rowId);
-            if (plate != null)
-                PlateCache.uncache(c, plate);
+            PlateCache.uncache(c, rowId);
         }
     }
 
     private void clearPlateSetCache(Container container, Collection<Integer> plateSetRowIds)
     {
         for (Integer plateSetId : plateSetRowIds)
-        {
-            PlateSet plateSet = PlateSetCache.getPlateSet(container, plateSetId);
-            if (plateSet != null)
-                PlateSetCache.uncache(container, plateSet);
-        }
+            PlateSetCache.uncache(container, plateSetId);
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1431,6 +1431,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 if (!emptyPlateSetIds.isEmpty())
                 {
                     beforePlateSetsDelete(emptyPlateSetIds);
+                    tx.addCommitTask(() -> clearPlateSetCache(container, emptyPlateSetIds), DbScope.CommitTaskOption.POSTCOMMIT);
 
                     SQLFragment sql = new SQLFragment("DELETE FROM ").append(schema.getTableInfoPlateSet())
                             .append(" WHERE RowId ").appendInClause(emptyPlateSetIds, schema.getSchema().getSqlDialect());
@@ -1831,7 +1832,6 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     private void clearCache(Container c)
     {
         PlateCache.uncache(c);
-        PlateSetCache.uncache(c);
     }
 
     /**

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -677,7 +677,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return (Plate) require(getPlate(container, plateRowId), "Plate id \"" + plateRowId + "\" not found.", errorPrefix);
     }
 
-    private @NotNull PlateSet requirePlateSet(Container container, int plateSetRowId, @Nullable String errorPrefix) throws ValidationException
+    public @NotNull PlateSet requirePlateSet(Container container, int plateSetRowId, @Nullable String errorPrefix) throws ValidationException
     {
         return (PlateSet) require(
             getPlateSet(container, plateSetRowId),

--- a/assay/src/org/labkey/assay/plate/PlateSetCache.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetCache.java
@@ -1,0 +1,171 @@
+package org.labkey.assay.plate;
+
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
+import org.labkey.api.assay.plate.PlateSet;
+import org.labkey.api.cache.Cache;
+import org.labkey.api.cache.CacheLoader;
+import org.labkey.api.cache.CacheManager;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.logging.LogHelper;
+import org.labkey.assay.query.AssayDbSchema;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PlateSetCache
+{
+    private static final PlateSetCache.Loader _loader = new PlateSetCache.Loader();
+    private static final Cache<String, PlateSet> PLATE_SET_CACHE = CacheManager.getBlockingStringKeyCache(CacheManager.UNLIMITED, CacheManager.DAY, "Plate Set Cache", _loader);
+    private static final Logger LOG = LogHelper.getLogger(PlateSetCache.class, "Plate set cache.");
+
+    private static class Loader implements CacheLoader<String, PlateSet>
+    {
+        private final Map<Container, List<PlateSet>> _containerPlateSet = new HashMap<>();            // internal collection to help un-cache all plate sets for a container
+
+        @Override
+        public PlateSet load(@NotNull String key, @Nullable Object argument)
+        {
+            // parse the cache key
+            PlateSetCacheKey cacheKey = new PlateSetCacheKey(key);
+
+            SimpleFilter filter = SimpleFilter.createContainerFilter(cacheKey._container);
+            filter.addCondition(FieldKey.fromParts(cacheKey._type.name()), cacheKey._identifier);
+
+            List<PlateSetImpl> plateSets = new TableSelector(AssayDbSchema.getInstance().getTableInfoPlateSet(), filter, null).getArrayList(PlateSetImpl.class);
+            if (plateSets.size() == 1)
+            {
+                PlateSet plateSet = plateSets.get(0);
+                LOG.debug(String.format("Caching plate set \"%s\" for folder %s", plateSet.getName(), cacheKey._container.getPath()));
+
+                // add all cache keys for this plate set
+                addCacheKeys(cacheKey, plateSet);
+                return plateSet;
+            }
+            return null;
+        }
+
+        private void addCacheKeys(PlateSetCacheKey cacheKey, PlateSet plateSet)
+        {
+            if (plateSet != null)
+            {
+                if (plateSet.getPlateSetId() == null)
+                    throw new IllegalArgumentException("Plate set cannot be cached, plateSetId is null");
+                if (plateSet.getRowId() == null)
+                    throw new IllegalArgumentException("Plate set cannot be cached, rowId is null");
+
+                // add the plate for the other key types
+                if (cacheKey._type != PlateSetCacheKey.Type.rowId)
+                    PLATE_SET_CACHE.put(PlateSetCacheKey.getCacheKey(plateSet.getContainer(), plateSet.getRowId()), plateSet);
+                if (cacheKey._type != PlateSetCacheKey.Type.plateSetId)
+                    PLATE_SET_CACHE.put(PlateSetCacheKey.getCacheKey(plateSet.getContainer(), plateSet.getPlateSetId()), plateSet);
+
+                _containerPlateSet.computeIfAbsent(cacheKey._container, k -> new ArrayList<>()).add(plateSet);
+            }
+        }
+    }
+
+    public static @Nullable PlateSet getPlateSet(ContainerFilter cf, int rowId)
+    {
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("RowId"), rowId);
+        Container c = PlateManager.getContainerWithPlateSetIdentifier(cf, filter);
+
+        return c != null ? PLATE_SET_CACHE.get(PlateSetCacheKey.getCacheKey(c, rowId)) : null;
+    }
+
+    public static @Nullable PlateSet getPlateSet(Container c, int rowId)
+    {
+        return PLATE_SET_CACHE.get(PlateSetCacheKey.getCacheKey(c, rowId));
+    }
+
+    public static @Nullable PlateSet getPlateSet(Container c, String plateSetId)
+    {
+        return PLATE_SET_CACHE.get(PlateSetCacheKey.getCacheKey(c, plateSetId));
+    }
+
+    public static void uncache(Container c)
+    {
+        LOG.debug(String.format("Clearing plate set cache for folder %s", c.getPath()));
+
+        // uncache all plate sets for this container
+        if (_loader._containerPlateSet.containsKey(c))
+        {
+            List<PlateSet> plateSets = new ArrayList<>(_loader._containerPlateSet.get(c));
+            for (PlateSet plateSet : plateSets)
+                uncache(c, plateSet);
+            _loader._containerPlateSet.remove(c);
+        }
+    }
+
+    public static void uncache(Container c, PlateSet plateSet)
+    {
+        LOG.debug(String.format("Un-caching plate set \"%s\"", plateSet.getPlateSetId()));
+        if (plateSet.getPlateSetId() == null)
+            throw new IllegalArgumentException("Plate set cannot be uncached, plateSetId is null");
+        if (plateSet.getRowId() == null)
+            throw new IllegalArgumentException("Plate set cannot be uncached, rowId is null");
+
+        PLATE_SET_CACHE.remove(PlateSetCacheKey.getCacheKey(c, plateSet.getPlateSetId()));
+        PLATE_SET_CACHE.remove(PlateSetCacheKey.getCacheKey(c, plateSet.getRowId()));
+
+        if (_loader._containerPlateSet.containsKey(plateSet.getContainer()))
+            _loader._containerPlateSet.get(plateSet.getContainer()).remove(plateSet);
+    }
+
+    public static void clearCache()
+    {
+        PLATE_SET_CACHE.clear();
+        _loader._containerPlateSet.clear();
+    }
+
+    private static class PlateSetCacheKey
+    {
+        enum Type
+        {
+            rowId,
+            plateSetId,
+        }
+
+        private final Type _type;
+        private final Container _container;
+        private final Object _identifier;
+
+        PlateSetCacheKey(String key)
+        {
+            JSONObject json = new JSONObject(key);
+
+            _type = json.getEnum(PlateSetCache.PlateSetCacheKey.Type.class, "type");
+            _container = ContainerManager.getForId(json.getString("container"));
+            _identifier = json.get("identifier");
+        }
+
+        public static String getCacheKey(Container c, String plateSetId)
+        {
+            return _getCacheKey(c, Type.plateSetId, plateSetId);
+        }
+
+        public static String getCacheKey(Container c, Integer rowId)
+        {
+            return _getCacheKey(c, Type.rowId, rowId);
+        }
+
+        private static String _getCacheKey(Container c, Type type, Object identifier)
+        {
+            JSONObject json = new JSONObject();
+            json.put("container", c.getId());
+            json.put("type", type.name());
+            json.put("identifier", identifier);
+
+            return json.toString();
+        }
+    }
+}

--- a/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
@@ -42,7 +42,6 @@ import org.labkey.assay.query.AssayDbSchema;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -231,9 +230,7 @@ public class PlateSetTable extends SimpleUserSchema.SimpleTable<UserSchema>
         protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, @Nullable Map<Enum, Object> configParameters) throws InvalidKeyException, ValidationException, QueryUpdateServiceException, SQLException
         {
             Integer plateSetId = (Integer) oldRow.get("rowId");
-            PlateSet plateSet = PlateManager.get().getPlateSet(container, plateSetId);
-            if (plateSet == null)
-                return Collections.emptyMap();
+            PlateSet plateSet = PlateManager.get().requirePlateSet(container, plateSetId, "Failed to update plate set.");
 
             try (DbScope.Transaction transaction = AssayDbSchema.getInstance().getScope().ensureTransaction())
             {

--- a/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSetTable.java
@@ -31,15 +31,18 @@ import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.RowIdForeignKey;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.assay.plate.PlateManager;
+import org.labkey.assay.plate.PlateSetCache;
 import org.labkey.assay.query.AssayDbSchema;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -218,8 +221,26 @@ public class PlateSetTable extends SimpleUserSchema.SimpleTable<UserSchema>
 
                 Map<String, Object> returnMap = super.deleteRow(user, container, oldRowMap);
 
+                transaction.addCommitTask(() -> PlateSetCache.uncache(container, plateSet), DbScope.CommitTaskOption.POSTCOMMIT);
                 transaction.commit();
                 return returnMap;
+            }
+        }
+
+        @Override
+        protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, @Nullable Map<Enum, Object> configParameters) throws InvalidKeyException, ValidationException, QueryUpdateServiceException, SQLException
+        {
+            Integer plateSetId = (Integer) oldRow.get("rowId");
+            PlateSet plateSet = PlateManager.get().getPlateSet(container, plateSetId);
+            if (plateSet == null)
+                return Collections.emptyMap();
+
+            try (DbScope.Transaction transaction = AssayDbSchema.getInstance().getScope().ensureTransaction())
+            {
+                Map<String, Object> newRow = super.updateRow(user, container, row, oldRow, configParameters);
+                transaction.addCommitTask(() -> PlateSetCache.uncache(container, plateSet), DbScope.CommitTaskOption.POSTCOMMIT);
+                transaction.commit();
+                return newRow;
             }
         }
     }


### PR DESCRIPTION
#### Rationale
Establishes an initial cache for plate sets and begins to use the cache for referencing (and uncaching) plate set objects. A follow on phase will be to move properties cached at the plate level into the plate sets. The only planned work at this time is for plate metadata to be moved (but not limited to).