### PR TITLE
Issue 50179: Exceptions logged by Radeox are difficult to track

### DIFF
--- a/api/src/org/labkey/api/wiki/WikiRenderer.java
+++ b/api/src/org/labkey/api/wiki/WikiRenderer.java
@@ -25,7 +25,6 @@ public interface WikiRenderer
 {
     /**
      * @param text the original text that should be rendered into HTML
-     * @param sourceDescription info on where the text came from for debugging purposes. For example: Announcement 6654 in /MyContainer
      */
-    FormattedHtml format(String text, String sourceDescription);
+    FormattedHtml format(String text);
 }

--- a/api/src/org/labkey/api/wiki/WikiRenderingService.java
+++ b/api/src/org/labkey/api/wiki/WikiRenderingService.java
@@ -36,13 +36,18 @@ public interface WikiRenderingService
      * @param sourceDescription info on where the text came from for debugging purposes. For example: Announcement 6654 in /MyContainer
      */
     HtmlString getFormattedHtml(WikiRendererType rendererType, String source, @Nullable String sourceDescription);
+
     /**
      * @param sourceDescription info on where the text came from for debugging purposes. For example: Announcement 6654 in /MyContainer
      */
     HtmlString getFormattedHtml(WikiRendererType rendererType, String source, @Nullable String sourceDescription,
                                 String attachPrefix, Collection<? extends Attachment> attachments);
 
+    /**
+     * @param sourceDescription info on where the text came from for debugging purposes. For example: Announcement 6654 in /MyContainer
+     */
     WikiRenderer getRenderer(WikiRendererType rendererType, String hrefPrefix,
                              String attachPrefix, Map<String, String> nameTitleMap,
-                             Collection<? extends Attachment> attachments);
+                             Collection<? extends Attachment> attachments,
+                             String sourceDescription);
 }

--- a/core/src/org/labkey/core/wiki/HtmlRenderer.java
+++ b/core/src/org/labkey/core/wiki/HtmlRenderer.java
@@ -80,7 +80,7 @@ public class HtmlRenderer implements WikiRenderer
     }
     
     @Override
-    public FormattedHtml format(String text, String sourceDescription)
+    public FormattedHtml format(String text)
     {
         LinkedList<String> errors = new LinkedList<>();
         if (text == null)

--- a/core/src/org/labkey/core/wiki/MarkdownRenderer.java
+++ b/core/src/org/labkey/core/wiki/MarkdownRenderer.java
@@ -33,7 +33,7 @@ public class MarkdownRenderer extends HtmlRenderer
     }
 
     @Override
-    public FormattedHtml format(String text, String sourceDescription)
+    public FormattedHtml format(String text)
     {
         // translate the markdown to html and reuse the html renderer
         MarkdownService markdownService = MarkdownService.get();
@@ -41,21 +41,21 @@ public class MarkdownRenderer extends HtmlRenderer
         {
             try
             {
-                return super.format(markdownService.toHtml(text), sourceDescription);
+                return super.format(markdownService.toHtml(text));
             }
             catch( NoSuchMethodException | ScriptException e)
             {
                 // if the translation from markdown to html doesnt work then show an error message in the view of the html
                 StringBuilder errorMsg = new StringBuilder("<div class=\"labkey-error\"><b>An exception occurred while converting markdown to HTML</b></div><br>The error message was: ");
                 errorMsg.append(e.getMessage());
-                return super.format(errorMsg.toString(), sourceDescription);
+                return super.format(errorMsg.toString());
             }
         }
         else
         {
             // if no markdownService available then show an error message in the view of the html
             String errorMsg = "<div class=\"labkey-error\"><b>No markdown service was available to convert the markdown to HTML</b></div><br>";
-            return super.format(errorMsg, sourceDescription);
+            return super.format(errorMsg);
         }
     }
 }

--- a/core/src/org/labkey/core/wiki/PlainTextRenderer.java
+++ b/core/src/org/labkey/core/wiki/PlainTextRenderer.java
@@ -39,7 +39,7 @@ public class PlainTextRenderer implements WikiRenderer
      * @param text Wiki source
      */
     @Override
-    public FormattedHtml format(String text, String sourceDescription)
+    public FormattedHtml format(String text)
     {
         if (text == null)
             return new FormattedHtml(HtmlString.EMPTY_STRING);

--- a/core/src/org/labkey/core/wiki/WikiRenderingServiceImpl.java
+++ b/core/src/org/labkey/core/wiki/WikiRenderingServiceImpl.java
@@ -30,7 +30,7 @@ public class WikiRenderingServiceImpl implements WikiRenderingService
                                        Collection<? extends Attachment> attachments)
     {
         return HtmlStringBuilder.of(WIKI_PREFIX)
-            .append(getRenderer(rendererType, null, attachPrefix, null, attachments).format(source, sourceDescription).getHtml())
+            .append(getRenderer(rendererType, null, attachPrefix, null, attachments, sourceDescription).format(source).getHtml())
             .append(WIKI_SUFFIX).getHtmlString();
     }
 
@@ -43,14 +43,14 @@ public class WikiRenderingServiceImpl implements WikiRenderingService
     @Override
     public WikiRenderer getRenderer(WikiRendererType rendererType, String hrefPrefix,
                                     String attachPrefix, Map<String, String> nameTitleMap,
-                                    Collection<? extends Attachment> attachments)
+                                    Collection<? extends Attachment> attachments, String sourceDescription)
     {
         WikiRenderer renderer;
 
         switch (rendererType)
         {
             case RADEOX:
-                renderer = new RadeoxRenderer(hrefPrefix, attachPrefix, nameTitleMap, attachments);
+                renderer = new RadeoxRenderer(hrefPrefix, attachPrefix, nameTitleMap, attachments, sourceDescription);
                 break;
             case HTML:
                 renderer = new HtmlRenderer(hrefPrefix, attachPrefix, nameTitleMap, attachments);
@@ -62,7 +62,7 @@ public class WikiRenderingServiceImpl implements WikiRenderingService
                 renderer = new MarkdownRenderer(hrefPrefix, attachPrefix, nameTitleMap, attachments);
                 break;
             default:
-                renderer = new RadeoxRenderer(null, attachPrefix, null, attachments);
+                renderer = new RadeoxRenderer(null, attachPrefix, null, attachments, sourceDescription);
         }
 
         return renderer;

--- a/core/src/org/radeox/api/engine/RenderEngine.java
+++ b/core/src/org/radeox/api/engine/RenderEngine.java
@@ -45,7 +45,7 @@ public interface RenderEngine {
    * Name of the RenderEngine. This is used to get a RenderEngine instance
    * with EngineManager.getInstance(name);
    *
-   * @return name Name of the engine
+   * @return Name of the engine
    */
   String getName();
 

--- a/core/src/org/radeox/engine/BaseRenderEngine.java
+++ b/core/src/org/radeox/engine/BaseRenderEngine.java
@@ -59,7 +59,7 @@ public class BaseRenderEngine implements RenderEngine {
   }
 
   public BaseRenderEngine() {
-    this(new BaseInitialRenderContext());
+    this(new BaseInitialRenderContext(null));
   }
 
   protected void init() {

--- a/core/src/org/radeox/engine/context/BaseInitialRenderContext.java
+++ b/core/src/org/radeox/engine/context/BaseInitialRenderContext.java
@@ -38,7 +38,8 @@ import java.util.Locale;
  */
 
 public class BaseInitialRenderContext extends BaseRenderContext implements InitialRenderContext {
-  public BaseInitialRenderContext() {
+  public BaseInitialRenderContext(String sourceDescription) {
+    super(sourceDescription);
     Locale languageLocale = Locale.getDefault();
     Locale locale = new Locale("Basic", "basic");
     set(RenderContext.INPUT_LOCALE, locale);

--- a/core/src/org/radeox/filter/regex/RegexReplaceFilter.java
+++ b/core/src/org/radeox/filter/regex/RegexReplaceFilter.java
@@ -64,8 +64,8 @@ public class RegexReplaceFilter extends RegexFilter {
     Pattern p;
     String s;
     for (int i = 0; i < size; i++) {
-      p = (Pattern) pattern.get(i);
-      s = (String) substitute.get(i);
+      p = pattern.get(i);
+      s = substitute.get(i);
       try {
         Matcher matcher = Matcher.create(result, p);
         result = matcher.substitute(s);

--- a/core/src/org/radeox/macro/CodeMacro.java
+++ b/core/src/org/radeox/macro/CodeMacro.java
@@ -56,13 +56,12 @@ import java.util.*;
 public class CodeMacro extends LocalePreserved {
   private static Logger log = LogManager.getLogger(CodeMacro.class);
 
-  private Map formatters;
-  private FilterContext nullContext = new BaseFilterContext();
+  private final Map<String, SourceCodeFormatter> formatters;
 
   private String start;
   private String end;
 
-  private String[] paramDescription =
+  private final String[] paramDescription =
       {"?1: syntax highlighter to use, defaults to java. Options include none, sql, xml, and java"};
 
   @Override
@@ -87,15 +86,15 @@ public class CodeMacro extends LocalePreserved {
   }
 
   public CodeMacro() {
-      formatters = new HashMap();
+      formatters = new HashMap<>();
 
-      Iterator formatterIt = Service.providers(SourceCodeFormatter.class);
+      Iterator<SourceCodeFormatter> formatterIt = Service.providers(SourceCodeFormatter.class);
     while (formatterIt.hasNext()) {
       try {
-        SourceCodeFormatter formatter = (SourceCodeFormatter) formatterIt.next();
+        SourceCodeFormatter formatter = formatterIt.next();
         String name = formatter.getName();
         if (formatters.containsKey(name)) {
-          SourceCodeFormatter existing = (SourceCodeFormatter) formatters.get(name);
+          SourceCodeFormatter existing = formatters.get(name);
           if (existing.getPriority() < formatter.getPriority()) {
             formatters.put(name, formatter);
             log.debug("Replacing formatter: " + formatter.getClass() + " (" + name + ")");
@@ -123,23 +122,24 @@ public class CodeMacro extends LocalePreserved {
   public void execute(Writer writer, MacroParameter params)
       throws IllegalArgumentException, IOException {
 
-    SourceCodeFormatter formatter = null;
+    SourceCodeFormatter formatter;
 
     if (params.getLength() == 0 || !formatters.containsKey(params.get("0"))) {
-      formatter = (SourceCodeFormatter) formatters.get(initialContext.get(RenderContext.DEFAULT_FORMATTER));
+      formatter = formatters.get(initialContext.get(RenderContext.DEFAULT_FORMATTER));
       if (null == formatter) {
         log.warn("Formatter not found.");
-        formatter = (SourceCodeFormatter) formatters.get("java");
+        formatter = formatters.get("java");
       }
     } else {
-      formatter = (SourceCodeFormatter) formatters.get(params.get("0"));
+      formatter = formatters.get(params.get("0"));
     }
 
-    String result = formatter.filter(params.getContent(), nullContext);
+    FilterContext context = new BaseFilterContext();
+    context.setRenderContext(initialContext);
+    String result = formatter.filter(params.getContent(), context);
 
     writer.write(start);
     writer.write(replace(result.trim()));
     writer.write(end);
-    return;
   }
 }

--- a/core/src/org/radeox/macro/Macro.java
+++ b/core/src/org/radeox/macro/Macro.java
@@ -44,7 +44,7 @@ public interface Macro extends Comparable {
    * in the input to the macro which should be called.
    * The method has to be implemented by subclassing classes.
    *
-   * @return name Name of the Macro
+   * @return Name of the Macro
    */
   public String getName();
 

--- a/core/src/org/radeox/macro/MacroLoader.java
+++ b/core/src/org/radeox/macro/MacroLoader.java
@@ -25,9 +25,6 @@
 
 package org.radeox.macro;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
 /**
  * Plugin loader for macros
  *
@@ -35,26 +32,21 @@ import org.apache.logging.log4j.LogManager;
  * @version $Id: MacroLoader.java,v 1.3 2003/06/11 10:04:27 stephan Exp $
  */
 
-public class MacroLoader extends PluginLoader {
-  private static Logger log = LogManager.getLogger(MacroLoader.class);
+public class MacroLoader extends PluginLoader<Macro> {
 
   @Override
-  public Class getLoadClass() {
+  public Class<Macro> getLoadClass() {
     return Macro.class;
   }
 
   /**
    * Add a plugin to the known plugin map
    *
-   * @param macro Macro to add
+   * @param m Macro to add
    */
   @Override
-  public void add(PluginRepository repository, Object plugin) {
-    if (plugin instanceof Macro) {
-      repository.put(((Macro) plugin).getName(), plugin);
-    } else {
-      log.debug("MacroLoader: " + plugin.getClass() + " not of Type " + getLoadClass());
-    }
+  public void add(PluginRepository<Macro> repository, Macro m) {
+      repository.put(m.getName(), m);
   }
 
 }

--- a/core/src/org/radeox/macro/MacroRepository.java
+++ b/core/src/org/radeox/macro/MacroRepository.java
@@ -38,7 +38,7 @@ import java.util.*;
  * @version $Id: MacroRepository.java,v 1.9 2003/12/17 13:35:36 stephan Exp $
  */
 
-public class MacroRepository extends PluginRepository {
+public class MacroRepository extends PluginRepository<Macro> {
   private static Logger log = LogManager.getLogger(MacroRepository.class);
 
   private InitialRenderContext context;

--- a/core/src/org/radeox/macro/PluginLoader.java
+++ b/core/src/org/radeox/macro/PluginLoader.java
@@ -38,12 +38,12 @@ import java.util.Iterator;
  * @version $Id: PluginLoader.java,v 1.6 2004/01/09 12:27:14 stephan Exp $
  */
 
-public abstract class PluginLoader {
-  private static Logger log = LogManager.getLogger(PluginLoader.class);
+public abstract class PluginLoader<T> {
+  private static final Logger log = LogManager.getLogger(PluginLoader.class);
 
   protected MacroRepository repository;
 
-  public PluginRepository loadPlugins(PluginRepository repository) {
+  public PluginRepository<T> loadPlugins(PluginRepository<T> repository) {
     return loadPlugins(repository, getLoadClass());
   }
 
@@ -51,17 +51,17 @@ public abstract class PluginLoader {
     this.repository = repository;
   }
 
-  public Iterator getPlugins(Class klass) {
+  public Iterator<T> getPlugins(Class<T> klass) {
     return Service.providers(klass);
   }
 
-  public PluginRepository loadPlugins(PluginRepository repository, Class klass) {
+  public PluginRepository<T> loadPlugins(PluginRepository<T> repository, Class<T> klass) {
     if (null != repository) {
       /* load all macros found in the services plugin control file */
-      Iterator iterator = getPlugins(klass);
+      Iterator<T> iterator = getPlugins(klass);
       while (iterator.hasNext()) {
         try {
-          Object plugin = iterator.next();
+          T plugin = iterator.next();
           add(repository, plugin);
           log.debug("PluginLoader: Loaded plugin: " + plugin.getClass());
         } catch (Exception e) {
@@ -77,7 +77,7 @@ public abstract class PluginLoader {
    *
    * @param plugin Plugin to add
    */
-  public abstract void add(PluginRepository repository, Object plugin);
+  public abstract void add(PluginRepository<T> repository, T plugin);
 
-  public abstract Class getLoadClass();
+  public abstract Class<T> getLoadClass();
 }

--- a/core/src/org/radeox/macro/PluginRepository.java
+++ b/core/src/org/radeox/macro/PluginRepository.java
@@ -37,15 +37,13 @@ import java.util.Map;
  * @version $Id: PluginRepository.java,v 1.5 2003/12/17 13:41:54 stephan Exp $
  */
 
-public class PluginRepository {
-  protected Map plugins;
-  protected List list;
-
-  protected static PluginRepository instance;
+public class PluginRepository<Type> {
+  protected Map<String, Type> plugins;
+  protected List<Type> list;
 
   public PluginRepository() {
-    plugins = new HashMap();
-    list = new ArrayList();
+    plugins = new HashMap<>();
+    list = new ArrayList<>();
   }
 
   public boolean containsKey(String key) {
@@ -56,11 +54,11 @@ public class PluginRepository {
     return plugins.get(key);
   }
 
-  public List getPlugins() {
-    return new ArrayList(plugins.values());
+  public List<Type> getPlugins() {
+    return new ArrayList<>(plugins.values());
   }
 
-  public void put(String key, Object value) {
+  public void put(String key, Type value) {
     plugins.put(key, value);
     list.add(value);
   }

--- a/core/src/org/radeox/macro/table/FunctionRepository.java
+++ b/core/src/org/radeox/macro/table/FunctionRepository.java
@@ -28,7 +28,6 @@ package org.radeox.macro.table;
 import org.radeox.macro.PluginRepository;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -38,9 +37,9 @@ import java.util.List;
  * @version $Id: FunctionRepository.java,v 1.2 2003/05/23 10:47:25 stephan Exp $
  */
 
-public class FunctionRepository extends PluginRepository {
+public class FunctionRepository extends PluginRepository<Function> {
   protected static FunctionRepository instance;
-  protected List loaders;
+  protected List<FunctionLoader> loaders;
 
   public synchronized  static FunctionRepository getInstance() {
     if (null == instance) {
@@ -50,14 +49,13 @@ public class FunctionRepository extends PluginRepository {
   }
 
  private void load() {
-    Iterator iterator = loaders.iterator();
-    while (iterator.hasNext()) {
-      FunctionLoader loader = (FunctionLoader) iterator.next();
-      loader.loadPlugins(this);
-    }
+     for (FunctionLoader loader : loaders)
+     {
+         loader.loadPlugins(this);
+     }
   }
   private FunctionRepository() {
-    loaders = new ArrayList();
+    loaders = new ArrayList<>();
     loaders.add(new FunctionLoader());
 
     load();

--- a/core/src/org/radeox/test/filter/BasicRegexTest.java
+++ b/core/src/org/radeox/test/filter/BasicRegexTest.java
@@ -70,7 +70,7 @@ public class BasicRegexTest {
     FilterContext context = new BaseFilterContext();
     context.setRenderContext(new BaseRenderContext());
     Filter filter = new HeadingFilter();
-    filter.setInitialContext(new BaseInitialRenderContext());
+    filter.setInitialContext(new BaseInitialRenderContext(null));
     assertEquals("Heading replaced", "<h3 class=\"heading-1\">test</h3>", filter.filter("1 test", context));
   }
 

--- a/core/src/org/radeox/test/filter/FilterTestSupport.java
+++ b/core/src/org/radeox/test/filter/FilterTestSupport.java
@@ -49,7 +49,7 @@ public class FilterTestSupport {
 
   public void setUp() throws Exception {
     if (null != filter) {
-      filter.setInitialContext(new BaseInitialRenderContext());
+      filter.setInitialContext(new BaseInitialRenderContext(null));
     }
   }
 }

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -519,9 +519,9 @@ public class WikiManager implements WikiService
         Map<String, String> nameTitleMap = WikiSelectManager.getNameAndAliasTitleMap(c);
 
         //get formatter specified for this version
-        WikiRenderer w = wikiversion.getRenderer(hrefPrefix, attachPrefix, nameTitleMap, wiki.getAttachments());
+        WikiRenderer w = wikiversion.getRenderer(hrefPrefix, attachPrefix, nameTitleMap, wiki.getAttachments(), "Wiki '" + wiki.getName() + "' version " + wikiversion.getVersion() + " in " + wiki.getContainerPath());
 
-        return w.format(wikiversion.getBody(), "Wiki '" + wiki.getName() + "' version " + wikiversion.getVersion() + " in " + wiki.getContainerPath());
+        return w.format(wikiversion.getBody());
     }
 
 

--- a/wiki/src/org/labkey/wiki/model/WikiVersion.java
+++ b/wiki/src/org/labkey/wiki/model/WikiVersion.java
@@ -211,12 +211,13 @@ public class WikiVersion
     public WikiRenderer getRenderer(String hrefPrefix,
                                     String attachPrefix,
                                     Map<String, String> nameTitleMap,
-                                    Collection<? extends Attachment> attachments)
+                                    Collection<? extends Attachment> attachments,
+                                    String sourceDescription)
     {
         if (_rendererType == null)
             _rendererType = WikiManager.DEFAULT_WIKI_RENDERER_TYPE;
 
-        return WikiRenderingService.get().getRenderer(_rendererType, hrefPrefix, attachPrefix, nameTitleMap, attachments);
+        return WikiRenderingService.get().getRenderer(_rendererType, hrefPrefix, attachPrefix, nameTitleMap, attachments, sourceDescription);
     }
 
     // Cache the rendered wiki content by default; set to false to avoid caching


### PR DESCRIPTION
#### Rationale
We need to push in the `sourceDescription` earlier in the Radeox initialization so it ends up in more `RenderContext` objects

#### Changes
- Include `sourceDescription` when getting the renderer itself, not just when rendering
- More Radeox code modernization