### PR TITLE
Issue 50569: Add ability for users to supply descriptions with API keys

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.11.1-apiKeyDescriptions.5",
+        "@labkey/components": "5.12.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3488,9 +3488,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.11.1-apiKeyDescriptions.5",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.11.1-apiKeyDescriptions.5.tgz",
-      "integrity": "sha512-0dQORX0/F4j1RZR8svwETxqwN/5xZF00Y48NQqgT7t7S8IIYgiuMX0GAsV39Cyy01JHgBfpIcda6ry2+68Oclw==",
+      "version": "5.12.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.12.0.tgz",
+      "integrity": "sha512-YGBEeJ7OWjDaMC/ptMFyP0IliqhJeOKKc2bZsHciYKgvFHuW0cxt8HSdgqpAFph+KNNI8sOO2kG2gpPut3swEA==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
         "@labkey/api": "1.35.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.11.1-apiKeyDescriptions.4",
+        "@labkey/components": "5.11.1-apiKeyDescriptions.5",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3488,9 +3488,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.11.1-apiKeyDescriptions.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.11.1-apiKeyDescriptions.4.tgz",
-      "integrity": "sha512-eqzkd3PkwK9kucOmodgmwDwTzvvj932YLAhS6FJKDgfvyQhZb2ZsDcnPagwc6pPBbGREWNto3AZaYeHnZIvYrg==",
+      "version": "5.11.1-apiKeyDescriptions.5",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.11.1-apiKeyDescriptions.5.tgz",
+      "integrity": "sha512-0dQORX0/F4j1RZR8svwETxqwN/5xZF00Y48NQqgT7t7S8IIYgiuMX0GAsV39Cyy01JHgBfpIcda6ry2+68Oclw==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
         "@labkey/api": "1.35.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.10.1-apiKeyDescriptions.1",
+        "@labkey/components": "5.10.1-apiKeyDescriptions.2",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3488,9 +3488,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.10.1-apiKeyDescriptions.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.10.1-apiKeyDescriptions.1.tgz",
-      "integrity": "sha512-yJ2jNJKI+xbo2EsUhe84fp8C+7+mJSLnxoGgiDiMeFdnvMLoekb3zzOzzAINdQjj4XR+2R+vqri0NiS/+k8TEQ==",
+      "version": "5.10.1-apiKeyDescriptions.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.10.1-apiKeyDescriptions.2.tgz",
+      "integrity": "sha512-RRv2rdixjCJggbo0zqowEHKR2Zhjyt8wCrxEhuWgr4oPfwAWg39kPlNLWjyhXktcGnTBydmfCl88i9OFGA/CGw==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
         "@labkey/api": "1.35.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.10.1-apiKeyDescriptions.2",
+        "@labkey/components": "5.10.1-apiKeyDescriptions.3",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3488,9 +3488,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.10.1-apiKeyDescriptions.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.10.1-apiKeyDescriptions.2.tgz",
-      "integrity": "sha512-RRv2rdixjCJggbo0zqowEHKR2Zhjyt8wCrxEhuWgr4oPfwAWg39kPlNLWjyhXktcGnTBydmfCl88i9OFGA/CGw==",
+      "version": "5.10.1-apiKeyDescriptions.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.10.1-apiKeyDescriptions.3.tgz",
+      "integrity": "sha512-PHFTKYTgORrNauTC52D2DmKdEkhne+AncQ4iU3TYtDmX2rHpjir1Y/alnwRecj2sZI5FyorGjFgM20jX4DYH/Q==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
         "@labkey/api": "1.35.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.10.0",
+        "@labkey/components": "5.10.1-apiKeyDescriptions.1",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3488,9 +3488,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.10.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.10.0.tgz",
-      "integrity": "sha512-PYbBzAKLOJtn9PlaUxRjBwTnE/irLd6w8SHj2IM8YdJv8dH5dIibceR7rtejMVMEp5MmfNQf0LRfq3DIFpvyPA==",
+      "version": "5.10.1-apiKeyDescriptions.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.10.1-apiKeyDescriptions.1.tgz",
+      "integrity": "sha512-yJ2jNJKI+xbo2EsUhe84fp8C+7+mJSLnxoGgiDiMeFdnvMLoekb3zzOzzAINdQjj4XR+2R+vqri0NiS/+k8TEQ==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
         "@labkey/api": "1.35.1",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "5.11.1-apiKeyDescriptions.4",
+    "@labkey/components": "5.11.1-apiKeyDescriptions.5",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "5.11.1-apiKeyDescriptions.5",
+    "@labkey/components": "5.12.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "5.10.1-apiKeyDescriptions.2",
+    "@labkey/components": "5.10.1-apiKeyDescriptions.3",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "5.10.0",
+    "@labkey/components": "5.10.1-apiKeyDescriptions.1",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "5.10.1-apiKeyDescriptions.1",
+    "@labkey/components": "5.10.1-apiKeyDescriptions.2",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/src/client/APIKeys/APIKeys.tsx
+++ b/core/src/client/APIKeys/APIKeys.tsx
@@ -25,8 +25,8 @@ export const App: FC<any> = () => {
     return (
         <ServerContextProvider initialContext={serverContext}>
             <AppContextProvider>
-                <APIKeysPanel includeSessionKeys={true}/>
+                <APIKeysPanel includeSessionKeys={true} />
             </AppContextProvider>
         </ServerContextProvider>
     );
-}
+};


### PR DESCRIPTION
#### Rationale
Issue [50569](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50569) - Sometimes users generate multiple API keys and want to add a description for when or how each is being used. The server-side addition of these fields has already been done. This PR and its relatives add the client-side changes.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1600
- https://github.com/LabKey/limsModules/pull/798
- https://github.com/LabKey/testAutomation/pull/2083

#### Changes
- package update
- test updates
