### PR TITLE
Issue 51521: Add switch to disable Server HTTP header

### DIFF
--- a/api/src/org/labkey/api/security/AuthFilter.java
+++ b/api/src/org/labkey/api/security/AuthFilter.java
@@ -57,6 +57,8 @@ public class AuthFilter implements Filter
     private static boolean _firstRequestHandled = false;
     private static volatile boolean _sslChecked = false;
     private static SecurityPointcutService _securityPointcut = null;
+    private static String _serverHeader = null;
+
 
     @Override
     public void init(FilterConfig filterConfig)
@@ -83,6 +85,15 @@ public class AuthFilter implements Filter
                 resp.setHeader("X-Frame-Options", AppProps.getInstance().getXFrameOption());
             resp.setHeader("X-Content-Type-Options", "nosniff");
             resp.setHeader("Referrer-Policy", "origin-when-cross-origin" );
+
+            if (AppProps.getInstance().isIncludeServerHttpHeader())
+            {
+                if (_serverHeader == null)
+                {
+                    _serverHeader =  "LabKey/" + AppProps.getInstance().getReleaseVersion();
+                }
+                resp.setHeader("Server", _serverHeader);
+            }
         }
 
         Throwable t = ModuleLoader.getInstance().getStartupFailure();

--- a/api/src/org/labkey/api/settings/AppProps.java
+++ b/api/src/org/labkey/api/settings/AppProps.java
@@ -231,6 +231,9 @@ public interface AppProps
 
     boolean isInvalidFilenameBlocked();
 
+    /** @return whether the server should include its name and version as a header in HTTP responses */
+    boolean isIncludeServerHttpHeader();
+
     /**
      *
      * @return List of configured external redirect hosts

--- a/api/src/org/labkey/api/settings/AppPropsImpl.java
+++ b/api/src/org/labkey/api/settings/AppPropsImpl.java
@@ -619,6 +619,12 @@ class AppPropsImpl extends AbstractWriteableSettingsGroup implements AppProps
     }
 
     @Override
+    public boolean isIncludeServerHttpHeader()
+    {
+        return lookupBooleanValue(includeServerHttpHeader, true);
+    }
+
+    @Override
     @NotNull
     public List<String> getExternalRedirectHosts()
     {

--- a/api/src/org/labkey/api/settings/SiteSettingsProperties.java
+++ b/api/src/org/labkey/api/settings/SiteSettingsProperties.java
@@ -196,6 +196,14 @@ public enum SiteSettingsProperties implements StartupProperty, SafeToRenderEnum
         {
             writeable.setNavAccessOpen(Boolean.parseBoolean(value));
         }
+    },
+    includeServerHttpHeader("If set to false, do not include a 'Server' header in HTTP responses")
+    {
+        @Override
+        public void setValue(WriteableAppProps writeable, String value)
+        {
+            writeable.setIncludeServerHttpHeader(Boolean.parseBoolean(value));
+        }
     };
 
     private final static Logger LOG = LogHelper.getLogger(SiteSettingsProperties.class, "Warnings about setting properties");

--- a/api/src/org/labkey/api/settings/WriteableAppProps.java
+++ b/api/src/org/labkey/api/settings/WriteableAppProps.java
@@ -174,6 +174,11 @@ public class WriteableAppProps extends AppPropsImpl
         storeBooleanValue(invalidFilenameBlocked, b);
     }
 
+    public void setIncludeServerHttpHeader(boolean b)
+    {
+        storeBooleanValue(includeServerHttpHeader, b);
+    }
+
     public void setAdministratorContactEmail(String email)
     {
         storeStringValue(administratorContactEmail, email);

--- a/api/src/org/labkey/api/view/ViewServlet.java
+++ b/api/src/org/labkey/api/view/ViewServlet.java
@@ -102,7 +102,6 @@ public class ViewServlet extends HttpServlet
     public static final String MOCK_REQUEST_CSRF = "Mock-Request-Inherently-Trusted-For-CSRF";
 
     private static ServletContext _servletContext = null;
-    private static String _serverHeader = null;
 
     private static final AtomicInteger _requestCount = new AtomicInteger();
     // NOTE: can't use ThreadLocal for this as you can't inspect the values for other threads
@@ -180,7 +179,6 @@ public class ViewServlet extends HttpServlet
 
         request.setAttribute(REQUEST_STARTTIME, startTime);
         UniqueID.initializeRequestScopedUID(request);
-        response.setHeader("Server", _serverHeader);
         HttpSession session = request.getSession(true);
 
         boolean isDebugEnabled = _log.isDebugEnabled();
@@ -321,8 +319,6 @@ public class ViewServlet extends HttpServlet
         initializeControllerMaps();
         initializeAllSpringControllers();
         securityPointcut = SecurityPointcutService.get();
-
-        _serverHeader =  "LabKey/" + AppProps.getInstance().getReleaseVersion();
     }
 
 

--- a/assay/src/org/labkey/assay/plate/PlateMetricsProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateMetricsProvider.java
@@ -191,7 +191,7 @@ public class PlateMetricsProvider implements UsageMetricsProvider
         Long standAlonePlateSetCount = new SqlSelector(schema.getSchema(), new SQLFragment("SELECT COUNT(*) FROM ").append(plateSetTable, "ps").append(" WHERE type =?").add(PlateSetType.assay).append(" AND rootplatesetid IS NULL")).getObject(Long.class);
         Long plateSetNoPlatesCount = plateSetPlatesCount(schema.getSchema(), plateSetTable, plateTable, 0);
         Long plateSetOnePlateCount = plateSetPlatesCount(schema.getSchema(), plateSetTable, plateTable, 1);
-        SQLFragment maxPlatesSql = new SQLFragment("SELECT MAX(count) FROM (").append(plateSetPlatesSQL(plateSetTable, plateTable)).append(")");
+        SQLFragment maxPlatesSql = new SQLFragment("SELECT MAX(count) FROM (").append(plateSetPlatesSQL(plateSetTable, plateTable)).append(") x");
         Long maxPlatesCount = new SqlSelector(schema.getSchema(), maxPlatesSql).getObject(Long.class);
         // too many items to use Map.of()
         Map<String, Long> plateSets = new HashMap<>();

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1378,6 +1378,7 @@ public class AdminController extends SpringActionController
                 return false;
             }
             props.setXFrameOption(frameOption);
+            props.setIncludeServerHttpHeader(form.isIncludeServerHttpHeader());
 
             props.save(getViewContext().getUser());
             UsageReportingLevel.reportNow();
@@ -2239,6 +2240,7 @@ public class AdminController extends SpringActionController
         private boolean _navAccessOpen;
 
         private String _XFrameOption;
+        private boolean _includeServerHttpHeader;
 
         public String getPipelineToolsDirectory()
         {
@@ -2478,6 +2480,16 @@ public class AdminController extends SpringActionController
         public void setXFrameOption(String XFrameOption)
         {
             _XFrameOption = XFrameOption;
+        }
+
+        public boolean isIncludeServerHttpHeader()
+        {
+            return _includeServerHttpHeader;
+        }
+
+        public void setIncludeServerHttpHeader(boolean includeServerHttpHeader)
+        {
+            _includeServerHttpHeader = includeServerHttpHeader;
         }
     }
 

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -433,6 +433,11 @@ Click the Save button at any time to accept the current settings and continue.</
         <option value="SAMEORIGIN" <%=selectedEq("SAMEORIGIN",option)%>>SAMEORIGIN</option>
         <option value="ALLOW" <%=selectedEq("ALLOW",option)%>>Allow</option></select></td>
 </tr>
+<tr><td colspan=3 class=labkey-title-area-line></td></tr>
+<tr>
+    <td class="labkey-form-label">Include a <code>Server</code> HTTP header in responses</td>
+    <td><labkey:checkbox id="<%=includeServerHttpHeader.name()%>" name="<%=includeServerHttpHeader.name()%>" checked="<%=AppProps.getInstance().isIncludeServerHttpHeader()%>" value="true"/></td>
+</tr>
 <tr>
     <td>&nbsp;</td>
 </tr>


### PR DESCRIPTION
#### Rationale
Some organizations don't like having the product and version identified in HTTP headers. We can make it optional.

#### Changes
- New site setting that lets admins opt-in or -out of the `Server` HTTP response header
- Move the setting of the header into `AuthFilter`, alongside other header setting, to be consistent across all responses
- Also fix SQL for new plate metrics