### PR TITLE
Issue 51316: disable update of assay run/result sample lineage

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -2111,6 +2111,9 @@ public abstract class AbstractAssayProvider implements AssayProvider
         }
     }
 
+    // Issue 51316: While this issue is being addressed this feature has been disabled.
+    private final static boolean ENABLE_UPDATE_PROPERTY_LINEAGE = false;
+
     @Override
     public void updatePropertyLineage(
         Container container,
@@ -2124,6 +2127,9 @@ public abstract class AbstractAssayProvider implements AssayProvider
         @NotNull Map<Integer, ExpMaterial> materialsCache
     ) throws ValidationException
     {
+        if (!ENABLE_UPDATE_PROPERTY_LINEAGE)
+            return;
+
         Domain domain = table.getDomain();
         if (domain == null || newRow == null || oldRow == null)
             return;

--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -2117,14 +2117,15 @@ public abstract class AbstractAssayProvider implements AssayProvider
         User user,
         TableInfo table,
         ExpRun run,
-        Map<String, Object> row,
+        Map<String, Object> newRow,
+        Map<String, Object> oldRow,
         boolean isRunProperties,
         @NotNull RemapCache cache,
         @NotNull Map<Integer, ExpMaterial> materialsCache
     ) throws ValidationException
     {
         Domain domain = table.getDomain();
-        if (domain == null)
+        if (domain == null || newRow == null || oldRow == null)
             return;
 
         Set<Integer> removedMaterialInputs = new HashSet<>();
@@ -2132,8 +2133,13 @@ public abstract class AbstractAssayProvider implements AssayProvider
 
         // There can be multiple columns within a row that are lineage-backed material lookups.
         // Coalesce these material input updates across columns.
-        for (var entry : row.entrySet())
+        for (var entry : newRow.entrySet())
         {
+            Object newValue = entry.getValue();
+            Object oldValue = oldRow.get(entry.getKey());
+            if (newValue == oldValue)
+                continue;
+
             ColumnInfo column = table.getColumn(entry.getKey());
 
             if (column != null && (!isRunProperties || column instanceof PropertyColumn))
@@ -2147,14 +2153,28 @@ public abstract class AbstractAssayProvider implements AssayProvider
                 {
                     String inputRole = AssayService.get().getPropertyInputLineageRole(dp);
 
-                    // Remove all material inputs with the same role
+                    // Remove material inputs with the same role
                     for (var materialEntry : run.getMaterialInputs().entrySet())
                     {
                         if (inputRole.equalsIgnoreCase(materialEntry.getValue()))
-                            removedMaterialInputs.add(materialEntry.getKey().getRowId());
+                        {
+                            // Issue 51316: Resolve the original material input rowId for this column
+                            Integer originalRowId = null;
+                            if (oldValue instanceof Integer _originalRowId)
+                                originalRowId = _originalRowId;
+                            else if (oldValue != null)
+                            {
+                                ExpMaterial originalMaterial = ExperimentService.get().findExpMaterial(container, user, oldValue, sampleType, cache, materialsCache);
+                                if (originalMaterial != null)
+                                    originalRowId = originalMaterial.getRowId();
+                            }
+
+                            if (originalRowId != null && originalRowId == materialEntry.getKey().getRowId())
+                                removedMaterialInputs.add(originalRowId);
+                        }
                     }
 
-                    ExpMaterial newInputMaterial = ExperimentService.get().findExpMaterial(container, user, entry.getValue(), sampleType, cache, materialsCache);
+                    ExpMaterial newInputMaterial = ExperimentService.get().findExpMaterial(container, user, newValue, sampleType, cache, materialsCache);
                     if (newInputMaterial != null)
                     {
                         // Prevent direct cycles

--- a/api/src/org/labkey/api/assay/AssayProvider.java
+++ b/api/src/org/labkey/api/assay/AssayProvider.java
@@ -390,7 +390,8 @@ public interface AssayProvider extends Handler<ExpProtocol>
         User user,
         TableInfo table,
         ExpRun run,
-        Map<String, Object> row,
+        Map<String, Object> newRow,
+        Map<String, Object> olRow,
         boolean isRunProperties,
         @NotNull RemapCache cache,
         @NotNull Map<Integer, ExpMaterial> materialsCache

--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -114,7 +114,7 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
 
         AssayProvider assayProvider = AssayService.get().getProvider(run);
         if (assayProvider != null)
-            assayProvider.updatePropertyLineage(container, user, getQueryTable(), run, updatedValues, false, getRemapCache(), getMaterialsCache());
+            assayProvider.updatePropertyLineage(container, user, getQueryTable(), run, updatedValues, oldRow, false, getRemapCache(), getMaterialsCache());
 
         String userComment = configParameters == null ? null : (String) configParameters.get(AuditUserComment);
         ExperimentService.get().auditRunEvent(user, run.getProtocol(), run, null, sb.toString(), userComment);

--- a/assay/src/org/labkey/assay/AssayIntegrationTestCase.jsp
+++ b/assay/src/org/labkey/assay/AssayIntegrationTestCase.jsp
@@ -594,7 +594,7 @@
     @Test
     public void testRunResultLineageUpdate() throws Exception
     {
-        // Regression coverage for Issue 45594.
+        // Regression coverage for Issue 45594 and Issue 51316.
         // Verify run/result properties backed by lineage update when query data is updated.
 
         // Arrange
@@ -602,24 +602,26 @@
         var provider = assayPair.first;
         var assayProtocol = assayPair.second;
 
-        var samples = createSamples(5);
+        var samples = createSamples(10);
         var runSample1 = samples.get(0);
         var runSample2 = samples.get(1);
         var resultSample1 = samples.get(2);
         var resultSample2 = samples.get(3);
-        var sampleLookupSample = samples.get(4);
+        var resultSample3 = samples.get(4);
+        var sampleLookupSample = samples.get(5);
 
         // create a file in the pipeline root to import
-        var fileContents = String.format("ResultExpMaterialsLookup\tSampleTypeLookup\n%s\t%s\n", resultSample1.getName(), sampleLookupSample.getName());
+        var fileContents = String.format("ResultExpMaterialsLookup\tSampleTypeLookup\n%s\t%s\n%s\n", resultSample1.getName(), sampleLookupSample.getName(), resultSample3.getName());
         var file = createAssayDataFile(fileContents);
 
         // create a run
         var run = assayImportFile(c, user, provider, assayProtocol, file, false, Map.of("runExpMaterialsLookup", runSample1.getName()));
 
         // Verify pre-conditions
-        assertEquals(3, run.getMaterialInputs().size());
+        assertEquals(4, run.getMaterialInputs().size());
         assertEquals("RunExpMaterialsLookup", run.getMaterialInputs().get(runSample1));
         assertEquals("ResultExpMaterialsLookup", run.getMaterialInputs().get(resultSample1));
+        assertEquals("ResultExpMaterialsLookup", run.getMaterialInputs().get(resultSample3));
         assertEquals("SampleTypeLookup", run.getMaterialInputs().get(sampleLookupSample));
 
         AssayProtocolSchema schema = provider.createProtocolSchema(user, c, assayProtocol, null);
@@ -633,18 +635,20 @@
         if (errors.hasErrors())
             throw errors;
 
-        var resultRow = new TableSelector(resultsTable).getMapArray()[0];
-        var updatedResultRow = CaseInsensitiveHashMap.of("RowId", resultRow.get("RowId"), "ResultExpMaterialsLookup", resultSample2.getRowId());
-        resultsTable.getUpdateService().updateRows(user, c, List.of((Map) updatedResultRow), null, errors, null, null);
+        var resultRows = new TableSelector(resultsTable).getMapArray();
+        var updatedResultRow1 = CaseInsensitiveHashMap.of("RowId", resultRows[0].get("RowId"), "ResultExpMaterialsLookup", resultSample2.getRowId());
+        var updatedResultRow2 = CaseInsensitiveHashMap.of("RowId", resultRows[1].get("RowId"), "resultProp", 42);
+        resultsTable.getUpdateService().updateRows(user, c, List.of(updatedResultRow1, updatedResultRow2), null, errors, null, null);
         if (errors.hasErrors())
             throw errors;
 
         // Assert
         var updatedRun = ExperimentService.get().getExpRun(run.getRowId());
         assertNotNull(updatedRun);
-        assertEquals(3, updatedRun.getMaterialInputs().size());
+        assertEquals(4, updatedRun.getMaterialInputs().size());
         assertEquals("RunExpMaterialsLookup", updatedRun.getMaterialInputs().get(runSample2));
         assertEquals("ResultExpMaterialsLookup", updatedRun.getMaterialInputs().get(resultSample2));
+        assertEquals("ResultExpMaterialsLookup", updatedRun.getMaterialInputs().get(resultSample3));
         assertEquals("SampleTypeLookup", updatedRun.getMaterialInputs().get(sampleLookupSample));
     }
 %>

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -1040,7 +1040,7 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
 
                 AssayProvider assayProvider = AssayService.get().getProvider(run);
                 if (assayProvider != null)
-                    assayProvider.updatePropertyLineage(container, user, getQueryTable(), run, row, true, _cache, getMaterialsCache());
+                    assayProvider.updatePropertyLineage(container, user, getQueryTable(), run, row, oldRow, true, _cache, getMaterialsCache());
 
                 run.save(user);
 


### PR DESCRIPTION
#### Rationale
This disables `AssayProvider.updatePropertyLineage()` processing in 24.9 and we'll revisit the implementation approach in a future release cycle. See [Issue 51316](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51316).

#### Related Pull Requests
- #5755

#### Changes
- ~~In addition to the `row` data pass in the `oldRow` data to `AssayProvider.updatePropertyLineage()` when updating assay run/result rows.~~
- ~~Inspect the old row value for the given lookup and only remove a sample as a material input if it was the original value.~~
- Disable `AssayProvider.updatePropertyLineage()` processing and `@Ignore` associated regression test coverage.