### PR TITLE
SAML: Check for PEM Format Not File Extension 

### DIFF
--- a/core/src/client/components/DynamicFields.tsx
+++ b/core/src/client/components/DynamicFields.tsx
@@ -212,7 +212,6 @@ export const SmallFileUpload: FC<SmallFileInputProps> = props => {
                         showLabel={false}
                         allowMultiple={false}
                         allowDirectories={false}
-                        acceptedFormats=".txt,.pem,.crt"
                         showAcceptedFormats={false}
                         onFileChange={onFileChange}
                         onFileRemoval={onFileRemoval}


### PR DESCRIPTION
#### Rationale
Prevent confusion by allowing users to upload certificate with any extension, as long as it contains a valid PEM-formatted certificate.

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/66

#### Changes
- Remove client side check for accepted file extensions.
