### PR TITLE
SelectDistinctAction bug when selected column starts with "distinct"

### DIFF
--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -471,9 +471,10 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
                 throw new IllegalArgumentException("ERROR: Limit SQL doesn't start with SELECT: " + sql);
 
             int index = 6;
+            // NOTE: check for the trailing space to ensure we do not accidentally split a field name that begins with distinct
             if (sql.substring(0, 16).equalsIgnoreCase("SELECT DISTINCT "))
-                index = 16;
-            frag.insert(index, " TOP " + (Table.NO_ROWS == maxRows ? 0 : maxRows) + " ");
+                index = 15;
+            frag.insert(index, " TOP " + (Table.NO_ROWS == maxRows ? 0 : maxRows));
         }
         return frag;
     }

--- a/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
+++ b/bigiron/src/org/labkey/bigiron/mssql/BaseMicrosoftSqlServerDialect.java
@@ -471,9 +471,9 @@ abstract class BaseMicrosoftSqlServerDialect extends SqlDialect
                 throw new IllegalArgumentException("ERROR: Limit SQL doesn't start with SELECT: " + sql);
 
             int index = 6;
-            if (sql.substring(0, 15).equalsIgnoreCase("SELECT DISTINCT"))
-                index = 15;
-            frag.insert(index, " TOP " + (Table.NO_ROWS == maxRows ? 0 : maxRows));
+            if (sql.substring(0, 16).equalsIgnoreCase("SELECT DISTINCT "))
+                index = 16;
+            frag.insert(index, " TOP " + (Table.NO_ROWS == maxRows ? 0 : maxRows) + " ");
         }
         return frag;
     }


### PR DESCRIPTION
I have long seen stacktraces for this issue on my servers and i finally took time to debug this. This PR addresses an interesting fringe case on SQL Server when using the SelectDistinct API, which users do when they open the data region filter dialog. The problem occurs if the column in question has a name that begins with "distinct", such as "distinctGenomes". Here is what happens:

SelectDistinctAction builds SQL, which might look like this:

```
SELECT distinctGenomes AS value FROM (-- <QueryServiceImpl.getSelectSQL(sequence_readsets)>
	SELECT DISTINCT distinctGenomes
	FROM (
	SELECT 
	(SELECT core.GROUP_CONCAT_DS(DISTINCT l.name, char(10), 1) as expr FROM sequenceanalysis.sequence_analyses a JOIN sequenceanalysis.reference_libraries l ON (a.library_id = l.rowid) WHERE a.readset = sequence_readsets.rowid) AS distinctGenomes,
	sequence_readsets.Container AS container
	FROM (SELECT * FROM sequenceanalysis.sequence_readsets
	WHERE (Container IN (SELECT c.EntityId FROM core.Containers c INNER JOIN (SELECT CAST(Id AS UNIQUEIDENTIFIER) AS Id FROM (VALUES ('B7976B71-9EA1-1032-AC19-C8BA61887899'/* Bimber */)) as _containerids_ (Id) ) x ON c.EntityId = x.Id OR (c.Parent = x.Id AND c.Type  IN (N'workbook'))))) sequence_readsets ) x
-- </QueryServiceImpl.getSelectSQL()>
) S ORDER BY value

```

Next, QueryController line 3866 adds a limit to it:
```
sql = table.getSqlDialect().limitRows(sql, settings.getMaxRows());
```

That defers to the SqlDialect. In the case of SQL Server, it has this logic, which checks for the string "SELECT DISTINCT" and tries to replace it:
```
            int index = 6;
            if (sql.substring(0, 15).equalsIgnoreCase("SELECT DISTINCT"))
                index = 15;
            frag.insert(index, " TOP " + (Table.NO_ROWS == maxRows ? 0 : maxRows));
```

In the SQL above, you will see that it does in fact begin with "SELECT distinctGenomes". The result is that the code inserts "TOP" into the middle of the field name:
```
SELECT distinct TOP 251Genomes AS value FROM (-- <QueryServiceImpl.getSelectSQL(sequence_readsets)>
```

Which as you can see results in invalid SQL. My proposal here is a minor change that:

1) Checks for a trailing space. I cannot think of any valid SQL for "SELECT DISTINCT" that doesnt have a trailing space, but we could do some kind of regex here.
2) Inserts the " TOP..." prior to that trailing space