### PR TITLE
Fix exceptions

### DIFF
--- a/api/src/org/labkey/api/data/dialect/StatementWrapper.java
+++ b/api/src/org/labkey/api/data/dialect/StatementWrapper.java
@@ -2850,9 +2850,10 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
                     {
                         o = ((Array) o).getArray();
                     }
-                    catch (SQLException e)
+                    catch (Exception e)
                     {
                         _log.error("Could not retrieve array", e);
+                        o = null;
                     }
                 }
 

--- a/api/src/org/labkey/api/search/SearchResultTemplate.java
+++ b/api/src/org/labkey/api/search/SearchResultTemplate.java
@@ -18,15 +18,14 @@ package org.labkey.api.search;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.search.SearchService.SearchCategory;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
 
-/**
- * User: adam
- * Date: 2/18/12
- * Time: 10:13 AM
- */
+import java.util.List;
+
 public interface SearchResultTemplate
 {
     @Nullable String getName();
@@ -73,15 +72,27 @@ public interface SearchResultTemplate
             case Folder:
             case FolderAndSubfolders:
                 title += " folder '";
-                if ("".equals(c.getName()))
+                if (c.getName().isEmpty())
                     title += "root'";
                 else
                     title += c.getName() + "'";
                 break;
         }
 
-        if (null != category)
-            title += " for " + category.replaceAll(" ", "s, ") + "s";
+        SearchService ss = SearchService.get();
+        if (ss != null)
+        {
+            List<SearchCategory> categories = ss.getCategories(category);
+
+            if (null != categories)
+            {
+                List<String> list = categories.stream()
+                    .map(SearchCategory::getDescription)
+                    .toList();
+
+                title += " for " + StringUtilsLabKey.joinWithConjunction(list, "and");
+            }
+        }
 
         root.addChild(title);
     }

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -44,6 +44,9 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -1230,12 +1233,18 @@ validNum:       {
     }
 
     /**
-     * Format specific LocalDate using folder-specified default pattern
+     * Format specific LocalDate using folder-specified default pattern.
      * Warning: Return value is unsafe and must be HTML filtered, if rendered to an HTML page
      */
-    public static String formatDate(Container c, LocalDate date)
+    public static String formatDate(Container c, @Nullable LocalDate date)
     {
-        return null == date ? null : date.format(DateTimeFormatter.ofPattern(getDateFormatString(c)));
+        if (null == date)
+            return null;
+
+        // LocalDate doesn't include time zone, but the display format might specify "z". Add the server's time zone to
+        // prevent an exception.
+        ZonedDateTime zoned = ZonedDateTime.of(date, LocalTime.MIDNIGHT, ZoneId.systemDefault());
+        return zoned.format(DateTimeFormatter.ofPattern(getDateFormatString(c)));
     }
 
     /**


### PR DESCRIPTION
#### Rationale
A couple exception reports found their way to me: 

* https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=38430  No idea why or how, but `PgArray.buildArrayList()` threw an NPE in one case. IDK, maybe the connection was closed. Regardless, we are just collecting parameters for the query profiler, so just catch Exception and stash `null`.
* https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=38254  A date time display format specifying time zone (z) was set at the project level. The project locking page then threw because `DateUtils.formatDate()` attempted to format a `LocalDate` (which doesn't include time zone) with that format. Solution is to use a `ZonedTimeDate` that uses the server's time zone.

And not an exception, but the search results page title needed some love. We were echoing back whatever category names were on the URL (these names are not super friendly and could be invalid). Now, we resolve the requested names to search category objects and concatenate their descriptions.