### PR TITLE
24.9 Increase test timeout value.

### DIFF
--- a/study/test/src/org/labkey/test/tests/search/SearchSyntaxTest.java
+++ b/study/test/src/org/labkey/test/tests/search/SearchSyntaxTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 import static org.junit.Assert.assertTrue;
 
 @Category({Daily.class, Search.class})
-@BaseWebDriverTest.ClassTimeout(minutes = 1)
+@BaseWebDriverTest.ClassTimeout(minutes = 2)
 public class SearchSyntaxTest extends BaseWebDriverTest
 {
     @Test


### PR DESCRIPTION
#### Rationale
Test setup is taking a little longer than before. Possibly selenium is taking a little more time to download a new driver. This increases the test timeout value.

#### Related Pull Requests
- None

#### Changes
- Increase test timeout value to 2 minutes.
