### PR TITLE
Handle null values for Timestamp JDBC parameters

### DIFF
--- a/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2016Dialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/MicrosoftSqlServer2016Dialect.java
@@ -159,7 +159,7 @@ public class MicrosoftSqlServer2016Dialect extends MicrosoftSqlServer2014Dialect
         @Override
         public void setObject(int parameterIndex, Object x, int targetSqlType, int scale) throws SQLException
         {
-            if (targetSqlType == Types.TIMESTAMP)
+            if (targetSqlType == Types.TIMESTAMP && x instanceof Timestamp)
                 setObject(parameterIndex, x);
             else
                 super.setObject(parameterIndex, x, targetSqlType, scale);
@@ -168,7 +168,7 @@ public class MicrosoftSqlServer2016Dialect extends MicrosoftSqlServer2014Dialect
         @Override
         public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException
         {
-            if (targetSqlType == Types.TIMESTAMP)
+            if (targetSqlType == Types.TIMESTAMP && x instanceof Timestamp)
                 setObject(parameterIndex, x);
             else
                 super.setObject(parameterIndex, x, targetSqlType);
@@ -183,7 +183,7 @@ public class MicrosoftSqlServer2016Dialect extends MicrosoftSqlServer2014Dialect
         @Override
         public void setObject(String parameterName, Object x, int targetSqlType, int scale) throws SQLException
         {
-            if (targetSqlType == Types.TIMESTAMP)
+            if (targetSqlType == Types.TIMESTAMP && x instanceof Timestamp)
                 setObject(parameterName, x);
             else
                 super.setObject(parameterName, x, targetSqlType, scale);
@@ -192,7 +192,7 @@ public class MicrosoftSqlServer2016Dialect extends MicrosoftSqlServer2014Dialect
         @Override
         public void setObject(String parameterName, Object x, int targetSqlType) throws SQLException
         {
-            if (targetSqlType == Types.TIMESTAMP)
+            if (targetSqlType == Types.TIMESTAMP && x instanceof Timestamp)
                 setObject(parameterName, x);
             else
                 super.setObject(parameterName, x, targetSqlType);


### PR DESCRIPTION
#### Rationale
There are a couple setObject functions that each takes a different set of params. PR  https://github.com/LabKey/platform/pull/5805 modified all of those to call our own override version, which all end up calling the 2-parametere version of the util, if targetSqlType == Types.TIMESTAMP. This is not working well for null values (not sure why, but the old way uses the N param function for null values), see the following test failure. 
[ETLTest.testStoredProcTransforms](https://teamcity.labkey.org/viewLog.html?buildId=3175197&tab=buildResultsDiv&buildTypeId=LabKey_247Release_Premium_ModulesSuites_DataIntegrationSqlserver#testNameId-5800387439352806963)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5805

#### Changes
- don't use the 2 parametered setObject when value is null
