### PR TITLE
clean up use of Renderable with DOM.Attribute

### DIFF
--- a/api/src/org/labkey/api/jsp/taglib/FormTag.java
+++ b/api/src/org/labkey/api/jsp/taglib/FormTag.java
@@ -38,7 +38,7 @@ public class FormTag extends BodyTagSupport
     private Boolean isNoValidate;
     private String name;
     private String method="GET";
-    private HtmlString action;
+    private String action;
     private String enctype;
     private String target;
     private String onsubmit;
@@ -77,12 +77,12 @@ public class FormTag extends BodyTagSupport
                 s = ctx.getActionURL().getController() + "-" + s;
         }
 
-        this.action = HtmlString.of(s);
+        this.action = s;
     }
 
     public void setAction(ActionURL action)
     {
-        this.action = null == action ? null : HtmlString.of(action.toString());
+        this.action = null == action ? null : action.toString();
     }
 
     public String getEnctype()
@@ -180,7 +180,7 @@ public class FormTag extends BodyTagSupport
             formAttributes.at(DOM.Attribute.name, name);
         if (isNotBlank(method))
             formAttributes.at(DOM.Attribute.method, method);
-        if (!HtmlString.isBlank(action))
+        if (isNotBlank(action))
             formAttributes.at(DOM.Attribute.action, action);
         if (isNotBlank(enctype))
             formAttributes.at(DOM.Attribute.enctype, enctype);

--- a/api/src/org/labkey/api/util/DOM.java
+++ b/api/src/org/labkey/api/util/DOM.java
@@ -828,9 +828,11 @@ public class DOM
         html.append(" ");
         html.append(key.name());
         html.append("=\"");
-        if (value instanceof HtmlString)
+        // NOTE it is somewhat unusual to pass in a Renderable, but it is possible that we
+        // want to render HTML into an attribute.  We still need to re-encode the value before trying to wrap with "".
+        if (value instanceof Renderable r)
         {
-            html.append(value.toString());
+            html.append(filter(r.renderToString()));
         }
         else
         {

--- a/api/src/org/labkey/api/util/HtmlString.java
+++ b/api/src/org/labkey/api/util/HtmlString.java
@@ -136,6 +136,12 @@ public final class HtmlString implements SafeToRender, DOM.Renderable, Comparabl
     }
 
     @Override
+    public String renderToString()
+    {
+        return _s;
+    }
+
+    @Override
     public boolean equals(Object o)
     {
         if (this == o) return true;

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -1540,7 +1540,7 @@ public class PageFlowUtil
             return DOM.createHtml(A(id(id).cl("_helpPopup").at(tabindex,"-1", style, "cursor: help")
                 .data(width != 0, "popupwidth", width)
                 .data(isNotBlank(titleText),"popuptitle", titleText)
-                .data("popupcontent", helpHtml.toString()),
+                .data("popupcontent", helpHtml.renderToString()),
                 linkHtml));
         }
     }


### PR DESCRIPTION
#### Rationale
Html rendered into an DOM.Attribute needs to be double-encoded.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
