### PR TITLE
Improve session tracking and invalidating

### DIFF
--- a/api/src/org/labkey/api/security/ApiKeyManager.java
+++ b/api/src/org/labkey/api/security/ApiKeyManager.java
@@ -153,13 +153,13 @@ public class ApiKeyManager
             @Override
             public boolean handleSession(HttpSession session)
             {
-                LOG.info("Checking if session {} used API key {}", session.getId(), rowId);
+                LOG.debug("Checking if session {} used API key {}", session.getId(), rowId);
                 Map<String, Object> map = AuthenticationManager.getAuthenticationProperties(session);
                 Integer apiKeyRowId = (Integer)map.get(API_KEY_ROW_ID);
 
                 if (Objects.equals(rowId, apiKeyRowId))
                 {
-                    LOG.info("Attempting to invalidate session {} which used API key {}", session.getId(), rowId);
+                    LOG.debug("Attempting to invalidate session {} which used API key {}", session.getId(), rowId);
                     session.invalidate();
                     return true;
                 }
@@ -170,7 +170,7 @@ public class ApiKeyManager
             @Override
             public void complete(int count)
             {
-                LOG.info("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "API key session"), user.getEmail());
+                LOG.debug("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "API key session"), user.getEmail());
             }
         });
     }

--- a/api/src/org/labkey/api/security/ApiKeyManager.java
+++ b/api/src/org/labkey/api/security/ApiKeyManager.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.security;
 
+import jakarta.servlet.http.HttpSession;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -25,6 +26,7 @@ import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DbScope.Transaction;
 import org.labkey.api.data.DbScope.TransactionKind;
+import org.labkey.api.data.Filter;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SimpleFilter.FilterClause;
@@ -42,23 +44,29 @@ import org.labkey.api.settings.StartupProperty;
 import org.labkey.api.settings.StartupPropertyEntry;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.GUID;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.SystemMaintenance.MaintenanceTask;
 import org.labkey.api.util.TestContext;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.UnauthorizedException;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 public class ApiKeyManager
 {
-    private final static ApiKeyManager INSTANCE = new ApiKeyManager();
-    private final static TransactionKind TRANSACTION_KIND = () -> "APIKEY";
+    private static final Logger LOG = LogHelper.getLogger(ApiKeyManager.class, "API key bookkeeping");
+    private static final ApiKeyManager INSTANCE = new ApiKeyManager();
+    private static final TransactionKind TRANSACTION_KIND = () -> "APIKEY";
+
+    public static final String API_KEY_ROW_ID = "apiKeyRowID";
 
     public static ApiKeyManager get()
     {
@@ -118,15 +126,50 @@ public class ApiKeyManager
         return apiKey;
     }
 
-    public void deleteKey(String apikey)
+    // Delete a single API key and clear any active sessions that were established using it
+    public void deleteKey(String apiKey)
     {
-        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("Crypt"), crypt(apikey));
+        deleteKeys(new SimpleFilter(FieldKey.fromParts("Crypt"), crypt(apiKey)));
+    }
 
+    // Delete all API keys that match the filter and clear all active sessions that were established using them
+    public void deleteKeys(Filter filter)
+    {
         try (Transaction t = CoreSchema.getInstance().getScope().beginTransaction(TRANSACTION_KIND))
         {
-            Table.delete(CoreSchema.getInstance().getTableAPIKeys(), filter);
+            new TableSelector(CoreSchema.getInstance().getTableAPIKeys(), filter, null)
+                .forEach(ApiKeyAuthentication.class, auth -> deleteKey(auth.getUser(), auth.rowId()));
             t.commit();
         }
+    }
+
+    // Delete a single API key and clear all active sessions that were established using it
+    public void deleteKey(User user, int rowId)
+    {
+        Table.delete(CoreSchema.getInstance().getTableAPIKeys(), rowId);
+        UserManager.handleSessionsForUser(user, new UserManager.SessionHandler()
+        {
+            @Override
+            public boolean handleSession(HttpSession session)
+            {
+                Map<String, Object> map = AuthenticationManager.getAuthenticationProperties(session);
+                Integer apiKeyRowId = (Integer)map.get(API_KEY_ROW_ID);
+
+                if (Objects.equals(rowId, apiKeyRowId))
+                {
+                    session.invalidate();
+                    return true;
+                }
+
+                return false;
+            }
+
+            @Override
+            public void complete(int count)
+            {
+                LOG.debug("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "API key session"), user.getEmail());
+            }
+        });
     }
 
     public void updateLastUsed(String apikey)
@@ -141,25 +184,34 @@ public class ApiKeyManager
         }
     }
 
+    public record ApiKeyAuthentication(int createdBy, int rowId)
+    {
+        public User getUser()
+        {
+            return UserManager.getUser(createdBy());
+        }
+    }
+
     /**
-     * Returns the User associated with the supplied API key, if API key is valid. User could be inactive.
+     * Returns a record containing the User associated with the supplied API key and the API key's rowID, if API key is
+     * valid. User could be inactive.
      * @param apiKey The API key to validate
-     * @return The User associated with the API key or null if API key is invalid
+     * @return An ApiKeyAuthentication associated with the API key or null if API key is invalid
      */
-    public @Nullable User authenticateFromApiKey(@NotNull String apiKey)
+    public @Nullable ApiKeyAuthentication authenticateFromApiKey(@NotNull String apiKey)
     {
         SimpleFilter filter = new SimpleFilter(getStillValidClause());
         filter.addCondition(FieldKey.fromParts("Crypt"), crypt(apiKey));
 
-        Integer userId;
+        ApiKeyAuthentication ret;
 
         try (Transaction t = CoreSchema.getInstance().getScope().beginTransaction(TRANSACTION_KIND))
         {
-            userId = new TableSelector(CoreSchema.getInstance().getTableAPIKeys(), Collections.singleton("CreatedBy"), filter, null).getObject(Integer.class);
+            ret = new TableSelector(CoreSchema.getInstance().getTableAPIKeys(), Set.of("CreatedBy", "RowId"), filter, null).getObject(ApiKeyAuthentication.class);
             t.commit();
         }
 
-        return null != userId ? UserManager.getUser(userId) : null;
+        return ret;
     }
 
     private static final String API_KEY_SCOPE = "ApiKey";
@@ -217,7 +269,6 @@ public class ApiKeyManager
         return new SQLClause(new SQLFragment("Expiration IS NULL OR Expiration > ?", new Date()), FieldKey.fromParts("Expiration"));
     }
 
-
     public static class TestCase extends Assert
     {
         @Test
@@ -227,11 +278,15 @@ public class ApiKeyManager
             String oneSecondKey = ApiKeyManager.get().createKey(user, 1, "Created by ApiKeyManager.TestCase");
             String noExpireKey = ApiKeyManager.get().createKey(user, -1, "Created by ApiKeyManager.TestCase");
 
-            assertEquals(user, ApiKeyManager.get().authenticateFromApiKey(oneSecondKey));
+            ApiKeyAuthentication auth = ApiKeyManager.get().authenticateFromApiKey(oneSecondKey);
+            assertNotNull(auth);
+            assertEquals(user, auth.getUser());
             Thread.sleep(1100);
             assertNull("API key should have expired after one second", ApiKeyManager.get().authenticateFromApiKey(oneSecondKey));
 
-            assertEquals(user, ApiKeyManager.get().authenticateFromApiKey(noExpireKey));
+            auth = ApiKeyManager.get().authenticateFromApiKey(noExpireKey);
+            assertNotNull(auth);
+            assertEquals(user, auth.getUser());
 
             ApiKeyManager.get().deleteKey(oneSecondKey);
             ApiKeyManager.get().deleteKey(noExpireKey);
@@ -255,10 +310,14 @@ public class ApiKeyManager
             try (Transaction ignored = DbScope.getLabKeyScope().beginTransaction())
             {
                 apikey = ApiKeyManager.get().createKey(user, 10, "Created by ApiKeyManager.TestCase");
-                assertEquals(user, ApiKeyManager.get().authenticateFromApiKey(apikey));
+                ApiKeyAuthentication auth = ApiKeyManager.get().authenticateFromApiKey(apikey);
+                assertNotNull(auth);
+                assertEquals(user, auth.getUser());
             }
 
-            assertEquals("API key should be valid even after rollback", user, ApiKeyManager.get().authenticateFromApiKey(apikey));
+            ApiKeyAuthentication auth = ApiKeyManager.get().authenticateFromApiKey(apikey);
+            assertNotNull(auth);
+            assertEquals("API key should be valid even after rollback", user, auth.getUser());
 
             ApiKeyManager.get().deleteKey(apikey);
             assertNull(ApiKeyManager.get().authenticateFromApiKey(apikey));

--- a/api/src/org/labkey/api/security/ApiKeyManager.java
+++ b/api/src/org/labkey/api/security/ApiKeyManager.java
@@ -37,6 +37,7 @@ import org.labkey.api.data.Table;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.security.UserManager.SessionHandler;
 import org.labkey.api.security.ValidEmail.InvalidEmailException;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.LenientStartupPropertyHandler;
@@ -147,7 +148,7 @@ public class ApiKeyManager
     private void deleteKey(User user, int rowId)
     {
         Table.delete(CoreSchema.getInstance().getTableAPIKeys(), rowId);
-        UserManager.handleSessionsForUser(user, new UserManager.SessionHandler()
+        UserManager.handleSessionsForUser(user, new SessionHandler()
         {
             @Override
             public boolean handleSession(HttpSession session)

--- a/api/src/org/labkey/api/security/ApiKeyManager.java
+++ b/api/src/org/labkey/api/security/ApiKeyManager.java
@@ -144,7 +144,7 @@ public class ApiKeyManager
     }
 
     // Delete a single API key and clear all active sessions that were established using it
-    public void deleteKey(User user, int rowId)
+    private void deleteKey(User user, int rowId)
     {
         Table.delete(CoreSchema.getInstance().getTableAPIKeys(), rowId);
         UserManager.handleSessionsForUser(user, new UserManager.SessionHandler()
@@ -152,11 +152,13 @@ public class ApiKeyManager
             @Override
             public boolean handleSession(HttpSession session)
             {
+                LOG.info("Checking if session {} used API key {}", session.getId(), rowId);
                 Map<String, Object> map = AuthenticationManager.getAuthenticationProperties(session);
                 Integer apiKeyRowId = (Integer)map.get(API_KEY_ROW_ID);
 
                 if (Objects.equals(rowId, apiKeyRowId))
                 {
+                    LOG.info("Attempting to invalidate session {} which used API key {}", session.getId(), rowId);
                     session.invalidate();
                     return true;
                 }
@@ -167,7 +169,7 @@ public class ApiKeyManager
             @Override
             public void complete(int count)
             {
-                LOG.debug("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "API key session"), user.getEmail());
+                LOG.info("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "API key session"), user.getEmail());
             }
         });
     }
@@ -341,12 +343,8 @@ public class ApiKeyManager
         @Override
         public void run(Logger log)
         {
-            try (Transaction t = CoreSchema.getInstance().getScope().beginTransaction(TRANSACTION_KIND))
-            {
-                // Delete all rows that are no longer valid (expired)
-                Table.delete(CoreSchema.getInstance().getTableAPIKeys(), new SimpleFilter(new NotClause(getStillValidClause())));
-                t.commit();
-            }
+            // Delete all rows that are no longer valid (expired)
+            ApiKeyManager.get().deleteKeys(new SimpleFilter(new NotClause(getStillValidClause())));
         }
 
         @Override

--- a/api/src/org/labkey/api/security/AuthFilter.java
+++ b/api/src/org/labkey/api/security/AuthFilter.java
@@ -263,10 +263,7 @@ public class AuthFilter implements Filter
             // across Tomcat restarts. Ensure that all authenticated users have their sessions tracked, so we can
             // accurately assess if anyone is logged in
             HttpSession s = req.getSession(false);
-            if (s != null && !user.isGuest())
-            {
-                UserManager.ensureSessionTracked(s);
-            }
+            UserManager.ensureSessionTracked(user, s);
 
             SecurityLogger.popSecurityContext();
             QueryService.get().clearEnvironment();

--- a/api/src/org/labkey/api/security/AuthenticatedRequest.java
+++ b/api/src/org/labkey/api/security/AuthenticatedRequest.java
@@ -594,7 +594,7 @@ public class AuthenticatedRequest extends HttpServletRequestWrapper implements A
                 if (_allocationThread != Thread.currentThread())
                     throw new IllegalStateException("Using request closed by a different thread");
                 else
-                    throw new IllegalStateException("Requset has been closed");
+                    throw new IllegalStateException("Request has been closed");
             }
             return true;
         }

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -1288,21 +1288,31 @@ public class AuthenticationManager
      * @return A case-insensitive map of user attribute names and values that was stashed in the associated session at
      * authentication time. This map will often be empty but will never be null.
      */
-    public static @NotNull Map<String, String> getAuthenticationAttributes(HttpServletRequest request)
+    public static @NotNull Map<String, String> getUserAttributes(HttpServletRequest request)
     {
         HttpSession session = request.getSession(false);
 
-        return getAuthenticationAttributes(session);
+        return getUserAttributes(session);
     }
 
-    public static @NotNull Map<String, String> getAuthenticationAttributes(HttpSession session)
+    public static @NotNull Map<String, String> getUserAttributes(HttpSession session)
     {
         Map<String, String> attributeMap = null;
 
         if (null != session)
-            attributeMap = (Map<String, String>)session.getAttribute(SecurityManager.AUTHENTICATION_ATTRIBUTES_KEY);
+            attributeMap = (Map<String, String>)session.getAttribute(SecurityManager.USER_ATTRIBUTES_KEY);
 
         return null != attributeMap ? attributeMap : Collections.emptyMap();
+    }
+
+    public static @NotNull Map<String, Object> getAuthenticationProperties(HttpSession session)
+    {
+        Map<String, Object> authenticationProperties = null;
+
+        if (null != session)
+            authenticationProperties = (Map<String, Object>)session.getAttribute(SecurityManager.AUTHENTICATION_PROPERTIES);
+
+        return null != authenticationProperties ? authenticationProperties : Collections.emptyMap();
     }
 
     private static boolean areNotBlank(String id, String password)

--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -271,7 +271,6 @@ public interface AuthenticationProvider
         long getUserDelay(String id) throws LoginDisabledException;
 
         /**
-         *
          * @param request
          * @param id
          * @param addCount
@@ -288,103 +287,61 @@ public interface AuthenticationProvider
 
     class AuthenticationResponse
     {
-        private final PrimaryAuthenticationConfiguration<?> _configuration;
+        private final PrimaryAuthenticationConfiguration<?> _configuration;               // The PrimaryAuthenticationConfiguration that was used in this authentication attempt
         // Success means either _user or _email is set, but not both. Check _user first.
         // Failure means both are null
-        private final @Nullable ValidEmail _email;
+        private final @Nullable ValidEmail _email;                                        // Valid email address of the authenticated user
         private final @Nullable User _user;
-        private final @Nullable AuthenticationValidator _validator;
         private final @Nullable FailureReason _failureReason;
-        private final @Nullable ActionURL _redirectURL;
-        private final @NotNull Map<String, String> _attributeMap;
-        private final @Nullable String _successDetails;
-        private final boolean _requireSecondary;
 
-        private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap, @Nullable String successDetails, boolean requireSecondary)
-        {
-            _configuration = configuration;
-            _user = null;
-            _email = email;
-            _validator = validator;
-            _attributeMap = attributeMap;
-            _failureReason = null;
-            _redirectURL = null;
-            _successDetails = null != successDetails ? successDetails : "the \"" + configuration.getDescription() + "\" configuration";
-            _requireSecondary = requireSecondary;
-        }
+        private @Nullable AuthenticationValidator _validator = null;
+        private @Nullable ActionURL _redirectURL = null;
+        private @NotNull Map<String, String> _userAttributeMap = Collections.emptyMap();  // A case-insensitive map of attribute names and values associated with the user
+        private @NotNull Map<String, Object> _authenticationProperties = Collections.emptyMap();
+        private boolean _requireSecondary = true;                                         // Require secondary authentication
+        private @Nullable String _successDetails = null;                                  // An optional string describing how successful authentication took place, which will
+                                                                                          // appear in the audit log. If null, the configuration's description will be used.
 
-        private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull User user, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap, @Nullable String successDetails, boolean requireSecondary)
+        private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @Nullable ValidEmail email, @Nullable User user)
         {
             _configuration = configuration;
             _user = user;
-            _email = null;
-            _validator = validator;
-            _attributeMap = attributeMap;
+            _email = email;
+            _successDetails = "the \"" + configuration.getDescription() + "\" configuration";
             _failureReason = null;
-            _redirectURL = null;
-            _successDetails = null != successDetails ? successDetails : "the \"" + configuration.getDescription() + "\" configuration";
-            _requireSecondary = requireSecondary;
         }
 
-        private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull FailureReason failureReason, @Nullable ActionURL redirectURL)
+        private AuthenticationResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull FailureReason failureReason)
         {
             _configuration = configuration;
             _user = null;
             _email = null;
-            _validator = null;
             _failureReason = failureReason;
-            _redirectURL = redirectURL;
-            _attributeMap = Collections.emptyMap();
-            _successDetails = null;
-            _requireSecondary = true;
         }
 
-        /**
-         * Creates a standard authentication provider response
-         * @param email Valid email address of the authenticated user
-         * @return A new successful authentication response containing the email address of the authenticated user
-         */
-        public static AuthenticationResponse createSuccessResponse(PrimaryAuthenticationConfiguration<?> configuration, ValidEmail email)
+        public static AuthenticationResponse success(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull ValidEmail email)
         {
-            return createSuccessResponse(configuration, email, null, Collections.emptyMap(), null, true);
+            return new AuthenticationResponse(configuration, email, null);
         }
 
-        public static AuthenticationResponse createSuccessResponse(PrimaryAuthenticationConfiguration<?> configuration, User user)
+        public static AuthenticationResponse success(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull User user)
         {
-            return new AuthenticationResponse(configuration, user, null, Collections.emptyMap(), null, true);
+            return new AuthenticationResponse(configuration, null, user);
         }
 
-        /**
-         * Creates an authentication provider response that can include a validator to be called on every request and a
-         * map of user attributes
-         *
-         * @param configuration     The PrimaryAuthenticationConfiguration that was used in this authentication attempt
-         * @param email             Valid email address of the authenticated user
-         * @param validator         An authentication validator
-         * @param attributeMap      A <b>case-insensitive</b> map of attribute names and values associated with this authentication
-         * @param successDetails    An optional string describing how successful authentication took place, which will appear in
-         *                          the audit log. If null, the configuration's description will be used.
-         * @param requireSecondary  Require secondary authentication
-         * @return A new successful authentication response containing the email address of the authenticated user and a validator
-         */
-        public static AuthenticationResponse createSuccessResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, ValidEmail email, @Nullable AuthenticationValidator validator, @NotNull Map<String, String> attributeMap, @Nullable String successDetails, boolean requireSecondary)
+        public static AuthenticationResponse failure(@NotNull PrimaryAuthenticationConfiguration<?> configuration, @NotNull FailureReason failureReason)
         {
-            return new AuthenticationResponse(configuration, email, validator, attributeMap, successDetails, requireSecondary);
-        }
-
-        public static AuthenticationResponse createFailureResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, FailureReason failureReason)
-        {
-            return new AuthenticationResponse(configuration, failureReason, null);
-        }
-
-        public static AuthenticationResponse createFailureResponse(@NotNull PrimaryAuthenticationConfiguration<?> configuration, FailureReason failureReason, @Nullable ActionURL redirectURL)
-        {
-            return new AuthenticationResponse(configuration, failureReason, redirectURL);
+            return new AuthenticationResponse(configuration, failureReason);
         }
 
         public boolean isAuthenticated()
         {
             return null != _email || null != _user;
+        }
+
+        public PrimaryAuthenticationConfiguration<?> getConfiguration()
+        {
+            return _configuration;
         }
 
         public @NotNull FailureReason getFailureReason()
@@ -412,9 +369,10 @@ public interface AuthenticationProvider
             return _validator;
         }
 
-        public PrimaryAuthenticationConfiguration<?> getConfiguration()
+        public AuthenticationResponse setValidator(@Nullable AuthenticationValidator validator)
         {
-            return _configuration;
+            _validator = validator;
+            return this;
         }
 
         public @Nullable ActionURL getRedirectURL()
@@ -422,12 +380,42 @@ public interface AuthenticationProvider
             return _redirectURL;
         }
 
-        /**
-         * @return A case-insensitive map of attribute names and values. This will often be empty but will never be null.
-         */
-        public @NotNull Map<String, String> getAttributeMap()
+        public AuthenticationResponse setRedirectURL(@Nullable ActionURL redirectURL)
         {
-            return _attributeMap;
+            _redirectURL = redirectURL;
+            return this;
+        }
+
+        /**
+         * @return A case-insensitive map of attribute names and values associated with the authenticated user. This
+         * will often be empty but will never be null.
+         */
+        public @NotNull Map<String, String> getUserAttributeMap()
+        {
+            return _userAttributeMap;
+        }
+
+        public AuthenticationResponse setUserAttributeMap(@NotNull Map<String, String> userAttributeMap)
+        {
+            _userAttributeMap = userAttributeMap;
+            return this;
+        }
+
+        /**
+         * @return A case-insensitive map of properties about the authentication process
+         */
+        public @NotNull Map<String, Object> getAuthenticationProperties()
+        {
+            return _authenticationProperties;
+        }
+
+        /**
+         * Set a case-insensitive map of properties about the authentication process
+         */
+        public AuthenticationResponse setAuthenticationProperties(Map<String, Object> map)
+        {
+            _authenticationProperties = map;
+            return this;
         }
 
         public @Nullable String getSuccessDetails()
@@ -435,9 +423,21 @@ public interface AuthenticationProvider
             return _successDetails;
         }
 
+        public AuthenticationResponse setSuccessDetails(@Nullable String successDetails)
+        {
+            _successDetails = successDetails;
+            return this;
+        }
+
         public boolean requireSecondary()
         {
             return _requireSecondary;
+        }
+
+        public AuthenticationResponse setRequireSecondary(boolean requireSecondary)
+        {
+            _requireSecondary = requireSecondary;
+            return this;
         }
     }
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -180,7 +180,8 @@ public class SecurityManager
     private static final String AUTHENTICATION_METHOD = "SecurityManager.authenticationMethod";
 
     public static final String PRIMARY_AUTHENTICATION_CONFIGURATION = PrimaryAuthenticationConfiguration.class.getName();
-    public static final String AUTHENTICATION_ATTRIBUTES_KEY = User.class.getName() + "$AuthenticationAttributes";
+    public static final String USER_ATTRIBUTES_KEY = User.class.getName() + "$UserAttributes";
+    public static final String AUTHENTICATION_PROPERTIES = AuthenticationManager.class.getName() + "$AuthenticationProperties";
     public static final String SCOPE_USER_ROLES = "UserRoles";
     public static final String SCOPE_GROUP_ROLES = "GroupRoles";
     public static final String SCOPE_USER_GROUPS = "UserGroups";
@@ -510,6 +511,16 @@ public class SecurityManager
         return "Basic".equals(request.getAttribute(AUTHENTICATION_METHOD));
     }
 
+    // Most callers should use getSessionUser() instead, which returns the impersonated user if impersonation is active.
+    // This method returns the user who originally established the session which could be an impersonating admin. This
+    // is useful for code paths that track user sessions.
+    public static @Nullable User getSessionOwner(@Nullable HttpSession session)
+    {
+        User sessionUser = getSessionUser(session);
+        return sessionUser != null ? (sessionUser.isImpersonated() ? sessionUser.getImpersonatingUser() : sessionUser) : null;
+    }
+
+    // If currently impersonating, returns the impersonated user with impersonation context set
     public static User getSessionUser(HttpServletRequest request)
     {
         User sessionUser = getSessionUser(request.getSession(false));
@@ -521,6 +532,7 @@ public class SecurityManager
         return sessionUser;
     }
 
+    // If currently impersonating, returns the impersonated user with impersonation context set
     public static User getSessionUser(HandshakeRequest request)
     {
         HttpSession session = (HttpSession) request.getHttpSession();
@@ -533,6 +545,7 @@ public class SecurityManager
         return sessionUser;
     }
 
+    // If currently impersonating, returns the impersonated user with impersonation context set
     public static @Nullable User getSessionUser(@Nullable HttpSession session)
     {
         User sessionUser = null;
@@ -540,7 +553,23 @@ public class SecurityManager
         Integer userId = null == session ? null : (Integer) session.getAttribute(USER_ID_KEY);
 
         if (null != userId)
+        {
             sessionUser = UserManager.getUser(userId);
+
+            if (null != sessionUser)
+            {
+                // NOTE: getUser() above returns a cloned object so _groups should be null. This is important to ensure
+                // group memberships are calculated on every request (but just once)
+                assert sessionUser._groups == null;
+
+                ImpersonationContextFactory factory = (ImpersonationContextFactory) session.getAttribute(IMPERSONATION_CONTEXT_FACTORY_KEY);
+
+                if (null != factory)
+                {
+                    sessionUser.setImpersonationContext(factory.getImpersonationContext());
+                }
+            }
+        }
 
         return sessionUser;
     }
@@ -588,28 +617,18 @@ public class SecurityManager
 
         try
         {
-            HttpSession session = request.getSession(false);
             User sessionUser = getSessionUser(request);
 
             if (null != sessionUser)
             {
                 AUTH_LOG.debug("   Session user present: " + sessionUser);
 
-                // NOTE: UserCache.getUser() above returns a cloned object so _groups should be null. This is important to ensure
-                // group memberships are calculated on every request (but just once)
-                assert sessionUser._groups == null;
-
-                ImpersonationContextFactory factory = (ImpersonationContextFactory) session.getAttribute(IMPERSONATION_CONTEXT_FACTORY_KEY);
-
-                if (null != factory)
-                {
-                    sessionUser.setImpersonationContext(factory.getImpersonationContext());
-                }
-                else if ("true".equalsIgnoreCase(request.getHeader("LabKey-Disallow-Global-Roles")))
+                if (!sessionUser.isImpersonated() && "true".equalsIgnoreCase(request.getHeader("LabKey-Disallow-Global-Roles")))
                 {
                     sessionUser.setImpersonationContext(DisallowPrivilegedRolesContext.get());
                 }
 
+                HttpSession session = request.getSession(false);
                 List<AuthenticationValidator> validators = getValidators(session);
 
                 // If we have validators, enumerate them to validate the session user's current login (e.g., smart card is still present)
@@ -628,7 +647,7 @@ public class SecurityManager
                         // If impersonating, stop so it gets logged
                         if (sessionUser.isImpersonated())
                         {
-                            stopImpersonating(request, factory);
+                            stopImpersonating(request, sessionUser.getImpersonationContext().getFactory());
                             sessionUser = sessionUser.getImpersonatingUser(); // Need to log out the admin
                         }
 
@@ -827,7 +846,8 @@ public class SecurityManager
         {
             PrimaryAuthenticationConfiguration<?> configuration = response.getConfiguration();
             newSession.setAttribute(PRIMARY_AUTHENTICATION_CONFIGURATION, configuration.getRowId());
-            newSession.setAttribute(AUTHENTICATION_ATTRIBUTES_KEY, response.getAttributeMap());
+            newSession.setAttribute(USER_ATTRIBUTES_KEY, response.getUserAttributeMap());
+            newSession.setAttribute(AUTHENTICATION_PROPERTIES, response.getAuthenticationProperties());
         }
 
         return newSession;

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -19,7 +19,6 @@ package org.labkey.api.security;
 import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.HttpSessionEvent;
 import jakarta.servlet.http.HttpSessionListener;
-import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.logging.log4j.Logger;
@@ -31,7 +30,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.AuditTypeEvent;
-import org.labkey.api.collections.ConcurrentSetValuedMap;
 import org.labkey.api.data.Aggregate;
 import org.labkey.api.data.ButtonBar;
 import org.labkey.api.data.ColumnInfo;
@@ -88,13 +86,13 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -524,14 +522,16 @@ public class UserManager
     /** In minutes */
     private static final AtomicLong _totalSessionDuration = new AtomicLong();
 
-    private static final MultiValuedMap<Integer, HttpSession> _activeSessions = new ConcurrentSetValuedMap<>();
+    public record SessionInformation(HttpSession session, User user) {}
+
+    private static final Map<String, SessionInformation> _activeSessions = new ConcurrentHashMap<>();
 
     public static void ensureSessionTracked(User user, HttpSession s)
     {
         if (s != null && !user.isGuest())
         {
             User sessionOwner = user.isImpersonated() ? user.getImpersonatingUser() : user;
-            if (_activeSessions.put(sessionOwner.getUserId(), s))
+            if (_activeSessions.put(s.getId(), new SessionInformation(s, sessionOwner)) == null)
                 LOG.info("Tracking a new session {} for user {}. {} active.", s.getId(), sessionOwner.getEmail(), StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
         }
     }
@@ -549,21 +549,19 @@ public class UserManager
         {
             // Issue 44761 - track session duration for authenticated users
             HttpSession session = event.getSession();
-            User user = SecurityManager.getSessionOwner(session);
-            LOG.info("Session {} for user {} has been destroyed", session.getId(), user);
-            if (user != null)
+            SessionInformation info = _activeSessions.remove(session.getId());
+            LOG.info("Session {} for user {} has been destroyed", session.getId(), null != info ? info.user() : null);
+            if (info != null)
             {
                 long duration = TimeUnit.MILLISECONDS.toMinutes(session.getLastAccessedTime() - session.getCreationTime());
                 _sessionCount.incrementAndGet();
                 _totalSessionDuration.addAndGet(duration);
-
-                if (_activeSessions.removeMapping(user.getUserId(), session))
-                    LOG.info("Removed session {} for user {}. Adding session duration of {} minutes to tally. {} active.", session.getId(), user.getEmail(), duration, StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
+                LOG.info("Removed session {} for user {} from active sessions. Adding session duration of {} minutes to tally. {} active.", session.getId(), info.user, duration, StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
             }
         }
     }
 
-    public static void terminateAllSessionsForUser(@Nullable User user)
+    public static void terminateAllSessionsForUser(User user)
     {
         handleSessionsForUser(user, new SessionHandler()
         {
@@ -577,40 +575,36 @@ public class UserManager
             @Override
             public void complete(int count)
             {
-                //noinspection DataFlowIssue
-                LOG.info("Invalidated {} for user {}.", StringUtilsLabKey.pluralize(count, "session"), user.getEmail());
+                LOG.info("Invalidated {} for user {}.", StringUtilsLabKey.pluralize(count, "session"), user);
             }
         });
     }
 
     public interface SessionHandler
     {
-        // Return true to increment the count passed to complete() after handleSession() has been invoked for each active session
+        // Called for every active session associated with the user. Return true to increment the count passed to
+        // complete() after handleSession() has been invoked for each active session.
         boolean handleSession(HttpSession session);
-        // Called after all sessions have been passed to handleSession(), only if user is non-null and was logged in.
-        // Useful for coalescing logging, for example.
+        // Called after all sessions have been passed to handleSession(). Useful for coalescing logging, for example.
         void complete(int count);
     }
 
     public static void handleSessionsForUser(@Nullable User user, SessionHandler handler)
     {
-        if (user != null && !user.isGuest())
-        {
-            MutableInt count = new MutableInt();
+        MutableInt count = new MutableInt();
 
-            // The SessionHandler may directly or indirectly mutate this user's session set, so enumerate a copy to avoid
-            // concurrent modification exceptions.
-            Set<HttpSession> sessions = new HashSet<>(_activeSessions.get(user.getUserId()));
-            LOG.info("Handling the following sessions for user {}: {}", user.getEmail(), sessions.stream()
-                .map(HttpSession::getId)
-                .collect(Collectors.joining(", ")));
-            sessions.forEach(session -> {
-                if (handler.handleSession(session))
-                    count.increment();
-            });
+        Set<SessionInformation> infos = _activeSessions.values().stream()
+            .filter(info -> info.user().equals(user))
+            .collect(Collectors.toSet());
+        LOG.info("Handling the following sessions for user {}: {}", user, infos.stream()
+            .map(info -> info.session().getId())
+            .collect(Collectors.joining(", ")));
+        infos.forEach(info -> {
+            if (handler.handleSession(info.session()))
+                count.increment();
+        });
 
-            handler.complete(count.intValue());
-        }
+        handler.complete(count.intValue());
     }
 
     public static int getActiveUserSessionCount()

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -550,6 +550,7 @@ public class UserManager
             // Issue 44761 - track session duration for authenticated users
             HttpSession session = event.getSession();
             User user = SecurityManager.getSessionOwner(session);
+            LOG.info("Session {} for user {} has been destroyed", session.getId(), user);
             if (user != null)
             {
                 long duration = TimeUnit.MILLISECONDS.toMinutes(session.getLastAccessedTime() - session.getCreationTime());
@@ -602,7 +603,7 @@ public class UserManager
             Set<HttpSession> sessions = new HashSet<>(_activeSessions.get(user.getUserId()));
             LOG.info("Handling the following sessions for user {}: {}", user.getEmail(), sessions.stream()
                 .map(HttpSession::getId)
-                .collect(Collectors.joining()));
+                .collect(Collectors.joining(", ")));
             sessions.forEach(session -> {
                 if (handler.handleSession(session))
                     count.increment();

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -98,8 +98,8 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
-import static org.labkey.api.security.SecurityManager.USER_ID_KEY;
 import static org.labkey.api.security.permissions.AbstractActionPermissionTest.APPLICATION_ADMIN_EMAIL;
 import static org.labkey.api.security.permissions.AbstractActionPermissionTest.SITE_ADMIN_EMAIL;
 
@@ -526,16 +526,13 @@ public class UserManager
 
     private static final MultiValuedMap<Integer, HttpSession> _activeSessions = new ConcurrentSetValuedMap<>();
 
-    public static void ensureSessionTracked(HttpSession s)
+    public static void ensureSessionTracked(User user, HttpSession s)
     {
-        if (s != null)
+        if (s != null && !user.isGuest())
         {
-            Integer userId = (Integer)s.getAttribute(USER_ID_KEY);
-            if (null != userId && getGuestUser().getUserId() != userId)
-            {
-                if (_activeSessions.put(userId, s))
-                    LOG.debug("Tracking a new session. {} active.", StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
-            }
+            User sessionOwner = user.isImpersonated() ? user.getImpersonatingUser() : user;
+            if (_activeSessions.put(sessionOwner.getUserId(), s))
+                LOG.debug("Tracking a new session {} for user {}. {} active.", s.getId(), sessionOwner.getEmail(), StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
         }
     }
 
@@ -551,15 +548,16 @@ public class UserManager
         public void sessionDestroyed(HttpSessionEvent event)
         {
             // Issue 44761 - track session duration for authenticated users
-            User user = SecurityManager.getSessionUser(event.getSession());
+            HttpSession session = event.getSession();
+            User user = SecurityManager.getSessionOwner(session);
             if (user != null)
             {
-                _activeSessions.removeMapping(user.getUserId(), event.getSession());
-
-                long duration = TimeUnit.MILLISECONDS.toMinutes(event.getSession().getLastAccessedTime() - event.getSession().getCreationTime());
-                LOG.debug("Destroyed session for {}. Adding session duration of {} minutes to tally. {} active.", user.getEmail(), duration, StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
+                long duration = TimeUnit.MILLISECONDS.toMinutes(session.getLastAccessedTime() - session.getCreationTime());
                 _sessionCount.incrementAndGet();
                 _totalSessionDuration.addAndGet(duration);
+
+                if (_activeSessions.removeMapping(user.getUserId(), session))
+                    LOG.debug("Removed session {} for user {}. Adding session duration of {} minutes to tally. {} active.", session.getId(), user.getEmail(), duration, StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
             }
         }
     }
@@ -579,7 +577,7 @@ public class UserManager
             public void complete(int count)
             {
                 //noinspection DataFlowIssue
-                LOG.debug("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "session"), user.getEmail());
+                LOG.debug("Invalidated {} for user {}.", StringUtilsLabKey.pluralize(count, "session"), user.getEmail());
             }
         });
     }
@@ -602,6 +600,9 @@ public class UserManager
             // The SessionHandler may directly or indirectly mutate this user's session set, so enumerate a copy to avoid
             // concurrent modification exceptions.
             Set<HttpSession> sessions = new HashSet<>(_activeSessions.get(user.getUserId()));
+            LOG.debug("Handling the following sessions for user {}: {}", user.getEmail(), sessions.stream()
+                .map(HttpSession::getId)
+                .collect(Collectors.joining()));
             sessions.forEach(session -> {
                 if (handler.handleSession(session))
                     count.increment();
@@ -938,7 +939,7 @@ public class UserManager
             executor.execute("DELETE FROM " + CORE.getTableInfoUsersData() + " WHERE UserId=?", userId);
             LoginManager.deleteLoginsRow(deletUser, null);
             executor.execute("DELETE FROM " + CORE.getTableInfoPrincipals() + " WHERE UserId=?", userId);
-            executor.execute("DELETE FROM " + CORE.getTableAPIKeys() + " WHERE CreatedBy=?", userId);
+            ApiKeyManager.get().deleteKeys(new SimpleFilter(FieldKey.fromParts("CreatedBy"), userId));
 
             OntologyManager.deleteOntologyObject(deletUser.getEntityId(), ContainerManager.getSharedContainer(), true);
 

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -532,7 +532,7 @@ public class UserManager
         {
             User sessionOwner = user.isImpersonated() ? user.getImpersonatingUser() : user;
             if (_activeSessions.put(s.getId(), new SessionInformation(s, sessionOwner)) == null)
-                LOG.info("Tracking a new session {} for user {}. {} active.", s.getId(), sessionOwner.getEmail(), StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
+                LOG.debug("Tracking a new session {} for user {}. {} active.", s.getId(), sessionOwner.getEmail(), StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
         }
     }
 
@@ -550,13 +550,13 @@ public class UserManager
             // Issue 44761 - track session duration for authenticated users
             HttpSession session = event.getSession();
             SessionInformation info = _activeSessions.remove(session.getId());
-            LOG.info("Session {} for user {} has been destroyed", session.getId(), null != info ? info.user() : null);
+            LOG.debug("Session {} for user {} has been destroyed", session.getId(), null != info ? info.user() : null);
             if (info != null)
             {
                 long duration = TimeUnit.MILLISECONDS.toMinutes(session.getLastAccessedTime() - session.getCreationTime());
                 _sessionCount.incrementAndGet();
                 _totalSessionDuration.addAndGet(duration);
-                LOG.info("Removed session {} for user {} from active sessions. Adding session duration of {} minutes to tally. {} active.", session.getId(), info.user, duration, StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
+                LOG.debug("Removed session {} for user {} from active sessions. Adding session duration of {} minutes to tally. {} active.", session.getId(), info.user, duration, StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
             }
         }
     }
@@ -575,7 +575,7 @@ public class UserManager
             @Override
             public void complete(int count)
             {
-                LOG.info("Invalidated {} for user {}.", StringUtilsLabKey.pluralize(count, "session"), user);
+                LOG.debug("Invalidated {} for user {}.", StringUtilsLabKey.pluralize(count, "session"), user);
             }
         });
     }
@@ -596,7 +596,7 @@ public class UserManager
         Set<SessionInformation> infos = _activeSessions.values().stream()
             .filter(info -> info.user().equals(user))
             .collect(Collectors.toSet());
-        LOG.info("Handling the following sessions for user {}: {}", user, infos.stream()
+        LOG.debug("Handling the following sessions for user {}: [{}]", user, infos.stream()
             .map(info -> info.session().getId())
             .collect(Collectors.joining(", ")));
         infos.forEach(info -> {

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -532,7 +532,7 @@ public class UserManager
         {
             User sessionOwner = user.isImpersonated() ? user.getImpersonatingUser() : user;
             if (_activeSessions.put(sessionOwner.getUserId(), s))
-                LOG.debug("Tracking a new session {} for user {}. {} active.", s.getId(), sessionOwner.getEmail(), StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
+                LOG.info("Tracking a new session {} for user {}. {} active.", s.getId(), sessionOwner.getEmail(), StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
         }
     }
 
@@ -557,7 +557,7 @@ public class UserManager
                 _totalSessionDuration.addAndGet(duration);
 
                 if (_activeSessions.removeMapping(user.getUserId(), session))
-                    LOG.debug("Removed session {} for user {}. Adding session duration of {} minutes to tally. {} active.", session.getId(), user.getEmail(), duration, StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
+                    LOG.info("Removed session {} for user {}. Adding session duration of {} minutes to tally. {} active.", session.getId(), user.getEmail(), duration, StringUtilsLabKey.pluralize(getActiveUserSessionCount(), "session"));
             }
         }
     }
@@ -577,7 +577,7 @@ public class UserManager
             public void complete(int count)
             {
                 //noinspection DataFlowIssue
-                LOG.debug("Invalidated {} for user {}.", StringUtilsLabKey.pluralize(count, "session"), user.getEmail());
+                LOG.info("Invalidated {} for user {}.", StringUtilsLabKey.pluralize(count, "session"), user.getEmail());
             }
         });
     }
@@ -600,7 +600,7 @@ public class UserManager
             // The SessionHandler may directly or indirectly mutate this user's session set, so enumerate a copy to avoid
             // concurrent modification exceptions.
             Set<HttpSession> sessions = new HashSet<>(_activeSessions.get(user.getUserId()));
-            LOG.debug("Handling the following sessions for user {}: {}", user.getEmail(), sessions.stream()
+            LOG.info("Handling the following sessions for user {}: {}", user.getEmail(), sessions.stream()
                 .map(HttpSession::getId)
                 .collect(Collectors.joining()));
             sessions.forEach(session -> {

--- a/api/src/org/labkey/api/websocket/BrowserEndpoint.java
+++ b/api/src/org/labkey/api/websocket/BrowserEndpoint.java
@@ -15,13 +15,6 @@
  */
 package org.labkey.api.websocket;
 
-import org.apache.logging.log4j.Logger;
-import org.labkey.api.security.AuthenticationManager;
-import org.labkey.api.security.SecurityManager;
-import org.labkey.api.security.User;
-import org.labkey.api.util.UnexpectedException;
-import org.labkey.api.util.logging.LogHelper;
-
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpSession;
 import jakarta.websocket.ClientEndpoint;
@@ -38,6 +31,13 @@ import jakarta.websocket.Session;
 import jakarta.websocket.WebSocketContainer;
 import jakarta.websocket.server.HandshakeRequest;
 import jakarta.websocket.server.ServerEndpointConfig;
+import org.apache.logging.log4j.Logger;
+import org.labkey.api.security.AuthenticationManager;
+import org.labkey.api.security.SecurityManager;
+import org.labkey.api.security.User;
+import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.util.logging.LogHelper;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -81,7 +81,7 @@ public abstract class BrowserEndpoint extends Endpoint
                 config.getUserProperties().put("httpSession", httpSession);
 
             config.getUserProperties().put("userId", null == user ? 0 : user.getUserId());
-            config.getUserProperties().put("attributes", AuthenticationManager.getAuthenticationAttributes(httpSession));
+            config.getUserProperties().put("attributes", AuthenticationManager.getUserAttributes(httpSession));
         }
     }
 

--- a/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
+++ b/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
@@ -24,6 +24,7 @@ import org.labkey.api.data.PropertyManager;
 import org.labkey.api.data.PropertyManager.WritablePropertyMap;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.ApiKeyManager;
+import org.labkey.api.security.ApiKeyManager.ApiKeyAuthentication;
 import org.labkey.api.security.AuthenticationManager.AuthenticationValidator;
 import org.labkey.api.security.AuthenticationProvider.LoginFormAuthenticationProvider;
 import org.labkey.api.security.ConfigurationSettings;
@@ -107,19 +108,22 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
         // Check for API key first
         if (API_KEY.equals(id))
         {
-            User user = ApiKeyManager.get().authenticateFromApiKey(password);
+            ApiKeyAuthentication auth = ApiKeyManager.get().authenticateFromApiKey(password);
             final AuthenticationResponse ret;
 
-            if (user != null)
+            if (auth != null)
             {
                 // API keys are exempt from secondary authentication, Issue 48764
-                ret = AuthenticationResponse.createSuccessResponse(configuration, new ValidEmail(user.getEmail()), null, Map.of(), UserManager.UserAuditEvent.API_KEY, false);
+                ret = AuthenticationResponse.success(configuration, auth.getUser()).setSuccessDetails(UserManager.UserAuditEvent.API_KEY)
+                    .setRequireSecondary(false)
+                    .setAuthenticationProperties(Map.of(ApiKeyManager.API_KEY_ROW_ID, auth.rowId()));
+
                 // Update core.ApiKeys.LastUsed (throttled)
                 API_KEY_LAST_USED_THROTTLE.execute(password);
             }
             else
             {
-                ret = AuthenticationResponse.createFailureResponse(configuration, FailureReason.badApiKey);
+                ret = AuthenticationResponse.failure(configuration, FailureReason.badApiKey);
             }
 
             return ret;
@@ -135,7 +139,7 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
                 user = UserManager.getUser(email);
                 hash = LoginManager.getPasswordHash(user);
                 if (null == hash)
-                    return AuthenticationResponse.createFailureResponse(configuration, FailureReason.userDoesNotExist);
+                    return AuthenticationResponse.failure(configuration, FailureReason.userDoesNotExist);
             }
             catch (InvalidEmailException e)
             {
@@ -150,7 +154,7 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
             }
 
             if (!LoginManager.matchPassword(password, hash))
-                return AuthenticationResponse.createFailureResponse(configuration, FailureReason.badPassword);
+                return AuthenticationResponse.failure(configuration, FailureReason.badPassword);
 
             if (user.isActive())
             {
@@ -174,7 +178,7 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
                 }
             }
 
-            return AuthenticationResponse.createSuccessResponse(configuration, user);
+            return AuthenticationResponse.success(configuration, user);
         }
     }
 
@@ -245,6 +249,6 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
             // Basic auth is checked in AuthFilter, so there won't be a ViewContext in that case. #11653
         }
 
-        return AuthenticationResponse.createFailureResponse(configuration, failureReason, redirectURL);
+        return AuthenticationResponse.failure(configuration, failureReason).setRedirectURL(redirectURL);
     }
 }

--- a/core/src/org/labkey/core/login/DbLoginManager.java
+++ b/core/src/org/labkey/core/login/DbLoginManager.java
@@ -109,7 +109,7 @@ public class DbLoginManager implements DbLoginService
                 @Override
                 public boolean handleSession(HttpSession session)
                 {
-                    LOG.debug("Checking if session {} used database authentication", session.getId());
+                    LOG.info("Checking if session {} used database authentication", session.getId());
                     PrimaryAuthenticationConfiguration<?> configuration = AuthenticationManager.getConfiguration(session);
 
                     if (configuration instanceof DbLoginConfiguration)
@@ -120,7 +120,7 @@ public class DbLoginManager implements DbLoginService
                         // Don't invalidate API key authentications
                         if (apiKeyRowId == null)
                         {
-                            LOG.debug("Attempting to invalidate session {}", session.getId());
+                            LOG.info("Attempting to invalidate session {}", session.getId());
                             session.invalidate();
                             return true;
                         }
@@ -132,7 +132,7 @@ public class DbLoginManager implements DbLoginService
                 @Override
                 public void complete(int count)
                 {
-                    LOG.debug("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "session"), affectedUser.getEmail());
+                    LOG.info("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "session"), affectedUser.getEmail());
                 }
             });
         }

--- a/core/src/org/labkey/core/login/DbLoginManager.java
+++ b/core/src/org/labkey/core/login/DbLoginManager.java
@@ -25,10 +25,12 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.PropertyManager;
 import org.labkey.api.data.PropertyManager.WritablePropertyMap;
+import org.labkey.api.security.ApiKeyManager;
 import org.labkey.api.security.AuthenticationConfiguration.PrimaryAuthenticationConfiguration;
 import org.labkey.api.security.AuthenticationConfigurationCache;
 import org.labkey.api.security.AuthenticationManager;
 import org.labkey.api.security.AuthenticationManager.AuthenticationResult;
+import org.labkey.api.security.AuthenticationManager.PrimaryAuthenticationResult;
 import org.labkey.api.security.AuthenticationSettingsAuditTypeProvider.AuthSettingsAuditEvent;
 import org.labkey.api.security.DbLoginService;
 import org.labkey.api.security.LoginManager;
@@ -61,6 +63,8 @@ public class DbLoginManager implements DbLoginService
 
     private static final Logger LOG = LogHelper.getLogger(DbLoginManager.class, "Database login information");
 
+    static final String DATABASE_AUTHENTICATION_CATEGORY_KEY = "DatabaseAuthentication";
+
     public static DbLoginConfiguration getConfiguration()
     {
         Collection<DbLoginConfiguration> configurations = AuthenticationManager.getActiveConfigurations(DbLoginConfiguration.class);
@@ -80,8 +84,6 @@ public class DbLoginManager implements DbLoginService
     {
         return getConfiguration().getExpiration();
     }
-
-    static final String DATABASE_AUTHENTICATION_CATEGORY_KEY = "DatabaseAuthentication";
 
     @Override
     public AuthenticationResult attemptSetPassword(Container c, User currentUser, String rawPassword, String rawPassword2, HttpServletRequest request, User affectedUser, URLHelper returnUrlHelper, String auditMessage, boolean clearVerification, boolean changeOperation, BindException errors) throws InvalidEmailException
@@ -107,12 +109,21 @@ public class DbLoginManager implements DbLoginService
                 @Override
                 public boolean handleSession(HttpSession session)
                 {
+                    LOG.debug("Checking if session {} used database authentication", session.getId());
                     PrimaryAuthenticationConfiguration<?> configuration = AuthenticationManager.getConfiguration(session);
 
                     if (configuration instanceof DbLoginConfiguration)
                     {
-                        session.invalidate();
-                        return true;
+                        Map<String, Object> map = AuthenticationManager.getAuthenticationProperties(session);
+                        Integer apiKeyRowId = (Integer)map.get(ApiKeyManager.API_KEY_ROW_ID);
+
+                        // Don't invalidate API key authentications
+                        if (apiKeyRowId == null)
+                        {
+                            LOG.debug("Attempting to invalidate session {}", session.getId());
+                            session.invalidate();
+                            return true;
+                        }
                     }
 
                     return false;
@@ -144,20 +155,21 @@ public class DbLoginManager implements DbLoginService
         }
 
         // The affected user's sessions were all terminated above. If the request's session doesn't exist or is a guest
-        // session then log the user in using the just-entered credentials. An admin resetting a password won't be
-        // affected. This check should be equivalent to currentUser.equals(user).
-        if (SecurityManager.getSessionUser(request.getSession()) == null)
+        // session then log the user in using the just-entered credentials. An admin resetting a password or changing a
+        // password while impersonating won't be affected.
+        if (SecurityManager.getSessionOwner(request.getSession()) == null)
         {
-            AuthenticationManager.PrimaryAuthenticationResult result = AuthenticationManager.authenticate(request, affectedUser.getEmail(), password, returnUrlHelper, true);
+            PrimaryAuthenticationResult result = AuthenticationManager.authenticate(request, affectedUser.getEmail(), password, returnUrlHelper, true);
 
             if (result.getStatus() == Success)
             {
                 // This user has passed primary authentication
                 AuthenticationManager.setPrimaryAuthenticationResult(request, result);
+                return AuthenticationManager.handleAuthentication(request, c);
             }
         }
 
-        return AuthenticationManager.handleAuthentication(request, c);
+        return new AuthenticationResult(returnUrlHelper);
     }
 
     public enum Key implements StartupProperty

--- a/core/src/org/labkey/core/login/DbLoginManager.java
+++ b/core/src/org/labkey/core/login/DbLoginManager.java
@@ -118,6 +118,7 @@ public class DbLoginManager implements DbLoginService
                         Integer apiKeyRowId = (Integer)map.get(ApiKeyManager.API_KEY_ROW_ID);
 
                         // Don't invalidate API key authentications
+                        LOG.info("Checking if session {} wasn't authenticated via an API key", session.getId());
                         if (apiKeyRowId == null)
                         {
                             LOG.info("Attempting to invalidate session {}", session.getId());
@@ -132,7 +133,7 @@ public class DbLoginManager implements DbLoginService
                 @Override
                 public void complete(int count)
                 {
-                    LOG.info("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "session"), affectedUser.getEmail());
+                    LOG.info("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "session"), affectedUser);
                 }
             });
         }

--- a/core/src/org/labkey/core/login/DbLoginManager.java
+++ b/core/src/org/labkey/core/login/DbLoginManager.java
@@ -109,7 +109,7 @@ public class DbLoginManager implements DbLoginService
                 @Override
                 public boolean handleSession(HttpSession session)
                 {
-                    LOG.info("Checking if session {} used database authentication", session.getId());
+                    LOG.debug("Checking if session {} used database authentication", session.getId());
                     PrimaryAuthenticationConfiguration<?> configuration = AuthenticationManager.getConfiguration(session);
 
                     if (configuration instanceof DbLoginConfiguration)
@@ -118,10 +118,10 @@ public class DbLoginManager implements DbLoginService
                         Integer apiKeyRowId = (Integer)map.get(ApiKeyManager.API_KEY_ROW_ID);
 
                         // Don't invalidate API key authentications
-                        LOG.info("Checking if session {} wasn't authenticated via an API key", session.getId());
+                        LOG.debug("Checking if session {} was authenticated via username/password (not an API key)", session.getId());
                         if (apiKeyRowId == null)
                         {
-                            LOG.info("Attempting to invalidate session {}", session.getId());
+                            LOG.debug("Attempting to invalidate session {}", session.getId());
                             session.invalidate();
                             return true;
                         }
@@ -133,7 +133,7 @@ public class DbLoginManager implements DbLoginService
                 @Override
                 public void complete(int count)
                 {
-                    LOG.info("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "session"), affectedUser);
+                    LOG.debug("Invalidated {} for {}.", StringUtilsLabKey.pluralize(count, "session"), affectedUser);
                 }
             });
         }

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1751,6 +1751,9 @@ public class LoginController extends SpringActionController
         @Override
         public ModelAndView getSuccessView(SetPasswordForm form)
         {
+            if (null == _successUrl)
+                _successUrl = AppProps.getInstance().getHomePageActionURL();
+
             // Issue 33599: allow the returnUrl for this action to redirect to an absolute URL (ex. labkey.org back to accounts.trial.labkey.host)
             return HttpView.redirect(_successUrl, true);
         }

--- a/core/src/org/labkey/core/query/UserApiKeysUpdateService.java
+++ b/core/src/org/labkey/core/query/UserApiKeysUpdateService.java
@@ -3,14 +3,17 @@ package org.labkey.core.query;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DefaultQueryUpdateService;
 import org.labkey.api.query.DuplicateKeyException;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.security.ApiKeyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.view.UnauthorizedException;
 
@@ -32,13 +35,13 @@ public class UserApiKeysUpdateService extends DefaultQueryUpdateService
     }
 
     @Override
-    protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, boolean allowOwner, boolean retainCreation) throws InvalidKeyException, ValidationException, QueryUpdateServiceException, SQLException
+    protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, boolean allowOwner, boolean retainCreation)
     {
         throw new UnsupportedOperationException("Updates are not allowed for table core.UserApiKeys.");
     }
 
     @Override
-    protected Map<String, Object> deleteRow(User user, Container container, Map<String, Object> oldRowMap) throws QueryUpdateServiceException, SQLException, InvalidKeyException
+    protected Map<String, Object> deleteRow(User user, Container container, Map<String, Object> oldRowMap)
     {
         if (oldRowMap == null)
             return null;
@@ -49,7 +52,9 @@ public class UserApiKeysUpdateService extends DefaultQueryUpdateService
         // so we skip the container permission check from the base class.
         aliasColumns(_columnMapping, oldRowMap);
 
-        _delete(container, oldRowMap);
+        Integer rowId = (Integer)oldRowMap.get("rowId");
+        ApiKeyManager.get().deleteKeys(new SimpleFilter(FieldKey.fromParts("RowId"), rowId));
+
         return oldRowMap;
     }
 

--- a/devtools/src/org/labkey/devtools/authentication/TestSsoController.java
+++ b/devtools/src/org/labkey/devtools/authentication/TestSsoController.java
@@ -39,9 +39,6 @@ import org.springframework.web.servlet.ModelAndView;
 
 import java.util.Map;
 
-/**
- * Created by adam on 6/5/2016.
- */
 public class TestSsoController extends SpringActionController
 {
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(TestSsoController.class);
@@ -96,7 +93,7 @@ public class TestSsoController extends SpringActionController
             if (null == configuration)
                 throw new NotFoundException("Invalid TestSso configuration");
 
-            return AuthenticationResponse.createSuccessResponse(configuration, new ValidEmail(form.getEmail()));
+            return AuthenticationResponse.success(configuration, new ValidEmail(form.getEmail()));
         }
     }
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4467,7 +4467,7 @@ public class QueryController extends SpringActionController
             try
             {
                 rows = json.getJSONArray(PROP_ROWS);
-                if (rows.length() < 1)
+                if (rows.isEmpty())
                     throw new ValidationException("No '" + PROP_ROWS + "' array supplied.");
             }
             catch (JSONException x)
@@ -4482,7 +4482,7 @@ public class QueryController extends SpringActionController
             if (!table.hasPermission(user, commandType.getPermission()))
                 throw new UnauthorizedException();
 
-            if (commandType != CommandType.insert && table.getPkColumns().size() == 0)
+            if (commandType != CommandType.insert && table.getPkColumns().isEmpty())
                 throw new IllegalArgumentException("The table '" + table.getPublicSchemaName() + "." +
                         table.getPublicName() + "' cannot be updated because it has no primary key defined!");
 


### PR DESCRIPTION
#### Rationale
* https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51638
* https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51637

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5994

#### Changes
* Fix session tracking to respect impersonation. Sessions are always tracked to the original user, not an impersonated user.
* On API key authentication, stash the API key's RowId in session. Use that to skip invalidation of API key sessions on password change and invalidate associated API key sessions on API key delete.
* Simplify creation of `AuthenticationResponse`