### PR TITLE
Reduce chances of race condition when closing connections to kill job

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -2141,7 +2141,6 @@ public class DbScope
         ConnectionWrapper.dumpLeaksForThread(Thread.currentThread());
         closeAllConnectionsForCurrentThread();
         QueryService.get().clearEnvironment();
-        ConnectionWrapper.releaseBan(Thread.currentThread());
     }
 
     /**

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1157,6 +1157,9 @@ public class DbScope
         {
             log(() -> 1 == _refCount ? "Releasing connection [1]: " + conn.toString() : "Attempting to decrease count of connection [" + _refCount + "]: " + conn.toString());
 
+            if (_conn == null)
+                throw new ConnectionAlreadyReleaseException("Connection has already been nulled out, but was passed: " + conn);
+
             if (_conn != conn)
                 throw new IllegalStateException("Incorrect Connection: " + conn + " vs. " + _conn);
 
@@ -1171,6 +1174,19 @@ public class DbScope
             }
 
             return 0 == _refCount;
+        }
+    }
+
+    /**
+     * Special case for when the connection being closed doesn't match the expected
+     * connection for this thread, to help scenarios that are prone to race conditions
+     * (like killing pipeline jobs) ignore it.
+     */
+    public static class ConnectionAlreadyReleaseException extends IllegalStateException
+    {
+        public ConnectionAlreadyReleaseException(String s)
+        {
+            super(s);
         }
     }
 
@@ -2080,7 +2096,6 @@ public class DbScope
      */
     public static void closeAllConnectionsForCurrentThread()
     {
-        Thread thread = getEffectiveThread();
         for (DbScope scope : getInitializedDbScopes())
         {
             TransactionImpl t = scope.getCurrentTransactionImpl();
@@ -2097,7 +2112,11 @@ public class DbScope
                 {
                     LOG.warn("Forcing close of still-pending transaction object. Current stack is ", new Throwable());
                     LOG.warn("Forcing close of still-pending transaction object started at ", t._creation);
-                    t.close(thread);
+                    t.close();
+                }
+                catch (ConnectionAlreadyReleaseException ignored)
+                {
+                    // The code in another thread has already released the connection
                 }
                 catch (Exception x)
                 {
@@ -2122,6 +2141,7 @@ public class DbScope
         ConnectionWrapper.dumpLeaksForThread(Thread.currentThread());
         closeAllConnectionsForCurrentThread();
         QueryService.get().clearEnvironment();
+        ConnectionWrapper.releaseBan(Thread.currentThread());
     }
 
     /**
@@ -2566,11 +2586,6 @@ public class DbScope
 
         @Override
         public void close()
-        {
-            close(getEffectiveThread());
-        }
-
-        public void close(Thread thread)
         {
             if (_closesToIgnore == 0)
             {


### PR DESCRIPTION
#### Rationale
A pipeline job may have closed its connection before the cancellation attempts to close it. We can detect this special case and avoid throwing an exception.

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres/3252738?expandBuildChangesSection=true&expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&hideProblemsFromDependencies=false

#### Changes
- Special exception to signal when the connection has already been closed