### PR TITLE
Issue 50998: Add container filter when getting samples from a transaction id

### DIFF
--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -470,7 +470,7 @@ public interface QueryService
      */
     void addAuditEvent(QueryView queryView, String comment, @Nullable Integer dataRowCount);
     void addAuditEvent(User user, Container c, String schemaName, String queryName, ActionURL sortFilter, String comment, @Nullable Integer dataRowCount);
-    List<DetailedAuditTypeEvent> getQueryUpdateAuditRecords(User user, Container container, long transactionAuditId);
+    List<DetailedAuditTypeEvent> getQueryUpdateAuditRecords(User user, Container container, long transactionAuditId, @Nullable ContainerFilter containerFilter);
     AuditHandler getDefaultAuditHandler();
 
     int moveAuditEvents(Container targetContainer, List<Integer> rowPks, String schemaName, String queryName);

--- a/audit/src/org/labkey/audit/AuditController.java
+++ b/audit/src/org/labkey/audit/AuditController.java
@@ -384,10 +384,11 @@ public class AuditController extends SpringActionController
         public Object execute(AuditTransactionForm form, BindException errors)
         {
             List<Integer> rowIds;
+            ContainerFilter cf = ContainerFilter.getContainerFilterByName(form.getContainerFilter(), getContainer(), getUser());
             if (form.isSampleType())
-                rowIds = AuditLogImpl.get().getTransactionSampleIds(form.getTransactionAuditId(), ElevatedUser.ensureCanSeeAuditLogRole(getContainer(), getUser()), getContainer());
+                rowIds = AuditLogImpl.get().getTransactionSampleIds(form.getTransactionAuditId(), ElevatedUser.ensureCanSeeAuditLogRole(getContainer(), getUser()), getContainer(), cf);
             else
-                rowIds = AuditLogImpl.get().getTransactionSourceIds(form.getTransactionAuditId(), getUser(), getContainer());
+                rowIds = AuditLogImpl.get().getTransactionSourceIds(form.getTransactionAuditId(), getUser(), getContainer(), cf);
 
             ApiSimpleResponse response = new ApiSimpleResponse();
             response.put("success", true);
@@ -402,6 +403,7 @@ public class AuditController extends SpringActionController
         private Long _transactionAuditId;
         private String _dataType;
         private boolean _isSampleType;
+        String _containerFilter;
 
         public Long getTransactionAuditId()
         {
@@ -426,6 +428,16 @@ public class AuditController extends SpringActionController
         public boolean isSampleType()
         {
             return _isSampleType;
+        }
+
+        public String getContainerFilter()
+        {
+            return _containerFilter;
+        }
+
+        public void setContainerFilter(String containerFilter)
+        {
+            _containerFilter = containerFilter;
         }
 
         public void validate(Errors errors)

--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -264,7 +264,7 @@ public class AuditLogImpl implements AuditLogService, StartupListener
         return new ActionURL(AuditController.ShowAuditLogAction.class, ContainerManager.getRoot());
     }
 
-    public List<Integer> getTransactionSampleIds(long transactionAuditId, User user, Container container)
+    public List<Integer> getTransactionSampleIds(long transactionAuditId, User user, Container container, @Nullable ContainerFilter containerFilter)
     {
         List<AuditTypeEvent> transactionEvents = TRANSACTION_EVENT_CACHE.get(transactionAuditId).second;
         if (!transactionEvents.isEmpty())
@@ -280,11 +280,11 @@ public class AuditLogImpl implements AuditLogService, StartupListener
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("TransactionID"), transactionAuditId);
 
-        List<SampleTimelineAuditEvent> events = AuditLogService.get().getAuditEvents(container, user, SampleTimelineAuditEvent.EVENT_TYPE, filter, null);
+        List<SampleTimelineAuditEvent> events = AuditLogService.get().getAuditEvents(container, user, SampleTimelineAuditEvent.EVENT_TYPE, filter, null, containerFilter);
         return events.stream().map(SampleTimelineAuditEvent::getSampleId).collect(Collectors.toList());
     }
 
-    public List<Integer> getTransactionSourceIds(long transactionAuditId, User user, Container container)
+    public List<Integer> getTransactionSourceIds(long transactionAuditId, User user, Container container, @Nullable ContainerFilter containerFilter)
     {
         List<String> lsids = new ArrayList<>();
         List<Integer> sourceIds = new ArrayList<>();
@@ -307,7 +307,7 @@ public class AuditLogImpl implements AuditLogService, StartupListener
         }
         else
         {
-            List<DetailedAuditTypeEvent> events = QueryService.get().getQueryUpdateAuditRecords(user, container, transactionAuditId);
+            List<DetailedAuditTypeEvent> events = QueryService.get().getQueryUpdateAuditRecords(user, container, transactionAuditId, containerFilter);
 
             events.forEach((event) -> {
                 if (event.getNewRecordMap() != null)

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -9704,7 +9704,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         {
             TableInfo provisioned = type.getTinfo();
             TableInfo tableInfo = samplesUserSchema.getTable(type.getName());
-            if (tableInfo == null)
+            if (tableInfo == null || provisioned == null)
                 continue;
             List<ColumnInfo> uniqueIdCols = provisioned.getColumns().stream().filter(ColumnInfo::isScannableField).toList();
             numUniqueIdCols += uniqueIdCols.size();

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3115,12 +3115,12 @@ public class QueryServiceImpl implements QueryService
     }
 
     @Override
-    public List<DetailedAuditTypeEvent> getQueryUpdateAuditRecords(User user, Container container, long transactionAuditId)
+    public List<DetailedAuditTypeEvent> getQueryUpdateAuditRecords(User user, Container container, long transactionAuditId, @Nullable ContainerFilter containerFilter)
     {
         SimpleFilter filter = new SimpleFilter();
         filter.addCondition(FieldKey.fromParts("TransactionID"), transactionAuditId);
 
-        return AuditLogService.get().getAuditEvents(container, user, QUERY_UPDATE_AUDIT_EVENT, filter, null);
+        return AuditLogService.get().getAuditEvents(container, user, QUERY_UPDATE_AUDIT_EVENT, filter, null, containerFilter);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Issue [50998](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50998)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1581
- https://github.com/LabKey/labkey-ui-premium/pull/535
- https://github.com/LabKey/limsModules/pull/717

#### Changes
- update `getQueryUpdateAuditRecords` and `getTransactionSampleIds` to accept a container filter
