### PR TITLE
Allow Troubleshooters to view experimental & deprecated feature flags

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -11647,12 +11647,6 @@ public class AdminController extends SpringActionController
                 new ShowAdminAction()
             );
 
-            // @AdminConsoleAction
-            // @RequiresPermission(AdminOperationsPermission.class)
-            assertForAdminOperationsPermission(ContainerManager.getRoot(), user,
-                controller.new OptionalFeaturesAction()
-            );
-
             // @RequiresSiteAdmin
             assertForRequiresSiteAdmin(user,
                 controller.new EnvironmentVariablesAction(),
@@ -11664,6 +11658,7 @@ public class AdminController extends SpringActionController
             );
 
             assertForTroubleshooterPermission(ContainerManager.getRoot(), user,
+                controller.new OptionalFeaturesAction(),
                 controller.new ShowModuleErrorsAction(),
                 new ModuleStatusAction()
             );

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -430,8 +430,8 @@ public class AdminController extends SpringActionController
         // Configuration
         AdminConsole.addLink(Configuration, "authentication", urlProvider(LoginUrls.class).getConfigureURL());
         AdminConsole.addLink(Configuration, "email customization", new ActionURL(CustomizeEmailAction.class, root), AdminPermission.class);
-        AdminConsole.addLink(Configuration, "deprecated features", new ActionURL(OptionalFeaturesAction.class, root).addParameter("type", FeatureType.Deprecated.name()), AdminOperationsPermission.class);
-        AdminConsole.addLink(Configuration, "experimental features", new ActionURL(OptionalFeaturesAction.class, root).addParameter("type", FeatureType.Experimental.name()), AdminOperationsPermission.class);
+        AdminConsole.addLink(Configuration, "deprecated features", new ActionURL(OptionalFeaturesAction.class, root).addParameter("type", FeatureType.Deprecated.name()), TroubleshooterPermission.class);
+        AdminConsole.addLink(Configuration, "experimental features", new ActionURL(OptionalFeaturesAction.class, root).addParameter("type", FeatureType.Experimental.name()), TroubleshooterPermission.class);
         if (!ProductRegistry.getProducts().isEmpty())
             AdminConsole.addLink(Configuration, "product configuration", new ActionURL(ProductConfigurationAction.class, root), AdminOperationsPermission.class);
         // TODO move to FileContentModule
@@ -9246,8 +9246,7 @@ public class AdminController extends SpringActionController
         }
     }
 
-    @AdminConsoleAction
-    @RequiresPermission(AdminOperationsPermission.class)
+    @RequiresPermission(TroubleshooterPermission.class)
     public class OptionalFeaturesAction extends SimpleViewAction<OptionalFeaturesForm>
     {
         private FeatureType _type;

--- a/core/src/org/labkey/core/admin/optionalFeatures.jsp
+++ b/core/src/org/labkey/core/admin/optionalFeatures.jsp
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.labkey.api.security.permissions.AdminOperationsPermission" %>
 <%@ page import="org.labkey.api.settings.AdminConsole" %>
 <%@ page import="org.labkey.api.settings.AdminConsole.OptionalFeatureFlag" %>
 <%@ page import="org.labkey.api.settings.OptionalFeatureService.FeatureType" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.core.admin.AdminController.OptionalFeaturesForm" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -25,6 +27,7 @@
     OptionalFeaturesForm form = (OptionalFeaturesForm)getModelBean();
     FeatureType type = form.getTypeEnum();
     boolean showHidden = form.isShowHidden();
+    boolean hasAdminOpsPerms = getContainer().hasPermission(getUser(), AdminOperationsPermission.class);
 %>
 <style>
     .toggle-label-text {
@@ -42,6 +45,7 @@
 <p class="labkey-error">
 <%=type.getAdminGuidance()%>
 </p>
+<%=getTroubleshooterWarning(hasAdminOpsPerms, HtmlString.EMPTY_STRING, HtmlString.unsafe("<br>"))%>
 <div class="list-group">
 <%
     for (OptionalFeatureFlag flag : AdminConsole.getOptionalFeatureFlags(type))
@@ -51,7 +55,7 @@
 %>
 <div class="list-group-item">
     <label>
-        <input id="<%=h(flag.getFlag())%>" type="checkbox" <%=checked(flag.isEnabled())%>>
+        <input id="<%=h(flag.getFlag())%>" type="checkbox"<%=checked(flag.isEnabled())%><%=disabled(!hasAdminOpsPerms)%>>
         <span class="toggle-label-text"><%=h(flag.getTitle())%></span>
     </label>
     <div class="list-group-item-text"><%=h(flag.getDescription())%></div>


### PR DESCRIPTION
#### Rationale
These pages are fair game for Troubleshooters

Ran into this while investigating a client ticket that hinged on whether an experimental feature was set or not: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51289