### PR TITLE
Issue 51466: Startup Properties applied in opposite order

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -2445,7 +2445,7 @@ public class ModuleLoader implements MemTrackerListener
         if (!propFiles.isEmpty())
         {
             List<FileLike> sortedPropFiles = propFiles.stream()
-                .sorted(Comparator.comparing(FileLike::getName))
+                .sorted(Comparator.comparing(FileLike::getName).reversed())
                 .toList();
 
             for (FileLike propFile : sortedPropFiles)


### PR DESCRIPTION
#### Rationale
A recent refactor accidentally dropped the `reversed()` from the `Comparator` setup

#### Changes
- Restore the reversal