### PR TITLE
Plates: support rearray of samples via reformat

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -542,14 +542,6 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return new SqlSelector(ExperimentService.get().getSchema(), sql);
     }
 
-    @NotNull Plate createPlateTemplate(Container container, String assayType, @NotNull PlateType plateType)
-    {
-        Plate plate = createPlate(container, assayType, plateType);
-        ((PlateImpl)plate).setTemplate(true);
-
-        return plate;
-    }
-
     @Override
     public @Nullable Plate getPlate(Container container, int rowId)
     {

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3126,8 +3126,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     {
         for (WellData wellData : wellDataList)
         {
-            boolean isSampleWell = WellGroup.Type.SAMPLE.equals(wellData.getType());
-            boolean isReplicateWell = WellGroup.Type.REPLICATE.equals(wellData.getType());
+            boolean isSampleWell = wellData.isSample();
+            boolean isReplicateWell = wellData.isReplicate();
             boolean isSampleOrReplicate = isSampleWell || isReplicateWell;
 
             Pair<WellGroup.Type, String> groupKey = null;

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -161,6 +161,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -3716,7 +3717,14 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public record ReformatResult(List<PlateData> previewData, Integer plateCount, Integer plateSetRowId, String plateSetName, List<Integer> plateRowIds) {}
+    public record ReformatResult(
+        List<PlateData> previewData,
+        Integer plateCount,
+        Integer plateSetRowId,
+        String plateSetName,
+        List<Integer> plateRowIds,
+        Integer platedSampleCount
+    ) {}
 
     /**
      * Reformat a set of source plates to new plates via a reformat operation (e.g. quadrant, stamp, etc.).
@@ -3747,11 +3755,15 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         PlateSetImpl sourcePlateSet = (PlateSetImpl) source.first;
         List<Plate> sourcePlates = source.second;
 
-        PlateType targetPlateType = null;
-        if (options.getTargetPlateTypeId() != null)
-            targetPlateType = requirePlateType(options.getTargetPlateTypeId(), null);
+        Pair<PlateType, Plate> targetPlateSource = getReformatTargetPlateSource(container, options);
+        PlateType targetPlateType = targetPlateSource.first;
+        Plate targetTemplate = targetPlateSource.second;
 
-        LayoutEngine engine = new LayoutEngine(options, sourcePlates, targetPlateType, getPlateTypes());
+        List<WellData> targetTemplateWellData = null;
+        if (targetTemplate != null)
+            targetTemplateWellData = getWellData(container, user, targetTemplate.getRowId(), false, false);
+
+        LayoutEngine engine = new LayoutEngine(options, sourcePlates, targetPlateType, targetTemplate, targetTemplateWellData, getPlateTypes());
 
         List<WellLayout> wellLayouts = engine.run();
         int availablePlateCount = destinationPlateSet.availablePlateCount();
@@ -3765,10 +3777,12 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             ));
         }
 
-        List<PlateData> plateData = hydratePlateDataFromWellLayout(container, user, wellLayouts, engine.getOperation());
+        Pair<List<PlateData>, Integer> hydratedResults = hydratePlateDataFromWellLayout(container, user, wellLayouts, engine.getOperation());
+        List<PlateData> plateData = hydratedResults.first;
+        Integer platedSampleCount = hydratedResults.second;
 
         if (options.isPreview())
-            return new ReformatResult(options.isPreviewData() ? plateData : null, plateData.size(), null, null, null);
+            return new ReformatResult(options.isPreviewData() ? plateData : null, plateData.size(), null, null, null, platedSampleCount);
 
         if (plateData.isEmpty())
             throw new ValidationException("This operation as configured does not create any plates.");
@@ -3792,7 +3806,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         }
 
         List<Integer> plateRowIds = newPlates.stream().map(Plate::getRowId).toList();
-        return new ReformatResult(null, plateRowIds.size(), plateSetRowId, plateSetName, plateRowIds);
+        return new ReformatResult(null, plateRowIds.size(), plateSetRowId, plateSetName, plateRowIds, platedSampleCount);
     }
 
     private @Nullable Integer getReformatParentPlateSetId(@NotNull PlateSet sourcePlateSet)
@@ -3874,6 +3888,36 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return plateSet;
     }
 
+    private @NotNull Pair<PlateType, Plate> getReformatTargetPlateSource(Container container, ReformatOptions options) throws ValidationException
+    {
+        PlateType targetPlateType = null;
+        Plate targetTemplate = null;
+
+        ReformatOptions.ReformatPlateSource plateSource = options.getTargetPlateSource();
+        if (plateSource != null)
+        {
+            if (plateSource.getSourceType() == null)
+                throw new ValidationException("A \"type\" must be specified for \"targetPlateSource\".");
+            if (plateSource.getRowId() == null || plateSource.getRowId() < 1)
+                throw new ValidationException("A \"rowId\" must be specified for \"targetPlateSource\".");
+
+            if (ReformatOptions.ReformatPlateSource.SourceType.type.equals(plateSource.getSourceType()))
+                targetPlateType = requirePlateType(plateSource.getRowId(), null);
+            else if (ReformatOptions.ReformatPlateSource.SourceType.template.equals(plateSource.getSourceType()))
+            {
+                targetTemplate = requirePlate(container, plateSource.getRowId(), null);
+                if (!targetTemplate.isTemplate())
+                    throw new ValidationException("Plate \"%s\" is not a valid template.", targetTemplate.getName());
+                if (targetTemplate.isArchived())
+                    throw new ValidationException("Template \"%s\" is archived and cannot be used for reformatting.", targetTemplate.getName());
+            }
+            else
+                throw new ValidationException("A valid \"type\" must be specified for \"targetPlateSource\".");
+        }
+
+        return Pair.of(targetPlateType, targetTemplate);
+    }
+
     private Pair<PlateSet, List<Plate>> getReformatSourcePlates(Container container, ReformatOptions options) throws ValidationException
     {
         List<Plate> sourcePlates = new ArrayList<>();
@@ -3899,7 +3943,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return Pair.of(sourcePlateSet, sourcePlates);
     }
 
-    private @NotNull List<PlateData> hydratePlateDataFromWellLayout(
+    private @NotNull Pair<List<PlateData>, Integer> hydratePlateDataFromWellLayout(
         Container container,
         User user,
         List<WellLayout> wellLayouts,
@@ -3907,52 +3951,98 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     )
     {
         if (wellLayouts.isEmpty())
-            return Collections.emptyList();
+            return Pair.of(emptyList(), null);
 
         List<PlateData> plates = new ArrayList<>();
         Map<Integer, List<WellData>> sourceWellDataMap = new HashMap<>();
+        Set<Integer> platedSampleIds = new HashSet<>();
 
         for (WellLayout wellLayout : wellLayouts)
         {
-            PlateType plateType = wellLayout.getPlateType();
             List<Map<String, Object>> targetWellData = new ArrayList<>();
 
-            for (WellLayout.Well well : wellLayout.getWells())
+            if (wellLayout.getTargetTemplateId() != null)
             {
-                if (well == null)
-                    continue;
-
-                List<WellData> sourceWellDatas = sourceWellDataMap.computeIfAbsent(
-                    well.sourcePlateId(),
-                    (plateRowId) -> getWellData(container, user, plateRowId, true, true)
+                List<WellData> templateWellData = sourceWellDataMap.computeIfAbsent(
+                    wellLayout.getTargetTemplateId(),
+                    (templateRowId) -> getWellData(container, user, templateRowId, false, true)
                 );
 
-                for (WellData wellData : sourceWellDatas)
+                for (WellData wellData : templateWellData)
                 {
-                    if (!wellData.hasData())
+                    WellData d = new WellData();
+
+                    int rowIdx = wellData.getRow();
+                    int colIdx = wellData.getCol();
+                    Position p = new PositionImpl(container, rowIdx, colIdx);
+                    d.setPosition(p.getDescription());
+
+                    WellLayout.Well well = wellLayout.getWell(rowIdx, colIdx);
+                    if (well != null)
+                    {
+                        Integer sampleId = well.sourceSampleId();
+                        d.setSampleId(sampleId);
+                        if (sampleId != null)
+                            platedSampleIds.add(sampleId);
+                    }
+
+                    d.setMetadata(wellData.getMetadata());
+                    d.setWellGroup(wellData.getWellGroup());
+                    d.setType(wellData.getType());
+
+                    targetWellData.add(d.getData());
+                }
+            }
+            else
+            {
+                for (WellLayout.Well well : wellLayout.getWells())
+                {
+                    if (well == null)
                         continue;
 
-                    if (wellData.getRow() == well.sourceRowIdx() && wellData.getCol() == well.sourceColIdx())
+                    List<WellData> sourceWellData = sourceWellDataMap.computeIfAbsent(
+                        well.sourcePlateId(),
+                        (plateRowId) -> getWellData(container, user, plateRowId, true, true)
+                    );
+
+                    for (WellData wellData : sourceWellData)
                     {
-                        Position p = new PositionImpl(container, well.destinationRowIdx(), well.destinationColIdx());
+                        if (!wellData.hasData())
+                            continue;
 
-                        WellData d = new WellData();
-                        d.setPosition(p.getDescription());
-                        d.setSampleId(wellData.getSampleId());
-                        d.setMetadata(wellData.getMetadata());
-                        d.setWellGroup(wellData.getWellGroup());
-                        d.setType(wellData.getType());
+                        if (wellData.getRow() == well.sourceRowIdx() && wellData.getCol() == well.sourceColIdx())
+                        {
+                            Position p = new PositionImpl(container, well.destinationRowIdx(), well.destinationColIdx());
 
-                        targetWellData.add(d.getData());
+                            WellData d = new WellData();
+                            d.setPosition(p.getDescription());
+                            d.setSampleId(wellData.getSampleId());
+
+                            if (wellLayout.isSampleOnly())
+                            {
+                                d.setType(WellGroup.Type.SAMPLE);
+                                if (d.getSampleId() != null)
+                                    platedSampleIds.add(d.getSampleId());
+                            }
+                            else
+                            {
+                                d.setMetadata(wellData.getMetadata());
+                                d.setWellGroup(wellData.getWellGroup());
+                                d.setType(wellData.getType());
+                            }
+
+                            targetWellData.add(d.getData());
+                            break;
+                        }
                     }
                 }
             }
 
             if (operation.produceEmptyPlates() || !targetWellData.isEmpty())
-                plates.add(new PlateData(null, plateType.getRowId(), null, null, targetWellData));
+                plates.add(new PlateData(null, wellLayout.getPlateType().getRowId(), null, null, targetWellData));
         }
 
-        return plates;
+        return Pair.of(plates, platedSampleIds.isEmpty() ? null : platedSampleIds.size());
     }
 
     private class BulkPlateIndexer extends Thread

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -378,18 +378,14 @@ public final class PlateManagerTest
     public void testCreatePlateTemplates() throws Exception
     {
         // Verify plate service assumptions about plate templates
-        Plate plate = PlateManager.get().createPlateTemplate(container, TsvPlateLayoutHandler.TYPE, PLATE_TYPE_384_WELLS);
-        plate.setName("my plate template");
-        int templateId = PlateManager.get().save(container, user, plate);
-        Plate template = PlateManager.get().getPlate(container, templateId);
+        Plate template = createPlateTemplate(PLATE_TYPE_384_WELLS, "my plate template", null);
 
         // Assert
         assertNotNull("Expected plate template to be persisted", template);
         assertTrue("Expected saved plate to have the template field set to true", template.isTemplate());
 
-        plate = PlateManager.get().createPlate(container, TsvPlateLayoutHandler.TYPE, PLATE_TYPE_96_WELLS);
-        plate.setName("non plate template");
-        PlateManager.get().save(container, user, plate);
+        // Create an additional plate to ensure getPlateTemplates() does not include it
+        createPlate(PLATE_TYPE_96_WELLS);
 
         // Verify only plate templates are returned
         List<Plate> templates = PlateManager.get().getPlateTemplates(container);
@@ -401,9 +397,8 @@ public final class PlateManagerTest
     @Test
     public void testCreatePlateMetadata() throws Exception
     {
-        Plate plate = PlateManager.get().createPlateTemplate(container, TsvPlateLayoutHandler.TYPE, PLATE_TYPE_384_WELLS);
-        plate.setName("new plate with metadata");
-        int plateId = PlateManager.get().save(container, user, plate);
+        Plate plate = createPlateTemplate(PLATE_TYPE_384_WELLS, "new plate with metadata", null);
+        int plateId = plate.getRowId();
 
         // Assert
         assertTrue("Expected saved plateId to be returned", plateId != 0);
@@ -1504,7 +1499,7 @@ public final class PlateManagerTest
         // Assert
         assertNotNull(result.previewData());
         assertEquals("Expected array by column operation to generate 2 12-well plates.", 2, result.previewData().size());
-        assertEquals("Expected 13 unique samples to be plated from the 2 source plates.", (Integer) 13, result.platedSampleCount());
+        assertEquals("Expected all unique samples to be plated from the 2 source plates.", (Integer) context.sampleRowIds.size(), result.platedSampleCount());
 
         Set<Integer> platedSamples = getSamples(result.previewData());
         Set<Integer> controlSampleIntersection = new HashSet<>(platedSamples);
@@ -1547,6 +1542,133 @@ public final class PlateManagerTest
                     case "C3" -> assertEquals(sampleRowIds.get(10).intValue(), sampleId);
                     case "C4" -> assertEquals(sampleRowIds.get(11).intValue(), sampleId);
                 }
+            }
+        }
+    }
+
+    @Test
+    public void testReformatArrayFromTemplate() throws Exception
+    {
+        // Arrange
+        ReformatContext context = initializeReformatContext();
+
+        // This template can support plating of 7 unique samples for the first plate and
+        // 4 more unique samples on each subsequent plate.
+        List<Map<String, Object>> templateData = List.of(
+            CaseInsensitiveHashMap.of("wellLocation", "A1", "type", "SAMPLE", "wellGroup", "S1", PlateMetadataFields.barcode.name(), "BC-A1"),
+            CaseInsensitiveHashMap.of("wellLocation", "A2", "type", "SAMPLE", PlateMetadataFields.barcode.name(), "BC-A2"),
+            CaseInsensitiveHashMap.of("wellLocation", "A3", "type", "SAMPLE", PlateMetadataFields.barcode.name(), "BC-A3"),
+            CaseInsensitiveHashMap.of("wellLocation", "A4", "type", "SAMPLE", PlateMetadataFields.barcode.name(), "BC-A4"),
+            CaseInsensitiveHashMap.of("wellLocation", "B1", "type", "REPLICATE", "wellGroup", "RBT1", PlateMetadataFields.barcode.name(), "BC-RB1"),
+            CaseInsensitiveHashMap.of("wellLocation", "B2", "type", "REPLICATE", "wellGroup", "RBT1", PlateMetadataFields.barcode.name(), "BC-RB1"),
+            CaseInsensitiveHashMap.of("wellLocation", "B3", "type", "REPLICATE", "wellGroup", "RBT2", PlateMetadataFields.barcode.name(), "BC-RB2"),
+            CaseInsensitiveHashMap.of("wellLocation", "B4", "type", "REPLICATE", "wellGroup", "RBT2", PlateMetadataFields.barcode.name(), "BC-RB2"),
+            CaseInsensitiveHashMap.of("wellLocation", "C1", "type", "CONTROL", PlateMetadataFields.barcode.name(), "BC-C1"),
+            CaseInsensitiveHashMap.of("wellLocation", "C2", "type", "SAMPLE", PlateMetadataFields.barcode.name(), "BC-C2"),
+            CaseInsensitiveHashMap.of("wellLocation", "C3", "type", "CONTROL", PlateMetadataFields.barcode.name(), "BC-C3"),
+            CaseInsensitiveHashMap.of("wellLocation", "C4", "type", "SAMPLE", "wellGroup", "S1", PlateMetadataFields.barcode.name(), "BC-C4")
+        );
+
+        Plate template = createPlateTemplate(PLATE_TYPE_12_WELLS, "Reformat array template", templateData);
+
+        ReformatOptions options = new ReformatOptions()
+            .setOperation(ReformatOptions.ReformatOperation.arrayFromTemplate)
+            .setPlateRowIds(context.sourcePlates.stream().map(Plate::getRowId).toList())
+            .setTargetPlateSet(new ReformatOptions.ReformatPlateSet().setRowId(context.targetPlateSetId))
+            .setTargetPlateSource(new ReformatOptions.ReformatPlateSource(template))
+            .setPreview(true);
+
+        // Act (preview)
+        PlateManager.ReformatResult result = PlateManager.get().reformat(container, user, options);
+
+        // Assert
+        assertNotNull(result.previewData());
+
+        assertEquals("Expected array from template operation to generate 3 12-well plates.", 3, result.previewData().size());
+        assertEquals("Expected all unique samples to be plated from the 2 source plates.", (Integer) context.sampleRowIds.size(), result.platedSampleCount());
+
+        Set<Integer> platedSamples = getSamples(result.previewData());
+        Set<Integer> controlSampleIntersection = new HashSet<>(platedSamples);
+        controlSampleIntersection.retainAll(new HashSet<>(context.controlRowIds));
+
+        assertTrue("Control samples should not be plated", controlSampleIntersection.isEmpty());
+
+        // Act (saved)
+        result = PlateManager.get().reformat(container, user, options.setPreview(false));
+
+        // Assert
+        assertNull(result.previewData());
+        assertEquals("Expected target plate set to be used", context.targetPlateSetId, result.plateSetRowId());
+        assertEquals(3, result.plateRowIds().size());
+
+        Plate newPlate = PlateManager.get().getPlate(container, result.plateRowIds().get(0));
+        assertNotNull(newPlate);
+        assertEquals(PLATE_TYPE_12_WELLS, newPlate.getPlateType());
+        List<Integer> sampleRowIds = context.sampleRowIds;
+
+        // Verify the first plate
+        try (var r = getPlateWellResults(newPlate.getRowId()))
+        {
+            int t = 0;
+            while (r.next())
+            {
+                var sampleId = r.getInt(FieldKey.fromParts(WellTable.Column.SampleId.name()));
+                var wellPosition = r.getString(FieldKey.fromParts("position"));
+
+                switch (wellPosition)
+                {
+                    case "A1" -> assertEquals(sampleRowIds.get(0).intValue(), sampleId); // Group "S1"
+                    case "A2" -> assertEquals(sampleRowIds.get(1).intValue(), sampleId);
+                    case "A3" -> assertEquals(sampleRowIds.get(2).intValue(), sampleId);
+                    case "A4" -> assertEquals(sampleRowIds.get(3).intValue(), sampleId);
+                    case "B1" -> assertEquals(sampleRowIds.get(4).intValue(), sampleId); // Group "RBT1"
+                    case "B2" -> assertEquals(sampleRowIds.get(4).intValue(), sampleId); // Group "RBT1"
+                    case "B3" -> assertEquals(sampleRowIds.get(5).intValue(), sampleId); // Group "RBT2"
+                    case "B4" -> assertEquals(sampleRowIds.get(5).intValue(), sampleId); // Group "RBT2"
+                    case "C1" -> assertEquals(0, sampleId); // Control
+                    case "C2" -> assertEquals(sampleRowIds.get(6).intValue(), sampleId);
+                    case "C3" -> assertEquals(0, sampleId); // Control
+                    case "C4" -> assertEquals(sampleRowIds.get(0).intValue(), sampleId); // Group "S1"
+                }
+
+                var barcode = r.getString(FieldKey.fromParts(PlateMetadataFields.barcode.name()));
+                assertEquals(String.format("Expected barcode to match for position %s", wellPosition), templateData.get(t).get(PlateMetadataFields.barcode.name()), barcode);
+                t++;
+            }
+        }
+
+        newPlate = PlateManager.get().getPlate(container, result.plateRowIds().get(2));
+        assertNotNull(newPlate);
+        assertEquals(PLATE_TYPE_12_WELLS, newPlate.getPlateType());
+
+        // Verify the third plate
+        try (var r = getPlateWellResults(newPlate.getRowId()))
+        {
+            int t = 0;
+            while (r.next())
+            {
+                var sampleId = r.getInt(FieldKey.fromParts(WellTable.Column.SampleId.name()));
+                var wellPosition = r.getString(FieldKey.fromParts("position"));
+
+                switch (wellPosition)
+                {
+                    case "A1" -> assertEquals(sampleRowIds.get(0).intValue(), sampleId); // Group "S1"
+                    case "A2" -> assertEquals(sampleRowIds.get(11).intValue(), sampleId);
+                    case "A3" -> assertEquals(sampleRowIds.get(12).intValue(), sampleId);
+                    case "A4" -> assertEquals(0, sampleId);
+                    case "B1" -> assertEquals(sampleRowIds.get(4).intValue(), sampleId); // Group "RBT1"
+                    case "B2" -> assertEquals(sampleRowIds.get(4).intValue(), sampleId); // Group "RBT1"
+                    case "B3" -> assertEquals(sampleRowIds.get(5).intValue(), sampleId); // Group "RBT2"
+                    case "B4" -> assertEquals(sampleRowIds.get(5).intValue(), sampleId); // Group "RBT2"
+                    case "C1" -> assertEquals(0, sampleId); // Control
+                    case "C2" -> assertEquals(0, sampleId);
+                    case "C3" -> assertEquals(0, sampleId); // Control
+                    case "C4" -> assertEquals(sampleRowIds.get(0).intValue(), sampleId); // Group "S1"
+                }
+
+                var barcode = r.getString(FieldKey.fromParts(PlateMetadataFields.barcode.name()));
+                assertEquals(String.format("Expected barcode to match for position %s", wellPosition), templateData.get(t).get(PlateMetadataFields.barcode.name()), barcode);
+                t++;
             }
         }
     }
@@ -1756,6 +1878,17 @@ public final class PlateManagerTest
     {
         PlateImpl plate = new PlateImpl(container, plateName, null, plateType);
         return PlateManager.get().createAndSavePlate(container, user, plate, plateSetId, plateData);
+    }
+
+    private Plate createPlateTemplate(
+        @NotNull PlateType plateType,
+        @NotNull String templateName,
+        @Nullable List<Map<String, Object>> templateData
+    ) throws Exception
+    {
+        PlateImpl plate = new PlateImpl(container, templateName, null, plateType);
+        plate.setTemplate(true);
+        return PlateManager.get().createAndSavePlate(container, user, plate, null, templateData);
     }
 
     private void assertCreatePlateThrows(

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -1073,7 +1073,7 @@ public final class PlateManagerTest
                 .setOperation(ReformatOptions.ReformatOperation.quadrant)
                 .setPlateRowIds(List.of(sourcePlate1.getRowId(), sourcePlate2.getRowId(), sourcePlate3.getRowId()))
                 .setTargetPlateSet(new ReformatOptions.ReformatPlateSet().setType(PlateSetType.assay))
-                .setTargetPlateTypeId(PLATE_TYPE_384_WELLS.getRowId())
+                .setTargetPlateSource(new ReformatOptions.ReformatPlateSource(PLATE_TYPE_384_WELLS))
                 .setPreview(true);
 
         // Act (preview)
@@ -1154,7 +1154,7 @@ public final class PlateManagerTest
             .setOperation(ReformatOptions.ReformatOperation.reverseQuadrant)
             .setPlateRowIds(List.of(sourcePlate.getRowId()))
             .setTargetPlateSet(new ReformatOptions.ReformatPlateSet().setRowId(targetPlateSetId))
-            .setTargetPlateTypeId(PLATE_TYPE_96_WELLS.getRowId())
+            .setTargetPlateSource(new ReformatOptions.ReformatPlateSource(PLATE_TYPE_96_WELLS))
             .setPreview(true);
 
         // Act (preview)
@@ -1233,7 +1233,7 @@ public final class PlateManagerTest
                 .setOperation(ReformatOptions.ReformatOperation.columnCompression)
                 .setPlateRowIds(List.of(sourcePlate.getRowId()))
                 .setTargetPlateSet(new ReformatOptions.ReformatPlateSet().setRowId(targetPlateSetId))
-                .setTargetPlateTypeId(PLATE_TYPE_12_WELLS.getRowId())
+                .setTargetPlateSource(new ReformatOptions.ReformatPlateSource(PLATE_TYPE_12_WELLS))
                 .setPreview(true);
 
         // Act (preview)
@@ -1314,7 +1314,7 @@ public final class PlateManagerTest
                 .setOperation(ReformatOptions.ReformatOperation.rowCompression)
                 .setPlateRowIds(List.of(sourcePlate.getRowId()))
                 .setTargetPlateSet(new ReformatOptions.ReformatPlateSet().setRowId(targetPlateSetId))
-                .setTargetPlateTypeId(PLATE_TYPE_12_WELLS.getRowId())
+                .setTargetPlateSource(new ReformatOptions.ReformatPlateSource(PLATE_TYPE_12_WELLS))
                 .setPreview(true);
 
         // Act (preview)

--- a/assay/src/org/labkey/assay/plate/data/WellData.java
+++ b/assay/src/org/labkey/assay/plate/data/WellData.java
@@ -51,6 +51,16 @@ public class WellData
         return _sampleId != null || _type != null && _wellGroup != null || !getMetadata().isEmpty();
     }
 
+    public boolean isReplicate()
+    {
+        return WellGroup.Type.REPLICATE.equals(getType());
+    }
+
+    public boolean isSample()
+    {
+        return WellGroup.Type.SAMPLE.equals(getType());
+    }
+
     public Integer getCol()
     {
         return _col;

--- a/assay/src/org/labkey/assay/plate/layout/ArrayOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/ArrayOperation.java
@@ -127,8 +127,8 @@ public class ArrayOperation implements LayoutOperation
 
             for (WellData wellData : targetTemplateWellData)
             {
-                boolean isSampleWell = WellGroup.Type.SAMPLE.equals(wellData.getType());
-                boolean isReplicateWell = WellGroup.Type.REPLICATE.equals(wellData.getType());
+                boolean isSampleWell = wellData.isSample();
+                boolean isReplicateWell = wellData.isReplicate();
                 boolean isSampleOrReplicate = isSampleWell || isReplicateWell;
 
                 Pair<WellGroup.Type, String> groupKey = null;
@@ -203,7 +203,7 @@ public class ArrayOperation implements LayoutOperation
             for (WellData wellData : sourceWellData)
             {
                 Integer wellSampleId = wellData.getSampleId();
-                if (wellSampleId != null && !sampleWells.containsKey(wellSampleId) && WellGroup.Type.SAMPLE.equals(wellData.getType()))
+                if (wellSampleId != null && !sampleWells.containsKey(wellSampleId) && (wellData.isSample() || wellData.isReplicate()))
                 {
                     sampleWells.put(wellSampleId, new WellLayout.Well(-1, -1, sourceRowId, wellData.getRow(), wellData.getCol(), null));
                 }

--- a/assay/src/org/labkey/assay/plate/layout/ArrayOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/ArrayOperation.java
@@ -1,0 +1,232 @@
+package org.labkey.assay.plate.layout;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateType;
+import org.labkey.api.assay.plate.Well;
+import org.labkey.api.assay.plate.WellGroup;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.util.Pair;
+import org.labkey.assay.plate.data.WellData;
+import org.labkey.assay.plate.model.ReformatOptions;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+
+public class ArrayOperation implements LayoutOperation
+{
+    public enum Layout
+    {
+        Column,
+        Row,
+        Template
+    }
+
+    private final Layout _layout;
+
+    public ArrayOperation(@NotNull Layout layout)
+    {
+        _layout = layout;
+    }
+
+    @Override
+    public List<WellLayout> execute(
+        ReformatOptions options,
+        @NotNull List<Plate> sourcePlates,
+        PlateType targetPlateType,
+        Plate targetTemplate,
+        List<WellData> targetTemplateWellData
+    ) throws ValidationException
+    {
+        Map<Integer, WellLayout.Well> sampleWells = getSampleWellsFromSourcePlates(sourcePlates);
+        if (sampleWells.isEmpty())
+            return emptyList();
+
+        if (Layout.Column.equals(_layout) || Layout.Row.equals(_layout))
+            return executeRowColumnLayout(sampleWells, targetPlateType);
+        else if (Layout.Template.equals(_layout))
+            return executeTemplateLayout(sampleWells, targetTemplate, targetTemplateWellData);
+
+        throw new UnsupportedOperationException(String.format("The layout \"%s\" is not supported.", _layout));
+    }
+
+    private List<WellLayout> executeRowColumnLayout(Map<Integer, WellLayout.Well> sampleWells, PlateType targetPlateType)
+    {
+        List<WellLayout> layouts = new ArrayList<>();
+        WellLayout target = null;
+        boolean isColumnLayout = Layout.Column.equals(_layout);
+
+        int targetCols = targetPlateType.getColumns();
+        int targetRows = targetPlateType.getRows();
+
+        int targetColIdx = 0;
+        int targetRowIdx = 0;
+
+        for (Map.Entry<Integer, WellLayout.Well> entry : sampleWells.entrySet())
+        {
+            if (target == null)
+                target = new WellLayout(targetPlateType, true, null);
+
+            WellLayout.Well sourceWell = entry.getValue();
+            target.setWell(targetRowIdx, targetColIdx, sourceWell.sourcePlateId(), sourceWell.sourceRowIdx(), sourceWell.sourceColIdx());
+
+            if (isColumnLayout)
+            {
+                targetRowIdx++;
+                if (targetRowIdx == targetRows)
+                {
+                    targetRowIdx = 0;
+                    targetColIdx++;
+
+                    if (targetColIdx == targetCols)
+                    {
+                        layouts.add(target);
+                        target = null;
+                        targetColIdx = 0;
+                    }
+                }
+            }
+            else
+            {
+                targetColIdx++;
+                if (targetColIdx == targetCols)
+                {
+                    targetColIdx = 0;
+                    targetRowIdx++;
+
+                    if (targetRowIdx == targetRows)
+                    {
+                        layouts.add(target);
+                        target = null;
+                        targetRowIdx = 0;
+                    }
+                }
+            }
+        }
+
+        if (target != null)
+            layouts.add(target);
+
+        return layouts;
+    }
+
+    private List<WellLayout> executeTemplateLayout(Map<Integer, WellLayout.Well> sampleWells, Plate targetTemplate, List<WellData> targetTemplateWellData) throws ValidationException
+    {
+        int counter = 0;
+        List<WellLayout> layouts = new ArrayList<>();
+        Map<Pair<WellGroup.Type, String>, Integer> groupSampleMap = new HashMap<>();
+
+        List<Integer> sampleIds = new ArrayList<>();
+        for (Map.Entry<Integer, WellLayout.Well> entry : sampleWells.entrySet())
+            sampleIds.add(entry.getKey());
+
+        while (counter < sampleIds.size())
+        {
+            int startCounter = counter;
+            WellLayout layout = new WellLayout(targetTemplate.getPlateType(), false, targetTemplate.getRowId());
+
+            for (WellData wellData : targetTemplateWellData)
+            {
+                boolean isSampleWell = WellGroup.Type.SAMPLE.equals(wellData.getType());
+                boolean isReplicateWell = WellGroup.Type.REPLICATE.equals(wellData.getType());
+                boolean isSampleOrReplicate = isSampleWell || isReplicateWell;
+
+                Pair<WellGroup.Type, String> groupKey = null;
+                if (isSampleOrReplicate && wellData.getWellGroup() != null)
+                {
+                    WellGroup.Type type = isSampleWell ? WellGroup.Type.SAMPLE : WellGroup.Type.REPLICATE;
+                    groupKey = Pair.of(type, wellData.getWellGroup());
+                }
+
+                if (counter >= sampleIds.size())
+                {
+                    // Fill remaining group wells
+                    if (isSampleOrReplicate && groupKey != null && groupSampleMap.containsKey(groupKey))
+                    {
+                        Integer sampleId = groupSampleMap.get(groupKey);
+                        WellLayout.Well sourceWell = sampleWells.get(sampleId);
+                        layout.setWell(wellData.getRow(), wellData.getCol(), sourceWell.sourcePlateId(), sourceWell.sourceRowIdx(), sourceWell.sourceColIdx(), sampleId);
+                    }
+                }
+                else if (isSampleOrReplicate)
+                {
+                    Integer sampleId = sampleIds.get(counter);
+
+                    if (groupKey != null)
+                    {
+                        if (groupSampleMap.containsKey(groupKey))
+                        {
+                            // Do not increment counter as this reuses the same sample within a group
+                            sampleId = groupSampleMap.get(groupKey);
+                        }
+                        else
+                        {
+                            groupSampleMap.put(groupKey, sampleId);
+                            counter++;
+                        }
+                    }
+                    else
+                    {
+                        counter++;
+                    }
+
+                    WellLayout.Well sourceWell = sampleWells.get(sampleId);
+                    layout.setWell(wellData.getRow(), wellData.getCol(), sourceWell.sourcePlateId(), sourceWell.sourceRowIdx(), sourceWell.sourceColIdx(), sampleId);
+                }
+            }
+
+            // The counter did not advance for this well layout meaning we did not plate any additional samples.
+            if (startCounter == counter)
+                throw new ValidationException(String.format("There are %d selected samples and only %d unique sample regions are available in \"%s\".", sampleIds.size(), counter, targetTemplate.getName()));
+
+            layouts.add(layout);
+        }
+
+        return layouts;
+    }
+
+    private Map<Integer, WellLayout.Well> getSampleWellsFromSourcePlates(@NotNull List<Plate> sourcePlates)
+    {
+        LinkedHashMap<Integer, WellLayout.Well> sampleWells = new LinkedHashMap<>();
+
+        for (Plate sourcePlate : sourcePlates)
+        {
+            int sourceRowId = sourcePlate.getRowId();
+            PlateType sourcePlateType = sourcePlate.getPlateType();
+
+            for (int r = 0; r < sourcePlateType.getRows(); r++)
+            {
+                for (int c = 0; c < sourcePlateType.getColumns(); c++)
+                {
+                    // TODO: May need to be more discerning regarding controls v samples
+                    Well well = sourcePlate.getWell(r, c);
+                    Integer wellSampleId = well.getSampleId();
+                    if (wellSampleId == null)
+                        continue;
+
+                    if (!sampleWells.containsKey(wellSampleId))
+                        sampleWells.put(wellSampleId, new WellLayout.Well(-1, -1, sourceRowId, r, c, null));
+                }
+            }
+        }
+
+        return sampleWells;
+    }
+
+    @Override
+    public boolean requiresTargetPlateType()
+    {
+        return Layout.Column.equals(_layout) || Layout.Row.equals(_layout);
+    }
+
+    @Override
+    public boolean requiresTargetTemplate()
+    {
+        return Layout.Template.equals(_layout);
+    }
+}

--- a/assay/src/org/labkey/assay/plate/layout/CompressionOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/CompressionOperation.java
@@ -3,8 +3,6 @@ package org.labkey.assay.plate.layout;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateType;
-import org.labkey.assay.plate.data.WellData;
-import org.labkey.assay.plate.model.ReformatOptions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,19 +23,19 @@ public class CompressionOperation implements LayoutOperation
     }
 
     @Override
-    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<WellData> targetTemplateWellData)
+    public List<WellLayout> execute(ExecutionContext context)
     {
         List<WellLayout> layouts = new ArrayList<>();
         WellLayout target = null;
         boolean isColumnLayout = Layout.Column.equals(_layout);
 
-        int targetCols = targetPlateType.getColumns();
-        int targetRows = targetPlateType.getRows();
+        int targetCols = context.targetPlateType().getColumns();
+        int targetRows = context.targetPlateType().getRows();
 
         int targetColIdx = 0;
         int targetRowIdx = 0;
 
-        for (Plate sourcePlate : sourcePlates)
+        for (Plate sourcePlate : context.sourcePlates())
         {
             int sourceRowId = sourcePlate.getRowId();
             PlateType sourcePlateType = sourcePlate.getPlateType();
@@ -47,7 +45,7 @@ public class CompressionOperation implements LayoutOperation
                 for (int c = 0; c < sourcePlateType.getColumns(); c++)
                 {
                     if (target == null)
-                        target = new WellLayout(targetPlateType);
+                        target = new WellLayout(context.targetPlateType());
 
                     if (sourcePlate.getWell(r, c).getSampleId() == null)
                         continue;

--- a/assay/src/org/labkey/assay/plate/layout/CompressionOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/CompressionOperation.java
@@ -3,6 +3,7 @@ package org.labkey.assay.plate.layout;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateType;
+import org.labkey.assay.plate.data.WellData;
 import org.labkey.assay.plate.model.ReformatOptions;
 
 import java.util.ArrayList;
@@ -24,7 +25,7 @@ public class CompressionOperation implements LayoutOperation
     }
 
     @Override
-    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType)
+    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<WellData> targetTemplateWellData)
     {
         List<WellLayout> layouts = new ArrayList<>();
         WellLayout target = null;

--- a/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
+++ b/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
@@ -2,7 +2,9 @@ package org.labkey.assay.plate.layout;
 
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateType;
+import org.labkey.api.data.Container;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.security.User;
 import org.labkey.assay.plate.data.WellData;
 import org.labkey.assay.plate.model.ReformatOptions;
 
@@ -14,41 +16,39 @@ public class LayoutEngine
     private final LayoutOperation _operation;
     private final ReformatOptions _options;
     private final List<Plate> _sourcePlates;
-    private final PlateType _targetPlateType;
-    private final Plate _targetTemplate;
-    private final List<WellData> _targetTemplateWellData;
+    private PlateType _targetPlateType;
+    private Plate _targetTemplate;
+    private List<WellData> _targetTemplateWellData;
 
-    public LayoutEngine(
-        ReformatOptions options,
-        List<Plate> sourcePlates,
-        PlateType targetPlateType,
-        Plate targetTemplate,
-        List<WellData> targetTemplateWellData,
-        List<? extends PlateType> allPlateTypes
-    )
+    public LayoutEngine(ReformatOptions options, List<Plate> sourcePlates, List<? extends PlateType> allPlateTypes)
     {
         _operation = layoutOperationFactory(options);
         _options = options;
         _sourcePlates = sourcePlates;
-        _targetPlateType = targetPlateType;
-        _targetTemplate = targetTemplate;
-        _targetTemplateWellData = targetTemplateWellData;
         _allPlateTypes = allPlateTypes;
     }
 
-    public List<WellLayout> run() throws ValidationException
+    public List<WellLayout> run(Container container, User user) throws ValidationException
     {
         if (_sourcePlates.isEmpty())
             throw new ValidationException("Invalid configuration. Source plates are required to run the layout engine.");
-
-        _operation.init(_options, _sourcePlates, _targetPlateType, _targetTemplate, _allPlateTypes);
 
         if (_operation.requiresTargetPlateType() && _targetPlateType == null)
             throw new ValidationException("A target plate type is required for this operation.");
         if (_operation.requiresTargetTemplate() && _targetTemplate == null)
             throw new ValidationException("A target plate template is required for this operation.");
 
-        return _operation.execute(_options, _sourcePlates, _targetPlateType, _targetTemplate, _targetTemplateWellData);
+        LayoutOperation.ExecutionContext context = new LayoutOperation.ExecutionContext(
+            _options,
+            _sourcePlates,
+            _targetPlateType,
+            _targetTemplate,
+            _targetTemplateWellData
+        );
+
+        _operation.init(container, user, context, _allPlateTypes);
+
+        return _operation.execute(context);
     }
 
     public LayoutOperation getOperation()
@@ -69,5 +69,16 @@ public class LayoutEngine
             case rowCompression -> new CompressionOperation(CompressionOperation.Layout.Row);
             case stamp -> new StampOperation();
         };
+    }
+
+    public void setTargetPlateType(PlateType targetPlateType)
+    {
+        _targetPlateType = targetPlateType;
+    }
+
+    public void setTargetTemplate(Plate targetTemplate, List<WellData> targetTemplateWellData)
+    {
+        _targetTemplate = targetTemplate;
+        _targetTemplateWellData = targetTemplateWellData;
     }
 }

--- a/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
+++ b/assay/src/org/labkey/assay/plate/layout/LayoutEngine.java
@@ -3,24 +3,36 @@ package org.labkey.assay.plate.layout;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateType;
 import org.labkey.api.query.ValidationException;
+import org.labkey.assay.plate.data.WellData;
 import org.labkey.assay.plate.model.ReformatOptions;
 
 import java.util.List;
 
 public class LayoutEngine
 {
+    private final List<? extends PlateType> _allPlateTypes;
     private final LayoutOperation _operation;
     private final ReformatOptions _options;
     private final List<Plate> _sourcePlates;
     private final PlateType _targetPlateType;
-    private final List<? extends PlateType> _allPlateTypes;
+    private final Plate _targetTemplate;
+    private final List<WellData> _targetTemplateWellData;
 
-    public LayoutEngine(ReformatOptions options, List<Plate> sourcePlates, PlateType targetPlateType, List<? extends PlateType> allPlateTypes)
+    public LayoutEngine(
+        ReformatOptions options,
+        List<Plate> sourcePlates,
+        PlateType targetPlateType,
+        Plate targetTemplate,
+        List<WellData> targetTemplateWellData,
+        List<? extends PlateType> allPlateTypes
+    )
     {
         _operation = layoutOperationFactory(options);
         _options = options;
         _sourcePlates = sourcePlates;
         _targetPlateType = targetPlateType;
+        _targetTemplate = targetTemplate;
+        _targetTemplateWellData = targetTemplateWellData;
         _allPlateTypes = allPlateTypes;
     }
 
@@ -29,12 +41,14 @@ public class LayoutEngine
         if (_sourcePlates.isEmpty())
             throw new ValidationException("Invalid configuration. Source plates are required to run the layout engine.");
 
-        _operation.init(_options, _sourcePlates, _targetPlateType, _allPlateTypes);
+        _operation.init(_options, _sourcePlates, _targetPlateType, _targetTemplate, _allPlateTypes);
 
         if (_operation.requiresTargetPlateType() && _targetPlateType == null)
             throw new ValidationException("A target plate type is required for this operation.");
+        if (_operation.requiresTargetTemplate() && _targetTemplate == null)
+            throw new ValidationException("A target plate template is required for this operation.");
 
-        return _operation.execute(_options, _sourcePlates, _targetPlateType);
+        return _operation.execute(_options, _sourcePlates, _targetPlateType, _targetTemplate, _targetTemplateWellData);
     }
 
     public LayoutOperation getOperation()
@@ -46,6 +60,9 @@ public class LayoutEngine
     {
         return switch (reformatOptions.getOperation())
         {
+            case arrayByColumn -> new ArrayOperation(ArrayOperation.Layout.Column);
+            case arrayByRow -> new ArrayOperation(ArrayOperation.Layout.Row);
+            case arrayFromTemplate -> new ArrayOperation(ArrayOperation.Layout.Template);
             case columnCompression -> new CompressionOperation(CompressionOperation.Layout.Column);
             case quadrant -> new QuadrantOperation();
             case reverseQuadrant -> new ReverseQuadrantOperation();

--- a/assay/src/org/labkey/assay/plate/layout/LayoutOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/LayoutOperation.java
@@ -1,9 +1,10 @@
 package org.labkey.assay.plate.layout;
 
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateType;
+import org.labkey.api.data.Container;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.security.User;
 import org.labkey.assay.plate.data.WellData;
 import org.labkey.assay.plate.model.ReformatOptions;
 
@@ -11,9 +12,9 @@ import java.util.List;
 
 public interface LayoutOperation
 {
-    List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<WellData> targetTemplateWellData) throws ValidationException;
+    List<WellLayout> execute(ExecutionContext context) throws ValidationException;
 
-    default void init(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<? extends PlateType> allPlateTypes) throws ValidationException
+    default void init(Container container, User user, ExecutionContext context, List<? extends PlateType> allPlateTypes) throws ValidationException
     {
     }
 
@@ -31,4 +32,12 @@ public interface LayoutOperation
     {
         return false;
     }
+
+    record ExecutionContext(
+        ReformatOptions options,
+        List<Plate> sourcePlates,
+        PlateType targetPlateType,
+        Plate targetTemplate,
+        List<WellData> targetTemplateWellData
+    ) {};
 }

--- a/assay/src/org/labkey/assay/plate/layout/LayoutOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/LayoutOperation.java
@@ -4,15 +4,16 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateType;
 import org.labkey.api.query.ValidationException;
+import org.labkey.assay.plate.data.WellData;
 import org.labkey.assay.plate.model.ReformatOptions;
 
 import java.util.List;
 
 public interface LayoutOperation
 {
-    List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType);
+    List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<WellData> targetTemplateWellData) throws ValidationException;
 
-    default void init(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, List<? extends PlateType> allPlateTypes) throws ValidationException
+    default void init(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<? extends PlateType> allPlateTypes) throws ValidationException
     {
     }
 
@@ -22,6 +23,11 @@ public interface LayoutOperation
     }
 
     default boolean requiresTargetPlateType()
+    {
+        return false;
+    }
+
+    default boolean requiresTargetTemplate()
     {
         return false;
     }

--- a/assay/src/org/labkey/assay/plate/layout/QuadrantOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/QuadrantOperation.java
@@ -3,9 +3,9 @@ package org.labkey.assay.plate.layout;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateType;
+import org.labkey.api.data.Container;
 import org.labkey.api.query.ValidationException;
-import org.labkey.assay.plate.data.WellData;
-import org.labkey.assay.plate.model.ReformatOptions;
+import org.labkey.api.security.User;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,17 +16,17 @@ public class QuadrantOperation implements LayoutOperation
     private PlateType _targetPlateType;
 
     @Override
-    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<WellData> targetTemplateWellData)
+    public List<WellLayout> execute(ExecutionContext context)
     {
         List<WellLayout> layouts = new ArrayList<>();
         WellLayout target = null;
 
-        for (int i = 0; i < sourcePlates.size(); i++)
+        for (int i = 0; i < context.sourcePlates().size(); i++)
         {
             if (target == null)
                 target = new WellLayout(_targetPlateType);
 
-            Plate sourcePlate = sourcePlates.get(i);
+            Plate sourcePlate = context.sourcePlates().get(i);
             Integer plateRowId = sourcePlate.getRowId();
 
             int quadrant = i % 4;
@@ -63,9 +63,9 @@ public class QuadrantOperation implements LayoutOperation
     }
 
     @Override
-    public void init(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<? extends PlateType> allPlateTypes) throws ValidationException
+    public void init(Container container, User user, ExecutionContext context, List<? extends PlateType> allPlateTypes) throws ValidationException
     {
-        _sourcePlateType = getSourcePlateType(sourcePlates);
+        _sourcePlateType = getSourcePlateType(context.sourcePlates());
         _targetPlateType = getTargetPlateType(_sourcePlateType, allPlateTypes);
     }
 

--- a/assay/src/org/labkey/assay/plate/layout/QuadrantOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/QuadrantOperation.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateType;
 import org.labkey.api.query.ValidationException;
+import org.labkey.assay.plate.data.WellData;
 import org.labkey.assay.plate.model.ReformatOptions;
 
 import java.util.ArrayList;
@@ -15,7 +16,7 @@ public class QuadrantOperation implements LayoutOperation
     private PlateType _targetPlateType;
 
     @Override
-    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType)
+    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<WellData> targetTemplateWellData)
     {
         List<WellLayout> layouts = new ArrayList<>();
         WellLayout target = null;
@@ -62,7 +63,7 @@ public class QuadrantOperation implements LayoutOperation
     }
 
     @Override
-    public void init(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, List<? extends PlateType> allPlateTypes) throws ValidationException
+    public void init(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<? extends PlateType> allPlateTypes) throws ValidationException
     {
         _sourcePlateType = getSourcePlateType(sourcePlates);
         _targetPlateType = getTargetPlateType(_sourcePlateType, allPlateTypes);

--- a/assay/src/org/labkey/assay/plate/layout/ReverseQuadrantOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/ReverseQuadrantOperation.java
@@ -3,9 +3,9 @@ package org.labkey.assay.plate.layout;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateType;
+import org.labkey.api.data.Container;
 import org.labkey.api.query.ValidationException;
-import org.labkey.assay.plate.data.WellData;
-import org.labkey.assay.plate.model.ReformatOptions;
+import org.labkey.api.security.User;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,9 +15,9 @@ public class ReverseQuadrantOperation implements LayoutOperation
     private PlateType _targetPlateType;
 
     @Override
-    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<WellData> targetTemplateWellData)
+    public List<WellLayout> execute(ExecutionContext context)
     {
-        Plate sourcePlate = sourcePlates.get(0);
+        Plate sourcePlate = context.sourcePlates().get(0);
         Integer plateRowId = sourcePlate.getRowId();
 
         List<WellLayout> layouts = new ArrayList<>();
@@ -64,12 +64,12 @@ public class ReverseQuadrantOperation implements LayoutOperation
     }
 
     @Override
-    public void init(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<? extends PlateType> allPlateTypes) throws ValidationException
+    public void init(Container container, User user, ExecutionContext context, List<? extends PlateType> allPlateTypes) throws ValidationException
     {
-        if (sourcePlates.size() != 1)
+        if (context.sourcePlates().size() != 1)
             throw new ValidationException("The reverse quadrant operation requires a single source plate.");
 
-        _targetPlateType = getTargetPlateType(sourcePlates.get(0).getPlateType(), allPlateTypes);
+        _targetPlateType = getTargetPlateType(context.sourcePlates().get(0).getPlateType(), allPlateTypes);
     }
 
     private @NotNull PlateType getTargetPlateType(@NotNull PlateType sourcePlateType, List<? extends PlateType> allPlateTypes) throws ValidationException

--- a/assay/src/org/labkey/assay/plate/layout/ReverseQuadrantOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/ReverseQuadrantOperation.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateType;
 import org.labkey.api.query.ValidationException;
+import org.labkey.assay.plate.data.WellData;
 import org.labkey.assay.plate.model.ReformatOptions;
 
 import java.util.ArrayList;
@@ -14,7 +15,7 @@ public class ReverseQuadrantOperation implements LayoutOperation
     private PlateType _targetPlateType;
 
     @Override
-    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType)
+    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<WellData> targetTemplateWellData)
     {
         Plate sourcePlate = sourcePlates.get(0);
         Integer plateRowId = sourcePlate.getRowId();
@@ -63,7 +64,7 @@ public class ReverseQuadrantOperation implements LayoutOperation
     }
 
     @Override
-    public void init(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, List<? extends PlateType> allPlateTypes) throws ValidationException
+    public void init(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<? extends PlateType> allPlateTypes) throws ValidationException
     {
         if (sourcePlates.size() != 1)
             throw new ValidationException("The reverse quadrant operation requires a single source plate.");

--- a/assay/src/org/labkey/assay/plate/layout/StampOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/StampOperation.java
@@ -3,6 +3,7 @@ package org.labkey.assay.plate.layout;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateType;
+import org.labkey.assay.plate.data.WellData;
 import org.labkey.assay.plate.model.ReformatOptions;
 
 import java.util.ArrayList;
@@ -11,7 +12,7 @@ import java.util.List;
 public class StampOperation implements LayoutOperation
 {
     @Override
-    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType)
+    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<WellData> targetTemplateWellData)
     {
         List<WellLayout> result = new ArrayList<>();
         for (Plate plate : sourcePlates)

--- a/assay/src/org/labkey/assay/plate/layout/StampOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/StampOperation.java
@@ -1,10 +1,6 @@
 package org.labkey.assay.plate.layout;
 
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.Plate;
-import org.labkey.api.assay.plate.PlateType;
-import org.labkey.assay.plate.data.WellData;
-import org.labkey.assay.plate.model.ReformatOptions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,10 +8,10 @@ import java.util.List;
 public class StampOperation implements LayoutOperation
 {
     @Override
-    public List<WellLayout> execute(ReformatOptions options, @NotNull List<Plate> sourcePlates, PlateType targetPlateType, Plate targetTemplate, List<WellData> targetTemplateWellData)
+    public List<WellLayout> execute(ExecutionContext context)
     {
         List<WellLayout> result = new ArrayList<>();
-        for (Plate plate : sourcePlates)
+        for (Plate plate : context.sourcePlates())
         {
             WellLayout wellLayout = new WellLayout(plate.getPlateType());
             int plateId = plate.getRowId();

--- a/assay/src/org/labkey/assay/plate/layout/WellLayout.java
+++ b/assay/src/org/labkey/assay/plate/layout/WellLayout.java
@@ -1,19 +1,47 @@
 package org.labkey.assay.plate.layout;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.plate.PlateType;
 
 public class WellLayout
 {
-    public record Well(int destinationRowIdx, int destinationColIdx, int sourcePlateId, int sourceRowIdx, int sourceColIdx) {}
+    public record Well(int destinationRowIdx, int destinationColIdx, int sourcePlateId, int sourceRowIdx, int sourceColIdx, Integer sourceSampleId) {}
 
     private final PlateType _plateType;
+    private final boolean _sampleOnly;
+    private final Integer _targetTemplateId;
     private final Well[] _wells;
 
     public WellLayout(@NotNull PlateType plateType)
     {
+        this(plateType, false, null);
+    }
+
+    public WellLayout(@NotNull PlateType plateType, boolean sampleOnly, @Nullable Integer targetTemplateId)
+    {
         _plateType = plateType;
+        _sampleOnly = sampleOnly;
+        _targetTemplateId = targetTemplateId;
         _wells = new Well[plateType.getWellCount()];
+    }
+
+    public @Nullable Integer getTargetTemplateId()
+    {
+        return _targetTemplateId;
+    }
+
+    private int getWellIndex(int destinationRowIdx, int destinationColIdx)
+    {
+        return destinationRowIdx * _plateType.getColumns() + destinationColIdx;
+    }
+
+    public @Nullable Well getWell(int destinationRowIdx, int destinationColIdx)
+    {
+        int index = getWellIndex(destinationRowIdx, destinationColIdx);
+        if (index < _wells.length)
+            return _wells[index];
+        return null;
     }
 
     public Well[] getWells()
@@ -21,10 +49,20 @@ public class WellLayout
         return _wells;
     }
 
+    public boolean isSampleOnly()
+    {
+        return _sampleOnly;
+    }
+
     public void setWell(int destinationRowIdx, int destinationColIdx, int sourcePlateId, int sourceWellRowIdx, int sourceWellColIdx)
     {
-        int index = destinationRowIdx * _plateType.getColumns() + destinationColIdx;
-        _wells[index] = new Well(destinationRowIdx, destinationColIdx, sourcePlateId, sourceWellRowIdx, sourceWellColIdx);
+        setWell(destinationRowIdx, destinationColIdx, sourcePlateId, sourceWellRowIdx, sourceWellColIdx, null);
+    }
+
+    public void setWell(int destinationRowIdx, int destinationColIdx, int sourcePlateId, int sourceWellRowIdx, int sourceWellColIdx, Integer sourceSampleId)
+    {
+        int index = getWellIndex(destinationRowIdx, destinationColIdx);
+        _wells[index] = new Well(destinationRowIdx, destinationColIdx, sourcePlateId, sourceWellRowIdx, sourceWellColIdx, sourceSampleId);
     }
 
     public PlateType getPlateType()

--- a/assay/src/org/labkey/assay/plate/model/ReformatOptions.java
+++ b/assay/src/org/labkey/assay/plate/model/ReformatOptions.java
@@ -1,6 +1,7 @@
 package org.labkey.assay.plate.model;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateSetType;
 import org.labkey.api.assay.plate.PlateType;
 
@@ -103,6 +104,12 @@ public class ReformatOptions
         {
             _sourceType = SourceType.type;
             _rowId = plateType.getRowId();
+        }
+
+        public ReformatPlateSource(@NotNull Plate template)
+        {
+            _sourceType = SourceType.template;
+            _rowId = template.getRowId();
         }
 
         public Integer getRowId()

--- a/assay/src/org/labkey/assay/plate/model/ReformatOptions.java
+++ b/assay/src/org/labkey/assay/plate/model/ReformatOptions.java
@@ -1,6 +1,8 @@
 package org.labkey.assay.plate.model;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.PlateSetType;
+import org.labkey.api.assay.plate.PlateType;
 
 import java.util.List;
 
@@ -8,6 +10,9 @@ public class ReformatOptions
 {
     public enum ReformatOperation
     {
+        arrayByColumn,
+        arrayByRow,
+        arrayFromTemplate,
         columnCompression,
         quadrant,
         reverseQuadrant,
@@ -79,13 +84,55 @@ public class ReformatOptions
         }
     }
 
+    public static class ReformatPlateSource
+    {
+        public enum SourceType
+        {
+            template,
+            type
+        }
+
+        private Integer _rowId;
+        private SourceType _sourceType;
+
+        public ReformatPlateSource()
+        {
+        }
+
+        public ReformatPlateSource(@NotNull PlateType plateType)
+        {
+            _sourceType = SourceType.type;
+            _rowId = plateType.getRowId();
+        }
+
+        public Integer getRowId()
+        {
+            return _rowId;
+        }
+
+        public void setRowId(Integer rowId)
+        {
+            _rowId = rowId;
+        }
+
+        public SourceType getSourceType()
+        {
+            return _sourceType;
+        }
+
+        public void setSourceType(SourceType sourceType)
+        {
+            _sourceType = sourceType;
+        }
+    }
+
     private ReformatOperation _operation;
     private List<Integer> _plateRowIds;
     private String _plateSelectionKey;
     private Boolean _preview = false;
     private Boolean _previewData = true;
     private ReformatPlateSet _targetPlateSet;
-    private Integer _targetPlateTypeId;
+    private ReformatPlateSource _targetPlateSource;
 
     public ReformatOperation getOperation()
     {
@@ -152,14 +199,14 @@ public class ReformatOptions
         return this;
     }
 
-    public Integer getTargetPlateTypeId()
+    public ReformatPlateSource getTargetPlateSource()
     {
-        return _targetPlateTypeId;
+        return _targetPlateSource;
     }
 
-    public ReformatOptions setTargetPlateTypeId(Integer targetPlateTypeId)
+    public ReformatOptions setTargetPlateSource(ReformatPlateSource targetPlateSource)
     {
-        _targetPlateTypeId = targetPlateTypeId;
+        _targetPlateSource = targetPlateSource;
         return this;
     }
 }


### PR DESCRIPTION
#### Rationale
This adds support for rearraying of samples from a collection of plates into a new plate via plate reformatting.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/541
- https://github.com/LabKey/platform/pull/5875
- https://github.com/LabKey/limsModules/pull/738

#### Changes
- Introduce new `ArrayOperation` and the associated operational mappings for reformatting.
- Refactor reformat API to accept a `targetPlateSource` in replacement of a `targetPlateTypeId`. 
- Encapsulate initialization of the `targetPlateSource`.
- Hydrate from well layouts into destination plate templates.
- Support sample and template transfer via `WellLayout`.
