### PR TITLE
51629: On a windows system, transform scripts with backslashes should be handled better

### DIFF
--- a/api/src/org/labkey/api/qc/TsvDataSerializer.java
+++ b/api/src/org/labkey/api/qc/TsvDataSerializer.java
@@ -122,7 +122,14 @@ public class TsvDataSerializer implements DataExchangeHandler.DataSerializer
                 else if (Object[].class.isAssignableFrom(o.getClass()))
                     pw.append(StringUtils.join((Object[]) o, ","));
                 else
-                    pw.append(String.valueOf(o));
+                {
+                    String val = String.valueOf(o);
+                    // double quote the value if it contains backslashes to avoid tab loader mangling
+                    // on import
+                    if (val.contains("\\"))
+                        val = "\"" + val + "\"";
+                    pw.append(val);
+                }
             }
             sep = "\t";
         }

--- a/api/src/org/labkey/api/qc/TsvDataSerializer.java
+++ b/api/src/org/labkey/api/qc/TsvDataSerializer.java
@@ -127,7 +127,7 @@ public class TsvDataSerializer implements DataExchangeHandler.DataSerializer
                     // Issue 51629 double quote the value if it contains backslashes to avoid tab loader mangling
                     // on import
                     if (!val.startsWith("\"") && !val.endsWith("\"") && val.contains("\\"))
-                        val = "\"" + val + "\"";
+                        val = "\"" + StringUtils.replace(val,"\"", "\"\"") + "\"";
                     pw.append(val);
                 }
             }

--- a/api/src/org/labkey/api/qc/TsvDataSerializer.java
+++ b/api/src/org/labkey/api/qc/TsvDataSerializer.java
@@ -124,9 +124,9 @@ public class TsvDataSerializer implements DataExchangeHandler.DataSerializer
                 else
                 {
                     String val = String.valueOf(o);
-                    // double quote the value if it contains backslashes to avoid tab loader mangling
+                    // Issue 51629 double quote the value if it contains backslashes to avoid tab loader mangling
                     // on import
-                    if (val.contains("\\"))
+                    if (!val.startsWith("\"") && !val.endsWith("\"") && val.contains("\\"))
                         val = "\"" + val + "\"";
                     pw.append(val);
                 }


### PR DESCRIPTION
[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51629)

#### Rationale
Transformed result data values that contain backslashes are `unescaped` during parsing on the subsequent import. It doesn't seem like this was a regression and it is possible that this scenario never worked. There was an addition to the test as part of this change:

https://github.com/LabKey/platform/pull/5781

That may have exposed the problem and didn't start failing until we recently started running that test on a windows agent.