### PR TITLE
WebSocket fix for selenium failure with "current thread was interrupted"

### DIFF
--- a/api/webapp/clientapi/dom/WebSocket.js
+++ b/api/webapp/clientapi/dom/WebSocket.js
@@ -92,7 +92,9 @@ LABKEY.WebSocket = new function ()
             }
             else if (evt.code === CloseEventCode.GOING_AWAY && evt.reason && evt.reason !== "") {
                 // 1001 sent when server is shutdown normally (AND on page reload in FireFox, but that one doesn't have a reason)
-                setTimeout(showDisconnectedMessage, 1000);
+                setTimeout(function() {
+                    showDisconnectedMessage(false, evt.reason);
+                }, 1000);
             }
             else if (evt.code === CloseEventCode.POLICY_VIOLATION) {
                 // Tomcat closes the websocket with "1008 Policy Violation" code when the session has expired.
@@ -124,14 +126,14 @@ LABKEY.WebSocket = new function ()
                 setTimeout(function() {
                     // Issue 51021: check for null _websocket before showing unavailable message as this can be triggered
                     // in FF by having the API call aborted because of a page navigation
-                    if (_websocket === null) showDisconnectedMessage();
+                    if (_websocket === null) showDisconnectedMessage(false, "Failed login-whoami.api call.");
                 }, 1000);
             }
         });
     }
 
-    function showDisconnectedMessage(skipReopen) {
-        displayModal("Server Unavailable", "The server is currently unavailable. Please try reloading the page to continue.", false, skipReopen);
+    function showDisconnectedMessage(skipReopen, reason) {
+        displayModal("Server Unavailable", "The server is currently unavailable. Please try reloading the page to continue. " + reason, false, skipReopen);
         // CONSIDER: Periodically attempt to reestablish connection until the server comes back up.
     }
 

--- a/api/webapp/clientapi/dom/WebSocket.js
+++ b/api/webapp/clientapi/dom/WebSocket.js
@@ -90,11 +90,13 @@ LABKEY.WebSocket = new function ()
                     }, 1000);
                 }
             }
-            else if (evt.code === CloseEventCode.GOING_AWAY && evt.reason && evt.reason !== "") {
+            else if (evt.code === CloseEventCode.GOING_AWAY && evt.reason) {
                 // 1001 sent when server is shutdown normally (AND on page reload in FireFox, but that one doesn't have a reason)
-                setTimeout(function() {
-                    showDisconnectedMessage(false, evt.reason);
-                }, 1000);
+                if (evt.reason !== "" && evt.reason.indexOf("The current thread was interrupted") === -1) {
+                    setTimeout(function () {
+                        showDisconnectedMessage(false, evt.reason);
+                    }, 1000);
+                }
             }
             else if (evt.code === CloseEventCode.POLICY_VIOLATION) {
                 // Tomcat closes the websocket with "1008 Policy Violation" code when the session has expired.
@@ -126,14 +128,14 @@ LABKEY.WebSocket = new function ()
                 setTimeout(function() {
                     // Issue 51021: check for null _websocket before showing unavailable message as this can be triggered
                     // in FF by having the API call aborted because of a page navigation
-                    if (_websocket === null) showDisconnectedMessage(false, "Failed login-whoami.api call.");
+                    if (_websocket === null) showDisconnectedMessage();
                 }, 1000);
             }
         });
     }
 
     function showDisconnectedMessage(skipReopen, reason) {
-        displayModal("Server Unavailable", "The server is currently unavailable. Please try reloading the page to continue. " + reason, false, skipReopen);
+        displayModal("Server Unavailable", "The server is currently unavailable. " + (reason ?? '') + " Please try reloading the page to continue.", false, skipReopen);
         // CONSIDER: Periodically attempt to reestablish connection until the server comes back up.
     }
 


### PR DESCRIPTION
#### Rationale
On TeamCity, a couple of tests (mainly ETLRemoteSourceTest.testTransformError) is intermittently failing with a screenshot that shows the "Server Unavailable" dialog which prevents the test from clicking other things. I believe this happens in cases where the test is checking for expected errors on the page and then sending an API call to clear those errors. When the test comes back to the original browser window, the test is trying to navigate. If that API call didn't finish, it seems that the WebSocket connection is sometimes getting an event saying that the thread was interrupted. This PR addresses that by specially skipping this event.reason.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5793

#### Changes
- ignore "thread was interrupted" event.reason for FF CloseEventCode.GOING_AWAY code
