### PR TITLE
Limit scope of LABKEY.WebSocket.hideModal

### DIFF
--- a/api/webapp/clientapi/dom/WebSocket.js
+++ b/api/webapp/clientapi/dom/WebSocket.js
@@ -159,6 +159,8 @@ LABKEY.WebSocket = new function ()
     }
 
     function hideModal() {
+        if (!_modalShowing) return;
+
         toggleBackgroundBlurred(false);
 
         var modal = $('#lk-utils-modal');


### PR DESCRIPTION
#### Rationale
`LABKEY.WebSocket.checkForExpiredSession` hides any `LABKEY.Utils.modal` on the page whenever a page opens or a tab gets focus. It should limit its scope to only hide the dialog if `LABKEY.WebSocket` created it.
This is breaking the save dialog on [`etlDefinition.jsp`](https://github.com/LabKey/dataintegration/blob/develop/src/org/labkey/di/view/etlDefinition.jsp#L188) when running on Firefox 128.

#### Related Pull Requests
- N/A

#### Changes
- Limit scope of `LABKEY.WebSocket.hideModal`
