### PR TITLE
Misc 24.11 Fixes

### DIFF
--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -1496,7 +1496,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                 }
             }
             // Issue 51136: insert calculated columns to match their index within defaultVisibleColumns (so that calc fields are closer to domain custom fields)
-            else if (!calculatedFieldKeys.isEmpty())
+            else if (!calculatedFieldKeys.isEmpty() && !getDefaultVisibleColumns().isEmpty())
             {
                 // find the index of the first calculated column
                 int index = 0;

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -1412,6 +1412,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
             }
 
             Map<FieldKey,ColumnInfo> existingColumns = new HashMap<>();
+            List<FieldKey> calculatedFieldKeys = new ArrayList<>();
             for (var col : _columnMap.values())
                 existingColumns.put(col.getFieldKey(), col);
 
@@ -1441,6 +1442,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                     HashSet<FieldKey> referencedColumns = new HashSet<>();
                     QueryService.get().bindQueryExpressionColumn(wrappedColumn, existingColumns, true, referencedColumns);
                     _referencedColumns.put(wrappedColumn.getFieldKey(), referencedColumns);
+                    calculatedFieldKeys.add(wrappedColumn.getFieldKey());
                     addColumn(wrappedColumn);
                 }
                 catch (QueryParseException qpe)
@@ -1450,33 +1452,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
                 }
             }
 
-            if (xmlTable.getUseColumnOrder())
-            {
-                // Reorder based on the sequence of columns in XML
-                Map<String, ColumnInfo> originalColumns = constructColumnMap();
-                assert initialColumnsAreAdded(); // getColumnNameSet() call above should have initialized the columns
-                originalColumns.putAll(_columnMap);
-                for (ColumnInfo columnInfo : originalColumns.values())
-                {
-                    // Remove all the existing columns
-                    removeColumn(columnInfo);
-                }
-                for (ColumnType xmlColumn : xmlTable.getColumns().getColumnArray())
-                {
-                    // Iterate through the ones in the XML and add them in the right order
-                    BaseColumnInfo column = (BaseColumnInfo)originalColumns.remove(xmlColumn.getColumnName());
-                    if (column != null)
-                    {
-                        addColumn(column);
-                    }
-                }
-                for (ColumnInfo column : originalColumns.values())
-                {
-                    // Read the rest of the columns that weren't in the XML. It's backed by a LinkedHashMap, so they'll
-                    // be in the same order they were in originally
-                    addColumn((BaseColumnInfo) column);
-                }
-            }
+            reorderColumns(xmlTable, calculatedFieldKeys);
         }
 
         if (xmlTable.getButtonBarOptions() != null)
@@ -1494,6 +1470,64 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
         }
 
         _warnings.addAll(warnings);
+    }
+
+    private void reorderColumns(TableType xmlTable, List<FieldKey> calculatedFieldKeys)
+    {
+        if (xmlTable.getUseColumnOrder() || !calculatedFieldKeys.isEmpty())
+        {
+            Map<String, ColumnInfo> originalColumns = constructColumnMap();
+            assert initialColumnsAreAdded(); // getColumnNameSet() call above should have initialized the columns
+            originalColumns.putAll(_columnMap);
+
+            // Remove all the existing columns
+            for (ColumnInfo columnInfo : originalColumns.values())
+                removeColumn(columnInfo);
+
+            // Iterate through the ones in the XML and add them in the right order
+            if (xmlTable.getUseColumnOrder())
+            {
+                // Iterate through the ones in the XML and add them in the right order
+                for (ColumnType xmlColumn : xmlTable.getColumns().getColumnArray())
+                {
+                    BaseColumnInfo column = (BaseColumnInfo) originalColumns.remove(xmlColumn.getColumnName());
+                    if (column != null)
+                        addColumn(column);
+                }
+            }
+            // Issue 51136: insert calculated columns to match their index within defaultVisibleColumns (so that calc fields are closer to domain custom fields)
+            else if (!calculatedFieldKeys.isEmpty())
+            {
+                // find the index of the first calculated column
+                int index = 0;
+                for (FieldKey defaultVisibleColumn : getDefaultVisibleColumns())
+                {
+                    if (calculatedFieldKeys.contains(defaultVisibleColumn))
+                        break;
+                    index++;
+                }
+                // add all columns up until the first calculated column
+                for (ColumnInfo column : originalColumns.values())
+                {
+                    addColumn((BaseColumnInfo) column);
+                    if (column.getFieldKey().equals(getDefaultVisibleColumns().get(index - 1)))
+                        break;
+                }
+                // add the calculated columns in the order they were defined
+                for (FieldKey calculatedFieldKey : calculatedFieldKeys)
+                {
+                    ColumnInfo column = originalColumns.get(calculatedFieldKey.toString());
+                    if (column != null && !_columnMap.containsKey(column.getName()))
+                        addColumn((BaseColumnInfo) column);
+                }
+            }
+
+            // Read the rest of the columns that weren't added back yet. It's backed by a LinkedHashMap, so they'll
+            // be in the same order they were in originally
+            for (ColumnInfo column : originalColumns.values())
+                if (!_columnMap.containsKey(column.getName()))
+                    addColumn((BaseColumnInfo) column);
+        }
     }
 
     protected void configureViaTableCustomizer(Collection<QueryException> errors, TableCustomizerType xmlCustomizer)

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -467,6 +467,10 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                 }
                 protocol.setProtocolParameters(newParams.values());
 
+                // Issue 51321: check reserved sample type name: First
+                if ("First".equalsIgnoreCase(assay.getName()) || "All".equalsIgnoreCase(assay.getName()))
+                    throw new ValidationException("Assay design name '" + assay.getName() + "' is reserved.");
+
                 if (hasNameChange)
                 {
                     if (AssayManager.get().getAssayProtocolByName(getContainer(), assay.getName()) != null)

--- a/assay/src/org/labkey/assay/actions/SaveProtocolAction.java
+++ b/assay/src/org/labkey/assay/actions/SaveProtocolAction.java
@@ -57,15 +57,7 @@ public class SaveProtocolAction extends MutatingApiAction<GWTProtocol>
         }
 
         if (protocol.getName() != null)
-        {
-            String protocolName = protocol.getName().trim();
-
-            // Issue 51321: check reserved sample type name: First
-            if ("First".equalsIgnoreCase(protocolName) || "All".equalsIgnoreCase(protocolName))
-                throw new IllegalArgumentException("Assay design name '" + protocolName + "' is reserved.");
-
-            protocol.setName(protocolName);
-        }
+            protocol.setName(protocol.getName().trim());
 
         AssayDomainService svc = new AssayDomainServiceImpl(getViewContext());
         GWTProtocol updated = svc.saveChanges(protocol, true);

--- a/assay/src/org/labkey/assay/actions/SaveProtocolAction.java
+++ b/assay/src/org/labkey/assay/actions/SaveProtocolAction.java
@@ -57,7 +57,15 @@ public class SaveProtocolAction extends MutatingApiAction<GWTProtocol>
         }
 
         if (protocol.getName() != null)
-            protocol.setName(protocol.getName().trim());
+        {
+            String protocolName = protocol.getName().trim();
+
+            // Issue 51321: check reserved sample type name: First
+            if ("First".equalsIgnoreCase(protocolName) || "All".equalsIgnoreCase(protocolName))
+                throw new IllegalArgumentException("Assay design name '" + protocolName + "' is reserved.");
+
+            protocol.setName(protocolName);
+        }
 
         AssayDomainService svc = new AssayDomainServiceImpl(getViewContext());
         GWTProtocol updated = svc.saveChanges(protocol, true);

--- a/core/src/org/labkey/core/view/configReportsAndScripts.jsp
+++ b/core/src/org/labkey/core/view/configReportsAndScripts.jsp
@@ -239,7 +239,7 @@
 
             if (selections.length == 0)
             {
-                Ext4.Msg.alert("Delete Engine Configuration", "There is no engine selected");
+                Ext4.Msg.show({title: 'Delete Engine Configuration', msg: 'There is no engine selected.', buttons: Ext4.Msg.OK, width: 200});
                 return false;
             }
 
@@ -248,13 +248,13 @@
 
             if (!record.external)
             {
-                Ext4.Msg.alert("Delete Engine Configuration", "JVM script engines cannot be deleted but you can disable them.");
+                Ext4.Msg.show({title: 'Delete Engine Configuration', msg: 'JVM script engines cannot be deleted but you can disable them.', buttons: Ext4.Msg.OK, width: 300});
                 return false;
             }
 
             if (record.default && countR > 1) {
                 // deletion of site default engine is not allowed, unless there is only one engine present
-                Ext4.Msg.alert("Delete Engine Configuration", "The site default R engine cannot be deleted. Please choose another engine as the site default prior to deleting this configuration.");
+                Ext4.Msg.show({title: 'Delete Engine Configuration', msg: 'The site default R engine cannot be deleted. Please choose another engine as the site default prior to deleting this configuration.', buttons: Ext4.Msg.OK, width: 400});
                 return false;
             }
 
@@ -282,7 +282,7 @@
             var selections = grid.getSelectionModel().getSelection();
             if (selections.length == 0)
             {
-                Ext4.Msg.alert("Edit Engine Configuration", "There is no engine selected");
+                Ext4.Msg.show({title: 'Edit Engine Configuration', msg: 'There is no engine selected.', buttons: Ext4.Msg.OK, width: 200});
                 return false;
             }
 
@@ -621,7 +621,7 @@
             var form = panel.getForm();
             if (form && !form.isValid())
             {
-                Ext4.Msg.alert('Engine Definition', 'Not all fields have been properly completed');
+                Ext4.Msg.show({title: 'Engine Definition', msg: 'Not all fields have been properly completed.', buttons: Ext4.Msg.OK, width: 300});
                 return false;
             }
 
@@ -631,12 +631,12 @@
             if (values.extensions  === R_EXTENSIONS) {
                 var rowId = values.rowId ? parseInt(values.rowId) : -1;
                 if (values.default && !values.enabled) {
-                    Ext4.Msg.alert("Engine Definition", "Site default engine must be enabled.");
+                    Ext4.Msg.show({title: 'Engine Definition', msg: 'Site default engine must be enabled.', buttons: Ext4.Msg.OK, width: 200});
                     return false;
                 }
 
                 if (!values.default && (defaultR && (rowId === defaultR.rowId))) {
-                    Ext4.Msg.alert("Engine Definition", "This engine is used as the site default. To change the site default, select another engine to use as the default.");
+                    Ext4.Msg.show({title: 'Engine Definition', msg: 'This engine is used as the site default. To change the site default, select another engine to use as the default.', buttons: Ext4.Msg.OK, width: 400});
                     return false;
                 }
 
@@ -647,7 +647,7 @@
                     }
                 }
                 else if (!values.default) {
-                    Ext4.Msg.alert('Engine Definition', 'Site default R engine missing. You must specify one R engine to be the site default.');
+                    Ext4.Msg.show({title: 'Engine Definition', msg: 'Site default R engine missing. You must specify one R engine to be the site default.', buttons: Ext4.Msg.OK, width: 300});
                     return false;
                 }
                 if (confirmChange && !confirm(confirmChange))

--- a/core/webapp/internal/ViewDesigner/tab/ColumnsTab.js
+++ b/core/webapp/internal/ViewDesigner/tab/ColumnsTab.js
@@ -266,7 +266,7 @@ Ext4.define('LABKEY.internal.ViewDesigner.tab.ColumnsTab', {
 
     validate : function() {
         if (this.getColumnStore().getCount() == 0) {
-            LABKEY.Utils.alert('Selection required', 'You must select at least one field to display in the grid.');
+            Ext4.Msg.show({title: 'Selection required', msg: 'You must select at least one field to display in the grid.', buttons: Ext4.Msg.OK, width: 320});
             return false;
 
             // XXX: check each fieldKey is selected only once


### PR DESCRIPTION
#### Rationale
Issue [51136](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51136): LKSM: Calculated Columns pushed to the bottom in the customize grid view
Issue [48684](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48684): Cutoff word in error message modal
Issue [51321](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51321): App sample parent issues when sample type is named "First"

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/850
- https://github.com/LabKey/premiumModules/pull/80

#### Changes
- Reorder columns in table info when calculated fields are added via `loadAllButCustomizerFromXML`
- Check for reserved names on assay design create/update: "First" and "All"
- use `Ext4.Msg.show` instead of `Ext4.Msg.alert` to prevent message clipping
