### PR TITLE
Allow adding alternate keys to dataiterator

### DIFF
--- a/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
@@ -22,6 +22,7 @@ import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.QueryUpdateService;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -227,7 +228,12 @@ public class DataIteratorContext
     @NotNull
     public Set<String> getAlternateKeys()
     {
-        return _alternateKeys;
+         return  Collections.unmodifiableSet(_alternateKeys);
+    }
+
+    public void addAlternateKeys(Set<String> alternateKeys)
+    {
+        _alternateKeys.addAll(alternateKeys);
     }
 
     /** if this etl should be killed, will execute <code>throw _errors;</code> */


### PR DESCRIPTION
#### Rationale
Add adder and update getter for alt keys.

#### Related Pull Requests
- https://github.com/LabKey/dataintegration/pull/280
- https://github.com/LabKey/ehrModules/pull/854
- https://github.com/LabKey/snd/pull/242

#### Changes
- Change getter to return unmodifiable set.
- Add addAlternateKeys
