### PR TITLE
Null checks for misc 24.11 exception reports

### DIFF
--- a/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
+++ b/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
@@ -713,8 +713,12 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
 
     protected @Nullable ModelAndView getAssayLinkedDataWarningView(ExpRun run)
     {
+        StudyPublishService service = StudyPublishService.get();
+        if (service == null) // Issue 51529
+            return null;
+
         final User user = getUser();
-        Set<? extends Dataset> datasets = StudyPublishService.get().getDatasetsForAssayRuns(Collections.singleton(run), user);
+        Set<? extends Dataset> datasets = service.getDatasetsForAssayRuns(Collections.singleton(run), user);
 
         if (!datasets.isEmpty())
         {

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1577,7 +1577,7 @@ public class AssayController extends SpringActionController
         {
             if (form.getState() == null)
                 errors.reject(ERROR_MSG, "QC State cannot be blank");
-            if (form.getRuns().isEmpty())
+            if (form.getRuns() == null || form.getRuns().isEmpty())
                 errors.reject(ERROR_MSG, "No runs were selected to update their QC State");
             else
             {


### PR DESCRIPTION
#### Rationale
Issue [51529](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51529): NullPointerException in org.labkey.api.assay.actions.UploadWizardAction.getAssayLinkedDataWarningView()

#### Related Pull Requests
- https://github.com/LabKey/commonAssays/pull/817

#### Changes
- Null check in AssayController.UpdateQCStateAction form.getRuns() check
- Issue 51529: Null check for StudyPublishService in UploadWizardAction.getAssayLinkedDataWarningView
