### PR TITLE
Fix core.Users.HasPassword

### DIFF
--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 24.009
+SchemaVersion: 24.010
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-create.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-create.sql
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 CREATE VIEW core.Users AS
-    SELECT p.Name AS Email, ud.*, p.Active, l.Email IS NOT NULL AS HasPassword
+    SELECT p.Name AS Email, ud.*, p.Active, l.UserId IS NOT NULL AS HasPassword
     FROM core.Principals p
         INNER JOIN core.UsersData ud ON p.UserId = ud.UserId
-        LEFT OUTER JOIN core.Logins l ON p.Name = l.Email
+        LEFT OUTER JOIN core.Logins l ON p.UserId = l.UserId
     WHERE Type = 'u';
 
 CREATE OR REPLACE RULE Users_Update AS

--- a/core/resources/schemas/dbscripts/sqlserver/core-create.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-create.sql
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 CREATE VIEW core.Users AS
-    SELECT p.Name AS Email, ud.*, p.Active, CAST(CASE WHEN l.Email IS NULL THEN 0 ELSE 1 END AS BIT) AS HasPassword
+    SELECT p.Name AS Email, ud.*, p.Active, CAST(CASE WHEN l.UserId IS NULL THEN 0 ELSE 1 END AS BIT) AS HasPassword
     FROM core.Principals p
         INNER JOIN core.UsersData ud ON p.UserId = ud.UserId
-        LEFT OUTER JOIN core.Logins l ON p.Name = l.Email
+        LEFT OUTER JOIN core.Logins l ON p.UserId = l.UserId
     WHERE Type = 'u';
 
 GO

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -6282,7 +6282,7 @@ public class AdminController extends SpringActionController
                 if (StringUtils.equalsIgnoreCase(absolutePath, form.getFolderRootPath()))
                 {
                     if (!ctx.getUser().hasRootPermission(AdminOperationsPermission.class))
-                        throw new UnauthorizedException("Only site admins change change file roots");
+                        throw new UnauthorizedException("Only site admins can change file roots");
                 }
             }
         }

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1781,7 +1781,7 @@ public class LoginController extends SpringActionController
         else
         {
             // Verification string wasn't found. User might have already verified, they don't have a login (should be
-            // using LDAP or SSO), or the link got mangled. Don't provide any guidance since that could reveal
+            // using LDAP or SSO), or the link got mangled. Don't provide detailed guidance since that could reveal
             // information about existing users.
             errors.reject("setPassword", "Verification failed. Make sure you've copied the entire link into your browser's address bar.");
         }


### PR DESCRIPTION
#### Rationale
`core.Users.HasPassword` was still using the deprecated and no-longer-populated `Email` column. Need to join on `UserId` and check that column for NULL.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6032