### PR TITLE
Issue 51648: Specify container filter for plate template well data

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.22.0"
+        "@labkey/components": "5.22.9"
       },
       "devDependencies": {
         "@labkey/build": "8.3.0",
@@ -2252,9 +2252,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.22.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.22.0.tgz",
-      "integrity": "sha512-NcfAcnAMqEW6yf2OuDTxtg7mrFLvTGbTRubNQ1dXRi6DtDlLNY3QAPkuXXElUHlJxN2LFzaLL3hF1ZnBrffyNA==",
+      "version": "5.22.9",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.22.9.tgz",
+      "integrity": "sha512-YkXditiUaA3pqRIRBMs71XcDG32knRSDKXub/JHq4vNs1+giJQk76s1neJpxCMhPmOgQPC63VFYiRDUfiSOsEA==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.36.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "5.22.0"
+    "@labkey/components": "5.22.9"
   },
   "devDependencies": {
     "@labkey/build": "8.3.0",

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -682,7 +682,10 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
      */
     public ContainerFilter getPlateContainerFilter(@Nullable ExpProtocol protocol, Container container, User user)
     {
-        return getPlateLookupContainerFilter(protocol != null ? protocol.getContainer() : container, user);
+        ContainerFilter containerFilter = QueryService.get().getContainerFilterForLookups(container, user);
+        if (containerFilter == null)
+            containerFilter = ContainerFilter.Type.Current.create(protocol != null ? protocol.getContainer() : container, user);
+        return containerFilter;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -682,9 +682,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
      */
     public ContainerFilter getPlateContainerFilter(@Nullable ExpProtocol protocol, Container container, User user)
     {
-        ContainerFilter lookupCf = QueryService.get().getContainerFilterForLookups(container, user);
-        ContainerFilter currentCf = ContainerFilter.Type.Current.create(protocol != null ? protocol.getContainer() : container, user);
-        return lookupCf != null ? lookupCf : currentCf;
+        return getPlateLookupContainerFilter(protocol != null ? protocol.getContainer() : container, user);
     }
 
     @Override
@@ -1531,14 +1529,19 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return getPlateTable(container, user, null);
     }
 
-    public @NotNull TableInfo getPlateTable(Container container, User user, @Nullable ContainerFilter cf)
+    private @NotNull TableInfo getPlateTable(Container container, User user, @Nullable ContainerFilter cf)
     {
         return getPlateUserSchema(container, user).getTableOrThrow(PlateTable.NAME, cf);
     }
 
     private @NotNull TableInfo getWellTable(Container container, User user)
     {
-        return getPlateUserSchema(container, user).getTableOrThrow(WellTable.NAME);
+        return getWellTable(container, user, null);
+    }
+
+    private @NotNull TableInfo getWellTable(Container container, User user, @Nullable ContainerFilter cf)
+    {
+        return getPlateUserSchema(container, user).getTableOrThrow(WellTable.NAME, cf);
     }
 
     private @NotNull QueryUpdateService requiredUpdateService(@NotNull TableInfo table)
@@ -3497,7 +3500,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         if (includeSamples)
             columns.add(WellTable.Column.SampleID.name());
 
-        var wellTable = getWellTable(container, user);
+        var wellTable = getWellTable(container, user, getPlateLookupContainerFilter(container, user));
         var filter = new SimpleFilter(FieldKey.fromParts(WellTable.Column.PlateId.name()), plateRowId);
         var wellDatas = new TableSelector(wellTable, columns, filter, new Sort(WellTable.Column.RowId.name())).getArrayList(WellData.class);
 

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.22.2",
+        "@labkey/components": "5.22.9",
         "@labkey/themes": "1.4.0"
       },
       "devDependencies": {
@@ -3058,9 +3058,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.22.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.22.2.tgz",
-      "integrity": "sha512-rx2Jzo/1l5axYrMWLuAjUQAlj+54moTsViuN6C8oezXEXKpmppSHeWGuDkqeTvsKyOc8SrAcxhA7D8b+qTp/yg==",
+      "version": "5.22.9",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.22.9.tgz",
+      "integrity": "sha512-YkXditiUaA3pqRIRBMs71XcDG32knRSDKXub/JHq4vNs1+giJQk76s1neJpxCMhPmOgQPC63VFYiRDUfiSOsEA==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.36.0",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "5.22.2",
+    "@labkey/components": "5.22.9",
     "@labkey/themes": "1.4.0"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.22.2"
+        "@labkey/components": "5.22.9"
       },
       "devDependencies": {
         "@labkey/build": "8.3.0",
@@ -2864,9 +2864,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.22.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.22.2.tgz",
-      "integrity": "sha512-rx2Jzo/1l5axYrMWLuAjUQAlj+54moTsViuN6C8oezXEXKpmppSHeWGuDkqeTvsKyOc8SrAcxhA7D8b+qTp/yg==",
+      "version": "5.22.9",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.22.9.tgz",
+      "integrity": "sha512-YkXditiUaA3pqRIRBMs71XcDG32knRSDKXub/JHq4vNs1+giJQk76s1neJpxCMhPmOgQPC63VFYiRDUfiSOsEA==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.36.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@labkey/build": "8.3.0",
-        "@labkey/test": "1.7.0",
+        "@labkey/test": "1.7.1",
         "@types/jest": "29.5.14",
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
@@ -2895,9 +2895,9 @@
       }
     },
     "node_modules/@labkey/test": {
-      "version": "1.7.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.7.0.tgz",
-      "integrity": "sha512-VcpMMRasPwubtF2yID+9Ovz4rpuJWYk45XcONmkWA7CVQxGWy8NoYae8DDY4R8g7sNNaDSWWGG2nHs4lcXq45Q==",
+      "version": "1.7.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.7.1.tgz",
+      "integrity": "sha512-74BDT3KB3NMCrsCzIScyIgOI9Q4IguOME71YJzU0o+nnxjuHChuHwUqj+1rEJm+nNzp4tbtp6g4vP3KiTFp3kg==",
       "dev": true,
       "dependencies": {
         "properties-reader": "2.3.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "5.22.2"
+    "@labkey/components": "5.22.9"
   },
   "devDependencies": {
     "@labkey/build": "8.3.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@labkey/build": "8.3.0",
-    "@labkey/test": "1.7.0",
+    "@labkey/test": "1.7.1",
     "@types/jest": "29.5.14",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "5.22.0"
+        "@labkey/components": "5.22.9"
       },
       "devDependencies": {
         "@labkey/build": "8.3.0",
@@ -2428,9 +2428,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "5.22.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.22.0.tgz",
-      "integrity": "sha512-NcfAcnAMqEW6yf2OuDTxtg7mrFLvTGbTRubNQ1dXRi6DtDlLNY3QAPkuXXElUHlJxN2LFzaLL3hF1ZnBrffyNA==",
+      "version": "5.22.9",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-5.22.9.tgz",
+      "integrity": "sha512-YkXditiUaA3pqRIRBMs71XcDG32knRSDKXub/JHq4vNs1+giJQk76s1neJpxCMhPmOgQPC63VFYiRDUfiSOsEA==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.36.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "5.22.0"
+    "@labkey/components": "5.22.9"
   },
   "devDependencies": {
     "@labkey/build": "8.3.0",


### PR DESCRIPTION
#### Rationale
This addresses [Issue 51648](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51648) by specifying a container filter on the query underlying fetching of well data from a plate template during re-array.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1643
- https://github.com/LabKey/limsModules/pull/911
- https://github.com/LabKey/platform/pull/6049

#### Changes
- Specify a container filter on `PlateManager.getWellData()` to ensure the correct container scope is applied when resolving well data for a plate/template.
