### PR TITLE
Issue 51440: Safari no longer needs special date formatting

### DIFF
--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -1330,18 +1330,17 @@ validNum:       {
 
     public static String formatJsonDateTime(Date date)
     {
-        if (HttpView.hasCurrentView())
+        if (date instanceof Time)
         {
-            ViewContext context = HttpView.currentContext();
-            if (context != null && context.getRequest() != null)
+            if (HttpView.hasCurrentView())
             {
-                if (date instanceof Time && context.getContainer() != null)
+                ViewContext context = HttpView.currentContext();
+                if (context != null && context.getContainer() != null)
                     return FastDateFormat.getInstance(FolderSettingsCache.getDefaultTimeFormat(context.getContainer())).format(date);
             }
-        }
 
-        if (date instanceof Time)
             return jsonTimeFormat.format(date);
+        }
 
         return jsonDateFormat.format(date);
     }

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -1145,12 +1145,6 @@ validNum:       {
         return "yyyy-MM-dd HH:mm:ss.SSS";
     }
 
-    public static String getSafariJsonDateTimeFormatString()
-    {
-        // Issue 43557 - Safari needs the ISO-8601-like 'T' between the date and time to parse this precise of a date
-        return "yyyy-MM-dd'T'HH:mm:ss.SSS";
-    }
-
     /**
      * Format current date using ISO 8601 pattern. This is appropriate only for persisting dates in machine-readable
      * form, for example, for export or in filenames. Most callers should use formatDate(Container c) instead.
@@ -1332,22 +1326,15 @@ validNum:       {
     }
 
     private static final FastDateFormat jsonDateFormat = FastDateFormat.getInstance(getJsonDateTimeFormatString());
-    private static final FastDateFormat safariJsonDateFormat = FastDateFormat.getInstance(getSafariJsonDateTimeFormatString());
     private static final FastDateFormat jsonTimeFormat = FastDateFormat.getInstance(ISO_TIME_FORMAT_STRING);
 
     public static String formatJsonDateTime(Date date)
     {
-        // Issue 43557 - Safari needs a 'T' between the date and time. Instead of needing to rev all client APIs to parse
-        // the new variant, conditionally send Safari its preferred format (which works fine in other browsers but not
-        // in all other parsing code)
-        boolean isSafari = false;
         if (HttpView.hasCurrentView())
         {
             ViewContext context = HttpView.currentContext();
             if (context != null && context.getRequest() != null)
             {
-                isSafari = HttpUtil.isSafari(context.getRequest());
-
                 if (date instanceof Time && context.getContainer() != null)
                     return FastDateFormat.getInstance(FolderSettingsCache.getDefaultTimeFormat(context.getContainer())).format(date);
             }
@@ -1356,7 +1343,7 @@ validNum:       {
         if (date instanceof Time)
             return jsonTimeFormat.format(date);
 
-        return isSafari ? safariJsonDateFormat.format(date) : jsonDateFormat.format(date);
+        return jsonDateFormat.format(date);
     }
 
     private static class _duration
@@ -1371,8 +1358,9 @@ validNum:       {
 
     public static boolean isSignedDuration(@NotNull String durationCandidate)
     {
-        try{
-            if(durationCandidate.isEmpty() || !(durationCandidate.startsWith("+") || durationCandidate.startsWith("-")))
+        try
+        {
+            if (durationCandidate.isEmpty() || !(durationCandidate.startsWith("+") || durationCandidate.startsWith("-")))
             {
                 return false;
             }
@@ -1387,16 +1375,14 @@ validNum:       {
 
     public static long applySignedDuration(long time, String duration)
     {
-        if(duration.startsWith("+"))
-        {
+        if (duration.startsWith("+"))
              return addDuration(time, duration.substring(1));
-        }
-        if(duration.startsWith("-"))
-        {
-            return subtractDuration(time,duration.substring(1));
-        }
+        if (duration.startsWith("-"))
+            return subtractDuration(time, duration.substring(1));
+
         throw new IllegalArgumentException("The duration provided is not valid: " + duration);
     }
+
     public static _duration _parseDuration(String s)
     {
         boolean period = false;

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -1332,12 +1332,9 @@ validNum:       {
     {
         if (date instanceof Time)
         {
-            if (HttpView.hasCurrentView())
-            {
-                ViewContext context = HttpView.currentContext();
-                if (context != null && context.getContainer() != null)
-                    return FastDateFormat.getInstance(FolderSettingsCache.getDefaultTimeFormat(context.getContainer())).format(date);
-            }
+            ViewContext context = HttpView.currentContext();
+            if (context != null && context.getContainer() != null)
+                return FastDateFormat.getInstance(FolderSettingsCache.getDefaultTimeFormat(context.getContainer())).format(date);
 
             return jsonTimeFormat.format(date);
         }


### PR DESCRIPTION
#### Rationale
This addresses [Issue 51440](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51440) by removing Safari-specific date format handling. See ticket for further details.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/2457

#### Changes
- Update `DateUtil.formatJsonDateTime()` to no longer analyze request for browser context
- Remove `DateUtil.getSafariJsonDateTimeFormatString()` 
