### PR TITLE
Issue 51557: fix counts for folder deletion summary

### DIFF
--- a/api/src/org/labkey/api/exp/query/ExpSampleTypeTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpSampleTypeTable.java
@@ -16,10 +16,8 @@
 
 package org.labkey.api.exp.query;
 
-/**
- * User: jeckels
- * Date: Oct 17, 2007
- */
+import org.labkey.api.query.FieldKey;
+
 public interface ExpSampleTypeTable extends ExpTable<ExpSampleTypeTable.Column>
 {
     enum Column
@@ -58,6 +56,11 @@ public interface ExpSampleTypeTable extends ExpTable<ExpSampleTypeTable.Column>
         Alias,
         Inputs,
         Outputs,
-        Properties
+        Properties;
+
+        public FieldKey fieldKey()
+        {
+            return FieldKey.fromParts(name());
+        }
     }
 }

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -386,7 +386,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     }
 
     @Override
-    public List<Summary> getDetailedSummary(Container c)
+    public @NotNull List<Summary> getDetailedSummary(Container c, User user)
     {
         return Collections.emptyList();
     }

--- a/api/src/org/labkey/api/module/MockModule.java
+++ b/api/src/org/labkey/api/module/MockModule.java
@@ -201,7 +201,7 @@ public class MockModule implements Module
     }
 
     @Override
-    public List<Summary> getDetailedSummary(Container c)
+    public @NotNull List<Summary> getDetailedSummary(Container c, User user)
     {
         return Collections.emptyList();
     }

--- a/api/src/org/labkey/api/module/Module.java
+++ b/api/src/org/labkey/api/module/Module.java
@@ -197,9 +197,10 @@ public interface Module
 
     /**
      * @param c container in which the items would be stored
+     * @param user user requesting the detailed summary
      * @return Description of the objects that this module has stored in the container. Used for deletion summary report in the products.
      */
-    List<Summary> getDetailedSummary(Container c);
+    @NotNull List<Summary> getDetailedSummary(Container c, User user);
 
     /**
      * Returns a map of pageflow name to controller class (for example, "wiki" -> WikiController) whose

--- a/api/src/org/labkey/api/module/Summary.java
+++ b/api/src/org/labkey/api/module/Summary.java
@@ -9,7 +9,7 @@ import org.json.JSONObject;
  */
 public class Summary
 {
-    private final int count;
+    private final long count;
     private final String nounSingular;
     private final String nounPlural;
 
@@ -37,14 +37,14 @@ public class Summary
         return StringUtils.replaceEach(nounSingular, search, replacements);
     }
 
-    public Summary(final int count, final String nounSingular, final String nounPlural)
+    public Summary(final long count, final String nounSingular, final String nounPlural)
     {
         this.count = count;
         this.nounSingular = nounSingular;
         this.nounPlural = nounPlural;
     }
 
-    public Summary(final int count, final String nounSingular)
+    public Summary(final long count, final String nounSingular)
     {
         String nounName = replaceNounTitles(nounSingular);
 

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.17.8"
+        "@labkey/components": "5.19.1"
       },
       "devDependencies": {
         "@labkey/build": "8.0.0",
@@ -2528,9 +2528,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.35.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.4.tgz",
-      "integrity": "sha512-7wJ6HKcCQiG/w6lQ4dY/BeTTrEUBdBBGkOGQjdqdbMfMAl0VqydojdGWHSw0qcg6H442VaYrq24hMUUkY2visQ=="
+      "version": "1.35.6",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.6.tgz",
+      "integrity": "sha512-sRXZZU4FbhKHI4SDQ2wHSYt8uvQPwD/jvP5Yh68nm+6r9spsn6EbOhBuR5LAL4WMmMnsXAmmCdwN1JZ3IGg/Cw=="
     },
     "node_modules/@labkey/build": {
       "version": "8.0.0",
@@ -2569,12 +2569,12 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.17.8",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.8.tgz",
-      "integrity": "sha512-YuxbkuggIEXIpePB9h32+c03ZvLhkt2P29bNautpeQ4nVpuBLrdLUuqPjqaDV+3VwxWgle1BPVVPnN4l0I8lMQ==",
+      "version": "5.19.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.19.1.tgz",
+      "integrity": "sha512-KysPfDQrjWf7p3b4X6nOxlqBtMwWmqsrdZY+pQQirwC2n7DOVWlfcbj2oVKc4NP3pxttX1MAx7rIbLQwaX+ViA==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
-        "@labkey/api": "1.35.4",
+        "@labkey/api": "1.35.6",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.5.0",
         "@testing-library/react": "~16.0.1",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "5.17.8"
+    "@labkey/components": "5.19.1"
   },
   "devDependencies": {
     "@labkey/build": "8.0.0",

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -284,13 +284,6 @@ public class AssayModule extends SpringModule
 
     @Override
     @NotNull
-    public Collection<String> getSummary(Container c)
-    {
-        return Collections.emptyList();
-    }
-
-    @Override
-    @NotNull
     public Set<String> getSchemaNames()
     {
         HashSet<String> set = new HashSet<>();

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.17.8",
+        "@labkey/components": "5.19.1",
         "@labkey/themes": "1.3.3"
       },
       "devDependencies": {
@@ -3447,9 +3447,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.35.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.4.tgz",
-      "integrity": "sha512-7wJ6HKcCQiG/w6lQ4dY/BeTTrEUBdBBGkOGQjdqdbMfMAl0VqydojdGWHSw0qcg6H442VaYrq24hMUUkY2visQ=="
+      "version": "1.35.6",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.6.tgz",
+      "integrity": "sha512-sRXZZU4FbhKHI4SDQ2wHSYt8uvQPwD/jvP5Yh68nm+6r9spsn6EbOhBuR5LAL4WMmMnsXAmmCdwN1JZ3IGg/Cw=="
     },
     "node_modules/@labkey/build": {
       "version": "8.0.0",
@@ -3488,12 +3488,12 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.17.8",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.8.tgz",
-      "integrity": "sha512-YuxbkuggIEXIpePB9h32+c03ZvLhkt2P29bNautpeQ4nVpuBLrdLUuqPjqaDV+3VwxWgle1BPVVPnN4l0I8lMQ==",
+      "version": "5.19.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.19.1.tgz",
+      "integrity": "sha512-KysPfDQrjWf7p3b4X6nOxlqBtMwWmqsrdZY+pQQirwC2n7DOVWlfcbj2oVKc4NP3pxttX1MAx7rIbLQwaX+ViA==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
-        "@labkey/api": "1.35.4",
+        "@labkey/api": "1.35.6",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.5.0",
         "@testing-library/react": "~16.0.1",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "5.17.8",
+    "@labkey/components": "5.19.1",
     "@labkey/themes": "1.3.3"
   },
   "devDependencies": {

--- a/core/src/org/labkey/core/CoreController.java
+++ b/core/src/org/labkey/core/CoreController.java
@@ -201,7 +201,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.labkey.api.view.template.WarningService.SESSION_WARNINGS_BANNER_KEY;
@@ -1674,11 +1673,11 @@ public class CoreController extends SpringActionController
 
             for (Module m : ModuleLoader.getInstance().getModules())
             {
-                List<Summary> summaries = m.getDetailedSummary(getContainer());
+                List<Summary> summaries = m.getDetailedSummary(getContainer(), getUser());
                 allSummaries.addAll(summaries);
             }
 
-            return new ApiSimpleResponse("moduleSummary", allSummaries.stream().map(Summary::toJSON).collect(Collectors.toList()));
+            return new ApiSimpleResponse("moduleSummary", allSummaries.stream().map(Summary::toJSON).toList());
         }
     }
 

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1332,12 +1332,12 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     }
 
     @Override
-    public List<Summary> getDetailedSummary(Container c)
+    public @NotNull List<Summary> getDetailedSummary(Container c, User user)
     {
-        int childContainerCount = ((Long) ContainerManager.getChildren(c).stream().filter(Container::isInFolderNav).count()).intValue();
-        return childContainerCount > 0
-                ? List.of(new Summary(childContainerCount, "Subfolder"))
-                : new ArrayList<>();
+        long childContainerCount = ContainerManager.getChildren(c).stream().filter(Container::isInFolderNav).count();
+        if (childContainerCount == 0)
+            return Collections.emptyList();
+        return List.of(new Summary(childContainerCount, "Subfolder"));
     }
 
     @Override

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.17.8"
+        "@labkey/components": "5.19.1"
       },
       "devDependencies": {
         "@labkey/build": "8.0.0",
@@ -3255,9 +3255,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.35.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.4.tgz",
-      "integrity": "sha512-7wJ6HKcCQiG/w6lQ4dY/BeTTrEUBdBBGkOGQjdqdbMfMAl0VqydojdGWHSw0qcg6H442VaYrq24hMUUkY2visQ=="
+      "version": "1.35.6",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.6.tgz",
+      "integrity": "sha512-sRXZZU4FbhKHI4SDQ2wHSYt8uvQPwD/jvP5Yh68nm+6r9spsn6EbOhBuR5LAL4WMmMnsXAmmCdwN1JZ3IGg/Cw=="
     },
     "node_modules/@labkey/build": {
       "version": "8.0.0",
@@ -3296,12 +3296,12 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.17.8",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.8.tgz",
-      "integrity": "sha512-YuxbkuggIEXIpePB9h32+c03ZvLhkt2P29bNautpeQ4nVpuBLrdLUuqPjqaDV+3VwxWgle1BPVVPnN4l0I8lMQ==",
+      "version": "5.19.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.19.1.tgz",
+      "integrity": "sha512-KysPfDQrjWf7p3b4X6nOxlqBtMwWmqsrdZY+pQQirwC2n7DOVWlfcbj2oVKc4NP3pxttX1MAx7rIbLQwaX+ViA==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
-        "@labkey/api": "1.35.4",
+        "@labkey/api": "1.35.6",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.5.0",
         "@testing-library/react": "~16.0.1",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "5.17.8"
+    "@labkey/components": "5.19.1"
   },
   "devDependencies": {
     "@labkey/build": "8.0.0",

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -63,6 +63,7 @@ import org.labkey.api.exp.property.DomainPropertyAuditProvider;
 import org.labkey.api.exp.property.ExperimentProperty;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.property.SystemProperty;
+import org.labkey.api.exp.query.ExpDataClassTable;
 import org.labkey.api.exp.query.ExpSampleTypeTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.exp.query.SamplesSchema;
@@ -77,7 +78,6 @@ import org.labkey.api.ontology.OntologyService;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QueryService;
-import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
@@ -108,6 +108,7 @@ import org.labkey.experiment.api.ExpDataTableImpl;
 import org.labkey.experiment.api.ExpMaterialImpl;
 import org.labkey.experiment.api.ExpProtocolImpl;
 import org.labkey.experiment.api.ExpSampleTypeImpl;
+import org.labkey.experiment.api.ExpSampleTypeTableImpl;
 import org.labkey.experiment.api.ExperimentServiceImpl;
 import org.labkey.experiment.api.ExperimentStressTest;
 import org.labkey.experiment.api.GraphAlgorithms;
@@ -154,6 +155,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -839,16 +841,6 @@ public class ExperimentModule extends SpringModule
                 list.add(runCount + " runs of type " + runType.getDescription());
         }
 
-        /*
-        ExpProtocol[] protocols = ExperimentService.get().getExpProtocols(c);
-        for (ExpProtocol protocol : protocols)
-        {
-            List<? extends ExpRun> runs = ExperimentService.get().getExpRunsForProtocolIds(true, protocol.getRowId());
-            if (runs != null && runs.size() > 0)
-                list.add(runs.size() + " runs of type " + protocol.getName());
-        }
-        */
-
         int dataClassCount = ExperimentService.get().getDataClasses(c, null, false).size();
         if (dataClassCount > 0)
             list.add(dataClassCount + " Data Class" + (dataClassCount > 1 ? "es" : ""));
@@ -861,18 +853,12 @@ public class ExperimentModule extends SpringModule
     }
 
     @Override
-    public ArrayList<Summary> getDetailedSummary(Container c)
+    public @NotNull ArrayList<Summary> getDetailedSummary(Container c, User user)
     {
         ArrayList<Summary> summaries = new ArrayList<>();
-        User user = HttpView.currentContext().getUser();
 
         // Assay types
-        int assayTypeCount = 0;
-        for (ExpProtocol protocol : AssayService.get().getAssayProtocols(c))
-        {
-            if (protocol.getContainer().equals(c))
-                assayTypeCount++;
-        }
+        long assayTypeCount = AssayService.get().getAssayProtocols(c).stream().filter(p -> p.getContainer().equals(c)).count();
         if (assayTypeCount > 0)
             summaries.add(new Summary(assayTypeCount, "Assay Type"));
 
@@ -887,23 +873,29 @@ public class ExperimentModule extends SpringModule
         if (dataClassCount > 0)
             summaries.add(new Summary(dataClassCount, "Data Class", "Data Classes"));
 
-        // Individual Data Class row counts
         ExpSchema expSchema = new ExpSchema(user, c);
 
-        // The table-level container filter is set to ensure data class types are included
-        // that may not be defined in the target container but may have rows of data in the target container
-        TableInfo dataClassesTable = ExpSchema.TableType.DataClasses.createTable(expSchema, null, ContainerFilter.Type.CurrentPlusProjectAndShared.create(c, user));
-
-        // Issue 47919: The "DataCounts" column is filtered to only count data in the target container
-        if (dataClassesTable instanceof ExpDataClassTableImpl)
-            ((ExpDataClassTableImpl) dataClassesTable).setDataCountContainerFilter(ContainerFilter.Type.Current.create(c, user));
-
-        Map<String, Object> dataClassResults = new TableSelector(dataClassesTable, dataClassesTable.getColumns("Name,DataCount"), null, null).getValueMap();
-        for (String k : dataClassResults.keySet())
+        // Individual Data Class row counts
         {
-            int count = ((Long) dataClassResults.get(k)).intValue();
-            if (count != 0)
-                summaries.add(new Summary(count, k));
+            // The table-level container filter is set to ensure data class types are included
+            // that may not be defined in the target container but may have rows of data in the target container
+            TableInfo table = ExpSchema.TableType.DataClasses.createTable(expSchema, null, ContainerFilter.Type.CurrentPlusProjectAndShared.create(c, user));
+
+            // Issue 47919: The "DataCount" column is filtered to only count data in the target container
+            if (table instanceof ExpDataClassTableImpl tableImpl)
+                tableImpl.setDataCountContainerFilter(ContainerFilter.Type.Current.create(c, user));
+
+            Set<String> columns = new LinkedHashSet<>();
+            columns.add(ExpDataClassTable.Column.Name.name());
+            columns.add(ExpDataClassTable.Column.DataCount.name());
+
+            Map<String, Long> results = new TableSelector(table, columns).getValueMap();
+            for (var entry : results.entrySet())
+            {
+                long count = entry.getValue();
+                if (count > 0)
+                    summaries.add(new Summary(count, entry.getKey()));
+            }
         }
 
         // Sample Types
@@ -912,19 +904,31 @@ public class ExperimentModule extends SpringModule
             summaries.add(new Summary(sampleTypeCount, "Sample Type"));
 
         // Individual Sample Type row counts
-        UserSchema userSchema = QueryService.get().getUserSchema(user, c, SchemaKey.fromParts(ExpSchema.SCHEMA_NAME));
-        ExpSampleTypeTable sampleTypeTable = ExperimentService.get().createSampleTypeTable(ExpSchema.TableType.SampleSets.toString(), userSchema, ContainerFilter.Type.CurrentPlusProjectAndShared.create(c, user));
-        sampleTypeTable.populate();
-        Map<String, Object> tsSamplesResults = new TableSelector(sampleTypeTable, sampleTypeTable.getColumns("Name,SampleCount"), null, null).getValueMap();
-        for (String k : tsSamplesResults.keySet())
         {
-            int count = ((Number) tsSamplesResults.get(k)).intValue();
-            if (count != 0)
+            // The table-level container filter is set to ensure data class types are included
+            // that may not be defined in the target container but may have rows of data in the target container
+            TableInfo table = ExpSchema.TableType.SampleSets.createTable(expSchema, null, ContainerFilter.Type.CurrentPlusProjectAndShared.create(c, user));
+
+            // Issue 51557: The "SampleCount" column is filtered to only count data in the target container
+            if (table instanceof ExpSampleTypeTableImpl tableImpl)
+                tableImpl.setSampleCountContainerFilter(ContainerFilter.Type.Current.create(c, user));
+
+            Set<String> columns = new LinkedHashSet<>();
+            columns.add(ExpSampleTypeTable.Column.Name.name());
+            columns.add(ExpSampleTypeTable.Column.SampleCount.name());
+
+            Map<String, Long> results = new TableSelector(table, columns).getValueMap();
+            for (var entry : results.entrySet())
             {
-                Summary s = k.equals("MixtureBatches")
-                        ? new Summary(count, "Batch", "Batches") // Special handling for name replacement + pluralization
-                        : new Summary(count, k);
-                summaries.add(s);
+                long count = entry.getValue();
+                if (count > 0)
+                {
+                    String name = entry.getKey();
+                    Summary s = name.equals("MixtureBatches")
+                            ? new Summary(count, "Batch", "Batches") // Special handling for name replacement + pluralization
+                            : new Summary(count, name);
+                    summaries.add(s);
+                }
             }
         }
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
@@ -185,9 +185,10 @@ public class ExpDataClassTableImpl extends ExpTableImpl<ExpDataClassTable.Column
                 .append(" AND ")
                 .append(dataCountContainerFilter.getSQLFragment(getSchema(), new SQLFragment("d.container")))
                 .append(")");
-        ExprColumn sampleCountColumnInfo = new ExprColumn(this, "DataCount", sql, JdbcType.INTEGER);
-        sampleCountColumnInfo.setDescription("Contains the number of data currently stored in this data class");
-        return sampleCountColumnInfo;
+        ExprColumn column = new ExprColumn(this, "DataCount", sql, JdbcType.INTEGER);
+        column.setDescription("Contains the number of data currently stored in this data class");
+
+        return column;
     }
 
     public void setDataCountContainerFilter(@NotNull ContainerFilter dataCountContainerFilter)

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTableImpl.java
@@ -16,6 +16,7 @@
 
 package org.labkey.experiment.api;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.AbstractTableInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
@@ -38,10 +39,6 @@ import static org.labkey.api.exp.api.ExpData.DATA_INPUTS_PREFIX;
 import static org.labkey.api.exp.api.SampleTypeService.MATERIAL_INPUTS_PREFIX;
 import static org.labkey.api.exp.query.ExpSchema.SAMPLE_TYPE_CATEGORY_TABLE;
 
-/**
- * User: jeckels
- * Date: Oct 17, 2007
- */
 public class ExpSampleTypeTableImpl extends ExpTableImpl<ExpSampleTypeTable.Column> implements ExpSampleTypeTable
 {
     public ExpSampleTypeTableImpl(String name, UserSchema schema, ContainerFilter cf)
@@ -93,17 +90,7 @@ public class ExpSampleTypeTableImpl extends ExpTableImpl<ExpSampleTypeTable.Colu
                 return columnInfo;
             }
             case SampleCount:
-            {
-                SQLFragment sql = new SQLFragment("(SELECT COUNT(*) FROM " +
-                    ExperimentServiceImpl.get().getTinfoMaterial() +
-                    " m WHERE m.CpasType = " + ExprColumn.STR_TABLE_ALIAS + ".LSID" +
-                    " AND ")
-                        .append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("m.container")))
-                        .append(")");
-                ExprColumn sampleCountColumnInfo = new ExprColumn(this, "SampleCount", sql, JdbcType.INTEGER);
-                sampleCountColumnInfo.setDescription("Contains the number of samples currently stored in this sample type");
-                return sampleCountColumnInfo;
-            }
+                return createSampleCountColumn(getContainerFilter());
             case ImportAliases:
                 return createImportAliasColumn("ImportAliases", null, "sample type");
             case MaterialInputImportAliases:
@@ -118,12 +105,31 @@ public class ExpSampleTypeTableImpl extends ExpTableImpl<ExpSampleTypeTable.Colu
                 var fk = QueryForeignKey.from(this.getUserSchema(), getContainerFilter())
                         .schema(ExpSchema.SCHEMA_NAME, getContainer())
                         .to(SAMPLE_TYPE_CATEGORY_TABLE, "Value", null);
-                col.setFk( fk );
+                col.setFk(fk);
                 return col;
             }
             default:
                 throw new IllegalArgumentException("Unknown column " + column);
         }
+    }
+
+    private ExprColumn createSampleCountColumn(@NotNull ContainerFilter sampleCountContainerFilter)
+    {
+        SQLFragment sql = new SQLFragment("(SELECT COUNT(*) FROM ").append(ExperimentServiceImpl.get().getTinfoMaterial(), "m")
+                .append(" WHERE m.CpasType = ").append(ExprColumn.STR_TABLE_ALIAS + ".LSID")
+                .append(" AND ")
+                .append(sampleCountContainerFilter.getSQLFragment(getSchema(), new SQLFragment("m.container")))
+                .append(")");
+        ExprColumn column = new ExprColumn(this, "SampleCount", sql, JdbcType.INTEGER);
+        column.setDescription("Contains the number of samples currently stored in this sample type");
+
+        return column;
+    }
+
+    public void setSampleCountContainerFilter(@NotNull ContainerFilter sampleCountContainerFilter)
+    {
+        checkLocked();
+        replaceColumn(createSampleCountColumn(sampleCountContainerFilter), getColumn(Column.SampleCount.fieldKey()));
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpTableImpl.java
@@ -189,7 +189,7 @@ abstract public class ExpTableImpl<C extends Enum>
     protected MutableColumnInfo addContainerColumn(C containerCol, ActionURL url)
     {
         var result = addColumn(containerCol);
-        Set<String> set = new LinkedHashSet(result.getImportAliasSet());
+        Set<String> set = new LinkedHashSet<>(result.getImportAliasSet());
         set.add("container");
         result.setImportAliasesSet(set);
         if (null != url)

--- a/list/src/org/labkey/list/ListModule.java
+++ b/list/src/org/labkey/list/ListModule.java
@@ -171,7 +171,7 @@ public class ListModule extends SpringModule
     {
         Collection<String> results = new ArrayList<>();
         Collection<ListDef> lists = ListManager.get().getLists(c);
-        if(lists.size() > 0)
+        if (!lists.isEmpty())
         {
             results.add(lists.size() + " lists");
         }
@@ -179,7 +179,7 @@ public class ListModule extends SpringModule
     }
 
     @Override
-    public List<Summary> getDetailedSummary(Container c)
+    public @NotNull List<Summary> getDetailedSummary(Container c, User user)
     {
         ArrayList<Summary> summary = new ArrayList<>();
         int picklistCount = ListManager.get().getPicklists(c, false).size();

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.17.8"
+        "@labkey/components": "5.19.1"
       },
       "devDependencies": {
         "@labkey/build": "8.0.0",
@@ -2701,9 +2701,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.35.4",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.4.tgz",
-      "integrity": "sha512-7wJ6HKcCQiG/w6lQ4dY/BeTTrEUBdBBGkOGQjdqdbMfMAl0VqydojdGWHSw0qcg6H442VaYrq24hMUUkY2visQ=="
+      "version": "1.35.6",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.35.6.tgz",
+      "integrity": "sha512-sRXZZU4FbhKHI4SDQ2wHSYt8uvQPwD/jvP5Yh68nm+6r9spsn6EbOhBuR5LAL4WMmMnsXAmmCdwN1JZ3IGg/Cw=="
     },
     "node_modules/@labkey/build": {
       "version": "8.0.0",
@@ -2742,12 +2742,12 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.17.8",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.17.8.tgz",
-      "integrity": "sha512-YuxbkuggIEXIpePB9h32+c03ZvLhkt2P29bNautpeQ4nVpuBLrdLUuqPjqaDV+3VwxWgle1BPVVPnN4l0I8lMQ==",
+      "version": "5.19.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.19.1.tgz",
+      "integrity": "sha512-KysPfDQrjWf7p3b4X6nOxlqBtMwWmqsrdZY+pQQirwC2n7DOVWlfcbj2oVKc4NP3pxttX1MAx7rIbLQwaX+ViA==",
       "dependencies": {
         "@hello-pangea/dnd": "16.6.0",
-        "@labkey/api": "1.35.4",
+        "@labkey/api": "1.35.6",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.5.0",
         "@testing-library/react": "~16.0.1",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "5.17.8"
+    "@labkey/components": "5.19.1"
   },
   "devDependencies": {
     "@labkey/build": "8.0.0",


### PR DESCRIPTION
#### Rationale
This addresses [Issue 51557](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51557) by applying a specific container filter to the "SampleCount" column so that the count only contains results for the target container.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1625
- https://github.com/LabKey/labkey-ui-premium/pull/578
- https://github.com/LabKey/limsModules/pull/867
- https://github.com/LabKey/platform/pull/6005

#### Changes
- Apply specific container filter to the "SampleCount" column when querying for detailed summary counts of samples in a container.
- Update `Summary` modeling to accept a `long` for the count.
- Update `Module.getDetailedSummary()` signature to require a user to be supplied.
