### PR TITLE
Update xstream to 1.4.21

### DIFF
--- a/pipeline/gradle.properties
+++ b/pipeline/gradle.properties
@@ -8,4 +8,4 @@ jugVersion=2.0.0
 # external repositories
 muleModuleBuildersVersion=1.4.4e
 
-xstreamVersion=1.4.20
+xstreamVersion=1.4.21


### PR DESCRIPTION
#### Rationale
[CVE](https://ossindex.sonatype.org/vulnerability/CVE-2024-47072)
Not a problem for us. Updating to quiet the dependency checker.

#### Related Pull Requests
- N/A

#### Changes
- Update xstream to 1.4.21
