### PR TITLE
Use separate caches for different Container caching needs

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -158,8 +158,8 @@ public class ContainerManager
     public static final String DEFAULT_SUPPORT_PROJECT_PATH = HOME_PROJECT_PATH + "/support";
 
     private static final Cache<String, Container> CACHE = CacheManager.getStringKeyCache(Constants.getMaxContainers(), CacheManager.DAY, "Containers");
-    private static final Cache<String, List<String>> CACHE_CHILDREN = CacheManager.getStringKeyCache(Constants.getMaxContainers(), CacheManager.DAY, "Containers");
-    private static final Cache<String, Set<Container>> CACHE_ALL_CHILDREN = CacheManager.getStringKeyCache(Constants.getMaxContainers(), CacheManager.DAY, "Containers");
+    private static final Cache<String, List<String>> CACHE_CHILDREN = CacheManager.getStringKeyCache(Constants.getMaxContainers(), CacheManager.DAY, "Child EntityIds of Containers");
+    private static final Cache<String, Set<Container>> CACHE_ALL_CHILDREN = CacheManager.getStringKeyCache(Constants.getMaxContainers(), CacheManager.DAY, "Child Container objects of Containers");
     private static final ReentrantLock DATABASE_QUERY_LOCK = new ReentrantLockWithName(ContainerManager.class, "DATABASE_QUERY_LOCK");
     public static final String FOLDER_TYPE_PROPERTY_SET_NAME = "folderType";
     public static final String FOLDER_TYPE_PROPERTY_NAME = "name";
@@ -669,7 +669,7 @@ public class ContainerManager
         }
         int maxProjectsCount = counts.get(totalFolderTypeMatch - 1);
         int totalProjectsCount = counts.stream().mapToInt(Integer::intValue).sum();
-        int averageProjectsCount = Math.round(totalProjectsCount/totalFolderTypeMatch);
+        int averageProjectsCount = Math.round((float) totalProjectsCount /totalFolderTypeMatch);
 
         metrics.put("totalSubProjectsCount", totalProjectsCount);
         metrics.put("averageSubProjectsPerHomeProject", averageProjectsCount);

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -157,7 +157,8 @@ public class ContainerManager
     public static final String HOME_PROJECT_PATH = "/home";
     public static final String DEFAULT_SUPPORT_PROJECT_PATH = HOME_PROJECT_PATH + "/support";
 
-    private static final Cache<String, Container> CACHE = CacheManager.getStringKeyCache(Constants.getMaxContainers(), CacheManager.DAY, "Containers");
+    // Use double the max count as the size since we cache by both EntityId and Path
+    private static final Cache<String, Container> CACHE = CacheManager.getStringKeyCache(Constants.getMaxContainers() * 2, CacheManager.DAY, "Containers");
     private static final Cache<String, List<String>> CACHE_CHILDREN = CacheManager.getStringKeyCache(Constants.getMaxContainers(), CacheManager.DAY, "Child EntityIds of Containers");
     private static final Cache<String, Set<Container>> CACHE_ALL_CHILDREN = CacheManager.getStringKeyCache(Constants.getMaxContainers(), CacheManager.DAY, "Child Container objects of Containers");
     private static final ReentrantLock DATABASE_QUERY_LOCK = new ReentrantLockWithName(ContainerManager.class, "DATABASE_QUERY_LOCK");
@@ -2049,7 +2050,7 @@ public class ContainerManager
         CACHE.remove(toString(c));
         CACHE.remove(c.getId());
 
-        // blow away the all children caches
+        // blow away the children caches
         CACHE_CHILDREN.clear();
         CACHE_ALL_CHILDREN.clear();
 


### PR DESCRIPTION
#### Rationale
We need to cache a few different things about containers. We can eliminate casting and awkward cache clearing by using separate caches.

#### Changes
- One cache per caching use case!