### PR TITLE
PlateGridInfo parsing to support measure annotations only when plate set only has a single plate

### DIFF
--- a/api/src/org/labkey/api/exp/property/PropertyService.java
+++ b/api/src/org/labkey/api/exp/property/PropertyService.java
@@ -140,6 +140,8 @@ public interface PropertyService
 
     ConceptURIVocabularyDomainProvider getConceptUriVocabularyDomainProvider(String conceptUri);
 
+    Set<String> getDomainPropertyImportAliases(DomainProperty property);
+
     @Nullable
     Object getDomainPropertyValueFromRow(DomainProperty property, Map<String, Object> row);
 

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -326,14 +326,15 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 
             // if the plate set only has one plate, then treat a single annotation as the measure
             // otherwise a single annotation can only be a plate identifier
-            if (plates.size() == 1 && annotations.size() == 1)
+            if (annotations.size() == 1)
             {
-                _plate = plates.get(0);
-                _measureName = annotations.get(0);
-            }
-            else if (annotations.size() == 1)
-            {
-                _plate = getPlateForId(annotations.get(0), plates);
+                if (plates.size() == 1)
+                {
+                    _plate = plates.get(0);
+                    _measureName = annotations.get(0);
+                }
+                else
+                    _plate = getPlateForId(annotations.get(0), plates);
             }
             else
             {

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -698,8 +698,6 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                             String measureName = gridInfo.getMeasureName();
                             if (measureName == null)
                                 throw new ExperimentException("The measure name for plate (" + gridInfo.getPlate().getPlateId() + ") has not been specified in the data file.");
-                            else if (!measureAliases.contains(measureName))
-                                throw new ExperimentException("The measure name (" + measureName + ") is not a valid measure property for the assay protocol.");
 
                             if (measures.contains(measureName))
                                 throw new ExperimentException("The measure name (" + measureName + ") has been previously associated with data for the same plate.");

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -324,9 +324,17 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             List<Plate> plates = PlateManager.get().getPlatesForPlateSet(plateSet);
             List<String> annotations = getAnnotations();
 
-            // single annotation can only be a plate identifier
-            if (annotations.size() == 1)
+            // if the plate set only has one plate, then treat a single annotation as the measure
+            // otherwise a single annotation can only be a plate identifier
+            if (plates.size() == 1 && annotations.size() == 1)
+            {
+                _plate = plates.get(0);
+                _measureName = annotations.get(0);
+            }
+            else if (annotations.size() == 1)
+            {
                 _plate = getPlateForId(annotations.get(0), plates);
+            }
             else
             {
                 // multiple annotation must have an annotation prefix

--- a/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
@@ -34,6 +34,7 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ConditionalFormat;
 import org.labkey.api.data.Container;
@@ -683,6 +684,20 @@ public class PropertyServiceImpl implements PropertyService, UsageMetricsProvide
     public ConceptURIVocabularyDomainProvider getConceptUriVocabularyDomainProvider(String conceptUri)
     {
         return _conceptUriVocabularyProvider.get(conceptUri);
+    }
+
+    public Set<String> getDomainPropertyImportAliases(DomainProperty property)
+    {
+        if (property == null)
+            return Collections.emptySet();
+
+        Set<String> aliases = new CaseInsensitiveHashSet();
+        aliases.add(property.getName());
+        if (property.getLabel() != null)
+            aliases.add(property.getLabel());
+        if (!property.getImportAliasSet().isEmpty())
+            aliases.addAll(property.getImportAliasSet());
+        return aliases;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We have an example file of graphical plate assay data with multiple measures where the plate annotations are the measure names/labels but the header annotations do not have the plate identifier. We can support this scenario with a small code change so that if the plate set selected only has a single plate, we use that as the plate for the import and assume that the single annotation is the measure name. 

#### Changes
- PlateGridInfo check for single plate in plate set for the single annotation case
