### PR TITLE
Rework categories option in advanced search

### DIFF
--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -115,21 +115,21 @@ import java.util.concurrent.TimeUnit;
 
 public class AssayManager implements AssayService
 {
-    SearchService.SearchCategory ASSAY_CATEGORY = new SearchService.SearchCategory("assay", "Study Assay") {
+    SearchService.SearchCategory ASSAY_CATEGORY = new SearchService.SearchCategory("assay", "Assays") {
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
         {
             return getPermittedContainerIds(user, containers, AssayReadPermission.class);
         }
     };
-    SearchService.SearchCategory ASSAY_BATCH_CATEGORY = new SearchService.SearchCategory("assayBatch", "Assay Batch") {
+    SearchService.SearchCategory ASSAY_BATCH_CATEGORY = new SearchService.SearchCategory("assayBatch", "Assay Batches", false) {
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
         {
             return getPermittedContainerIds(user, containers, AssayReadPermission.class);
         }
     };
-    SearchService.SearchCategory ASSAY_RUN_CATEGORY = new SearchService.SearchCategory("assayRun", "Assay Run") {
+    SearchService.SearchCategory ASSAY_RUN_CATEGORY = new SearchService.SearchCategory("assayRun", "Assay Runs", false) {
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
         {

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -193,7 +193,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     // when those calls are being made for a plate save operation.
     public static final String PLATE_SAVE_FLAG = ".plateSave";
 
-    public SearchService.SearchCategory PLATE_CATEGORY = new SearchService.SearchCategory("plate", "Plate") {
+    public SearchService.SearchCategory PLATE_CATEGORY = new SearchService.SearchCategory("plate", "Assay Plates", false) {
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
         {

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
@@ -16,7 +16,6 @@
 package org.labkey.experiment.api;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -80,14 +79,14 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
     public static final String NAMESPACE_PREFIX = "DataClass";
     private static final String SEARCH_CATEGORY_NAME = "dataClass";
     private static final String MEDIA_SEARCH_CATEGORY_NAME = "media";
-    public static final SearchService.SearchCategory SEARCH_CATEGORY = new SearchService.SearchCategory(SEARCH_CATEGORY_NAME, "Collection of data objects") {
+    public static final SearchService.SearchCategory SEARCH_CATEGORY = new SearchService.SearchCategory(SEARCH_CATEGORY_NAME, "Collections of data objects", false) {
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
         {
             return getPermittedContainerIds(user, containers, DataClassReadPermission.class);
         }
     };
-    public static final SearchService.SearchCategory MEDIA_SEARCH_CATEGORY = new SearchService.SearchCategory(MEDIA_SEARCH_CATEGORY_NAME, "Collections of media data and samples") {
+    public static final SearchService.SearchCategory MEDIA_SEARCH_CATEGORY = new SearchService.SearchCategory(MEDIA_SEARCH_CATEGORY_NAME, "Collections of media data and samples", false) {
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
         {

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -134,14 +134,14 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         }
     }
 
-    public static final SearchService.SearchCategory expDataCategory = new SearchService.SearchCategory("data", "ExpData") {
+    public static final SearchService.SearchCategory expDataCategory = new SearchService.SearchCategory("data", "ExpDatas", false) {
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
         {
             return getPermittedContainerIds(user, containers, DataClassReadPermission.class);
         }
     };
-    public static final SearchService.SearchCategory expMediaDataCategory = new SearchService.SearchCategory("mediaData", "ExpData for media objects") {
+    public static final SearchService.SearchCategory expMediaDataCategory = new SearchService.SearchCategory("mediaData", "ExpDatas for media objects", false) {
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
         {

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -134,14 +134,14 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         }
     }
 
-    public static final SearchService.SearchCategory expDataCategory = new SearchService.SearchCategory("data", "ExpDatas", false) {
+    public static final SearchService.SearchCategory expDataCategory = new SearchService.SearchCategory("data", "ExpData", false) {
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
         {
             return getPermittedContainerIds(user, containers, DataClassReadPermission.class);
         }
     };
-    public static final SearchService.SearchCategory expMediaDataCategory = new SearchService.SearchCategory("mediaData", "ExpDatas for media objects", false) {
+    public static final SearchService.SearchCategory expMediaDataCategory = new SearchService.SearchCategory("mediaData", "ExpData for media objects", false) {
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
         {

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -86,8 +86,8 @@ import static org.labkey.api.util.StringUtilsLabKey.append;
 
 public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements ExpMaterial
 {
-    public static final SearchService.SearchCategory searchCategory = new SearchService.SearchCategory("material", "Material/Sample");
-    public static final SearchService.SearchCategory mediaSearchCategory = new SearchService.SearchCategory("media", "Media samples"){
+    public static final SearchService.SearchCategory searchCategory = new SearchService.SearchCategory("material", "Materials/Samples", false);
+    public static final SearchService.SearchCategory mediaSearchCategory = new SearchService.SearchCategory("media", "Media Samples", false){
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
         {

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -91,8 +91,8 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
 {
     private static final String categoryName = "materialSource";
     private static final String mediaCategoryName = "mediaMaterialSource";
-    public static final SearchService.SearchCategory searchCategory = new SearchService.SearchCategory(categoryName, "Set of Samples");
-    public static final SearchService.SearchCategory mediaSearchCategory = new SearchService.SearchCategory(mediaCategoryName, "Set of Media Samples") {
+    public static final SearchService.SearchCategory searchCategory = new SearchService.SearchCategory(categoryName, "Sample Types", false);
+    public static final SearchService.SearchCategory mediaSearchCategory = new SearchService.SearchCategory(mediaCategoryName, "Media Sample Types", false) {
         @Override
         public Set<String> getPermittedContainerIds(User user, Map<String, Container> containers)
         {

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -469,7 +469,7 @@ public class ListManager implements SearchService.DocumentProvider
         _listDefCache.remove(c.getId());
     }
 
-    public static final SearchService.SearchCategory listCategory = new SearchService.SearchCategory("list", "List");
+    public static final SearchService.SearchCategory listCategory = new SearchService.SearchCategory("list", "Lists");
 
     // Index all lists in this container
     @Override

--- a/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
+++ b/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
@@ -49,7 +49,7 @@ public class ExternalSchemaDocumentProvider implements SearchService.DocumentPro
     private static final Logger LOG = LogManager.getLogger(ExternalSchemaDocumentProvider.class);
     private static final SearchService.DocumentProvider _instance = new ExternalSchemaDocumentProvider();
 
-    public static final SearchService.SearchCategory externalTableCategory = new SearchService.SearchCategory("externalTable", "External Table");
+    public static final SearchService.SearchCategory externalTableCategory = new SearchService.SearchCategory("externalTable", "External Schema Tables", false);
 
     private ExternalSchemaDocumentProvider()
     {

--- a/search/src/org/labkey/search/view/SearchWebPart.java
+++ b/search/src/org/labkey/search/view/SearchWebPart.java
@@ -19,11 +19,6 @@ import org.labkey.api.view.JspView;
 import org.labkey.search.SearchController;
 import org.labkey.search.SearchController.SearchForm;
 
-/**
- * User: adam
- * Date: Jan 19, 2010
- * Time: 1:59:42 PM
- */
 public class SearchWebPart extends JspView<SearchController.SearchForm>
 {
     public SearchWebPart(boolean includeSubfolders, int textBoxWidth, boolean includeHelpLink, boolean isWebPart)

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -231,8 +231,8 @@ import static org.labkey.study.query.StudyQuerySchema.TREATMENT_TABLE_NAME;
 
 public class StudyManager
 {
-    public static final SearchService.SearchCategory datasetCategory = new SearchService.SearchCategory("dataset", "Study Dataset");
-    public static final SearchService.SearchCategory subjectCategory = new SearchService.SearchCategory("subject", "Study Subject");
+    public static final SearchService.SearchCategory datasetCategory = new SearchService.SearchCategory("dataset", "Study Datasets");
+    public static final SearchService.SearchCategory subjectCategory = new SearchService.SearchCategory("subject", "Study Subjects");
 
     private static final Logger _log = LogManager.getLogger(StudyManager.class);
     private static final StudyManager _instance = new StudyManager();


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51111

Add "Projects and Folders" as an additional search category for advanced search. More importantly, switch from a hard-coded list of categories (including categories that might not even exist in the deployment) to a dynamically generated list based on existing categories that specify "Show in Advanced Options". Update some descriptions to plurals and modern conventions.

Note: Advanced search is displaying the same categories as before with the addition of "Projects and Folders", but it's now trivial to add other categories to the list.
