### PR TITLE
Plates: Importing assay runs for plates with replicates

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultDataTransformer.java
+++ b/api/src/org/labkey/api/assay/DefaultDataTransformer.java
@@ -150,7 +150,8 @@ public class DefaultDataTransformer<ProviderType extends AssayProvider> implemen
 
                         Map<String, String> paramMap = new HashMap<>();
 
-                        paramMap.put(RUN_INFO_REPLACEMENT, runInfo.toNioPathForWrite().toFile().getAbsolutePath());
+                        // Issue 51543: Resolve windows path to run properties
+                        paramMap.put(RUN_INFO_REPLACEMENT, runInfo.toNioPathForWrite().toFile().getAbsolutePath().replaceAll("\\\\", "/"));
 
                         addStandardParameters(context.getRequest(), context.getContainer(), scriptFile, session.getApiKey(), paramMap);
 

--- a/api/src/org/labkey/api/assay/pipeline/AssayRunAsyncContext.java
+++ b/api/src/org/labkey/api/assay/pipeline/AssayRunAsyncContext.java
@@ -74,6 +74,7 @@ public class AssayRunAsyncContext<ProviderType extends AssayProvider> implements
     /** RowIds for all the domains associated with properties we need to remember */
     private final Set<Integer> _domainIds = new HashSet<>();
     private Integer _reRunId;
+    private ReImportOption _reImportOption;
     private boolean _allowCrossRunFileInputs;
 
     private File _originalFileLocation;
@@ -116,6 +117,7 @@ public class AssayRunAsyncContext<ProviderType extends AssayProvider> implements
         _actionURL = originalContext.getActionURL();
         _uploadedData = CollectionUtils.checkValueClass(originalContext.getUploadedData(),FileLike.class);
         _reRunId = originalContext.getReRunId();
+        _reImportOption = originalContext.getReImportOption();
         _originalFileLocation = originalContext.getOriginalFileLocation();
 
         _batchProperties = originalContext.getBatchProperties();
@@ -383,6 +385,12 @@ public class AssayRunAsyncContext<ProviderType extends AssayProvider> implements
     public Integer getReRunId()
     {
         return _reRunId;
+    }
+
+    @Override
+    public ReImportOption getReImportOption()
+    {
+        return _reImportOption;
     }
 
     @Override

--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -22,7 +22,6 @@ import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.vfs.FileLike;
 
-import java.io.File;
 import java.util.List;
 import java.util.Map;
 
@@ -119,23 +118,28 @@ public interface AssayPlateMetadataService
     /**
      * Computes and inserts replicate statistics into the protocol schema table.
      *
-     * @param run The run associated with the replicate values, only required in the insert case
-     * @param forInsert Boolean value to indicate insert or update of the table rows
+     * @param run The run associated with the replicate values
      * @param replicateRows The assay result rows grouped by replicate well lsid.
      */
     void insertReplicateStats(
-            Container container,
-            User user,
-            ExpProtocol protocol,
-            @Nullable ExpRun run,
-            boolean forInsert,
-            Map<Lsid, List<Map<String, Object>>> replicateRows
+        Container container,
+        User user,
+        ExpProtocol protocol,
+        @NotNull ExpRun run,
+        Map<Lsid, List<Map<String, Object>>> replicateRows
+    ) throws ExperimentException;
+
+    void updateReplicateStats(
+        Container container,
+        User user,
+        ExpProtocol protocol,
+        Map<Lsid, List<Map<String, Object>>> replicateRows
     ) throws ExperimentException;
 
     void deleteReplicateStats(
-            Container container,
-            User user,
-            ExpProtocol protocol,
-            List<Map<String, Object>> keys
+        Container container,
+        User user,
+        ExpProtocol protocol,
+        List<Map<String, Object>> keys
     ) throws ExperimentException;
 }

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.17.0"
+        "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0"
       },
       "devDependencies": {
         "@labkey/build": "7.7.1",
@@ -2528,9 +2528,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.35.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.2.tgz",
-      "integrity": "sha512-ksOQ9GpkWyuL04p3h0lr2JvKwRfYR9xw5AH6KP5ZsCiX3ScqaJA30hHM6Qy+RD9vm+HRQvWsa41U3van+qJtaA=="
+      "version": "1.35.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.3.tgz",
+      "integrity": "sha512-ma6CTKkdPuGobJekbnI6VBoGSRJV9rzPo+wF0VuJ0+vTvinAWDBlrI4zm3Fam/FizyD8pOkZiBFjRprCXb4SfA=="
     },
     "node_modules/@labkey/build": {
       "version": "7.7.1",
@@ -2569,12 +2569,12 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.17.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.0.tgz",
-      "integrity": "sha512-PJKfsK9CF1cAJkg//VJGCMU/HaL14SsGaceHTywmm9TpCPoxL884+SsTymL2BGfET4msjjs44hmQFIwh7TOPsA==",
+      "version": "5.17.4-fb-assay-plate-import-ux.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.4-fb-assay-plate-import-ux.0.tgz",
+      "integrity": "sha512-HWDNljn+TTa7npX5JnAgFBrewIMWEJOGwk9gJ+4Qk5VRCCODif5cuT5COjaXToSB9yvCeoSs1zhAfPzart5mIQ==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
-        "@labkey/api": "1.35.2",
+        "@labkey/api": "1.35.3",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.5.0",
         "@testing-library/react": "~16.0.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0"
+        "@labkey/components": "5.17.4"
       },
       "devDependencies": {
         "@labkey/build": "7.7.1",
@@ -2569,9 +2569,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.17.4-fb-assay-plate-import-ux.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.4-fb-assay-plate-import-ux.0.tgz",
-      "integrity": "sha512-HWDNljn+TTa7npX5JnAgFBrewIMWEJOGwk9gJ+4Qk5VRCCODif5cuT5COjaXToSB9yvCeoSs1zhAfPzart5mIQ==",
+      "version": "5.17.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.4.tgz",
+      "integrity": "sha512-Xb9Dv2Eb2HnID4baig0Kq1rUBS0j8gLGAQOCujyjJ0X+rqYQgsGmwxRdy9szXn8Rg2GqiwpfriIWE4tZPG404A==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
         "@labkey/api": "1.35.3",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "5.17.0"
+    "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0"
   },
   "devDependencies": {
     "@labkey/build": "7.7.1",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0"
+    "@labkey/components": "5.17.4"
   },
   "devDependencies": {
     "@labkey/build": "7.7.1",

--- a/assay/src/org/labkey/assay/TSVProtocolSchema.java
+++ b/assay/src/org/labkey/assay/TSVProtocolSchema.java
@@ -236,7 +236,7 @@ public class TSVProtocolSchema extends AssayProtocolSchema
     }
 
     @Nullable
-    public TableInfo createPlateReplicateStatsTable(ContainerFilter cf, boolean allowInsertUpdate)
+    public TableInfo createPlateReplicateStatsTable(@Nullable ContainerFilter cf, boolean allowInsertUpdate)
     {
         Domain domain = AssayPlateMetadataService.get().getPlateReplicateStatsDomain(getProtocol());
         if (domain != null)

--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -98,7 +98,7 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
         Map<String, Object> batchProperties = null;
         String targetStudy;
         Integer reRunId;
-        AssayRunUploadContext.ReImportOption reImportOption;
+        AssayRunUploadContext.ReImportOption reImportOption = null;
         String runFilePath;
         String moduleName;
         List<Map<String, Object>> rawData = null;
@@ -152,7 +152,8 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
             // CONSIDER: Should we also look at the batch and run properties for the targetStudy?
             targetStudy = json.optString("targetStudy", null);
             reRunId = json.has("reRunId") ? json.optInt("reRunId") : null;
-            reImportOption = json.has("reImportOption") ? json.getEnum(AssayRunUploadContext.ReImportOption.class, "reImportOption") : AssayRunUploadContext.ReImportOption.REPLACE;
+            if (json.has("reImportOption"))
+                reImportOption = json.getEnum(AssayRunUploadContext.ReImportOption.class, "reImportOption");
             runFilePath = json.optString("runFilePath", null);
             moduleName = json.optString("module", null);
             auditUserComment  = json.optString("auditUserComment", null);
@@ -187,6 +188,14 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
             allowCrossRunFileInputs = form.isAllowCrossRunFileInputs();
             allowLookupByAlternateKey = form.isAllowLookupByAlternateKey();
             auditUserComment = form.getAuditUserComment();
+        }
+
+        if (reImportOption == null)
+        {
+            if (provider != null && protocol != null && provider.isPlateMetadataEnabled(protocol))
+                reImportOption = AssayRunUploadContext.ReImportOption.MERGE_DATA;
+            else
+                reImportOption = AssayRunUploadContext.ReImportOption.REPLACE;
         }
 
         // Import the file at runFilePath if it is available, otherwise AssayRunUploadContextImpl.getUploadedData() will use the multi-part form POSTed file
@@ -355,7 +364,7 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
         private String _name;
         private Integer _workflowTask;
         private Integer _reRunId;
-        private AssayRunUploadContext.ReImportOption _reImportOption = AssayRunUploadContext.ReImportOption.REPLACE;
+        private AssayRunUploadContext.ReImportOption _reImportOption;
         private String _targetStudy;
         private Map<String, Object> _properties = new HashMap<>();
         private Map<String, Object> _batchProperties = new HashMap<>();

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -444,7 +444,11 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                         .append(" JOIN ").append(ExperimentService.get().getTinfoData(), "ED")
                         .append(" ON AR.dataid = ED.rowid")
                         .append(" WHERE ED.runId = ? ").add(run.getRowId())
-                        .append(" AND AR.plate NOT ").appendInClause(prevPlateRowIDs, scope.getSqlDialect());
+                        .append(" AND AR.plate NOT IN (")
+                        .append(StringUtils.repeat("?", ", ", prevPlateRowIDs.size()))
+                        .append(")")
+                        .addAll(prevPlateRowIDs);
+
                 List<Integer> rowIds = new SqlSelector(scope, sql).getArrayList(Integer.class);
                 if (!rowIds.isEmpty())
                     PlateManager.get().deleteHits(protocol.getRowId(), rowIds);

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -480,7 +480,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         {
             for (ExpData data : expData.getRun().getDataOutputs())
             {
-                if (data.getDataType().getNamespacePrefix().equalsIgnoreCase(TsvDataHandler.NAMESPACE))
+                if (data.getDataType()!= null && data.getDataType().getNamespacePrefix().equalsIgnoreCase(TsvDataHandler.NAMESPACE))
                 {
                     if (data.getSourceApplication() != null)
                         return data;

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -360,23 +360,25 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         if (resultsTable == null)
             throw new ExperimentException(String.format("Unable to query the assay results for protocol : %s", protocol.getName()));
 
-        // The plate identifier is either a row ID or plate ID on incoming data, need to match that when merging
-        // existing data
-        Object plateObj = rows.get(0).get(AssayResultDomainKind.PLATE_COLUMN_NAME);
-        final FieldKey plateFieldKey;
-        if (plateObj instanceof String)
-            plateFieldKey = FieldKey.fromParts(AssayResultDomainKind.PLATE_COLUMN_NAME, PlateTable.Column.PlateId.name());
-        else
-            plateFieldKey = FieldKey.fromParts(AssayResultDomainKind.PLATE_COLUMN_NAME);
+        // The plate identifier is either a row ID or plate ID on incoming data, need to match that when merging existing data.
+        FieldKey plateFieldKey = FieldKey.fromParts(AssayResultDomainKind.PLATE_COLUMN_NAME);
+        // Note that in the case where there is a transform script on the assay design, the LK data parsing might not have
+        // found any rows and we might be deferring to the transform script to do that parsing. This block of code should
+        // be able to proceed in that case by just passing through all run results to the transform script for the run being replaced.
+        if (!rows.isEmpty())
+        {
+            Object plateObj = rows.get(0).get(AssayResultDomainKind.PLATE_COLUMN_NAME);
+            if (plateObj instanceof String)
+                plateFieldKey = FieldKey.fromParts(AssayResultDomainKind.PLATE_COLUMN_NAME, PlateTable.Column.PlateId.name());
+        }
 
+        FieldKey finalPlateFieldKey = plateFieldKey;
         List<FieldKey> columns = resultsTable.getDomain().getProperties().stream().map(dp -> {
             if (dp.getName().equalsIgnoreCase(AssayResultDomainKind.PLATE_COLUMN_NAME))
-                return plateFieldKey;
+                return finalPlateFieldKey;
             return FieldKey.fromParts(dp.getName());
         }).toList();
         Map<FieldKey, ColumnInfo> columnInfoMap = QueryService.get().getColumns(resultsTable, columns);
-        if (!columnInfoMap.containsKey(plateFieldKey))
-            throw new ExperimentException("The assay results doesn't have a plate column");
 
         List<Map<String, Object>> newRows = new ArrayList<>();
         Set<Integer> prevPlateRowIDs = new HashSet<>();

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -729,10 +729,15 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             }
         }
 
-        if (!multipleMeasures && measureProperties.size() != 1)
-            throw new ExperimentException("The assay protocol must have exactly one measure property to support graphical plate layout file parsing.");
-        else if (multipleMeasures && measureProperties.isEmpty())
-            throw new ExperimentException("There are multiple measures specified in the data file but the assay protocol does not define any measures");
+        // if we didn't parse any plate data from the input file, it is possible that a transform script might be
+        //  handling the file parsing so we don't want to error out here
+        if (!plateTypeGrids.isEmpty())
+        {
+            if (!multipleMeasures && measureProperties.size() != 1)
+                throw new ExperimentException("The assay protocol must have exactly one measure property to support graphical plate layout file parsing.");
+            else if (multipleMeasures && measureProperties.isEmpty())
+                throw new ExperimentException("There are multiple measures specified in the data file but the assay protocol does not define any measures");
+        }
 
         String defaultMeasureName = measureProperties.get(0).getName();
 

--- a/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
@@ -50,7 +50,7 @@ public class AssayPlateTriggerFactory implements TriggerFactory
      */
     private class ReplicateStatsTrigger implements Trigger
     {
-        private Map<String, Boolean> _replicateLsid = new HashMap<>();
+        private final Map<String, Boolean> _replicateLsid = new HashMap<>();
 
         private void checkForChanges(@Nullable Map<String, Object> oldRow, boolean isUpdate)
         {
@@ -64,60 +64,66 @@ public class AssayPlateTriggerFactory implements TriggerFactory
         }
 
         @Override
-        public void afterUpdate(TableInfo table, Container c, User user, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, ValidationException errors, Map<String, Object> extraContext) throws ValidationException
+        public void afterUpdate(TableInfo table, Container c, User user, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, ValidationException errors, Map<String, Object> extraContext)
         {
+            if (errors.hasErrors())
+                return;
+
             checkForChanges(oldRow, true);
         }
 
         @Override
-        public void afterDelete(TableInfo table, Container c, User user, @Nullable Map<String, Object> oldRow, ValidationException errors, Map<String, Object> extraContext) throws ValidationException
+        public void afterDelete(TableInfo table, Container c, User user, @Nullable Map<String, Object> oldRow, ValidationException errors, Map<String, Object> extraContext)
         {
+            if (errors.hasErrors())
+                return;
+
             checkForChanges(oldRow, false);
         }
 
         @Override
         public void complete(TableInfo table, Container c, User user, TableInfo.TriggerType event, BatchValidationException errors, Map<String, Object> extraContext)
         {
-            if (!_replicateLsid.isEmpty())
+            if (_replicateLsid.isEmpty() || errors.hasErrors())
+                return;
+
+            // recompute the stats for the changed replicate rows
+            AssayProvider provider = AssayService.get().getProvider(_protocol);
+            if (provider == null)
+                throw new IllegalStateException(String.format("Unable to find the provider for protocol : %s", _protocol.getName()));
+
+            AssayProtocolSchema schema = provider.createProtocolSchema(user, c, _protocol, null);
+            TableInfo dataTable = schema.createDataTable(null, false);
+            if (dataTable == null)
+                return;
+
+            try
             {
-                // recompute the stats for the changed replicate rows
-                AssayProvider provider = AssayService.get().getProvider(_protocol);
-                if (provider == null)
-                    throw new IllegalStateException(String.format("Unable to find the provider for protocol : %s", _protocol.getName()));
+                SimpleFilter filter = new SimpleFilter().addInClause(FieldKey.fromParts(AssayResultDomainKind.REPLICATE_LSID_COLUMN_NAME), _replicateLsid.keySet());
+                Map<Lsid, List<Map<String, Object>>> replicates = new HashMap<>();
 
-                AssayProtocolSchema schema = provider.createProtocolSchema(user, c, _protocol, null);
-                TableInfo dataTable = schema.createDataTable(null, false);
-                if (dataTable != null)
+                new TableSelector(dataTable, filter, null).getResults().forEach(row -> {
+                    var lsid = row.get(AssayResultDomainKind.REPLICATE_LSID_COLUMN_NAME);
+                    replicates.computeIfAbsent(Lsid.parse(String.valueOf(lsid)), m -> new ArrayList<>()).add(row);
+                    _replicateLsid.remove(lsid.toString());
+                });
+
+                // if results are being deleted, check if all rows for the well group have been deleted
+                List<Map<String, Object>> deletedRows = new ArrayList<>();
+                for (Map.Entry<String, Boolean> entry : _replicateLsid.entrySet())
                 {
-                    try
-                    {
-                        SimpleFilter filter = new SimpleFilter().addInClause(FieldKey.fromParts(AssayResultDomainKind.REPLICATE_LSID_COLUMN_NAME), _replicateLsid.keySet());
-                        Map<Lsid, List<Map<String, Object>>> replicates = new HashMap<>();
-
-                        new TableSelector(dataTable, filter, null).getResults().forEach(row -> {
-                            var lsid = row.get(AssayResultDomainKind.REPLICATE_LSID_COLUMN_NAME);
-                            replicates.computeIfAbsent(Lsid.parse(String.valueOf(lsid)), m -> new ArrayList<>()).add(row);
-                            _replicateLsid.remove(lsid.toString());
-                        });
-
-                        // if results are being deleted, check if all rows for the well group have been deleted
-                        List<Map<String, Object>> deletedRows = new ArrayList<>();
-                        for (Map.Entry<String, Boolean> entry : _replicateLsid.entrySet())
-                        {
-                            if (!entry.getValue())
-                                deletedRows.add(Map.of(PlateReplicateStatsDomainKind.Column.Lsid.name(), entry.getKey()));
-                        }
-
-                        if (!deletedRows.isEmpty())
-                            AssayPlateMetadataService.get().deleteReplicateStats(c, user, _protocol, deletedRows);
-
-                        AssayPlateMetadataService.get().insertReplicateStats(c, user, _protocol, null, false, replicates);
-                    }
-                    catch (ExperimentException e)
-                    {
-                        throw UnexpectedException.wrap(e);
-                    }
+                    if (!entry.getValue())
+                        deletedRows.add(Map.of(PlateReplicateStatsDomainKind.Column.Lsid.name(), entry.getKey()));
                 }
+
+                if (!deletedRows.isEmpty())
+                    AssayPlateMetadataService.get().deleteReplicateStats(c, user, _protocol, deletedRows);
+
+                AssayPlateMetadataService.get().updateReplicateStats(c, user, _protocol, replicates);
+            }
+            catch (ExperimentException e)
+            {
+                throw UnexpectedException.wrap(e);
             }
         }
     }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -508,7 +508,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 .stream().filter(provider::isPlateMetadataEnabled).toList();
 
         // get the runIds for each protocol, query against its assay results table
-        List<Integer> runIds = new ArrayList<>();
+        List<SQLFragment> fragments = new ArrayList<>();
         for (ExpProtocol protocol : protocols)
         {
             AssayProtocolSchema assayProtocolSchema = provider.createProtocolSchema(user, protocol.getContainer(), protocol, null);
@@ -518,23 +518,38 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 ColumnInfo dataIdCol = assayDataTable.getColumn("DataId");
                 if (dataIdCol != null)
                 {
-                    SQLFragment subSelectSql = new SQLFragment("SELECT DISTINCT dataid FROM ")
-                            .append(assayDataTable)
-                            .append(" WHERE plate = ?")
+                    SQLFragment subSelectSql = new SQLFragment("SELECT DISTINCT AD.DataId FROM ")
+                            .append(assayDataTable.getFromSQL("AD", Set.of(FieldKey.fromParts("DataId"), FieldKey.fromParts("Plate"))))
+                            .append(" WHERE AD.Plate = ?")
                             .add(plate.getRowId());
 
-                    SQLFragment sql = new SQLFragment("SELECT DISTINCT runid FROM ")
-                            .append(ExperimentService.get().getTinfoData())
-                            .append(" WHERE rowid IN (").append(subSelectSql).append(")");
+                    SQLFragment sql = new SQLFragment("SELECT DISTINCT D.RunId FROM\n")
+                            .append(ExperimentService.get().getTinfoData(), "D")
+                            .append(" INNER JOIN ")
+                            .append(ExperimentService.get().getTinfoExperimentRun(), "R")
+                            .append(" ON D.RunId = R.RowId\n")
+                            .append(" WHERE R.ReplacedByRunId IS NULL AND D.RowId IN (").append(subSelectSql).append(")\n");
 
-                    Collection<Integer> assayRunIds = new SqlSelector(ExperimentService.get().getSchema(), sql).getCollection(Integer.class);
-                    if (!assayRunIds.isEmpty())
-                        runIds.addAll(assayRunIds);
+                    fragments.add(sql);
                 }
             }
         }
 
-        return runIds;
+        if (fragments.isEmpty())
+            return emptyList();
+
+        SQLFragment sql = new SQLFragment();
+        String union = null;
+        for (SQLFragment fragment : fragments)
+        {
+            if (union == null)
+                union = "UNION\n";
+            else
+                sql.append(union);
+            sql.append(fragment);
+        }
+
+        return new SqlSelector(ExperimentService.get().getSchema(), sql).getArrayList(Integer.class);
     }
 
     private @Nullable SqlSelector selectRunUsingPlateTemplate(@NotNull Container c, @NotNull User user, @NotNull Plate plate)

--- a/assay/src/org/labkey/assay/plate/PlateReplicateStatsDomainKind.java
+++ b/assay/src/org/labkey/assay/plate/PlateReplicateStatsDomainKind.java
@@ -29,12 +29,6 @@ public class PlateReplicateStatsDomainKind extends AssayDomainKind
     public static final String ASSAY_PLATE_REPLICATE = ExpProtocol.ASSAY_DOMAIN_PREFIX + NAME;
     public static final String KIND_NAME = NAME + "DomainKind";
 
-    private static String XAR_SUBSTITUTION_SCHEMA_NAME = "SchemaName";
-    private static String XAR_SUBSTITUTION_TABLE_NAME = "TableName";
-
-    private static String DOMAIN_NAMESPACE_PREFIX_TEMPLATE = "%s-${SchemaName}";
-    private static String DOMAIN_LSID_TEMPLATE = "${FolderLSIDBase}:${TableName}";
-
     // replicate stats columns suffixes
     public static final String REPLICATE_MEAN_SUFFIX = "_Mean";
     public static final String REPLICATE_STD_DEV_SUFFIX = "_Standard_Deviation";
@@ -105,11 +99,11 @@ public class PlateReplicateStatsDomainKind extends AssayDomainKind
         try
         {
             XarContext xc = new XarContext("Domains", c, u);
-            xc.addSubstitution(XAR_SUBSTITUTION_SCHEMA_NAME, schemaName);
-            xc.addSubstitution(XAR_SUBSTITUTION_TABLE_NAME, PageFlowUtil.encode(tableName));
+            xc.addSubstitution("SchemaName", schemaName);
+            xc.addSubstitution("TableName", PageFlowUtil.encode(tableName));
 
-            String template = String.format(DOMAIN_NAMESPACE_PREFIX_TEMPLATE, namespacePrefix);
-            return LsidUtils.resolveLsidFromTemplate(DOMAIN_LSID_TEMPLATE, xc, template);
+            String template = String.format("%s-${SchemaName}", namespacePrefix);
+            return LsidUtils.resolveLsidFromTemplate("${FolderLSIDBase}:${TableName}", xc, template);
         }
         catch (XarFormatException xfe)
         {
@@ -133,8 +127,6 @@ public class PlateReplicateStatsDomainKind extends AssayDomainKind
      */
     public static List<String> getStatsFieldNames(String colName)
     {
-        return List.of(
-                colName + REPLICATE_MEAN_SUFFIX,
-                colName + REPLICATE_STD_DEV_SUFFIX);
+        return List.of(colName + REPLICATE_MEAN_SUFFIX, colName + REPLICATE_STD_DEV_SUFFIX);
     }
 }

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.17.2",
+        "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3488,9 +3488,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.17.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.2.tgz",
-      "integrity": "sha512-XU63Quz3EGjaK7zrbHfUufxX9nn9DEoJOlZVhQsY/pdQR3IoYjRWzi+WbrCVpGWzYAxVn87pscfEEQ52GH+BxA==",
+      "version": "5.17.4-fb-assay-plate-import-ux.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.4-fb-assay-plate-import-ux.0.tgz",
+      "integrity": "sha512-HWDNljn+TTa7npX5JnAgFBrewIMWEJOGwk9gJ+4Qk5VRCCODif5cuT5COjaXToSB9yvCeoSs1zhAfPzart5mIQ==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
         "@labkey/api": "1.35.3",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0",
+        "@labkey/components": "5.17.4",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3488,9 +3488,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.17.4-fb-assay-plate-import-ux.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.4-fb-assay-plate-import-ux.0.tgz",
-      "integrity": "sha512-HWDNljn+TTa7npX5JnAgFBrewIMWEJOGwk9gJ+4Qk5VRCCODif5cuT5COjaXToSB9yvCeoSs1zhAfPzart5mIQ==",
+      "version": "5.17.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.4.tgz",
+      "integrity": "sha512-Xb9Dv2Eb2HnID4baig0Kq1rUBS0j8gLGAQOCujyjJ0X+rqYQgsGmwxRdy9szXn8Rg2GqiwpfriIWE4tZPG404A==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
         "@labkey/api": "1.35.3",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "5.17.2",
+    "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0",
+    "@labkey/components": "5.17.4",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.17.1"
+        "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0"
       },
       "devDependencies": {
         "@labkey/build": "7.7.1",
@@ -3296,9 +3296,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.17.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.1.tgz",
-      "integrity": "sha512-9WcRUCl6I1fW23BJmuHWJSBjyNh0cka1L05fYNT2nlbFivgt2xXUg7xV5ebPMkzFU+spp80/c4Q9kmKGxaUdyA==",
+      "version": "5.17.4-fb-assay-plate-import-ux.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.4-fb-assay-plate-import-ux.0.tgz",
+      "integrity": "sha512-HWDNljn+TTa7npX5JnAgFBrewIMWEJOGwk9gJ+4Qk5VRCCODif5cuT5COjaXToSB9yvCeoSs1zhAfPzart5mIQ==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
         "@labkey/api": "1.35.3",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0"
+        "@labkey/components": "5.17.4"
       },
       "devDependencies": {
         "@labkey/build": "7.7.1",
@@ -3296,9 +3296,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.17.4-fb-assay-plate-import-ux.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.4-fb-assay-plate-import-ux.0.tgz",
-      "integrity": "sha512-HWDNljn+TTa7npX5JnAgFBrewIMWEJOGwk9gJ+4Qk5VRCCODif5cuT5COjaXToSB9yvCeoSs1zhAfPzart5mIQ==",
+      "version": "5.17.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.4.tgz",
+      "integrity": "sha512-Xb9Dv2Eb2HnID4baig0Kq1rUBS0j8gLGAQOCujyjJ0X+rqYQgsGmwxRdy9szXn8Rg2GqiwpfriIWE4tZPG404A==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
         "@labkey/api": "1.35.3",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "5.17.1"
+    "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0"
   },
   "devDependencies": {
     "@labkey/build": "7.7.1",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0"
+    "@labkey/components": "5.17.4"
   },
   "devDependencies": {
     "@labkey/build": "7.7.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.17.0"
+        "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0"
       },
       "devDependencies": {
         "@labkey/build": "7.7.1",
@@ -2701,9 +2701,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.35.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.2.tgz",
-      "integrity": "sha512-ksOQ9GpkWyuL04p3h0lr2JvKwRfYR9xw5AH6KP5ZsCiX3ScqaJA30hHM6Qy+RD9vm+HRQvWsa41U3van+qJtaA=="
+      "version": "1.35.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.3.tgz",
+      "integrity": "sha512-ma6CTKkdPuGobJekbnI6VBoGSRJV9rzPo+wF0VuJ0+vTvinAWDBlrI4zm3Fam/FizyD8pOkZiBFjRprCXb4SfA=="
     },
     "node_modules/@labkey/build": {
       "version": "7.7.1",
@@ -2742,12 +2742,12 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.17.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.0.tgz",
-      "integrity": "sha512-PJKfsK9CF1cAJkg//VJGCMU/HaL14SsGaceHTywmm9TpCPoxL884+SsTymL2BGfET4msjjs44hmQFIwh7TOPsA==",
+      "version": "5.17.4-fb-assay-plate-import-ux.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.4-fb-assay-plate-import-ux.0.tgz",
+      "integrity": "sha512-HWDNljn+TTa7npX5JnAgFBrewIMWEJOGwk9gJ+4Qk5VRCCODif5cuT5COjaXToSB9yvCeoSs1zhAfPzart5mIQ==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
-        "@labkey/api": "1.35.2",
+        "@labkey/api": "1.35.3",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.5.0",
         "@testing-library/react": "~16.0.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0"
+        "@labkey/components": "5.17.4"
       },
       "devDependencies": {
         "@labkey/build": "7.7.1",
@@ -2742,9 +2742,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.17.4-fb-assay-plate-import-ux.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.4-fb-assay-plate-import-ux.0.tgz",
-      "integrity": "sha512-HWDNljn+TTa7npX5JnAgFBrewIMWEJOGwk9gJ+4Qk5VRCCODif5cuT5COjaXToSB9yvCeoSs1zhAfPzart5mIQ==",
+      "version": "5.17.4",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.4.tgz",
+      "integrity": "sha512-Xb9Dv2Eb2HnID4baig0Kq1rUBS0j8gLGAQOCujyjJ0X+rqYQgsGmwxRdy9szXn8Rg2GqiwpfriIWE4tZPG404A==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
         "@labkey/api": "1.35.3",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "5.17.0"
+    "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0"
   },
   "devDependencies": {
     "@labkey/build": "7.7.1",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "5.17.4-fb-assay-plate-import-ux.0"
+    "@labkey/components": "5.17.4"
   },
   "devDependencies": {
     "@labkey/build": "7.7.1",


### PR DESCRIPTION
#### Rationale
Support re-import of plate-based assay runs.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1617
- https://github.com/LabKey/labkey-ui-premium/pull/572
- https://github.com/LabKey/limsModules/pull/855
- https://github.com/LabKey/platform/pull/5978

#### Changes
- Default to `ReImportOption.MERGE_DATA` for plate-based assay run re-import.
- Resolve plate identifiers to plate rowIds/plateIds when extracting data from tabular and graphical plate data.
- Bump `@labkey` packages.