### PR TITLE
Make it more likely that cancelled jobs won't end up in ERROR state

### DIFF
--- a/api/src/org/labkey/api/pipeline/CancelledException.java
+++ b/api/src/org/labkey/api/pipeline/CancelledException.java
@@ -15,14 +15,18 @@
  */
 package org.labkey.api.pipeline;
 
+import org.apache.logging.log4j.LoggingException;
+
 /**
  * Indicates that a pipeline job has been cancelled and no further work should be done for it.
  *
- * It would be reasonable to convert this to a checked exception, but it would involve changing a lot of method
- * signatures.
- * User: jeckels
- * Date: Feb 15, 2012
+ * Extend LoggingException so that Log4J lets it through. Otherwise, the exception can be suppressed in
+ * AbstractLogger.handleLogMessageException() when it happens in the context of a call to PipelineJob.error() or fatal()
  */
-public class CancelledException extends RuntimeException
+public class CancelledException extends LoggingException
 {
+    public CancelledException()
+    {
+        super((String)null);
+    }
 }

--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -416,7 +416,7 @@ abstract public class PipelineJob extends Job implements Serializable
         return _activeTaskStatus;
     }
 
-    /** @return whether or not the status was set successfully */
+    /** @return whether the status was set successfully */
     public boolean setActiveTaskStatus(@NotNull TaskStatus activeTaskStatus)
     {
         _activeTaskStatus = activeTaskStatus;
@@ -883,7 +883,7 @@ abstract public class PipelineJob extends Job implements Serializable
             getLogger().info("Skipping already completed task '" + factory.getId() + "' at location '" + factory.getExecutionLocation() + "'");
         }
 
-        if (getActiveTaskStatus() != TaskStatus.complete)
+        if (getActiveTaskStatus() != TaskStatus.complete && getActiveTaskStatus() != TaskStatus.cancelled)
             setActiveTaskStatus(TaskStatus.complete);
     }
 

--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -630,6 +630,7 @@ abstract public class PipelineJob extends Job implements Serializable
         // Rethrow so it doesn't get handled like other RuntimeExceptions
         catch (CancelledException e)
         {
+            _activeTaskStatus = TaskStatus.cancelled;
             throw e;
         }
         catch (RuntimeException e)
@@ -1527,11 +1528,15 @@ abstract public class PipelineJob extends Job implements Serializable
                     }
                 }, throwable);
             }
+
+            // Write to the job's log before setting the error status, which may end up throwing a CancelledException
+            // to signal that we need to bail out right away
+            write(msg.getFormattedMessage(), throwable, mgsLevel.getStandardLevel().name());
+
             if (mgsLevel.isMoreSpecificThan(Level.ERROR))
             {
                 setErrorStatus(msg.getFormattedMessage());
             }
-            write(msg.getFormattedMessage(), throwable, mgsLevel.getStandardLevel().name());
         }
 
         private void write(String message, @Nullable Throwable t, String level)

--- a/api/src/org/labkey/api/pipeline/PipelineJob.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJob.java
@@ -1488,7 +1488,7 @@ abstract public class PipelineJob extends Job implements Serializable
 
         public void setErrorStatus(Object message)
         {
-            if (_isSettingStatus)
+            if (_isSettingStatus || _job._activeTaskStatus == TaskStatus.cancelled)
                 return;
 
             _isSettingStatus = true;

--- a/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
@@ -207,7 +207,7 @@ public class PipelineStatusManager
             else
             {
                 boolean cancelled = false;
-                if ((PipelineJob.TaskStatus.cancelling.matches(sfExist.getStatus()) || PipelineJob.TaskStatus.cancelled.matches(sfExist.getStatus())) &&
+                if ((PipelineJob.TaskStatus.cancelling.matches(sfExist.getStatus())) &&
                         (sfSet.isActive() || PipelineJob.TaskStatus.error.matches(sfSet.getStatus())))
                 {
                     // Mark as officially dead

--- a/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
@@ -207,7 +207,7 @@ public class PipelineStatusManager
             else
             {
                 boolean cancelled = false;
-                if (PipelineJob.TaskStatus.cancelling.matches(sfExist.getStatus()) &&
+                if ((PipelineJob.TaskStatus.cancelling.matches(sfExist.getStatus()) || PipelineJob.TaskStatus.cancelled.matches(sfExist.getStatus())) &&
                         (sfSet.isActive() || PipelineJob.TaskStatus.error.matches(sfSet.getStatus())))
                 {
                     // Mark as officially dead


### PR DESCRIPTION
#### Rationale
There's a race condition for whether a job will end up CANCELLED or ERROR after it's cancelled. Making the job remember that it was cancelled prevents it from setting it to ERROR later

#### Changes
- Accurately track cancelled state in the job itself
- Reorder job logging to make sure we don't lose message