### PR TITLE
Prepare each DbScope before logging details

### DIFF
--- a/api/src/org/labkey/api/data/DbScopeLoader.java
+++ b/api/src/org/labkey/api/data/DbScopeLoader.java
@@ -72,7 +72,6 @@ class DbScopeLoader
                     try
                     {
                         scope = new DbScope(this);
-                        scope.getSqlDialect().prepare(scope);
                     }
                     catch (Throwable t)
                     {

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -794,13 +794,13 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     }
 
     @Override
-    public void prepare(DbScope scope)
+    public String prepare(DbScope scope)
     {
         initializeUserDefinedTypes(scope);
         initializeInClauseGenerator(scope);
         determineSettings(scope);
         determineIfArraySortFunctionExists(scope);
-        super.prepare(scope);
+        return super.prepare(scope);
     }
 
     @Override

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -449,13 +449,15 @@ public abstract class SqlDialect
     // Do dialect-specific initialization work for this scope. This is called after prepare(LabKeyDataSource) and
     // after the "other connections to this database" check. Note: this might be called multiple times, for example,
     // during bootstrap or upgrade.
-    public void prepare(DbScope scope)
+    public @Nullable String prepare(DbScope scope)
     {
         synchronized (this)
         {
             // prepare code may have changed state that requires a new stringHandler
             _stringHandler = null;
         }
+
+        return null;
     }
 
     public abstract void prepareConnection(Connection conn) throws SQLException;

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -1728,12 +1728,12 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
     }
 
     @Override
-    public void prepare(DbScope scope)
+    public String prepare(DbScope scope)
     {
         _groupConcatInstalled = GroupConcatInstallationManager.get().isInstalled(scope);
         _edition = getEdition(scope);
 
-        super.prepare(scope);
+        return super.prepare(scope);
     }
 
     @Override

--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2016Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2016Dialect.java
@@ -47,7 +47,7 @@ public class MicrosoftSqlServer2016Dialect extends MicrosoftSqlServer2014Dialect
     private volatile DateTimeFormatter _timestampFormatter = null;
 
     @Override
-    public void prepare(DbScope scope)
+    public String prepare(DbScope scope)
     {
         super.prepare(scope);
 
@@ -67,7 +67,7 @@ public class MicrosoftSqlServer2016Dialect extends MicrosoftSqlServer2014Dialect
 
         _timestampFormatter = DateTimeFormatter.ofPattern("yyyy-" + mdFormat + " HH:mm:ss.SSS");
 
-        LOG.info("\n    Language:                 {}\n    DateFormat:               {}", _language, _dateFormat);
+        return "\n    Language:                 " + _language + "\n    DateFormat:               " + _dateFormat;
     }
 
     private record Settings(String language, String dateFormat) {}

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -639,7 +639,7 @@ public class QueryController extends SpringActionController
                                 TR(
                                     cl(rowStyle),
                                     hasAdminOpsPerms ? TD(connected ? new ButtonBuilder("Test").href(new ActionURL(TestDataSourceConfirmAction.class, getContainer()).addParameter("dataSource", scope.getDataSourceName())) : "") : null,
-                                    TD(scope.getDisplayName()),
+                                    TD(HtmlString.NBSP, scope.getDisplayName()),
                                     TD(status),
                                     TD(scope.getDatabaseUrl()),
                                     TD(scope.getDatabaseName()),


### PR DESCRIPTION
#### Rationale
The `SqlDialect`-specific `prepare(DbScope)` step might gather additional information that's useful to log. For example, SQL Server edition and language/date format. Attempt to prepare each scope before logging its details and give the dialect an opportunity to provide more properties to log. If prepare fails, logs what we have on hand (as before).
