### PR TITLE
Fix a couple of exception reports

### DIFF
--- a/api/src/org/labkey/api/query/QueryWebPart.java
+++ b/api/src/org/labkey/api/query/QueryWebPart.java
@@ -203,8 +203,7 @@ public class QueryWebPart extends VBox
         }
 
         QueryDefinition queryDef = _settings.getQueryDef(_schema);
-
-        if (_metadata != null)
+        if (_metadata != null && queryDef != null)
             queryDef.setMetadataXml(_metadata);
 
         // need to return any parse errors before we start sending anything back through the response so

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -9634,6 +9634,8 @@ public class AdminController extends SpringActionController
                 // If we had to truncate the name then we want to set the caption to the un-truncated version of the name.
                 CaseInsensitiveHashMap<Portal.PortalPage> pages = new CaseInsensitiveHashMap<>(Portal.getPages(container, true));
                 Portal.PortalPage page = pages.get(name);
+                // Get a mutable copy
+                page = page.copy();
                 page.setCaption(caption);
                 Portal.updatePortalPage(container, page);
             }


### PR DESCRIPTION
#### Rationale
We can easily avoid the NPE and failure to mutate the cached PortalPage

#### Changes
- Null check before blindly setting metadata
- Get a mutable copy of the page before setting the caption