### PR TITLE
RecordFactory: an ObjectFactory that handles Java records

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -65,6 +65,7 @@ import org.labkey.api.data.MaterializedQueryHelper;
 import org.labkey.api.data.MultiValuedRenderContext;
 import org.labkey.api.data.NameGenerator;
 import org.labkey.api.data.PropertyManager;
+import org.labkey.api.data.RecordFactory;
 import org.labkey.api.data.ResultSetSelectorTestCase;
 import org.labkey.api.data.RowTrackingResultSetWrapper;
 import org.labkey.api.data.SQLFragment;
@@ -487,6 +488,7 @@ public class ApiModule extends CodeOnlyModule
             Portal.TestCase.class,
             PropertyManager.TestCase.class,
             //RateLimiter.TestCase.class,
+            RecordFactory.TestCase.class,
             ResultSetDataIterator.TestCase.class,
             ResultSetSelectorTestCase.class,
             RoleSet.TestCase.class,

--- a/api/src/org/labkey/api/collections/CaseInsensitiveHashMap.java
+++ b/api/src/org/labkey/api/collections/CaseInsensitiveHashMap.java
@@ -30,8 +30,6 @@ import java.util.Random;
 /**
  * {@link Map} implementation that uses case-insensitive {@link String}s for keys. Unlike many other implementations,
  * retains the original case of the String for use when iterating and such.
- * User: arauch
- * Date: Dec 25, 2004
  */
 public class CaseInsensitiveHashMap<V> extends CaseInsensitiveMapWrapper<V> implements Serializable, CaseInsensitiveCollection
 {
@@ -48,18 +46,14 @@ public class CaseInsensitiveHashMap<V> extends CaseInsensitiveMapWrapper<V> impl
     public CaseInsensitiveHashMap(Map<String, V> map)
     {
         this(map.size());
-
-        for (Map.Entry<String, V> entry : map.entrySet())
-            put(entry.getKey(), entry.getValue());
+        this.putAll(map);
     }
 
     /** Share the canonical key casing with the caseMapping instance */
     public CaseInsensitiveHashMap(Map<String, V> map, CaseInsensitiveMapWrapper<V> caseMapping)
     {
         this(map.size(), caseMapping);
-
-        for (Map.Entry<String, V> entry : map.entrySet())
-            put(entry.getKey(), entry.getValue());
+        this.putAll(map);
     }
 
     /** Share the canonical key casing with the caseMapping instance */
@@ -116,6 +110,15 @@ public class CaseInsensitiveHashMap<V> extends CaseInsensitiveMapWrapper<V> impl
         map.put(k4, v4);
         map.put(k5, v5);
         return map;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <MAP extends Map<String, ?> & CaseInsensitiveCollection> MAP ensure(Map<String, ?> map)
+    {
+        if (map instanceof CaseInsensitiveCollection)
+            return (MAP)map;
+        else
+            return (MAP)new CaseInsensitiveHashMap<>(map);
     }
 
     public static class TestCase extends Assert

--- a/api/src/org/labkey/api/collections/ResultSetRowMapFactory.java
+++ b/api/src/org/labkey/api/collections/ResultSetRowMapFactory.java
@@ -29,11 +29,6 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 
-/**
-* User: adam
-* Date: May 4, 2009
-* Time: 1:11:17 PM
-*/
 public class ResultSetRowMapFactory extends RowMapFactory<Object> implements Serializable
 {
     private boolean _convertBigDecimalToDouble = false;
@@ -77,7 +72,7 @@ public class ResultSetRowMapFactory extends RowMapFactory<Object> implements Ser
         {
             String propName = md.getColumnLabel(i);
 
-            if (propName.length() > 0 && Character.isUpperCase(propName.charAt(0)))
+            if (!propName.isEmpty() && Character.isUpperCase(propName.charAt(0)))
                 propName = Introspector.decapitalize(propName);
 
             findMap.put(propName, i);
@@ -101,7 +96,7 @@ public class ResultSetRowMapFactory extends RowMapFactory<Object> implements Ser
         int currentRow = rs.getRow();
         List<Object> _list = map.getRow();
 
-        if (0 == _list.size())
+        if (_list.isEmpty())
             _list.add(currentRow);
         else
             _list.set(0, currentRow);

--- a/api/src/org/labkey/api/collections/RowMap.java
+++ b/api/src/org/labkey/api/collections/RowMap.java
@@ -17,12 +17,6 @@ package org.labkey.api.collections;
 
 import java.util.List;
 
-/**
- * User: adam
- * Date: Apr 30, 2009
- * Time: 11:48:46 PM
- */
-
 public class RowMap<V> extends ArrayListMap<String, V> implements CaseInsensitiveCollection
 {
     protected RowMap()

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -545,7 +545,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                     break;
                 }
             }
-            if (null == _titleColumn && getColumns().size() > 0)
+            if (null == _titleColumn && !getColumns().isEmpty())
                 _titleColumn = getColumns().get(0).getName();
         }
 
@@ -1585,17 +1585,24 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         }
     }
 
-    private static void addAndLogError(Collection<QueryException> errors, String message, Exception e)
+    private static void addAndLogError(Collection<QueryException> errors, String message, @Nullable Exception e)
     {
-        QueryException ex;
-        if (e instanceof QueryException)
-            ex = (QueryException)e;
-        else if (e.getCause() instanceof QueryException)
-            ex = (QueryException)e.getCause();
+        if (e != null)
+        {
+            QueryException ex;
+            if (e instanceof QueryException qe)
+                ex = qe;
+            else if (e.getCause() instanceof QueryException qe)
+                ex = qe;
+            else
+                ex = new QueryException(message, e);
+            errors.add(ex);
+            LOG.warn("{}{}", message, e.getMessage() == null ? "" : " " + e.getMessage());
+        }
         else
-            ex = new QueryException(message, e);
-        errors.add(ex);
-        LOG.warn(message + (e.getMessage() == null ? "" : e.getMessage()));
+        {
+            LOG.warn(message);
+        }
     }
 
     private void setAggregateRowConfig(TableType xmlTable)
@@ -1988,7 +1995,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             }
         }
 
-        if (templates.size() == 0)
+        if (templates.isEmpty())
         {
             ActionURL url = Objects.requireNonNull(PageFlowUtil.urlProvider(QueryUrls.class)).urlCreateExcelTemplate(ctx.getContainer(), getPublicSchemaName(), getName());
             url.addParameter("headerType", ColumnHeaderType.DisplayFieldKey.name());

--- a/api/src/org/labkey/api/data/BeanObjectFactory.java
+++ b/api/src/org/labkey/api/data/BeanObjectFactory.java
@@ -27,14 +27,12 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.labkey.api.collections.CaseInsensitiveCollection;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
-import org.labkey.api.collections.RowMap;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.util.UnexpectedException;
 import org.springframework.beans.factory.InitializingBean;
 
 import java.beans.PropertyDescriptor;
-import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.ResultSet;
@@ -175,7 +173,7 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
                 }
                 catch (IllegalArgumentException | ConversionException x)
                 {
-                    _log.warn("Bean [" + bean.getClass().getName() + "] could not set property: " + prop + "=" + value + ": " + x.getMessage());
+                    _log.warn("Bean [{}] could not set property: {}={}: {}", bean.getClass().getName(), prop, value, x.getMessage());
                 }
             }
         }
@@ -307,15 +305,6 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
         }
 
         return list;
-    }
-
-
-    @Override
-    public K[] handleArray(ResultSet rs) throws SQLException
-    {
-        ArrayList<K> list = handleArrayList(rs);
-        @SuppressWarnings("unchecked") K[] array = (K[]) Array.newInstance(_class, list.size());
-        return list.toArray(array);
     }
 
 

--- a/api/src/org/labkey/api/data/BuilderObjectFactory.java
+++ b/api/src/org/labkey/api/data/BuilderObjectFactory.java
@@ -27,14 +27,12 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveCollection;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
-import org.labkey.api.collections.RowMap;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.util.UnexpectedException;
 
 import java.beans.Introspector;
-import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -311,15 +309,6 @@ public class BuilderObjectFactory<K> implements ObjectFactory<K>
         }
 
         return list;
-    }
-
-
-    @Override
-    public K[] handleArray(ResultSet rs) throws SQLException
-    {
-        ArrayList<K> list = handleArrayList(rs);
-        K[] array = (K[]) Array.newInstance(_class, list.size());
-        return list.toArray(array);
     }
 
 

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -3079,13 +3079,6 @@ public class ContainerManager
             }
             return list;
         }
-
-        @Override
-        public Container[] handleArray(ResultSet rs) throws SQLException
-        {
-            ArrayList<Container> list = handleArrayList(rs);
-            return list.toArray(new Container[0]);
-        }
     }
 
     public static Container createFakeContainer(@Nullable String name, @Nullable Container parent)

--- a/api/src/org/labkey/api/data/DataIteratorResultsImpl.java
+++ b/api/src/org/labkey/api/data/DataIteratorResultsImpl.java
@@ -49,9 +49,6 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
- * User: kevink
- * Date: 3/5/14
- *
  * Adapts a DataIterator to the Results interface.
  */
 public class DataIteratorResultsImpl implements Results, TableResultSet
@@ -59,7 +56,6 @@ public class DataIteratorResultsImpl implements Results, TableResultSet
     private final DataIterator _di;
     private final Map<FieldKey, ColumnInfo> _fieldKeyMap;
     private final Map<FieldKey, Integer> _fieldKeyIndexMap;
-    private final Map<String, Integer> _nameIndexMap;
 
     // JDBC-style 1-based row id index, 0 means before first row.
     private int _rowId = 0;
@@ -70,7 +66,6 @@ public class DataIteratorResultsImpl implements Results, TableResultSet
         _di = di;
         _fieldKeyMap = Collections.unmodifiableMap(DataIteratorUtil.createFieldKeyMap(di));
         _fieldKeyIndexMap = Collections.unmodifiableMap(DataIteratorUtil.createFieldIndexMap(di));
-        _nameIndexMap = Collections.unmodifiableMap(DataIteratorUtil.createColumnAndPropertyMap(di));
     }
 
     @Override
@@ -627,15 +622,9 @@ public class DataIteratorResultsImpl implements Results, TableResultSet
     }
 
     @Override
-    public int findColumn(String s)
-            throws SQLException
+    public int findColumn(String s) throws SQLException
     {
-        Integer i = findColumn(FieldKey.fromString(s));
-        if (null == i)
-            i = _nameIndexMap.get(s);
-        if (null == i)
-            throw new SQLException(s + " not found.");
-        return i;
+        return findColumn(FieldKey.fromString(s));
     }
 
     @Override

--- a/api/src/org/labkey/api/data/ObjectFactory.java
+++ b/api/src/org/labkey/api/data/ObjectFactory.java
@@ -58,10 +58,8 @@ public interface ObjectFactory<K>
             {
                 try
                 {
-                    // Make sure the class is loaded in case it statically registers a custom factory. Skip this for
-                    // records, since forName() throws with them.
-                    if (!clss.isRecord())
-                        Class.forName(clss.getName());
+                    // Make sure the class is loaded in case it statically registers a custom factory
+                    Class.forName(clss.getName());
                     f = (ObjectFactory<K>) _registry.get(clss);
 
                     if (f == null)

--- a/api/src/org/labkey/api/data/ObjectFactory.java
+++ b/api/src/org/labkey/api/data/ObjectFactory.java
@@ -35,8 +35,14 @@ public interface ObjectFactory<K>
 
     Map<String, Object> toMap(K bean, @Nullable Map<String, Object> m);
 
+    /**
+     * Transforms the current row. Callers are expected to close() the ResultSet.
+     */
     K handle(ResultSet rs) throws SQLException;
 
+    /**
+     * Method consumes the ResultSet, but callers are expected to close() it.
+     */
     ArrayList<K> handleArrayList(ResultSet rs) throws SQLException;
 
 

--- a/api/src/org/labkey/api/data/RecordFactory.java
+++ b/api/src/org/labkey/api/data/RecordFactory.java
@@ -147,14 +147,15 @@ public class RecordFactory<K> implements ObjectFactory<K>
                 Assert.assertEquals(users.get(0), factory.handle(rs));
             }
             MiniUser randomUser = users.get((int)(Math.random() * users.size()));
-            MiniUser selectedUser = new TableSelector(CoreSchema.getInstance().getTableInfoUsers(), new SimpleFilter(FieldKey.fromString("UserId"), randomUser.userId), null).getObject(MiniUser.class);
+            MiniUser selectedUser = new TableSelector(CoreSchema.getInstance().getTableInfoUsers(), new SimpleFilter(FieldKey.fromString("UserId"), randomUser.userid), null).getObject(MiniUser.class);
             Assert.assertEquals(randomUser, selectedUser);
 
             // Test fromMap() variant (should ignore selectedUser)
             assertEquals(adHocUser, factory.fromMap(selectedUser, adHocMap));
         }
 
-        public record MiniUser(String firstName, String lastName, Date LastLogin, int userId)
+        // Simple test record. Weird casing is intentional to test case-insensitivity.
+        private record MiniUser(String FIRSTname, String LASTNAME, Date LastLogin, int userid)
         {
         }
     }

--- a/api/src/org/labkey/api/data/RecordFactory.java
+++ b/api/src/org/labkey/api/data/RecordFactory.java
@@ -37,7 +37,8 @@ public class RecordFactory<K> implements ObjectFactory<K>
 
     public RecordFactory(Class<K> clazz)
     {
-        assert clazz.isRecord() : clazz + " is not a record!";
+        if (!clazz.isRecord())
+            throw new IllegalStateException(clazz + " is not a record!");
         //noinspection unchecked
         _constructor = (Constructor<K>) clazz.getDeclaredConstructors()[0];
         _constructor.setAccessible(true);

--- a/api/src/org/labkey/api/data/RecordFactory.java
+++ b/api/src/org/labkey/api/data/RecordFactory.java
@@ -1,0 +1,114 @@
+package org.labkey.api.data;
+
+import org.apache.commons.beanutils.ConvertUtils;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveCollection;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.RowMap;
+import org.labkey.api.util.ResultSetUtil;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Parameter;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * An ObjectFactory that handles records. It doesn't care about the record's visibility (e.g., it can be private). All
+ * maps are read in a case-insensitive manner.
+ */
+public class RecordFactory<K> implements ObjectFactory<K>
+{
+    private final Constructor<K> _constructor;
+    private final Parameter[] _parameters;
+    private final List<Field> _fields;
+
+    public RecordFactory(Class<K> clazz)
+    {
+        assert clazz.isRecord() : clazz + " is not a record!";
+        //noinspection unchecked
+        _constructor = (Constructor<K>) clazz.getDeclaredConstructors()[0];
+        _constructor.setAccessible(true);
+        _parameters = _constructor.getParameters();
+        _fields = Arrays.stream(clazz.getDeclaredFields())
+            .peek(field -> field.setAccessible(true))
+            .toList();
+    }
+
+    private <MAP extends Map<String, ?> & CaseInsensitiveCollection> K fromCaseInsensitiveMap(MAP m)
+    {
+        Object[] params = Arrays.stream(_parameters).map(p -> {
+            Object value = m.get(p.getName());
+            return ConvertUtils.convert(value, p.getType());
+        }).toArray();
+
+        try
+        {
+            return _constructor.newInstance(params);
+        }
+        catch (InstantiationException | IllegalAccessException | InvocationTargetException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public K fromMap(Map<String, ?> m)
+    {
+        return fromCaseInsensitiveMap(CaseInsensitiveHashMap.ensure(m));
+    }
+
+    /**
+     * Creates a new record from the map, same as above. Ignores the passed-in record since it's immutable.
+     */
+    @Override
+    public K fromMap(K record, Map<String, ?> map)
+    {
+        return fromMap(map);
+    }
+
+    /**
+     * Populates the passed-in map (if provided) or returns a CaseInsensitiveHashMap if map is null
+     */
+    @Override
+    public Map<String, Object> toMap(K record, @Nullable Map<String, Object> m)
+    {
+        final Map<String, Object> map = (null == m ? new CaseInsensitiveHashMap<>() : m);
+
+        _fields.forEach(field -> {
+            try
+            {
+                map.put(field.getName(), field.get(record));
+            }
+            catch (IllegalAccessException e)
+            {
+                throw new RuntimeException(e);
+            }
+        });
+
+        return map;
+    }
+
+    @Override
+    public K handle(ResultSet rs) throws SQLException
+    {
+        Map<String, Object> map = ResultSetUtil.mapRow(rs);
+        return fromMap(map);
+    }
+
+    @Override
+    public ArrayList<K> handleArrayList(ResultSet rs) throws SQLException
+    {
+        Iterable<Map<String, Object>> iterable = () -> new ResultSetIterator(rs);
+        return StreamSupport.stream(iterable.spliterator(), false)
+            .map(rowMap -> fromCaseInsensitiveMap((RowMap<Object>)rowMap))
+            .collect(Collectors.toCollection(ArrayList::new));
+    }
+}

--- a/api/src/org/labkey/api/data/ResultSetIterator.java
+++ b/api/src/org/labkey/api/data/ResultSetIterator.java
@@ -17,6 +17,7 @@
 package org.labkey.api.data;
 
 import org.labkey.api.collections.ResultSetRowMapFactory;
+import org.labkey.api.collections.RowMap;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -60,7 +61,7 @@ public class ResultSetIterator implements Iterator<Map<String, Object>>
     }
 
     @Override
-    public Map<String, Object> next()
+    public RowMap<Object> next()
     {
         try
         {

--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -452,7 +452,7 @@ public class Table
 
     private static final Map<Class<?>, Getter> _getterMap = new HashMap<>(20);
 
-    enum Getter
+    public enum Getter
     {
         STRING(String.class) {
             @Override

--- a/api/src/org/labkey/api/data/TableResultSet.java
+++ b/api/src/org/labkey/api/data/TableResultSet.java
@@ -24,11 +24,6 @@ import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.Map;
 
-/**
-* User: adam
-* Date: 12/7/13
-* Time: 7:52 PM
-*/
 public interface TableResultSet extends ResultSet, Iterable<Map<String, Object>>
 {
     boolean isComplete();

--- a/api/src/org/labkey/api/module/MockModule.java
+++ b/api/src/org/labkey/api/module/MockModule.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.api.module;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
@@ -35,11 +37,8 @@ import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.writer.ContainerUser;
 import org.springframework.web.servlet.mvc.Controller;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -52,8 +51,6 @@ import java.util.function.Supplier;
 
 /**
  * A module that does nothing. Used for unit and integration tests.
- * User: Dave
- * Date: Dec 2, 2008
  */
 public class MockModule implements Module
 {

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2016Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2016Dialect.java
@@ -37,7 +37,6 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Map;
 
 public class MicrosoftSqlServer2016Dialect extends MicrosoftSqlServer2014Dialect
 {
@@ -52,9 +51,9 @@ public class MicrosoftSqlServer2016Dialect extends MicrosoftSqlServer2014Dialect
     {
         super.prepare(scope);
 
-        Map<String, Object> map = new SqlSelector(scope, "SELECT language, date_format FROM sys.dm_exec_sessions WHERE session_id = @@spid").getMap();
-        _language = (String) map.get("language");
-        _dateFormat = (String) map.get("date_format");
+        Settings settings = new SqlSelector(scope, "SELECT language, date_format AS dateFormat FROM sys.dm_exec_sessions WHERE session_id = @@spid").getObject(Settings.class);
+        _language = settings.language;
+        _dateFormat = settings.dateFormat;
 
         // This seems to be the only string format acceptable for sending Timestamps, but unfortunately it's ambiguous;
         // SQL Server interprets the "MM-dd" portion based on the database's regional settings. So we must query the
@@ -70,6 +69,8 @@ public class MicrosoftSqlServer2016Dialect extends MicrosoftSqlServer2014Dialect
 
         LOG.info("\n    Language:                 {}\n    DateFormat:               {}", _language, _dateFormat);
     }
+
+    private record Settings(String language, String dateFormat) {}
 
     @Override
     public StatementWrapper getStatementWrapper(ConnectionWrapper conn, Statement stmt)

--- a/devtools/src/org/labkey/devtools/test/JspTestCaseTest.jsp
+++ b/devtools/src/org/labkey/devtools/test/JspTestCaseTest.jsp
@@ -3,8 +3,12 @@
 <%@ page extends="org.labkey.api.jsp.JspTest.DRT" %>
 
 <%!
+    record MiniUser(String first, String last)
+    {
+    }
+
     @Test
-    public void test1()
+    public void test1() throws InvocationTargetException, InstantiationException, IllegalAccessException
     {
         assertTrue(1==1);
     }

--- a/devtools/src/org/labkey/devtools/test/JspTestCaseTest.jsp
+++ b/devtools/src/org/labkey/devtools/test/JspTestCaseTest.jsp
@@ -3,12 +3,8 @@
 <%@ page extends="org.labkey.api.jsp.JspTest.DRT" %>
 
 <%!
-    record MiniUser(String first, String last)
-    {
-    }
-
     @Test
-    public void test1() throws InvocationTargetException, InstantiationException, IllegalAccessException
+    public void test1()
     {
         assertTrue(1==1);
     }

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -16,6 +16,9 @@
 
 package org.labkey.issue;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -148,9 +151,6 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.Controller;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -1823,8 +1823,8 @@ public class IssuesController extends SpringActionController
 
             try (Results results = r.getResults(new RenderContext(getViewContext())))
             {
-                ObjectFactory f = ObjectFactory.Registry.getFactory(IssueObject.class);
-                IssueObject[] issues = (IssueObject[]) f.handleArray(results);
+                ObjectFactory<IssueObject> f = ObjectFactory.Registry.getFactory(IssueObject.class);
+                List<IssueObject> issues = f.handleArrayList(results);
 
                 ActionURL url = getDetailsURL(getContainer(), 1, isPrint());
                 String filteredURLString = PageFlowUtil.filter(url);
@@ -1855,10 +1855,10 @@ public class IssuesController extends SpringActionController
 
     public static class RssBean
     {
-        public IssueObject[] issues;
+        public List<IssueObject> issues;
         public String filteredURLString;
 
-        private RssBean(IssueObject[] issues, String filteredURLString)
+        private RssBean(List<IssueObject> issues, String filteredURLString)
         {
             this.issues = issues;
             this.filteredURLString = filteredURLString;

--- a/study/src/org/labkey/study/model/VisitTag.java
+++ b/study/src/org/labkey/study/model/VisitTag.java
@@ -97,12 +97,6 @@ public class VisitTag
         }
 
         @Override
-        public VisitTag[] handleArray(ResultSet rs)
-        {
-            throw new java.lang.UnsupportedOperationException();
-        }
-
-        @Override
         public VisitTag handle(ResultSet rs)
         {
             throw new java.lang.UnsupportedOperationException();

--- a/study/src/org/labkey/study/model/VisitTagMapEntry.java
+++ b/study/src/org/labkey/study/model/VisitTagMapEntry.java
@@ -96,12 +96,6 @@ public class VisitTagMapEntry
         }
 
         @Override
-        public VisitTagMapEntry[] handleArray(ResultSet rs)
-        {
-            throw new java.lang.UnsupportedOperationException();
-        }
-
-        @Override
         public VisitTagMapEntry handle(ResultSet rs)
         {
             throw new java.lang.UnsupportedOperationException();


### PR DESCRIPTION
#### Rationale
`Selector` methods can produce beans and simple classes, but can't produce records. `RecordFactory` enables production of records from Selector and other code paths that use `ObjectFactory.getFactory()`.

Remove `ObjectFactory.handleArray()` and all implementations. Arrays are lame and this method was called in exactly one place, and that code doesn't even care about arrays.

Clean up some warnings and an NPE waiting to happen.