### PR TITLE
Issue 51500: Better WebDAV support for Editor w/o Delete role, part 2

### DIFF
--- a/core/src/org/labkey/core/webdav/WebFilesResolverImpl.java
+++ b/core/src/org/labkey/core/webdav/WebFilesResolverImpl.java
@@ -255,7 +255,7 @@ public class WebFilesResolverImpl extends AbstractWebdavResolver implements File
             if (user.isGuest() || !hasAccess(user))
                 return false;
             Set<Class<? extends Permission>> perms = getPermissions(user);
-            return perms.contains(UpdatePermission.class) || perms.contains(DeletePermission.class);
+            return perms.contains(DeletePermission.class);
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
The UI was also inconsistent in the optional _webfiles structure. Same style of permission checks for WebDAV delete for the semi-recently-introduced "Editor without Delete" role

#### Changes
- Consistent check for deletion