### PR TITLE
Wait for data region update after adding columns

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
@@ -155,7 +155,7 @@ public class AutoLinkToStudyTest extends BaseWebDriverTest
         customizeView.addColumn("linked_to_Auto_Link_To_Study_Test_Study_2_Study");
         customizeView.addColumn("linked_to_Auto_Link_To_Study_Test_Study_3_Study");
         customizeView.addColumn("linked_to_Auto_Link_To_Study_Test_Study");
-        customizeView.clickViewGrid();
+        customizeView.applyCustomView();
 
         /*
             Ensuring additional 'Linked to Study' columns are not visible for linked Datasets.


### PR DESCRIPTION
#### Rationale
`CustomizeView.clickViewGrid` doesn't wait for the data region to update. `applyCustomView` should be used in most cases.

#### Related Pull Requests
* N/A

#### Changes
* Wait for data region update after adding columns