### PR TITLE
Lineage: only serialize "comment" when "includeProperties" is true

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentJSONConverter.java
@@ -594,12 +594,10 @@ public class ExperimentJSONConverter
             jsonObject.put(MODIFIED_BY, object.getModifiedBy().getEmail());
         }
         jsonObject.put(MODIFIED, object.getModified());
-        String comment = object.getComment();
-        if (comment != null)
-            jsonObject.put(COMMENT, object.getComment());
 
         if (settings.isIncludeProperties())
         {
+            jsonObject.put(COMMENT, object.getComment());
             JSONObject propertiesObject = serializeOntologyProperties(object, properties, settings);
             if (!propertiesObject.isEmpty())
                 jsonObject.put(PROPERTIES, propertiesObject);


### PR DESCRIPTION
#### Rationale
The experiment lineage API serializes experiment objects to JSON. The API provides a flag `includeProperties` which when true includes additional ontology-based properties about each object. Including these properties can incur the use of a significant amount of memory due to how they are persisted and cached.

However, there is one property, `"comment"`, which is backed by these ontology-based properties that is currently being included regardless of the flag setting which incurs the full cost of calling into / utilizing the properties. This changes moves the `"comment"` property to only be included when `includeProperties=true`. This is also consistent with how comments are included for run and run group serialization.

#### Changes
- Move inclusion of the `"comment"` property under the `includeProperties` flag for experiment objects.
- Remove null check as serialization will not include null values.
