### PR TITLE
core.Containers should have only one key field

### DIFF
--- a/api/src/org/labkey/api/data/ContainerTable.java
+++ b/api/src/org/labkey/api/data/ContainerTable.java
@@ -31,7 +31,6 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.query.column.BuiltInColumnTypes;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
@@ -51,8 +50,6 @@ import java.util.TreeMap;
 /**
  * Wrapper class around the underlying database's core.containers table that adds virtual columns and sets up
  * custom rendering.
- * User: jeckels
- * Date: Feb 22, 2007
  */
 public class ContainerTable extends FilteredTable<UserSchema>
 {
@@ -83,14 +80,11 @@ public class ContainerTable extends FilteredTable<UserSchema>
 
         var entityIdColumn = getMutableColumn("EntityId");
         entityIdColumn.setHidden(true);
-        entityIdColumn.setKeyField(true);
         entityIdColumn.setReadOnly(true);
 
         getMutableColumn("RowId").setHidden(true);
         getMutableColumn("RowId").setReadOnly(true);
         getMutableColumn("RowId").setUserEditable(true);
-
-        var parentColumn = getMutableColumn("Parent");
 
         if (url == null)
             url = PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(ContainerManager.getRoot());
@@ -100,6 +94,7 @@ public class ContainerTable extends FilteredTable<UserSchema>
         MutableColumnInfo col = this.wrapColumn("ID", getRealTable().getColumn("RowId"));
         col.setReadOnly(true);
         col.setURL(detailsURL);
+        col.setKeyField(false); // RowId column is a key. We don't want to double post this value on delete, etc.
         this.addColumn(col);
 
         var name = getMutableColumn("Name");
@@ -177,9 +172,10 @@ public class ContainerTable extends FilteredTable<UserSchema>
         title.setURL(detailsURL);
 
         var activeModules = new AliasedColumn("ActiveModules", getColumn("RowId"));
-        activeModules.setDisplayColumnFactory(rowIdCol -> new ActiveModulesDisplayColumn(rowIdCol));
+        activeModules.setDisplayColumnFactory(ActiveModulesDisplayColumn::new);
         activeModules.setReadOnly(true);
         activeModules.setHidden(true);
+        activeModules.setKeyField(false);
         addColumn(activeModules);
 
         setTitleColumn("DisplayName");

--- a/core/resources/schemas/core.xml
+++ b/core/resources/schemas/core.xml
@@ -33,10 +33,18 @@
       <column columnName="Type"/>
       <column columnName="Title"/>
       <column columnName="Searchable"/>
-      <column columnName="LockState"/>
-      <column columnName="ExpirationDate"/>
-      <column columnName="FileRootSize"/>
-      <column columnName="FileRootLastCrawled"/>
+      <column columnName="LockState">
+        <isUserEditable>false</isUserEditable>
+      </column>
+      <column columnName="ExpirationDate">
+        <isUserEditable>false</isUserEditable>
+      </column>
+      <column columnName="FileRootSize">
+        <isUserEditable>false</isUserEditable>
+      </column>
+      <column columnName="FileRootLastCrawled">
+        <isUserEditable>false</isUserEditable>
+      </column>
     </columns>
   </table>
   <table tableName="Documents" tableDbType="TABLE">

--- a/core/src/org/labkey/core/workbook/WorkbooksTableInfo.java
+++ b/core/src/org/labkey/core/workbook/WorkbooksTableInfo.java
@@ -225,7 +225,7 @@ public class WorkbooksTableInfo extends ContainerTable implements UpdateableTabl
         @Override
         public DataIteratorBuilder createImportDIB(User user, Container container, DataIteratorBuilder data, DataIteratorContext context)
         {
-            // NOTE: we aren't using the StardardETL since it Path column is overriding the Name column
+            // NOTE: we aren't using the StandardETL since its Path column is overriding the Name column
             DataIteratorBuilder etl = LessThanStandardDIB.forInsert(getQueryTable(), data, container, user, context);
             return ((UpdateableTableInfo)getQueryTable()).persistRows(etl, context);
         }


### PR DESCRIPTION
#### Rationale
Adding `RowId` as the `core.Containers` primary key ended up giving us too many key columns (e.g., columns that wrap RowId), causing errors when attempting to delete a workbook.

Also, some recently added Container fields were appearing on the "edit workbook" page. They should not.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5952