### PR TITLE
attempt to fix intermittently-failing test in StudySimpleExportTest

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
@@ -30,6 +30,7 @@ import org.labkey.test.components.DomainDesignerPage;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.pages.ImportDataPage;
+import org.labkey.test.pages.files.FileContentPage;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.pages.study.ManageDatasetQCStatesPage;
 import org.labkey.test.pages.study.ManageStudyPage;
@@ -40,6 +41,7 @@ import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.StudyHelper;
+import org.labkey.test.util.TextSearcher;
 import org.labkey.test.util.ext4cmp.Ext4GridRef;
 
 import java.io.File;
@@ -313,11 +315,20 @@ public class StudySimpleExportTest extends StudyBaseTest
         _containerHelper.createSubfolder(getProjectName(), getProjectName(), "Query Validation", "Collaboration", null, true);
         importFolderFromZip(TestFileUtils.getSampleData("studies/LabkeyDemoStudyWithCharts.folder.zip"), false, 1);
         goToModule("FileContent");
+        var filesPage = new FileContentPage(getDriver());
         Locator.XPathLocator fileLoc = Locator.tag("div").startsWith("folder_load_");
         waitForElement(fileLoc);
-        doubleClick(fileLoc);
+        doubleClick(fileLoc); // double-clicking should open the log in a separate tab, and select it in the current one
+
+        // download the file instead of trying to scrape its contents from the browser, which intermittently times the test out
+        File folder_load_log = filesPage.fileBrowserHelper().downloadSelectedFiles();
+        assertTextPresentInThisOrder(new TextSearcher(folder_load_log),
+                "Loading folder properties (folder type, settings and active modules)",
+                " queries imported",
+                "Skipping query validation.");
+
+        // verify clicking a file item in fileBrowserHelper pops a new tab to view it
         switchToWindow(1);
-        assertTextPresentInThisOrder("Loading folder properties (folder type, settings and active modules)", " queries imported", "Skipping query validation.");
         getDriver().close();
         switchToMainWindow();
     }


### PR DESCRIPTION
#### Rationale
Intermittently, [StudySimpleExportTest.verifySuppressQueryValidation](https://teamcity.labkey.org/test/-903265045397405732?currentProjectId=LabkeyTrunk_DailySuites&expandTestHistoryInvestigationsSection=true&expandTestHistoryChartSection=true&expandedTest=build%3A%28id%3A3186563%29%2Cid%3A2000000022) fails while attempting to assert expected text to be present in order in a view of an import log file.

The test performs an import, navigates to the `FileContentBrowser `view, double-clicks the log-file object and attempts to assert that a few expected string values are present in the page that's opened in a separate browser tab- and when the test fails, it does so with error text like this: [Timed out getting page text. Page is probably too complex. Refactor test to look for specific element(s) instead.]

This change downloads the log file and uses a `TextSearcher `to assert the expected string values in order from it, rather than trying to scrape that much string value out of the browser.

#### Related Pull Requests
n/a

#### Changes

- [x] download the file and check its contents instead of getting the entire page text from the browser
