### PR TITLE
AssayPlateTriggerFactory: query table provided to trigger

### DIFF
--- a/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
@@ -4,9 +4,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayResultDomainKind;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
+import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableResultSet;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.triggers.Trigger;
 import org.labkey.api.data.triggers.TriggerFactory;
@@ -19,6 +21,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.util.UnexpectedException;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -43,7 +46,8 @@ public class AssayPlateTriggerFactory implements TriggerFactory
     }
 
     /**
-     * Trigger to handle updates, inserts are handled during assay run creation
+     * Recompute the stats for the changed replicate rows.
+     * Trigger to handle updates, inserts are handled during assay run creation.
      */
     private class ReplicateStatsTrigger implements Trigger
     {
@@ -84,21 +88,22 @@ public class AssayPlateTriggerFactory implements TriggerFactory
             if (_replicateLsid.isEmpty() || errors.hasErrors())
                 return;
 
-            // recompute the stats for the changed replicate rows
-            try
+            var filter = new SimpleFilter(FieldKey.fromParts(AssayResultDomainKind.REPLICATE_LSID_COLUMN_NAME), _replicateLsid.keySet(), CompareType.IN);
+
+            try (TableResultSet rs = new TableSelector(table, filter, null).getResultSet())
             {
-                SimpleFilter filter = new SimpleFilter().addInClause(FieldKey.fromParts(AssayResultDomainKind.REPLICATE_LSID_COLUMN_NAME), _replicateLsid.keySet());
-                Map<Lsid, List<Map<String, Object>>> replicates = new HashMap<>();
+                var replicates = new HashMap<Lsid, List<Map<String, Object>>>();
 
-                new TableSelector(table, filter, null).getResults().forEach(row -> {
-                    var lsid = row.get(AssayResultDomainKind.REPLICATE_LSID_COLUMN_NAME);
-                    replicates.computeIfAbsent(Lsid.parse(String.valueOf(lsid)), m -> new ArrayList<>()).add(row);
-                    _replicateLsid.remove(lsid.toString());
-                });
+                while (rs.next())
+                {
+                    var lsid = rs.getString(AssayResultDomainKind.REPLICATE_LSID_COLUMN_NAME);
+                    replicates.computeIfAbsent(Lsid.parse(String.valueOf(lsid)), m -> new ArrayList<>()).add(rs.getRowMap());
+                    _replicateLsid.remove(lsid);
+                }
 
-                // if results are being deleted, check if all rows for the well group have been deleted
-                List<Map<String, Object>> deletedRows = new ArrayList<>();
-                for (Map.Entry<String, Boolean> entry : _replicateLsid.entrySet())
+                // If results are being deleted, check if all rows for the well group have been deleted
+                var deletedRows = new ArrayList<Map<String, Object>>();
+                for (var entry : _replicateLsid.entrySet())
                 {
                     if (!entry.getValue())
                         deletedRows.add(Map.of(PlateReplicateStatsDomainKind.Column.Lsid.name(), entry.getKey()));
@@ -109,7 +114,7 @@ public class AssayPlateTriggerFactory implements TriggerFactory
 
                 AssayPlateMetadataService.get().updateReplicateStats(c, user, _protocol, replicates);
             }
-            catch (ExperimentException e)
+            catch (ExperimentException | SQLException e)
             {
                 throw UnexpectedException.wrap(e);
             }

--- a/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
@@ -2,10 +2,7 @@ package org.labkey.assay.plate;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.assay.AssayProtocolSchema;
-import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayResultDomainKind;
-import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
@@ -88,21 +85,12 @@ public class AssayPlateTriggerFactory implements TriggerFactory
                 return;
 
             // recompute the stats for the changed replicate rows
-            AssayProvider provider = AssayService.get().getProvider(_protocol);
-            if (provider == null)
-                throw new IllegalStateException(String.format("Unable to find the provider for protocol : %s", _protocol.getName()));
-
-            AssayProtocolSchema schema = provider.createProtocolSchema(user, c, _protocol, null);
-            TableInfo dataTable = schema.createDataTable(null, false);
-            if (dataTable == null)
-                return;
-
             try
             {
                 SimpleFilter filter = new SimpleFilter().addInClause(FieldKey.fromParts(AssayResultDomainKind.REPLICATE_LSID_COLUMN_NAME), _replicateLsid.keySet());
                 Map<Lsid, List<Map<String, Object>>> replicates = new HashMap<>();
 
-                new TableSelector(dataTable, filter, null).getResults().forEach(row -> {
+                new TableSelector(table, filter, null).getResults().forEach(row -> {
                     var lsid = row.get(AssayResultDomainKind.REPLICATE_LSID_COLUMN_NAME);
                     replicates.computeIfAbsent(Lsid.parse(String.valueOf(lsid)), m -> new ArrayList<>()).add(row);
                     _replicateLsid.remove(lsid.toString());


### PR DESCRIPTION
#### Rationale
This fixes an issue where the underlying result set does not close after getting results from a separately loaded instance of the assay results table.

```
ERROR CachedResultSet          2024-11-04T15:20:30,985                Finalizer : CachedResultSet was not closed.
URL: http://localhost:8080/8f2c8f71-7d30-103d-a6ce-8ee7bf181780/query-updateRows.api
Stack trace from the creation:
    at org.labkey.api.data.CachedResultSets.create(CachedResultSets.java:61)
    at org.labkey.api.data.SqlExecutingSelector.wrapResultSet(SqlExecutingSelector.java:200)
    at org.labkey.api.data.SqlExecutingSelector.lambda$getResultSet$2(SqlExecutingSelector.java:191)
    at org.labkey.api.data.SqlExecutingSelector$ExecutingResultSetFactory.handleResultSet(SqlExecutingSelector.java:438)
    at org.labkey.api.data.SqlExecutingSelector.getResultSet(SqlExecutingSelector.java:191)
    at org.labkey.api.data.TableSelector.getResults(TableSelector.java:333)
    at org.labkey.api.data.TableSelector.getResults(TableSelector.java:316)
    at org.labkey.api.data.TableSelector.getResults(TableSelector.java:305)
    at org.labkey.assay.plate.AssayPlateTriggerFactory$ReplicateStatsTrigger.complete(AssayPlateTriggerFactory.java:105)
    at org.labkey.api.data.triggers.Trigger.batchTrigger(Trigger.java:93)
    at org.labkey.api.data.AbstractTableInfo.fireBatchTrigger(AbstractTableInfo.java:1903)
    at org.labkey.api.query.AbstractQueryUpdateService.updateRows(AbstractQueryUpdateService.java:824)
    at org.labkey.api.assay.AssayResultUpdateService.updateRows(AssayResultUpdateService.java:79)
    at org.labkey.query.controllers.QueryController$CommandType$5.saveRows(QueryController.java:4297)
    at org.labkey.query.controllers.QueryController$BaseSaveRowsAction.executeJson(QueryController.java:4585)
    at org.labkey.query.controllers.QueryController$BaseSaveRowsAction.executeJson(QueryController.java:4454)
    at org.labkey.query.controllers.QueryController$UpdateRowsAction.execute(QueryController.java:4729)
    at org.labkey.query.controllers.QueryController$UpdateRowsAction.execute(QueryController.java:4722)
    at org.labkey.api.action.BaseApiAction.handlePost(BaseApiAction.java:239)
```

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/881

#### Changes
- Use table provided to trigger rather than instantiating a new table
- Use try with resources to ensure result set is closed
