### PR TITLE
Issue 50774: Track processes a job launches, kill them when job is canceled

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultDataTransformer.java
+++ b/api/src/org/labkey/api/assay/DefaultDataTransformer.java
@@ -23,6 +23,10 @@ import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.pipeline.PipelineJobService;
+import org.labkey.api.pipeline.PipelineService;
+import org.labkey.api.pipeline.PipelineStatusFile;
 import org.labkey.api.qc.DataExchangeHandler;
 import org.labkey.api.qc.DataTransformer;
 import org.labkey.api.qc.DefaultTransformResult;
@@ -147,6 +151,17 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
                         addStandardParameters(context.getRequest(), context.getContainer(), scriptFile, session.getApiKey(), paramMap);
 
                         bindings.put(ExternalScriptEngine.PARAM_REPLACEMENT_MAP, paramMap);
+
+                        // Issue 50774 - associate external process with the job that spawned it so that we can
+                        // kill it if the job is canceled
+                        if (run.getJobId() != null)
+                        {
+                            PipelineStatusFile statusFile = PipelineService.get().getStatusFile(run.getJobId());
+                            if (statusFile != null)
+                            {
+                                bindings.put(ExternalScriptEngine.PIPELINE_JOB_GUID, statusFile.getJobId());
+                            }
+                        }
 
                         Object output = engine.eval(script);
 

--- a/api/src/org/labkey/api/pipeline/PipelineJobService.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJobService.java
@@ -120,7 +120,7 @@ public interface PipelineJobService extends TaskPipelineRegistry
 
     @NotNull LocationType getLocationType();
 
-    /** @return all of the engines that are currently known to the pipeline module */
+    /** @return all the engines that are currently known to the pipeline module */
     List<? extends RemoteExecutionEngine<?>> getRemoteExecutionEngines();
 
     /** Registers a remote execution engine. Intended for calling during module startup */
@@ -131,6 +131,21 @@ public interface PipelineJobService extends TaskPipelineRegistry
      * @param installPath if non-null, use this as the path to the file instead of the standard tools directory
      */
     String getExecutablePath(String exeRel, @Nullable String installPath, String packageName, String ver, Logger jobLogger) throws FileNotFoundException;
+
+    interface Closer extends AutoCloseable
+    {
+        @Override
+        void close();
+    }
+
+    /**
+     * Tracks processes launched by pipeline jobs so they can be killed if the pipeline job gets canceled.
+     * Callers should invoke the close() on the returned object when the process completes normally and no longer
+     * needs to be tracked
+     */
+    Closer trackForJobCancellation(String jobGuid, Process process);
+
+    void cancelForJob(String jobGuid);
 
     /**
      * Similar to getExecutablePath(), but allows resolution of non-executable tool directory files

--- a/api/src/org/labkey/api/reports/ExternalScriptEngine.java
+++ b/api/src/org/labkey/api/reports/ExternalScriptEngine.java
@@ -66,6 +66,7 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
      */
     public static final String WORKING_DIRECTORY = "external.script.engine.workingDirectory";
     public static final String PARAM_REPLACEMENT_MAP = "external.script.engine.replacementMap";
+    /** Identifier of the pipeline job that initiated the script execution, if any */
     public static final String PIPELINE_JOB_GUID = "external.script.engine.pipelineJobGuid";
     public static final String PARAM_SCRIPT = "scriptFile";
     public static final String SCRIPT_PATH = "scriptPath";

--- a/api/src/org/labkey/api/reports/ExternalScriptEngine.java
+++ b/api/src/org/labkey/api/reports/ExternalScriptEngine.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.miniprofiler.CustomTiming;
 import org.labkey.api.miniprofiler.MiniProfiler;
+import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.reader.Readers;
 import org.labkey.api.reports.report.r.ParamReplacementSvc;
 import org.labkey.api.util.ExceptionUtil;
@@ -65,6 +66,7 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
      */
     public static final String WORKING_DIRECTORY = "external.script.engine.workingDirectory";
     public static final String PARAM_REPLACEMENT_MAP = "external.script.engine.replacementMap";
+    public static final String PIPELINE_JOB_GUID = "external.script.engine.pipelineJobGuid";
     public static final String PARAM_SCRIPT = "scriptFile";
     public static final String SCRIPT_PATH = "scriptPath";
     public static final String SCRIPT_NAME_REPLACEMENT = "${scriptName}";
@@ -136,7 +138,7 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
             int exitCode = runProcess(context, pb, output, timeout, TimeUnit.SECONDS);
             if (exitCode != 0)
             {
-                throw new ScriptException("An error occurred when running the script '" + scriptFile.getName() + "', exit code: " + exitCode + ").\n" + output.toString());
+                throw new ScriptException("An error occurred when running the script '" + scriptFile.getName() + "', exit code: " + exitCode + ".\n" + output);
             }
             else
                 return output.toString();
@@ -318,6 +320,9 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
      */
     protected int runProcess(ScriptContext context, ProcessBuilder pb, StringBuffer output, long timeout, TimeUnit timeoutUnit)
     {
+        String jobGuid = (String)context.getBindings(ScriptContext.ENGINE_SCOPE).get(PIPELINE_JOB_GUID);
+        AutoCloseable canceler = null;
+
         Process proc;
         try
         {
@@ -337,81 +342,84 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
             throw new RuntimeException(message, eio);
         }
 
-        // Write script process output to the provided writer
-        // if the writer isn't the original writer (a PrintWriter over the tomcat console).
-        Writer writer = context.getWriter() == _originalWriter ? null : context.getWriter();
+        try (PipelineJobService.Closer ignored = PipelineJobService.get().trackForJobCancellation(jobGuid, proc))
+        {
+            // Write script process output to the provided writer
+            // if the writer isn't the original writer (a PrintWriter over the tomcat console).
+            Writer writer = context.getWriter() == _originalWriter ? null : context.getWriter();
 
-        // create thread pool for collecting the process output
-        ExecutorService pool = Executors.newSingleThreadExecutor();
+            // create thread pool for collecting the process output
+            ExecutorService pool = Executors.newSingleThreadExecutor();
 
-        // collect output using separate thread so we can enforce a timeout on the process
-        Future<Integer> out = pool.submit(() -> {
-            try (BufferedReader procReader = Readers.getReader(proc.getInputStream()))
-            {
-                String line;
-                int count = 0;
-                while ((line = procReader.readLine()) != null)
+            // collect output using separate thread so we can enforce a timeout on the process
+            Future<Integer> out = pool.submit(() -> {
+                try (BufferedReader procReader = Readers.getReader(proc.getInputStream()))
                 {
-                    count++;
-                    output.append(line);
-                    output.append('\n');
-                    if (writer != null)
+                    String line;
+                    int count = 0;
+                    while ((line = procReader.readLine()) != null)
                     {
-                        writer.write(line);
-                        writer.write('\n');
-                        // flush after every write so LogPrintWriter will forward the message to the Log4j Logger
+                        count++;
+                        output.append(line);
+                        output.append('\n');
+                        if (writer != null)
+                        {
+                            writer.write(line);
+                            writer.write('\n');
+                            // flush after every write so LogPrintWriter will forward the message to the Log4j Logger
+                            writer.flush();
+                        }
+                    }
+                    if (writer != null)
                         writer.flush();
+                    return count;
+                }
+            });
+
+            try
+            {
+                if (timeout > 0)
+                {
+                    if (!proc.waitFor(timeout, timeoutUnit))
+                    {
+                        proc.destroyForcibly().waitFor();
+
+                        String msg = "Process killed after exceeding timeout of " + timeout + " " + timeoutUnit.name().toLowerCase() + "\n";
+                        output.append(msg);
+                        if (writer != null)
+                            writer.write(msg);
                     }
                 }
-                if (writer != null)
-                    writer.flush();
-                return count;
-            }
-        });
-
-        try
-        {
-            if (timeout > 0)
-            {
-                if (!proc.waitFor(timeout, timeoutUnit))
+                else
                 {
-                    proc.destroyForcibly().waitFor();
-
-                    String msg = "Process killed after exceeding timeout of " + timeout + " " + timeoutUnit.name().toLowerCase() + "\n";
-                    output.append(msg);
-                    if (writer != null)
-                        writer.write(msg);
+                    proc.waitFor();
                 }
+
+                int code = proc.exitValue();
+
+                appendConsoleOutput(context, output);
+
+                int count = out.get();
+
+                return code;
             }
-            else
+            catch (IOException ex)
             {
-                proc.waitFor();
+                throw new RuntimeException("Failed writing output for process in '" + pb.directory().getPath() + "'.", ex);
             }
+            catch (InterruptedException ei)
+            {
+                throw new RuntimeException("Interrupted process for '" + pb.command() + " in " + pb.directory() + "'.", ei);
+            }
+            catch (ExecutionException ex)
+            {
+                // Exception thrown in output collecting thread
+                Throwable cause = ex.getCause();
+                if (cause instanceof IOException)
+                    throw new RuntimeException("Failed writing output for process in '" + pb.directory().getPath() + "'.", cause);
 
-            int code = proc.exitValue();
-
-            appendConsoleOutput(context, output);
-
-            int count = out.get();
-
-            return code;
-        }
-        catch (IOException ex)
-        {
-            throw new RuntimeException("Failed writing output for process in '" + pb.directory().getPath() + "'.", ex);
-        }
-        catch (InterruptedException ei)
-        {
-            throw new RuntimeException("Interrupted process for '" + pb.command() + " in " + pb.directory() + "'.", ei);
-        }
-        catch (ExecutionException ex)
-        {
-            // Exception thrown in output collecting thread
-            Throwable cause = ex.getCause();
-            if (cause instanceof IOException)
-                throw new RuntimeException("Failed writing output for process in '" + pb.directory().getPath() + "'.", cause);
-
-            throw new RuntimeException(cause);
+                throw new RuntimeException(cause);
+            }
         }
     }
 
@@ -522,10 +530,8 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
         String fileName = _def.getOutputFileName();
         if (fileName != null)
         {
-            if (context.getAttribute(REWRITTEN_SCRIPT_FILE) instanceof File)
+            if (context.getAttribute(REWRITTEN_SCRIPT_FILE) instanceof File scriptFile)
             {
-                File scriptFile = (File)context.getAttribute(REWRITTEN_SCRIPT_FILE);
-
                 // Replace the ${scriptName} substitution with the actual name of the script file (minus extension)
                 // E.g., if "script.R" is the filename and "${scriptName}.Rout" is the replacement, try "script.Rout"
                 int index = scriptFile.getName().lastIndexOf(".");

--- a/pipeline/src/org/labkey/pipeline/analysis/CommandTaskImpl.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/CommandTaskImpl.java
@@ -620,7 +620,7 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
         Container container = null;
         if (PipelineJobService.get().isWebServer())
         {
-            // We're inside of the web server so we have access to the DB and can set up a transform session, among
+            // We're inside the web server so we have access to the DB and can set up a transform session, among
             // other resources
             session = SecurityManager.createTransformSession(getJob().getUser());
             container = getJob().getContainer();
@@ -706,7 +706,7 @@ public class CommandTaskImpl extends WorkDirectoryTask<CommandTaskImpl.Factory> 
 
         List<String> args = pb.command();
 
-        if (args.size() == 0)
+        if (args.isEmpty())
             return false;
 
         String commandLine = StringUtils.join(args, " ");

--- a/pipeline/src/org/labkey/pipeline/api/ScriptTaskImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/ScriptTaskImpl.java
@@ -175,6 +175,9 @@ public class ScriptTaskImpl extends CommandTaskImpl
 
             Map<String, String> replacements = createReplacements(scriptFile, apiKey, container);
             bindings.put(ExternalScriptEngine.PARAM_REPLACEMENT_MAP, replacements);
+            // Issue 50774 - associate external process with the job that spawned it so that we can kill it if the job
+            // is canceled
+            bindings.put(ExternalScriptEngine.PIPELINE_JOB_GUID, getJob().getJobGUID());
 
             // Write task properties file into the work directory
             // This needs to be called after the PIPELINE_ROOT is set in the engine bindings


### PR DESCRIPTION
#### Rationale
Users want to be able to cancel pipeline jobs and have them kill any spawned external processes, and terminate the job immediately.

#### Changes
- Track the processes launched by jobs
- Kill the processes when a user cancels a job
- Minor code cleanup