### PR TITLE
Issue 51263: Deadlock while deleting materialIndexed values

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -149,7 +149,7 @@ import java.util.stream.Collectors;
 import static org.labkey.api.exp.api.ExpRunItem.PARENT_IMPORT_ALIAS_MAP_PROP;
 import static org.labkey.api.exp.query.ExpDataClassDataTable.Column.Name;
 import static org.labkey.api.exp.query.ExpDataClassDataTable.Column.QueryableInputs;
-import static org.labkey.api.exp.query.ExpMaterialTable.Column.RowId;
+import static org.labkey.api.exp.query.ExpDataClassDataTable.Column.RowId;
 import static org.labkey.experiment.ExpDataIterators.incrementCounts;
 
 /**
@@ -918,18 +918,27 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         {
             PersistDataIteratorBuilder step0 = new ExpDataIterators.PersistDataIteratorBuilder(data, this, propertiesTable, _dataClass, getUserSchema().getContainer(), getUserSchema().getUser(), _dataClass.getImportAliases(), null);
             SearchService searchService = SearchService.get();
+            ExperimentServiceImpl experimentServiceImpl = ExperimentServiceImpl.get();
             if (null != searchService)
             {
                 final var scope = propertiesTable.getSchema().getScope();
-                // Queue indexing after committing
-                step0.setIndexFunction(lsids -> scope.addCommitTask(() -> ListUtils.partition(lsids, 100).forEach(sublist ->
-                        searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
-                                scope.executeWithRetryReadOnly(tx -> {
-                                            for (ExpDataImpl expData : ExperimentServiceImpl.get().getExpDatasByLSID(sublist))
-                                                expData.index(searchService.defaultTask(), this);
-                                            return (Void)null;
-                                }))
-                ), DbScope.CommitTaskOption.POSTCOMMIT));
+                step0.setIndexFunction(lsidRowIds -> scope.addCommitTask(() ->
+                {
+                    List<String> lsids = lsidRowIds.first;
+                    List<Integer> orderedRowIds = new ArrayList<>(lsidRowIds.second);
+                    if (orderedRowIds.isEmpty() && !lsids.isEmpty()) // either lsids or rowIds is empty
+                        orderedRowIds = experimentServiceImpl.getOrderedRowIdsFromLsids(experimentServiceImpl.getTinfoData(), lsids);
+
+                    // Issue 51263: order by RowId to reduce deadlock
+                    ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
+                            searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
+                                    scope.executeWithRetryReadOnly(tx -> {
+                                        for (ExpDataImpl expData : experimentServiceImpl.getExpDatas(sublist))
+                                            expData.index(searchService.defaultTask(), this);
+                                        return (Void) null;
+                                    }))
+                    );
+                }, DbScope.CommitTaskOption.POSTCOMMIT));
             }
             DataIteratorBuilder builder = LoggingDataIterator.wrap(step0);
             return LoggingDataIterator.wrap(new AliasDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), ExperimentService.get().getTinfoDataAliasMap()));
@@ -1106,10 +1115,12 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     class DataClassDataUpdateService extends DefaultQueryUpdateService
     {
         IntegerConverter _converter = new IntegerConverter();
+        final ExpDataClassDataTableImpl _expDataClassDataTableImpl;
 
         public DataClassDataUpdateService(ExpDataClassDataTableImpl table)
         {
             super(table, table.getRealTable());
+            _expDataClassDataTableImpl = table;
             // Note that this class actually overrides createImportDIB(), so currently we're not looking at this flag.
             _enableExistingRecordsDataIterator = false;
         }
@@ -1361,15 +1372,9 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             ret.putAll(attachments);
             addAttachments(user, c, ret, lsid);
 
-            // search index
-            SearchService ss = SearchService.get();
-            if (ss != null)
-            {
-                if (data == null)
-                    data = ExperimentServiceImpl.get().getExpData(lsid);
-                data.index(null, ExpDataClassDataTableImpl.this);
-            }
+            // search index done in postcommit
 
+            ret.put("RowId", oldRow.get("RowId")); // return rowId for SearchService
             ret.put("lsid", lsid);
             return ret;
         }
@@ -1393,6 +1398,32 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             else
             {
                 results = super.updateRows(user, container, rows, oldKeys, errors, configParameters, extraScriptContext);
+
+                SearchService searchService = SearchService.get();
+                if (searchService != null)
+                {
+                    DbScope scope = getUserSchema().getDbSchema().getScope();
+                    scope.addCommitTask(() ->
+                    {
+                        List<Integer> orderedRowIds = new ArrayList<>();
+                        for (Map<String, Object> result : results)
+                        {
+                            Integer rowId = (Integer) result.get(RowId.name());
+                            if (rowId != null)
+                                orderedRowIds.add(rowId);
+                        }
+                        Collections.sort(orderedRowIds);
+
+                        // Issue 51263: order by RowId to reduce deadlock
+                        ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
+                                searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
+                                {
+                                    for (ExpDataImpl expData : ExperimentServiceImpl.get().getExpDatas(sublist))
+                                        expData.index(null, _expDataClassDataTableImpl);
+                                })
+                        );
+                    }, DbScope.CommitTaskOption.POSTCOMMIT);
+                }
 
                 /* setup mini dataiterator pipeline to process lineage */
                 DataIterator di = _toDataIteratorBuilder("updateRows.lineage", results).getDataIterator(new DataIteratorContext());

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -687,27 +687,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return getExpDatas(new SimpleFilter(FieldKey.fromParts(ExpDataTable.Column.LSID.name()), lsids, IN));
     }
 
-
-    public List<Integer> getOrderedRowIdsFromLsids(TableInfo tableInfo, List<String> lsids)
-    {
-        List<Integer> allRowIds = new ArrayList<>();
-        ListUtils.partition(lsids, 100).forEach(sublist ->
-                {
-                    List<Integer> rowIds = new TableSelector(
-                            tableInfo,
-                            Collections.singleton("RowId"),
-                            new SimpleFilter(FieldKey.fromParts("LSID"), lsids, CompareType.IN),
-                            null
-                    ).getArrayList(Integer.class);
-                    allRowIds.addAll(rowIds);
-                }
-        );
-
-        Collections.sort(allRowIds);
-
-        return allRowIds;
-    }
-
     @Override
     public @NotNull List<ExpDataImpl> getExpDatas(Collection<Integer> rowIds)
     {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -284,6 +284,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 .append(" ON m.RowId = mi.MaterialId WHERE m.LSID NOT LIKE ").appendValue("%:" + StudyService.SPECIMEN_NAMESPACE_PREFIX + "%", getExpSchema().getSqlDialect())
                 .append(" AND m.cpasType = ?").add(sampleType.getLSID())
                 .append(" AND (mi.lastIndexed IS NULL OR mi.lastIndexed < ? OR (m.modified IS NOT NULL AND mi.lastIndexed < m.modified))")
+                .append(" ORDER BY m.RowId") // Issue 51263: order by RowId to reduce deadlock
                 .add(sampleType.getModified());
 
         new SqlSelector(getExpSchema().getScope(), sql).forEachBatch(Material.class, 1000, batch -> {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -17,6 +17,7 @@ package org.labkey.experiment.api;
 
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.converters.IntegerConverter;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
@@ -473,18 +474,43 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         useDib = useDib && hasUniformKeys(rows);
 
         List<Map<String, Object>> results;
+        DbScope scope = getSchema().getDbSchema().getScope();
         if (useDib)
         {
             Map<Enum, Object> finalConfigParameters = configParameters == null ? new HashMap<>() : configParameters;
             finalConfigParameters.put(ExperimentService.QueryOptions.UseLsidForUpdate, true);
 
-            DbScope scope = getSchema().getDbSchema().getScope();
             results = scope.executeWithRetry(transaction ->
                     super._updateRowsUsingDIB(user, container, rows, getDataIteratorContext(errors, InsertOption.UPDATE, finalConfigParameters), extraScriptContext));
         }
         else
         {
             results = super.updateRows(user, container, rows, oldKeys, errors, configParameters, extraScriptContext);
+
+            SearchService searchService = SearchService.get();
+            if (searchService != null)
+            {
+                scope.addCommitTask(() ->
+                {
+                    List<Integer> orderedRowIds = new ArrayList<>();
+                    for (Map<String, Object> result : results)
+                    {
+                        Integer rowId = (Integer) result.get(RowId.name());
+                        if (rowId != null)
+                            orderedRowIds.add(rowId);
+                    }
+                    Collections.sort(orderedRowIds);
+
+                    // Issue 51263: order by RowId to reduce deadlock
+                    ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
+                            searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
+                            {
+                                for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterials(sublist))
+                                    expMaterial.index(searchService.defaultTask());
+                            })
+                    );
+                }, DbScope.CommitTaskOption.POSTCOMMIT);
+            }
 
             /* setup mini dataiterator pipeline to process lineage */
             DataIterator di = _toDataIteratorBuilder("updateRows.lineage", results).getDataIterator(new DataIteratorContext());
@@ -798,18 +824,11 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         if (row.containsKey("Alias"))
             AliasInsertHelper.handleInsertUpdate(getContainer(), user, lsid, ExperimentService.get().getTinfoMaterialAliasMap(), row.get("Alias"));
 
-        // search index
-        SearchService ss = SearchService.get();
-        if (ss != null)
-        {
-            if (sample == null)
-                sample = ExperimentServiceImpl.get().getExpMaterial(lsid);
-            if (sample != null)
-                sample.index(null);
-        }
+        // search done in postcommit
 
         ret.put("lsid", lsid);
         ret.put(AliquotedFromLSID.name(), oldRow.get(AliquotedFromLSID.name()));
+        ret.put(RowId.name(), oldRow.get(RowId.name())); // add RowId for SearchService
         return ret;
     }
 


### PR DESCRIPTION
#### Rationale
From the [exception](https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=38512) report, there are 2 transactions deadlocked waiting for ShareLock on exp.materialindexed table. One thread is attempting to delete a exp.materialindexed record (cascade deletion) as part of a sample type deletion.  The other thread is indexing samples in the sample type, which would insert/update the exp.materialindexed records. It's unknown which action triggered the search index to index or re-index the samples due to lack of server log. 

Sample type type delete action deletes samples in ascending rowId order. If the search indexer happened to be indexing a set of samples that's not in the same ascending order, deadlock might occur. This PR modifies sample/dataclass data so that they are indexed in rowId ascending order. 

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- index sample/data in ascending rowId order for various CRUD actions to reduce deadlocks
