### PR TITLE
Issue 51553: All assay plate parsing empty well value to be overridden via the PlateReader implementation

### DIFF
--- a/assay/api-src/org/labkey/api/assay/plate/ExcelPlateReader.java
+++ b/assay/api-src/org/labkey/api/assay/plate/ExcelPlateReader.java
@@ -28,7 +28,6 @@ import org.labkey.api.reader.DataLoaderFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 /**
  * User: Karl Lum
@@ -37,6 +36,8 @@ import java.util.Map;
 public class ExcelPlateReader extends AbstractPlateReader implements PlateReader
 {
     public static final String TYPE = "xls";
+
+    double emptyWellValue = 0.0d;
     
     @Override
     public String getType()
@@ -101,5 +102,16 @@ public class ExcelPlateReader extends AbstractPlateReader implements PlateReader
             }
         }
         return false;
+    }
+
+    @Override
+    public double getEmptyWellValue()
+    {
+        return emptyWellValue;
+    }
+
+    public void setEmptyWellValue(double emptyWellValue)
+    {
+        this.emptyWellValue = emptyWellValue;
     }
 }

--- a/assay/api-src/org/labkey/api/assay/plate/PlateReader.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateReader.java
@@ -81,4 +81,10 @@ public interface PlateReader
      * @throws ValidationException - if the value cannot be converted, will halt parsing of the plate
      */
     double convertWellValue(String token) throws ValidationException;
+
+    // Issue 51553: Empty well value should be 0.0d by default but can be overridden via the PlateReader implementation
+    default double getEmptyWellValue()
+    {
+        return 0.0d;
+    }
 }

--- a/assay/api-src/org/labkey/api/assay/plate/PlateUtils.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateUtils.java
@@ -340,7 +340,7 @@ public class PlateUtils
             // If the value is not null or a number, stop parsing.
             Object value = rowMap.get(startCol + j);
             if (value == null)
-                cells[j] = 0.0d;
+                cells[j] = reader != null ? reader.getEmptyWellValue() : 0.0d;
             else if (value instanceof String)
             {
                 try

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -696,6 +696,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
     {
         // parse the data file for each distinct plate type found in the set of plates for the plateSetId
         ExcelPlateReader plateReader = new ExcelPlateReader();
+        plateReader.setEmptyWellValue(Double.NaN); // Issue 51553
         MultiValuedMap<PlateType, PlateGridInfo> plateTypeGrids = new HashSetValuedHashMap<>();
 
         boolean hasPlateIdentifiers = false;
@@ -772,7 +773,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                             // get wells guarantees a consistent row/column oriented order
                             for (Well well : dataForPlate.getWells())
                             {
-                                measureDataRows.computeIfAbsent(well, f -> getDataRowFromWell(currentPlate.getPlateId(), well, measureName)).put(measureName, well.getValue());
+                                measureDataRows.computeIfAbsent(well, f -> getDataRowFromWell(currentPlate.getPlateId(), well, measureName)).put(measureName, getWellValue(well));
                             }
                         }
 
@@ -829,8 +830,16 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         Map<String, Object> row = new CaseInsensitiveHashMap<>();
         row.put(AssayResultDomainKind.PLATE_COLUMN_NAME, plateId);
         row.put(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME, well.getDescription());
-        row.put(measure, well.getValue());
+        row.put(measure, getWellValue(well));
         return row;
+    }
+
+    // Issue 51553: account for empty wells in the plate graphical parsing by using Double.NaN
+    private Double getWellValue(Well well)
+    {
+        if (Double.isNaN(well.getValue()))
+            return null;
+        return well.getValue();
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -835,11 +835,10 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
     }
 
     // Issue 51553: account for empty wells in the plate graphical parsing by using Double.NaN
-    private Double getWellValue(Well well)
+    private @Nullable Double getWellValue(Well well)
     {
-        if (Double.isNaN(well.getValue()))
-            return null;
-        return well.getValue();
+        double value = well.getValue();
+        return Double.isNaN(value) ? null : value;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51553

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6030
- https://github.com/LabKey/limsModules/pull/894

#### Changes
- should be 0.0d by default for backwards compatibility
- set emptyWellValue to Double.NaN for AssayPlateMetadataServiceImpl.parsePlateGrids
- convert Double.NaN values back to null before adding to dataRows
