### PR TITLE
Issue 51404: Get transaction from table being updated when changing container values

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -2666,7 +2666,7 @@ public class ContainerManager
 
     public static int updateContainer(TableInfo dataTable, String idField, Collection<?> ids, Container targetContainer, User user, boolean withModified)
     {
-        try (DbScope.Transaction transaction = ensureTransaction())
+        try (DbScope.Transaction transaction = dataTable.getSchema().getScope().ensureTransaction())
         {
             SQLFragment dataUpdate = new SQLFragment("UPDATE ").append(dataTable)
                     .append(" SET container = ").appendValue(targetContainer.getEntityId());


### PR DESCRIPTION
#### Rationale
Issue [51404](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51404)

#### Changes
- Don't use `ensureTransaction` that acquires `DATABASE_QUERY_LOCK` in `ContainerManager.updateContainer`
