### PR TITLE
use objectid instead of lsid for performance

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
@@ -343,7 +343,16 @@ abstract public class ExpTableImpl<C extends Enum>
         for (DomainProperty dp : domain.getProperties())
         {
             PropertyDescriptor pd = dp.getPropertyDescriptor();
-            PropertyColumn propColumn = new PropertyColumn(pd, getColumn("LSID"), getContainer(), _userSchema.getUser(), false, containerFilter);
+            PropertyColumn propColumn;
+            if (null != getExpObjectColumn())
+            {
+                propColumn = new PropertyColumn(pd, getExpObjectColumn(), getContainer(), _userSchema.getUser(), false, containerFilter);
+                propColumn.setParentIsObjectId(true);
+            }
+            else
+            {
+                propColumn = new PropertyColumn(pd, getColumn("LSID"), getContainer(), _userSchema.getUser(), false, containerFilter);
+            }
             if (getColumn(propColumn.getName()) == null)
             {
                 addColumn(propColumn);


### PR DESCRIPTION
#### Rationale
I noticed some over complicated assay queries (e.g. luminex).  This should help.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
