### PR TITLE
Register the audit domain kinds earlier

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.audit;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.audit.data.DataMapColumn;
 import org.labkey.api.audit.data.DataMapDiffColumn;
 import org.labkey.api.audit.query.AbstractAuditDomainKind;
@@ -99,7 +100,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
         this(null);
     }
 
-    public AbstractAuditTypeProvider(AbstractAuditDomainKind domainKind)
+    public AbstractAuditTypeProvider(@NotNull AbstractAuditDomainKind domainKind)
     {
         // TODO : consolidate domain kind initialization to either this constructor or to override
         // getDomainKind.
@@ -110,7 +111,9 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
 
     protected AbstractAuditDomainKind getDomainKind()
     {
-        assert null != _domainKind;
+        if (_domainKind == null)
+            throw new IllegalStateException(String.format("The audit type : \"%s\" has a null domain kind", getLabel()));
+
         return _domainKind;
     }
 

--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -91,7 +91,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
     public static final String COLUMN_NAME_TRANSACTION_ID = "TransactionID";
     public static final String COLUMN_NAME_DATA_CHANGES = "DataChanges";
 
-    final AbstractAuditDomainKind domainKind;
+    final AbstractAuditDomainKind _domainKind;
 
 
     public AbstractAuditTypeProvider()
@@ -101,21 +101,23 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
 
     public AbstractAuditTypeProvider(AbstractAuditDomainKind domainKind)
     {
-        this.domainKind = domainKind;
+        // TODO : consolidate domain kind initialization to either this constructor or to override
+        // getDomainKind.
+        _domainKind = domainKind;
+        // Register the DomainKind
+        PropertyService.get().registerDomainKind(getDomainKind());
     }
 
     protected AbstractAuditDomainKind getDomainKind()
     {
-        assert null != domainKind;
-        return domainKind;
+        assert null != _domainKind;
+        return _domainKind;
     }
 
     @Override
     public void initializeProvider(User user)
     {
-        // Register the DomainKind
         AbstractAuditDomainKind domainKind = getDomainKind();
-        PropertyService.get().registerDomainKind(domainKind);
         Domain domain = getDomain();
 
         // if the domain doesn't exist, create it
@@ -191,6 +193,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
     // NOTE: Changing the name of an existing PropertyDescriptor will lose data!
     private void ensureProperties(User user, Domain domain)
     {
+        AbstractAuditDomainKind domainKind = getDomainKind();
         if (domain != null && domainKind != null)
         {
             // Create a map of desired properties


### PR DESCRIPTION
#### Rationale
In this previous [PR](https://github.com/LabKey/platform/pull/5790) we deferred initialization and fixup of audit domains until after the server had completed startup. However, domain kinds still need to registered early. Otherwise existing domain descriptors may not get initialized properly in the cache.

I also added a note to clean up how domain kinds get associated with each audit provider but plan to do that on `develop`.