### PR TITLE
Issue 51403: Slow container renames end up timing out other threads

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -87,6 +87,7 @@ import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.MinorConfigurationException;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.QuietCloser;
 import org.labkey.api.util.ReentrantLockWithName;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.util.logging.LogHelper;
@@ -294,10 +295,10 @@ public class ContainerManager
 
         StringBuilder error = new StringBuilder();
         if (!Container.isLegalName(name, parent.isRoot(), error))
-            throw new IllegalArgumentException(error.toString());
+            throw new ApiUsageException(error.toString());
 
         if (!Container.isLegalTitle(title, error))
-            throw new IllegalArgumentException(error.toString());
+            throw new ApiUsageException(error.toString());
 
         Path path = makePath(parent, name);
         SQLException sqlx = null;
@@ -666,7 +667,7 @@ public class ContainerManager
         {
             int low = counts.get(totalFolderTypeMatch/2 - 1);
             int high = counts.get(totalFolderTypeMatch/2);
-            median = Math.round((low + high) / 2);
+            median = Math.round((low + high) / 2.0f);
         }
         int maxProjectsCount = counts.get(totalFolderTypeMatch - 1);
         int totalProjectsCount = counts.stream().mapToInt(Integer::intValue).sum();
@@ -742,10 +743,6 @@ public class ContainerManager
     @NotNull
     public static Container ensureContainer(@NotNull Path path, @NotNull User user)
     {
-        // NOTE: Running outside a tx doesn't seem to be necessary.
-//        if (CORE.getSchema().getScope().isTransactionActive())
-//            throw new IllegalStateException("Transaction should not be active");
-
         Container c = null;
 
         try
@@ -1199,7 +1196,6 @@ public class ContainerManager
         }
     }
 
-    @SuppressWarnings({"serial"})
     public static class RootContainerException extends RuntimeException
     {
         private RootContainerException(String message, Throwable cause)
@@ -1613,83 +1609,87 @@ public class ContainerManager
     // @return true if project has changed (should probably redirect to security page)
     public static boolean move(Container c, final Container newParent, User user) throws ValidationException
     {
-        if (c.isRoot())
-            throw new IllegalArgumentException("can't move root container");
-
         if (!isRenameable(c))
         {
             throw new IllegalArgumentException("Can't move container " + c.getPath());
         }
 
-        List<String> errors = new ArrayList<>();
-        for (ContainerListener listener : getListeners())
+        try (QuietCloser ignored = lockForMutation(MutatingOperation.move, c))
         {
-            try
+            List<String> errors = new ArrayList<>();
+            for (ContainerListener listener : getListeners())
             {
-                errors.addAll(listener.canMove(c, newParent, user));
+                try
+                {
+                    errors.addAll(listener.canMove(c, newParent, user));
+                }
+                catch (Exception e)
+                {
+                    ExceptionUtil.logExceptionToMothership(null, new IllegalStateException(listener.getClass().getName() + ".canMove() threw an exception or violated @NotNull contract"));
+                }
             }
-            catch (Exception e)
+            if (!errors.isEmpty())
             {
-                ExceptionUtil.logExceptionToMothership(null, new IllegalStateException(listener.getClass().getName() + ".canMove() threw an exception or violated @NotNull contract"));
-            }
-        }
-        if (!errors.isEmpty())
-        {
-            ValidationException exception = new ValidationException();
-            for (String error : errors)
-            {
-                exception.addError(new SimpleValidationError(error));
-            }
-            throw exception;
-        }
-
-        if (c.getParent().getId().equals(newParent.getId()))
-            return false;
-
-        Container oldParent = c.getParent();
-        Container oldProject = c.getProject();
-        Container newProject = newParent.isRoot() ? c : newParent.getProject();
-
-        boolean changedProjects = !oldProject.getId().equals(newProject.getId());
-
-        // Synchronize the transaction, but not the listeners -- see #9901
-        try (DbScope.Transaction t = ensureTransaction())
-        {
-            new SqlExecutor(CORE.getSchema()).execute("UPDATE " + CORE.getTableInfoContainers() + " SET Parent = ? WHERE EntityId = ?", newParent.getId(), c.getId());
-
-            // Refresh the container directly from the database so the container reflects the new parent, isProject(), etc.
-            c = getForRowId(c.getRowId());
-
-            // this could be done in the trigger, but I prefer to put it in the transaction
-            if (changedProjects)
-                SecurityManager.changeProject(c, oldProject, newProject, user);
-
-            clearCache();
-
-            try
-            {
-                ExperimentService.get().moveContainer(c, oldParent, newParent);
-            }
-            catch (ExperimentException e)
-            {
-                throw new RuntimeException(e);
+                ValidationException exception = new ValidationException();
+                for (String error : errors)
+                {
+                    exception.addError(new SimpleValidationError(error));
+                }
+                throw exception;
             }
 
-            // Clear after the commit has propagated the state to other threads and transactions
-            // Do this in a commit task in case we've joined another existing DbScope.Transaction instead of starting our own
-            t.addCommitTask(() ->
+            if (c.getParent().getId().equals(newParent.getId()))
+                return false;
+
+            Container oldParent = c.getParent();
+            Container oldProject = c.getProject();
+            Container newProject = newParent.isRoot() ? c : newParent.getProject();
+
+            boolean changedProjects = !oldProject.getId().equals(newProject.getId());
+
+            // Synchronize the transaction, but not the listeners -- see #9901
+            try (DbScope.Transaction t = ensureTransaction())
             {
+                new SqlExecutor(CORE.getSchema()).execute("UPDATE " + CORE.getTableInfoContainers() + " SET Parent = ? WHERE EntityId = ?", newParent.getId(), c.getId());
+
+                // Refresh the container directly from the database so the container reflects the new parent, isProject(), etc.
+                c = getForRowId(c.getRowId());
+
+                // this could be done in the trigger, but I prefer to put it in the transaction
+                if (changedProjects)
+                    SecurityManager.changeProject(c, oldProject, newProject, user);
+
                 clearCache();
-                getChildrenMap(newParent); // reload the cache
-            }, DbScope.CommitTaskOption.POSTCOMMIT);
 
-            t.commit();
+                try
+                {
+                    ExperimentService.get().moveContainer(c, oldParent, newParent);
+                }
+                catch (ExperimentException e)
+                {
+                    throw new RuntimeException(e);
+                }
+
+                // Clear after the commit has propagated the state to other threads and transactions
+                // Do this in a commit task in case we've joined another existing DbScope.Transaction instead of starting our own
+                t.addCommitTask(() ->
+                {
+                    clearCache();
+                    getChildrenMap(newParent); // reload the cache
+                }, DbScope.CommitTaskOption.POSTCOMMIT);
+
+                t.commit();
+            }
+
+            Container newContainer = getForId(c.getId());
+            fireMoveContainer(newContainer, oldParent, user);
+
+            return changedProjects;
         }
-
-        Container newContainer = getForId(c.getId());
-        fireMoveContainer(newContainer, oldParent, user);
-
-        return changedProjects;
+        finally
+        {
+            mutatingContainers.remove(c.getRowId());
+        }
     }
 
     public static void rename(@NotNull Container c, User user, String name)
@@ -1703,7 +1703,8 @@ public class ContainerManager
      */
     public static Container rename(@NotNull Container c, User user, String name, @Nullable String title, boolean addAlias)
     {
-        try (DbScope.Transaction tx = ensureTransaction())
+        try (QuietCloser ignored = lockForMutation(MutatingOperation.rename, c);
+            DbScope.Transaction tx = ensureTransaction())
         {
             final String oldName = c.getName();
             final String newName = StringUtils.trimToNull(name);
@@ -1715,17 +1716,17 @@ public class ContainerManager
             {
                 // Issue 16221: Don't allow renaming of system reserved folders (e.g. /Shared, home, root, etc).
                 if (!isRenameable(c))
-                    throw new IllegalArgumentException("This folder may not be renamed as it is reserved by the system.");
+                    throw new ApiUsageException("This folder may not be renamed as it is reserved by the system.");
 
                 if (!Container.isLegalName(newName, c.isProject(), errors))
-                    throw new IllegalArgumentException(errors.toString());
+                    throw new ApiUsageException(errors.toString());
 
                 // Issue 19061: Unable to do case-only container rename
                 if (c.getParent().hasChild(newName) && !c.equals(c.getParent().getChild(newName)))
                 {
                     if (c.getParent().isRoot())
-                        throw new IllegalArgumentException("The server already has a project with this name.");
-                    throw new IllegalArgumentException("The " + (c.getParent().isProject() ? "project " : "folder ") + c.getParent().getPath() + " already has a folder with this name.");
+                        throw new ApiUsageException("The server already has a project with this name.");
+                    throw new ApiUsageException("The " + (c.getParent().isProject() ? "project " : "folder ") + c.getParent().getPath() + " already has a folder with this name.");
                 }
 
                 new SqlExecutor(CORE.getSchema()).execute("UPDATE " + CORE.getTableInfoContainers() + " SET Name=? WHERE EntityId=?", newName, c.getId());
@@ -1751,7 +1752,7 @@ public class ContainerManager
             if (!c.getTitle().equals(title))
             {
                 if (!Container.isLegalTitle(title, errors))
-                    throw new IllegalArgumentException(errors.toString());
+                    throw new ApiUsageException(errors.toString());
                 updateTitle(c, title, user);
             }
 
@@ -1798,36 +1799,64 @@ public class ContainerManager
         }
     }
 
-    private static final Map<String,Integer> deletingContainers = Collections.synchronizedMap(new HashMap<>());
-
-    public static boolean isDeleting(final Container c)
+    public enum MutatingOperation
     {
-        return deletingContainers.containsKey(c.getId());
+        delete,
+        rename,
+        move
+    }
+
+    private static final Map<Integer, MutatingOperation> mutatingContainers = Collections.synchronizedMap(new HashMap<>());
+
+    private static QuietCloser lockForMutation(MutatingOperation op, Container c)
+    {
+        return lockForMutation(op, Collections.singletonList(c));
+    }
+
+    private static QuietCloser lockForMutation(MutatingOperation op, Collection<Container> containers)
+    {
+        List<Integer> ids = new ArrayList<>(containers.size());
+        synchronized (mutatingContainers)
+        {
+            for (Container container : containers)
+            {
+                MutatingOperation currentOp = mutatingContainers.get(container.getRowId());
+                if (currentOp != null)
+                {
+                    throw new ApiUsageException("Cannot start a " + op + " operation on " + container.getPath() + ". It is currently undergoing a " + currentOp);
+                }
+                ids.add(container.getRowId());
+            }
+            ids.forEach(id -> mutatingContainers.put(id, op));
+        }
+        return () ->
+        {
+            synchronized (mutatingContainers)
+            {
+                ids.forEach(mutatingContainers::remove);
+            }
+        };
+    }
+
+    public static MutatingOperation isMutating(final Container c)
+    {
+        return mutatingContainers.get(c.getRowId());
     }
 
     // Delete containers from the database
     private static boolean delete(final Collection<Container> containers, User user, @Nullable String comment)
     {
-        List<String> containerIds = containers.stream().map(Container::getId).toList();
-
-        try
+        // Do this check before we bother with any synchronization
+        for (Container container : containers)
         {
-            synchronized (deletingContainers)
+            if (!isDeletable(container))
             {
-                for (Container container : containers)
-                {
-                    if (!isDeletable(container))
-                    {
-                        throw new ApiUsageException("Cannot delete container: " + container.getPath());
-                    }
-
-                    if (deletingContainers.containsKey(container.getId()))
-                    {
-                        throw new ApiUsageException("Container is already being deleted: " + container.getPath());
-                    }
-                }
-                containerIds.forEach(id -> deletingContainers.put(id, user.getUserId()));
+                throw new ApiUsageException("Cannot delete container: " + container.getPath());
             }
+        }
+
+        try (QuietCloser ignored = lockForMutation(MutatingOperation.delete, containers))
+        {
             boolean deleted = true;
             for (Container c : containers)
             {
@@ -1835,17 +1864,13 @@ public class ContainerManager
             }
             return deleted;
         }
-        finally
-        {
-            containerIds.forEach(deletingContainers::remove);
-        }
     }
 
     // Delete a container from the database
     private static boolean delete(final Container c, User user, @Nullable String comment)
     {
         // Verify method isn't called inappropriately
-        if (!deletingContainers.containsKey(c.getId()))
+        if (isMutating(c) != MutatingOperation.delete)
         {
             throw new IllegalStateException("Container not flagged as being deleted: " + c.getPath());
         }
@@ -1941,6 +1966,7 @@ public class ContainerManager
         return !isSystemContainer(c);
     }
 
+    /** System containers include the root container, /Home, and /Shared */
     public static boolean isSystemContainer(Container c)
     {
          return c.equals(getRoot()) || c.equals(getHomeContainer()) || c.equals(getSharedContainer());
@@ -1949,7 +1975,7 @@ public class ContainerManager
     // Has Container been deleted or is it in the process of being deleted?
     public static boolean exists(Container c)
     {
-        return null != getForId(c.getEntityId()) && !isDeleting(c);
+        return null != getForId(c.getEntityId()) && isMutating(c) != MutatingOperation.delete;
     }
 
     public static void deleteAll(Container root, User user, @Nullable String comment) throws UnauthorizedException
@@ -2234,7 +2260,7 @@ public class ContainerManager
 
     public static SQLFragment getIdsAsCsvList(Set<Container> containers, SqlDialect d)
     {
-        if (0 == containers.size())
+        if (containers.isEmpty())
             return new SQLFragment("(NULL)");    // WHERE x IN (NULL) should match no rows
 
         SQLFragment csvList = new SQLFragment("(");
@@ -2585,7 +2611,7 @@ public class ContainerManager
         String subPath = "";
         for (int i=0; i < splits.size()-1; i++) // minus 1 due to leaving off last container
         {
-            if (splits.get(i).length() > 0)
+            if (!splits.get(i).isEmpty())
                 subPath += "/" + splits.get(i);
         }
 
@@ -2711,11 +2737,6 @@ public class ContainerManager
             LOG.debug("Creating new container for path '" + path + "'");
             newContainer = true;
             c = ensureContainer(path, user);
-        }
-
-        if (c == null)
-        {
-            throw new IllegalStateException("Unable to ensure container for path '" + path + "'");
         }
 
         // Only set permissions if there are no explicit permissions

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1799,7 +1799,7 @@ public class ContainerManager
         }
     }
 
-    public enum MutatingOperation
+    private enum MutatingOperation
     {
         delete,
         rename,

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -2809,9 +2809,9 @@ public class ContainerManager
         @Test
         public void testImproperFolderNamesBlocked()
         {
-            String[] badnames = {"", "f\\o", "f/o", "f\\\\o", "foo;", "@foo", "foo" + '\u001F', '\u0000' + "foo", "fo" + '\u007F' + "o", "" + '\u009F'};
+            String[] badNames = {"", "f\\o", "f/o", "f\\\\o", "foo;", "@foo", "foo" + '\u001F', '\u0000' + "foo", "fo" + '\u007F' + "o", "" + '\u009F'};
 
-            for (String name: badnames)
+            for (String name: badNames)
             {
                 try
                 {
@@ -2820,12 +2820,12 @@ public class ContainerManager
                     {
                         assertTrue(delete(c, TestContext.get().getUser()));
                     }
-                    catch(Exception ignored){}
-                    fail("Should have thrown illegal argument when trying to create container with name: " + name);
+                    catch (Exception ignored) {}
+                    fail("Should have thrown exception when trying to create container with name: " + name);
                 }
-                catch(IllegalArgumentException e)
+                catch (ApiUsageException e)
                 {
-                        //Do nothing, this is expected
+                    // Do nothing, this is expected
                 }
             }
         }

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1838,11 +1838,6 @@ public class ContainerManager
         };
     }
 
-    public static MutatingOperation isMutating(final Container c)
-    {
-        return mutatingContainers.get(c.getRowId());
-    }
-
     // Delete containers from the database
     private static boolean delete(final Collection<Container> containers, User user, @Nullable String comment)
     {
@@ -1870,7 +1865,7 @@ public class ContainerManager
     private static boolean delete(final Container c, User user, @Nullable String comment)
     {
         // Verify method isn't called inappropriately
-        if (isMutating(c) != MutatingOperation.delete)
+        if (mutatingContainers.get(c.getRowId()) != MutatingOperation.delete)
         {
             throw new IllegalStateException("Container not flagged as being deleted: " + c.getPath());
         }
@@ -1972,10 +1967,10 @@ public class ContainerManager
          return c.equals(getRoot()) || c.equals(getHomeContainer()) || c.equals(getSharedContainer());
     }
 
-    // Has Container been deleted or is it in the process of being deleted?
-    public static boolean exists(Container c)
+    /** Has the container already been deleted or is it in the process of being deleted? */
+    public static boolean exists(@Nullable Container c)
     {
-        return null != getForId(c.getEntityId()) && isMutating(c) != MutatingOperation.delete;
+        return c != null && null != getForId(c.getEntityId()) && mutatingContainers.get(c.getRowId()) != MutatingOperation.delete;
     }
 
     public static void deleteAll(Container root, User user, @Nullable String comment) throws UnauthorizedException

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -177,7 +177,7 @@ public class DataGenerator<T extends DataGenerator.Config>
             throw new CancelledException();
         }
 
-        if (ContainerManager.isMutating(c) == ContainerManager.MutatingOperation.delete)
+        if (!ContainerManager.exists(c))
         {
             job.warn("Container is being deleted: " + c.getPath());
             throw new CancelledException();

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -15,8 +15,10 @@ import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DetailedAuditLogDataIterator;
 import org.labkey.api.dataiterator.ListofMapsDataIterator;
+import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.DataClassDomainKindProperties;
 import org.labkey.api.exp.api.ExpDataClass;
@@ -175,7 +177,7 @@ public class DataGenerator<T extends DataGenerator.Config>
             throw new CancelledException();
         }
 
-        if (ContainerManager.isDeleting(c))
+        if (ContainerManager.isMutating(c) == ContainerManager.MutatingOperation.delete)
         {
             job.warn("Container is being deleted: " + c.getPath());
             throw new CancelledException();
@@ -760,7 +762,7 @@ public class DataGenerator<T extends DataGenerator.Config>
 
     protected int importRows(List<Map<String, Object>> rows, BatchValidationException errors, QueryUpdateService service, Container container) throws BatchValidationException, SQLException
     {
-        ListofMapsDataIterator rowsDI = new ListofMapsDataIterator(rows.get(0).keySet(), rows);
+        DataIteratorBuilder rowsDI = MapDataIterator.of(rows);
         var numImported = service.importRows(_user, container, rowsDI, errors, _config.getImportConfig(), null);
         if (errors.hasErrors())
             throw errors;
@@ -770,9 +772,7 @@ public class DataGenerator<T extends DataGenerator.Config>
     public void logTimes()
     {
         _log.info("===== Timing Summary ======");
-        _timers.forEach((timer) -> {
-            _log.info(String.format("%s\t%s", timer.getName(), timer.getDuration()));
-        });
+        _timers.forEach((timer) -> _log.info(String.format("%s\t%s", timer.getName(), timer.getDuration())));
     }
 
     public CPUTimer addTimer(String name)

--- a/api/src/org/labkey/api/exp/LsidManager.java
+++ b/api/src/org/labkey/api/exp/LsidManager.java
@@ -375,7 +375,7 @@ public class LsidManager
      */
     public boolean testResolveAll(Container c)
     {
-        if (ContainerManager.isDeleting(c))
+        if (ContainerManager.isMutating(c) != null)
             return true;
 
         List<String> objectURIs = new TableSelector(OntologyManager.getTinfoObject(), Set.of("ObjectURI"), SimpleFilter.createContainerFilter(c), new Sort("ObjectId")).getArrayList(String.class);

--- a/api/src/org/labkey/api/exp/LsidManager.java
+++ b/api/src/org/labkey/api/exp/LsidManager.java
@@ -375,7 +375,7 @@ public class LsidManager
      */
     public boolean testResolveAll(Container c)
     {
-        if (ContainerManager.isMutating(c) != null)
+        if (!ContainerManager.exists(c))
             return true;
 
         List<String> objectURIs = new TableSelector(OntologyManager.getTinfoObject(), Set.of("ObjectURI"), SimpleFilter.createContainerFilter(c), new Sort("ObjectId")).getArrayList(String.class);

--- a/api/src/org/labkey/api/pipeline/AppPipelineJobNotificationProvider.java
+++ b/api/src/org/labkey/api/pipeline/AppPipelineJobNotificationProvider.java
@@ -311,7 +311,7 @@ abstract public class AppPipelineJobNotificationProvider implements PipelineJobN
         }
 
         // don't attempt to add a notification if the Container has been deleted or is deleting
-        if (ContainerManager.getForId(job.getContainerId()) == null || ContainerManager.isMutating(job.getContainer()) == ContainerManager.MutatingOperation.delete)
+        if (!ContainerManager.exists(job.getContainer()))
         {
             job.getLogger().info("Job container has been deleted or is being deleted; skipping notification for '{}'", Objects.toString(job.getDescription(), job.toString()));
             return;

--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -52,6 +52,7 @@ import org.labkey.api.util.GUID;
 import org.labkey.api.util.Job;
 import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.NetworkDrive;
+import org.labkey.api.util.QuietCloser;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
@@ -1341,7 +1342,7 @@ abstract public class PipelineJob extends Job implements Serializable
         }
 
 
-        try (PipelineJobService.Closer ignored = PipelineJobService.get().trackForJobCancellation(_jobGUID, proc))
+        try (QuietCloser ignored = PipelineJobService.get().trackForJobCancellation(_jobGUID, proc))
         {
             // create thread pool for collecting the process output
             ExecutorService pool = Executors.newSingleThreadExecutor();

--- a/api/src/org/labkey/api/pipeline/PipelineJobNotificationProvider.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJobNotificationProvider.java
@@ -134,7 +134,7 @@ public interface PipelineJobNotificationProvider
                 return false;
 
             // don't attempt to add a notification if the Container has been deleted or is deleting
-            if (ContainerManager.getForId(job.getContainerId()) == null || ContainerManager.isMutating(job.getContainer()) == ContainerManager.MutatingOperation.delete)
+            if (!ContainerManager.exists(job.getContainer()))
             {
                 job.getLogger().info("Job container has been deleted or is being deleted; skipping notification for '" + Objects.toString(job.getDescription(), job.toString()) + "'");
                 return false;

--- a/api/src/org/labkey/api/pipeline/PipelineJobNotificationProvider.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJobNotificationProvider.java
@@ -13,6 +13,7 @@ import org.labkey.api.util.URLHelper;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public interface PipelineJobNotificationProvider
@@ -35,7 +36,6 @@ public interface PipelineJobNotificationProvider
     }
 
     /**
-     * @param job
      * @param info Allow passing results (such as imported rows, transaction id) of the run to provider
      */
     default void onJobSuccess(PipelineJob job, @Nullable Map<String, Object> info)
@@ -96,7 +96,7 @@ public interface PipelineJobNotificationProvider
             Notification n = new Notification(job.getJobGUID(), job.getNotificationType(status), user);
             if (StringUtils.isEmpty(msgContent))
             {
-                String description = StringUtils.defaultString(job.getDescription(), job.toString());
+                String description = Objects.toString(job.getDescription(), job.toString());
                 n.setContent(String.format("Background job %s\n%s", status.toString().toLowerCase(), description), "text/plain");
             }
             else
@@ -134,9 +134,9 @@ public interface PipelineJobNotificationProvider
                 return false;
 
             // don't attempt to add a notification if the Container has been deleted or is deleting
-            if (ContainerManager.getForId(job.getContainerId()) == null || ContainerManager.isDeleting(job.getContainer()))
+            if (ContainerManager.getForId(job.getContainerId()) == null || ContainerManager.isMutating(job.getContainer()) == ContainerManager.MutatingOperation.delete)
             {
-                job.getLogger().info("Job container has been deleted or is being deleted; skipping notification for '" + StringUtils.defaultString(job.getDescription(), job.toString()) + "'");
+                job.getLogger().info("Job container has been deleted or is being deleted; skipping notification for '" + Objects.toString(job.getDescription(), job.toString()) + "'");
                 return false;
             }
 

--- a/api/src/org/labkey/api/pipeline/PipelineJobService.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJobService.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.formSchema.FormSchema;
 import org.labkey.api.pipeline.file.PathMapper;
+import org.labkey.api.util.QuietCloser;
 
 import java.io.FileNotFoundException;
 import java.util.List;
@@ -138,18 +139,12 @@ public interface PipelineJobService extends TaskPipelineRegistry
      */
     String getExecutablePath(String exeRel, @Nullable String installPath, String packageName, String ver, Logger jobLogger) throws FileNotFoundException;
 
-    interface Closer extends AutoCloseable
-    {
-        @Override
-        void close();
-    }
-
     /**
      * Tracks processes launched by pipeline jobs so they can be killed if the pipeline job gets canceled.
      * Callers should invoke the close() on the returned object when the process completes normally and no longer
      * needs to be tracked
      */
-    Closer trackForJobCancellation(String jobGuid, Process process);
+    QuietCloser trackForJobCancellation(String jobGuid, Process process);
 
     void cancelForJob(String jobGuid);
 

--- a/api/src/org/labkey/api/reports/ExternalScriptEngine.java
+++ b/api/src/org/labkey/api/reports/ExternalScriptEngine.java
@@ -26,6 +26,7 @@ import org.labkey.api.reader.Readers;
 import org.labkey.api.reports.report.r.ParamReplacementSvc;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.QuietCloser;
 import org.labkey.api.util.URIUtil;
 
 import javax.script.AbstractScriptEngine;
@@ -342,7 +343,7 @@ public class ExternalScriptEngine extends AbstractScriptEngine implements LabKey
             throw new RuntimeException(message, eio);
         }
 
-        try (PipelineJobService.Closer ignored = PipelineJobService.get().trackForJobCancellation(jobGuid, proc))
+        try (QuietCloser ignored = PipelineJobService.get().trackForJobCancellation(jobGuid, proc))
         {
             // Write script process output to the provided writer
             // if the writer isn't the original writer (a PrintWriter over the tomcat console).

--- a/api/src/org/labkey/api/util/QuietCloser.java
+++ b/api/src/org/labkey/api/util/QuietCloser.java
@@ -1,0 +1,10 @@
+package org.labkey.api.util;
+
+/**
+ * Variant of AutoCloseable that doesn't throw any checked exceptions.
+ */
+public interface QuietCloser extends AutoCloseable
+{
+    @Override
+    void close();
+}

--- a/api/src/org/labkey/api/view/NavTree.java
+++ b/api/src/org/labkey/api/view/NavTree.java
@@ -545,11 +545,6 @@ public class NavTree implements Collapsible
         return _usePost;
     }
 
-    public String childrenToJS()
-    {
-        return toJS(_children, new StringBuilder(), false).toString();
-    }
-
     public String toJS()
     {
         return toJS(new StringBuilder(), true, false).toString();
@@ -670,12 +665,6 @@ public class NavTree implements Collapsible
             lb.nofollow();
 
         return lb;
-    }
-
-    @Deprecated
-    public static StringBuilder toJS(Collection<NavTree> list, @Nullable StringBuilder sb, boolean asMenu)
-    {
-        return toJS(list,sb,asMenu,!asMenu);
     }
 
     public static StringBuilder toJS(Collection<NavTree> list, @Nullable StringBuilder sb, boolean asMenu, boolean withIds)

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -863,7 +863,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         {
             ActionURL show = new ActionURL(ExperimentController.ShowDataClassAction.class, getContainer()).addParameter("rowId", dc.getRowId());
             NavTree t = new NavTree(dc.getName(), show);
-            String nav = NavTree.toJS(Collections.singleton(t), null, false).toString();
+            String nav = NavTree.toJS(Collections.singleton(t), null, false, true).toString();
             props.put(SearchService.PROPERTY.navtrail.toString(), nav);
 
             props.put(DataSearchResultTemplate.PROPERTY, dc.getName());

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -17,7 +17,6 @@
 package org.labkey.list.model;
 
 import org.apache.commons.collections4.MultiValuedMap;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -534,7 +533,7 @@ public class ListManager implements SearchService.DocumentProvider
             Runnable r = () ->
             {
                 Container c = def.lookupContainer();
-                if (c == null || ContainerManager.isDeleting(c))
+                if (c == null || ContainerManager.isMutating(c) == ContainerManager.MutatingOperation.delete)
                 {
                     LOG.info("List container has been deleted or is being deleted; not indexing list \"" + def.getName() + "\"");
                 }
@@ -716,7 +715,7 @@ public class ListManager implements SearchService.DocumentProvider
                 ActionURL gridURL = list.urlShowData();
                 gridURL.setExtraPath(list.getContainer().getId()); // Use ID to guard against folder moves/renames
                 NavTree t = new NavTree("list", gridURL);
-                String nav = NavTree.toJS(Collections.singleton(t), null, false).toString();
+                String nav = NavTree.toJS(Collections.singleton(t), null, false, true).toString();
                 r.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
 
                 task.addResource(r, SearchService.PRIORITY.item);
@@ -1122,9 +1121,7 @@ public class ListManager implements SearchService.DocumentProvider
         String listSchemaName = ListSchema.getInstance().getSchemaName();
 
         // Now clear LastIndexed column of every underlying list table, which addresses the "index each list item as a separate document" case. See #28748.
-        new TableSelector(getListMetadataTable()).forEach(ListDef.class, listDef -> {
-            clearLastIndexed(scope, listSchemaName, listDef);
-        });
+        new TableSelector(getListMetadataTable()).forEach(ListDef.class, listDef -> clearLastIndexed(scope, listSchemaName, listDef));
     }
 
     private void clearLastIndexed(DbScope scope, String listSchemaName, ListDef listDef)
@@ -1225,7 +1222,7 @@ public class ListManager implements SearchService.DocumentProvider
                     continue;
 
                 ColumnInfo col = ti.getColumn(FieldKey.fromParts(baseKey));
-                String value = ObjectUtils.toString(entry.getValue());
+                String value = Objects.toString(entry.getValue(), "");
                 String key = null;
 
                 if (null != col)

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -533,7 +533,7 @@ public class ListManager implements SearchService.DocumentProvider
             Runnable r = () ->
             {
                 Container c = def.lookupContainer();
-                if (c == null || ContainerManager.isMutating(c) == ContainerManager.MutatingOperation.delete)
+                if (!ContainerManager.exists(c))
                 {
                     LOG.info("List container has been deleted or is being deleted; not indexing list \"" + def.getName() + "\"");
                 }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -72,6 +72,7 @@ import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.MinorConfigurationException;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.QuietCloser;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.TestContext;
@@ -263,7 +264,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
     }
 
     @Override
-    public Closer trackForJobCancellation(String jobGuid, Process process)
+    public QuietCloser trackForJobCancellation(String jobGuid, Process process)
     {
         if (jobGuid == null)
         {

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4377,7 +4377,7 @@ public class StudyManager
         if (null == study)
             return;
 
-        final String nav = NavTree.toJS(Collections.singleton(new NavTree("study", PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(c))), null, false).toString();
+        final String nav = NavTree.toJS(Collections.singleton(new NavTree("study", PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(c))), null, false, true).toString();
 
         SQLFragment baseFragment = new SQLFragment();
         baseFragment.append("SELECT Container, ParticipantId FROM ");
@@ -4547,7 +4547,7 @@ public class StudyManager
             return;
 
         ActionURL begin = PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(study.getContainer());
-        String nav = NavTree.toJS(Collections.singleton(new NavTree("study", begin)), null, false).toString();
+        String nav = NavTree.toJS(Collections.singleton(new NavTree("study", begin)), null, false, true).toString();
         AttachmentService serv = AttachmentService.get();
         Path p = study.getContainer().getParsedPath().append("@study");
 

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -854,7 +854,7 @@ public class WikiManager implements WikiService
                         documentName, searchCategory);
 
                 NavTree t = new NavTree("wiki page", wikiUrl);
-                String nav = NavTree.toJS(Collections.singleton(t), null, false).toString();
+                String nav = NavTree.toJS(Collections.singleton(t), null, false, true).toString();
                 attachmentRes.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
                 task.addResource(attachmentRes, SearchService.PRIORITY.item);
             }


### PR DESCRIPTION
#### Rationale
It's a bad idea to allow multiple threads to concurrently rename, move, or delete the same container. We had delete protection in place and should expand it to other mutation events.

A future expansion would be to also lock all child containers.

#### Changes
- Track renames and moves alongside deletes
- Convert more errors to ApiUsageException as they're bad input, not buggy code
- Create a reusable AutoCloseable that doesn't throw exceptions
- Assorted code cleanup