### PR TITLE
Issue 51213: Add temp tokens to prevent temp tables from disappearing before use

### DIFF
--- a/api/src/org/labkey/api/data/TempTableTracker.java
+++ b/api/src/org/labkey/api/data/TempTableTracker.java
@@ -142,7 +142,7 @@ public class TempTableTracker extends WeakReference<Object>
     private boolean sqlDelete()
     {
         DbSchema schema = getSchema();
-        _log.info("Deleting table " + schema.getName() + "." + tableName);
+        _log.debug("Deleting table " + schema.getName() + "." + tableName);
         schema.dropTableIfExists(tableName);
         return true;
     }

--- a/api/src/org/labkey/api/data/TempTableTracker.java
+++ b/api/src/org/labkey/api/data/TempTableTracker.java
@@ -142,6 +142,7 @@ public class TempTableTracker extends WeakReference<Object>
     private boolean sqlDelete()
     {
         DbSchema schema = getSchema();
+        _log.info("Deleting table " + schema.getName() + "." + tableName);
         schema.dropTableIfExists(tableName);
         return true;
     }

--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -301,13 +301,12 @@ public class ClosureQueryHelper
         try
         {
             Object ref = new Object();
-            String tempTableName = "closinc_"+temptableNumber.incrementAndGet();
+            String tempTableName = "closinc_" + temptableNumber.incrementAndGet();
             ttt = TempTableTracker.track(tempTableName, ref);
             SQLFragment from = new SQLFragment("FROM temp." + familyTempTable).append(" WHERE ObjectType = ").appendValue(isSampleType ? "m" : "d").append(" ");
             SQLFragment selectInto = selectIntoTempTableSql(getScope().getSqlDialect(), from, tempTableName);
             int count = new SqlExecutor(getScope()).execute(selectInto);
-            if (count == 0)
-                return;
+            logger.debug("Selected {} rows into {} for recompute.", count, tempTableName);
 
             SQLFragment upsert;
             TableInfo tInfo = isSampleType ? ExperimentServiceImpl.get().getTinfoMaterialAncestors() : ExperimentServiceImpl.get().getTinfoDataAncestors();
@@ -316,6 +315,9 @@ public class ClosureQueryHelper
 
             // delete the ancestor data for the ids in the family
             new SqlExecutor(getScope()).execute(invalidateAncestorData(tInfo, familyTempTable, isSampleType));
+
+            if (count == 0)
+                return;
 
             if (dialect.isPostgreSQL())
             {
@@ -449,7 +451,8 @@ public class ClosureQueryHelper
                 // complete hack to get SQLServer to not make RowId an identity column in the target table so the subsequent insert will work without complaint
                 selectIntoSql.append(" UNION ALL SELECT RowId, ObjectId, 'x' AS ObjectType FROM " ).append(isSampleType ? "exp.material" : "exp.data").append(" WHERE 1 <> 1");
             int numSeeds = new SqlExecutor(getScope()).execute(selectIntoSql);
-            // if we didn't actually insert any items into the table (perhaps because someone else was deleting), there's nothing more to be done
+            logger.debug("Added {} seed rows to {}", numSeeds, familyTableName);
+            // if we didn't actually insert any items into the table, there's nothing more to be done
             if (numSeeds == 0)
                 return;
 
@@ -463,8 +466,8 @@ public class ClosureQueryHelper
 
             descendants.append("INSERT INTO temp.").append(familyTableName)
                     .append(" (RowId, ObjectId, ObjectType) ").append(descendantClosureSelectSql);
-            //TODO if there are no descendants, perhaps there's nothing to do, or we may need different logic to clear out any existing ones
             int numRows = new SqlExecutor(getScope()).execute(descendants);
+            logger.debug("Added {} descendant rows for {}", numRows, familyTableName);
 
             // recompute the ancestors for the seed ids and the descendants
             incrementalRecomputeFromTempTable(familyTableName, isSampleType);
@@ -477,15 +480,8 @@ public class ClosureQueryHelper
         }
     }
 
-    public static void recomputeMaterialAncestors(int rowId)
+    private static void recomputeMaterialAncestors(int rowId)
     {
-        var tx = getScope().getCurrentTransaction();
-        if (null != tx)
-        {
-            tx.addCommitTask(() -> recomputeMaterialAncestors(rowId), DbScope.CommitTaskOption.POSTCOMMIT);
-            return;
-        }
-
         SQLFragment selectSeedsSql = new SQLFragment()
                 .append("SELECT m.RowId, m.ObjectId, 'm' AS ObjectType FROM exp.material m\n")
                 .append("WHERE m.RowId = ").appendValue(rowId);
@@ -531,15 +527,8 @@ public class ClosureQueryHelper
         recomputeFromSeeds(selectSeedsSql, true);
     }
 
-    public static void recomputeDataObjectAncestors(int rowId)
+    private static void recomputeDataObjectAncestors(int rowId)
     {
-        var tx = getScope().getCurrentTransaction();
-        if (null != tx)
-        {
-            tx.addCommitTask(() -> recomputeDataObjectAncestors(rowId), DbScope.CommitTaskOption.POSTCOMMIT);
-            return;
-        }
-
         SQLFragment selectSeedsSql = new SQLFragment()
                 .append("SELECT d.RowId, d.ObjectId, 'd' AS ObjectType FROM exp.data d\n")
                 .append("WHERE d.RowId = ").appendValue(rowId);

--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -309,7 +309,7 @@ public class ClosureQueryHelper
             SQLFragment selectInto = selectIntoTempTableSql(getScope().getSqlDialect(), from, tableNameSql);
             selectInto.addTempToken(ref);
             int count = new SqlExecutor(getScope()).execute(selectInto);
-            logger.info("Selected {} rows into temp.{} for recompute of {} ancestors.", count, tempTableName, isSampleType ? "sample" : "data");
+            logger.debug("Selected {} rows into temp.{} for recompute of {} ancestors.", count, tempTableName, isSampleType ? "sample" : "data");
 
             SQLFragment upsert;
             TableInfo tInfo = isSampleType ? ExperimentServiceImpl.get().getTinfoMaterialAncestors() : ExperimentServiceImpl.get().getTinfoDataAncestors();
@@ -456,7 +456,7 @@ public class ClosureQueryHelper
                 // complete hack to get SQLServer to not make RowId an identity column in the target table so the subsequent insert will work without complaint
                 selectIntoSql.append(" UNION ALL SELECT RowId, ObjectId, 'x' AS ObjectType FROM " ).append(isSampleType ? "exp.material" : "exp.data").append(" WHERE 1 <> 1");
             int numSeeds = new SqlExecutor(getScope()).execute(selectIntoSql);
-            logger.info("Added {} seed {} rows to temp.{}", numSeeds, isSampleType ? "sample" : "data", familyTableName);
+            logger.debug("Added {} seed {} rows to temp.{}", numSeeds, isSampleType ? "sample" : "data", familyTableName);
             // if we didn't actually insert any items into the table, there's nothing more to be done
             if (numSeeds == 0)
                 return;


### PR DESCRIPTION
#### Rationale
Issue [51213](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51213) - we are seeing a good number of exception reports referencing temp tables used during computation of ancestor data. The complaint in the exception reports is that the tables needed don't exist.  The theory is that these tables are getting cleaned up prematurely because the reference object used to create the `TempTableTracker` isn't used elsewhere and is thus seen as a candidate for garbage collection, which then will cause the temp tables to be deleted before use. We do see a lot of GC activity in our production instances, which lends credence to this theory.

This PR attaches the `ref` `Objects` used for the tracker to the relevant SQL fragments so they should stick around.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Add some logging (may want to reduce to debug level, though)
- Exit methods earlier if we don't have any work to do
- Update `SQLFragments` with a temp token that should keep the relevant temp tables alive.
