### PR TITLE
Issue 51410: LKSM: A deleted required source type still shows up in the sample type grids

### DIFF
--- a/experiment/src/client/test/integration/DataClassCrud.ispec.ts
+++ b/experiment/src/client/test/integration/DataClassCrud.ispec.ts
@@ -226,7 +226,7 @@ describe('Data Class Designer - Permissions', () => {
 
 describe('Data Class - Required Lineage', () => {
     it('Test dataclass with required dataclass parents', async () => {
-        await verifyRequiredLineageInsertUpdate(server, false, false, topFolderOptions, subfolder1Options, designerReaderOptions, readerUserOptions, editorUserOptions);
+        await verifyRequiredLineageInsertUpdate(server, false, false, topFolderOptions, subfolder1Options, designerReaderOptions, readerUserOptions, editorUserOptions, adminOptions);
     });
 
 });

--- a/experiment/src/client/test/integration/SampleTypeCrud.ispec.ts
+++ b/experiment/src/client/test/integration/SampleTypeCrud.ispec.ts
@@ -249,14 +249,25 @@ describe('Sample Type Designer - Permissions', () => {
 
             // verify cannot add a required import alias with existing data that don't have such parent
             updatedDomainPayload.options.importAliases = {
+                'legacyupdate': 'MaterialInputs/' + sampleType,
+                'newAliasUpdate': {
+                    inputType: 'MaterialInputs/' + sampleType, // verify MaterialInputs/ and materialInputs/
+                    required: true,
+                }
+            };
+
+            let requiredNotAllowedResp = await server.post('property', 'saveDomain', updatedDomainPayload, {...topFolderOptions, ...designerReaderOptions});
+            expect(requiredNotAllowedResp['body']['success']).toBeFalsy();
+            expect(requiredNotAllowedResp['body']['exception']).toBe("'FailedDelete' cannot be required as a parent type when there are existing samples without a parent of this type.");
+
+            updatedDomainPayload.options.importAliases = {
                 'legacyupdate': 'materialInputs/' + sampleType,
                 'newAliasUpdate': {
                     inputType: 'materialInputs/' + sampleType,
                     required: true,
                 }
             };
-
-            const requiredNotAllowedResp = await server.post('property', 'saveDomain', updatedDomainPayload, {...topFolderOptions, ...designerReaderOptions});
+            requiredNotAllowedResp = await server.post('property', 'saveDomain', updatedDomainPayload, {...topFolderOptions, ...designerReaderOptions});
             expect(requiredNotAllowedResp['body']['success']).toBeFalsy();
             expect(requiredNotAllowedResp['body']['exception']).toBe("'FailedDelete' cannot be required as a parent type when there are existing samples without a parent of this type.");
 
@@ -850,11 +861,11 @@ describe('Aliquot crud', () => {
 
     describe('Sample Type - Required Lineage', () => {
         it('Test sample type with required dataclass parents', async () => {
-            await verifyRequiredLineageInsertUpdate(server, false, true, topFolderOptions, subfolder1Options, adminOptions /* so user can create both dataclass and sample type*/, readerUserOptions, editorUserOptions);
+            await verifyRequiredLineageInsertUpdate(server, false, true, topFolderOptions, subfolder1Options, adminOptions /* so user can create both dataclass and sample type*/, readerUserOptions, editorUserOptions, adminOptions);
         });
 
         it('Test sample type with required sample parents', async () => {
-            await verifyRequiredLineageInsertUpdate(server, true, true, topFolderOptions, subfolder1Options, designerReaderOptions, readerUserOptions, editorUserOptions);
+            await verifyRequiredLineageInsertUpdate(server, true, true, topFolderOptions, subfolder1Options, designerReaderOptions, readerUserOptions, editorUserOptions, adminOptions);
         });
     });
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -9392,7 +9392,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         {
             try
             {
-                if (sampleType.getRequiredImportAliases().containsValue(targetInputType))
+                if (new CaseInsensitiveHashSet(sampleType.getRequiredImportAliases().values()).contains(targetInputType))
                     sampleTypes.add(sampleType.getDomain().getLabel());
             }
             catch (IOException ignore)
@@ -9403,7 +9403,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         {
             try
             {
-                if (dataClass.getRequiredImportAliases().containsValue(targetInputType))
+                if (new CaseInsensitiveHashSet(dataClass.getRequiredImportAliases().values()).contains(targetInputType))
                     dataClasses.add(dataClass.getDomain().getLabel());
             }
             catch (IOException ignore)
@@ -9470,8 +9470,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             String dataType = (String) newEntry.getValue().get("inputType");
             if ((Boolean) newEntry.getValue().get("required") && !existingRequiredInputs.contains(dataType))
             {
-                boolean isParentSamples = dataType.startsWith(MATERIAL_INPUTS_ALIAS_PREFIX);
-                String dataTypeName = dataType.replace(isParentSamples ? MATERIAL_INPUTS_ALIAS_PREFIX : DATA_INPUTS_ALIAS_PREFIX, "");
+                boolean isParentSamples = dataType.toLowerCase().startsWith(MATERIAL_INPUTS_ALIAS_PREFIX.toLowerCase());
+                String dataTypeName = dataType.substring(isParentSamples ? MATERIAL_INPUTS_ALIAS_PREFIX.length() : DATA_INPUTS_ALIAS_PREFIX.length());
 
                 String parentCpas = null;
                 if (isParentSamples)

--- a/experiment/src/org/labkey/experiment/samples/ExperimentQueryChangeListener.java
+++ b/experiment/src/org/labkey/experiment/samples/ExperimentQueryChangeListener.java
@@ -27,7 +27,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.labkey.api.exp.api.ExperimentJSONConverter.DATA_INPUTS;
+import static org.labkey.api.exp.api.ExperimentJSONConverter.DATA_INPUTS_ALIAS_PREFIX;
 import static org.labkey.api.exp.api.ExperimentJSONConverter.MATERIAL_INPUTS;
+import static org.labkey.api.exp.api.ExperimentJSONConverter.MATERIAL_INPUTS_ALIAS_PREFIX;
 
 public class ExperimentQueryChangeListener implements QueryChangeListener
 {
@@ -115,11 +117,12 @@ public class ExperimentQueryChangeListener implements QueryChangeListener
             return;
 
         String prefix = (isSamples ? MATERIAL_INPUTS : DATA_INPUTS) + "\\/";
+        String parsedPrefix = isSamples ? MATERIAL_INPUTS_ALIAS_PREFIX : DATA_INPUTS_ALIAS_PREFIX;
 
         for (String removed : queries)
         {
-            String inputType = prefix + removed;
-            String searchStr = "\"" + inputType + "\"";
+            String inputType = parsedPrefix + removed;
+            String searchStr = "\"" + prefix + removed + "\"";
 
             for (ExpSampleTypeImpl sampleType : getRenamedSampleTypes(container, searchStr))
             {
@@ -130,7 +133,7 @@ public class ExperimentQueryChangeListener implements QueryChangeListener
                     for (String alias : originalMap.keySet())
                     {
                         String dataType = (String) originalMap.get(alias).get("inputType");
-                        if (!dataType.equals(inputType))
+                        if (!dataType.equalsIgnoreCase(inputType))
                             updatedMap.put(alias, originalMap.get(alias));
                     }
                     sampleType.setImportAliasMap(updatedMap);
@@ -151,7 +154,7 @@ public class ExperimentQueryChangeListener implements QueryChangeListener
                     for (String alias : originalMap.keySet())
                     {
                         String dataType = (String) originalMap.get(alias).get("inputType");
-                        if (!dataType.equals(inputType))
+                        if (!dataType.equalsIgnoreCase(inputType))
                             updatedMap.put(alias, originalMap.get(alias));
                     }
                     dataClass.setImportAliasMap(updatedMap);


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/553
- https://github.com/LabKey/platform/pull/5914
- https://github.com/LabKey/limsModules/pull/794

#### Changes
- fix ExperimentQueryChangeListener to check correct json parsed datatype name during delete
- allow both materialInputs/ as well as MaterialInputs/ as stored alias data type
- add api tests for issue 51410
- add test for materialInputs/ vs MaterialInputs/ 