### PR TITLE
Allow case insensitive special date/time format for datetime fields

### DIFF
--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.pipeline.PipelineJobService;
@@ -1368,6 +1369,8 @@ validNum:       {
         return FolderSettingsCache.getDefaultTimeFormat(c);
     }
 
+    public static final Set<String> META_FORMATS = CaseInsensitiveHashSet.of("Date", "DateTime", "Time");
+
     /**
      * Test a date format string to determine if it matches one of LabKey's special named date formats (Date, DateTime, Time)
      * @param dateFormat Format string to test
@@ -1375,7 +1378,7 @@ validNum:       {
      */
     public static boolean isSpecialNamedFormat(String dateFormat)
     {
-        return "Date".equals(dateFormat) || "DateTime".equals(dateFormat) || "Time".equals(dateFormat);
+        return META_FORMATS.contains(dateFormat);
     }
 
     private static final FastDateFormat jsonDateFormat = FastDateFormat.getInstance(getJsonDateTimeFormatString());

--- a/core/src/org/labkey/core/admin/DisplayFormatAnalyzer.java
+++ b/core/src/org/labkey/core/admin/DisplayFormatAnalyzer.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 
 import static org.labkey.api.settings.AbstractSettingsGroup.SITE_CONFIG_USER;
 import static org.labkey.api.settings.LookAndFeelFolderProperties.LOOK_AND_FEEL_SET_NAME;
+import static org.labkey.api.util.DateUtil.META_FORMATS;
 
 public class DisplayFormatAnalyzer
 {
@@ -97,8 +98,6 @@ public class DisplayFormatAnalyzer
             .filter(candidate -> isNonStandardFormat(candidate.type(), candidate.format()))
             .forEach(candidate -> _propertyCandidateMap.put(candidate.container(), candidate));
     }
-
-    private static final Set<String> META_FORMATS = CaseInsensitiveHashSet.of("Date", "DateTime", "Time");
 
     // Allows standard formats and standard meta formats
     private boolean isNonStandardFormat(DateDisplayFormatType type, String format)

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -447,7 +447,7 @@ public class DomainImpl implements Domain
             if (!StringUtils.isEmpty(dp.getFormat()))
             {
                 String ptype = dp.getRangeURI();
-                if (ptype.equalsIgnoreCase(PropertyType.DATE_TIME.getTypeUri()))
+                if (ptype.equalsIgnoreCase(PropertyType.DATE_TIME.getTypeUri())) // TODO: Check Date and Time also?
                 {
                     type = " for type " + PropertyType.DATE_TIME.getXarName();
                     // Allow special named formats (these would otherwise fail validation)


### PR DESCRIPTION
#### Rationale
For DateTime fields, there is a check in `validatePropertyFormat` to check special/meta formats. This is not done for Date or Time fields. But also, this check is case sensitive. The app allows case insensitive meta formats. This PR updates the server side check to be consistent. 

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
