### PR TITLE
Fix time zone issue with timestamp formatting

### DIFF
--- a/search/src/org/labkey/search/model/IndexInspector.java
+++ b/search/src/org/labkey/search/model/IndexInspector.java
@@ -152,7 +152,7 @@ public class IndexInspector
 
                         if (titles.length != 1 || urls.length != 1 || uniqueIds.length != 1 || containerIds.length != 1)
                         {
-                            // Skip the special "serverGuid" doc
+                            // Skip the special "server GUID" doc
                             if (doc.get(LuceneSearchServiceImpl.SERVER_GUID_NAME) != null)
                                 continue;
 


### PR DESCRIPTION
#### Rationale
`ProjectSettingsTest.testInjection` failed with a timestamp conversion error after my fix to accommodate non-US SQL Server settings. Seems like a time zone issue. Revert to good-old-reliable `FastDateFormat` and add a few test cases.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5805