### PR TITLE
Ignore restricted issues during indexing

### DIFF
--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -953,9 +953,16 @@ public class IssueManager
 
         for (Integer id : ids)
         {
-            IssueObject issue = IssueManager.getIssue(container, user, id);
-            if (issue != null)
-                queueIssue(task, id, issue.getProperties(), issue.getCommentObjects());
+            try
+            {
+                IssueObject issue = IssueManager.getIssue(container, user, id);
+                if (issue != null)
+                    queueIssue(task, id, issue.getProperties(), issue.getCommentObjects());
+            }
+            catch (UnauthorizedException e)
+            {
+                // Issue 51607 ignore restricted issue failures
+            }
         }
     }
 


### PR DESCRIPTION
#### Rationale
related [issue](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51607).

The client is reporting `UnauthorizedException` showing up in the logs because the search user does not have access to their restricted issue list issues. I've given them the option of allowing them to be indexed which would allow valid users to view the issue. However they have requested that the exception be ignored and restricted issues are not searchable. 

Although not a critical fix, services has requested a `24.7` patch due to upgrade timing concerns.