### PR TITLE
Issue 51590: Shiny app not working with httpclient5 v5.4

### DIFF
--- a/api/src/org/mitre/dsmiley/httpproxy/LabKeyProxyServlet.java
+++ b/api/src/org/mitre/dsmiley/httpproxy/LabKeyProxyServlet.java
@@ -24,7 +24,7 @@ public class LabKeyProxyServlet extends ProxyServlet
 
     protected String sourcePath;
     private boolean flexRedirectProtocol;
-    private boolean _allowProtocolUpgradeLK;
+    private boolean _allowProtocolUpgrade;
 
     @Override
     protected void initTarget() throws ServletException
@@ -41,7 +41,7 @@ public class LabKeyProxyServlet extends ProxyServlet
 
         // httpclient5 v5.4 protocolUpgradeEnabled default to true
         // https://github.com/apache/httpcomponents-client/commit/3235f00
-        this._allowProtocolUpgradeLK = readBooleanConfigParam(ALLOW_PROTOCOL_UPGRADE_PARAM_NAME, true);
+        this._allowProtocolUpgrade = readBooleanConfigParam(ALLOW_PROTOCOL_UPGRADE_PARAM_NAME, true);
     }
 
     protected String getSourcePath(HttpServletRequest request)
@@ -172,7 +172,7 @@ public class LabKeyProxyServlet extends ProxyServlet
     @Override
     protected boolean allowProtocolUpgrade()
     {
-        return _allowProtocolUpgradeLK;
+        return _allowProtocolUpgrade;
     }
 
 }

--- a/api/src/org/mitre/dsmiley/httpproxy/LabKeyProxyServlet.java
+++ b/api/src/org/mitre/dsmiley/httpproxy/LabKeyProxyServlet.java
@@ -20,10 +20,13 @@ public class LabKeyProxyServlet extends ProxyServlet
     /** The source URI to proxy from , defaults to /{contextpath}/{servletpath}  */
     protected static final String P_SOURCE_PATH = "sourcePath";
     protected static final String FLEX_REDIRECT_PROTOCOL = "flexRedirectProtocol";
+    public static final String ALLOW_PROTOCOL_UPGRADE_PARAM_NAME = "LKS-protocolUpgradeEnabled";
 
     protected String sourcePath;
     private boolean flexRedirectProtocol;
+    private boolean _allowProtocolUpgradeLK;
 
+    @Override
     protected void initTarget() throws ServletException
     {
         super.initTarget();
@@ -35,6 +38,10 @@ public class LabKeyProxyServlet extends ProxyServlet
         {
             this.flexRedirectProtocol = Boolean.parseBoolean(flexRedirectProtocolString);
         }
+
+        // httpclient5 v5.4 protocolUpgradeEnabled default to true
+        // https://github.com/apache/httpcomponents-client/commit/3235f00
+        this._allowProtocolUpgradeLK = readBooleanConfigParam(ALLOW_PROTOCOL_UPGRADE_PARAM_NAME, true);
     }
 
     protected String getSourcePath(HttpServletRequest request)
@@ -160,6 +167,12 @@ public class LabKeyProxyServlet extends ProxyServlet
 
         }
         return theUrl;
+    }
+
+    @Override
+    protected boolean allowProtocolUpgrade()
+    {
+        return _allowProtocolUpgradeLK;
     }
 
 }

--- a/api/src/org/mitre/dsmiley/httpproxy/ProxyServlet.java
+++ b/api/src/org/mitre/dsmiley/httpproxy/ProxyServlet.java
@@ -291,14 +291,23 @@ public class ProxyServlet extends HttpServlet {
      */
     protected CloseableHttpClient createHttpClient() {
         RequestConfig config = RequestConfig.custom()
-            .setRedirectsEnabled(readBooleanConfigParam("http.protocol.handle-redirects", false))
-            .setCookieSpec(StandardCookieSpec.IGNORE)
-            .build();
+                .setRedirectsEnabled(readBooleanConfigParam("http.protocol.handle-redirects", false))
+                .setCookieSpec(StandardCookieSpec.IGNORE)
+                .setProtocolUpgradeEnabled(allowProtocolUpgrade()) // LKS override
+                .build();
 
         return HttpClientBuilder.create()
             .useSystemProperties()
             .setDefaultRequestConfig(config)
             .build();
+    }
+
+    // LKS override
+    protected boolean allowProtocolUpgrade()
+    {
+        // httpclient5 v5.4 protocolUpgradeEnabled default to true
+        // https://github.com/apache/httpcomponents-client/commit/3235f00
+        return true;
     }
 
     /**


### PR DESCRIPTION
#### Rationale
httpclient5 v5.4 by default upgrades connection to TLS/1.2. This upgrade seems harmless with most proxy interactions but is resulting in error code 500 when interacting with RStudio Shiny app. This PR adds a setProtocolUpgradeEnabled that allows shiny app requests to skip upgrading. 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6017
- https://github.com/LabKey/premiumModules/pull/89

- https://github.com/LabKey/server/pull/908

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
