### PR TITLE
Add metric to track default session timeout

### DIFF
--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1193,6 +1193,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             // Report the total number of login entries in the audit log
             results.put("totalLogins", UserManager.getAuthCount(null, false, false, false));
             results.put("apiKeyLogins", UserManager.getAuthCount(null, false, true, false));
+            results.put("sessionTimeout", ModuleLoader.getServletContext().getSessionTimeout());
             results.put("userLimits", new LimitActiveUsersSettings().getMetricsMap());
             results.put("systemUserCount", UserManager.getSystemUserCount());
             results.put("workbookCount", ContainerManager.getWorkbookCount());


### PR DESCRIPTION
#### Rationale
We show the session timeout in the Admin Console, but it's helpful to report on these more centrally.

#### Changes
- Include the HTTP session timeout with the Core module's metrics