### PR TITLE
Fix intermittent PipelineCancelTest failure

### DIFF
--- a/api/src/org/labkey/api/data/AsyncQueryRequest.java
+++ b/api/src/org/labkey/api/data/AsyncQueryRequest.java
@@ -142,7 +142,7 @@ public class AsyncQueryRequest<T>
         Thread thread = new Thread(runnable, "AsyncQueryRequest: " + Thread.currentThread().getName());
         // We want the async thread to use the same database connection, in case we have a transaction open, and
         // so that when the original thread finishes processing the results it ends up closing the right connection
-        try (DbScope.ConnectionSharingCloseable ignored = DbScope.shareConnections(thread);
+        try (DbScope.ConnectionSharingCloseable ignored = DbScope.shareConnections(Thread.currentThread(), thread);
              Scope ignore = tracer.activateSpan(span))
         {
             thread.start();

--- a/api/src/org/labkey/api/data/ConnectionWrapper.java
+++ b/api/src/org/labkey/api/data/ConnectionWrapper.java
@@ -34,7 +34,6 @@ import org.labkey.api.util.SimpleLoggerWriter;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ViewServlet;
 
-import java.lang.reflect.Method;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.CallableStatement;
@@ -95,9 +94,6 @@ public class ConnectionWrapper implements java.sql.Connection
 
     /** Remember code that closed the Transaction but didn't commit - it may be faulty if it doesn't signal the failure back to the caller */
     private Throwable _suspiciousCloseStackTrace;
-
-    /** For debugging issue 23044 */
-    private static Method _transactionStateMethod;
 
     private volatile boolean _allowClose = true;
 
@@ -177,8 +173,9 @@ public class ConnectionWrapper implements java.sql.Connection
         return true;
     }
 
-    public static void closeConnections(Thread thread)
+    public static void closeConnections()
     {
+        Thread thread = DbScope.getEffectiveThread();
         List<ConnectionWrapper> toClose = new ArrayList<>();
 
         synchronized (_openConnections)
@@ -196,7 +193,7 @@ public class ConnectionWrapper implements java.sql.Connection
         {
             try
             {
-                connectionWrapper.close(thread);
+                connectionWrapper.close();
             }
             catch (SQLException ignored) {}
         }
@@ -396,14 +393,9 @@ public class ConnectionWrapper implements java.sql.Connection
     @Override
     public void close() throws SQLException
     {
-        close(Thread.currentThread());
-    }
-
-    public void close(Thread thread) throws SQLException
-    {
         DbScope.Transaction t;
 
-        if (_type != ConnectionType.Pooled && null != (t = _scope.getTransactionImpl(thread)))
+        if (_type != ConnectionType.Pooled && null != (t = _scope.getCurrentTransactionImpl()))
         {
             assert t.getConnection() == this : "Attempting to close a different connection from the one associated with this thread: " + this + " vs " + t.getConnection(); //Should release same conn we handed out
         }
@@ -428,31 +420,6 @@ public class ConnectionWrapper implements java.sql.Connection
         // if it's already been closed instead of doing a no-op
         if (null != _connection && !isClosed())
         {
-            /* For debugging issue 23044, look for connections that are set to be autoCommit but the driver thinks are mid-transaction */
-            Connection connection = DbScope.getDelegate(_connection);
-            if (connection != null && connection.getAutoCommit() && "org.postgresql.jdbc4.Jdbc4Connection".equals(connection.getClass().getName()))
-            {
-                try
-                {
-                    if (_transactionStateMethod == null)
-                    {
-                        _transactionStateMethod = connection.getClass().getMethod("getTransactionState");
-                        _log.debug("Got transactionStateMethod from org.postgresql.jdbc4.Jdbc4Connection. " + _transactionStateMethod);
-                    }
-                    Object state = _transactionStateMethod.invoke(connection);
-
-                    // org.postgresql.core.ProtocolConnection.TRANSACTION_OPEN = 1
-                    if (1 == ((Number) state).intValue())
-                    {
-                        _log.error("Transaction state does not match autoCommit for " + this, new Throwable());
-                    }
-                }
-                catch (Exception e)
-                {
-                    _log.error("Reflection error", e);
-                }
-            }
-
             try
             {
                 _runOnClose.close();
@@ -1051,15 +1018,15 @@ public class ConnectionWrapper implements java.sql.Connection
     }
 
     @Override
-    public void setNetworkTimeout(Executor executor, int milliseconds)
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException
     {
-        throw new UnsupportedOperationException();
+        _connection.setNetworkTimeout(executor, milliseconds);
     }
 
     @Override
-    public int getNetworkTimeout()
+    public int getNetworkTimeout() throws SQLException
     {
-        throw new UnsupportedOperationException();
+        return _connection.getNetworkTimeout();
     }
 
     private void checkForSuspiciousClose() throws SQLException

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1038,17 +1038,13 @@ public class DbScope
         }
     }
 
-    private static Thread getEffectiveThread()
-    {
-        return getEffectiveThread(Thread.currentThread());
-    }
-
     /**
      * @return the thread that owns the connections for the given thread. Background threads may piggyback on an
-     * HTTP request thread, for example. If no sharing has been established, the same thread as passed
+     * HTTP request thread, for example. If no sharing has been established, use the current thread
      */
-    private static Thread getEffectiveThread(Thread thread)
+    public static Thread getEffectiveThread()
     {
+        Thread thread = Thread.currentThread();
         synchronized (_sharedConnections)
         {
             Thread result = _sharedConnections.get(thread);
@@ -1073,12 +1069,7 @@ public class DbScope
     /* package */
     @Nullable TransactionImpl getCurrentTransactionImpl()
     {
-        return getTransactionImpl(Thread.currentThread());
-    }
-
-    /* package */ @Nullable TransactionImpl getTransactionImpl(Thread thread)
-    {
-        thread = getEffectiveThread(thread);
+        Thread thread = getEffectiveThread();
         synchronized (_transaction)
         {
             List<TransactionImpl> transactions = _transaction.get(thread);
@@ -2084,21 +2075,15 @@ public class DbScope
     }
 
     /**
-     * Shuts down any connections associated with DbScopes that have been handed out to the current thread
+     * Shuts down any connections associated with DbScopes that have been handed out to the current thread or its
+     * associated/effective thread. Also releases locks acquired as part of opening the transaction.
      */
     public static void closeAllConnectionsForCurrentThread()
     {
-        closeAllConnectionsForThread(getEffectiveThread());
-    }
-    /**
-     * Shuts down any connections associated with DbScopes that have been handed out to the current thread. Also
-     * releases locks acquired as part of opening the transaction.
-     */
-    public static void closeAllConnectionsForThread(Thread thread)
-    {
+        Thread thread = getEffectiveThread();
         for (DbScope scope : getInitializedDbScopes())
         {
-            TransactionImpl t = scope.getTransactionImpl(thread);
+            TransactionImpl t = scope.getCurrentTransactionImpl();
             int count = 0;
             while (t != null)
             {
@@ -2120,13 +2105,13 @@ public class DbScope
                 }
 
                 // We may have nested concurrent transactions for a given scope, so be sure we close them all
-                TransactionImpl t2 = scope.getTransactionImpl(thread);
+                TransactionImpl t2 = scope.getCurrentTransactionImpl();
                 t = (t2 == null || t2 == t) ? null : t2;
             }
         }
 
         // Also close down connections that might not have been connected with a Transaction object
-        ConnectionWrapper.closeConnections(thread);
+        ConnectionWrapper.closeConnections();
     }
 
     /**
@@ -2143,21 +2128,22 @@ public class DbScope
      * Causes any connections associated with the current thread to be used by the passed-in thread. This allows
      * an async thread to participate in the same transaction as the original HTTP request processing thread, for
      * example
-     * @param asyncThread the thread that should use the database connections of the current thread
+     * @param primaryThread the thread that should be treated as the owner for any connections used
+     * @param piggybackingThread the thread that should use the database connections of the primary thread
      * @return an AutoCloseable that will stop sharing the database connection with the other thread
      */
-    public static ConnectionSharingCloseable shareConnections(final Thread asyncThread)
+    public static ConnectionSharingCloseable shareConnections(Thread primaryThread, final Thread piggybackingThread)
     {
         synchronized (_sharedConnections)
         {
-            if (_sharedConnections.containsKey(asyncThread))
+            if (_sharedConnections.containsKey(piggybackingThread))
             {
-                throw new IllegalStateException("Thread '" + asyncThread.getName() + "' is already sharing the connections of thread '" + _sharedConnections.get(asyncThread) + "'");
+                throw new IllegalStateException("Thread '" + piggybackingThread.getName() + "' is already sharing the connections of thread '" + _sharedConnections.get(piggybackingThread) + "'");
             }
-            _sharedConnections.put(asyncThread, Thread.currentThread());
+            _sharedConnections.put(piggybackingThread, primaryThread);
         }
 
-        return new ConnectionSharingCloseable(asyncThread);
+        return new ConnectionSharingCloseable(piggybackingThread);
     }
 
     interface ConnectionMap
@@ -2441,8 +2427,9 @@ public class DbScope
     };
 
 
-    private void popCurrentTransaction(Thread thread)
+    private void popCurrentTransaction()
     {
+        Thread thread = getEffectiveThread();
         synchronized (_transaction)
         {
             List<TransactionImpl> transactions = _transaction.get(thread);
@@ -2601,7 +2588,7 @@ public class DbScope
                 {
                     // Don't pop until locks are empty, because other closes have yet to occur,
                     // and we want to use _abort to ensure no one tries to commit this transaction
-                    popCurrentTransaction(thread);
+                    popCurrentTransaction();
 
                     if (_aborted)
                     {
@@ -2666,7 +2653,7 @@ public class DbScope
                                 conn.internalClose();
                         }
 
-                        popCurrentTransaction(getEffectiveThread());
+                        popCurrentTransaction();
 
                         CommitTaskOption.POSTCOMMIT.run(this);
                     }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -300,7 +300,11 @@ public class PipelineJobServiceImpl implements PipelineJobService
             Thread jobThread = _jobThreads.get(jobGuid);
             if (jobThread != null)
             {
-                DbScope.closeAllConnectionsForThread(jobThread);
+                // Piggyback on the job thread so we can shut down open connections on its behalf
+                try (DbScope.ConnectionSharingCloseable ignored = DbScope.shareConnections(jobThread, Thread.currentThread()))
+                {
+                    DbScope.closeAllConnectionsForCurrentThread();
+                }
             }
         }
     }


### PR DESCRIPTION
#### Rationale
We need to ensure connections are shared between job and cancelling threads. This wasn't fully correct in the initial work for Issue 50131

#### Changes
- Fully share connections between the thread doing the cancellation and the job thread
- Remove some long-obsoleted debugging code
- Prep for setting timeouts on DB queries