### PR TITLE
Fix java.nio.channels.OverlappingFileLockException

### DIFF
--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -941,7 +941,7 @@ public class FileUtil
 
         try (FileOutputStream os = new FileOutputStream(dst);
              FileChannel out = os.getChannel();
-             FileLock lockOut = out.lock())
+             FileLock lockOut = out.tryLock())
         {
             do
             {


### PR DESCRIPTION
#### Rationale
[Exception](https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=38415) report.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- call FileChannel.tryLock instead of lock to handle the case when a file was already locked by JVM. 
