### PR TITLE
Don't show edit button if folder can't be renamed

### DIFF
--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -5372,7 +5372,7 @@ public class DavController extends SpringActionController
                 methodsAllowed.append(", GET, HEAD, COPY");
             if (delete)
                 methodsAllowed.append(", DELETE");
-            if (delete && read)
+            if (delete && read && resource.canRename(user,false))
                 methodsAllowed.append(", MOVE");
             if (_locking)
                 methodsAllowed.append(", LOCK, UNLOCK");


### PR DESCRIPTION
#### Rationale
DavController wasn't checking explicit canRename() method

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
