### PR TITLE
Revert PK add to core.Containers

### DIFF
--- a/api/src/org/labkey/api/data/ContainerTable.java
+++ b/api/src/org/labkey/api/data/ContainerTable.java
@@ -78,8 +78,10 @@ public class ContainerTable extends FilteredTable<UserSchema>
         wrapAllColumns(true);
         getMutableColumn("_ts").setHidden(true);
 
+        // Although not designated as such in the DB (plus it's a nullable column), we treat EntityId as the PK
         var entityIdColumn = getMutableColumn("EntityId");
         entityIdColumn.setHidden(true);
+        entityIdColumn.setKeyField(true);
         entityIdColumn.setReadOnly(true);
 
         getMutableColumn("RowId").setHidden(true);
@@ -94,7 +96,6 @@ public class ContainerTable extends FilteredTable<UserSchema>
         MutableColumnInfo col = this.wrapColumn("ID", getRealTable().getColumn("RowId"));
         col.setReadOnly(true);
         col.setURL(detailsURL);
-        col.setKeyField(false); // RowId column is a key. We don't want to double post this value on delete, etc.
         this.addColumn(col);
 
         var name = getMutableColumn("Name");
@@ -175,7 +176,6 @@ public class ContainerTable extends FilteredTable<UserSchema>
         activeModules.setDisplayColumnFactory(ActiveModulesDisplayColumn::new);
         activeModules.setReadOnly(true);
         activeModules.setHidden(true);
-        activeModules.setKeyField(false);
         addColumn(activeModules);
 
         setTitleColumn("DisplayName");

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -3299,7 +3299,7 @@ public class DbScope
             final User user = TestContext.get().getUser();
 
             Lock lockUser = new ServerPrimaryKeyLock(true, CoreSchema.getInstance().getTableInfoUsersData(), user.getUserId());
-            Lock lockHome = new ServerPrimaryKeyLock(true, CoreSchema.getInstance().getTableInfoContainers(), ContainerManager.getHomeContainer().getRowId());
+            Lock lockHome = new ServerPrimaryKeyLock(true, CoreSchema.getInstance().getTableInfoContainers(), ContainerManager.getHomeContainer().getId());
 
             Pair<Throwable, Throwable> throwables = attemptToDeadlock(lockUser, lockHome, (x) -> {});
 

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 24.006
+SchemaVersion: 24.007
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-24.006-24.007.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-24.006-24.007.sql
@@ -1,0 +1,4 @@
+-- Adding a PK on RowId seemed like a good idea, but it broke existing lookups to core.Containers and other assumptions.
+-- We could add a PK on EntityId, but that column is currently nullable. For now, we'll just live without a PK.
+ALTER TABLE core.Containers DROP CONSTRAINT PK_Containers;
+ALTER TABLE core.Containers ADD CONSTRAINT UQ_Containers_RowId UNIQUE (RowId);

--- a/core/resources/schemas/dbscripts/sqlserver/core-24.006-24.007.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-24.006-24.007.sql
@@ -1,0 +1,4 @@
+-- Adding a PK on RowId seemed like a good idea, but it broke existing lookups to core.Containers and other assumptions.
+-- We could add a PK on EntityId, but that column is currently nullable. For now, we'll just live without a PK.
+ALTER TABLE core.Containers DROP CONSTRAINT PK_Containers;
+ALTER TABLE core.Containers ADD CONSTRAINT UQ_Containers_RowId UNIQUE CLUSTERED (RowId);


### PR DESCRIPTION
#### Rationale
My attempt to designate `core.Containers.RowId` as this table's PK failed. Too many code paths assume `EntityId` is the (pseudo) PK... for example, lookups to the Containers table. Best to revert it for now. Better would be to designate `EntityId` as an actual PK, but it's a nullable column so this is not a trivial change.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5952