### PR TITLE
Issue 51403: Also handle drag/drop container moves

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1686,10 +1686,6 @@ public class ContainerManager
 
             return changedProjects;
         }
-        finally
-        {
-            mutatingContainers.remove(c.getRowId());
-        }
     }
 
     public static void rename(@NotNull Container c, User user, String name)

--- a/core/webapp/admin/FolderManagementPanel.js
+++ b/core/webapp/admin/FolderManagementPanel.js
@@ -401,7 +401,7 @@ Ext4.define('LABKEY.ext4.panel.FolderManagement', {
                                 successHandler();
                             },
                             failure  : function(response, ops) {
-                                var _msg = "Failed to complete move. This folder may have already been moved or deleted.";
+                                var _msg = response.exception || "Failed to complete move. This folder may have already been moved or deleted.";
                                 if (response && response.errors) {
                                     var errors = response.errors;
                                     _msg = "";


### PR DESCRIPTION
#### Rationale
We have two ways to initiate a container move through the UI: clicking the Move button and choosing a target, or drag/dropping within the tree. We weren't showing the updated error message in the latter case.

#### Changes
- Show the error from the server if we have one
- Don't release the lock on the container when the move fails to initiate