### PR TITLE
Another batch of exception report fixes

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -30,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.labkey.api.Constants;
+import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.admin.FolderExportContext;
 import org.labkey.api.admin.FolderImportContext;
@@ -1817,12 +1818,12 @@ public class ContainerManager
                 {
                     if (!isDeletable(container))
                     {
-                        throw new IllegalArgumentException("Cannot delete container: " + container.getPath());
+                        throw new ApiUsageException("Cannot delete container: " + container.getPath());
                     }
 
                     if (deletingContainers.containsKey(container.getId()))
                     {
-                        throw new IllegalArgumentException("Container is already being deleted: " + container.getPath());
+                        throw new ApiUsageException("Container is already being deleted: " + container.getPath());
                     }
                 }
                 containerIds.forEach(id -> deletingContainers.put(id, user.getUserId()));

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -224,6 +224,10 @@ public class SecurityManager
         };
     }
 
+    /**
+     * @param key short description of the purpose of the allowed connection. Mostly to make it possible to update
+     *            afterward in the case of dynamically configured sources.
+     */
     public static void registerAllowedConnectionSource(String key, String serviceURL)
     {
         if (StringUtils.trimToNull(serviceURL) == null)

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -558,7 +558,10 @@ public class DomainImpl implements Domain
             {
                 DomainDescriptor ddCheck = OntologyManager.getDomainDescriptor(_dd.getDomainId());
                 if (saveOnlyIfNotExists && null != ddCheck)
+                {
+                    transaction.commit();
                     return;
+                }
                 if (!isDomainNew && !JdbcUtil.rowVersionEqual(ddCheck.get_Ts(), _dd.get_Ts()))
                     throw new OptimisticConflictException("Domain has been updated by another user or process.", Table.SQLSTATE_TRANSACTION_STATE, 0);
             }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineManager.java
@@ -216,8 +216,7 @@ public class PipelineManager
         sql.append("UPDATE ").append(ExperimentService.get().getTinfoExperimentRun()).
                 append(" SET JobId = NULL WHERE JobId IN (SELECT RowId FROM ").
                 append(pipeline.getTableInfoStatusFiles(), "p").
-                append(" WHERE container = ? ) AND Container = ?");
-        sql.add(container.getId());
+                append(" WHERE container = ?)");
         sql.add(container.getId());
 
         try (DbScope.Transaction transaction = ExperimentService.get().ensureTransaction())


### PR DESCRIPTION
#### Rationale
A handful of unrelated fixes for very small issues

#### Changes
- Switch to use an exception that won't get logged when attempting to double-delete a container
- Add a little JavaDoc I've been sitting on for a long time
- Be sure to leave the transaction object in a good state if we bail out early on a Domain update
- Update all of the experiment runs that reference pipeline jobs in the container being deleted, even if they're now in a another container