### PR TITLE
CalculateCurveFitAction and support for 3PL curve fit

### DIFF
--- a/api/src/org/labkey/api/data/statistics/CurveFit.java
+++ b/api/src/org/labkey/api/data/statistics/CurveFit.java
@@ -146,4 +146,54 @@ public interface CurveFit<P extends CurveFit.Parameters>
      * @return The integrated area under the curve.
      */
     double calculateAUC(StatsService.AUCType type, double startX, double endX) throws FitFailedException;
+
+    default double residualSumSquares(P parameters)
+    {
+        double sumSq = 0;
+        for (DoublePoint point : getData())
+        {
+            double expectedValue = point.getY();
+            double foundValue = fitCurve(point.getX(), parameters);
+
+            sumSq += Math.pow(foundValue - expectedValue, 2);
+        }
+        return sumSq;
+    }
+
+    default double rootMeanSquareError(P parameters)
+    {
+        return Math.sqrt(residualSumSquares(parameters) / getData().length);
+    }
+
+    default double totalSumSquares()
+    {
+        double sumSq = 0;
+        double mean = 0;
+        for (DoublePoint point : getData())
+            mean += point.getY();
+        mean /= getData().length;
+
+        for (DoublePoint point : getData())
+        {
+            double expectedValue = point.getY();
+            sumSq += Math.pow(expectedValue - mean, 2);
+        }
+        return sumSq;
+    }
+
+    default double rSquared(P parameters)
+    {
+        return 1 - residualSumSquares(parameters) / totalSumSquares();
+    }
+
+    default double adjustedRSquared(P parameters)
+    {
+        return Double.NaN;
+    }
+
+    default double adjustedRSquared(P parameters, int p)
+    {
+        int n = getData().length;
+        return 1 - (1 - rSquared(parameters)) * (n - 1) / (n - p - 1);
+    }
 }

--- a/api/src/org/labkey/api/data/statistics/CurveFit.java
+++ b/api/src/org/labkey/api/data/statistics/CurveFit.java
@@ -147,6 +147,11 @@ public interface CurveFit<P extends CurveFit.Parameters>
      */
     double calculateAUC(StatsService.AUCType type, double startX, double endX) throws FitFailedException;
 
+    /**
+     * Calculates the residual sum of squares (RSS) for the curve fit (https://en.wikipedia.org/wiki/Residual_sum_of_squares)
+     * @param parameters the parameters to use for the give calculated curve fit
+     * @return the calculated residual sum of squares
+     */
     default double residualSumSquares(P parameters)
     {
         double sumSq = 0;
@@ -160,11 +165,22 @@ public interface CurveFit<P extends CurveFit.Parameters>
         return sumSq;
     }
 
+    /**
+     * Calculates the root mean square error (RMSE), or root mean square deviation (RMSD),
+     * for the curve fit (https://en.wikipedia.org/wiki/Root_mean_square_deviation)
+     * @param parameters the parameters to use for the give calculated curve fit
+     * @return the calculated root mean square error
+     */
     default double rootMeanSquareError(P parameters)
     {
         return Math.sqrt(residualSumSquares(parameters) / getData().length);
     }
 
+    /**
+     * Calculates the total sum of squares (TSS) for the data points (https://en.wikipedia.org/wiki/Total_sum_of_squares).
+     * This value is used in the R^2 calculation.
+     * @return the calculated total sum of squares
+     */
     default double totalSumSquares()
     {
         double sumSq = 0;
@@ -181,16 +197,29 @@ public interface CurveFit<P extends CurveFit.Parameters>
         return sumSq;
     }
 
+    /**
+     * Calculates the R^2 value for the curve fit (https://en.wikipedia.org/wiki/Coefficient_of_determination)
+     * using the residualSumSquares() and totalSumSquares() methods.
+     * @param parameters the parameters to use for the give calculated curve fit
+     * @return the calculated R^2 value
+     */
     default double rSquared(P parameters)
     {
         return 1 - residualSumSquares(parameters) / totalSumSquares();
     }
 
+    // see description below, this version of the method is here so that each applicable curve fit can override it
+    // to set the correct p value for the degrees of freedom
     default double adjustedRSquared(P parameters)
     {
         return Double.NaN;
     }
 
+    /**
+     * Calculates the adjusted R^2 value for the curve fit (https://en.wikipedia.org/wiki/Coefficient_of_determination)
+     * @param parameters the parameters to use for the give calculated curve fit
+     * @return the calculated adjusted R^2 value (if possible)
+     */
     default double adjustedRSquared(P parameters, int p)
     {
         int n = getData().length;

--- a/api/src/org/labkey/api/data/statistics/StatsService.java
+++ b/api/src/org/labkey/api/data/statistics/StatsService.java
@@ -39,9 +39,9 @@ public interface StatsService
 
     enum CurveFitType
     {
-        THREE_PARAMETER("Three Parameter", "3PL"),
         FOUR_PARAMETER("Four Parameter", "4pl"),
         FIVE_PARAMETER("Five Parameter", "5pl"),
+        THREE_PARAMETER("3 Parameter", "3param"),
         FOUR_PARAMETER_SIMPLEX("4 Parameter", "4param"),
         POLYNOMIAL("Polynomial", "poly"),
         LINEAR("Linear", "linear"),

--- a/api/src/org/labkey/api/data/statistics/StatsService.java
+++ b/api/src/org/labkey/api/data/statistics/StatsService.java
@@ -39,6 +39,7 @@ public interface StatsService
 
     enum CurveFitType
     {
+        THREE_PARAMETER("Three Parameter", "3pl"),
         FOUR_PARAMETER("Four Parameter", "4pl"),
         FIVE_PARAMETER("Five Parameter", "5pl"),
         FOUR_PARAMETER_SIMPLEX("4 Parameter", "4param"),

--- a/api/src/org/labkey/api/data/statistics/StatsService.java
+++ b/api/src/org/labkey/api/data/statistics/StatsService.java
@@ -39,9 +39,10 @@ public interface StatsService
 
     enum CurveFitType
     {
+        THREE_PARAMETER("Three Parameter", "3pl"),
         FOUR_PARAMETER("Four Parameter", "4pl"),
         FIVE_PARAMETER("Five Parameter", "5pl"),
-        THREE_PARAMETER("3 Parameter", "3param"),
+        THREE_PARAMETER_ALT("3 Parameter", "3param"),
         FOUR_PARAMETER_SIMPLEX("4 Parameter", "4param"),
         POLYNOMIAL("Polynomial", "poly"),
         LINEAR("Linear", "linear"),

--- a/api/src/org/labkey/api/data/statistics/StatsService.java
+++ b/api/src/org/labkey/api/data/statistics/StatsService.java
@@ -39,8 +39,7 @@ public interface StatsService
 
     enum CurveFitType
     {
-        THREE_PARAMETER("Three Parameter", "3pl"),
-        THREE_PARAMETER_ALT("Three Parameter (Alternate)", "3param"), // TODO name TBD
+        THREE_PARAMETER("Three Parameter", "3PL"),
         FOUR_PARAMETER("Four Parameter", "4pl"),
         FIVE_PARAMETER("Five Parameter", "5pl"),
         FOUR_PARAMETER_SIMPLEX("4 Parameter", "4param"),

--- a/api/src/org/labkey/api/data/statistics/StatsService.java
+++ b/api/src/org/labkey/api/data/statistics/StatsService.java
@@ -40,6 +40,7 @@ public interface StatsService
     enum CurveFitType
     {
         THREE_PARAMETER("Three Parameter", "3pl"),
+        THREE_PARAMETER_ALT("Three Parameter (Alternate)", "3param"), // TODO name TBD
         FOUR_PARAMETER("Four Parameter", "4pl"),
         FIVE_PARAMETER("Five Parameter", "5pl"),
         FOUR_PARAMETER_SIMPLEX("4 Parameter", "4param"),

--- a/api/src/org/labkey/api/data/statistics/StatsService.java
+++ b/api/src/org/labkey/api/data/statistics/StatsService.java
@@ -120,4 +120,5 @@ public interface StatsService
      * @param data an array of {@code DoublePoint} instances to initialize the curve fit with.
      */
     CurveFit getCurveFit(CurveFitType type, DoublePoint[] data);
+    CurveFit getCurveFit(CurveFitType type, DoublePoint[] data, @Nullable Double asymptoteMin, @Nullable Double asymptoteMax);
 }

--- a/core/src/org/labkey/core/statistics/DefaultCurveFit.java
+++ b/core/src/org/labkey/core/statistics/DefaultCurveFit.java
@@ -318,14 +318,7 @@ public abstract class DefaultCurveFit<P extends CurveFit.Parameters> implements 
 
     protected double calculateFitError(P parameters)
     {
-        double deviationValue = 0;
-        for (DoublePoint point : getData())
-        {
-            double expectedValue = point.getY();
-            double foundValue = fitCurve(point.getX(), parameters);
-            deviationValue += Math.pow(foundValue - expectedValue, 2);
-        }
-        return Math.sqrt(deviationValue / getData().length);
+        return rootMeanSquareError(parameters);
     }
 
     @Override

--- a/core/src/org/labkey/core/statistics/FourParameterSimplex.java
+++ b/core/src/org/labkey/core/statistics/FourParameterSimplex.java
@@ -106,26 +106,13 @@ public class FourParameterSimplex extends ParameterCurveFit implements Multivari
 
     protected double calculateFitError(SigmoidalParameters parameters)
     {
-        double deviationValue = 0;
-        double varianceValue = 0;
-        double total = 0;
+        return rSquared(parameters);
+    }
 
-        // find the mean
-        for (DoublePoint point : getData())
-        {
-            total += point.getY();
-        }
-        double mean = total / getData().length;
-
-        for (DoublePoint point : getData())
-        {
-            double expectedValue = point.getY();
-            double foundValue = fitCurve(point.getX(), parameters);
-            deviationValue += Math.pow(foundValue - expectedValue, 2);
-            varianceValue += Math.pow(expectedValue - mean, 2);
-        }
-
-        return 1 - deviationValue / varianceValue;
+    @Override
+    public double adjustedRSquared(SigmoidalParameters parameters)
+    {
+        return adjustedRSquared(parameters, 4);
     }
 
     @Override
@@ -139,15 +126,7 @@ public class FourParameterSimplex extends ParameterCurveFit implements Multivari
     private double sumSquares(double[] params)
     {
         SigmoidalParameters parameters = createParams(params);
-        double sumSq = 0;
-        for (DoublePoint point : getData())
-        {
-            double expectedValue = point.getY();
-            double foundValue = fitCurve(point.getX(), parameters);
-
-            sumSq += Math.pow(foundValue - expectedValue, 2);
-        }
-        return sumSq;
+        return residualSumSquares(parameters);
     }
 
     private SigmoidalParameters createParams(double[] params)

--- a/core/src/org/labkey/core/statistics/FourParameterSimplex.java
+++ b/core/src/org/labkey/core/statistics/FourParameterSimplex.java
@@ -37,7 +37,7 @@ public class FourParameterSimplex extends ParameterCurveFit implements Multivari
 
     public FourParameterSimplex(DoublePoint[] data)
     {
-        super(data, StatsService.CurveFitType.FOUR_PARAMETER_SIMPLEX);
+        super(data, StatsService.CurveFitType.FOUR_PARAMETER_SIMPLEX, null, null);
     }
 
     @Override

--- a/core/src/org/labkey/core/statistics/ParameterCurveFit.java
+++ b/core/src/org/labkey/core/statistics/ParameterCurveFit.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.core.statistics;
 
+import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.data.statistics.CurveFit;
 import org.labkey.api.data.statistics.DoublePoint;
@@ -32,7 +33,9 @@ import java.util.Map;
  */
 public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.SigmoidalParameters> implements CurveFit<ParameterCurveFit.SigmoidalParameters>
 {
-    private final StatsService.CurveFitType _fitType;
+    protected final StatsService.CurveFitType _fitType;
+    private Double _asymptoteMin;
+    private Double _asymptoteMax;
 
     public static class SigmoidalParameters implements CurveFit.Parameters, Cloneable
     {
@@ -112,16 +115,38 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
         }
     }
 
-    public ParameterCurveFit(DoublePoint[] data, StatsService.CurveFitType fitType)
+    public ParameterCurveFit(DoublePoint[] data, StatsService.CurveFitType fitType, @Nullable Double asymptoteMin, @Nullable Double asymptoteMax)
     {
         super(data);
         _fitType = fitType;
+        setAsymptoteMin(asymptoteMin);
+        setAsymptoteMax(asymptoteMax);
     }
 
     @Override
     public StatsService.CurveFitType getType()
     {
         return _fitType;
+    }
+
+    public Double getAsymptoteMin()
+    {
+        return _asymptoteMin;
+    }
+
+    public void setAsymptoteMin(Double asymptoteMin)
+    {
+        _asymptoteMin = asymptoteMin;
+    }
+
+    public Double getAsymptoteMax()
+    {
+        return _asymptoteMax;
+    }
+
+    public void setAsymptoteMax(Double asymptoteMax)
+    {
+        _asymptoteMax = asymptoteMax;
     }
 
     @Override
@@ -209,14 +234,14 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
         // reaches 200 or min reaches -100, since these values don't seem biologically reasonable.
         for (double min = minValue; (bestFit == null || min > 0 - step) && min > (minValue - 100); min -= step )
         {
-            parameters.min = min;
+            parameters.min = getAsymptoteMin() != null ? getAsymptoteMin() : min;
             for (double max = maxValue; (bestFit == null || max <= 100 + step) && max < (maxValue + 100); max += step )
             {
                 double absoluteCutoff = min + (0.5 * (max - min));
                 double relativeEC50 = getInterpolatedCutoffXValue(absoluteCutoff);
                 if (!Double.isInfinite(relativeEC50) && !Double.isNaN(relativeEC50))
                 {
-                    parameters.max = max;
+                    parameters.max = getAsymptoteMax() != null ? getAsymptoteMax() : max;
                     parameters.inflection = relativeEC50;
                     for (double slopeRadians = 0; slopeRadians < Math.PI; slopeRadians += Math.PI / 30)
                     {

--- a/core/src/org/labkey/core/statistics/ParameterCurveFit.java
+++ b/core/src/org/labkey/core/statistics/ParameterCurveFit.java
@@ -223,7 +223,7 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
 
     private boolean is3Parameter()
     {
-        return _fitType == StatsService.CurveFitType.THREE_PARAMETER || _fitType == StatsService.CurveFitType.THREE_PARAMETER_ALT;
+        return _fitType == StatsService.CurveFitType.THREE_PARAMETER;
     }
 
     private boolean is4Parameter()
@@ -269,7 +269,6 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
                                 }
                                 break;
                             case THREE_PARAMETER:
-                            case THREE_PARAMETER_ALT:
                             case FOUR_PARAMETER:
                                 parameters.asymmetry = 1;
                                 parameters.fitError = calculateFitError(parameters);

--- a/core/src/org/labkey/core/statistics/ParameterCurveFit.java
+++ b/core/src/org/labkey/core/statistics/ParameterCurveFit.java
@@ -223,7 +223,7 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
 
     private boolean is3Parameter()
     {
-        return _fitType == StatsService.CurveFitType.THREE_PARAMETER;
+        return _fitType == StatsService.CurveFitType.THREE_PARAMETER || _fitType == StatsService.CurveFitType.THREE_PARAMETER_ALT;
     }
 
     private boolean is4Parameter()
@@ -235,7 +235,8 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
     {
         SigmoidalParameters bestFit = null;
         SigmoidalParameters parameters = new SigmoidalParameters();
-        double step = getAsymptoteMax() != null ? Math.min(getAsymptoteMax() / 100, 10) : 10;
+        Double asymptoteDiff = getAsymptoteMax() != null && getAsymptoteMin() != null ? Math.abs(getAsymptoteMax() - getAsymptoteMin()) : null;
+        double step = asymptoteDiff != null ? Math.min(asymptoteDiff / 100, 10) : 10;
         if (is3Parameter() || is4Parameter())
             parameters.asymmetry = 1;
 
@@ -268,6 +269,7 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
                                 }
                                 break;
                             case THREE_PARAMETER:
+                            case THREE_PARAMETER_ALT:
                             case FOUR_PARAMETER:
                                 parameters.asymmetry = 1;
                                 parameters.fitError = calculateFitError(parameters);

--- a/core/src/org/labkey/core/statistics/ParameterCurveFit.java
+++ b/core/src/org/labkey/core/statistics/ParameterCurveFit.java
@@ -221,6 +221,18 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
         }
     }
 
+    @Override
+    public double adjustedRSquared(SigmoidalParameters parameters)
+    {
+        return switch (_fitType)
+        {
+            case THREE_PARAMETER, THREE_PARAMETER_ALT -> adjustedRSquared(parameters, 3);
+            case FOUR_PARAMETER -> adjustedRSquared(parameters, 4);
+            case FIVE_PARAMETER -> adjustedRSquared(parameters, 5);
+            default -> throw new IllegalStateException("Unsupported curve fit type: " + _fitType.name());
+        };
+    }
+
     private boolean is3Parameter()
     {
         return _fitType == StatsService.CurveFitType.THREE_PARAMETER || _fitType == StatsService.CurveFitType.THREE_PARAMETER_ALT;

--- a/core/src/org/labkey/core/statistics/ParameterCurveFit.java
+++ b/core/src/org/labkey/core/statistics/ParameterCurveFit.java
@@ -221,12 +221,22 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
         }
     }
 
+    private boolean is3Parameter()
+    {
+        return _fitType == StatsService.CurveFitType.THREE_PARAMETER;
+    }
+
+    private boolean is4Parameter()
+    {
+        return _fitType == StatsService.CurveFitType.FOUR_PARAMETER;
+    }
+
     protected SigmoidalParameters calculateFitParameters(double minValue, double maxValue)
     {
         SigmoidalParameters bestFit = null;
         SigmoidalParameters parameters = new SigmoidalParameters();
-        double step = 10;
-        if (_fitType == StatsService.CurveFitType.FOUR_PARAMETER)
+        double step = getAsymptoteMax() != null ? Math.min(getAsymptoteMax() / 100, 10) : 10;
+        if (is3Parameter() || is4Parameter())
             parameters.asymmetry = 1;
 
         // try reasonable variants of max and min, in case there's a better fit.  We'll keep going past "reasonable" if
@@ -257,6 +267,7 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
                                         bestFit = parameters.copy();
                                 }
                                 break;
+                            case THREE_PARAMETER:
                             case FOUR_PARAMETER:
                                 parameters.asymmetry = 1;
                                 parameters.fitError = calculateFitError(parameters);

--- a/core/src/org/labkey/core/statistics/ParameterCurveFit.java
+++ b/core/src/org/labkey/core/statistics/ParameterCurveFit.java
@@ -223,7 +223,7 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
 
     private boolean is3Parameter()
     {
-        return _fitType == StatsService.CurveFitType.THREE_PARAMETER;
+        return _fitType == StatsService.CurveFitType.THREE_PARAMETER || _fitType == StatsService.CurveFitType.THREE_PARAMETER_ALT;
     }
 
     private boolean is4Parameter()
@@ -269,6 +269,7 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
                                 }
                                 break;
                             case THREE_PARAMETER:
+                            case THREE_PARAMETER_ALT:
                             case FOUR_PARAMETER:
                                 parameters.asymmetry = 1;
                                 parameters.fitError = calculateFitError(parameters);

--- a/core/src/org/labkey/core/statistics/StatsServiceImpl.java
+++ b/core/src/org/labkey/core/statistics/StatsServiceImpl.java
@@ -67,7 +67,9 @@ public class StatsServiceImpl implements StatsService
         switch (type)
         {
             case THREE_PARAMETER:
-                return new ThreeParameterCurveFit(data, asymptoteMax);
+                return new ParameterCurveFit(data, type, 0.0, asymptoteMax);
+            case THREE_PARAMETER_ALT:
+                return new ThreeParameterAlternateCurveFit(data, asymptoteMax);
             case FOUR_PARAMETER_SIMPLEX:
                 return new FourParameterSimplex(data);
             case FOUR_PARAMETER:

--- a/core/src/org/labkey/core/statistics/StatsServiceImpl.java
+++ b/core/src/org/labkey/core/statistics/StatsServiceImpl.java
@@ -66,6 +66,8 @@ public class StatsServiceImpl implements StatsService
     {
         switch (type)
         {
+            case THREE_PARAMETER:
+                return new ThreeParameterCurveFit(data, asymptoteMax);
             case FOUR_PARAMETER_SIMPLEX:
                 return new FourParameterSimplex(data);
             case FOUR_PARAMETER:

--- a/core/src/org/labkey/core/statistics/StatsServiceImpl.java
+++ b/core/src/org/labkey/core/statistics/StatsServiceImpl.java
@@ -66,10 +66,12 @@ public class StatsServiceImpl implements StatsService
     {
         switch (type)
         {
-            case THREE_PARAMETER:
+            case THREE_PARAMETER_ALT:
                 return new ThreeParameterCurveFit(data, asymptoteMax);
             case FOUR_PARAMETER_SIMPLEX:
                 return new FourParameterSimplex(data);
+            case THREE_PARAMETER:
+                return new ParameterCurveFit(data, type, 0.0, asymptoteMax);
             case FOUR_PARAMETER:
             case FIVE_PARAMETER:
                 return new ParameterCurveFit(data, type, asymptoteMin, asymptoteMax);
@@ -128,6 +130,7 @@ public class StatsServiceImpl implements StatsService
             v1.setResults(CurveFitType.POLYNOMIAL, new CurveResults(2, .044, .052));
             v1.setResults(CurveFitType.FOUR_PARAMETER_SIMPLEX, new CurveResults(.898, .044, .052));
             v1.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(3.09, .065, .065));
+            v1.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(3.09, .065, .065));
             v1.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(2.5, .031, .045));
             v1.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(2.2, .046, .054));
             v1.setResults(CurveFitType.LINEAR, new CurveResults(6.8, .070, .070));
@@ -137,6 +140,7 @@ public class StatsServiceImpl implements StatsService
             v2.setResults(CurveFitType.POLYNOMIAL, new CurveResults(5.4, .414, .424));
             v2.setResults(CurveFitType.FOUR_PARAMETER_SIMPLEX, new CurveResults(.994, .419, .419));
             v2.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(3.45, .414, .414));
+            v2.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(3.45, .414, .414));
             v2.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(3.4, .403, .403));
             v2.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(3.1, .420, .420));
             v2.setResults(CurveFitType.LINEAR, new CurveResults(36.8, .553, .553));
@@ -146,6 +150,7 @@ public class StatsServiceImpl implements StatsService
             v3.setResults(CurveFitType.POLYNOMIAL, new CurveResults(4.1, .055, .056));
             v3.setResults(CurveFitType.FOUR_PARAMETER_SIMPLEX, new CurveResults(.640, .052, .061));
             v3.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(5.0, .078, .078));
+            v3.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(5.0, .078, .078));
             v3.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(4.7, .048, .049));
             v3.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(4.6, .080, .082));
             v3.setResults(CurveFitType.LINEAR, new CurveResults(5.9, .070, .070));
@@ -155,6 +160,7 @@ public class StatsServiceImpl implements StatsService
             v4.setResults(CurveFitType.POLYNOMIAL, new CurveResults(2.4, .259, .273));
             v4.setResults(CurveFitType.FOUR_PARAMETER_SIMPLEX, new CurveResults(.994, .258, .271));
             v4.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(4.34, .280, .280));
+            v4.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(4.34, .280, .280));
             v4.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(4.5, .226, .247));
             v4.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(3.7, .245, .262));
             v4.setResults(CurveFitType.LINEAR, new CurveResults(27.5, .374, .374));
@@ -164,6 +170,7 @@ public class StatsServiceImpl implements StatsService
             v5.setResults(CurveFitType.POLYNOMIAL, new CurveResults(5.9, .207, .263));
             v5.setResults(CurveFitType.FOUR_PARAMETER_SIMPLEX, new CurveResults(.988, .211, .263));
             v5.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(7.86, .281, .281));
+            v5.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(7.86, .281, .281));
             v5.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(5, .201, .263));
             v5.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(5.1, .221, .277));
             v5.setResults(CurveFitType.LINEAR, new CurveResults(38.0, .363, .363));

--- a/core/src/org/labkey/core/statistics/StatsServiceImpl.java
+++ b/core/src/org/labkey/core/statistics/StatsServiceImpl.java
@@ -17,6 +17,7 @@ package org.labkey.core.statistics;
 
 import org.apache.commons.math3.random.RandomDataImpl;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.data.statistics.CurveFit;
@@ -57,13 +58,19 @@ public class StatsServiceImpl implements StatsService
     @Override
     public CurveFit getCurveFit(CurveFitType type, DoublePoint[] data)
     {
+        return getCurveFit(type, data, null, null);
+    }
+
+    @Override
+    public CurveFit getCurveFit(CurveFitType type, DoublePoint[] data, @Nullable Double asymptoteMin, @Nullable Double asymptoteMax)
+    {
         switch (type)
         {
             case FOUR_PARAMETER_SIMPLEX:
                 return new FourParameterSimplex(data);
             case FOUR_PARAMETER:
             case FIVE_PARAMETER:
-                return new ParameterCurveFit(data, type);
+                return new ParameterCurveFit(data, type, asymptoteMin, asymptoteMax);
             case POLYNOMIAL:
                 return new PolynomialCurveFit(data);
             case LINEAR:

--- a/core/src/org/labkey/core/statistics/StatsServiceImpl.java
+++ b/core/src/org/labkey/core/statistics/StatsServiceImpl.java
@@ -128,6 +128,8 @@ public class StatsServiceImpl implements StatsService
 
             CurveValidation v1 = new CurveValidation(new double[]{12.54, 12.04, 9.11, 7.48, .576, -.512, 1.99, -6.60});
             v1.setResults(CurveFitType.POLYNOMIAL, new CurveResults(2, .044, .052));
+            v1.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(3.09, .065, .065));
+            v1.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(3.09, .065, .065));
             v1.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(2.5, .031, .045));
             v1.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(2.2, .046, .054));
             v1.setResults(CurveFitType.LINEAR, new CurveResults(6.8, .070, .070));
@@ -135,6 +137,8 @@ public class StatsServiceImpl implements StatsService
 
             CurveValidation v2 = new CurveValidation(new double[]{93.28, 88.65, 74.12, 46.16, 28.34, 17.41, 6.17, -1.79});
             v2.setResults(CurveFitType.POLYNOMIAL, new CurveResults(5.4, .414, .424));
+            v2.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(3.45, .414, .414));
+            v2.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(3.45, .414, .414));
             v2.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(3.4, .403, .403));
             v2.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(3.1, .420, .420));
             v2.setResults(CurveFitType.LINEAR, new CurveResults(36.8, .553, .553));
@@ -142,6 +146,8 @@ public class StatsServiceImpl implements StatsService
 
             CurveValidation v3 = new CurveValidation(new double[]{10.79, 3.21, .599, 9.96, 9.5, 8.39, 1.56, -5.81});
             v3.setResults(CurveFitType.POLYNOMIAL, new CurveResults(4.1, .055, .056));
+            v3.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(5.0, .078, .078));
+            v3.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(5.0, .078, .078));
             v3.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(4.7, .048, .049));
             v3.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(4.6, .080, .082));
             v3.setResults(CurveFitType.LINEAR, new CurveResults(5.9, .070, .070));
@@ -149,6 +155,8 @@ public class StatsServiceImpl implements StatsService
 
             CurveValidation v4 = new CurveValidation(new double[]{75.94, 58.52, 39.42, 28.84, 19.37, 9.91, 6.04, -7.35});
             v4.setResults(CurveFitType.POLYNOMIAL, new CurveResults(2.4, .259, .273));
+            v4.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(4.34, .280, .280));
+            v4.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(4.34, .280, .280));
             v4.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(4.5, .226, .247));
             v4.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(3.7, .245, .262));
             v4.setResults(CurveFitType.LINEAR, new CurveResults(27.5, .374, .374));
@@ -156,6 +164,8 @@ public class StatsServiceImpl implements StatsService
 
             CurveValidation v5 = new CurveValidation(new double[]{89.34, 74.24, 45.69, 18.34, .365, -1.65, -.77, -16.59});
             v5.setResults(CurveFitType.POLYNOMIAL, new CurveResults(5.9, .207, .263));
+            v5.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(7.86, .281, .281));
+            v5.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(7.86, .281, .281));
             v5.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(5, .201, .263));
             v5.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(5.1, .221, .277));
             v5.setResults(CurveFitType.LINEAR, new CurveResults(38.0, .363, .363));
@@ -171,9 +181,9 @@ public class StatsServiceImpl implements StatsService
                         CurveResults results = validation.getResults(fitType);
 
                         // validate calculated and expected fit error and auc
-                        assertEquals(fit.getFitError(), results.getFitError(), 0.05);
-                        assertEquals(fit.calculateAUC(AUCType.NORMAL), results.getAuc(), 0.005);
-                        assertEquals(fit.calculateAUC(AUCType.POSITIVE), results.getPositiveAuc(), 0.005);
+                        assertEquals(results.getFitError(), fit.getFitError(), 0.05);
+                        assertEquals(results.getAuc(), fit.calculateAUC(AUCType.NORMAL), 0.005);
+                        assertEquals(results.getPositiveAuc(), fit.calculateAUC(AUCType.POSITIVE), 0.005);
                     }
                 }
             }

--- a/core/src/org/labkey/core/statistics/StatsServiceImpl.java
+++ b/core/src/org/labkey/core/statistics/StatsServiceImpl.java
@@ -67,9 +67,7 @@ public class StatsServiceImpl implements StatsService
         switch (type)
         {
             case THREE_PARAMETER:
-                return new ParameterCurveFit(data, type, 0.0, asymptoteMax);
-            case THREE_PARAMETER_ALT:
-                return new ThreeParameterAlternateCurveFit(data, asymptoteMax);
+                return new ThreeParameterCurveFit(data, asymptoteMax);
             case FOUR_PARAMETER_SIMPLEX:
                 return new FourParameterSimplex(data);
             case FOUR_PARAMETER:
@@ -129,7 +127,6 @@ public class StatsServiceImpl implements StatsService
             CurveValidation v1 = new CurveValidation(new double[]{12.54, 12.04, 9.11, 7.48, .576, -.512, 1.99, -6.60});
             v1.setResults(CurveFitType.POLYNOMIAL, new CurveResults(2, .044, .052));
             v1.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(3.09, .065, .065));
-            v1.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(3.09, .065, .065));
             v1.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(2.5, .031, .045));
             v1.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(2.2, .046, .054));
             v1.setResults(CurveFitType.LINEAR, new CurveResults(6.8, .070, .070));
@@ -138,7 +135,6 @@ public class StatsServiceImpl implements StatsService
             CurveValidation v2 = new CurveValidation(new double[]{93.28, 88.65, 74.12, 46.16, 28.34, 17.41, 6.17, -1.79});
             v2.setResults(CurveFitType.POLYNOMIAL, new CurveResults(5.4, .414, .424));
             v2.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(3.45, .414, .414));
-            v2.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(3.45, .414, .414));
             v2.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(3.4, .403, .403));
             v2.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(3.1, .420, .420));
             v2.setResults(CurveFitType.LINEAR, new CurveResults(36.8, .553, .553));
@@ -147,7 +143,6 @@ public class StatsServiceImpl implements StatsService
             CurveValidation v3 = new CurveValidation(new double[]{10.79, 3.21, .599, 9.96, 9.5, 8.39, 1.56, -5.81});
             v3.setResults(CurveFitType.POLYNOMIAL, new CurveResults(4.1, .055, .056));
             v3.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(5.0, .078, .078));
-            v3.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(5.0, .078, .078));
             v3.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(4.7, .048, .049));
             v3.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(4.6, .080, .082));
             v3.setResults(CurveFitType.LINEAR, new CurveResults(5.9, .070, .070));
@@ -156,7 +151,6 @@ public class StatsServiceImpl implements StatsService
             CurveValidation v4 = new CurveValidation(new double[]{75.94, 58.52, 39.42, 28.84, 19.37, 9.91, 6.04, -7.35});
             v4.setResults(CurveFitType.POLYNOMIAL, new CurveResults(2.4, .259, .273));
             v4.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(4.34, .280, .280));
-            v4.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(4.34, .280, .280));
             v4.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(4.5, .226, .247));
             v4.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(3.7, .245, .262));
             v4.setResults(CurveFitType.LINEAR, new CurveResults(27.5, .374, .374));
@@ -165,7 +159,6 @@ public class StatsServiceImpl implements StatsService
             CurveValidation v5 = new CurveValidation(new double[]{89.34, 74.24, 45.69, 18.34, .365, -1.65, -.77, -16.59});
             v5.setResults(CurveFitType.POLYNOMIAL, new CurveResults(5.9, .207, .263));
             v5.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(7.86, .281, .281));
-            v5.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(7.86, .281, .281));
             v5.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(5, .201, .263));
             v5.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(5.1, .221, .277));
             v5.setResults(CurveFitType.LINEAR, new CurveResults(38.0, .363, .363));

--- a/core/src/org/labkey/core/statistics/StatsServiceImpl.java
+++ b/core/src/org/labkey/core/statistics/StatsServiceImpl.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.data.statistics.CurveFit;
 import org.labkey.api.data.statistics.DoublePoint;
+import org.labkey.api.data.statistics.FitFailedException;
 import org.labkey.api.data.statistics.MathStat;
 import org.labkey.api.data.statistics.StatsService;
 import org.labkey.api.view.Stats;
@@ -255,6 +256,137 @@ public class StatsServiceImpl implements StatsService
             {
                 return _positiveAuc;
             }
+        }
+
+        @Test
+        public void TestCurveFitParameters() throws Exception
+        {
+            StatsService service = StatsService.get();
+            double delta = 0.005;
+
+            DoublePoint[] data1 = new DoublePoint[]{
+                    new DoublePoint(0.025, 0.67),
+                    new DoublePoint(0.05, 1),
+                    new DoublePoint(0.1, 2),
+                    new DoublePoint(0.2, 3.17),
+            };
+
+            CurveFit fit = service.getCurveFit(CurveFitType.LINEAR, data1);
+            fit.setLogXScale(false);
+            assertEquals(14.442, (Double) fit.getParameters().toMap().get("slope"), delta);
+            assertEquals(0.356, (Double) fit.getParameters().toMap().get("intercept"), delta);
+            assertEquals(0.986, fit.rSquared(fit.getParameters()), delta);
+
+            fit = service.getCurveFit(CurveFitType.POLYNOMIAL, data1);
+            fit.setLogXScale(false);
+            assertEquals(0.088, ((PolynomialCurveFit.PolynomialParameters)fit.getParameters()).getCoefficients()[0], delta);
+            assertEquals(21.8001, ((PolynomialCurveFit.PolynomialParameters)fit.getParameters()).getCoefficients()[1], delta);
+            assertEquals(-31.785, ((PolynomialCurveFit.PolynomialParameters)fit.getParameters()).getCoefficients()[2], delta);
+            assertEquals(0.996, fit.rSquared(fit.getParameters()), delta);
+
+            fit = service.getCurveFit(CurveFitType.THREE_PARAMETER, data1);
+            fit.setLogXScale(false);
+            verifySigmoidalParameters(fit, 0.0, 3.17, 2.246, 0.096, 1.0);
+            assertEquals(-1.667, fit.rSquared(fit.getParameters()), delta);
+            fit = service.getCurveFit(CurveFitType.THREE_PARAMETER, data1, 0.0, 4.0);
+            fit.setLogXScale(true);
+            verifySigmoidalParameters(fit, 0.0, 4.0, 1.376, 0.095, 1.0);
+            assertEquals(0.974, fit.rSquared(fit.getParameters()), delta);
+
+            fit = service.getCurveFit(CurveFitType.THREE_PARAMETER_ALT, data1);
+            fit.setLogXScale(false);
+            verifySigmoidalParameters(fit, 0.0, 3.17, -1.732, 0.096, 1.0);
+            assertEquals(0.786, fit.rSquared(fit.getParameters()), delta);
+            fit = service.getCurveFit(CurveFitType.THREE_PARAMETER_ALT, data1, 0.0, 4.0);
+            fit.setLogXScale(true);
+            verifySigmoidalParameters(fit, 0.0, 4.0, -1.376, 0.095, 1.0);
+            assertEquals(0.974, fit.rSquared(fit.getParameters()), delta);
+
+            fit = service.getCurveFit(CurveFitType.FOUR_PARAMETER, data1);
+            fit.setLogXScale(false);
+            verifySigmoidalParameters(fit, 0.67, 3.17, null, 0.096, 1.0);
+            assertEquals(-1.138, fit.rSquared(fit.getParameters()), delta);
+            fit = service.getCurveFit(CurveFitType.FOUR_PARAMETER, data1, null, 4.0);
+            fit.setLogXScale(true);
+            verifySigmoidalParameters(fit, 0.67, 4.0, 2.246, 0.095, 1.0);
+            assertEquals(0.892, fit.rSquared(fit.getParameters()), delta);
+
+            fit = service.getCurveFit(CurveFitType.FOUR_PARAMETER_SIMPLEX, data1);
+            fit.setLogXScale(false);
+            verifySigmoidalParameters(fit, 0.581, 3.787, 2.402, 0.110, 0.0);
+            assertEquals(1.0, fit.rSquared(fit.getParameters()), delta);
+            fit = service.getCurveFit(CurveFitType.FOUR_PARAMETER_SIMPLEX, data1);
+            fit.setLogXScale(true);
+            verifySigmoidalParameters(fit, 0.581, 3.787, 2.402, 0.110, 0.0);
+            assertEquals(1.0, fit.rSquared(fit.getParameters()), delta);
+
+            fit = service.getCurveFit(CurveFitType.FIVE_PARAMETER, data1);
+            fit.setLogXScale(false);
+            verifySigmoidalParameters(fit, 0.67, 3.17, 1.111, 0.096, 2.932);
+            assertEquals(-1.624, fit.rSquared(fit.getParameters()), delta);
+            fit = service.getCurveFit(CurveFitType.FIVE_PARAMETER, data1, null, 4.0);
+            fit.setLogXScale(true);
+            verifySigmoidalParameters(fit, 0.67, 4.0, 2.246, 0.095, 1.466);
+            assertEquals(0.997, fit.rSquared(fit.getParameters()), delta);
+        }
+
+        @Test
+        public void TestCurveFitParametersNAbCase() throws Exception
+        {
+            StatsService service = StatsService.get();
+            double delta = 0.005;
+
+            DoublePoint[] data1 = new DoublePoint[]{
+                    new DoublePoint(0.01, 93),
+                    new DoublePoint(0.1, 89),
+                    new DoublePoint(1, 74),
+                    new DoublePoint(10, 46),
+                    new DoublePoint(100, 28),
+                    new DoublePoint(1000, 17),
+                    new DoublePoint(10000, 6),
+                    new DoublePoint(100000, -2),
+            };
+
+            CurveFit fit = service.getCurveFit(CurveFitType.FIVE_PARAMETER, data1);
+            fit.setLogXScale(true);
+            verifySigmoidalParameters(fit, -2.0, 93.0, -0.445, 10.661, 0.838);
+            assertEquals(3.493, fit.getFitError(), delta);
+            assertEquals(0.990, fit.rSquared(fit.getParameters()), delta);
+
+            fit = service.getCurveFit(CurveFitType.FOUR_PARAMETER, data1);
+            fit.setLogXScale(true);
+            verifySigmoidalParameters(fit, -2.0, 103.0, -0.325, 6.907, 1.0);
+            assertEquals(4.126, fit.getFitError(), delta);
+            assertEquals(0.986, fit.rSquared(fit.getParameters()), delta);
+
+            fit = service.getCurveFit(CurveFitType.FOUR_PARAMETER_SIMPLEX, data1);
+            fit.setLogXScale(true);
+            verifySigmoidalParameters(fit, -2.540, 102.643, -0.374, 9.985, 0.0);
+            assertEquals(0.994, fit.getFitError(), delta);
+            assertEquals(0.994, fit.rSquared(fit.getParameters()), delta);
+
+            fit = service.getCurveFit(CurveFitType.THREE_PARAMETER, data1);
+            fit.setLogXScale(true);
+            verifySigmoidalParameters(fit, 0.0, 103.0, -0.445, 6.907, 1.0);
+            assertEquals(3.631, fit.getFitError(), delta);
+            assertEquals(0.989, fit.rSquared(fit.getParameters()), delta);
+
+            fit = service.getCurveFit(CurveFitType.THREE_PARAMETER_ALT, data1);
+            fit.setLogXScale(true);
+            verifySigmoidalParameters(fit, 0.0, 103.0, 0.445, 6.907, 1.0);
+            assertEquals(3.631, fit.getFitError(), delta);
+            assertEquals(0.989, fit.rSquared(fit.getParameters()), delta);
+        }
+
+        private void verifySigmoidalParameters(CurveFit fit, Double min, Double max, Double slope, Double inflection, Double asymmetry) throws FitFailedException
+        {
+            double delta = 0.005;
+            Map<String, Object> params = fit.getParameters().toMap();
+            assertEquals(min, (Double) params.get("min"), delta);
+            assertEquals(max, (Double) params.get("max"), delta);
+            if (slope != null) assertEquals(slope, (Double) params.get("slope"), delta);
+            assertEquals(inflection, (Double) params.get("inflection"), delta);
+            assertEquals(asymmetry, (Double) params.get("asymmetry"), delta);
         }
     }
 }

--- a/core/src/org/labkey/core/statistics/StatsServiceImpl.java
+++ b/core/src/org/labkey/core/statistics/StatsServiceImpl.java
@@ -126,6 +126,7 @@ public class StatsServiceImpl implements StatsService
 
             CurveValidation v1 = new CurveValidation(new double[]{12.54, 12.04, 9.11, 7.48, .576, -.512, 1.99, -6.60});
             v1.setResults(CurveFitType.POLYNOMIAL, new CurveResults(2, .044, .052));
+            v1.setResults(CurveFitType.FOUR_PARAMETER_SIMPLEX, new CurveResults(.898, .044, .052));
             v1.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(3.09, .065, .065));
             v1.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(2.5, .031, .045));
             v1.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(2.2, .046, .054));
@@ -134,6 +135,7 @@ public class StatsServiceImpl implements StatsService
 
             CurveValidation v2 = new CurveValidation(new double[]{93.28, 88.65, 74.12, 46.16, 28.34, 17.41, 6.17, -1.79});
             v2.setResults(CurveFitType.POLYNOMIAL, new CurveResults(5.4, .414, .424));
+            v2.setResults(CurveFitType.FOUR_PARAMETER_SIMPLEX, new CurveResults(.994, .419, .419));
             v2.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(3.45, .414, .414));
             v2.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(3.4, .403, .403));
             v2.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(3.1, .420, .420));
@@ -142,6 +144,7 @@ public class StatsServiceImpl implements StatsService
 
             CurveValidation v3 = new CurveValidation(new double[]{10.79, 3.21, .599, 9.96, 9.5, 8.39, 1.56, -5.81});
             v3.setResults(CurveFitType.POLYNOMIAL, new CurveResults(4.1, .055, .056));
+            v3.setResults(CurveFitType.FOUR_PARAMETER_SIMPLEX, new CurveResults(.640, .052, .061));
             v3.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(5.0, .078, .078));
             v3.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(4.7, .048, .049));
             v3.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(4.6, .080, .082));
@@ -150,6 +153,7 @@ public class StatsServiceImpl implements StatsService
 
             CurveValidation v4 = new CurveValidation(new double[]{75.94, 58.52, 39.42, 28.84, 19.37, 9.91, 6.04, -7.35});
             v4.setResults(CurveFitType.POLYNOMIAL, new CurveResults(2.4, .259, .273));
+            v4.setResults(CurveFitType.FOUR_PARAMETER_SIMPLEX, new CurveResults(.994, .258, .271));
             v4.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(4.34, .280, .280));
             v4.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(4.5, .226, .247));
             v4.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(3.7, .245, .262));
@@ -158,6 +162,7 @@ public class StatsServiceImpl implements StatsService
 
             CurveValidation v5 = new CurveValidation(new double[]{89.34, 74.24, 45.69, 18.34, .365, -1.65, -.77, -16.59});
             v5.setResults(CurveFitType.POLYNOMIAL, new CurveResults(5.9, .207, .263));
+            v5.setResults(CurveFitType.FOUR_PARAMETER_SIMPLEX, new CurveResults(.988, .211, .263));
             v5.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(7.86, .281, .281));
             v5.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(5, .201, .263));
             v5.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(5.1, .221, .277));
@@ -168,7 +173,7 @@ public class StatsServiceImpl implements StatsService
             {
                 for (CurveFitType fitType : CurveFitType.values())
                 {
-                    if (fitType != CurveFitType.NONE && fitType != CurveFitType.FOUR_PARAMETER_SIMPLEX)
+                    if (fitType != CurveFitType.NONE)
                     {
                         CurveFit fit = service.getCurveFit(fitType, validation.getData());
                         CurveResults results = validation.getResults(fitType);

--- a/core/src/org/labkey/core/statistics/ThreeParameterAlternateCurveFit.java
+++ b/core/src/org/labkey/core/statistics/ThreeParameterAlternateCurveFit.java
@@ -5,10 +5,10 @@ import org.labkey.api.data.statistics.DoublePoint;
 
 import static org.labkey.api.data.statistics.StatsService.CurveFitType.THREE_PARAMETER;
 
-public class ThreeParameterCurveFit extends ParameterCurveFit
+public class ThreeParameterAlternateCurveFit extends ParameterCurveFit
 {
 
-    public ThreeParameterCurveFit(DoublePoint[] data, @Nullable Double asymptoteMax)
+    public ThreeParameterAlternateCurveFit(DoublePoint[] data, @Nullable Double asymptoteMax)
     {
         super(data, THREE_PARAMETER, 0.0, asymptoteMax);
     }

--- a/core/src/org/labkey/core/statistics/ThreeParameterCurveFit.java
+++ b/core/src/org/labkey/core/statistics/ThreeParameterCurveFit.java
@@ -1,0 +1,42 @@
+package org.labkey.core.statistics;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.statistics.DoublePoint;
+
+import static org.labkey.api.data.statistics.StatsService.CurveFitType.THREE_PARAMETER;
+
+public class ThreeParameterCurveFit extends ParameterCurveFit
+{
+
+    public ThreeParameterCurveFit(DoublePoint[] data, @Nullable Double asymptoteMax)
+    {
+        super(data, THREE_PARAMETER, 0.0, asymptoteMax);
+    }
+
+    @Override
+    public double fitCurve(double x, SigmoidalParameters params)
+    {
+        if (params != null)
+        {
+            // TODO hasXLogScale()?
+
+            if (x <= 0)
+            {
+                if (params.getSlope() < 0)
+                    return 0;
+                else
+                    return params.getMax();
+            }
+            else
+            {
+                if (params.getSlope() > 0)
+                    return params.getMax() / (1 + Math.pow(Math.abs(x / params.getInflection()), params.getSlope()));
+                else
+                    return params.getMax() * Math.pow(Math.abs(x / params.getInflection()), Math.abs(params.getSlope())) /
+                            (1 + Math.pow(Math.abs(x / params.getInflection()), Math.abs(params.getSlope())));
+            }
+
+        }
+        throw new IllegalArgumentException("No curve fit parameters for " + _fitType.name());
+    }
+}

--- a/core/src/org/labkey/core/statistics/ThreeParameterCurveFit.java
+++ b/core/src/org/labkey/core/statistics/ThreeParameterCurveFit.java
@@ -5,12 +5,18 @@ import org.labkey.api.data.statistics.DoublePoint;
 
 import static org.labkey.api.data.statistics.StatsService.CurveFitType.THREE_PARAMETER;
 
-public class ThreeParameterAlternateCurveFit extends ParameterCurveFit
+/* Based on the equation from SigmaPlot */
+public class ThreeParameterCurveFit extends ParameterCurveFit
 {
-
-    public ThreeParameterAlternateCurveFit(DoublePoint[] data, @Nullable Double asymptoteMax)
+    public ThreeParameterCurveFit(DoublePoint[] data, @Nullable Double asymptoteMax)
     {
         super(data, THREE_PARAMETER, 0.0, asymptoteMax);
+    }
+
+    @Override
+    public double solveForX(double y)
+    {
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
@@ -18,8 +24,6 @@ public class ThreeParameterAlternateCurveFit extends ParameterCurveFit
     {
         if (params != null)
         {
-            // TODO hasXLogScale()?
-
             if (x <= 0)
             {
                 if (params.getSlope() < 0)

--- a/core/src/org/labkey/core/statistics/ThreeParameterCurveFit.java
+++ b/core/src/org/labkey/core/statistics/ThreeParameterCurveFit.java
@@ -43,4 +43,10 @@ public class ThreeParameterCurveFit extends ParameterCurveFit
         }
         throw new IllegalArgumentException("No curve fit parameters for " + _fitType.name());
     }
+
+    @Override
+    public double adjustedRSquared(SigmoidalParameters parameters)
+    {
+        return adjustedRSquared(parameters, 3);
+    }
 }


### PR DESCRIPTION
#### Rationale
We will be adding support for including a curve fit line in the chart wizard. This set of PRs are the first step: adding an API to request a curve fit for a set of data points. The API uses our existing curve fit types along with the new 3PL fit type. The response includes the curve fit parameters for the requested fit type, the stats for the fit, and generated data points to use for plotting (optional).

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6053
- https://github.com/LabKey/premiumModules/pull/103

#### Changes
- ParameterCurveFit to support constants for min and max asymptote
- Add Sigmoidal Logistic 3 Parameter curve fit
- StatsServiceImpl.TestCase update for 3PL curve fit and 4PL simplex fit
- Add curve fit stats for new API: residual sum of squares, root mean square error, R2, adjusted R2