### PR TITLE
Introduce WritablePropertyMap

### DIFF
--- a/api/src/org/labkey/api/collections/CollectionUtils.java
+++ b/api/src/org/labkey/api/collections/CollectionUtils.java
@@ -140,12 +140,10 @@ public class CollectionUtils
     /**
      * Attempts to determine if the provided Set implementation is stable-ordered, i.e., its iteration order matches its
      * insertion order. Currently, LinkedHashSet, Collections.singleton(), and Collections.emptySet() are considered
-     * stable-ordered; HashSet and TreeSet are not. Sets returned by Set.of() are also considered not stable-ordered;
-     * although they seem to iterate in insertion order in current JVMs, their JavaDoc clearly states that "the
-     * iteration order of set elements is unspecified and is subject to change." Similarly, we used to special case
-     * unstable sets with size 1, allowing them since they obviously iterate in a predicable manner. However, we then
-     * encountered code paths that usually pass a one-element set, but in some circumstances pass a larger set. We now
-     * flag all unstable sets regardless of size. If you want to pass a single value then use Collections.singleton().
+     * stable-ordered; HashSet, TreeSet, and sets returned from Set.of() are not. We used to special case unstable sets
+     * with size 1, allowing them since they obviously iterate in a predicable manner. However, we then encountered code
+     * paths that usually pass a one-element set, but in some circumstances pass a larger set. We now flag all unstable
+     * sets regardless of size. If you want to pass a single value then use Collections.singleton().
      */
     public static boolean isStableOrderedSet(@NotNull Set<?> set)
     {

--- a/api/src/org/labkey/api/data/AbstractPropertyStore.java
+++ b/api/src/org/labkey/api/data/AbstractPropertyStore.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.CacheLoader;
 import org.labkey.api.data.PropertyManager.PropertyMap;
+import org.labkey.api.data.PropertyManager.WritablePropertyMap;
 import org.labkey.api.security.Encryption;
 import org.labkey.api.security.User;
 
@@ -77,37 +78,37 @@ public abstract class AbstractPropertyStore implements PropertyStore
     }
 
     @Override
-    public PropertyMap getWritableProperties(User user, Container container, String category, boolean create)
+    public WritablePropertyMap getWritableProperties(User user, Container container, String category, boolean create)
     {
         PropertyMap existingMap = _cache.getProperties(user, container, category);
         if (existingMap != null)
         {
-            return new PropertyMap(existingMap);
+            return new WritablePropertyMap(existingMap);
         }
 
         if (create)
         {
-            // Assign a dummy ID we can use later to tell if we need to insert a brand new set during save
-            return new PropertyMap(-1, user, container.getId(), category, getPreferredPropertyEncryption(), this);
+            // Assign a dummy ID we can use later to tell if we need to insert a brand-new set during save
+            return new WritablePropertyMap(-1, user, container.getId(), category, getPreferredPropertyEncryption(), this);
         }
 
         return null;
     }
 
     @Override
-    public PropertyMap getWritableProperties(User user, String category, boolean create)
+    public WritablePropertyMap getWritableProperties(User user, String category, boolean create)
     {
         return getWritableProperties(user, ContainerManager.getRoot(), category, create);
     }
 
     @Override
-    public PropertyMap getWritableProperties(Container container, String category, boolean create)
+    public WritablePropertyMap getWritableProperties(Container container, String category, boolean create)
     {
         return getWritableProperties(PropertyManager.SHARED_USER, container, category, create);
     }
 
     @Override
-    public PropertyMap getWritableProperties(String category, boolean create)
+    public WritablePropertyMap getWritableProperties(String category, boolean create)
     {
         return getWritableProperties(ContainerManager.getRoot(), category, create);
     }

--- a/api/src/org/labkey/api/data/EncryptedPropertyStore.java
+++ b/api/src/org/labkey/api/data/EncryptedPropertyStore.java
@@ -75,17 +75,9 @@ public class EncryptedPropertyStore extends AbstractPropertyStore implements Enc
     }
 
     @Override
-    protected void fillValueMap(TableSelector selector, final PropertyMap props)
+    protected String decryptValue(@Nullable String value, PropertyEncryption encryption)
     {
-        final PropertyEncryption propertyEncryption = props.getEncryptionAlgorithm();
-
-        validatePropertyMap(props);
-
-        selector.forEach(rs -> {
-            String encryptedValue = rs.getString(2);
-            String value = null == encryptedValue ? null : propertyEncryption.decrypt(Base64.decodeBase64(encryptedValue));
-            props.put(rs.getString(1), value);
-        });
+        return null == value ? null : encryption.decrypt(Base64.decodeBase64(value));
     }
 
     @Override

--- a/api/src/org/labkey/api/data/NormalPropertyStore.java
+++ b/api/src/org/labkey/api/data/NormalPropertyStore.java
@@ -16,6 +16,7 @@
 package org.labkey.api.data;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.PropertyManager.PropertyMap;
 
 /**
  * A PropertyStore that does not encrypt its values when persisted in the database.
@@ -34,21 +35,19 @@ public class NormalPropertyStore extends AbstractPropertyStore
     }
 
     @Override
-    protected boolean isValidPropertyMap(PropertyManager.PropertyMap props)
+    protected boolean isValidPropertyMap(PropertyMap props)
     {
         return props.getEncryptionAlgorithm() == PropertyEncryption.None;
     }
 
     @Override
-    protected void fillValueMap(TableSelector selector, PropertyManager.PropertyMap props)
+    protected String decryptValue(@Nullable String value, PropertyEncryption encryption)
     {
-        validatePropertyMap(props);
-
-        selector.fillValueMap(props);
+        return value;
     }
 
     @Override
-    protected String getSaveValue(PropertyManager.PropertyMap props, @Nullable String value)
+    protected String getSaveValue(PropertyMap props, @Nullable String value)
     {
         if (props.getEncryptionAlgorithm() != PropertyEncryption.None)
             throw new IllegalStateException("NormalPropertyStore should not be saving a PropertyMap encrypted with " + props.getEncryptionAlgorithm());

--- a/api/src/org/labkey/api/data/PropertyStore.java
+++ b/api/src/org/labkey/api/data/PropertyStore.java
@@ -17,6 +17,7 @@ package org.labkey.api.data;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.PropertyManager.PropertyMap;
+import org.labkey.api.data.PropertyManager.WritablePropertyMap;
 import org.labkey.api.security.User;
 
 import java.util.stream.Stream;
@@ -33,10 +34,10 @@ public interface PropertyStore
     @NotNull PropertyMap getProperties(String category);
 
     // If create == true, then never returns null. If create == false, will return null if property set doesn't exist.
-    PropertyMap getWritableProperties(User user, Container container, String category, boolean create);
-    PropertyMap getWritableProperties(User user, String category, boolean create);
-    PropertyMap getWritableProperties(Container container, String category, boolean create);
-    PropertyMap getWritableProperties(String category, boolean create);
+    WritablePropertyMap getWritableProperties(User user, Container container, String category, boolean create);
+    WritablePropertyMap getWritableProperties(User user, String category, boolean create);
+    WritablePropertyMap getWritableProperties(Container container, String category, boolean create);
+    WritablePropertyMap getWritableProperties(String category, boolean create);
 
     void deletePropertySet(User user, Container container, String category);
     void deletePropertySet(User user, String category);

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -1289,9 +1289,10 @@ validNum:       {
     }
 
     /**
-     * Get the default date format string to use in this Container
+     * Get the default date display format string to use in this Container
      * Note: The display format is specified by an admin; it could contain any characters, hence, it may not be safe.
      * Any value formatted by this pattern must be HTML filtered, if rendered to an HTML page.
+     * THIS IS A DISPLAY FORMAT STRING; DO NOT USE IT FOR PARSING!
      */
     public static String getDateFormatString(Container c)
     {
@@ -1299,15 +1300,22 @@ validNum:       {
     }
 
     /**
-     * Get the default date/time format string set in this Container (or one of its parents)
+     * Get the default date/time display format string set in this Container (or one of its parents)
      * Note: The display format is specified by an admin; it could contain any characters, hence, it may not be safe.
      * Any value formatted by this pattern must be HTML filtered, if rendered to an HTML page.
+     * THIS IS A DISPLAY FORMAT STRING; DO NOT USE IT FOR PARSING!
      */
     public static String getDateTimeFormatString(Container c)
     {
         return FolderSettingsCache.getDefaultDateTimeFormat(c);
     }
 
+    /**
+     * Get the default time display format string set in this Container (or one of its parents)
+     * Note: The display format is specified by an admin; it could contain any characters, hence, it may not be safe.
+     * Any value formatted by this pattern must be HTML filtered, if rendered to an HTML page.
+     * THIS IS A DISPLAY FORMAT STRING; DO NOT USE IT FOR PARSING!
+     */
     public static String getTimeFormatString(Container c)
     {
         return FolderSettingsCache.getDefaultTimeFormat(c);

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -173,7 +173,7 @@ public class PageFlowUtil
     }
 
     private static final Logger _log = LogHelper.getLogger(PageFlowUtil.class, "HTML validation and file operation errors");
-    private static final String _newline = System.getProperty("line.separator");
+    private static final String _newline = System.lineSeparator();
 
     private static final Pattern urlPatternStart = Pattern.compile("((http|https|ftp|mailto)://\\S+).*");
 
@@ -376,7 +376,6 @@ public class PageFlowUtil
 
     /**
      * Creates a JavaScript string literal of an HTML escaped value.
-     *
      * Ext, for example, will use the 'id' config parameter as an attribute value in an XTemplate.
      * The string value is inserted directly into the dom and so should be HTML encoded.
      *
@@ -1246,7 +1245,7 @@ public class PageFlowUtil
 
     public static boolean empty(String str)
     {
-        return null == str || str.trim().length() == 0;
+        return null == str || str.trim().isEmpty();
     }
 
 
@@ -1556,7 +1555,7 @@ public class PageFlowUtil
         return convertNodeToString(node, TransformFormat.xml);
     }
 
-    public static String convertNodeToString(Node node, TransformFormat format) throws TransformerException, IOException
+    private static String convertNodeToString(Node node, TransformFormat format) throws TransformerException, IOException
     {
         try
         {
@@ -2689,11 +2688,6 @@ public class PageFlowUtil
         }
 
         return urlProvider(inter);
-    }
-
-    static private String h(Object o)
-    {
-        return PageFlowUtil.filter(o);
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Currently, `PropertyMap` is a mutable Map that also offers delete(), save(), etc., even for property maps that should be read-only. This is poor practice and has led to caching issues and bugs like https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48993

A better approach is to make PropertyMap read-only (immutable) and introduce `WritablePropertyMap`, which allows map mutation (e.g., put(), remove()) and implements delete(), save(), etc. Property maps are used in many repositories, so this initial PR introduces the new class without yet splitting out our persistence methods. Once all repos are converted to use the new class we'll move those methods.