### PR TITLE
Updates to CPUTimer

### DIFF
--- a/api/src/org/labkey/api/util/CPUTimer.java
+++ b/api/src/org/labkey/api/util/CPUTimer.java
@@ -117,15 +117,18 @@ public class CPUTimer
 
     protected void _update(long elapsed)
     {
-        _cumulative += elapsed;
-        _min = Math.min(_min, elapsed);
-        _max = Math.max(_max, elapsed);
-        if (_first == 0)
+        synchronized(timers)
         {
-            _first = elapsed;
+            _cumulative += elapsed;
+            _min = Math.min(_min, elapsed);
+            _max = Math.max(_max, elapsed);
+            if (_first == 0)
+            {
+                _first = elapsed;
+            }
+            _last = elapsed;
+            _calls++;
         }
-        _last = elapsed;
-        _calls++;
     }
 
     public boolean saveTo(CPUTimer accumulator)

--- a/api/src/org/labkey/api/util/CPUTimer.java
+++ b/api/src/org/labkey/api/util/CPUTimer.java
@@ -146,13 +146,39 @@ public class CPUTimer
     }
 
     /**
-     * Sets cumulative and average time to 0. Does not reset max, min, first or last.
+     * Reset all the values in the timer.
      *
      * @return Always returns true.
      */
 	public boolean clear()
     {
-		_cumulative = 0;
+        synchronized(timers)
+        {
+            _cumulative = 0;
+            _min = Long.MAX_VALUE;
+            _max = Long.MIN_VALUE;
+            _first = 0;
+            _last = 0;
+            _start = 0;
+            _stop = 0;
+            _calls = 0;
+        }
+        return true;
+    }
+
+    /**
+     * Remove this time from the internal collection of timers.
+     *
+     * @return Always return true.
+     */
+    public boolean remove()
+    {
+        this.stop();
+        clear();
+        synchronized(timers)
+        {
+            timers.remove(this);
+        }
         return true;
     }
 

--- a/api/src/org/labkey/api/util/CPUTimer.java
+++ b/api/src/org/labkey/api/util/CPUTimer.java
@@ -161,7 +161,7 @@ public class CPUTimer
     }
 
     /**
-     * Remove this time from the internal collection of timers.
+     * Stop this timer and remove it from the internal collection of timers.
      *
      * @return Always return true.
      */
@@ -170,8 +170,6 @@ public class CPUTimer
 
         if(started())
             stop();
-
-        clear();
 
         synchronized(timers)
         {

--- a/api/src/org/labkey/api/util/CPUTimer.java
+++ b/api/src/org/labkey/api/util/CPUTimer.java
@@ -117,18 +117,15 @@ public class CPUTimer
 
     protected void _update(long elapsed)
     {
-        synchronized(timers)
+        _cumulative += elapsed;
+        _min = Math.min(_min, elapsed);
+        _max = Math.max(_max, elapsed);
+        if (_first == 0)
         {
-            _cumulative += elapsed;
-            _min = Math.min(_min, elapsed);
-            _max = Math.max(_max, elapsed);
-            if (_first == 0)
-            {
-                _first = elapsed;
-            }
-            _last = elapsed;
-            _calls++;
+            _first = elapsed;
         }
+        _last = elapsed;
+        _calls++;
     }
 
     public boolean saveTo(CPUTimer accumulator)
@@ -152,17 +149,14 @@ public class CPUTimer
      */
 	public boolean clear()
     {
-        synchronized(timers)
-        {
-            _cumulative = 0;
-            _min = Long.MAX_VALUE;
-            _max = Long.MIN_VALUE;
-            _first = 0;
-            _last = 0;
-            _start = 0;
-            _stop = 0;
-            _calls = 0;
-        }
+        _cumulative = 0;
+        _min = Long.MAX_VALUE;
+        _max = Long.MIN_VALUE;
+        _first = 0;
+        _last = 0;
+        _start = 0;
+        _stop = 0;
+        _calls = 0;
         return true;
     }
 
@@ -173,12 +167,17 @@ public class CPUTimer
      */
     public boolean remove()
     {
-        this.stop();
+
+        if(started())
+            stop();
+
         clear();
+
         synchronized(timers)
         {
             timers.remove(this);
         }
+
         return true;
     }
 


### PR DESCRIPTION
#### Rationale
The CPUTimer maintains an internal list of timers, this adds a method to the class that allows the caller to remove a timer from the collection.
Updated the clear method to reset all the internal timing variables. This can be used if a caller wants the timer to remain but doesn't want the current information. Example: throwing away the first iteration in a run.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/812

#### Changes
- Add a remove method.
- Update clear method to reset all local variable.
