### PR TITLE
Issue 51483: DB query can be left running after shutting down server

### DIFF
--- a/api/src/org/labkey/api/data/ConnectionWrapper.java
+++ b/api/src/org/labkey/api/data/ConnectionWrapper.java
@@ -27,9 +27,11 @@ import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.StatementWrapper;
 import org.labkey.api.data.queryprofiler.QueryProfiler;
 import org.labkey.api.miniprofiler.MiniProfiler;
+import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.LoggerWriter;
 import org.labkey.api.util.MemTracker;
+import org.labkey.api.util.ShutdownListener;
 import org.labkey.api.util.SimpleLoggerWriter;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ViewServlet;
@@ -52,7 +54,9 @@ import java.sql.Statement;
 import java.sql.Struct;
 import java.text.DateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -99,6 +103,43 @@ public class ConnectionWrapper implements java.sql.Connection
     private Throwable _suspiciousCloseStackTrace;
 
     private volatile boolean _allowClose = true;
+
+    static
+    {
+        // Issue 51483: DB query can be left running after shutting down server
+        ContextListener.addShutdownListener(ShutdownListener.of("DB connection closer", null, () -> {
+
+            // Only kill connections that have been open for more than two seconds to avoid
+            // interrupting work related to the shutdown
+            Calendar cutoffCal = Calendar.getInstance();
+            cutoffCal.add(Calendar.SECOND, -2);
+            Date cutoffDate = new Date(cutoffCal.getTimeInMillis());
+
+            // Build up the list and release the lock on _openConnections
+            List<ConnectionWrapper> toClose = new ArrayList<>();
+            for (ConnectionWrapper openConnection : _openConnections)
+            {
+                if (openConnection._allocationTime.before(cutoffDate))
+                {
+                    toClose.add(openConnection);
+                }
+            }
+
+            // Close the connections
+            for (ConnectionWrapper connectionWrapper : toClose)
+            {
+                try
+                {
+                    LOG.info("Forcibly closing DB connection prior to shut down: {}", connectionWrapper);
+                    connectionWrapper.close();
+                }
+                catch (Exception e)
+                {
+                    LOG.warn("Failed to cleanly shut down connection: {}", connectionWrapper, e);
+                }
+            }
+        }));
+    }
 
     private static boolean initializeExplicitLogger()
     {
@@ -885,7 +926,7 @@ public class ConnectionWrapper implements java.sql.Connection
     @Override
     public String toString()
     {
-        return "Connection wrapper " + _count + " for SPID " + _spid + ", originally allocated to thread " + _allocatingThread.getName() + " at " + DateFormat.getInstance().format(_allocationTime) + ", real connection: " + System.identityHashCode(_connection) + " - " + _connection.getClass() + (_referencingThreadNames.size() > 1 ? (", accessed by threads: " + _referencingThreadNames) : "");
+        return "Connection wrapper " + _count + " for SPID " + _spid + ", originally allocated to thread " + _allocatingThread.getName() + " at " + DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM).format(_allocationTime) + ", real connection: " + System.identityHashCode(_connection) + " - " + _connection.getClass() + (_referencingThreadNames.size() > 1 ? (", accessed by threads: " + _referencingThreadNames) : "");
     }
 
 

--- a/api/src/org/labkey/api/data/DbSequenceManager.java
+++ b/api/src/org/labkey/api/data/DbSequenceManager.java
@@ -76,30 +76,13 @@ public class DbSequenceManager
     // we are totally 'leaking' these sequences, however a) they are small b) we leak < 2 a day, so...
     static final ConcurrentHashMap<String, DbSequence.Preallocate> _sequences = new ConcurrentHashMap<>();
 
-    static final ShutdownListener shutdownListener = new ShutdownListener()
-    {
-        @Override
-        public String getName()
+    static final ShutdownListener shutdownListener = ShutdownListener.of("DbSequenceManager", null, () -> {
+        synchronized (_sequences)
         {
-            return "DbSequenceManager";
+            for (var seq : _sequences.values())
+                seq.sync();
         }
-
-        @Override
-        public void shutdownPre()
-        {
-            // pass
-        }
-
-        @Override
-        public void shutdownStarted()
-        {
-            synchronized (_sequences)
-            {
-                for (var seq : _sequences.values())
-                    seq.sync();
-            }
-        }
-    };
+    });
 
     static
     {

--- a/api/src/org/labkey/api/util/ShutdownListener.java
+++ b/api/src/org/labkey/api/util/ShutdownListener.java
@@ -16,6 +16,9 @@
 
 package org.labkey.api.util;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Callback to be notified when the server is shutting down. Complement to {@link StartupListener}.
  * User: brittp
@@ -32,10 +35,46 @@ public interface ShutdownListener
      * called first, should be used only for non-blocking operations (set _shuttingDown=true, interrupt threads)
      * also possible to launch an async shutdown task here!
      */
-    void shutdownPre();
+    default void shutdownPre() {}
 
     /**
      * perform shutdown tasks
      */
-    void shutdownStarted();
+    default void shutdownStarted() {}
+
+    static ShutdownListener of(@NotNull String name, Runnable preShutdown)
+    {
+        return of(name, preShutdown, null);
+    }
+
+    static ShutdownListener of(String name, @Nullable Runnable preShutdown, @Nullable Runnable shutdown)
+    {
+        return new ShutdownListener()
+        {
+            @Override
+            public String getName()
+            {
+                return name;
+            }
+
+            @Override
+            public void shutdownStarted()
+            {
+                if (shutdown != null)
+                {
+                    shutdown.run();
+                }
+
+            }
+
+            @Override
+            public void shutdownPre()
+            {
+                if (preShutdown != null)
+                {
+                    preShutdown.run();
+                }
+            }
+        };
+    }
 }

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -958,24 +958,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         }
         ContextListener.addShutdownListener(TempTableTracker.getShutdownListener());
         ContextListener.addShutdownListener(DavController.getShutdownListener());
-        ContextListener.addShutdownListener(new ShutdownListener()
-        {
-            @Override
-            public String getName()
-            {
-                return "Temp file cleanup";
-            }
-
-            @Override
-            public void shutdownPre()
-            {}
-
-            @Override
-            public void shutdownStarted()
-            {
-                deleteTempFiles();
-            }
-        });
+        ContextListener.addShutdownListener(ShutdownListener.of("Temp file cleanup", null, this::deleteTempFiles));
 
         SimpleMetricsService.setInstance(new SimpleMetricsServiceImpl());
 

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -6582,26 +6582,10 @@ public class DavController extends SpringActionController
 
     public static ShutdownListener getShutdownListener()
     {
-        return new ShutdownListener()
-        {
-            @Override
-            public String getName()
-            {
-                return "Temp file deletion";
-            }
-
-            @Override
-            public void shutdownPre()
-            {
-            }
-
-            @Override
-            public void shutdownStarted()
-            {
-                for (Object path : _tempFiles.toArray())
-                    new File((String)path).delete();
-            }
-        };
+        return ShutdownListener.of("Temp file deletion", null, () -> {
+                for (String path : new ArrayList<>(_tempFiles))
+                    new File(path).delete();
+            });
     }
 
 
@@ -6731,14 +6715,14 @@ public class DavController extends SpringActionController
         }
 
         @Override
-        public int read(byte[] bytes) throws IOException
+        public int read(@NotNull byte[] bytes) throws IOException
         {
             access();
             return super.read(bytes, 0, bytes.length);
         }
 
         @Override
-         public int read(byte[] bytes, int i, int i1) throws IOException
+         public int read(byte @NotNull [] bytes, int i, int i1) throws IOException
         {
             access();
             return super.read(bytes, i, i1);
@@ -6766,23 +6750,25 @@ public class DavController extends SpringActionController
         {
             // Test that we don't blow up on bogus input
             assertNull(getLastModified(new ByteArrayInputStream("<badXML".getBytes(StringUtilsLabKey.DEFAULT_CHARSET))));
-            assertNull(getLastModified(new ByteArrayInputStream(("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n" +
-                    "<D:propertyupdate xmlns:D=\"DAV:\" xmlns:Z=\"urn:schemas-microsoft-com:\">\n" +
-                    " <D:set>\n" +
-                    "   <D:prop>\n" +
-                    "     <Z:Win32LastModifiedTime>BogusDate</Z:Win32LastModifiedTime>\n" +
-                    "   </D:prop>\n" +
-                    " </D:set>\n" +
-                    "</D:propertyupdate>").getBytes(StringUtilsLabKey.DEFAULT_CHARSET))));
+            assertNull(getLastModified(new ByteArrayInputStream(("""
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <D:propertyupdate xmlns:D="DAV:" xmlns:Z="urn:schemas-microsoft-com:">
+                     <D:set>
+                       <D:prop>
+                         <Z:Win32LastModifiedTime>BogusDate</Z:Win32LastModifiedTime>
+                       </D:prop>
+                     </D:set>
+                    </D:propertyupdate>""").getBytes(StringUtilsLabKey.DEFAULT_CHARSET))));
 
-            assertEquals(FileTime.fromMillis(1540256025000l), getLastModified(new ByteArrayInputStream(("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n" +
-                    "<D:propertyupdate xmlns:D=\"DAV:\" xmlns:Z=\"urn:schemas-microsoft-com:\">\n" +
-                    " <D:set>\n" +
-                    "   <D:prop>\n" +
-                    "     <Z:Win32LastModifiedTime>Tue, 23 Oct 2018 00:53:45 GMT</Z:Win32LastModifiedTime>\n" +
-                    "   </D:prop>\n" +
-                    " </D:set>\n" +
-                    "</D:propertyupdate>").getBytes(StringUtilsLabKey.DEFAULT_CHARSET))));
+            assertEquals(FileTime.fromMillis(1540256025000L), getLastModified(new ByteArrayInputStream(("""
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <D:propertyupdate xmlns:D="DAV:" xmlns:Z="urn:schemas-microsoft-com:">
+                     <D:set>
+                       <D:prop>
+                         <Z:Win32LastModifiedTime>Tue, 23 Oct 2018 00:53:45 GMT</Z:Win32LastModifiedTime>
+                       </D:prop>
+                     </D:set>
+                    </D:propertyupdate>""").getBytes(StringUtilsLabKey.DEFAULT_CHARSET))));
         }
 
         @Test

--- a/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
@@ -180,6 +180,7 @@ public class PipelineStatusManager
             // We're shutting down so it's likely that failures are from us killing DB connections to interrupt
             // long-running queries. Don't put them in the error state so jobs will resume on startup (and can be
             // cancelled by admins then if desired)
+            // See issues 51483 and 51385
             return true;
         }
 

--- a/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineStatusManager.java
@@ -48,7 +48,9 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.ConfigurationException;
+import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.ShutdownListener;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
@@ -82,6 +84,13 @@ public class PipelineStatusManager
 
     private static final PipelineSchema _schema = PipelineSchema.getInstance();
     private static final Logger LOG = LogHelper.getLogger(PipelineStatusManager.class, "Manages setting states for pipeline jobs");
+
+    private static boolean _shuttingDown = false;
+
+    static
+    {
+        ContextListener.addShutdownListener(ShutdownListener.of("PipelineStatusManager", () -> _shuttingDown = true));
+    }
 
     public static TableInfo getTableInfo()
     {
@@ -166,6 +175,14 @@ public class PipelineStatusManager
 
     public static boolean setStatusFile(PipelineJob job, User user, String status, @Nullable String info, boolean allowInsert)
     {
+        if (_shuttingDown && PipelineJob.TaskStatus.error.matches(status))
+        {
+            // We're shutting down so it's likely that failures are from us killing DB connections to interrupt
+            // long-running queries. Don't put them in the error state so jobs will resume on startup (and can be
+            // cancelled by admins then if desired)
+            return true;
+        }
+
         try
         {
             PipelineStatusFileImpl sfExist = getJobStatusFile(job.getJobGUID());

--- a/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
@@ -743,11 +743,6 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
         {
             interrupt();
         }
-
-        @Override
-        public void shutdownStarted()
-        {
-        }
     }
 
     // Unfortunately complex generics here. In English, the container key of the outer map is the source


### PR DESCRIPTION
#### Rationale
Postgres doesn't always notice when the web server shuts down. Some connections and queries can linger for many minutes or hours depending on exactly what they're doing.

Explicitly closing the connection prior to shutdown helps in at least some cases.

#### Changes
- New shutdown listener that slams closed any connection that's been open for more than two seconds (to avoid interfering with DB connections related to the shutdown itself)
- Avoid moving pipeline jobs to ERROR state if the error is encountered during shutdown, as it's likely it's caused by slamming the DB connection closed and we want to restart the job
- Easier mechanism for registering simple shutdown listeners
- Convert a few shutdown listeners to the new registration mechanism