### PR TITLE
getColumn("ObjectId") !== getExpObjectColumn()

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
@@ -344,9 +344,9 @@ abstract public class ExpTableImpl<C extends Enum>
         {
             PropertyDescriptor pd = dp.getPropertyDescriptor();
             PropertyColumn propColumn;
-            if (null != getExpObjectColumn())
+            if (null != getColumn("ObjectId"))
             {
-                propColumn = new PropertyColumn(pd, getExpObjectColumn(), getContainer(), _userSchema.getUser(), false, containerFilter);
+                propColumn = new PropertyColumn(pd, getColumn("ObjectId"), getContainer(), _userSchema.getUser(), false, containerFilter);
                 propColumn.setParentIsObjectId(true);
             }
             else


### PR DESCRIPTION
#### Rationale
getExpObjectColumn() returns a wrapped column which is not appropriate in this case.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
