### PR TITLE
Fix name expression when import alias is used as field name and when all parent samples have integer-like names

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -2299,7 +2299,7 @@ public class NameGenerator
                         });
                     }
 
-                    if (value instanceof String) // convert "parent1,parent2" to [parent1, parent2]
+                    if (!parents.isEmpty()) // convert "parent1,parent2" to [parent1, parent2]
                         inputs.computeIfAbsent(parts[0] + "/" + parts[1],  (s) -> new LinkedHashSet<>()).addAll(parents);
                 }
             }


### PR DESCRIPTION
#### Rationale
When a parent alias is used as the import field name, but all parent samples have integer-like names, name expressions don't work as expected. When used by itself, the name expression generates error. When used inside a withCounter expression, the expression silently returns empty value.

([Workflow Endpoints postgres](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_WorkflowEndpoints)) [Parent data type with special characters](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_WorkflowEndpoints/3195226?buildTab=tests&status=failed&name=Parent+data+type+with+special+characters)

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- don't check String parent type
