### PR TITLE
Issue 51480: Pipeline OutputLogger fails to log parameterized messages

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -28,7 +28,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.simple.SimpleLogger;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.jetbrains.annotations.NotNull;
@@ -1447,92 +1449,11 @@ abstract public class PipelineJob extends Job implements Serializable
         private final String LINE_SEP = System.lineSeparator();
         private final String datePattern = "dd MMM yyyy HH:mm:ss,SSS";
 
-        @Deprecated //Prefer the Path version
-        protected OutputLogger(PipelineJob job, File file, String name, Level level)
-        {
-            this(job, file.toPath(), name, level);
-        }
-
         protected OutputLogger(PipelineJob job, Path file, String name, Level level)
         {
             super(name, level, false, false, false, false, "", null, new PropertiesUtil(PropertiesUtil.getSystemProperties()), null);
             _job = job;
             _file = file;
-
-        }
-
-        @Override
-        public void debug(String message)
-        {
-            _job.getClassLogger().debug(getSystemLogMessage(message));
-            write(message, null, Level.DEBUG.toString());
-        }
-
-        @Override
-        public void debug(String message, @Nullable Throwable t)
-        {
-            _job.getClassLogger().debug(getSystemLogMessage(message), t);
-            write(message, t, Level.DEBUG.toString());
-        }
-
-        @Override
-        public void info(String message)
-        {
-            _job.getClassLogger().info(getSystemLogMessage(message));
-            write(message, null, Level.INFO.toString());
-        }
-
-        @Override
-        public void info(String message, @Nullable Throwable t)
-        {
-            _job.getClassLogger().info(getSystemLogMessage(message), t);
-            write(message, t, Level.INFO.toString());
-        }
-
-        @Override
-        public void warn(String message)
-        {
-            _job.getClassLogger().warn(getSystemLogMessage(message));
-            write(message, null, Level.WARN.toString());
-        }
-
-        @Override
-        public void warn(String message, @Nullable Throwable t)
-        {
-            _job.getClassLogger().warn(getSystemLogMessage(message), t);
-            write(message, t, Level.WARN.toString());
-        }
-
-        @Override
-        public void error(String message)
-        {
-            _job.getClassLogger().error(getSystemLogMessage(message));
-            write(message, null, Level.ERROR.toString());
-            setErrorStatus(message);
-        }
-
-        @Override
-        public void error(String message, @Nullable Throwable t)
-        {
-            _job.getClassLogger().error(getSystemLogMessage(message), t);
-            write(message, t, Level.ERROR.toString());
-            setErrorStatus(message);
-        }
-
-        @Override
-        public void fatal(String message)
-        {
-            _job.getClassLogger().fatal(getSystemLogMessage(message));
-            write(message, null, Level.FATAL.toString());
-            setErrorStatus(message);
-        }
-
-        @Override
-        public void fatal(String message, Throwable t)
-        {
-            _job.getClassLogger().fatal(getSystemLogMessage(message), t);
-            write(message, t, Level.FATAL.toString());
-            setErrorStatus(message);
         }
 
         // called from LogOutputStream.flush()
@@ -1580,7 +1501,40 @@ abstract public class PipelineJob extends Job implements Serializable
             }
         }
 
-        public void write(String message, @Nullable Throwable t, String level)
+        @Override
+        public void logMessage(String fqcn, Level mgsLevel, Marker marker, Message msg, Throwable throwable)
+        {
+            if (_job.getClassLogger().isEnabled(mgsLevel, marker))
+            {
+                _job.getClassLogger().log(mgsLevel, marker, new Message()
+                {
+                    @Override
+                    public String getFormattedMessage()
+                    {
+                        return getSystemLogMessage(msg.getFormattedMessage());
+                    }
+
+                    @Override
+                    public Object[] getParameters()
+                    {
+                        return msg.getParameters();
+                    }
+
+                    @Override
+                    public Throwable getThrowable()
+                    {
+                        return msg.getThrowable();
+                    }
+                }, throwable);
+            }
+            if (mgsLevel.isMoreSpecificThan(Level.WARN))
+            {
+                setErrorStatus(msg.getFormattedMessage());
+            }
+            write(msg.getFormattedMessage(), throwable, mgsLevel.getStandardLevel().name());
+        }
+
+        private void write(String message, @Nullable Throwable t, String level)
         {
             String formattedDate = DateUtil.formatDateTime(new Date(), datePattern);
 

--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -1527,7 +1527,7 @@ abstract public class PipelineJob extends Job implements Serializable
                     }
                 }, throwable);
             }
-            if (mgsLevel.isMoreSpecificThan(Level.WARN))
+            if (mgsLevel.isMoreSpecificThan(Level.ERROR))
             {
                 setErrorStatus(msg.getFormattedMessage());
             }

--- a/filecontent/src/org/labkey/filecontent/FileRootMaintenanceTask.java
+++ b/filecontent/src/org/labkey/filecontent/FileRootMaintenanceTask.java
@@ -93,11 +93,9 @@ public class FileRootMaintenanceTask implements MaintenanceTask
                 });
 
             if (finished.getValue())
-                //noinspection StringConcatenationArgumentToLogCall - pipeline logger doesn't support parameterized messages yet! Issue #51480
-                log.info("Completed crawling all " + rootCount.getValue() + " file roots");
+                log.info("Completed crawling all {} file roots", rootCount.getValue());
             else
-                //noinspection StringConcatenationArgumentToLogCall
-                log.info("Crawled " + rootCount.getValue() + " file roots before reaching the " + MAX_MINUTES + "-minute deadline. Crawling will continue during the next system maintenance run.");
+                log.info("Crawled {} file roots before reaching the {}-minute deadline. Crawling will continue during the next system maintenance run.", rootCount.getValue(), MAX_MINUTES);
         }
     }
 


### PR DESCRIPTION
#### Rationale
IntelliJ is encouraging us to switch to parameterized Log4J logging, so it's time for the pipeline job logger to catch up.

#### Changes
- Hook in at a lower level to support all variants of the various logging methods