### PR TITLE
Ensure S3 WebDAV paths are URL-encoded, fixing S3 tests

### DIFF
--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -1399,15 +1399,7 @@ public class FileContentServiceImpl implements FileContentService, WarningProvid
 
             if (relPath != null)
             {
-                if (!isCloudRoot(container))
-                {
-                    relPath = Path.parse(FilenameUtils.separatorsToUnix(relPath)).encode();
-                }
-                else
-                {
-                    // Do not encode path from S3 folder.  It is already encoded.
-                    relPath = Path.parse(FilenameUtils.separatorsToUnix(relPath)).toString();
-                }
+                relPath = Path.parse(FilenameUtils.separatorsToUnix(relPath)).encode();
 
                 return switch (type)
                 {

--- a/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
@@ -107,7 +107,7 @@ public class StatusDetailsBean
         if (filePath != null && container != null)
         {
             // Path.of is FileSystem dependant and may not properly handle unencoded URI strings. ISSUE #45122
-            Path logPath = FileUtil.stringToPath(container, filePath, false);
+            Path logPath = FileUtil.stringToPath(container, filePath, true);
             if (Files.exists(logPath))
             {
                 return FileContentService.get().getWebDavUrl(logPath, container, FileContentService.PathType.serverRelative);

--- a/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusDetailsBean.java
@@ -107,7 +107,7 @@ public class StatusDetailsBean
         if (filePath != null && container != null)
         {
             // Path.of is FileSystem dependant and may not properly handle unencoded URI strings. ISSUE #45122
-            Path logPath = FileUtil.stringToPath(container, filePath, true);
+            Path logPath = FileUtil.stringToPath(container, filePath, false);
             if (Files.exists(logPath))
             {
                 return FileContentService.get().getWebDavUrl(logPath, container, FileContentService.PathType.serverRelative);


### PR DESCRIPTION
#### Rationale
We've made changes to more consistently encode WebDAV URLs. We can now encode these paths whether they're S3-backed or file-backed

#### Changes
- No need to special case S3 in this codepath anymore