### PR TITLE
PropertyMaps can no longer be saved or deleted

### DIFF
--- a/api/src/org/labkey/api/collections/CollectionUtils.java
+++ b/api/src/org/labkey/api/collections/CollectionUtils.java
@@ -26,7 +26,8 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.cache.CacheManager;
-import org.labkey.api.data.PropertyManager;
+import org.labkey.api.data.PropertyManager.PropertyMap;
+import org.labkey.api.data.PropertyManager.WritablePropertyMap;
 import org.labkey.api.util.PageFlowUtil;
 
 import java.util.ArrayList;
@@ -90,12 +91,7 @@ public class CollectionUtils
         if (value instanceof CacheManager.Sealable sealable && sealable.isSealed())
             return null;
 
-        if (value instanceof PropertyManager.PropertyMap)
-        {
-            if (!((PropertyManager.PropertyMap)value).isLocked())
-                return "a modifiable PropertyMap";
-        }
-        else if (value instanceof Collection)
+        if (value instanceof Collection)
         {
             if (!UNMODIFIABLE_COLLECTION_CLASS.isInstance(value))
             {
@@ -114,6 +110,11 @@ public class CollectionUtils
                     return "a modifiable collection (" + value.getClass() + ")";
                 }
             }
+        }
+        else if (value instanceof PropertyMap pm)
+        {
+            if (pm instanceof WritablePropertyMap)
+                return "a WritablePropertyMap";
         }
         else if (value instanceof Map)
         {

--- a/api/src/org/labkey/api/data/AbstractPropertyStore.java
+++ b/api/src/org/labkey/api/data/AbstractPropertyStore.java
@@ -140,7 +140,7 @@ public abstract class AbstractPropertyStore implements PropertyStore
     {
         try
         {
-            PropertyMap propertyMap = getWritableProperties(user, container, category, false);
+            WritablePropertyMap propertyMap = getWritableProperties(user, container, category, false);
             if (propertyMap != null)
             {
                 propertyMap.delete();
@@ -206,12 +206,8 @@ public abstract class AbstractPropertyStore implements PropertyStore
             String category = (String)params[2];
 
             validateStore();
-            PropertyMap m = getPropertyMapFromDatabase(user, container, category);
-            if (m == null) return null;
-            m.afterPropertiesSet(); // clear modified flag
 
-            m.lock();
-            return m;
+            return getPropertyMapFromDatabase(user, container, category);
         }
     }
 

--- a/api/src/org/labkey/api/data/PropertyManager.java
+++ b/api/src/org/labkey/api/data/PropertyManager.java
@@ -831,10 +831,10 @@ public class PropertyManager
             assertFalse(map.containsKey("zoo"));
 
             // Test immutability of PropertyMap
-            assertThrows(IllegalStateException.class, () -> map.put("bar", "blue"));
-            assertThrows(IllegalStateException.class, () -> map.putAll(Map.of("foo", "bar", "color", "red")));
-            assertThrows(IllegalStateException.class, () -> map.remove("foo"));
-            assertThrows(IllegalStateException.class, map::clear);
+            assertThrows(UnsupportedOperationException.class, () -> map.put("bar", "blue"));
+            assertThrows(UnsupportedOperationException.class, () -> map.putAll(Map.of("foo", "bar", "color", "red")));
+            assertThrows(UnsupportedOperationException.class, () -> map.remove("foo"));
+            assertThrows(UnsupportedOperationException.class, map::clear);
         }
 
         @Test


### PR DESCRIPTION
#### Rationale
Now that we've introduced `WritablePropertyMap` and used it in every code path that calls `delete()` or `save()`, move those persistence methods from `PropertyMap` to `WritablePropertyMap`. Eliminate `setLock()` and `checkLock()` since PropertyMap is immutable. Simplify initialization of `_modified`.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5905