### PR TITLE
Issue 51465: UsageReportingLevel timer initialization issues

### DIFF
--- a/api/src/org/labkey/api/util/UsageReportingLevel.java
+++ b/api/src/org/labkey/api/util/UsageReportingLevel.java
@@ -142,15 +142,6 @@ public enum UsageReportingLevel implements SafeToRenderEnum
         _timer.cancel();
     }
 
-    public static void init()
-    {
-        if (_task != null)
-        {
-            throw new IllegalStateException("Already initialized");
-        }
-        reportNow();
-    }
-
     /** Reset the timer and immediately check in (or not) based on current configuration */
     public static void reportNow()
     {

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1318,7 +1318,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         // On bootstrap in production mode, this will send an initial ping with very little information, as the admin will
         // not have set up their account yet. On later startups, depending on the reporting level, this will send an immediate
         // ping, and then once every 24 hours.
-        UsageReportingLevel.init();
+        UsageReportingLevel.reportNow();
         TempTableTracker.init();
 
         // Loading the PDFBox font cache can be very slow on some agents; fill it proactively. Issue 50601


### PR DESCRIPTION
#### Rationale
We don't need to track initialization as aggressively. `reportNow()` initializes the timer as needed.

#### Changes
- Remove `init()` method
- Call `reportNow()` instead