### PR TITLE
Stop passing around email addresses

### DIFF
--- a/api/src/org/labkey/api/security/DbLoginService.java
+++ b/api/src/org/labkey/api/security/DbLoginService.java
@@ -21,12 +21,6 @@ public interface DbLoginService
         return ServiceRegistry.get().getService(DbLoginService.class);
     }
 
-    @Deprecated // Call the variant that takes a changeOperation parameter
-    default AuthenticationResult attemptSetPassword(Container c, User currentUser, String rawPassword, String rawPassword2, HttpServletRequest request, ValidEmail email, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, BindException errors) throws InvalidEmailException
-    {
-        return attemptSetPassword(c, currentUser, rawPassword, rawPassword2, request, email, returnUrlHelper, auditMessage, clearVerification, false, errors);
-    }
-
     AuthenticationResult attemptSetPassword(Container c, User currentUser, String rawPassword, String rawPassword2, HttpServletRequest request, ValidEmail email, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, boolean changeOperation, BindException errors) throws InvalidEmailException;
 
     PasswordRule getPasswordRule();

--- a/api/src/org/labkey/api/security/DbLoginService.java
+++ b/api/src/org/labkey/api/security/DbLoginService.java
@@ -21,7 +21,7 @@ public interface DbLoginService
         return ServiceRegistry.get().getService(DbLoginService.class);
     }
 
-    AuthenticationResult attemptSetPassword(Container c, User currentUser, String rawPassword, String rawPassword2, HttpServletRequest request, ValidEmail email, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, boolean changeOperation, BindException errors) throws InvalidEmailException;
+    AuthenticationResult attemptSetPassword(Container c, User currentUser, String rawPassword, String rawPassword2, HttpServletRequest request, User affectedUser, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, boolean changeOperation, BindException errors) throws InvalidEmailException;
 
     PasswordRule getPasswordRule();
 }

--- a/api/src/org/labkey/api/security/LoginManager.java
+++ b/api/src/org/labkey/api/security/LoginManager.java
@@ -1,0 +1,297 @@
+package org.labkey.api.security;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.Selector;
+import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.SqlSelector;
+import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.Pair;
+import org.labkey.api.view.ActionURL;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+// Handles all CRUD operations on the core.Logins table
+public class LoginManager
+{
+    public static final int TEMP_PASSWORD_LENGTH = 32;
+    private static final int MAX_HISTORY = 10;
+    private static final CoreSchema CORE = CoreSchema.getInstance();
+    private static final String PASSWORD_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    // Create record for database login, saving UserId and hashed password. Return verification token.
+    public static String createLogin(int userId, ValidEmail email /* Just for logging errors */) throws SecurityManager.UserManagementException
+    {
+        // Create a placeholder password hash and a separate email verification key that will get emailed to the new user
+        String tempPassword = createTempPassword();
+        String verification = createTempPassword();
+
+        String crypt = Crypt.MD5.digestWithPrefix(tempPassword);
+
+        try
+        {
+            // TODO: Stop inserting Email after removing that column
+            // Don't need to set LastChanged -- it defaults to current date/time.
+            int rowCount = new SqlExecutor(CORE.getSchema()).execute("INSERT INTO " + CORE.getTableInfoLogins() +
+                    " (UserId, Email, Crypt, LastChanged, Verification, PreviousCrypts) VALUES (?, ?, ?, ?, ?, ?)",
+                    userId, email.getEmailAddress(), crypt, new Date(), verification, crypt);
+            if (1 != rowCount)
+                throw new SecurityManager.UserManagementException(email, "Login creation statement affected " + rowCount + " rows.");
+        }
+        catch (DataIntegrityViolationException e)
+        {
+            throw new SecurityManager.UserAlreadyExistsException(email);
+        }
+
+        return verification;
+    }
+
+    public static void setPassword(User user, String password) throws SecurityManager.UserManagementException
+    {
+        String crypt = Crypt.BCrypt.digestWithPrefix(password);
+        List<String> history = new ArrayList<>(getCryptHistory(user));
+        history.add(crypt);
+
+        // Remember only the last 10 password hashes
+        int itemsToDelete = Math.max(0, history.size() - MAX_HISTORY);
+        if (itemsToDelete > 0)
+        {
+            history.subList(0, itemsToDelete).clear();
+        }
+        String cryptHistory = StringUtils.join(history, ",");
+
+        int rows = new SqlExecutor(CORE.getSchema()).execute("UPDATE " + CORE.getTableInfoLogins() + " SET Crypt=?, LastChanged=?, PreviousCrypts=? WHERE UserId=?", crypt, new Date(), cryptHistory, user.getUserId());
+        if (1 != rows)
+            throw new SecurityManager.UserManagementException(user.getEmail(), "Password update statement affected " + rows + " rows.");
+    }
+
+    private static List<String> getCryptHistory(User user)
+    {
+        Selector selector = new SqlSelector(CORE.getSchema(), new SQLFragment("SELECT PreviousCrypts FROM " + CORE.getTableInfoLogins() + " WHERE UserId=?", user.getUserId()));
+        String cryptHistory = selector.getObject(String.class);
+
+        if (null == cryptHistory)
+        {
+            return Collections.emptyList();
+        }
+        else
+        {
+            List<String> cryptList = Arrays.asList(cryptHistory.split(","));
+            assert cryptList.size() <= MAX_HISTORY;
+
+            return cryptList;
+        }
+    }
+
+    public static boolean matchesPreviousPassword(String password, User user)
+    {
+        List<String> history = getCryptHistory(user);
+
+        for (String hash : history)
+        {
+            if (matchPassword(password, hash))
+                return true;
+        }
+
+        return false;
+    }
+
+    public static Date getLastChanged(User user)
+    {
+        SqlSelector selector = new SqlSelector(CORE.getSchema(), new SQLFragment("SELECT LastChanged FROM " + CORE.getTableInfoLogins() + " WHERE UserId = ?", user.getUserId()));
+        return selector.getObject(Date.class);
+    }
+
+    // Look up email in Logins table and return the corresponding password hash
+    @Deprecated
+    private static String getPasswordHash(ValidEmail email)
+    {
+        return getPasswordHash(email.getEmailAddress());
+    }
+
+    // For internal use only, plus database login and change email workflows, where existing email address could be invalid (i.e., non-conforming per RFC 822)
+    @Deprecated
+    private static String getPasswordHash(String email)
+    {
+        SqlSelector selector = new SqlSelector(CORE.getSchema(), new SQLFragment("SELECT Crypt FROM " + CORE.getTableInfoLogins() + " WHERE Email = ?", email));
+        return selector.getObject(String.class);
+    }
+
+    public static @Nullable String getPasswordHash(@Nullable User user)
+    {
+        return null != user ? new SqlSelector(CORE.getSchema(), new SQLFragment("SELECT Crypt FROM " + CORE.getTableInfoLogins() + " WHERE UserId = ?", user.getUserId()))
+            .getObject(String.class) : null;
+    }
+
+    public static boolean matchPassword(String password, String hash)
+    {
+        if (StringUtils.isEmpty(hash) || hash.startsWith("disabled:"))
+            return false;
+        else if (Crypt.BCrypt.acceptPrefix(hash))
+            return Crypt.BCrypt.matchesWithPrefix(password, hash);
+        else if (Crypt.SaltMD5.acceptPrefix(hash))
+            return Crypt.SaltMD5.matchesWithPrefix(password, hash);
+        else if (Crypt.MD5.acceptPrefix(hash))
+            return Crypt.MD5.matchesWithPrefix(password, hash);
+        else
+            return Crypt.MD5.matches(password, hash);
+    }
+
+    // Used in the case of set password or email change... current email address could be invalid (i.e., non-conforming per RFC 822)
+    @Deprecated
+    public static boolean loginExists(String email)
+    {
+        return (null != getPasswordHash(email));
+    }
+
+    @Deprecated
+    public static boolean loginExists(ValidEmail email)
+    {
+        return (null != getPasswordHash(email));
+    }
+
+    public static boolean loginExists(User user)
+    {
+        return (null != getPasswordHash(user));
+    }
+
+    public static String createTempPassword()
+    {
+        StringBuilder tempPassword = new StringBuilder(TEMP_PASSWORD_LENGTH);
+
+        for (int i = 0; i < TEMP_PASSWORD_LENGTH; i++)
+            tempPassword.append(PASSWORD_CHARS.charAt((int) Math.floor((Math.random() * PASSWORD_CHARS.length()))));
+
+        return tempPassword.toString();
+    }
+
+    public static ActionURL createVerificationURL(Container c, ValidEmail email, String verification, @Nullable List<Pair<String, String>> extraParameters)
+    {
+        return PageFlowUtil.urlProvider(LoginUrls.class).getVerificationURL(c, email, verification, extraParameters);
+    }
+
+    public static ActionURL createModuleVerificationURL(Container c, ValidEmail email, String verification, @Nullable List<Pair<String, String>> extraParameters, String provider, boolean isAddUser)
+    {
+        ActionURL defaultUrl = createVerificationURL(c, email, verification, extraParameters);
+        if (provider == null)
+            return defaultUrl;
+
+        AuthenticationProvider.ResetPasswordProvider urlProvider = AuthenticationManager.getResetPasswordProvider(provider);
+        if (urlProvider == null)
+            return defaultUrl;
+
+        ActionURL verificationUrl = urlProvider.getAPIVerificationURL(c, isAddUser);
+        verificationUrl.addParameter("verification", verification);
+        verificationUrl.addParameter("email", email.getEmailAddress());
+
+        if (null != extraParameters)
+            verificationUrl.addParameters(extraParameters);
+
+        return verificationUrl;
+    }
+
+    // Test if user has been verified for database authentication
+    @Deprecated
+    public static boolean isVerified(ValidEmail email)
+    {
+        return (null == getVerification(email));
+    }
+
+    // Test if user has been verified for database authentication. Use only when email address could be invalid ().
+    @Deprecated
+    public static boolean isVerified(String email)
+    {
+        return (null == getVerification(email));
+    }
+
+    @Deprecated
+    public static boolean verify(ValidEmail email, String verification)
+    {
+        String dbVerification = getVerification(email);
+        return (dbVerification != null && dbVerification.equals(verification));
+    }
+
+    @Deprecated
+    public static void setVerification(ValidEmail email, @Nullable String verification) throws SecurityManager.UserManagementException
+    {
+        int rows = new SqlExecutor(CORE.getSchema()).execute("UPDATE " + CORE.getTableInfoLogins() + " SET Verification=? WHERE LOWER(email)=LOWER(?)", verification, email.getEmailAddress());
+        if (1 != rows)
+            throw new SecurityManager.UserManagementException(email, "Unexpected number of rows returned when setting verification: " + rows);
+    }
+
+    public static void setVerification(User user, @Nullable String verification) throws SecurityManager.UserManagementException
+    {
+        int rows = new SqlExecutor(CORE.getSchema()).execute("UPDATE " + CORE.getTableInfoLogins() + " SET Verification=? WHERE LOWER(email)=LOWER(?)", verification, user.getUserId());
+        if (1 != rows)
+            throw new SecurityManager.UserManagementException(user.getEmail(), "Unexpected number of rows returned when setting verification: " + rows);
+    }
+
+    @Deprecated
+    public static String getVerification(ValidEmail email)
+    {
+        return getVerification(email.getEmailAddress());
+    }
+
+    private static String getVerification(String email)
+    {
+        return new SqlSelector(CORE.getSchema(), "SELECT Verification FROM " + CORE.getTableInfoLogins() + " WHERE Email = ?", email).getObject(String.class);
+    }
+
+    public record VerifyEmail(String requestedEmail, String verification, Date verificationTimeout)
+    {
+        public boolean isVerified(String userProvidedToken)
+        {
+            return userProvidedToken != null && userProvidedToken.equals(verification);
+        }
+    }
+
+    public static VerifyEmail getVerifyEmail(User user)
+    {
+        SqlSelector sqlSelector = new SqlSelector(CORE.getSchema(), "SELECT RequestedEmail, Verification, VerificationTimeout FROM " + CORE.getTableInfoLogins()
+                + " WHERE UserId = ?", user.getUserId());
+        return sqlSelector.getObject(VerifyEmail.class);
+    }
+
+    public static void requestEmailChange(User userToChange, ValidEmail requestedEmail, String verificationToken, User currentUser) throws SecurityManager.UserManagementException
+    {
+        if (loginExists(userToChange))
+        {
+            DbScope scope = CORE.getSchema().getScope();
+            try (DbScope.Transaction transaction = scope.ensureTransaction())
+            {
+                Instant timeoutDate = Instant.now().plus(UserManager.VERIFICATION_EMAIL_TIMEOUT, ChronoUnit.MINUTES);
+                SqlExecutor executor = new SqlExecutor(CORE.getSchema());
+                int rows = executor.execute("UPDATE " + CORE.getTableInfoLogins() + " SET RequestedEmail = ?, Verification = ?, VerificationTimeout = ? WHERE UserId = ?",
+                        requestedEmail.getEmailAddress(), verificationToken, Date.from(timeoutDate), userToChange.getUserId());
+                if (1 != rows)
+                    throw new SecurityManager.UserManagementException(requestedEmail, "Unexpected number of rows returned when setting verification: " + rows);
+                UserManager.addToUserHistory(userToChange, currentUser + " requested email address change from " + userToChange.getEmail() + " to " + requestedEmail +
+                        " with token '" + verificationToken + "' and timeout date '" + Date.from(timeoutDate) + "'.");
+                transaction.commit();
+            }
+        }
+    }
+
+    // Admins can delete passwords (i.e., entries in the core.Logins table), see #42691
+    public static void deleteLoginsRow(@Nullable User userToChange, @Nullable User adminUser)
+    {
+        if (null != userToChange)
+        {
+            new SqlExecutor(CoreSchema.getInstance().getScope()).execute("DELETE FROM " + CoreSchema.getInstance().getTableInfoLogins() + " WHERE UserId = ?", userToChange.getUserId());
+
+            if (adminUser != null)
+                UserManager.addToUserHistory(userToChange, adminUser.getEmail() + " deleted the password.");
+        }
+    }
+}

--- a/api/src/org/labkey/api/security/LoginManager.java
+++ b/api/src/org/labkey/api/security/LoginManager.java
@@ -117,13 +117,6 @@ public class LoginManager
     @Deprecated
     private static String getPasswordHash(ValidEmail email)
     {
-        return getPasswordHash(email.getEmailAddress());
-    }
-
-    // For internal use only, plus database login and change email workflows, where existing email address could be invalid (i.e., non-conforming per RFC 822)
-    @Deprecated
-    private static String getPasswordHash(String email)
-    {
         SqlSelector selector = new SqlSelector(CORE.getSchema(), new SQLFragment("SELECT Crypt FROM " + CORE.getTableInfoLogins() + " WHERE Email = ?", email));
         return selector.getObject(String.class);
     }
@@ -132,6 +125,17 @@ public class LoginManager
     {
         return null != user ? new SqlSelector(CORE.getSchema(), new SQLFragment("SELECT Crypt FROM " + CORE.getTableInfoLogins() + " WHERE UserId = ?", user.getUserId()))
             .getObject(String.class) : null;
+    }
+
+    @Deprecated
+    public static boolean loginExists(ValidEmail email)
+    {
+        return (null != getPasswordHash(email));
+    }
+
+    public static boolean loginExists(User user)
+    {
+        return (null != getPasswordHash(user));
     }
 
     public static boolean matchPassword(String password, String hash)
@@ -146,17 +150,6 @@ public class LoginManager
             return Crypt.MD5.matchesWithPrefix(password, hash);
         else
             return Crypt.MD5.matches(password, hash);
-    }
-
-    @Deprecated
-    public static boolean loginExists(ValidEmail email)
-    {
-        return (null != getPasswordHash(email));
-    }
-
-    public static boolean loginExists(User user)
-    {
-        return (null != getPasswordHash(user));
     }
 
     public static String createTempPassword()
@@ -200,32 +193,17 @@ public class LoginManager
         return (null == getVerification(user));
     }
 
-    @Deprecated
-    public static boolean verify(ValidEmail email, String verification)
+    public static boolean verify(User user, String verification)
     {
-        String dbVerification = getVerification(email);
+        String dbVerification = getVerification(user);
         return (dbVerification != null && dbVerification.equals(verification));
-    }
-
-    @Deprecated
-    public static void setVerification(ValidEmail email, @Nullable String verification) throws SecurityManager.UserManagementException
-    {
-        int rows = new SqlExecutor(CORE.getSchema()).execute("UPDATE " + CORE.getTableInfoLogins() + " SET Verification=? WHERE LOWER(email)=LOWER(?)", verification, email.getEmailAddress());
-        if (1 != rows)
-            throw new SecurityManager.UserManagementException(email, "Unexpected number of rows returned when setting verification: " + rows);
     }
 
     public static void setVerification(User user, @Nullable String verification) throws SecurityManager.UserManagementException
     {
-        int rows = new SqlExecutor(CORE.getSchema()).execute("UPDATE " + CORE.getTableInfoLogins() + " SET Verification=? WHERE LOWER(email)=LOWER(?)", verification, user.getUserId());
+        int rows = new SqlExecutor(CORE.getSchema()).execute("UPDATE " + CORE.getTableInfoLogins() + " SET Verification = ? WHERE UserId = ?", verification, user.getUserId());
         if (1 != rows)
             throw new SecurityManager.UserManagementException(user.getEmail(), "Unexpected number of rows returned when setting verification: " + rows);
-    }
-
-    @Deprecated
-    public static String getVerification(ValidEmail email)
-    {
-        return new SqlSelector(CORE.getSchema(), "SELECT Verification FROM " + CORE.getTableInfoLogins() + " WHERE Email = ?", email.getEmailAddress()).getObject(String.class);
     }
 
     public static String getVerification(User user)

--- a/api/src/org/labkey/api/security/LoginManager.java
+++ b/api/src/org/labkey/api/security/LoginManager.java
@@ -148,13 +148,6 @@ public class LoginManager
             return Crypt.MD5.matches(password, hash);
     }
 
-    // Used in the case of set password or email change... current email address could be invalid (i.e., non-conforming per RFC 822)
-    @Deprecated
-    public static boolean loginExists(String email)
-    {
-        return (null != getPasswordHash(email));
-    }
-
     @Deprecated
     public static boolean loginExists(ValidEmail email)
     {
@@ -176,14 +169,14 @@ public class LoginManager
         return tempPassword.toString();
     }
 
-    public static ActionURL createVerificationURL(Container c, ValidEmail email, String verification, @Nullable List<Pair<String, String>> extraParameters)
+    public static ActionURL createVerificationURL(Container c, User user, String verification, @Nullable List<Pair<String, String>> extraParameters)
     {
-        return PageFlowUtil.urlProvider(LoginUrls.class).getVerificationURL(c, email, verification, extraParameters);
+        return PageFlowUtil.urlProvider(LoginUrls.class).getVerificationURL(c, user, verification, extraParameters);
     }
 
-    public static ActionURL createModuleVerificationURL(Container c, ValidEmail email, String verification, @Nullable List<Pair<String, String>> extraParameters, String provider, boolean isAddUser)
+    public static ActionURL createModuleVerificationURL(Container c, User user, String verification, @Nullable List<Pair<String, String>> extraParameters, String provider, boolean isAddUser)
     {
-        ActionURL defaultUrl = createVerificationURL(c, email, verification, extraParameters);
+        ActionURL defaultUrl = createVerificationURL(c, user, verification, extraParameters);
         if (provider == null)
             return defaultUrl;
 
@@ -193,7 +186,7 @@ public class LoginManager
 
         ActionURL verificationUrl = urlProvider.getAPIVerificationURL(c, isAddUser);
         verificationUrl.addParameter("verification", verification);
-        verificationUrl.addParameter("email", email.getEmailAddress());
+        verificationUrl.addParameter("user", user.getUserId());
 
         if (null != extraParameters)
             verificationUrl.addParameters(extraParameters);
@@ -201,18 +194,10 @@ public class LoginManager
         return verificationUrl;
     }
 
-    // Test if user has been verified for database authentication
-    @Deprecated
-    public static boolean isVerified(ValidEmail email)
-    {
-        return (null == getVerification(email));
-    }
-
     // Test if user has been verified for database authentication. Use only when email address could be invalid ().
-    @Deprecated
-    public static boolean isVerified(String email)
+    public static boolean isVerified(User user)
     {
-        return (null == getVerification(email));
+        return (null == getVerification(user));
     }
 
     @Deprecated
@@ -240,12 +225,12 @@ public class LoginManager
     @Deprecated
     public static String getVerification(ValidEmail email)
     {
-        return getVerification(email.getEmailAddress());
+        return new SqlSelector(CORE.getSchema(), "SELECT Verification FROM " + CORE.getTableInfoLogins() + " WHERE Email = ?", email.getEmailAddress()).getObject(String.class);
     }
 
-    private static String getVerification(String email)
+    public static String getVerification(User user)
     {
-        return new SqlSelector(CORE.getSchema(), "SELECT Verification FROM " + CORE.getTableInfoLogins() + " WHERE Email = ?", email).getObject(String.class);
+        return new SqlSelector(CORE.getSchema(), "SELECT Verification FROM " + CORE.getTableInfoLogins() + " WHERE UserId = ?", user.getUserId()).getObject(String.class);
     }
 
     public record VerifyEmail(String requestedEmail, String verification, Date verificationTimeout)

--- a/api/src/org/labkey/api/security/LoginManager.java
+++ b/api/src/org/labkey/api/security/LoginManager.java
@@ -166,7 +166,7 @@ public class LoginManager
 
         ActionURL verificationUrl = urlProvider.getAPIVerificationURL(c, isAddUser);
         verificationUrl.addParameter("verification", verification);
-        verificationUrl.addParameter("user", user.getUserId());
+        verificationUrl.addParameter("userId", user.getUserId());
 
         if (null != extraParameters)
             verificationUrl.addParameters(extraParameters);

--- a/api/src/org/labkey/api/security/LoginManager.java
+++ b/api/src/org/labkey/api/security/LoginManager.java
@@ -1,5 +1,6 @@
 package org.labkey.api.security;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
@@ -31,7 +32,6 @@ public class LoginManager
     public static final int TEMP_PASSWORD_LENGTH = 32;
     private static final int MAX_HISTORY = 10;
     private static final CoreSchema CORE = CoreSchema.getInstance();
-    private static final String PASSWORD_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
     // Create record for database login, saving UserId and hashed password. Return verification token.
     public static String createLogin(int userId, String email /* Just for logging errors */) throws SecurityManager.UserManagementException
@@ -44,11 +44,9 @@ public class LoginManager
 
         try
         {
-            // TODO: Stop inserting Email after removing that column
-            // Don't need to set LastChanged -- it defaults to current date/time.
             int rowCount = new SqlExecutor(CORE.getSchema()).execute("INSERT INTO " + CORE.getTableInfoLogins() +
-                    " (UserId, Email, Crypt, LastChanged, Verification, PreviousCrypts) VALUES (?, ?, ?, ?, ?, ?)",
-                    userId, email, crypt, new Date(), verification, crypt);
+                " (UserId, Crypt, LastChanged, Verification, PreviousCrypts) VALUES (?, ?, ?, ?, ?)",
+                userId, crypt, new Date(), verification, crypt);
             if (1 != rowCount)
                 throw new SecurityManager.UserManagementException(email, "Login creation statement affected " + rowCount + " rows.");
         }
@@ -144,12 +142,7 @@ public class LoginManager
 
     public static String createTempPassword()
     {
-        StringBuilder tempPassword = new StringBuilder(TEMP_PASSWORD_LENGTH);
-
-        for (int i = 0; i < TEMP_PASSWORD_LENGTH; i++)
-            tempPassword.append(PASSWORD_CHARS.charAt((int) Math.floor((Math.random() * PASSWORD_CHARS.length()))));
-
-        return tempPassword.toString();
+        return RandomStringUtils.secureStrong().nextAlphanumeric(TEMP_PASSWORD_LENGTH);
     }
 
     public static ActionURL createVerificationURL(Container c, User user, String verification, @Nullable List<Pair<String, String>> extraParameters)
@@ -169,7 +162,6 @@ public class LoginManager
 
         ActionURL verificationUrl = urlProvider.getAPIVerificationURL(c, isAddUser);
         verificationUrl.addParameter("verification", verification);
-        verificationUrl.addParameter("userId", user.getUserId());
 
         if (null != extraParameters)
             verificationUrl.addParameters(extraParameters);
@@ -177,7 +169,7 @@ public class LoginManager
         return verificationUrl;
     }
 
-    // Test if user has been verified for database authentication. Use only when email address could be invalid ().
+    // Test if user has been verified for database authentication
     public static boolean isVerified(User user)
     {
         return (null == getVerification(user));

--- a/api/src/org/labkey/api/security/LoginManager.java
+++ b/api/src/org/labkey/api/security/LoginManager.java
@@ -31,7 +31,7 @@ public class LoginManager
     private static final String PASSWORD_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
     // Create record for database login, saving UserId and hashed password. Return verification token.
-    public static String createLogin(int userId, ValidEmail email /* Just for logging errors */) throws SecurityManager.UserManagementException
+    public static String createLogin(int userId, String email /* Just for logging errors */) throws SecurityManager.UserManagementException
     {
         // Create a placeholder password hash and a separate email verification key that will get emailed to the new user
         String tempPassword = createTempPassword();
@@ -45,7 +45,7 @@ public class LoginManager
             // Don't need to set LastChanged -- it defaults to current date/time.
             int rowCount = new SqlExecutor(CORE.getSchema()).execute("INSERT INTO " + CORE.getTableInfoLogins() +
                     " (UserId, Email, Crypt, LastChanged, Verification, PreviousCrypts) VALUES (?, ?, ?, ?, ?, ?)",
-                    userId, email.getEmailAddress(), crypt, new Date(), verification, crypt);
+                    userId, email, crypt, new Date(), verification, crypt);
             if (1 != rowCount)
                 throw new SecurityManager.UserManagementException(email, "Login creation statement affected " + rowCount + " rows.");
         }
@@ -113,24 +113,11 @@ public class LoginManager
         return selector.getObject(Date.class);
     }
 
-    // Look up email in Logins table and return the corresponding password hash
-    @Deprecated
-    private static String getPasswordHash(ValidEmail email)
-    {
-        SqlSelector selector = new SqlSelector(CORE.getSchema(), new SQLFragment("SELECT Crypt FROM " + CORE.getTableInfoLogins() + " WHERE Email = ?", email));
-        return selector.getObject(String.class);
-    }
-
+    // Look up user ID in core.Logins table and return the corresponding password hash
     public static @Nullable String getPasswordHash(@Nullable User user)
     {
         return null != user ? new SqlSelector(CORE.getSchema(), new SQLFragment("SELECT Crypt FROM " + CORE.getTableInfoLogins() + " WHERE UserId = ?", user.getUserId()))
             .getObject(String.class) : null;
-    }
-
-    @Deprecated
-    public static boolean loginExists(ValidEmail email)
-    {
-        return (null != getPasswordHash(email));
     }
 
     public static boolean loginExists(User user)

--- a/api/src/org/labkey/api/security/LoginManager.java
+++ b/api/src/org/labkey/api/security/LoginManager.java
@@ -7,8 +7,11 @@ import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.Selector;
+import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
@@ -180,10 +183,17 @@ public class LoginManager
         return (null == getVerification(user));
     }
 
-    public static boolean verify(User user, String verification)
+    // Look up a user based on the verification string
+    public static @Nullable User verify(String verification)
     {
-        String dbVerification = getVerification(user);
-        return (dbVerification != null && dbVerification.equals(verification));
+        Integer userId = null;
+        if (StringUtils.length(verification) == TEMP_PASSWORD_LENGTH)
+        {
+            TableInfo logins = CORE.getTableInfoLogins();
+            userId = new TableSelector(CORE.getTableInfoLogins(), Collections.singleton("UserId"), new SimpleFilter(logins.getColumn("Verification").getFieldKey(), verification), null)
+                .getObject(Integer.class);
+        }
+        return userId != null ? UserManager.getUser(userId) : null;
     }
 
     public static void setVerification(User user, @Nullable String verification) throws SecurityManager.UserManagementException

--- a/api/src/org/labkey/api/security/LoginUrls.java
+++ b/api/src/org/labkey/api/security/LoginUrls.java
@@ -22,19 +22,13 @@ import org.labkey.api.security.AuthenticationConfiguration.SSOAuthenticationConf
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.NavTree;
 
 import java.util.List;
 
-/**
- * User: adam
- * Date: May 15, 2008
- * Time: 9:40:56 AM
- */
 public interface LoginUrls extends UrlProvider
 {
     ActionURL getConfigureURL();
-    ActionURL getVerificationURL(Container c, ValidEmail email, String verification, @Nullable List<Pair<String, String>> extraParameters);
+    ActionURL getVerificationURL(Container c, User user, String verification, @Nullable List<Pair<String, String>> extraParameters);
     ActionURL getChangePasswordURL(Container c, User user, URLHelper returnURL, @Nullable String message);
     ActionURL getInitialUserURL();
     ActionURL getLoginURL();

--- a/api/src/org/labkey/api/security/PasswordRule.java
+++ b/api/src/org/labkey/api/security/PasswordRule.java
@@ -89,7 +89,7 @@ public enum PasswordRule
             return false;
         }
 
-        if (_validator.isPreviousPasswordForbidden() && SecurityManager.matchesPreviousPassword(password1, user))
+        if (_validator.isPreviousPasswordForbidden() && LoginManager.matchesPreviousPassword(password1, user))
         {
             messages.add("Your password must not match a recently used password.");
             return false;

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2317,7 +2317,7 @@ public class SecurityManager
                 {
                     message.append("  Click ");
                     message.unsafeAppend("<a href=\"");
-                    message.append(LoginManager.createVerificationURL(context.getContainer(), email, newUserStatus.getVerification(), extraParameters).toString());
+                    message.append(LoginManager.createVerificationURL(context.getContainer(), newUser, newUserStatus.getVerification(), extraParameters).toString());
                     message.unsafeAppend("\" target=\"_blank\">here</a>");
                     message.append(" to change the password from the random one that was assigned.");
                 }
@@ -2371,11 +2371,12 @@ public class SecurityManager
     {
         Container c = context.getContainer();
         User currentUser = context.getUser();
+        User newUser = newUserStatus.getUser();
 
-        ActionURL verificationURL = LoginManager.createModuleVerificationURL(context.getContainer(), email, newUserStatus.getVerification(), extraParameters, provider, isAddUser);
+        ActionURL verificationURL = LoginManager.createModuleVerificationURL(context.getContainer(), newUser, newUserStatus.getVerification(), extraParameters, provider, isAddUser);
 
         sendEmail(c, currentUser, getRegistrationMessage(mailPrefix, false), email.getEmailAddress(), verificationURL);
-        if (!currentUser.isGuest() && !currentUser.getEmail().equals(email.getEmailAddress()))
+        if (!currentUser.isGuest() && !currentUser.equals(newUser))
         {
             SecurityMessage msg = getRegistrationMessage(mailPrefix, true);
             msg.setTo(email.getEmailAddress());
@@ -2704,6 +2705,11 @@ public class SecurityManager
         // We let admins create passwords (i.e., entries in the logins table) if they don't already exist.
         // This addresses SSO and LDAP scenarios, see #10374.
         User affectedUser = UserManager.getUser(email);
+        if (null == affectedUser)
+        {
+            errors.addError(new LabKeyError(new Exception("Failed to reset password; user not found")));
+            return;
+        }
         boolean loginExists = LoginManager.loginExists(affectedUser);
         String pastVerb = loginExists ? "reset" : "created";
         String infinitiveVerb = loginExists ? "reset" : "create";
@@ -2718,7 +2724,7 @@ public class SecurityManager
                 // verification key that gets emailed.
                 verification = LoginManager.createTempPassword();
                 LoginManager.setPassword(affectedUser, LoginManager.createTempPassword());
-                LoginManager.setVerification(email, verification);
+                LoginManager.setVerification(affectedUser, verification);
             }
             else
             {
@@ -2728,7 +2734,7 @@ public class SecurityManager
 
             try
             {
-                ActionURL verificationURL = LoginManager.createVerificationURL(c, email, verification, null);
+                ActionURL verificationURL = LoginManager.createVerificationURL(c, affectedUser, verification, null);
                 sendEmail(c, currentUser, getResetMessage(false), email.getEmailAddress(), verificationURL);
 
                 if (!currentUser.getEmail().equals(email.getEmailAddress()))

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -993,12 +993,12 @@ public class SecurityManager
     {
         public UserAlreadyExistsException(ValidEmail email)
         {
-            this(email, "User already exists");
+            this(email.getEmailAddress());
         }
 
-        public UserAlreadyExistsException(ValidEmail email, String message)
+        public UserAlreadyExistsException(String email)
         {
-            super(email, message);
+            super(email, "User already exists");
         }
     }
 
@@ -1047,7 +1047,7 @@ public class SecurityManager
                 {
                     if (!"23000".equals(e.getSQLState()))
                     {
-                        LOG.debug("createUser: Something failed user: " + email, e);
+                        LOG.debug("createUser: Something failed user: {}", email, e);
                         throw e;
                     }
                 }
@@ -1061,7 +1061,7 @@ public class SecurityManager
                 if (null == userId)
                 {
                     assert false : "User should either exist or not; synchronization problem?";
-                    LOG.debug("createUser: Something failed user: " + email);
+                    LOG.debug("createUser: Something failed user: {}", email);
                     return null;
                 }
 
@@ -1070,7 +1070,7 @@ public class SecurityManager
                 //
                 if (createLogin && !status.isLdapOrSsoEmail())
                 {
-                    String verification = LoginManager.createLogin(userId, email);
+                    String verification = LoginManager.createLogin(userId, email.getEmailAddress());
                     status.setVerification(verification);
                 }
 
@@ -1147,28 +1147,28 @@ public class SecurityManager
         return displayName;
     }
 
-    public static void sendEmail(Container c, User user, SecurityMessage message, String to, ActionURL verificationURL) throws ConfigurationException, MessagingException
+    public static void sendEmail(Container c, User fromUser, SecurityMessage message, String to, ActionURL verificationURL) throws ConfigurationException, MessagingException
     {
-        MimeMessage m = createMessage(c, user, message, to, verificationURL);
-        MailHelper.send(m, user, c);
+        MimeMessage m = createMessage(c, fromUser, message, to, verificationURL);
+        MailHelper.send(m, fromUser, c);
     }
 
-    public static void renderEmail(Container c, User user, SecurityMessage message, String to, ActionURL verificationURL, Writer out) throws MessagingException
+    public static void renderEmail(Container c, User fromUser, SecurityMessage message, String to, ActionURL verificationURL, Writer out) throws MessagingException
     {
-        MimeMessage m = createMessage(c, user, message, to, verificationURL);
+        MimeMessage m = createMessage(c, fromUser, message, to, verificationURL);
         MailHelper.renderHtml(m, message.getType(), out);
     }
 
-    private static MimeMessage createMessage(Container c, User user, SecurityMessage message, String to, ActionURL verificationURL) throws MessagingException
+    private static MimeMessage createMessage(Container c, User fromUser, SecurityMessage message, String to, ActionURL verificationURL) throws MessagingException
     {
         try
         {
             // Issue 33254: only allow Site Admins to see the verification token
-            if (message.isMaskToken() && !user.hasSiteAdminPermission())
+            if (message.isMaskToken() && !fromUser.hasSiteAdminPermission())
                 verificationURL.replaceParameter("verification", "**********");
 
             message.setVerificationURL(verificationURL.getURIString());
-            message.setOriginatingUser(user);
+            message.setOriginatingUser(fromUser);
             if (message.getTo() == null)
                 message.setTo(to);
 
@@ -2695,21 +2695,16 @@ public class SecurityManager
         return (null!=c && c.hasPermission(user, SeeFilePathsPermission.class)) || user.hasRootPermission(SeeFilePathsPermission.class);
     }
 
-    public static void adminRotatePassword(ValidEmail email, BindException errors, Container c, User user)
+    public static void adminRotatePassword(User affectedUser, BindException errors, Container c, User user)
     {
-        adminRotatePassword(email, errors, c, user, HtmlString.EMPTY_STRING);
+        adminRotatePassword(affectedUser, errors, c, user, HtmlString.EMPTY_STRING);
     }
 
-    public static void adminRotatePassword(ValidEmail email, BindException errors, Container c, User currentUser, HtmlString mailErrorHtml)
+    public static void adminRotatePassword(User affectedUser, BindException errors, Container c, User currentUser, HtmlString mailErrorHtml)
     {
         // We let admins create passwords (i.e., entries in the logins table) if they don't already exist.
         // This addresses SSO and LDAP scenarios, see #10374.
-        User affectedUser = UserManager.getUser(email);
-        if (null == affectedUser)
-        {
-            errors.addError(new LabKeyError(new Exception("Failed to reset password; user not found")));
-            return;
-        }
+
         boolean loginExists = LoginManager.loginExists(affectedUser);
         String pastVerb = loginExists ? "reset" : "created";
         String infinitiveVerb = loginExists ? "reset" : "create";
@@ -2728,34 +2723,33 @@ public class SecurityManager
             }
             else
             {
-
-                verification = LoginManager.createLogin(affectedUser.getUserId(), email);
+                verification = LoginManager.createLogin(affectedUser.getUserId(), affectedUser.getEmail());
             }
 
             try
             {
                 ActionURL verificationURL = LoginManager.createVerificationURL(c, affectedUser, verification, null);
-                sendEmail(c, currentUser, getResetMessage(false), email.getEmailAddress(), verificationURL);
+                sendEmail(c, currentUser, getResetMessage(false), affectedUser.getEmail(), verificationURL);
 
-                if (!currentUser.getEmail().equals(email.getEmailAddress()))
+                if (!currentUser.equals(affectedUser))
                 {
                     SecurityMessage msg = getResetMessage(true);
-                    msg.setTo(email.getEmailAddress());
+                    msg.setTo(affectedUser.getEmail());
                     sendEmail(c, currentUser, msg, currentUser.getEmail(), verificationURL);
                 }
-                UserManager.addToUserHistory(UserManager.getUser(email), currentUser.getEmail() + " " + pastVerb + " the password.");
+                UserManager.addToUserHistory(affectedUser, currentUser.getEmail() + " " + pastVerb + " the password.");
             }
             catch (ConfigurationException | MessagingException e)
             {
                 String message = "Failed to send email due to: " + e.getMessage();
                 errors.addError(!mailErrorHtml.isEmpty() ? new LabKeyErrorWithHtml(message, mailErrorHtml) : new LabKeyError(message));
-                UserManager.addToUserHistory(UserManager.getUser(email), currentUser.getEmail() + " " + pastVerb + " the password, but sending the email failed.");
+                UserManager.addToUserHistory(affectedUser, currentUser.getEmail() + " " + pastVerb + " the password, but sending the email failed.");
             }
         }
         catch (UserManagementException e)
         {
             errors.addError(new LabKeyError(new Exception("Failed to reset password due to: " + e.getMessage(), e)));
-            UserManager.addToUserHistory(UserManager.getUser(email), currentUser.getEmail() + " attempted to " + infinitiveVerb + " the password, but the " + infinitiveVerb + " failed: " + e.getMessage());
+            UserManager.addToUserHistory(affectedUser, currentUser.getEmail() + " attempted to " + infinitiveVerb + " the password, but the " + infinitiveVerb + " failed: " + e.getMessage());
         }
     }
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2291,7 +2291,7 @@ public class SecurityManager
             if (newUserStatus.getHasLogin() && sendMail)
             {
                 Container c = context.getContainer();
-                messageContentsURL = PageFlowUtil.urlProvider(SecurityUrls.class).getShowRegistrationEmailURL(c, email, mailPrefix);
+                messageContentsURL = PageFlowUtil.urlProvider(SecurityUrls.class).getShowRegistrationEmailURL(c, newUserStatus.getUser(), mailPrefix);
 
                 sendRegistrationEmail(context, email, mailPrefix, newUserStatus, extraParameters, provider, isAddUser);
             }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3294,7 +3294,7 @@ public class SecurityManager
                 rawEmail = "test_" + Math.round(Math.random() * 10000) + "@localhost.xyz";
                 email = new ValidEmail(rawEmail);
             }
-            while (LoginManager.loginExists(email));
+            while (UserManager.getUser(email) != null);
 
             User user = null;
 
@@ -3305,10 +3305,10 @@ public class SecurityManager
                 user = status.getUser();
                 assertTrue("addUser", user.getUserId() != 0);
 
-                boolean success = LoginManager.verify(email, status.getVerification());
+                boolean success = LoginManager.verify(user, status.getVerification());
                 assertTrue("verify", success);
 
-                LoginManager.setVerification(email, null);
+                LoginManager.setVerification(user, null);
 
                 String password = generateStrongPassword(user);
                 LoginManager.setPassword(user, password);

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -1102,12 +1102,6 @@ public class SecurityManager
 
         try (Transaction transaction = scope.ensureTransaction())
         {
-            if (createLogin && !status.isLdapOrSsoEmail())
-            {
-                String verification = createLogin(email);
-                status.setVerification(verification);
-            }
-
             try
             {
                 Integer userId = null;
@@ -1142,6 +1136,15 @@ public class SecurityManager
                     assert false : "User should either exist or not; synchronization problem?";
                     LOG.debug("createUser: Something failed user: " + email);
                     return null;
+                }
+
+                //
+                // Add row to Logins table, if needed
+                //
+                if (createLogin && !status.isLdapOrSsoEmail())
+                {
+                    String verification = createLogin(userId, email);
+                    status.setVerification(verification);
                 }
 
                 //
@@ -1257,8 +1260,8 @@ public class SecurityManager
         }
     }
 
-    // Create record for database login, saving email address and hashed password. Return verification token.
-    public static String createLogin(ValidEmail email) throws UserManagementException
+    // Create record for database login, saving UserId and hashed password. Return verification token.
+    public static String createLogin(int userId, ValidEmail email /* Just for logging errors */) throws UserManagementException
     {
         // Create a placeholder password hash and a separate email verification key that will get emailed to the new user
         String tempPassword = createTempPassword();
@@ -1268,10 +1271,11 @@ public class SecurityManager
 
         try
         {
+            // TODO: Stop inserting Email after removing that column
             // Don't need to set LastChanged -- it defaults to current date/time.
             int rowCount = new SqlExecutor(core.getSchema()).execute("INSERT INTO " + core.getTableInfoLogins() +
-                    " (Email, Crypt, LastChanged, Verification, PreviousCrypts) VALUES (?, ?, ?, ?, ?)",
-                    email.getEmailAddress(), crypt, new Date(), verification, crypt);
+                    " (UserId, Email, Crypt, LastChanged, Verification, PreviousCrypts) VALUES (?, ?, ?, ?, ?, ?)",
+                    userId, email.getEmailAddress(), crypt, new Date(), verification, crypt);
             if (1 != rowCount)
                 throw new UserManagementException(email, "Login creation statement affected " + rowCount + " rows.");
         }
@@ -2889,11 +2893,12 @@ public class SecurityManager
         adminRotatePassword(email, errors, c, user, HtmlString.EMPTY_STRING);
     }
 
-    public static void adminRotatePassword(ValidEmail email, BindException errors, Container c, User user, HtmlString mailErrorHtml)
+    public static void adminRotatePassword(ValidEmail email, BindException errors, Container c, User currentUser, HtmlString mailErrorHtml)
     {
         // We let admins create passwords (i.e., entries in the logins table) if they don't already exist.
         // This addresses SSO and LDAP scenarios, see #10374.
         boolean loginExists = loginExists(email);
+        User affectedUser = UserManager.getUser(email);
         String pastVerb = loginExists ? "reset" : "created";
         String infinitiveVerb = loginExists ? "reset" : "create";
 
@@ -2911,33 +2916,34 @@ public class SecurityManager
             }
             else
             {
-                verification = createLogin(email);
+
+                verification = createLogin(affectedUser.getUserId(), email);
             }
 
             try
             {
                 ActionURL verificationURL = createVerificationURL(c, email, verification, null);
-                sendEmail(c, user, getResetMessage(false), email.getEmailAddress(), verificationURL);
+                sendEmail(c, currentUser, getResetMessage(false), email.getEmailAddress(), verificationURL);
 
-                if (!user.getEmail().equals(email.getEmailAddress()))
+                if (!currentUser.getEmail().equals(email.getEmailAddress()))
                 {
                     SecurityMessage msg = getResetMessage(true);
                     msg.setTo(email.getEmailAddress());
-                    sendEmail(c, user, msg, user.getEmail(), verificationURL);
+                    sendEmail(c, currentUser, msg, currentUser.getEmail(), verificationURL);
                 }
-                UserManager.addToUserHistory(UserManager.getUser(email), user.getEmail() + " " + pastVerb + " the password.");
+                UserManager.addToUserHistory(UserManager.getUser(email), currentUser.getEmail() + " " + pastVerb + " the password.");
             }
             catch (ConfigurationException | MessagingException e)
             {
                 String message = "Failed to send email due to: " + e.getMessage();
                 errors.addError(!mailErrorHtml.isEmpty() ? new LabKeyErrorWithHtml(message, mailErrorHtml) : new LabKeyError(message));
-                UserManager.addToUserHistory(UserManager.getUser(email), user.getEmail() + " " + pastVerb + " the password, but sending the email failed.");
+                UserManager.addToUserHistory(UserManager.getUser(email), currentUser.getEmail() + " " + pastVerb + " the password, but sending the email failed.");
             }
         }
         catch (UserManagementException e)
         {
             errors.addError(new LabKeyError(new Exception("Failed to reset password due to: " + e.getMessage(), e)));
-            UserManager.addToUserHistory(UserManager.getUser(email), user.getEmail() + " attempted to " + infinitiveVerb + " the password, but the " + infinitiveVerb + " failed: " + e.getMessage());
+            UserManager.addToUserHistory(UserManager.getUser(email), currentUser.getEmail() + " attempted to " + infinitiveVerb + " the password, but the " + infinitiveVerb + " failed: " + e.getMessage());
         }
     }
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -901,79 +901,6 @@ public class SecurityManager
         return (List<AuthenticationValidator>)session.getAttribute(AUTHENTICATION_VALIDATORS_KEY);
     }
 
-    private static final String passwordChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    public static final int tempPasswordLength = 32;
-
-    public static String createTempPassword()
-    {
-        StringBuilder tempPassword = new StringBuilder(tempPasswordLength);
-
-        for (int i = 0; i < tempPasswordLength; i++)
-            tempPassword.append(passwordChars.charAt((int) Math.floor((Math.random() * passwordChars.length()))));
-
-        return tempPassword.toString();
-    }
-
-    public static ActionURL createVerificationURL(Container c, ValidEmail email, String verification, @Nullable List<Pair<String, String>> extraParameters)
-    {
-        return PageFlowUtil.urlProvider(LoginUrls.class).getVerificationURL(c, email, verification, extraParameters);
-    }
-
-    public static ActionURL createModuleVerificationURL(Container c, ValidEmail email, String verification, @Nullable List<Pair<String, String>> extraParameters, String provider, boolean isAddUser)
-    {
-        ActionURL defaultUrl = createVerificationURL(c, email, verification, extraParameters);
-        if (provider == null)
-            return defaultUrl;
-
-        ResetPasswordProvider urlProvider = AuthenticationManager.getResetPasswordProvider(provider);
-        if (urlProvider == null)
-            return defaultUrl;
-
-        ActionURL verificationUrl = urlProvider.getAPIVerificationURL(c, isAddUser);
-        verificationUrl.addParameter("verification", verification);
-        verificationUrl.addParameter("email", email.getEmailAddress());
-
-        if (null != extraParameters)
-            verificationUrl.addParameters(extraParameters);
-
-        return verificationUrl;
-    }
-
-    // Test if user has been verified for database authentication
-    public static boolean isVerified(ValidEmail email)
-    {
-        return (null == getVerification(email));
-    }
-
-    // Test if user has been verified for database authentication. Use only when email address could be invalid ().
-    public static boolean isVerified(String email)
-    {
-        return (null == getVerification(email));
-    }
-
-    public static boolean verify(ValidEmail email, String verification)
-    {
-        String dbVerification = getVerification(email);
-        return (dbVerification != null && dbVerification.equals(verification));
-    }
-
-    public static void setVerification(ValidEmail email, @Nullable String verification) throws UserManagementException
-    {
-        int rows = new SqlExecutor(core.getSchema()).execute("UPDATE " + core.getTableInfoLogins() + " SET Verification=? WHERE LOWER(email)=LOWER(?)", verification, email.getEmailAddress());
-        if (1 != rows)
-            throw new UserManagementException(email, "Unexpected number of rows returned when setting verification: " + rows);
-    }
-
-    public static String getVerification(ValidEmail email)
-    {
-        return getVerification(email.getEmailAddress());
-    }
-
-    private static String getVerification(String email)
-    {
-        return new SqlSelector(core.getSchema(), "SELECT Verification FROM " + core.getTableInfoLogins() + " WHERE Email = ?", email).getObject(String.class);
-    }
-
     public static class NewUserStatus
     {
         private final ValidEmail _email;
@@ -1143,7 +1070,7 @@ public class SecurityManager
                 //
                 if (createLogin && !status.isLdapOrSsoEmail())
                 {
-                    String verification = createLogin(userId, email);
+                    String verification = LoginManager.createLogin(userId, email);
                     status.setVerification(verification);
                 }
 
@@ -1258,127 +1185,6 @@ public class SecurityManager
         {
             throw new MessagingException("Failed to set template context.", e);
         }
-    }
-
-    // Create record for database login, saving UserId and hashed password. Return verification token.
-    public static String createLogin(int userId, ValidEmail email /* Just for logging errors */) throws UserManagementException
-    {
-        // Create a placeholder password hash and a separate email verification key that will get emailed to the new user
-        String tempPassword = createTempPassword();
-        String verification = createTempPassword();
-
-        String crypt = Crypt.MD5.digestWithPrefix(tempPassword);
-
-        try
-        {
-            // TODO: Stop inserting Email after removing that column
-            // Don't need to set LastChanged -- it defaults to current date/time.
-            int rowCount = new SqlExecutor(core.getSchema()).execute("INSERT INTO " + core.getTableInfoLogins() +
-                    " (UserId, Email, Crypt, LastChanged, Verification, PreviousCrypts) VALUES (?, ?, ?, ?, ?, ?)",
-                    userId, email.getEmailAddress(), crypt, new Date(), verification, crypt);
-            if (1 != rowCount)
-                throw new UserManagementException(email, "Login creation statement affected " + rowCount + " rows.");
-        }
-        catch (DataIntegrityViolationException e)
-        {
-            throw new UserAlreadyExistsException(email);
-        }
-
-        return verification;
-    }
-
-    public static void setPassword(ValidEmail email, String password) throws UserManagementException
-    {
-        String crypt = Crypt.BCrypt.digestWithPrefix(password);
-        List<String> history = new ArrayList<>(getCryptHistory(email.getEmailAddress()));
-        history.add(crypt);
-
-        // Remember only the last 10 password hashes
-        int itemsToDelete = Math.max(0, history.size() - MAX_HISTORY);
-        for (int i = 0; i < itemsToDelete; i++)
-            history.remove(i);
-        String cryptHistory = StringUtils.join(history, ",");
-
-        int rows = new SqlExecutor(core.getSchema()).execute("UPDATE " + core.getTableInfoLogins() + " SET Crypt=?, LastChanged=?, PreviousCrypts=? WHERE Email=?", crypt, new Date(), cryptHistory, email.getEmailAddress());
-        if (1 != rows)
-            throw new UserManagementException(email, "Password update statement affected " + rows + " rows.");
-    }
-
-    private static final int MAX_HISTORY = 10;
-
-    private static List<String> getCryptHistory(String email)
-    {
-        Selector selector = new SqlSelector(core.getSchema(), new SQLFragment("SELECT PreviousCrypts FROM " + core.getTableInfoLogins() + " WHERE Email=?", email));
-        String cryptHistory = selector.getObject(String.class);
-
-        if (null == cryptHistory)
-        {
-            return Collections.emptyList();
-        }
-        else
-        {
-            List<String> cryptList = Arrays.asList(cryptHistory.split(","));
-            assert cryptList.size() <= MAX_HISTORY;
-
-            return cryptList;
-        }
-    }
-
-    public static boolean matchesPreviousPassword(String password, User user)
-    {
-        List<String> history = getCryptHistory(user.getEmail());
-
-        for (String hash : history)
-        {
-            if (matchPassword(password, hash))
-                return true;
-        }
-
-        return false;
-    }
-
-    public static Date getLastChanged(User user)
-    {
-        SqlSelector selector = new SqlSelector(core.getSchema(), new SQLFragment("SELECT LastChanged FROM " + core.getTableInfoLogins() + " WHERE Email=?", user.getEmail()));
-        return selector.getObject(Date.class);
-    }
-
-    // Look up email in Logins table and return the corresponding password hash
-    public static String getPasswordHash(ValidEmail email)
-    {
-        return getPasswordHash(email.getEmailAddress());
-    }
-
-    // For internal use only, plus database login and change email workflows, where existing email address could be invalid (i.e., non-conforming per RFC 822)
-    public static String getPasswordHash(String email)
-    {
-        SqlSelector selector = new SqlSelector(core.getSchema(), new SQLFragment("SELECT Crypt FROM " + core.getTableInfoLogins() + " WHERE Email = ?", email));
-        return selector.getObject(String.class);
-    }
-
-    public static boolean matchPassword(String password, String hash)
-    {
-        if (StringUtils.isEmpty(hash) || hash.startsWith("disabled:"))
-            return false;
-        else if (Crypt.BCrypt.acceptPrefix(hash))
-            return Crypt.BCrypt.matchesWithPrefix(password, hash);
-        else if (Crypt.SaltMD5.acceptPrefix(hash))
-            return Crypt.SaltMD5.matchesWithPrefix(password, hash);
-        else if (Crypt.MD5.acceptPrefix(hash))
-            return Crypt.MD5.matchesWithPrefix(password, hash);
-        else
-            return Crypt.MD5.matches(password, hash);
-    }
-
-    // Used in the case of set password or email change... current email address could be invalid (i.e., non-conforming per RFC 822)
-    public static boolean loginExists(String email)
-    {
-        return (null != getPasswordHash(email));
-    }
-
-    public static boolean loginExists(ValidEmail email)
-    {
-        return (null != getPasswordHash(email));
     }
 
     public static Group createGroup(Container c, String name)
@@ -2511,7 +2317,7 @@ public class SecurityManager
                 {
                     message.append("  Click ");
                     message.unsafeAppend("<a href=\"");
-                    message.append(createVerificationURL(context.getContainer(), email, newUserStatus.getVerification(), extraParameters).toString());
+                    message.append(LoginManager.createVerificationURL(context.getContainer(), email, newUserStatus.getVerification(), extraParameters).toString());
                     message.unsafeAppend("\" target=\"_blank\">here</a>");
                     message.append(" to change the password from the random one that was assigned.");
                 }
@@ -2566,7 +2372,7 @@ public class SecurityManager
         Container c = context.getContainer();
         User currentUser = context.getUser();
 
-        ActionURL verificationURL = createModuleVerificationURL(context.getContainer(), email, newUserStatus.getVerification(), extraParameters, provider, isAddUser);
+        ActionURL verificationURL = LoginManager.createModuleVerificationURL(context.getContainer(), email, newUserStatus.getVerification(), extraParameters, provider, isAddUser);
 
         sendEmail(c, currentUser, getRegistrationMessage(mailPrefix, false), email.getEmailAddress(), verificationURL);
         if (!currentUser.isGuest() && !currentUser.getEmail().equals(email.getEmailAddress()))
@@ -2897,8 +2703,8 @@ public class SecurityManager
     {
         // We let admins create passwords (i.e., entries in the logins table) if they don't already exist.
         // This addresses SSO and LDAP scenarios, see #10374.
-        boolean loginExists = loginExists(email);
         User affectedUser = UserManager.getUser(email);
+        boolean loginExists = LoginManager.loginExists(affectedUser);
         String pastVerb = loginExists ? "reset" : "created";
         String infinitiveVerb = loginExists ? "reset" : "create";
 
@@ -2910,19 +2716,19 @@ public class SecurityManager
             {
                 // Create a placeholder password that's impossible to guess and a separate email
                 // verification key that gets emailed.
-                verification = createTempPassword();
-                setPassword(email, createTempPassword());
-                setVerification(email, verification);
+                verification = LoginManager.createTempPassword();
+                LoginManager.setPassword(affectedUser, LoginManager.createTempPassword());
+                LoginManager.setVerification(email, verification);
             }
             else
             {
 
-                verification = createLogin(affectedUser.getUserId(), email);
+                verification = LoginManager.createLogin(affectedUser.getUserId(), email);
             }
 
             try
             {
-                ActionURL verificationURL = createVerificationURL(c, email, verification, null);
+                ActionURL verificationURL = LoginManager.createVerificationURL(c, email, verification, null);
                 sendEmail(c, currentUser, getResetMessage(false), email.getEmailAddress(), verificationURL);
 
                 if (!currentUser.getEmail().equals(email.getEmailAddress()))
@@ -2945,13 +2751,6 @@ public class SecurityManager
             errors.addError(new LabKeyError(new Exception("Failed to reset password due to: " + e.getMessage(), e)));
             UserManager.addToUserHistory(UserManager.getUser(email), currentUser.getEmail() + " attempted to " + infinitiveVerb + " the password, but the " + infinitiveVerb + " failed: " + e.getMessage());
         }
-    }
-
-    // We let admins delete passwords (i.e., entries in the logins table), see #42691
-    public static void adminDeletePassword(ValidEmail email, User user)
-    {
-        new SqlExecutor(CoreSchema.getInstance().getScope()).execute("DELETE FROM " + CoreSchema.getInstance().getTableInfoLogins() + " WHERE Email = ?", email.getEmailAddress());
-        UserManager.addToUserHistory(UserManager.getUser(email), user.getEmail() + " deleted the password.");
     }
 
     private static final class UserGroupsStartupProperty implements StartupProperty
@@ -3489,7 +3288,7 @@ public class SecurityManager
                 rawEmail = "test_" + Math.round(Math.random() * 10000) + "@localhost.xyz";
                 email = new ValidEmail(rawEmail);
             }
-            while (loginExists(email));
+            while (LoginManager.loginExists(email));
 
             User user = null;
 
@@ -3500,13 +3299,13 @@ public class SecurityManager
                 user = status.getUser();
                 assertTrue("addUser", user.getUserId() != 0);
 
-                boolean success = verify(email, status.getVerification());
+                boolean success = LoginManager.verify(email, status.getVerification());
                 assertTrue("verify", success);
 
-                setVerification(email, null);
+                LoginManager.setVerification(email, null);
 
                 String password = generateStrongPassword(user);
-                setPassword(email, password);
+                LoginManager.setPassword(user, password);
 
                 User user2 = AuthenticationManager.authenticate(ViewServlet.mockRequest("GET", new ActionURL(), null, null, null), rawEmail, password);
                 assertNotNull("\"" + rawEmail + "\" failed to authenticate with password \"" + password + "\"; check labkey.log around timestamp " + DateUtil.formatDateTime(new Date(), "HH:mm:ss,SSS") + " for the reason", user2);
@@ -3527,7 +3326,7 @@ public class SecurityManager
             // rules disallow.
             do
             {
-                password = createTempPassword() + "Az9!";
+                password = LoginManager.createTempPassword() + "Az9!";
             }
             while (!PasswordRule.Good.isValidForLogin(password, user, null));
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -3297,10 +3297,12 @@ public class SecurityManager
             {
                 NewUserStatus status = addUser(email, null);
                 user = status.getUser();
+                assertNotNull(user);
                 assertTrue("addUser", user.getUserId() != 0);
 
-                boolean success = LoginManager.verify(user, status.getVerification());
-                assertTrue("verify", success);
+                User verifiedUser = LoginManager.verify(status.getVerification());
+                assertNotNull(verifiedUser);
+                assertEquals(user, verifiedUser);
 
                 LoginManager.setVerification(user, null);
 

--- a/api/src/org/labkey/api/security/SecurityUrls.java
+++ b/api/src/org/labkey/api/security/SecurityUrls.java
@@ -32,7 +32,7 @@ public interface SecurityUrls extends UrlProvider
     ActionURL getPermissionsURL(Container container, URLHelper returnURL);
     ActionURL getSiteGroupsURL(Container container, URLHelper returnURL);
     ActionURL getContainerURL(Container container);
-    ActionURL getShowRegistrationEmailURL(Container container, ValidEmail email, String mailPrefix);
+    ActionURL getShowRegistrationEmailURL(Container container, User user, String mailPrefix);
     ActionURL getAddUsersURL(Container container);
     ActionURL getFolderAccessURL(Container container);
     ActionURL getExternalToolsViewURL(User user, Container c, @NotNull ActionURL returnURL);

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -884,10 +884,9 @@ public class UserManager
                     throw new UserManagementException(oldEmail, "Unexpected number of rows returned when setting new display name: " + rows);
             }
 
-            ValidEmail validNewEmail = new ValidEmail(newEmail);
-            if (LoginManager.loginExists(validNewEmail))
+            if (LoginManager.loginExists(userToChange))
             {
-                LoginManager.setVerification(validNewEmail, null);  // so we don't let user use this link again
+                LoginManager.setVerification(userToChange, null);  // so we don't let user use this link again
             }
 
             transaction.commit();

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -80,8 +80,6 @@ import org.labkey.api.view.ViewContext;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.sql.Timestamp;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -846,26 +844,6 @@ public class UserManager
         addToUserHistory(toUpdate, "Contact information for " + toUpdate.getEmail() + " was updated");
     }
 
-    public static void requestEmailChange(User userToChange, ValidEmail requestedEmail, String verificationToken, User currentUser) throws UserManagementException
-    {
-        if (SecurityManager.loginExists(userToChange.getEmail()))
-        {
-            DbScope scope = CORE.getSchema().getScope();
-            try (Transaction transaction = scope.ensureTransaction())
-            {
-                Instant timeoutDate = Instant.now().plus(VERIFICATION_EMAIL_TIMEOUT, ChronoUnit.MINUTES);
-                SqlExecutor executor = new SqlExecutor(CORE.getSchema());
-                int rows = executor.execute("UPDATE " + CORE.getTableInfoLogins() + " SET RequestedEmail = ?, Verification = ?, VerificationTimeout = ? WHERE Email = ?",
-                        requestedEmail.getEmailAddress(), verificationToken, Date.from(timeoutDate), userToChange.getEmail());
-                if (1 != rows)
-                    throw new UserManagementException(requestedEmail, "Unexpected number of rows returned when setting verification: " + rows);
-                addToUserHistory(userToChange, currentUser + " requested email address change from " + userToChange.getEmail() + " to " + requestedEmail +
-                        " with token '" + verificationToken + "' and timeout date '" + Date.from(timeoutDate) + "'.");
-                transaction.commit();
-            }
-        }
-    }
-
     public static void changeEmail(User currentUser, User userToChange, boolean isAdmin, String newEmail, String verificationToken)
             throws UserManagementException, ValidEmail.InvalidEmailException
     {
@@ -879,7 +857,7 @@ public class UserManager
         {
             if (!isAdmin)
             {
-                if (!getVerifyEmail(oldEmail).isVerified(verificationToken))  // shouldn't happen! should be testing this earlier too
+                if (!LoginManager.getVerifyEmail(userToChange).isVerified(verificationToken))  // shouldn't happen! should be testing this earlier too
                 {
                     throw new UserManagementException(oldEmail, "Verification token '" + verificationToken + "' is incorrect for email change for user " + oldEmail);
                 }
@@ -890,7 +868,6 @@ public class UserManager
             if (1 != rows)
                 throw new UserManagementException(oldEmail, "Unexpected number of rows returned when setting new name: " + rows);
 
-            executor.execute("UPDATE " + CORE.getTableInfoLogins() + " SET Email = ? WHERE Email = ?", newEmail, oldEmail);  // won't update if non-LabKey-managed, because there is no data here
             if (isAdmin)
             {
                 addToUserHistory(userToChange, "Admin " + currentUser + " changed an email address from " + oldEmail + " to " + newEmail + ".");
@@ -908,9 +885,9 @@ public class UserManager
             }
 
             ValidEmail validNewEmail = new ValidEmail(newEmail);
-            if (SecurityManager.loginExists(validNewEmail))
+            if (LoginManager.loginExists(validNewEmail))
             {
-                SecurityManager.setVerification(validNewEmail, null);  // so we don't let user use this link again
+                LoginManager.setVerification(validNewEmail, null);  // so we don't let user use this link again
             }
 
             transaction.commit();
@@ -931,79 +908,15 @@ public class UserManager
                 " with token '" + verificationToken + "', but the verification token for that email address was not correct.");
     }
 
-    public static VerifyEmail getVerifyEmail(String email)
-    {
-        SqlSelector sqlSelector = new SqlSelector(CORE.getSchema(), "SELECT Email, RequestedEmail, Verification, VerificationTimeout FROM " + CORE.getTableInfoLogins()
-                + " WHERE Email = ?", email);
-        return sqlSelector.getObject(VerifyEmail.class);
-    }
-
-    public static class VerifyEmail
-    {
-        private String _email;
-        private String _requestedEmail;
-        private String _verification;
-        private Date _verificationTimeout;
-
-        public String getEmail()
-        {
-            return _email;
-        }
-
-        @SuppressWarnings("unused")
-        public void setEmail(String email)
-        {
-            _email = email;
-        }
-
-        public String getRequestedEmail()
-        {
-            return _requestedEmail;
-        }
-
-        @SuppressWarnings("unused")
-        public void setRequestedEmail(String requestedEmail)
-        {
-            _requestedEmail = requestedEmail;
-        }
-
-        public String getVerification()
-        {
-            return _verification;
-        }
-
-        @SuppressWarnings("unused")
-        public void setVerification(String verification)
-        {
-            _verification = verification;
-        }
-
-        public Date getVerificationTimeout()
-        {
-            return _verificationTimeout;
-        }
-
-        @SuppressWarnings("unused")
-        public void setVerificationTimeout(Date verificationTimeout)
-        {
-            _verificationTimeout = verificationTimeout;
-        }
-
-        public boolean isVerified(String userProvidedToken)
-        {
-            return userProvidedToken != null && userProvidedToken.equals(_verification);
-        }
-    }
-
     public static void deleteUser(int userId) throws UserManagementException
     {
-        User user = getUser(userId);
-        if (null == user)
+        User deletUser = getUser(userId);
+        if (null == deletUser)
             return;
 
-        removeRecentUser(user);
+        removeRecentUser(deletUser);
 
-        List<Throwable> errors = fireDeleteUser(user);
+        List<Throwable> errors = fireDeleteUser(deletUser);
 
         if (!errors.isEmpty())
         {
@@ -1016,19 +929,19 @@ public class UserManager
 
         try (Transaction transaction = CORE.getScope().ensureTransaction())
         {
-            boolean needToEnsureRootAdmins = SecurityManager.isRootAdmin(user);
+            boolean needToEnsureRootAdmins = SecurityManager.isRootAdmin(deletUser);
 
             SqlExecutor executor = new SqlExecutor(CORE.getSchema());
             executor.execute("DELETE FROM " + CORE.getTableInfoRoleAssignments() + " WHERE UserId=?", userId);
             executor.execute("DELETE FROM " + CORE.getTableInfoMembers() + " WHERE UserId=?", userId);
-            addToUserHistory(user, user.getEmail() + " was deleted from the system");
+            addToUserHistory(deletUser, deletUser.getEmail() + " was deleted from the system");
 
             executor.execute("DELETE FROM " + CORE.getTableInfoUsersData() + " WHERE UserId=?", userId);
-            executor.execute("DELETE FROM " + CORE.getTableInfoLogins() + " WHERE Email=?", user.getEmail());
+            LoginManager.deleteLoginsRow(deletUser, null);
             executor.execute("DELETE FROM " + CORE.getTableInfoPrincipals() + " WHERE UserId=?", userId);
             executor.execute("DELETE FROM " + CORE.getTableAPIKeys() + " WHERE CreatedBy=?", userId);
 
-            OntologyManager.deleteOntologyObject(user.getEntityId(), ContainerManager.getSharedContainer(), true);
+            OntologyManager.deleteOntologyObject(deletUser.getEntityId(), ContainerManager.getSharedContainer(), true);
 
             // Clear user list immediately (before the last root admin check) and again after commit/rollback
             transaction.addCommitTask(UserManager::clearUserList, CommitTaskOption.IMMEDIATE, CommitTaskOption.POSTCOMMIT, CommitTaskOption.POSTROLLBACK);
@@ -1041,7 +954,7 @@ public class UserManager
         catch (Exception e)
         {
             LOG.error("deleteUser: " + e);
-            throw new UserManagementException(user.getEmail(), e);
+            throw new UserManagementException(deletUser.getEmail(), e);
         }
 
         //TODO: Delete User files

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 24.008
+SchemaVersion: 24.009
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 24.007
+SchemaVersion: 24.008
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/core.xml
+++ b/core/resources/schemas/core.xml
@@ -67,6 +67,7 @@
   </table>
   <table tableName="Logins" tableDbType="TABLE">
     <columns>
+      <column columnName="UserId"/>
       <column columnName="Email"/>
       <column columnName="Crypt"/>
       <column columnName="Verification"/>

--- a/core/resources/schemas/dbscripts/postgresql/core-24.007-24.008.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-24.007-24.008.sql
@@ -1,5 +1,5 @@
 -- Shift the core.Logins PK from Email to UserId. Add UserId column as NULLABLE, populate it from core.Principals,
--- delete rows that didn't join (RowId IS NULL), make RowId NOT NULL, drop the old PK, and add the new PK.
+-- delete rows that didn't join (UserId IS NULL), make UserId NOT NULL, drop the old PK, and add the new PK.
 
 ALTER TABLE core.Logins ADD UserId USERID;
 UPDATE core.Logins SET UserId = (SELECT UserId FROM core.Principals p WHERE Name = Email);

--- a/core/resources/schemas/dbscripts/postgresql/core-24.007-24.008.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-24.007-24.008.sql
@@ -1,0 +1,9 @@
+-- Shift the core.Logins PK from Email to UserId. Add UserId column as NULLABLE, populate it from core.Principals,
+-- delete rows that didn't join (RowId IS NULL), make RowId NOT NULL, drop the old PK, and add the new PK.
+
+ALTER TABLE core.Logins ADD UserId USERID;
+UPDATE core.Logins SET UserId = (SELECT UserId FROM core.Principals p WHERE Name = Email);
+DELETE FROM core.Logins WHERE UserId IS NULL;
+ALTER TABLE core.Logins ALTER COLUMN UserId DROP NOT NULL;
+ALTER TABLE core.Logins DROP CONSTRAINT PK_Logins;
+ALTER TABLE core.Logins ADD CONSTRAINT PK_Logins PRIMARY KEY (UserId);

--- a/core/resources/schemas/dbscripts/postgresql/core-24.008-24.009.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-24.008-24.009.sql
@@ -1,0 +1,2 @@
+-- LabKey no longer reads or writes to the Email column. But we'll leave the column in place until 24.12 as a precaution.
+ALTER TABLE core.Logins ALTER COLUMN Email DROP NOT NULL;

--- a/core/resources/schemas/dbscripts/sqlserver/core-24.007-24.008.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-24.007-24.008.sql
@@ -1,5 +1,5 @@
 -- Shift the core.Logins PK from Email to UserId. Add UserId column as NULLABLE, populate it from core.Principals,
--- delete rows that didn't join (RowId IS NULL), make RowId NOT NULL, drop the old PK, and add the new PK.
+-- delete rows that didn't join (UserId IS NULL), make UserId NOT NULL, drop the old PK, and add the new PK.
 
 ALTER TABLE core.Logins ADD UserId USERID;
 GO

--- a/core/resources/schemas/dbscripts/sqlserver/core-24.007-24.008.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-24.007-24.008.sql
@@ -1,0 +1,13 @@
+-- Shift the core.Logins PK from Email to UserId. Add UserId column as NULLABLE, populate it from core.Principals,
+-- delete rows that didn't join (RowId IS NULL), make RowId NOT NULL, drop the old PK, and add the new PK.
+
+ALTER TABLE core.Logins ADD UserId USERID;
+GO
+
+UPDATE core.Logins SET UserId = (SELECT UserId FROM core.Principals p WHERE Name = Email);
+DELETE FROM core.Logins WHERE UserId IS NULL;
+ALTER TABLE core.Logins ALTER COLUMN UserId USERID NOT NULL;
+GO
+
+ALTER TABLE core.Logins DROP CONSTRAINT PK_Logins;
+ALTER TABLE core.Logins ADD CONSTRAINT PK_Logins PRIMARY KEY (UserId);

--- a/core/resources/schemas/dbscripts/sqlserver/core-24.008-24.009.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-24.008-24.009.sql
@@ -1,0 +1,3 @@
+-- LabKey no longer reads or writes to the Email column. But we'll leave the column in place until 24.12 as a precaution.
+ALTER TABLE core.Logins ALTER COLUMN Email VARCHAR(255) NULL;
+GO

--- a/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
+++ b/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
@@ -27,10 +27,10 @@ import org.labkey.api.security.ApiKeyManager;
 import org.labkey.api.security.AuthenticationManager.AuthenticationValidator;
 import org.labkey.api.security.AuthenticationProvider.LoginFormAuthenticationProvider;
 import org.labkey.api.security.ConfigurationSettings;
+import org.labkey.api.security.LoginManager;
 import org.labkey.api.security.LoginUrls;
 import org.labkey.api.security.PasswordExpiration;
 import org.labkey.api.security.PasswordRule;
-import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.ValidEmail;
@@ -132,24 +132,24 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
             try
             {
                 ValidEmail email = new ValidEmail(id);
-                hash = SecurityManager.getPasswordHash(email);
                 user = UserManager.getUser(email);
-                if (null == hash || null == user)
+                hash = LoginManager.getPasswordHash(user);
+                if (null == hash)
                     return AuthenticationResponse.createFailureResponse(configuration, FailureReason.userDoesNotExist);
             }
             catch (InvalidEmailException e)
             {
                 // This invalid email address might be in the database. If so, attempt to authenticate; if not, throw.
-                hash = SecurityManager.getPasswordHash(id);
                 user = UserManager.getUsers(true).stream()
                     .filter(u -> u.getEmail().equals(id))
                     .findAny()
                     .orElse(null);
-                if (null == hash || null == user)
+                hash = LoginManager.getPasswordHash(user);
+                if (null == hash)
                     throw e;
             }
 
-            if (!SecurityManager.matchPassword(password, hash))
+            if (!LoginManager.matchPassword(password, hash))
                 return AuthenticationResponse.createFailureResponse(configuration, FailureReason.badPassword);
 
             if (user.isActive())
@@ -167,7 +167,7 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
                     PasswordExpiration expiration = configuration.getExpiration();
                     User user2 = user;
 
-                    if (expiration.hasExpired(() -> SecurityManager.getLastChanged(user2)))
+                    if (expiration.hasExpired(() -> LoginManager.getLastChanged(user2)))
                     {
                         return getChangePasswordResponse(configuration, user, returnURL, FailureReason.expired);
                     }

--- a/core/src/org/labkey/core/login/DbLoginManager.java
+++ b/core/src/org/labkey/core/login/DbLoginManager.java
@@ -31,6 +31,7 @@ import org.labkey.api.security.AuthenticationManager;
 import org.labkey.api.security.AuthenticationManager.AuthenticationResult;
 import org.labkey.api.security.AuthenticationSettingsAuditTypeProvider.AuthSettingsAuditEvent;
 import org.labkey.api.security.DbLoginService;
+import org.labkey.api.security.LoginManager;
 import org.labkey.api.security.PasswordExpiration;
 import org.labkey.api.security.PasswordRule;
 import org.labkey.api.security.SecurityManager;
@@ -101,7 +102,7 @@ public class DbLoginManager implements DbLoginService
 
         try
         {
-            SecurityManager.setPassword(email, password);
+            LoginManager.setPassword(user, password);
             // Invalidate all sessions belonging to this user that were authenticated via database authentication
             UserManager.handleSessionsForUser(user, new SessionHandler()
             {
@@ -136,7 +137,7 @@ public class DbLoginManager implements DbLoginService
         try
         {
             if (clearVerification)
-                SecurityManager.setVerification(email, null);
+                LoginManager.setVerification(user, null);
             UserManager.addToUserHistory(user, auditMessage);
         }
         catch (SecurityManager.UserManagementException e)

--- a/core/src/org/labkey/core/login/DbLoginManager.java
+++ b/core/src/org/labkey/core/login/DbLoginManager.java
@@ -85,15 +85,14 @@ public class DbLoginManager implements DbLoginService
     static final String DATABASE_AUTHENTICATION_CATEGORY_KEY = "DatabaseAuthentication";
 
     @Override
-    public AuthenticationResult attemptSetPassword(Container c, User currentUser, String rawPassword, String rawPassword2, HttpServletRequest request, ValidEmail email, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, boolean changeOperation, BindException errors) throws InvalidEmailException
+    public AuthenticationResult attemptSetPassword(Container c, User currentUser, String rawPassword, String rawPassword2, HttpServletRequest request, User affectedUser, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, boolean changeOperation, BindException errors) throws InvalidEmailException
     {
         String password = StringUtils.trimToEmpty(rawPassword);
         String password2 = StringUtils.trimToEmpty(rawPassword2);
 
         Collection<String> messages = new LinkedList<>();
-        User user = UserManager.getUser(email);
 
-        if (!getPasswordRule().isValidToStore(password, password2, user, changeOperation, messages))
+        if (!getPasswordRule().isValidToStore(password, password2, affectedUser, changeOperation, messages))
         {
             for (String message : messages)
                 errors.reject("setPassword", message);
@@ -102,9 +101,9 @@ public class DbLoginManager implements DbLoginService
 
         try
         {
-            LoginManager.setPassword(user, password);
+            LoginManager.setPassword(affectedUser, password);
             // Invalidate all sessions belonging to this user that were authenticated via database authentication
-            UserManager.handleSessionsForUser(user, new SessionHandler()
+            UserManager.handleSessionsForUser(affectedUser, new SessionHandler()
             {
                 @Override
                 public boolean handleSession(HttpSession session)
@@ -123,8 +122,7 @@ public class DbLoginManager implements DbLoginService
                 @Override
                 public void complete(int count)
                 {
-                    //noinspection DataFlowIssue
-                    LOG.debug("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "session"), user.getEmail());
+                    LOG.debug("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "session"), affectedUser.getEmail());
                 }
             });
         }
@@ -137,8 +135,8 @@ public class DbLoginManager implements DbLoginService
         try
         {
             if (clearVerification)
-                LoginManager.setVerification(user, null);
-            UserManager.addToUserHistory(user, auditMessage);
+                LoginManager.setVerification(affectedUser, null);
+            UserManager.addToUserHistory(affectedUser, auditMessage);
         }
         catch (SecurityManager.UserManagementException e)
         {
@@ -151,7 +149,7 @@ public class DbLoginManager implements DbLoginService
         // affected. This check should be equivalent to currentUser.equals(user).
         if (SecurityManager.getSessionUser(request.getSession()) == null)
         {
-            AuthenticationManager.PrimaryAuthenticationResult result = AuthenticationManager.authenticate(request, email.getEmailAddress(), password, returnUrlHelper, true);
+            AuthenticationManager.PrimaryAuthenticationResult result = AuthenticationManager.authenticate(request, affectedUser.getEmail(), password, returnUrlHelper, true);
 
             if (result.getStatus() == Success)
             {

--- a/core/src/org/labkey/core/login/DbLoginManager.java
+++ b/core/src/org/labkey/core/login/DbLoginManager.java
@@ -38,7 +38,6 @@ import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.UserManager.SessionHandler;
-import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.ValidEmail.InvalidEmailException;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.settings.StartupProperty;

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1774,16 +1774,16 @@ public class LoginController extends SpringActionController
 
     private static boolean attemptVerification(SetPasswordForm form, ValidEmail email, Errors errors)
     {
+        User user = UserManager.getUser(email); // TODO
         String verification = form.getVerification();
-        boolean isVerified = LoginManager.verify(email, verification);
+        boolean isVerified = LoginManager.verify(user, verification);
 
-        User user = UserManager.getUser(email);
-        LoginController.checkVerificationErrors(isVerified, user, email.getEmailAddress(), verification, errors);
+        LoginController.checkVerificationErrors(isVerified, user, verification, errors);
 
         return isVerified && !errors.hasErrors();
     }
 
-    public static void checkVerificationErrors(boolean isVerified, User user, String email, String verification, Errors errors)
+    public static void checkVerificationErrors(boolean isVerified, User user, String verification, Errors errors)
     {
         if (isVerified)
         {
@@ -1801,7 +1801,7 @@ public class LoginController extends SpringActionController
         {
             if (!LoginManager.loginExists(user))
             {
-                if (AuthenticationManager.isLdapOrSsoEmail(email))
+                if (AuthenticationManager.isLdapOrSsoEmail(user.getEmail()))
                     errors.reject("setPassword", "You can authenticate your account using LDAP/SSO and you do not need to set a separate password.");
                 else
                     errors.reject("setPassword", "This email address is not associated with an account. Make sure you've copied the entire link into your browser's address bar.");

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -68,6 +68,7 @@ import org.labkey.api.security.DbLoginService;
 import org.labkey.api.security.EntropyPasswordValidator;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.IgnoresTermsOfUse;
+import org.labkey.api.security.LoginManager;
 import org.labkey.api.security.LoginUrls;
 import org.labkey.api.security.PasswordExpiration;
 import org.labkey.api.security.PasswordRule;
@@ -750,7 +751,9 @@ public class LoginController extends SpringActionController
             ValidEmail email = form.getValidEmail(getViewContext(), errors);
             if (!errors.hasErrors())
             {
-                validateChangePassword(email, errors);
+                // TODO: Change to UserId
+                User user = UserManager.getUser(email);
+                validateChangePassword(user, errors);
                 _email = email;
             }
         }
@@ -853,7 +856,7 @@ public class LoginController extends SpringActionController
             return resetPasswordResponse(user, null, null);
         }
 
-        if (!SecurityManager.loginExists(email))
+        if (!LoginManager.loginExists(user))
         {
             _log.error("Password reset attempted for an account that doesn't have a password: " + email);
             return resetPasswordResponse(user, "You cannot reset the password for your account because it doesn't have a password. This usually means you log in via LDAP or single sign-on. Contact a server administrator if you have questions.", "Reset Password failed: " + email + " does not have a password");
@@ -867,14 +870,14 @@ public class LoginController extends SpringActionController
         try
         {
             // Create a verification key to email the user
-            String verification = SecurityManager.createTempPassword();
-            SecurityManager.setVerification(email, verification);
+            String verification = LoginManager.createTempPassword();
+            LoginManager.setVerification(user, verification);
             try
             {
                 Container c = getContainer();
                 LookAndFeelProperties laf = LookAndFeelProperties.getInstance(c);
                 final SecurityMessage message = SecurityManager.getResetMessage(false, user, providerName);
-                ActionURL verificationURL = SecurityManager.createModuleVerificationURL(c, email, verification, null, providerName, false);
+                ActionURL verificationURL = LoginManager.createModuleVerificationURL(c, email, verification, null, providerName, false);
 
                 final User system = new User(laf.getSystemEmailAddress(), 0);
                 system.setFirstName(laf.getCompanyName());
@@ -1772,7 +1775,7 @@ public class LoginController extends SpringActionController
     private static boolean attemptVerification(SetPasswordForm form, ValidEmail email, Errors errors)
     {
         String verification = form.getVerification();
-        boolean isVerified = SecurityManager.verify(email, verification);
+        boolean isVerified = LoginManager.verify(email, verification);
 
         User user = UserManager.getUser(email);
         LoginController.checkVerificationErrors(isVerified, user, email.getEmailAddress(), verification, errors);
@@ -1796,16 +1799,16 @@ public class LoginController extends SpringActionController
         }
         else
         {
-            if (!SecurityManager.loginExists(email))
+            if (!LoginManager.loginExists(email))
             {
                 if (AuthenticationManager.isLdapOrSsoEmail(email))
                     errors.reject("setPassword", "You can authenticate your account using LDAP/SSO and you do not need to set a separate password.");
                 else
                     errors.reject("setPassword", "This email address is not associated with an account. Make sure you've copied the entire link into your browser's address bar.");
             }
-            else if (SecurityManager.isVerified(email))
+            else if (LoginManager.isVerified(email))
                 errors.reject("setPassword", "This email address has already been verified.");
-            else if (null == verification || verification.length() < SecurityManager.tempPasswordLength)
+            else if (null == verification || verification.length() < LoginManager.TEMP_PASSWORD_LENGTH)
                 errors.reject("setPassword", "Make sure you've copied the entire link into your browser's address bar.");
             else
                 // Incorrect verification string
@@ -1980,7 +1983,8 @@ public class LoginController extends SpringActionController
         @Override
         protected void verify(SetPasswordForm form, ValidEmail email, Errors errors)
         {
-            _unrecoverableError = validateChangePassword(email, errors);
+            User user = UserManager.getUser(email);
+            _unrecoverableError = validateChangePassword(user, errors);
 
             if (!_unrecoverableError)
                 _email = email;
@@ -2037,8 +2041,9 @@ public class LoginController extends SpringActionController
 
     private boolean isOldPasswordMatch(String oldPassword, SetPasswordForm form, BindException errors) throws InvalidEmailException
     {
-        String hash = SecurityManager.getPasswordHash(new ValidEmail(form.getEmail()));
-        if (!SecurityManager.matchPassword(oldPassword, hash))
+        User user = UserManager.getUser(new ValidEmail(form.getEmail()));
+        String hash = LoginManager.getPasswordHash(user);
+        if (!LoginManager.matchPassword(oldPassword, hash))
         {
             errors.reject("password", "Incorrect old password.");
             return false;
@@ -2047,9 +2052,9 @@ public class LoginController extends SpringActionController
         return true;
     }
 
-    private boolean validateChangePassword(ValidEmail email, Errors errors)
+    private boolean validateChangePassword(User user, Errors errors)
     {
-        if (!SecurityManager.loginExists(email))
+        if (!LoginManager.loginExists(user))
         {
             errors.reject("setPassword", "This email address is not associated with an account.");
             return true;

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1858,7 +1858,7 @@ public class LoginController extends SpringActionController
             boolean success = false;
             DbScope scope = CoreSchema.getInstance().getSchema().getScope();
 
-           // All initial user creation steps need to be transacted
+            // All initial user creation steps need to be transacted
             try (DbScope.Transaction transaction = scope.ensureTransaction())
             {
                 ValidEmail email = new ValidEmail(form.getEmail());
@@ -1902,11 +1902,11 @@ public class LoginController extends SpringActionController
             }
             catch (UserManagementException e)
             {
-                errors.reject(ERROR_MSG, "Unable to create user '" + PageFlowUtil.filter(e.getEmail()) + "': " + e.getMessage());
+                errors.reject(ERROR_MSG, "Unable to create user '" + e.getEmail() + "': " + e.getMessage());
             }
             catch (InvalidEmailException e)
             {
-                errors.rejectValue("email", ERROR_MSG, "The string '" + PageFlowUtil.filter(form.getEmail()) + "' is not a valid email address. Please enter an email address in this form: user@domain.tld");
+                errors.rejectValue("email", ERROR_MSG, "'" + form.getEmail() + "' is not a valid email address. Please enter an email address in this form: user@domain.tld");
             }
 
             return success;

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -190,7 +190,7 @@ public class LoginController extends SpringActionController
             //FIX: 6021, use project container for this URL so it remains short but maintains the project look & feel settings
             ActionURL url = new ActionURL(SetPasswordAction.class, LookAndFeelProperties.getSettingsContainer(c));
             url.addParameter("verification", verification);
-            url.addParameter("user", user.getUserId());
+            url.addParameter("userId", user.getUserId());
 
             if (null != extraParameters)
                 url.addParameters(extraParameters);

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -189,7 +189,6 @@ public class LoginController extends SpringActionController
             //FIX: 6021, use project container for this URL so it remains short but maintains the project look & feel settings
             ActionURL url = new ActionURL(SetPasswordAction.class, LookAndFeelProperties.getSettingsContainer(c));
             url.addParameter("verification", verification);
-            url.addParameter("userId", user.getUserId());
 
             if (null != extraParameters)
                 url.addParameters(extraParameters);
@@ -1757,7 +1756,7 @@ public class LoginController extends SpringActionController
         }
     }
 
-    //
+    // Return the user associated with the verification token if there's a match, otherwise return null
     private static @Nullable User attemptVerification(SetPasswordForm form, Errors errors)
     {
         String verification = form.getVerification();

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1906,7 +1906,7 @@ public class LoginController extends SpringActionController
             }
             catch (InvalidEmailException e)
             {
-                errors.rejectValue("email", ERROR_MSG, "'" + form.getEmail() + "' is not a valid email address. Please enter an email address in this form: user@domain.tld");
+                errors.rejectValue("email", ERROR_MSG, "'" + StringUtils.trimToEmpty(form.getEmail()) + "' is not a valid email address. Please enter an email address in this form: user@domain.tld");
             }
 
             return success;

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -185,12 +185,12 @@ public class LoginController extends SpringActionController
         }
 
         @Override
-        public ActionURL getVerificationURL(Container c, ValidEmail email, String verification, @Nullable List<Pair<String, String>> extraParameters)
+        public ActionURL getVerificationURL(Container c, User user, String verification, @Nullable List<Pair<String, String>> extraParameters)
         {
-            //FIX: 6021, use project container for this URL so it remains short but maintains the project look & feel settings 
+            //FIX: 6021, use project container for this URL so it remains short but maintains the project look & feel settings
             ActionURL url = new ActionURL(SetPasswordAction.class, LookAndFeelProperties.getSettingsContainer(c));
             url.addParameter("verification", verification);
-            url.addParameter("email", email.getEmailAddress());
+            url.addParameter("user", user.getUserId());
 
             if (null != extraParameters)
                 url.addParameters(extraParameters);
@@ -877,7 +877,7 @@ public class LoginController extends SpringActionController
                 Container c = getContainer();
                 LookAndFeelProperties laf = LookAndFeelProperties.getInstance(c);
                 final SecurityMessage message = SecurityManager.getResetMessage(false, user, providerName);
-                ActionURL verificationURL = LoginManager.createModuleVerificationURL(c, email, verification, null, providerName, false);
+                ActionURL verificationURL = LoginManager.createModuleVerificationURL(c, user, verification, null, providerName, false);
 
                 final User system = new User(laf.getSystemEmailAddress(), 0);
                 system.setFirstName(laf.getCompanyName());
@@ -1799,14 +1799,14 @@ public class LoginController extends SpringActionController
         }
         else
         {
-            if (!LoginManager.loginExists(email))
+            if (!LoginManager.loginExists(user))
             {
                 if (AuthenticationManager.isLdapOrSsoEmail(email))
                     errors.reject("setPassword", "You can authenticate your account using LDAP/SSO and you do not need to set a separate password.");
                 else
                     errors.reject("setPassword", "This email address is not associated with an account. Make sure you've copied the entire link into your browser's address bar.");
             }
-            else if (LoginManager.isVerified(email))
+            else if (LoginManager.isVerified(user))
                 errors.reject("setPassword", "This email address has already been verified.");
             else if (null == verification || verification.length() < LoginManager.TEMP_PASSWORD_LENGTH)
                 errors.reject("setPassword", "Make sure you've copied the entire link into your browser's address bar.");

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -747,12 +747,9 @@ public class LoginController extends SpringActionController
         @Override
         public void validateForm(SetPasswordForm form, Errors errors)
         {
-            User user = form.getUser(errors);
-            if (!errors.hasErrors())
-            {
-                if (!validateChangePassword(user, errors))
-                    _user = user;
-            }
+            User user = form.getUser();
+            if (!validateChangePassword(user, errors))
+                _user = user;
         }
 
         @Override
@@ -1578,16 +1575,8 @@ public class LoginController extends SpringActionController
         @Override
         public void validateCommand(SetPasswordForm form, Errors errors)
         {
-            _user = form.getUser(errors);
-
-            if (errors.hasErrors())
-            {
-                _unrecoverableError = true;
-            }
-            else
-            {
-                verify(form, errors);
-            }
+            _user = form.getUser();
+            verify(form, errors);
         }
 
         protected void verifyBeforeView(SetPasswordForm form, boolean reshow, BindException errors) throws RedirectException
@@ -1622,7 +1611,7 @@ public class LoginController extends SpringActionController
                     nonPasswordInputs, passwordInputs, getClass(), isCancellable(form),
                     buttonText, getTitle()
             );
-            HttpView view = new JspView<>("/org/labkey/core/login/setPassword.jsp", bean, errors);
+            JspView<SetPasswordBean> view = new JspView<>("/org/labkey/core/login/setPassword.jsp", bean, errors);
 
             PageConfig page = getPageConfig();
             page.setTemplate(PageConfig.Template.Dialog);
@@ -1793,7 +1782,7 @@ public class LoginController extends SpringActionController
         else
         {
             // Verification string wasn't found. User might have already verified, they don't have a login (should be
-            // using LDAP or SSO), or the link got mangled. Don't provide any more information since that could reveal
+            // using LDAP or SSO), or the link got mangled. Don't provide any guidance since that could reveal
             // information about existing users.
             errors.reject("setPassword", "Verification failed. Make sure you've copied the entire link into your browser's address bar.");
         }
@@ -1878,6 +1867,7 @@ public class LoginController extends SpringActionController
                 {
                     // Add the initial user
                     SecurityManager.NewUserStatus newUserBean = SecurityManager.addUser(email, null);
+                    _user = newUserBean.getUser();
                     // Set the password
                     success = super.handlePost(form, errors);
 
@@ -2131,15 +2121,10 @@ public class LoginController extends SpringActionController
             _message = message;
         }
 
-        @Nullable User getUser(Errors errors)
+        @Nullable User getUser()
         {
             // If no userId is specified, look up user from verification parameter
-            User user = (null == _userId ? LoginManager.verify(_verification) : UserManager.getUser(_userId));
-
-            if (null == user)
-                errors.reject("setPassword", "User not found.");
-
-            return user;
+            return null == _userId ? LoginManager.verify(_verification) : UserManager.getUser(_userId);
         }
     }
 

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -201,7 +201,7 @@ public class LoginController extends SpringActionController
         public ActionURL getChangePasswordURL(Container c, User user, URLHelper returnURL, @Nullable String message)
         {
             ActionURL url = new ActionURL(ChangePasswordAction.class, LookAndFeelProperties.getSettingsContainer(c));
-            url.addParameter("email", user.getEmail());     // TODO: seems peculiar... why not user id?
+            url.addParameter("userId", user.getUserId());
 
             if (null != message)
                 url.addParameter("message", message);

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -114,7 +114,6 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.VBox;
-import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartView;
 import org.labkey.api.view.template.PageConfig;
 import org.labkey.api.wiki.WikiRendererType;
@@ -743,18 +742,16 @@ public class LoginController extends SpringActionController
     @AllowedDuringUpgrade
     public class ChangePasswordApiAction extends MutatingApiAction<SetPasswordForm>
     {
-        protected ValidEmail _email = null;
+        protected User _user = null;
 
         @Override
         public void validateForm(SetPasswordForm form, Errors errors)
         {
-            ValidEmail email = form.getValidEmail(getViewContext(), errors);
+            User user = form.getUser(errors);
             if (!errors.hasErrors())
             {
-                // TODO: Change to UserId
-                User user = UserManager.getUser(email);
-                validateChangePassword(user, errors);
-                _email = email;
+                if (!validateChangePassword(user, errors))
+                    _user = user;
             }
         }
 
@@ -767,7 +764,7 @@ public class LoginController extends SpringActionController
 
             if (isOldPasswordMatch(oldPassword, form, errors))
             {
-                AuthenticationResult result = attemptSetPassword(_email, form.getReturnURLHelper(), "Changed password.", false, errors);
+                AuthenticationResult result = attemptSetPassword(_user, form.getReturnURLHelper(), "Changed password.", false, errors);
                 if (result != null)
                     response.put(ActionURL.Param.returnUrl.name(), result.getRedirectURL());
             }
@@ -789,13 +786,13 @@ public class LoginController extends SpringActionController
         public Object execute(SetPasswordForm form, BindException errors) throws Exception
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
-            ValidEmail email = form.getValidEmail(getViewContext(), errors);
 
             if (!errors.hasErrors())
             {
-                if (attemptVerification(form, email, errors))
+                User user = attemptVerification(form, errors);
+                if (user != null)
                 {
-                    AuthenticationResult result = attemptSetPassword(email, form.getReturnURLHelper(), "Verified and chose a password.", true, errors);
+                    AuthenticationResult result = attemptSetPassword(user, form.getReturnURLHelper(), "Verified and chose a password.", true, errors);
                     if (result != null)
                         response.put(ActionURL.Param.returnUrl.name(), result.getRedirectURL());
                 }
@@ -1574,19 +1571,23 @@ public class LoginController extends SpringActionController
 
     public abstract class AbstractSetPasswordAction extends FormViewAction<SetPasswordForm>
     {
-        protected ValidEmail _email = null;
+        protected User _user = null;
         protected boolean _unrecoverableError = false;
         protected URLHelper _successUrl = null;
 
         @Override
         public void validateCommand(SetPasswordForm form, Errors errors)
         {
-            ValidEmail email = form.getValidEmail(getViewContext(), errors);
+            _user = form.getUser(errors);
 
             if (errors.hasErrors())
+            {
                 _unrecoverableError = true;
+            }
             else
-                verify(form, email, errors);
+            {
+                verify(form, errors);
+            }
         }
 
         protected void verifyBeforeView(SetPasswordForm form, boolean reshow, BindException errors) throws RedirectException
@@ -1605,7 +1606,7 @@ public class LoginController extends SpringActionController
 
         protected String getEmailForForm(SetPasswordForm form)
         {
-            return null != _email ? _email.getEmailAddress() : form.getEmail();
+            return null != _user ? _user.getEmail() : null;
         }
 
         @Override
@@ -1650,7 +1651,7 @@ public class LoginController extends SpringActionController
         @Override
         public boolean handlePost(SetPasswordForm form, BindException errors) throws Exception
         {
-            AuthenticationResult result = attemptSetPassword(_email, form.getReturnURLHelper(), getAuditMessage(), clearVerification(), errors);
+            AuthenticationResult result = attemptSetPassword(_user, form.getReturnURLHelper(), getAuditMessage(), clearVerification(), errors);
 
             if (errors.hasErrors())
                 return false;
@@ -1685,7 +1686,7 @@ public class LoginController extends SpringActionController
             return "Set Password";
         }
 
-        protected abstract void verify(SetPasswordForm form, ValidEmail email, Errors errors);
+        protected abstract void verify(SetPasswordForm form, Errors errors);
         protected abstract String getMessage(SetPasswordForm form);
         protected abstract NamedObjectList getPasswordInputs(SetPasswordForm form);
         protected boolean clearVerification()
@@ -1696,7 +1697,7 @@ public class LoginController extends SpringActionController
         protected abstract boolean isCancellable(SetPasswordForm form);
     }
 
-    private AuthenticationResult attemptSetPassword(ValidEmail email, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, BindException errors) throws InvalidEmailException
+    private AuthenticationResult attemptSetPassword(User affectedUser, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, BindException errors) throws InvalidEmailException
     {
         HttpServletRequest request = getViewContext().getRequest();
         // TODO: This is unreliable... e.g., the "change password via email validation" scenario isn't considered a
@@ -1704,7 +1705,7 @@ public class LoginController extends SpringActionController
         // operation vs. an initial password. Need a flag or perhaps separate actions.
         boolean changeOperation = StringUtils.startsWithIgnoreCase(auditMessage, "change");
 
-        return DbLoginService.get().attemptSetPassword(getContainer(), getUser(), request.getParameter("password"), request.getParameter("password2"), request, email, returnUrlHelper, auditMessage, clearVerification, changeOperation, errors);
+        return DbLoginService.get().attemptSetPassword(getContainer(), getUser(), request.getParameter("password"), request.getParameter("password2"), request, affectedUser, returnUrlHelper, auditMessage, clearVerification, changeOperation, errors);
     }
 
     @RequiresNoPermission
@@ -1712,22 +1713,17 @@ public class LoginController extends SpringActionController
     public class SetPasswordAction extends AbstractSetPasswordAction
     {
         @Override
-        protected void verify(SetPasswordForm form, ValidEmail email, Errors errors)
+        protected void verify(SetPasswordForm form, Errors errors)
         {
-            if (!attemptVerification(form, email, errors))
-            {
+            _user = attemptVerification(form, errors);
+            if (null == _user)
                 _unrecoverableError = true;
-            }
-            else
-            {
-                _email = email;
-            }
         }
 
         @Override
         protected String getMessage(SetPasswordForm form)
         {
-            return "Your email address (" + form.getEmail() + ") has been verified! Create an account password below.";
+            return "Your email address (" + _user.getEmail() + ") has been verified! Create an account password below.";
         }
 
         @Override
@@ -1772,26 +1768,23 @@ public class LoginController extends SpringActionController
         }
     }
 
-    private static boolean attemptVerification(SetPasswordForm form, ValidEmail email, Errors errors)
+    //
+    private static @Nullable User attemptVerification(SetPasswordForm form, Errors errors)
     {
-        User user = UserManager.getUser(email); // TODO
         String verification = form.getVerification();
-        boolean isVerified = LoginManager.verify(user, verification);
+        User user = LoginManager.verify(verification);
+        boolean isVerified = user != null;
 
-        LoginController.checkVerificationErrors(isVerified, user, verification, errors);
+        LoginController.checkVerificationErrors(isVerified, user, errors);
 
-        return isVerified && !errors.hasErrors();
+        return isVerified && !errors.hasErrors() ? user : null;
     }
 
-    public static void checkVerificationErrors(boolean isVerified, User user, String verification, Errors errors)
+    public static void checkVerificationErrors(boolean isVerified, User user, Errors errors)
     {
         if (isVerified)
         {
-            if (user == null)
-            {
-                errors.reject("setPassword", "This user doesn't exist. Make sure you've copied the entire link into your browser's address bar.");
-            }
-            else if (!user.isActive())
+            if (!user.isActive())
             {
                 errors.reject("setPassword", "This user account has been deactivated. Please contact a system "
                         + "administrator if you need to reactivate this account.");
@@ -1799,20 +1792,10 @@ public class LoginController extends SpringActionController
         }
         else
         {
-            if (!LoginManager.loginExists(user))
-            {
-                if (AuthenticationManager.isLdapOrSsoEmail(user.getEmail()))
-                    errors.reject("setPassword", "You can authenticate your account using LDAP/SSO and you do not need to set a separate password.");
-                else
-                    errors.reject("setPassword", "This email address is not associated with an account. Make sure you've copied the entire link into your browser's address bar.");
-            }
-            else if (LoginManager.isVerified(user))
-                errors.reject("setPassword", "This email address has already been verified.");
-            else if (null == verification || verification.length() < LoginManager.TEMP_PASSWORD_LENGTH)
-                errors.reject("setPassword", "Make sure you've copied the entire link into your browser's address bar.");
-            else
-                // Incorrect verification string
-                errors.reject("setPassword", "Verification failed. Make sure you've copied the entire link into your browser's address bar.");
+            // Verification string wasn't found. User might have already verified, they don't have a login (should be
+            // using LDAP or SSO), or the link got mangled. Don't provide any more information since that could reveal
+            // information about existing users.
+            errors.reject("setPassword", "Verification failed. Make sure you've copied the entire link into your browser's address bar.");
         }
     }
 
@@ -1822,19 +1805,18 @@ public class LoginController extends SpringActionController
     public class InitialUserAction extends AbstractSetPasswordAction
     {
         @Override
-        protected void verify(SetPasswordForm form, ValidEmail email, Errors errors)
+        protected void verify(SetPasswordForm form, Errors errors)
         {
             if (!UserManager.hasNoRealUsers())
                 throw new RedirectException(AdminController.getModuleStatusURL(null));
 
-            _email = email;
             _unrecoverableError = false;
         }
 
         @Override
         protected void verifyBeforeView(SetPasswordForm form, boolean reshow, BindException errors) throws RedirectException
         {
-            verify(form, null, errors);
+            verify(form, errors);
         }
 
         @Override
@@ -1981,13 +1963,9 @@ public class LoginController extends SpringActionController
     public class ChangePasswordAction extends AbstractSetPasswordAction
     {
         @Override
-        protected void verify(SetPasswordForm form, ValidEmail email, Errors errors)
+        protected void verify(SetPasswordForm form, Errors errors)
         {
-            User user = UserManager.getUser(email);
-            _unrecoverableError = validateChangePassword(user, errors);
-
-            if (!_unrecoverableError)
-                _email = email;
+            _unrecoverableError = validateChangePassword(_user, errors);
         }
 
         @Override
@@ -2056,7 +2034,7 @@ public class LoginController extends SpringActionController
     {
         if (!LoginManager.loginExists(user))
         {
-            errors.reject("setPassword", "This email address is not associated with an account.");
+            errors.reject("setPassword", "User does not have a password.");
             return true;
         }
 
@@ -2104,14 +2082,20 @@ public class LoginController extends SpringActionController
 
     public static class SetPasswordForm extends AbstractLoginForm
     {
-        private String _verification;
+        private Integer _userId;
         private String _email;
+        private String _verification;
         private String _message;
 
-        @SuppressWarnings({"UnusedDeclaration"})
-        public void setEmail(String email)
+        public Integer getUserId()
         {
-            _email = email;
+            return _userId;
+        }
+
+        @SuppressWarnings({"UnusedDeclaration"})
+        public void setUserId(Integer userId)
+        {
+            _userId = userId;
         }
 
         public String getEmail()
@@ -2119,38 +2103,21 @@ public class LoginController extends SpringActionController
             return _email;
         }
 
-        // Actions should use this method for consistency
-        public ValidEmail getValidEmail(ViewContext context, Errors errors)
+        @SuppressWarnings({"UnusedDeclaration"})
+        public void setEmail(String email)
         {
-            String rawEmail = getEmail();
+            _email = email;
+        }
 
-            // Some plain text email clients get confused by the encoding... explicitly look for encoded name
-            if (null == rawEmail)
-                rawEmail = context.getActionURL().getParameter("amp;email");
-
-            ValidEmail email = null;
-
-            try
-            {
-                email = new ValidEmail(rawEmail);
-            }
-            catch (InvalidEmailException e)
-            {
-                errors.reject("setPassword", "Invalid email address" + (null == rawEmail ? "" : ": " + rawEmail));
-            }
-
-            return email;
+        public String getVerification()
+        {
+            return _verification;
         }
 
         @SuppressWarnings({"UnusedDeclaration"})
         public void setVerification(String verification)
         {
             _verification = verification;
-        }
-
-        public String getVerification()
-        {
-            return _verification;
         }
 
         public String getMessage()
@@ -2163,13 +2130,24 @@ public class LoginController extends SpringActionController
         {
             _message = message;
         }
+
+        @Nullable User getUser(Errors errors)
+        {
+            // If no userId is specified, look up user from verification parameter
+            User user = (null == _userId ? LoginManager.verify(_verification) : UserManager.getUser(_userId));
+
+            if (null == user)
+                errors.reject("setPassword", "User not found.");
+
+            return user;
+        }
     }
 
     @RequiresNoPermission
     @AllowedDuringUpgrade
     public class ResetPasswordAction extends FormViewAction<LoginForm>
     {
-        private HttpView _finishView = null;
+        private JspView<?> _finishView = null;
 
         @Override
         public void validateCommand(LoginForm form, Errors errors)
@@ -2191,7 +2169,7 @@ public class LoginController extends SpringActionController
             if (null != _finishView)
                 return _finishView;
 
-            JspView view = new JspView<>("/org/labkey/core/login/resetPassword.jsp", form, errors);
+            JspView<LoginForm> view = new JspView<>("/org/labkey/core/login/resetPassword.jsp", form, errors);
 
             if (null == form.getEmail())
             {

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -117,6 +117,10 @@
             <labkey:input type="hidden" name="email" value="<%=bean.email%>"/>
         <% }
 
+        if (null != bean.form.getUserId()) { %>
+            <labkey:input type="hidden" name="userId" value="<%=bean.form.getUserId()%>"/>
+        <% }
+
         if (null != bean.form.getVerification()) { %>
             <labkey:input type="hidden" name="verification" value="<%=bean.form.getVerification()%>"/>
         <% }

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -81,6 +81,7 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewContext;
+import org.labkey.core.security.SecurityController.UserForm;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
@@ -1977,13 +1978,13 @@ public class SecurityApiActions
      * Invalidate existing password and send new password link
      */
     @RequiresPermission(UpdateUserPermission.class)
-    public static class AdminRotatePasswordAction extends MutatingApiAction<SecurityController.EmailForm>
+    public static class AdminRotatePasswordAction extends MutatingApiAction<UserForm>
     {
         @Override
-        public void validateForm(SecurityController.EmailForm form, Errors errors)
+        public void validateForm(UserForm form, Errors errors)
         {
             // don't let non-site admin reset password of site admin
-            User formUser = form.getUserObject();
+            User formUser = form.getUser();
             if (null == formUser)
                 errors.rejectValue("User", ERROR_MSG, "User not found");
             else if (!getUser().hasSiteAdminPermission() && formUser.hasSiteAdminPermission())
@@ -1991,9 +1992,9 @@ public class SecurityApiActions
         }
 
         @Override
-        public ApiSimpleResponse execute(SecurityController.EmailForm form, BindException errors)
+        public ApiSimpleResponse execute(UserForm form, BindException errors)
         {
-            User affectedUser = form.getUserObject(true);
+            User affectedUser = form.getUser(true);
             SecurityManager.adminRotatePassword(affectedUser, errors, getContainer(), getUser());
 
             ApiSimpleResponse response = new ApiSimpleResponse();

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -23,7 +23,6 @@ import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.ApiVersion;
 import org.labkey.api.action.FormApiAction;
-import org.labkey.api.action.LabKeyError;
 import org.labkey.api.action.Marshal;
 import org.labkey.api.action.Marshaller;
 import org.labkey.api.action.MutatingApiAction;
@@ -97,12 +96,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.labkey.api.action.SpringActionController.ERROR_MSG;
-
-/*
-* User: Dave
-* Date: May 12, 2009
-* Time: 1:18:27 PM
-*/
 
 /**
  * Set of API actions registered with the SecurityController
@@ -1748,7 +1741,6 @@ public class SecurityApiActions
             return resp;
         }
 
-
         public void writeToAuditLog(Group group, String oldName)
         {
             GroupAuditProvider.GroupAuditEvent event = new GroupAuditProvider.GroupAuditEvent(getContainer().getId(), "The security group named '" + oldName + "' was renamed to '" + group.getName() + "'.");
@@ -1990,38 +1982,19 @@ public class SecurityApiActions
         @Override
         public void validateForm(SecurityController.EmailForm form, Errors errors)
         {
-            ValidEmail email;
-
-            try
-            {
-                email = new ValidEmail(form.getEmail());
-
-                // don't let non-site admin reset password of site admin
-                User formUser = UserManager.getUser(email);
-                if (null == formUser)
-                    errors.rejectValue("email", ERROR_MSG, "User not found");
-                else if (!getUser().hasSiteAdminPermission() && formUser.hasSiteAdminPermission())
-                    errors.rejectValue("Email", "Can not reset password for a Site Admin user");
-            }
-            catch (InvalidEmailException e)
-            {
-                errors.rejectValue("Email", "Invalid user email");
-            }
+            // don't let non-site admin reset password of site admin
+            User formUser = form.getUserObject();
+            if (null == formUser)
+                errors.rejectValue("User", ERROR_MSG, "User not found");
+            else if (!getUser().hasSiteAdminPermission() && formUser.hasSiteAdminPermission())
+                errors.rejectValue("User", "Can not reset password for a Site Admin user");
         }
 
         @Override
         public ApiSimpleResponse execute(SecurityController.EmailForm form, BindException errors)
         {
-            try
-            {
-                ValidEmail email = new ValidEmail(form.getEmail());
-                SecurityManager.adminRotatePassword(email, errors, getContainer(), getUser());
-            }
-            catch (ValidEmail.InvalidEmailException e)
-            {
-                //Should be caught in api validation
-                errors.addError(new LabKeyError(new Exception("Invalid email address." + e.getMessage(), e)));
-            }
+            User affectedUser = form.getUserObject(true);
+            SecurityManager.adminRotatePassword(affectedUser, errors, getContainer(), getUser());
 
             ApiSimpleResponse response = new ApiSimpleResponse();
             response.put("success", !errors.hasErrors());

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1786,32 +1786,20 @@ public class SecurityController extends SpringActionController
         }
     }
 
-    public static class EmailForm extends ReturnUrlForm
+    public static class UserForm extends ReturnUrlForm
     {
         private User _user;
-        private String _email;
         private String _mailPrefix;
 
-        public Integer getUser()
+        public Integer getUserId()
         {
             return _user != null ? _user.getUserId() : null;
         }
 
         @SuppressWarnings({"UnusedDeclaration"})
-        public void setUser(Integer user)
+        public void setUserId(Integer user)
         {
             _user = user != null ? UserManager.getUser(user) : null;
-        }
-
-        public String getEmail()
-        {
-            return _email;
-        }
-
-        @SuppressWarnings({"UnusedDeclaration"})
-        public void setEmail(String email)
-        {
-            _email = email;
         }
 
         public String getMailPrefix()
@@ -1825,12 +1813,12 @@ public class SecurityController extends SpringActionController
             _mailPrefix = mailPrefix;
         }
 
-        public @Nullable User getUserObject()
+        public @Nullable User getUser()
         {
             return _user;
         }
 
-        public @NotNull User getUserObject(boolean throwIfNull)
+        public @NotNull User getUser(boolean throwIfNull)
         {
             if (throwIfNull && null == _user)
                 throw new IllegalStateException("User not found");
@@ -1839,15 +1827,15 @@ public class SecurityController extends SpringActionController
         }
     }
 
-    private abstract static class AbstractEmailAction extends SimpleViewAction<EmailForm>
+    private abstract static class AbstractEmailAction extends SimpleViewAction<UserForm>
     {
-        protected abstract SecurityMessage createMessage(EmailForm form);
+        protected abstract SecurityMessage createMessage(UserForm form);
 
         @Override
-        public ModelAndView getView(EmailForm form, BindException errors) throws Exception
+        public ModelAndView getView(UserForm form, BindException errors) throws Exception
         {
             Writer out = getViewContext().getResponse().getWriter();
-            User affectedUser = form.getUserObject();
+            User affectedUser = form.getUser();
             if (null == affectedUser)
             {
                 out.write("User not found");
@@ -1884,12 +1872,12 @@ public class SecurityController extends SpringActionController
     public static class ShowRegistrationEmailAction extends AbstractEmailAction
     {
         @Override
-        protected SecurityMessage createMessage(EmailForm form)
+        protected SecurityMessage createMessage(UserForm form)
         {
             // Site admins can see the email for everyone, but project admins can only see it for users they added
             if (!getUser().hasRootPermission(AddUserPermission.class))
             {
-                User affectedUser = form.getUserObject(true);
+                User affectedUser = form.getUser(true);
                 if (affectedUser.getCreatedBy() == null || getUser().getUserId() != affectedUser.getCreatedBy().intValue())
                 {
                     throw new UnauthorizedException();
@@ -1904,7 +1892,7 @@ public class SecurityController extends SpringActionController
     public static class ShowResetEmailAction extends AbstractEmailAction
     {
         @Override
-        protected SecurityMessage createMessage(EmailForm form)
+        protected SecurityMessage createMessage(UserForm form)
         {
             return SecurityManager.getResetMessage(false);
         }
@@ -1914,26 +1902,27 @@ public class SecurityController extends SpringActionController
     /**
      * Base class for admin password actions
      */
-    private abstract static class AdminPasswordAction extends ConfirmAction<EmailForm>
+    private abstract static class AdminPasswordAction extends ConfirmAction<UserForm>
     {
         abstract String getTitle();
         abstract String getVerb();
         abstract HtmlString getConfirmationMessage(boolean loginExists, String emailAddress);
 
         @Override
-        public ModelAndView getConfirmView(EmailForm emailForm, BindException errors)
+        public ModelAndView getConfirmView(UserForm form, BindException errors)
         {
-            boolean loginExists = LoginManager.loginExists(emailForm.getUserObject(true));
+            User affectedUser = form.getUser(true);
+            boolean loginExists = LoginManager.loginExists(affectedUser);
             setTitle(getTitle());
 
-            return new HtmlView(getConfirmationMessage(loginExists, emailForm.getEmail()));
+            return new HtmlView(getConfirmationMessage(loginExists, affectedUser.getEmail()));
         }
 
         @Override
-        public void validateCommand(EmailForm form, Errors errors)
+        public void validateCommand(UserForm form, Errors errors)
         {
             // don't let non-site admin delete/reset password of site admin
-            User formUser = form.getUserObject();
+            User formUser = form.getUser();
             if (null == formUser)
                 errors.reject(ERROR_MSG, getVerb() + " failed: user not found.");
             else if (!getUser().hasSiteAdminPermission() && formUser.hasSiteAdminPermission())
@@ -1941,9 +1930,9 @@ public class SecurityController extends SpringActionController
         }
 
         @Override
-        public @NotNull URLHelper getSuccessURL(EmailForm emailForm)
+        public @NotNull URLHelper getSuccessURL(UserForm form)
         {
-            return emailForm.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL());
+            return form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL());
         }
     }
 
@@ -1976,23 +1965,24 @@ public class SecurityController extends SpringActionController
         private boolean _loginExists;
 
         @Override
-        public boolean handlePost(EmailForm form, BindException errors) throws Exception
+        public boolean handlePost(UserForm form, BindException errors) throws Exception
         {
-            User affectedUser = form.getUserObject(true);
+            User affectedUser = form.getUser(true);
             _loginExists = LoginManager.loginExists(affectedUser);
-            SecurityManager.adminRotatePassword(affectedUser, errors, getContainer(), getUser(), getMailHelpText(form.getEmail()));
+            SecurityManager.adminRotatePassword(affectedUser, errors, getContainer(), getUser(), getMailHelpText(affectedUser));
 
             return !errors.hasErrors();
         }
 
         @Override
-        public ModelAndView getSuccessView(EmailForm form)
+        public ModelAndView getSuccessView(UserForm form)
         {
-            ActionURL actionURL = new ActionURL(ShowResetEmailAction.class, getContainer()).addParameter("email", form.getEmail());
+            User affectedUser = form.getUser(true);
+            ActionURL actionURL = new ActionURL(ShowResetEmailAction.class, getContainer()).addParameter("userId", affectedUser.getUserId());
 
             String page = String.format(
                 "<p>%1$s: Password %2$s.</p><p>Email sent. Click <a href=\"%3$s\" target=\"_blank\">here</a> to see the email.</p>%4$s",
-                PageFlowUtil.filter(form.getEmail()),
+                PageFlowUtil.filter(affectedUser.getEmail()),
                 _loginExists ? "reset" : "created",
                 PageFlowUtil.filter(actionURL.getLocalURIString()),
                 PageFlowUtil.button("Done").href(form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL()))
@@ -2005,11 +1995,11 @@ public class SecurityController extends SpringActionController
         }
 
         @Override
-        public ModelAndView getFailView(EmailForm form, BindException errors)
+        public ModelAndView getFailView(UserForm form, BindException errors)
         {
             HtmlStringBuilder builder = HtmlStringBuilder.of()
                 .unsafeAppend("<p>")
-                .append(form.getEmail() + ": Password " + (_loginExists ? "reset" : "created") + ".")
+                .append(form.getUser(true).getEmail() + ": Password " + (_loginExists ? "reset" : "created") + ".")
                 .unsafeAppend("</p><p>")
                 .append(getErrorMessage(errors))
                 .unsafeAppend("</p>")
@@ -2035,9 +2025,9 @@ public class SecurityController extends SpringActionController
             return builder.getHtmlString();
         }
 
-        private HtmlString getMailHelpText(String emailAddress)
+        private HtmlString getMailHelpText(User user)
         {
-            ActionURL mailHref = new ActionURL(ShowResetEmailAction.class, getContainer()).addParameter("email", emailAddress);
+            ActionURL mailHref = new ActionURL(ShowResetEmailAction.class, getContainer()).addParameter("userId", user.getUserId());
 
             HtmlStringBuilder builder = HtmlStringBuilder.of()
                 .unsafeAppend("<p>")
@@ -2115,9 +2105,9 @@ public class SecurityController extends SpringActionController
         }
 
         @Override
-        public boolean handlePost(EmailForm form, BindException errors) throws Exception
+        public boolean handlePost(UserForm form, BindException errors) throws Exception
         {
-            User userToChange = form.getUserObject(true);
+            User userToChange = form.getUser(true);
             LoginManager.deleteLoginsRow(userToChange, getUser());
 
             return !errors.hasErrors();

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1828,20 +1828,22 @@ public class SecurityController extends SpringActionController
             try
             {
                 ValidEmail email = new ValidEmail(rawEmail);
+                User affectedUser = UserManager.getUser(email);
+                // TODO: NULL check?
 
                 SecurityMessage message = createMessage(form);
 
                 // Issue 33254: only allow Site Admins to see the verification token
                 message.setMaskToken(true);
 
-                if (LoginManager.isVerified(email))
+                if (LoginManager.isVerified(affectedUser))
                 {
                     out.write("Can't display " + message.getType().toLowerCase() + "; " + PageFlowUtil.filter(email) + " has already chosen a password.");
                 }
                 else
                 {
-                    String verification = LoginManager.getVerification(email);
-                    ActionURL verificationURL = LoginManager.createVerificationURL(getContainer(), email, verification, null);
+                    String verification = LoginManager.getVerification(affectedUser);
+                    ActionURL verificationURL = LoginManager.createVerificationURL(getContainer(), affectedUser, verification, null);
                     SecurityManager.renderEmail(getContainer(), getUser(), message, email.getEmailAddress(), verificationURL, out);
                 }
             }

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -134,7 +134,6 @@ import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.AjaxCompletion;
 import org.labkey.api.view.HtmlView;
-import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
@@ -1789,8 +1788,20 @@ public class SecurityController extends SpringActionController
 
     public static class EmailForm extends ReturnUrlForm
     {
+        private User _user;
         private String _email;
         private String _mailPrefix;
+
+        public Integer getUser()
+        {
+            return _user != null ? _user.getUserId() : null;
+        }
+
+        @SuppressWarnings({"UnusedDeclaration"})
+        public void setUser(Integer user)
+        {
+            _user = user != null ? UserManager.getUser(user) : null;
+        }
 
         public String getEmail()
         {
@@ -1813,9 +1824,22 @@ public class SecurityController extends SpringActionController
         {
             _mailPrefix = mailPrefix;
         }
+
+        public @Nullable User getUserObject()
+        {
+            return _user;
+        }
+
+        public @NotNull User getUserObject(boolean throwIfNull)
+        {
+            if (throwIfNull && null == _user)
+                throw new IllegalStateException("User not found");
+
+            return _user;
+        }
     }
 
-    private abstract class AbstractEmailAction extends SimpleViewAction<EmailForm>
+    private abstract static class AbstractEmailAction extends SimpleViewAction<EmailForm>
     {
         protected abstract SecurityMessage createMessage(EmailForm form);
 
@@ -1823,14 +1847,13 @@ public class SecurityController extends SpringActionController
         public ModelAndView getView(EmailForm form, BindException errors) throws Exception
         {
             Writer out = getViewContext().getResponse().getWriter();
-            String rawEmail = form.getEmail();
-
-            try
+            User affectedUser = form.getUserObject();
+            if (null == affectedUser)
             {
-                ValidEmail email = new ValidEmail(rawEmail);
-                User affectedUser = UserManager.getUser(email);
-                // TODO: NULL check?
-
+                out.write("User not found");
+            }
+            else
+            {
                 SecurityMessage message = createMessage(form);
 
                 // Issue 33254: only allow Site Admins to see the verification token
@@ -1838,18 +1861,14 @@ public class SecurityController extends SpringActionController
 
                 if (LoginManager.isVerified(affectedUser))
                 {
-                    out.write("Can't display " + message.getType().toLowerCase() + "; " + PageFlowUtil.filter(email) + " has already chosen a password.");
+                    out.write("Can't display " + message.getType().toLowerCase() + "; " + PageFlowUtil.filter(affectedUser.getEmail()) + " has already chosen a password.");
                 }
                 else
                 {
                     String verification = LoginManager.getVerification(affectedUser);
                     ActionURL verificationURL = LoginManager.createVerificationURL(getContainer(), affectedUser, verification, null);
-                    SecurityManager.renderEmail(getContainer(), getUser(), message, email.getEmailAddress(), verificationURL, out);
+                    SecurityManager.renderEmail(getContainer(), getUser(), message, affectedUser.getEmail(), verificationURL, out);
                 }
-            }
-            catch (InvalidEmailException e)
-            {
-                out.write("Invalid email address: " + PageFlowUtil.filter(rawEmail));
             }
 
             return null;
@@ -1862,7 +1881,7 @@ public class SecurityController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class ShowRegistrationEmailAction extends AbstractEmailAction
+    public static class ShowRegistrationEmailAction extends AbstractEmailAction
     {
         @Override
         protected SecurityMessage createMessage(EmailForm form)
@@ -1870,22 +1889,10 @@ public class SecurityController extends SpringActionController
             // Site admins can see the email for everyone, but project admins can only see it for users they added
             if (!getUser().hasRootPermission(AddUserPermission.class))
             {
-                try
+                User affectedUser = form.getUserObject(true);
+                if (affectedUser.getCreatedBy() == null || getUser().getUserId() != affectedUser.getCreatedBy().intValue())
                 {
-                    ValidEmail email = new ValidEmail(form.getEmail());
-                    User user = UserManager.getUser(email);
-                    if (user == null)
-                    {
-                        throw new NotFoundException();
-                    }
-                    if (user.getCreatedBy() == null || getUser().getUserId() != user.getCreatedBy().intValue())
-                    {
-                        throw new UnauthorizedException();
-                    }
-                }
-                catch (InvalidEmailException e)
-                {
-                    throw new NotFoundException("Invalid email address: " + form.getEmail());
+                    throw new UnauthorizedException();
                 }
             }
             return SecurityManager.getRegistrationMessage(form.getMailPrefix(), false);
@@ -1894,7 +1901,7 @@ public class SecurityController extends SpringActionController
 
 
     @RequiresPermission(UpdateUserPermission.class)
-    public class ShowResetEmailAction extends AbstractEmailAction
+    public static class ShowResetEmailAction extends AbstractEmailAction
     {
         @Override
         protected SecurityMessage createMessage(EmailForm form)
@@ -1916,18 +1923,8 @@ public class SecurityController extends SpringActionController
         @Override
         public ModelAndView getConfirmView(EmailForm emailForm, BindException errors)
         {
+            boolean loginExists = LoginManager.loginExists(emailForm.getUserObject(true));
             setTitle(getTitle());
-
-            boolean loginExists = false;
-
-            try
-            {
-                loginExists = LoginManager.loginExists(new ValidEmail(emailForm.getEmail()));
-            }
-            catch (InvalidEmailException e)
-            {
-                // Allow display and edit of users with invalid email addresses so they can be fixed, #12276.
-            }
 
             return new HtmlView(getConfirmationMessage(loginExists, emailForm.getEmail()));
         }
@@ -1935,21 +1932,12 @@ public class SecurityController extends SpringActionController
         @Override
         public void validateCommand(EmailForm form, Errors errors)
         {
-            String rawEmail = form.getEmail();
-
-            try
-            {
-                ValidEmail email = new ValidEmail(rawEmail);
-
-                // don't let non-site admin delete/reset password of site admin
-                User formUser = UserManager.getUser(email);
-                if (formUser != null && !getUser().hasSiteAdminPermission() && formUser.hasSiteAdminPermission())
-                    errors.reject(ERROR_MSG, "Permission denied: not authorized to " + getVerb() + " password for a Site Admin user.");
-            }
-            catch (InvalidEmailException e)
-            {
-                errors.reject(ERROR_MSG, getVerb() + " failed: invalid email address.");
-            }
+            // don't let non-site admin delete/reset password of site admin
+            User formUser = form.getUserObject();
+            if (null == formUser)
+                errors.reject(ERROR_MSG, getVerb() + " failed: user not found.");
+            else if (!getUser().hasSiteAdminPermission() && formUser.hasSiteAdminPermission())
+                errors.reject(ERROR_MSG, "Permission denied: not authorized to " + getVerb() + " password for a Site Admin user.");
         }
 
         @Override
@@ -1963,7 +1951,7 @@ public class SecurityController extends SpringActionController
      * Invalidate existing password and send new password link
      */
     @RequiresPermission(UpdateUserPermission.class)
-    public class AdminResetPasswordAction extends AdminPasswordAction
+    public static class AdminResetPasswordAction extends AdminPasswordAction
     {
         @Override
         String getTitle()
@@ -1990,17 +1978,9 @@ public class SecurityController extends SpringActionController
         @Override
         public boolean handlePost(EmailForm form, BindException errors) throws Exception
         {
-            try
-            {
-                ValidEmail email = new ValidEmail(form.getEmail());
-                _loginExists = LoginManager.loginExists(email);
-                SecurityManager.adminRotatePassword(email, errors, getContainer(), getUser(), getMailHelpText(form.getEmail()));
-            }
-            catch (InvalidEmailException e)
-            {
-                //Should be caught in validation
-                errors.addError(new LabKeyError(new Exception("Invalid email address." + e.getMessage(), e)));
-            }
+            User affectedUser = form.getUserObject(true);
+            _loginExists = LoginManager.loginExists(affectedUser);
+            SecurityManager.adminRotatePassword(affectedUser, errors, getContainer(), getUser(), getMailHelpText(form.getEmail()));
 
             return !errors.hasErrors();
         }
@@ -2081,7 +2061,7 @@ public class SecurityController extends SpringActionController
      * Delete existing password
      */
     @RequiresPermission(UpdateUserPermission.class)
-    public class AdminDeletePasswordAction extends AdminPasswordAction
+    public static class AdminDeletePasswordAction extends AdminPasswordAction
     {
         @Override
         String getTitle()
@@ -2137,17 +2117,8 @@ public class SecurityController extends SpringActionController
         @Override
         public boolean handlePost(EmailForm form, BindException errors) throws Exception
         {
-            try
-            {
-                ValidEmail email = new ValidEmail(form.getEmail());
-                User userToChange = UserManager.getUser(email);
-                LoginManager.deleteLoginsRow(userToChange, getUser());
-            }
-            catch (InvalidEmailException e)
-            {
-                //Should be caught in validation
-                errors.addError(new LabKeyError(new Exception("Invalid email address." + e.getMessage(), e)));
-            }
+            User userToChange = form.getUserObject(true);
+            LoginManager.deleteLoginsRow(userToChange, getUser());
 
             return !errors.hasErrors();
         }
@@ -2156,9 +2127,9 @@ public class SecurityController extends SpringActionController
     public static class GroupDiagramViewFactory implements SecurityManager.ViewFactory
     {
         @Override
-        public HttpView createView(ViewContext context)
+        public JspView<Void> createView(ViewContext context)
         {
-            JspView view = new JspView("/org/labkey/core/security/groupDiagram.jsp");
+            JspView<Void> view = new JspView<>("/org/labkey/core/security/groupDiagram.jsp");
             view.setTitle("Group Diagram");
 
             return view;
@@ -2167,7 +2138,7 @@ public class SecurityController extends SpringActionController
 
 
     @RequiresPermission(AdminPermission.class)
-    public class GroupDiagramAction extends ReadOnlyApiAction<GroupDiagramForm>
+    public static class GroupDiagramAction extends ReadOnlyApiAction<GroupDiagramForm>
     {
         @Override
         public ApiResponse execute(GroupDiagramForm form, BindException errors) throws Exception
@@ -2495,16 +2466,16 @@ public class SecurityController extends SpringActionController
                 controller.new GroupExportAction(),
                 controller.new GroupPermissionAction(),
                 controller.new UpdatePermissionsAction(),
-                controller.new ShowRegistrationEmailAction(),
-                controller.new GroupDiagramAction(),
+                    new ShowRegistrationEmailAction(),
+                    new GroupDiagramAction(),
                 controller.new FolderAccessAction()
             );
 
             // @RequiresPermission(UserManagementPermission.class)
             assertForUserPermissions(user,
                 controller.new AddUsersAction(),
-                controller.new ShowResetEmailAction(),
-                controller.new AdminResetPasswordAction()
+                    new ShowResetEmailAction(),
+                    new AdminResetPasswordAction()
             );
         }
 

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -293,7 +293,8 @@ public class SecurityController extends SpringActionController
         {
             ActionURL url = new ActionURL(ShowRegistrationEmailAction.class, container);
             url.addParameter("userId", user.getUserId());
-            url.addParameter("mailPrefix", mailPrefix);
+            if (mailPrefix != null)
+                url.addParameter("mailPrefix", mailPrefix);
 
             return url;
         }

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -289,10 +289,10 @@ public class SecurityController extends SpringActionController
         }
 
         @Override
-        public ActionURL getShowRegistrationEmailURL(Container container, ValidEmail email, String mailPrefix)
+        public ActionURL getShowRegistrationEmailURL(Container container, User user, String mailPrefix)
         {
             ActionURL url = new ActionURL(ShowRegistrationEmailAction.class, container);
-            url.addParameter("email", email.getEmailAddress());
+            url.addParameter("userId", user.getUserId());
             url.addParameter("mailPrefix", mailPrefix);
 
             return url;

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -74,6 +74,7 @@ import org.labkey.api.security.Group;
 import org.labkey.api.security.GroupManager;
 import org.labkey.api.security.GroupMembershipCache;
 import org.labkey.api.security.InvalidGroupMembershipException;
+import org.labkey.api.security.LoginManager;
 import org.labkey.api.security.MemberType;
 import org.labkey.api.security.MutableSecurityPolicy;
 import org.labkey.api.security.PrincipalArray;
@@ -1833,14 +1834,14 @@ public class SecurityController extends SpringActionController
                 // Issue 33254: only allow Site Admins to see the verification token
                 message.setMaskToken(true);
 
-                if (SecurityManager.isVerified(email))
+                if (LoginManager.isVerified(email))
                 {
                     out.write("Can't display " + message.getType().toLowerCase() + "; " + PageFlowUtil.filter(email) + " has already chosen a password.");
                 }
                 else
                 {
-                    String verification = SecurityManager.getVerification(email);
-                    ActionURL verificationURL = SecurityManager.createVerificationURL(getContainer(), email, verification, null);
+                    String verification = LoginManager.getVerification(email);
+                    ActionURL verificationURL = LoginManager.createVerificationURL(getContainer(), email, verification, null);
                     SecurityManager.renderEmail(getContainer(), getUser(), message, email.getEmailAddress(), verificationURL, out);
                 }
             }
@@ -1919,7 +1920,7 @@ public class SecurityController extends SpringActionController
 
             try
             {
-                loginExists = SecurityManager.loginExists(new ValidEmail(emailForm.getEmail()));
+                loginExists = LoginManager.loginExists(new ValidEmail(emailForm.getEmail()));
             }
             catch (InvalidEmailException e)
             {
@@ -1990,7 +1991,7 @@ public class SecurityController extends SpringActionController
             try
             {
                 ValidEmail email = new ValidEmail(form.getEmail());
-                _loginExists = SecurityManager.loginExists(email);
+                _loginExists = LoginManager.loginExists(email);
                 SecurityManager.adminRotatePassword(email, errors, getContainer(), getUser(), getMailHelpText(form.getEmail()));
             }
             catch (InvalidEmailException e)
@@ -2137,7 +2138,8 @@ public class SecurityController extends SpringActionController
             try
             {
                 ValidEmail email = new ValidEmail(form.getEmail());
-                SecurityManager.adminDeletePassword(email, getUser());
+                User userToChange = UserManager.getUser(email);
+                LoginManager.deleteLoginsRow(userToChange, getUser());
             }
             catch (InvalidEmailException e)
             {

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -1902,9 +1902,9 @@ public class UserController extends SpringActionController
                     String requestedEmail = verifyEmail.requestedEmail();
                     String verificationToken = form.getVerificationToken();
                     boolean isVerified = verifyEmail.isVerified(verificationToken);
-                    LoginController.checkVerificationErrors(isVerified, loggedInUser, verificationToken, errors);
+                    LoginController.checkVerificationErrors(isVerified, loggedInUser, errors);
 
-                    if (errors.getErrorCount() == 0)  // verified and active
+                    if (!errors.hasErrors())  // verified and active
                     {
                         // Note: Verification timeout only applies to self-service change email workflow currently
                         Instant verificationTimeoutInstant = verifyEmail.verificationTimeout().toInstant();

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -1902,7 +1902,7 @@ public class UserController extends SpringActionController
                     String requestedEmail = verifyEmail.requestedEmail();
                     String verificationToken = form.getVerificationToken();
                     boolean isVerified = verifyEmail.isVerified(verificationToken);
-                    LoginController.checkVerificationErrors(isVerified, loggedInUser, oldEmail, verificationToken, errors);
+                    LoginController.checkVerificationErrors(isVerified, loggedInUser, verificationToken, errors);
 
                     if (errors.getErrorCount() == 0)  // verified and active
                     {

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -1646,7 +1646,7 @@ public class UserController extends SpringActionController
                     // with LDAP/SSO and later needing to use database authentication. Also allows site admin to have
                     // an alternate login, e.g., in case LDAP server goes down or configuration changes.
                     ActionURL resetURL = new ActionURL(AdminResetPasswordAction.class, c);
-                    resetURL.addParameter("user", detailsUser.getUserId());
+                    resetURL.addParameter("userId", detailsUser.getUserId());
                     resetURL.addReturnURL(currentUrl);
                     ActionButton reset = new ActionButton(resetURL, loginExists ? "Reset Password" : "Create Password");
                     reset.setActionType(ActionButton.Action.LINK);
@@ -1655,7 +1655,7 @@ public class UserController extends SpringActionController
                     if (loginExists)
                     {
                         ActionURL deleteURL = new ActionURL(AdminDeletePasswordAction.class, c);
-                        deleteURL.addParameter("user", detailsUser.getUserId());
+                        deleteURL.addParameter("userId", detailsUser.getUserId());
                         deleteURL.addReturnURL(currentUrl);
                         ActionButton delete = new ActionButton(deleteURL, "Delete Password");
                         delete.setActionType(ActionButton.Action.LINK);

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -78,6 +78,7 @@ import org.labkey.api.security.AuthenticationManager;
 import org.labkey.api.security.AvatarThumbnailProvider;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.LimitActiveUsersService;
+import org.labkey.api.security.LoginManager;
 import org.labkey.api.security.LoginUrls;
 import org.labkey.api.security.MemberType;
 import org.labkey.api.security.RequiresAllOf;
@@ -1586,7 +1587,7 @@ public class UserController extends SpringActionController
             // don't let a non-site admin manage certain parts of a site-admin's account
             boolean canManageDetailsUser = currentUser.hasSiteAdminPermission() || !detailsUser.hasSiteAdminPermission();
             String detailsEmail = detailsUser.getEmail();
-            boolean loginExists = SecurityManager.loginExists(detailsEmail); // Note: Not using ValidEmail variant since existing address could be invalid
+            boolean loginExists = LoginManager.loginExists(detailsEmail); // Note: Not using ValidEmail variant since existing address could be invalid
 
             UserSchema schema = form.getSchema();
             if (schema == null)
@@ -1898,9 +1899,8 @@ public class UserController extends SpringActionController
                 else
                 {
                     String oldEmail = userToChange.getEmail();
-                    UserManager.VerifyEmail verifyEmail = UserManager.getVerifyEmail(oldEmail);
-                    assert oldEmail.equals(verifyEmail.getEmail());
-                    String requestedEmail = verifyEmail.getRequestedEmail();
+                    LoginManager.VerifyEmail verifyEmail = LoginManager.getVerifyEmail(userToChange);
+                    String requestedEmail = verifyEmail.requestedEmail();
                     String verificationToken = form.getVerificationToken();
                     boolean isVerified = verifyEmail.isVerified(verificationToken);
                     LoginController.checkVerificationErrors(isVerified, loggedInUser, oldEmail, verificationToken, errors);
@@ -1908,7 +1908,7 @@ public class UserController extends SpringActionController
                     if (errors.getErrorCount() == 0)  // verified and active
                     {
                         // Note: Verification timeout only applies to self-service change email workflow currently
-                        Instant verificationTimeoutInstant = verifyEmail.getVerificationTimeout().toInstant();
+                        Instant verificationTimeoutInstant = verifyEmail.verificationTimeout().toInstant();
                         if (Instant.now().isAfter(verificationTimeoutInstant))
                         {
                             if (!canUpdateUser)  // don't bother auditing admin password link clicks
@@ -1920,19 +1920,19 @@ public class UserController extends SpringActionController
                     }
                     else
                     {
-                        if (verificationToken == null || verificationToken.length() != SecurityManager.tempPasswordLength)
+                        if (verificationToken == null || verificationToken.length() != LoginManager.TEMP_PASSWORD_LENGTH)
                         {
                             if (!canUpdateUser)  // don't bother auditing admin verification link clicks
                             {
-                                UserManager.auditBadVerificationToken(loggedInUser.getUserId(), oldEmail, verifyEmail.getRequestedEmail(), verificationToken, loggedInUser);
+                                UserManager.auditBadVerificationToken(loggedInUser.getUserId(), oldEmail, verifyEmail.requestedEmail(), verificationToken, loggedInUser);
                             }
                             errors.reject(ERROR_MSG, "Verification was incorrect. Make sure you've copied the entire link into your browser's address bar.");  // double error, to better explain to user
                         }
-                        else if (!verificationToken.equals(verifyEmail.getVerification()))
+                        else if (!verificationToken.equals(verifyEmail.verification()))
                         {
                             if (!canUpdateUser)  // don't bother auditing admin verification link clicks
                             {
-                                UserManager.auditBadVerificationToken(loggedInUser.getUserId(), oldEmail, verifyEmail.getRequestedEmail(), verificationToken, loggedInUser);
+                                UserManager.auditBadVerificationToken(loggedInUser.getUserId(), oldEmail, verifyEmail.requestedEmail(), verificationToken, loggedInUser);
                             }
                         }
                     }
@@ -2028,8 +2028,8 @@ public class UserController extends SpringActionController
                     boolean isAuthenticated = authenticate(userEmail, form.getPassword(), getViewContext().getActionURL().getReturnURL(), errors);
                     if (isAuthenticated)
                     {
-                        String verificationToken = SecurityManager.createTempPassword();
-                        UserManager.requestEmailChange(userToChange, validRequestedEmail, verificationToken, getUser());
+                        String verificationToken = LoginManager.createTempPassword();
+                        LoginManager.requestEmailChange(userToChange, validRequestedEmail, verificationToken, getUser());
                         // verification email
                         Container c = getContainer();
 

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -1586,8 +1586,7 @@ public class UserController extends SpringActionController
 
             // don't let a non-site admin manage certain parts of a site-admin's account
             boolean canManageDetailsUser = currentUser.hasSiteAdminPermission() || !detailsUser.hasSiteAdminPermission();
-            String detailsEmail = detailsUser.getEmail();
-            boolean loginExists = LoginManager.loginExists(detailsEmail); // Note: Not using ValidEmail variant since existing address could be invalid
+            boolean loginExists = LoginManager.loginExists(detailsUser);
 
             UserSchema schema = form.getSchema();
             if (schema == null)
@@ -1641,13 +1640,13 @@ public class UserController extends SpringActionController
             if (isUserManager)
             {
                 // Always display "Reset/Create Password" button (even for LDAP and SSO users)... except for admin's own record
-                if (null != detailsEmail && !isOwnRecord && canManageDetailsUser && !isLoginAutoRedirect)
+                if (!isOwnRecord && canManageDetailsUser && !isLoginAutoRedirect)
                 {
                     // Allow admins to create a logins entry if it doesn't exist. Addresses scenario of user logging in
                     // with LDAP/SSO and later needing to use database authentication. Also allows site admin to have
                     // an alternate login, e.g., in case LDAP server goes down or configuration changes.
                     ActionURL resetURL = new ActionURL(AdminResetPasswordAction.class, c);
-                    resetURL.addParameter("email", detailsEmail);
+                    resetURL.addParameter("user", detailsUser.getUserId());
                     resetURL.addReturnURL(currentUrl);
                     ActionButton reset = new ActionButton(resetURL, loginExists ? "Reset Password" : "Create Password");
                     reset.setActionType(ActionButton.Action.LINK);
@@ -1656,7 +1655,7 @@ public class UserController extends SpringActionController
                     if (loginExists)
                     {
                         ActionURL deleteURL = new ActionURL(AdminDeletePasswordAction.class, c);
-                        deleteURL.addParameter("email", detailsEmail);
+                        deleteURL.addParameter("user", detailsUser.getUserId());
                         deleteURL.addReturnURL(currentUrl);
                         ActionButton delete = new ActionButton(deleteURL, "Delete Password");
                         delete.setActionType(ActionButton.Action.LINK);


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51520

#### Changes
* Add `UserId` column to `core.Logins` and populate it from the `core.Principals` table. Make this the primary key.
* Consolidate all core.Logins-handling methods from `UserManager` & `SecurityManager` into `LoginManager`. Migrate these methods and their callers to use UserId instead of email address.
* Update actions to pass and use `userId` parameter
* Update verification URLs to remove email parameter and not add userId. Verification is now a lookup based solely on the verification token.
* Make `Email` column nullable and stop populating it. It'll get removed in 24.12.