### PR TITLE
Issue 51443: Slow file downloads via webdav from a remote file mount

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -224,7 +224,7 @@ public class ApiModule extends CodeOnlyModule
 
         LabKeyManagement.register(new StandardMBean(new OperationsMXBeanImpl(), OperationsMXBean.class, true), "Operations");
 
-        AdminConsole.addExperimentalFeatureFlag(FileStream.STAGE_FILE_UPLOADS, "Stage file uploads before moving to final destination", "When using a non-local file system, using a specific API that requires a locally staged copy of the file as the source can sometimes be significantly faster than streaming the uploaded file directly", false);
+        AdminConsole.addExperimentalFeatureFlag(FileStream.STAGE_FILE_TRANSFERS, "Stage file uploads and downloads to temporary local file", "When using a non-local file system, using a specific API that requires a locally staged copy of the file as the source can sometimes be significantly faster than streaming the file directly to/from storage", false);
     }
 
     @NotNull

--- a/api/src/org/labkey/api/util/FileStream.java
+++ b/api/src/org/labkey/api/util/FileStream.java
@@ -51,7 +51,7 @@ public interface FileStream
     Logger LOG = LogHelper.getLogger(FileStream.class, "File transfers");
 
     // See issue 50620
-    String STAGE_FILE_UPLOADS = "StageFileUploads";
+    String STAGE_FILE_TRANSFERS = "StageFileUploads";
 
     /** @return -1 if unknown */
     long getSize() throws IOException;
@@ -83,9 +83,9 @@ public interface FileStream
         }
 
         long size = s.getSize();
-        if (ExperimentalFeatureService.get().isFeatureEnabled(STAGE_FILE_UPLOADS))
+        if (ExperimentalFeatureService.get().isFeatureEnabled(STAGE_FILE_TRANSFERS))
         {
-            File tempFile = FileUtil.createTempFile(STAGE_FILE_UPLOADS, ".tmp");
+            File tempFile = FileUtil.createTempFile(STAGE_FILE_TRANSFERS, ".tmp");
             try
             {
                 // Although the FileStream passed here is backed by temp file on disk, the underlying FileChannelImpl

--- a/api/src/org/labkey/api/util/URIUtil.java
+++ b/api/src/org/labkey/api/util/URIUtil.java
@@ -17,6 +17,7 @@ package org.labkey.api.util;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.net.URIBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,7 +32,7 @@ import java.net.URISyntaxException;
  */
 public class URIUtil
 {
-    static public boolean isDescendant(URI base, URI descendant)
+    static public boolean isDescendant(@NotNull URI base, @NotNull URI descendant)
     {
         // to protect against paths that are trying to escape the base, return false if the descendant includes "/../"
         if (descendant.getPath().contains("/../"))

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -68,6 +68,7 @@ import org.labkey.api.security.permissions.BrowserDeveloperPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.LookAndFeelProperties;
+import org.labkey.api.settings.ExperimentalFeatureService;
 import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.*;
 import org.labkey.api.util.logging.LogHelper;
@@ -131,6 +132,7 @@ import java.io.DataOutput;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.FilterInputStream;
 import java.io.FilterWriter;
 import java.io.IOException;
@@ -145,6 +147,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.SocketException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
@@ -5008,6 +5011,8 @@ public class DavController extends SpringActionController
         return name.contains(".cache.") || name.endsWith(".ttf") || name.endsWith(".woff") || name.endsWith(".woff2");
     }
 
+    private static final URI PROJECT_ROOT = AppProps.getInstance().getProjectRoot() == null ? null : new File(AppProps.getInstance().getProjectRoot()).toURI();
+
     private WebdavStatus serveResource(WebdavResource resource, boolean content)
             throws DavException, IOException
     {
@@ -5131,11 +5136,18 @@ public class DavController extends SpringActionController
                     }
                 }
 
+                // Issue 51344 - slow downloads from remote file system, but only for files that aren't part of the
+                // webapp itself, or under the source root (for development machines)
+                boolean stageFile = file != null &&
+                        ExperimentalFeatureService.get().isFeatureEnabled(FileStream.STAGE_FILE_TRANSFERS) &&
+                        !URIUtil.isDescendant(ModuleLoader.getInstance().getWebappDir().getParentFile().toURI(), file.toUri()) &&
+                        (PROJECT_ROOT == null || !URIUtil.isDescendant(PROJECT_ROOT, file.toUri()));
+
                 HttpServletRequest request = getRequest();
-                if (null != file && !FileUtil.hasCloudScheme(file) && Boolean.TRUE == request.getAttribute("org.apache.tomcat.sendfile.support"))
+                if (!stageFile && null != file && !FileUtil.hasCloudScheme(file) && Boolean.TRUE == request.getAttribute("org.apache.tomcat.sendfile.support"))
                 {
-                    String absolutePath = file.toFile().getAbsolutePath();     // TODO: can this code be used for cloud?
-                    long length  = Files.size(file);
+                    String absolutePath = file.toFile().getAbsolutePath();
+                    long length = Files.size(file);
                     request.setAttribute("org.apache.tomcat.sendfile.filename", absolutePath);
                     request.setAttribute("org.apache.tomcat.sendfile.start", Long.valueOf(0L));
                     request.setAttribute("org.apache.tomcat.sendfile.end", Long.valueOf(length));
@@ -5162,13 +5174,43 @@ public class DavController extends SpringActionController
                         }
                     }
 
-                    InputStream is = getResourceInputStream(gz==null?resource:gz,getUser());
-                    if (ostream != null)
+                    File tempFile = null;
+                    try
                     {
-                        copy(is, ostream);
+                        InputStream is = getResourceInputStream(gz == null ? resource : gz, getUser());
+                        if (stageFile)
+                        {
+                            // Issue 51344 - slow downloads from remote file system
+                            tempFile = FileUtil.createTempFile(FileStream.STAGE_FILE_TRANSFERS, ".tmp");
+                            _log.debug("Staging " + file + " to " + tempFile + " for faster download.");
+                            try (FileOutputStream fOut = new FileOutputStream(tempFile))
+                            {
+                                is.transferTo(fOut);
+                                is.close();
+                                is = new FileInputStream(tempFile);
+                            }
+                            _log.debug("Finished staging " + file);
+                        }
+
+                        if (ostream != null)
+                        {
+                            copy(is, ostream);
+                        }
+                        else if (writer != null)
+                            copy(is, writer);
                     }
-                    else if (writer != null)
-                        copy(is, writer);
+                    finally
+                    {
+                        if (tempFile != null)
+                        {
+                            boolean deleted = tempFile.delete();
+                            _log.debug("{} staged file {}", deleted ? "Deleted" : "Failed to delete", tempFile);
+                            if (!deleted)
+                            {
+                                tempFile.deleteOnExit();
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -6473,7 +6515,7 @@ public class DavController extends SpringActionController
 
 
     /** Converts FileNotFound into SC_NOT_FOUND */
-    private InputStream getResourceInputStream(WebdavResource r, User user) throws IOException, DavException
+    @NotNull private InputStream getResourceInputStream(WebdavResource r, User user) throws IOException, DavException
     {
         try
         {


### PR DESCRIPTION
#### Rationale
We've previously added an experimental/optional feature that stages WebDav file uploads to a temp file to let us use a different method to copy to its intended destination, a remote file system. That approach is more than 10x performant.

We can get a similar boost for downloads by simply avoiding SendFile (which is now possible on our cloud instances given the Tomcat upgrade) and return to using the approach that I previously optimized.

#### Changes
- For GET WebDAV requests, for files that aren't part of the webapp itself, don't use Tomcat's SendFile implementation
- Update the description for the experimental/optional feature to reflect that it's useful in both directions