### PR TITLE
Misc 24.11 fixes

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -749,6 +749,8 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     List<? extends ExpRun> getRunsUsingDatas(List<ExpData> datas);
 
+    List<? extends ExpRun> getRunsUsingDataIds(List<Integer> ids);
+
     ExpRun getCreatingRun(File file, Container c);
 
     List<? extends ExpRun> getExpRunsForProtocolIds(boolean includeRelated, int... rowIds);

--- a/api/src/org/labkey/api/security/roles/AuthorRole.java
+++ b/api/src/org/labkey/api/security/roles/AuthorRole.java
@@ -36,8 +36,7 @@ public class AuthorRole extends AbstractRole
 {
     public AuthorRole()
     {
-        super("Author", "Authors may read and add information in some cases, but may update and delete only information they added. Supported for only " +
-                        "Message Boards. See the online documentation for details.",
+        super("Author", "Authors may read and add some information. They can also update and delete some information they added.",
                 ReadPermission.class,
                 ReadSomePermission.class,
                 AssayReadPermission.class,

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
@@ -143,6 +143,42 @@ public void nameNotNull() throws Exception
     }
 }
 
+    @Test // Issue 51321
+public void reservedNameFirst() throws Exception
+{
+    final User user = TestContext.get().getUser();
+
+    try
+    {
+        List<GWTPropertyDescriptor> props = new ArrayList<>();
+        props.add(new GWTPropertyDescriptor("foo", "string"));
+
+        ExperimentServiceImpl.get().createDataClass(c, user, "First", null, props, emptyList(), null, null);
+    }
+    catch (IllegalArgumentException e)
+    {
+        assertEquals("DataClass name 'First' is reserved.", e.getMessage());
+    }
+}
+
+@Test // Issue 51321
+public void reservedNameAll() throws Exception
+{
+    final User user = TestContext.get().getUser();
+
+    try
+    {
+        List<GWTPropertyDescriptor> props = new ArrayList<>();
+        props.add(new GWTPropertyDescriptor("foo", "string"));
+
+        ExperimentServiceImpl.get().createDataClass(c, user, "All", null, props, emptyList(), null, null);
+    }
+    catch (IllegalArgumentException e)
+    {
+        assertEquals("DataClass name 'All' is reserved.", e.getMessage());
+    }
+}
+
 // validate name scale
 @Test
 public void nameScale() throws Exception

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
@@ -37,7 +37,6 @@
 <%@ page import="org.labkey.api.data.TableSelector" %>
 <%@ page import="org.labkey.api.dataiterator.DataIteratorContext" %>
 <%@ page import="org.labkey.api.dataiterator.DetailedAuditLogDataIterator" %>
-<%@ page import="org.labkey.api.dataiterator.ListofMapsDataIterator" %>
 <%@ page import="org.labkey.api.exp.ExperimentException" %>
 <%@ page import="org.labkey.api.exp.Lsid" %>
 <%@ page import="org.labkey.api.exp.OntologyManager" %>
@@ -141,9 +140,49 @@ public void nameNotNull() throws Exception
                 null, null, props, Collections.emptyList(),
                 -1, -1, -1, -1, null, null);
     }
-    catch (ExperimentException ee)
+    catch (IllegalArgumentException ee)
     {
-        assertEquals("SampleType name is required", ee.getMessage());
+        assertEquals("Sample Type name is required.", ee.getMessage());
+    }
+}
+
+@Test // Issue 51321
+public void reservedNameFirst() throws Exception
+{
+    final User user = TestContext.get().getUser();
+
+    try
+    {
+        List<GWTPropertyDescriptor> props = new ArrayList<>();
+        props.add(new GWTPropertyDescriptor("name", "string"));
+
+        final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
+                "First", null, props, Collections.emptyList(),
+                -1, -1, -1, -1, null, null);
+    }
+    catch (IllegalArgumentException ee)
+    {
+        assertEquals("Sample Type name 'First' is reserved.", ee.getMessage());
+    }
+}
+
+@Test // Issue 51321
+public void reservedNameAll() throws Exception
+{
+    final User user = TestContext.get().getUser();
+
+    try
+    {
+        List<GWTPropertyDescriptor> props = new ArrayList<>();
+        props.add(new GWTPropertyDescriptor("name", "string"));
+
+        final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
+                "All", null, props, Collections.emptyList(),
+                -1, -1, -1, -1, null, null);
+    }
+    catch (IllegalArgumentException ee)
+    {
+        assertEquals("Sample Type name 'All' is reserved.", ee.getMessage());
     }
 }
 
@@ -164,9 +203,9 @@ public void nameScale() throws Exception
                 name, null, props, Collections.emptyList(),
                 -1, -1, -1, -1, null, null);
     }
-    catch (ExperimentException ee)
+    catch (IllegalArgumentException ee)
     {
-        assertEquals("SampleType name may not exceed 100 characters.", ee.getMessage());
+        assertEquals("Sample Type name may not exceed 100 characters.", ee.getMessage());
     }
 }
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8123,13 +8123,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         {
             validateDataClassOptions(c, u, options);
             newName = StringUtils.trimToNull(options.getName());
-            if (newName != null && !oldDataClassName.equals(newName))
+            if (!oldDataClassName.equals(newName))
             {
+                validateDataClassName(c, u, newName);
                 hasNameChange = true;
                 dataClass.setName(newName);
-                ExpDataClass existing = getDataClass(c, u, newName);
-                if (existing != null)
-                    throw new IllegalArgumentException("DataClass '" + newName + "' already exists.");
             }
             dataClass.setDescription(options.getDescription());
             dataClass.setNameExpression(options.getNameExpression());
@@ -8207,6 +8205,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         ExpDataClass existing = getDataClass(c, u, name);
         if (existing != null)
             throw new IllegalArgumentException("DataClass '" + existing.getName() + "' already exists.");
+
+        // Issue 51321: check reserved data class name: First, All
+        if ("First".equalsIgnoreCase(name) || "All".equalsIgnoreCase(name))
+            throw new IllegalArgumentException("DataClass name '" + name + "' is reserved.");
     }
 
     private void validateDataClassOptions(@NotNull Container c, @NotNull User u, @Nullable DataClassDomainKindProperties options)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -705,17 +705,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                                               @Nullable List<String> excludedContainerIds, @Nullable List<String> excludedDashboardContainerIds)
         throws ExperimentException
     {
-        if (name == null)
-            throw new ExperimentException("SampleType name is required");
-
-        TableInfo materialSourceTable = ExperimentService.get().getTinfoSampleType();
-        int nameMax = materialSourceTable.getColumn("Name").getScale();
-        if (name.length() > nameMax)
-            throw new ExperimentException("SampleType name may not exceed " + nameMax + " characters.");
-
-        ExpSampleType existing = getSampleType(c, name);
-        if (existing != null)
-            throw new IllegalArgumentException("SampleType '" + existing.getName() + "' already exists");
+        validateSampleTypeName(c, u, name);
 
         if (properties == null || properties.isEmpty())
             throw new ExperimentException("At least one property is required");
@@ -751,6 +741,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         }
 
         // Validate the name expression length
+        TableInfo materialSourceTable = ExperimentService.get().getTinfoSampleType();
         int nameExpMax = materialSourceTable.getColumn("NameExpression").getScale();
         if (nameExpression != null && nameExpression.length() > nameExpMax)
             throw new ExperimentException("Name expression may not exceed " + nameExpMax + " characters.");
@@ -973,6 +964,24 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         };
     }
 
+    private void validateSampleTypeName(Container container, User user, String name)
+    {
+        if (name == null || StringUtils.isBlank(name))
+            throw new IllegalArgumentException("Sample Type name is required.");
+
+        TableInfo materialSourceTable = ExperimentService.get().getTinfoSampleType();
+        int nameMax = materialSourceTable.getColumn("Name").getScale();
+        if (name.length() > nameMax)
+            throw new IllegalArgumentException("Sample Type name may not exceed " + nameMax + " characters.");
+
+        if (getSampleType(container, user, name) != null)
+            throw new IllegalArgumentException("A Sample Type with name '" + name + "' already exists.");
+
+        // Issue 51321: check reserved sample type name: First
+        if ("First".equalsIgnoreCase(name) || "All".equalsIgnoreCase(name))
+            throw new IllegalArgumentException("Sample Type name '" + name + "' is reserved.");
+    }
+
     @Override
     public ValidationException updateSampleType(GWTDomain<? extends GWTPropertyDescriptor> original, GWTDomain<? extends GWTPropertyDescriptor> update, SampleTypeDomainKindProperties options, Container container, User user, boolean includeWarnings)
     {
@@ -983,12 +992,9 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         String newName = StringUtils.trimToNull(update.getName());
         String oldSampleTypeName = st.getName();
         boolean hasNameChange = false;
-        if (newName != null && !oldSampleTypeName.equals(newName))
+        if (!oldSampleTypeName.equals(newName))
         {
-            ExpSampleType duplicateType = SampleTypeService.get().getSampleType(container, user, newName);
-            if (duplicateType != null)
-                throw new IllegalArgumentException("A Sample Type with name '" + newName + "' already exists.");
-
+            validateSampleTypeName(container, user, newName);
             hasNameChange = true;
             st.setName(newName);
         }

--- a/experiment/src/org/labkey/experiment/xar/XarExportSelection.java
+++ b/experiment/src/org/labkey/experiment/xar/XarExportSelection.java
@@ -67,7 +67,12 @@ public class XarExportSelection implements Serializable
     public void addRuns(Collection<? extends ExpRun> runs)
     {
         // Issue 44306 - be sure to retain the ordering of the runs as passed in the collection
-        _runIds.addAll(runs.stream().map(ExpObject::getRowId).collect(Collectors.toList()));
+        _runIds.addAll(runs.stream().map(ExpObject::getRowId).toList());
+    }
+
+    public void addRunIds(Collection<Integer> runIds)
+    {
+        _runIds.addAll(runIds);
     }
 
     public void addDataIds(int... dataIds)


### PR DESCRIPTION
#### Rationale
Issue [51373](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51373): Simplify description of Author role to match other roles
Issue [51321](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51321): Sample Type and Data Class to consider "All" and "First" as reserved names
Issue [50376](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=50376): DataClassFolderWriter refactor to get ExpRuns ids per data class instead of all at once

#### Changes
- simplify author permissions role description
- create and update domain for SampleType and DataClass to check for reserved type names
- DataClassFolderWriter refactor to get ExpRuns ids per data class instead of all at once
