### PR TITLE
Assay: resolve a single provider/protocol before creating protocol schema

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -881,20 +881,35 @@ public abstract class AbstractAssayProvider implements AssayProvider
     }
 
     @Override
-    public List<Pair<Domain, Map<DomainProperty, Object>>> getDomains(ExpProtocol protocol)
+    public @NotNull List<Domain> getDomains(ExpProtocol protocol)
     {
-        List<Pair<Domain, Map<DomainProperty, Object>>> domains = new ArrayList<>();
+        List<Domain> domains = new ArrayList<>();
         for (String uri : getPropertyDomains(protocol))
         {
             Domain domain = PropertyService.get().getDomain(protocol.getContainer(), uri);
             if (domain != null)
-            {
-                Map<DomainProperty, Object> values = DefaultValueService.get().getDefaultValues(domain.getContainer(), domain);
-                domains.add(new Pair<>(domain, values));
-            }
+                domains.add(domain);
         }
-        sortDomainList(domains);
+
+        // Rely on the assay provider to return a list of default domains in the right order (Collections.sort() is
+        // stable so that domains that haven't been inserted and have id 0 stay in the same order), and rely on the fact
+        // that they get inserted in the same order, so they will have ascending ids.
+        domains.sort(Comparator.comparing(Domain::getTypeId));
+
         return domains;
+    }
+
+    @Override
+    public @NotNull List<Pair<Domain, Map<DomainProperty, Object>>> getDomainsAndDefaultValues(ExpProtocol protocol)
+    {
+        List<Pair<Domain, Map<DomainProperty, Object>>> domainAndDefaultValues = new ArrayList<>();
+        for (Domain domain : getDomains(protocol))
+        {
+            Map<DomainProperty, Object> values = DefaultValueService.get().getDefaultValues(domain.getContainer(), domain);
+            domainAndDefaultValues.add(Pair.of(domain, values));
+        }
+
+        return domainAndDefaultValues;
     }
 
     @Override
@@ -903,14 +918,6 @@ public abstract class AbstractAssayProvider implements AssayProvider
         ExpProtocol copy = ExperimentService.get().createExpProtocol(targetContainer, ExpProtocol.ApplicationType.ExperimentRun, "Unknown");
         copy.setName(null);
         return new Pair<>(copy, createDefaultDomains(targetContainer, user));
-    }
-
-    protected void sortDomainList(List<Pair<Domain, Map<DomainProperty, Object>>> domains)
-    {
-        // Rely on the assay provider to return a list of default domains in the right order (Collections.sort() is
-        // stable so that domains that haven't been inserted and have id 0 stay in the same order), and rely on the fact
-        // that they get inserted in the same order, so they will have ascending ids.
-        domains.sort(Comparator.comparingInt(pair -> pair.getKey().getTypeId()));
     }
 
     @Override
@@ -925,7 +932,7 @@ public abstract class AbstractAssayProvider implements AssayProvider
         }
         copy.setObjectProperties(copiedProps);
 
-        List<Pair<Domain, Map<DomainProperty, Object>>> originalDomains = getDomains(toCopy);
+        List<Pair<Domain, Map<DomainProperty, Object>>> originalDomains = getDomainsAndDefaultValues(toCopy);
         List<Pair<Domain, Map<DomainProperty, Object>>> copiedDomains = new ArrayList<>(originalDomains.size());
         for (Pair<Domain, Map<DomainProperty, Object>> domainInfo : originalDomains)
         {
@@ -1113,18 +1120,15 @@ public abstract class AbstractAssayProvider implements AssayProvider
     @Override
     public void deleteProtocol(ExpProtocol protocol, User user, @Nullable final String auditUserComment) throws ExperimentException
     {
-        List<Pair<Domain, Map<DomainProperty, Object>>> domainInfos =  getDomains(protocol);
-        List<Domain> domains = new ArrayList<>();
-        for (Pair<Domain, Map<DomainProperty, Object>> domainInfo : domainInfos)
-            domains.add(domainInfo.getKey());
+        List<Domain> domains = getDomains(protocol);
 
         Set<Container> defaultValueContainers = new HashSet<>();
         defaultValueContainers.add(protocol.getContainer());
         defaultValueContainers.addAll(protocol.getExpRunContainers());
         clearDefaultValues(defaultValueContainers, domains);
-        for (Pair<Domain, Map<DomainProperty, Object>> domainInfo : domainInfos)
+
+        for (Domain domain : domains)
         {
-            Domain domain = domainInfo.getKey();
             for (DomainProperty prop : domain.getProperties())
             {
                 prop.delete();
@@ -1537,12 +1541,14 @@ public abstract class AbstractAssayProvider implements AssayProvider
     {
         Container protocolContainer = protocol.getContainer();
         Container contextContainer = context.getContainer();
-
         NavTree manageMenu = new NavTree(MANAGE_ASSAY_DESIGN_LINK);
+
+        final AssayUrls assayUrls = Objects.requireNonNull(PageFlowUtil.urlProvider(AssayUrls.class));
+        final ExperimentUrls experimentUrls = Objects.requireNonNull(PageFlowUtil.urlProvider(ExperimentUrls.class));
 
         if (allowUpdate(context, protocol))
         {
-            ActionURL editURL = PageFlowUtil.urlProvider(AssayUrls.class).getDesignerURL(protocolContainer, protocol, false, context.getActionURL());
+            ActionURL editURL = assayUrls.getDesignerURL(protocolContainer, protocol, false, context.getActionURL());
             if (editURL != null)
             {
                 var child = manageMenu.addChild("Edit assay design","");
@@ -1552,32 +1558,30 @@ public abstract class AbstractAssayProvider implements AssayProvider
                     child.setScript("if (window.confirm('This assay is defined in the " + protocolContainer.getPath() + " folder. Would you still like to edit it?')) { window.location = " + jsString(editURL.toString()) + "; } return false;");
             }
 
-            ActionURL copyURL = PageFlowUtil.urlProvider(AssayUrls.class).getChooseCopyDestinationURL(protocol, protocolContainer);
+            ActionURL copyURL = assayUrls.getChooseCopyDestinationURL(protocol, protocolContainer);
             if (copyURL != null)
                 manageMenu.addChild("Copy assay design", copyURL.toString());
         }
 
         if (allowDelete(context, protocol))
         {
-            manageMenu.addChild("Delete assay design", PageFlowUtil.urlProvider(ExperimentUrls.class).getDeleteProtocolURL(protocol, PageFlowUtil.urlProvider(AssayUrls.class).getAssayListURL(contextContainer)));
+            manageMenu.addChild("Delete assay design", experimentUrls.getDeleteProtocolURL(protocol, assayUrls.getAssayListURL(contextContainer)));
         }
 
-        ActionURL exportURL = PageFlowUtil.urlProvider(ExperimentUrls.class).getExportProtocolURL(protocolContainer, protocol);
+        ActionURL exportURL = experimentUrls.getExportProtocolURL(protocolContainer, protocol);
         manageMenu.addChild("Export assay design", exportURL.toString());
 
         if (contextContainer.hasPermission(context.getUser(), AdminPermission.class))
         {
-            List<Pair<Domain, Map<DomainProperty, Object>>> domainInfos = getDomains(protocol);
-            if (!domainInfos.isEmpty())
+            List<Domain> domains = getDomains(protocol);
+            if (!domains.isEmpty())
             {
                 NavTree setDefaultsTree = new NavTree(SET_DEFAULT_VALUES_LINK);
-                AssayUrls urls = PageFlowUtil.urlProvider(AssayUrls.class);
-                for (Pair<Domain, Map<DomainProperty, Object>> domainInfo : domainInfos)
+                for (Domain domain : domains)
                 {
-                    Domain domain = domainInfo.getKey();
                     if (allowDefaultValues(domain) && !domain.getProperties().isEmpty())
                     {
-                        ActionURL url = urls.getSetDefaultValuesAssayURL(contextContainer, getName(), domain, context.getActionURL());
+                        ActionURL url = assayUrls.getSetDefaultValuesAssayURL(contextContainer, getName(), domain, context.getActionURL());
                         setDefaultsTree.addChild(domain.getName(), url);
                     }
                 }

--- a/api/src/org/labkey/api/assay/AssayDomainService.java
+++ b/api/src/org/labkey/api/assay/AssayDomainService.java
@@ -16,7 +16,6 @@
 
 package org.labkey.api.assay;
 
-import org.labkey.api.gwt.client.assay.AssayException;
 import org.labkey.api.gwt.client.assay.model.GWTProtocol;
 import org.labkey.api.query.ValidationException;
 

--- a/api/src/org/labkey/api/assay/AssayProvider.java
+++ b/api/src/org/labkey/api/assay/AssayProvider.java
@@ -163,7 +163,9 @@ public interface AssayProvider extends Handler<ExpProtocol>
 
     List<ParticipantVisitResolverType> getParticipantVisitResolverTypes();
 
-    List<Pair<Domain, Map<DomainProperty, Object>>> getDomains(ExpProtocol protocol);
+    @NotNull List<Domain> getDomains(ExpProtocol protocol);
+
+    @NotNull List<Pair<Domain, Map<DomainProperty, Object>>> getDomainsAndDefaultValues(ExpProtocol protocol);
 
     Pair<ExpProtocol, List<Pair<Domain, Map<DomainProperty, Object>>>> getAssayTemplate(User user, Container targetContainer);
 

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -232,11 +232,6 @@ public interface AssayService
      */
     <FlagType extends ExpQCFlag> List<FlagType> getFlags(AssayProvider provider, int runId, Class<FlagType> cls);
 
-    /**
-     * Returns the TableInfo for the given assay domain based on the assay domain ID.
-     */
-    TableInfo getTableInfoForDomainId(User user, Container container, int domainId, @Nullable ContainerFilter cf);
-
     void onBeforeAssayResultDelete(Container container, User user, ExpRun run, Map<String, Object> resultRow);
 
     /**

--- a/api/src/org/labkey/api/exp/property/AbstractDomainKind.java
+++ b/api/src/org/labkey/api/exp/property/AbstractDomainKind.java
@@ -53,11 +53,6 @@ import java.util.Set;
 import static org.labkey.api.exp.api.ExpData.DATA_INPUTS_PREFIX;
 import static org.labkey.api.exp.api.SampleTypeService.MATERIAL_INPUTS_PREFIX;
 
-/**
- * User: kevink
- * Date: Jun 4, 2010
- * Time: 3:29:46 PM
- */
 public abstract class AbstractDomainKind<T> extends DomainKind<T>
 {
     public static final String OBJECT_URI_COLUMN_NAME = "lsid";
@@ -181,10 +176,8 @@ public abstract class AbstractDomainKind<T> extends DomainKind<T>
             long nonBlankRows = new SqlSelector(ExperimentService.get().getSchema(), nonBlankRowsSQL).getRowCount();
             return totalRows != nonBlankRows;
         }
-        else
-        {
-            return false;
-        }
+
+        return false;
     }
 
     protected boolean getTotalAndNonBlankSql(Domain domain, DomainProperty prop, SQLFragment allRowsSQL, SQLFragment nonBlankRowsSQL)
@@ -205,7 +198,8 @@ public abstract class AbstractDomainKind<T> extends DomainKind<T>
 
             return true;
         }
-        else if (domain.getStorageTableName() != null)
+
+        if (domain.getStorageTableName() != null)
         {
             String table = domain.getStorageTableName();
             allRowsSQL.append("SELECT * FROM " + getStorageSchemaName() + "." + table);
@@ -224,12 +218,11 @@ public abstract class AbstractDomainKind<T> extends DomainKind<T>
                 nonBlankRowsSQL.append(mvColumn.getName().toLowerCase());
                 nonBlankRowsSQL.append(" IS NOT NULL");
             }
+
             return true;
         }
-        else
-        {
-            return false;
-        }
+
+        return false;
     }
 
     @Override
@@ -251,7 +244,6 @@ public abstract class AbstractDomainKind<T> extends DomainKind<T>
     {
         return DomainTemplate.findTemplate(domain.getTemplateInfo(), getKindName());
     }
-
 
     @Override
     public Set<String> getNonProvisionedTableNames()
@@ -315,10 +307,17 @@ public abstract class AbstractDomainKind<T> extends DomainKind<T>
     }
 
     @Override
+    @Nullable
     public List<String> getDomainNamePreviews(String schemaName, String queryName, Container container, User user)
     {
         String domainURI = PropertyService.get().getDomainURI(schemaName, queryName, container, user);
-        GWTDomain gwtDomain = DomainUtil.getDomainDescriptor(user, domainURI, container, true);
+        if (domainURI == null)
+            return null;
+
+        GWTDomain<?> gwtDomain = DomainUtil.getDomainDescriptor(user, domainURI, container, true);
+        if (gwtDomain == null)
+            return null;
+
         Domain domain = PropertyService.get().getDomain(container, gwtDomain.getDomainURI());
         if (null != domain && null != domain.getDomainKind())
         {

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -53,7 +53,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-abstract public class DomainKind<T>  implements Handler<String>
+abstract public class DomainKind<T> implements Handler<String>
 {
     abstract public String getKindName();
 
@@ -110,6 +110,7 @@ abstract public class DomainKind<T>  implements Handler<String>
      * @return set of strings containing the names. This will be compared ignoring case
      */
     abstract public Set<String> getReservedPropertyNames(Domain domain, User user);
+
     public Set<String> getReservedPropertyNames(Domain domain, User user, boolean forCreate)
     {
         return getReservedPropertyNames(domain, user);
@@ -256,19 +257,18 @@ abstract public class DomainKind<T>  implements Handler<String>
 
     /**
      * Default for all domain kinds is to not delete data. Lists and Datasets override this.
-     * @return
      */
     public boolean isDeleteAllDataOnFieldImport()
     {
         return false;
     }
 
-    public TableInfo getTableInfo(User user, Container container, String name, @Nullable ContainerFilter cf)
+    public @Nullable TableInfo getTableInfo(User user, Container container, String name, @Nullable ContainerFilter cf)
     {
         return null;
     }
 
-    public TableInfo getTableInfo(User user, Container container, Domain domain, @Nullable ContainerFilter cf)
+    public @Nullable TableInfo getTableInfo(User user, Container container, Domain domain, @Nullable ContainerFilter cf)
     {
         return getTableInfo(user, container, domain.getName(), cf);
     }
@@ -348,6 +348,7 @@ abstract public class DomainKind<T>  implements Handler<String>
     {
         return DefaultValueType.FIXED_EDITABLE;
     }
+
     public String getObjectUriColumnName()
     {
         return null;
@@ -385,14 +386,11 @@ abstract public class DomainKind<T>  implements Handler<String>
     }
 
     /**
-     * @param schemaName
-     * @param queryName
-     * @param container
-     * @param user
-     * @return  Return preview name(s) based on the name expression configured for the designer. For DataClass, up to one preview names is returned.
-     * For samples, up to 2 names can be returned, with the 1st one being the sample preview name and the 2nd being the aliquot preview name.
+     * @return Return preview name(s) based on the name expression configured for the designer. For DataClass,
+     * up to one preview names is returned. For samples, up to 2 names can be returned, with the 1st one being
+     * the sample preview name and the 2nd being the aliquot preview name.
      */
-    public List<String> getDomainNamePreviews(String schemaName, String queryName, Container container, User user)
+    public @Nullable List<String> getDomainNamePreviews(String schemaName, String queryName, Container container, User user)
     {
         return null;
     }

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -101,11 +101,6 @@ import static org.labkey.api.dataiterator.DetailedAuditLogDataIterator.AuditConf
 import static org.labkey.api.gwt.client.ui.PropertyType.CALCULATED_CONCEPT_URI;
 import static org.labkey.api.util.StringExpressionFactory.SUBSTITUTION_EXP_PATTERN;
 
-/**
- * User: jgarms
- * Date: Aug 12, 2008
- * Time: 3:44:30 PM
- */
 public class DomainUtil
 {
     private static final Logger LOG = LogManager.getLogger(DomainUtil.class);
@@ -228,7 +223,11 @@ public class DomainUtil
         DomainDescriptor dd = OntologyManager.getDomainDescriptor(typeURI, domainContainer);
         if (null == dd)
             return null;
+
         Domain domain = PropertyService.get().getDomain(dd.getDomainId());
+        if (domain == null)
+            return null;
+
         return getDomainDescriptor(domainContainer, user, domain, skipPKCol);
     }
 
@@ -253,49 +252,40 @@ public class DomainUtil
     @NotNull
     public static GWTDomain<GWTPropertyDescriptor> getDomainDescriptor(Container container, User user, @NotNull Domain domain, boolean skipPKCols)
     {
-        GWTDomain<GWTPropertyDescriptor> d = getDomain(domain);
-
-        ArrayList<GWTPropertyDescriptor> list = new ArrayList<>();
-
-        List<? extends DomainProperty> properties = domain.getProperties();
-
-        Map<DomainProperty, Object> defaultValues = DefaultValueService.get().getDefaultValues(container, domain);
-
-        DomainKind domainKind = domain.getDomainKind();
+        DomainKind<?> domainKind = domain.getDomainKind();
         if (domainKind == null)
-        {
             throw new IllegalStateException("Could not find a DomainKind for " + domain.getTypeURI());
-        }
 
-        Set<String> mandatoryProperties = new CaseInsensitiveHashSet(domainKind.getMandatoryPropertyNames(domain));
-
-        Map<String, Object> pkColMap = new HashMap<>();
         TableInfo tableInfo = null;
-        List<GWTPropertyDescriptor> calculatedFields = new ArrayList<>();
+        Set<String> pkColumnNames = Collections.emptySet();
+        List<GWTPropertyDescriptor> calculatedFields = Collections.emptyList();
+
+        // FIXME: This is not a good pattern and the flag is poorly named given the side-effects. It is rather adhoc
+        // what is included with this flag and can have a significant processing performance impact (which seems to be
+        // why it was introduced) depending on its value.
         if (!skipPKCols)
         {
             tableInfo = domainKind.getTableInfo(user, container, domain, null);
             if (null != tableInfo)
             {
-                // get PK columns
-                if (null != tableInfo.getPkColumns())
-                    pkColMap = tableInfo.getPkColumns().stream().collect(Collectors.toMap(ColumnInfo :: getColumnName, ColumnInfo :: isKeyField));
-
+                pkColumnNames = new CaseInsensitiveHashSet(tableInfo.getPkColumns().stream().map(ColumnInfo::getColumnName).collect(Collectors.toSet()));
                 calculatedFields = getCalculatedFieldsForTableInfo(tableInfo);
             }
         }
 
-        // Reuse defaultSchemas
+        ArrayList<GWTPropertyDescriptor> fields = new ArrayList<>();
         Map<Container, DefaultSchema> lookupDefaultSchemaMap = null;
+        Map<DomainProperty, Object> defaultValues = DefaultValueService.get().getDefaultValues(container, domain);
+        CaseInsensitiveHashSet mandatoryProperties = new CaseInsensitiveHashSet(domainKind.getMandatoryPropertyNames(domain));
 
-        for (DomainProperty prop : properties)
+        for (DomainProperty prop : domain.getProperties())
         {
-            GWTPropertyDescriptor p = getPropertyDescriptor(prop);
+            GWTPropertyDescriptor field = getPropertyDescriptor(prop);
 
             Object defaultValue = defaultValues.get(prop);
             String formattedDefaultValue = getFormattedDefaultValue(user, prop, defaultValue);
-            p.setDefaultDisplayValue(formattedDefaultValue);
-            p.setDefaultValue(ConvertUtils.convert(defaultValue));
+            field.setDefaultDisplayValue(formattedDefaultValue);
+            field.setDefaultValue(ConvertUtils.convert(defaultValue));
 
             // Set valid lookup flag for display in UI
             if (prop.getLookup() != null)
@@ -303,80 +293,84 @@ public class DomainUtil
                 if (null == lookupDefaultSchemaMap)
                     lookupDefaultSchemaMap = new HashMap<>();
 
-                p.setLookupIsValid(isValidPdLookup(user, container, p, lookupDefaultSchemaMap));
+                field.setLookupIsValid(isValidPdLookup(user, container, field, lookupDefaultSchemaMap));
             }
 
             //set property as PK
-            if (pkColMap.containsKey(p.getName()))
+            if (pkColumnNames.contains(field.getName()))
             {
-                p.setIsPrimaryKey(true);
+                field.setIsPrimaryKey(true);
             }
 
             //partially lock mandatory properties (ex. for issues, specimen domains)
-            if (mandatoryProperties.contains(p.getName()))
+            if (mandatoryProperties.contains(field.getName()))
             {
-                p.setLockType(LockedPropertyType.PartiallyLocked.name());
+                field.setLockType(LockedPropertyType.PartiallyLocked.name());
             }
 
             //fully lock shared columns or columns not in the same container (ex. for dataset domain)
-            if (!p.getContainer().equalsIgnoreCase(container.getId()))
+            if (!field.getContainer().equalsIgnoreCase(container.getId()))
             {
-                p.setLockType(LockedPropertyType.FullyLocked.name());
+                field.setLockType(LockedPropertyType.FullyLocked.name());
             }
 
-            list.add(p);
+            fields.add(field);
         }
 
         // add calculated columns to the list of properties
-        list.addAll(calculatedFields);
+        fields.addAll(calculatedFields);
 
-        d.setFields(list);
+        GWTDomain<GWTPropertyDescriptor> gwtDomain = getDomain(domain);
+        gwtDomain.setFields(fields);
 
         // Handle reserved property names
         Set<String> reservedProperties = domainKind.getReservedPropertyNames(domain, user);
-        d.setReservedFieldNames(new CaseInsensitiveHashSet(reservedProperties));
-        d.setReservedFieldNamePrefixes(domainKind.getReservedPropertyNamePrefixes());
-        d.setMandatoryFieldNames(new CaseInsensitiveHashSet(mandatoryProperties));
-        d.setExcludeFromExportFieldNames(new CaseInsensitiveHashSet(domainKind.getAdditionalProtectedPropertyNames(domain)));
-        d.setProvisioned(domain.isProvisioned());
-        d.setDefaultValueOptions(domainKind.getDefaultValueOptions(domain), domainKind.getDefaultDefaultType(domain));
+        gwtDomain.setReservedFieldNames(new CaseInsensitiveHashSet(reservedProperties));
+        gwtDomain.setReservedFieldNamePrefixes(domainKind.getReservedPropertyNamePrefixes());
+        gwtDomain.setMandatoryFieldNames(mandatoryProperties);
+        gwtDomain.setExcludeFromExportFieldNames(new CaseInsensitiveHashSet(domainKind.getAdditionalProtectedPropertyNames(domain)));
+        gwtDomain.setProvisioned(domain.isProvisioned());
+        gwtDomain.setDefaultValueOptions(domainKind.getDefaultValueOptions(domain), domainKind.getDefaultDefaultType(domain));
 
-        d.setSchemaName(domainKind.getMetaDataSchemaName());
-        d.setQueryName(domainKind.getMetaDataTableName());
-        d.setDomainKindName(domainKind.getKindName());
+        gwtDomain.setSchemaName(domainKind.getMetaDataSchemaName());
+        gwtDomain.setQueryName(domainKind.getMetaDataTableName());
+        gwtDomain.setDomainKindName(domainKind.getKindName());
         if (null != domain.getTemplateInfo())
         {
             TemplateInfo t = domain.getTemplateInfo();
-            d.setTemplateDescription(t.getModuleName() + ": " + t.getTemplateGroupName() + "#" + t.getTableName());
+            gwtDomain.setTemplateDescription(t.getModuleName() + ": " + t.getTemplateGroupName() + "#" + t.getTableName());
         }
 
         // if not set via domain kind, provide the public schemaName and queryName for the domain
-        if (d.getSchemaName() == null && d.getQueryName() == null && tableInfo != null)
+        if (gwtDomain.getSchemaName() == null && gwtDomain.getQueryName() == null && tableInfo != null)
         {
-            d.setSchemaName(tableInfo.getPublicSchemaName());
-            d.setQueryName(tableInfo.getPublicName());
+            gwtDomain.setSchemaName(tableInfo.getPublicSchemaName());
+            gwtDomain.setQueryName(tableInfo.getPublicName());
         }
 
-        d.setDisabledSystemFields(domain.getDisabledSystemFields());
+        gwtDomain.setDisabledSystemFields(domain.getDisabledSystemFields());
 
         if (domainKind.allowUniqueConstraintProperties())
         {
             SchemaTableInfo schemaTableInfo = StorageProvisioner.get().getSchemaTableInfo(domain);
             Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> allIndices = schemaTableInfo.getAllIndices();
-            if (allIndices.size() > 0)
+            if (!allIndices.isEmpty())
             {
-                List<Pair<TableInfo.IndexType, List<ColumnInfo>>> indices = allIndices.values().stream().filter(index -> !index.getKey().equals(TableInfo.IndexType.Primary)).toList();
-                d.setIndices(indices.stream().map(index -> new GWTIndex(index.getValue().stream().map(ColumnInfo::getColumnName).toList(), index.getKey().isUnique())).toList());
+                List<GWTIndex> indices = allIndices.values().stream()
+                        .filter(index -> !index.getKey().equals(TableInfo.IndexType.Primary))
+                        .map(index -> new GWTIndex(index.getValue().stream().map(ColumnInfo::getColumnName).toList(), index.getKey().isUnique()))
+                        .toList();
+
+                gwtDomain.setIndices(indices);
             }
         }
 
-        return d;
+        return gwtDomain;
     }
 
     // get calculated fields (i.e. those with value expressions) for a tableInfo from the related XML metadata
-    private static List<GWTPropertyDescriptor> getCalculatedFieldsForTableInfo(@NotNull TableInfo tableInfo)
+    private static @NotNull List<GWTPropertyDescriptor> getCalculatedFieldsForTableInfo(@NotNull TableInfo tableInfo)
     {
-
         ArrayList<QueryException> errors = new ArrayList<>();
         Collection<TableType> metadata = QueryService.get().findMetadataOverride(tableInfo.getUserSchema(), tableInfo.getName(), false, false, errors, null);
         if (metadata == null)
@@ -454,7 +448,7 @@ public class DomainUtil
         return gwtDomain;
     }
 
-    public static GWTDomain<GWTPropertyDescriptor> getTemplateDomainForDomainKind(DomainKind kind)
+    public static GWTDomain<GWTPropertyDescriptor> getTemplateDomainForDomainKind(DomainKind<?> kind)
     {
         GWTDomain<GWTPropertyDescriptor> gwtDomain = new GWTDomain<>();
         gwtDomain.setDomainKindName(kind.getKindName());

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -111,7 +111,6 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         return _description;
     }
 
-
     public void setRestricted(boolean restricted)
     {
         _restricted = restricted;
@@ -126,20 +125,17 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
                getContainer().hasPermission(getName() + ".canReadSchema()", user, InsertPermission.class);
     }
 
-
     public void checkCanReadSchema() throws UnauthorizedException
     {
         if (!canReadSchema())
             throw new UnauthorizedException("User cannot read schema: " + getName());
     }
 
-
     /* does user have access to cubes associated with this schema */
     public void checkCanReadSchemaOlap() throws UnauthorizedException
     {
         checkCanReadSchema();
     }
-
 
     public void checkCanExecuteMDX() throws UnauthorizedException
     {
@@ -369,12 +365,6 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
     public List<TableInfo> getSortedTables()
     {
         return TableSorter.sort(this);
-    }
-
-    @Override
-    public Container getContainer()
-    {
-        return _container;
     }
 
     /** Returns a SchemaKey encoded name for this schema. */
@@ -826,7 +816,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
     {
         Container permissionContainer = rowContainer.getContainerFor(ContainerType.DataType.permissions);
 
-        // If a row supplies an alternate container, it is possible that permisions differ.  TableInfo can supply custom permissions.
+        // If a row supplies an alternate container, it is possible that permissions differ.  TableInfo can supply custom permissions.
         // If the effective permission container for the row-level container is actually the same as the original table (which is currently always true, such as Workbook->Parent,
         // then just defer to the original TableInfo.  If this is not the case, attempt to construct a new TableInfo and fail if we cannot do this.
         boolean hasPermission = false;
@@ -867,9 +857,9 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
      * those scenario.  It is up to the caller to ensure proper caching when ContainerFilter may differ.  The
      * suggested way to do that is to call ContainerFilter.getCacheKey().
      *
-     * Importantly, the key should reflect all the properties that affect how this table is created (e.g. additional filters, etc).
+     * Importantly, the key should reflect all the properties that affect how this table is created (e.g. additional filters, etc.).
      */
-    private Map<String,TableInfo> tableInfoCache = Collections.synchronizedMap(new CaseInsensitiveHashMap<TableInfo>());
+    private final Map<String,TableInfo> tableInfoCache = Collections.synchronizedMap(new CaseInsensitiveHashMap<>());
 
     public TableInfo getCachedLookupTableInfo(String key, Callable<TableInfo> call)
     {

--- a/assay/api-src/org/labkey/api/assay/AssayDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayDomainKind.java
@@ -33,7 +33,6 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.BaseAbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
-import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.gwt.client.model.GWTDomain;
@@ -50,14 +49,8 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.writer.ContainerUser;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-/**
- * User: brittp
- * Date: June 25, 2007
- * Time: 1:01:43 PM
- */
 public abstract class AssayDomainKind extends BaseAbstractDomainKind
 {
     private final String _namespacePrefix;
@@ -142,7 +135,7 @@ public abstract class AssayDomainKind extends BaseAbstractDomainKind
         return new SQLFragment("NULL");
     }
 
-    protected ExpProtocol findProtocol(Domain domain)
+    protected @Nullable ExpProtocol findProtocol(Domain domain)
     {
         Pair<AssayProvider, ExpProtocol> pair = findProviderAndProtocol(domain);
         if (pair == null)
@@ -160,41 +153,39 @@ public abstract class AssayDomainKind extends BaseAbstractDomainKind
             AssayProvider provider = AssayService.get().getProvider(protocol);
             if (provider != null)
             {
-                for (Pair<Domain, Map<DomainProperty, Object>> protocolDomain : provider.getDomains(protocol))
+                for (Domain protocolDomain : provider.getDomains(protocol))
                 {
-                    if (protocolDomain.getKey().getTypeURI().equals(domain.getTypeURI()))
+                    if (protocolDomain.getTypeURI().equals(domain.getTypeURI()))
                     {
                         return Pair.of(provider, protocol);
                     }
                 }
             }
         }
+
         return null;
     }
 
-
     @Override
+    @Nullable
     public ActionURL urlShowData(Domain domain, ContainerUser containerUser)
     {
         ExpProtocol protocol = findProtocol(domain);
-        if (protocol != null)
-        {
-            return PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(containerUser.getContainer(), protocol);
-        }
-        return null;
-    }
+        if (protocol == null)
+            return null;
 
+        return PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(containerUser.getContainer(), protocol);
+    }
 
     @Override
     @Nullable
     public ActionURL urlEditDefinition(Domain domain, ContainerUser containerUser)
     {
         ExpProtocol protocol = findProtocol(domain);
-        if (protocol != null)
-        {
-            return PageFlowUtil.urlProvider(AssayUrls.class).getDesignerURL(containerUser.getContainer(), protocol, false, null);
-        }
-        return null;
+        if (protocol == null)
+            return null;
+
+        return PageFlowUtil.urlProvider(AssayUrls.class).getDesignerURL(containerUser.getContainer(), protocol, false, null);
     }
 
     @Override
@@ -243,7 +234,33 @@ public abstract class AssayDomainKind extends BaseAbstractDomainKind
     @Override
     public TableInfo getTableInfo(User user, Container container, Domain domain, @Nullable ContainerFilter cf)
     {
-        return AssayService.get().getTableInfoForDomainId(user, container, domain.getTypeId(), cf);
+        if (domain == null)
+            return null;
+
+        Pair<AssayProvider, ExpProtocol> providerAndProtocol = findProviderAndProtocol(domain);
+        if (providerAndProtocol == null)
+            return null;
+
+        AssayProvider provider = providerAndProtocol.first;
+        ExpProtocol protocol = providerAndProtocol.second;
+
+        AssayProtocolSchema schema = provider.createProtocolSchema(user, container, protocol, null);
+        for (var tableName : schema.getTableNames())
+        {
+            // First, fetch a table that is more likely to be cached
+            var table = schema.getTable(tableName);
+            if (table != null)
+            {
+                var tableDomain = table.getDomain();
+                if (tableDomain != null && tableDomain.getTypeURI().equals(domain.getTypeURI()))
+                {
+                    // Now that we have a matching table fetch the more expensive table with extra metadata
+                    return schema.getTable(tableName, cf, true, true);
+                }
+            }
+        }
+
+        return null;
     }
 
     @Override
@@ -252,10 +269,11 @@ public abstract class AssayDomainKind extends BaseAbstractDomainKind
         if (perm == ReadPermission.class)
         {
             Set<Role> roles = null;
-            if (userSchema instanceof UserSchema.HasContextualRoles)
-                roles = ((UserSchema.HasContextualRoles) userSchema).getContextualRoles();
+            if (userSchema instanceof UserSchema.HasContextualRoles schemaWithRoles)
+                roles = schemaWithRoles.getContextualRoles();
             return userSchema.getContainer().hasPermission(user, AssayReadPermission.class, roles);
         }
+
         return super.hasPermission(user, perm, userSchema);
     }
 }

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -307,9 +307,9 @@ public class AssayController extends SpringActionController
         {
             if (_id != null && protocol.getRowId() != _id.intValue())
                 return false;
-            if (_name != null && !_name.equals(protocol.getName()))
+            if (_name != null && !_name.equalsIgnoreCase(protocol.getName()))
                 return false;
-            if (_type != null && !_type.equals(provider.getName()))
+            if (_type != null && !_type.equalsIgnoreCase(provider.getName()))
                 return false;
             if (_status != null && !_status.equalsIgnoreCase(protocol.getStatus().name()))
                 return false;

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -390,10 +390,10 @@ public class AssayController extends SpringActionController
         }
 
         Map<String, List<Map<String, Object>>> domains = new HashMap<>();
-        for (Pair<Domain, Map<DomainProperty, Object>> domain : provider.getDomains(protocol))
+        for (Domain domain : provider.getDomains(protocol))
         {
-            TableInfo table = tableInfoMap.get(domain.getKey().getTypeURI());
-            domains.put(domain.getKey().getName(), serializeDomain(domain.getKey(), table, user));
+            TableInfo table = tableInfoMap.get(domain.getTypeURI());
+            domains.put(domain.getName(), serializeDomain(domain, table, user));
         }
 
         Map<ExpProtocol.AssayDomainTypes, String> domainTypes = new EnumMap<>(ExpProtocol.AssayDomainTypes.class);

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -411,7 +411,8 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                         }
                         else
                         {
-                            updateDomainDescriptor(domain, protocol, assayProvider, false);
+                            GWTDomain<GWTPropertyDescriptor> previous = DomainUtil.getDomainDescriptor(getUser(), domain.getDomainURI(), protocol.getContainer());
+                            updateDomainDescriptor(domain, protocol, previous, assayProvider, false);
                             domainURIs.add(domain.getDomainURI());
                         }
 
@@ -566,7 +567,8 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
 
                 for (GWTDomain<GWTPropertyDescriptor> domain : assay.getDomains())
                 {
-                    GWTDomain<GWTPropertyDescriptor> previous = updateDomainDescriptor(domain, protocol, provider, hasNameChange);
+                    GWTDomain<GWTPropertyDescriptor> previous = DomainUtil.getDomainDescriptor(getUser(), domain.getDomainURI(), protocol.getContainer());
+                    updateDomainDescriptor(domain, protocol, previous, provider, hasNameChange);
                     boolean hasExistingCalcFields = previous != null && !previous.getCalculatedFields().isEmpty();
 
                     GWTDomain<GWTPropertyDescriptor> savedDomain = DomainUtil.getDomainDescriptor(getUser(), domain.getDomainURI(), protocol.getContainer());
@@ -593,9 +595,14 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
         }
     }
 
-    private GWTDomain<GWTPropertyDescriptor> updateDomainDescriptor(GWTDomain<GWTPropertyDescriptor> domain, ExpProtocol protocol, AssayProvider provider, boolean hasNameChange) throws ValidationException
+    private void updateDomainDescriptor(
+        GWTDomain<GWTPropertyDescriptor> domain,
+        ExpProtocol protocol,
+        GWTDomain<GWTPropertyDescriptor> previous,
+        AssayProvider provider,
+        boolean hasNameChange
+    ) throws ValidationException
     {
-        GWTDomain<GWTPropertyDescriptor> previous = DomainUtil.getDomainDescriptor(getUser(), domain.getDomainURI(), protocol.getContainer());
         for (GWTPropertyDescriptor prop : domain.getFields())
         {
             if (prop.getLookupQuery() != null)
@@ -614,8 +621,6 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
         ValidationException domainErrors = DomainUtil.updateDomainDescriptor(previous, domain, getContainer(), getUser(), hasNameChange, auditComment);
         if (domainErrors.hasErrors())
             throw domainErrors;
-
-        return previous;
     }
 
     private boolean canUpdateProtocols()

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -107,7 +107,7 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                 if (copy)
                     assayInfo = provider.getAssayTemplate(getUser(), getContainer(), protocol);
                 else
-                    assayInfo = new Pair<>(protocol, provider.getDomains(protocol));
+                    assayInfo = new Pair<>(protocol, provider.getDomainsAndDefaultValues(protocol));
                 return getAssayTemplate(provider, assayInfo, copy);
             }
         }
@@ -151,7 +151,7 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
             gwtDomain.setProvisioned(domain.isProvisioned());
             gwtDomains.add(gwtDomain);
 
-            DomainKind kind = domain.getDomainKind();
+            DomainKind<?> kind = domain.getDomainKind();
 
             List<GWTPropertyDescriptor> gwtProps = new ArrayList<>();
             List<? extends DomainProperty> properties = domain.getProperties();
@@ -212,14 +212,14 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
             gwtProtocolParams.put(property.getOntologyEntryURI(), property.getStringValue());
         }
         result.setProtocolParameters(gwtProtocolParams);
-        if (provider instanceof PlateBasedAssayProvider)
+        if (provider instanceof PlateBasedAssayProvider plateProvider)
         {
-            Plate plateTemplate = ((PlateBasedAssayProvider)provider).getPlate(getContainer(), protocol);
+            Plate plateTemplate = plateProvider.getPlate(getContainer(), protocol);
             if (plateTemplate != null)
                 result.setSelectedPlateTemplate(plateTemplate.getName());
             setPlateTemplateList(provider, result);
 
-            SampleMetadataInputFormat[] formats = ((PlateBasedAssayProvider) provider).getSupportedMetadataInputFormats();
+            SampleMetadataInputFormat[] formats = plateProvider.getSupportedMetadataInputFormats();
             if (formats.length > 1)
             {
                 Map<String, String> metadataFormats = new LinkedHashMap<>();
@@ -237,11 +237,10 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                 result.setAvailableMetadataInputFormats(metadataFormats);
                 result.setMetadataInputFormatHelp(sbHelp.toString());
             }
-            result.setSelectedMetadataInputFormat(((PlateBasedAssayProvider)provider).getMetadataInputFormat(protocol).name());
+            result.setSelectedMetadataInputFormat(plateProvider.getMetadataInputFormat(protocol).name());
         }
-        if (provider instanceof DetectionMethodAssayProvider)
+        if (provider instanceof DetectionMethodAssayProvider dmProvider)
         {
-            DetectionMethodAssayProvider dmProvider = (DetectionMethodAssayProvider)provider;
             String method = dmProvider.getSelectedDetectionMethod(getContainer(), protocol);
             if (method != null)
                 result.setSelectedDetectionMethod(method);
@@ -301,9 +300,9 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
         result.setAllowPlateMetadata(provider.supportsPlateMetadata(protocol));
 
         boolean supportsFlag = provider.supportsFlagColumnType(ExpProtocol.AssayDomainTypes.Result);
-        for (GWTDomain d : result.getDomains())
-            if (d.getDomainURI().contains(":" + ExpProtocol.AssayDomainTypes.Result.getPrefix() + "."))
-                d.setAllowFlagProperties(supportsFlag);
+        for (GWTDomain<?> gwtDomain : result.getDomains())
+            if (gwtDomain.getDomainURI().contains(":" + ExpProtocol.AssayDomainTypes.Result.getPrefix() + "."))
+                gwtDomain.setAllowFlagProperties(supportsFlag);
 
         return result;
     }
@@ -400,11 +399,11 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                     assay.setProtocolId(protocol.getRowId());
 
                     Set<String> domainURIs = new HashSet<>();
-                    for (GWTDomain domain : assay.getDomains())
+                    for (GWTDomain<GWTPropertyDescriptor> domain : assay.getDomains())
                     {
                         domain.setDomainURI(LsidUtils.resolveLsidFromTemplate(domain.getDomainURI(), context));
                         domain.setName(assay.getName() + " " + domain.getName());
-                        GWTDomain<GWTPropertyDescriptor> gwtDomain = DomainUtil.getDomainDescriptor(getUser(), domain.getDomainURI(), getContainer());
+                        GWTDomain<GWTPropertyDescriptor> gwtDomain = DomainUtil.getDomainDescriptor(getUser(), domain.getDomainURI(), getContainer(), true);
                         if (gwtDomain == null)
                         {
                             Domain newDomain = DomainUtil.createDomain(PropertyService.get().getDomainKind(domain.getDomainURI()).getKindName(), domain, null, getContainer(), getUser(), domain.getName(), null);
@@ -412,11 +411,7 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                         }
                         else
                         {
-                            ValidationException domainErrors = updateDomainDescriptor(domain, protocol, assayProvider, false);
-                            if (domainErrors.hasErrors())
-                            {
-                                throw domainErrors;
-                            }
+                            updateDomainDescriptor(domain, protocol, assayProvider, false);
                             domainURIs.add(domain.getDomainURI());
                         }
 
@@ -571,15 +566,8 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
 
                 for (GWTDomain<GWTPropertyDescriptor> domain : assay.getDomains())
                 {
-                    GWTDomain<GWTPropertyDescriptor> previous = DomainUtil.getDomainDescriptor(getUser(), domain.getDomainURI(), protocol.getContainer());
+                    GWTDomain<GWTPropertyDescriptor> previous = updateDomainDescriptor(domain, protocol, provider, hasNameChange);
                     boolean hasExistingCalcFields = previous != null && !previous.getCalculatedFields().isEmpty();
-
-                    ValidationException domainErrors = updateDomainDescriptor(domain, protocol, provider, hasNameChange);
-
-                    // Need to bail out inside of the loop because some errors may have left the DB connection in
-                    // an unusable state.
-                    if (domainErrors.hasErrors())
-                        throw domainErrors;
 
                     GWTDomain<GWTPropertyDescriptor> savedDomain = DomainUtil.getDomainDescriptor(getUser(), domain.getDomainURI(), protocol.getContainer());
                     QueryService.get().saveCalculatedFieldsMetadata(savedDomain.getSchemaName(), savedDomain.getQueryName(), null, domain.getCalculatedFields(), hasExistingCalcFields, getUser(), protocol.getContainer());
@@ -605,7 +593,7 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
         }
     }
 
-    private ValidationException updateDomainDescriptor(GWTDomain<GWTPropertyDescriptor> domain, ExpProtocol protocol, AssayProvider provider, boolean hasNameChange)
+    private GWTDomain<GWTPropertyDescriptor> updateDomainDescriptor(GWTDomain<GWTPropertyDescriptor> domain, ExpProtocol protocol, AssayProvider provider, boolean hasNameChange) throws ValidationException
     {
         GWTDomain<GWTPropertyDescriptor> previous = DomainUtil.getDomainDescriptor(getUser(), domain.getDomainURI(), protocol.getContainer());
         for (GWTPropertyDescriptor prop : domain.getFields())
@@ -623,7 +611,11 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
             auditComment = "The name of the assay domain '" + previous.getName() + "' was changed to '" + domain.getName() + "'.";
         }
 
-        return DomainUtil.updateDomainDescriptor(previous, domain, getContainer(), getUser(), hasNameChange, auditComment);
+        ValidationException domainErrors = DomainUtil.updateDomainDescriptor(previous, domain, getContainer(), getUser(), hasNameChange, auditComment);
+        if (domainErrors.hasErrors())
+            throw domainErrors;
+
+        return previous;
     }
 
     private boolean canUpdateProtocols()

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -422,24 +422,6 @@ public class AssayManager implements AssayService
     }
 
     @Override
-    public TableInfo getTableInfoForDomainId(User user, Container container, int domainId, @Nullable ContainerFilter cf)
-    {
-        for (ExpProtocol protocol : getAssayProtocols(container))
-        {
-            AssayProvider provider = getProvider(protocol);
-            AssayProtocolSchema schema = provider.createProtocolSchema(user, container, protocol, null);
-            for (String tableName : schema.getTableNames())
-            {
-                TableInfo table = schema.getTable(tableName, cf, true, true);
-                if (table != null && table.getDomain() != null && table.getDomain().getTypeId() == domainId)
-                    return table;
-            }
-        }
-
-        return null;
-    }
-
-    @Override
     public void onBeforeAssayResultDelete(Container container, User user, ExpRun run, Map<String, Object> resultRow)
     {
         for (AssayListener listener : _listeners)

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -34,7 +34,6 @@ import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
@@ -100,28 +99,10 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
 
     // For serialization
     protected ExpMaterialImpl() {}
-    
+
     public ExpMaterialImpl(Material material)
     {
         super(material);
-    }
-
-    @Override
-    public void setName(String name)
-    {
-        super.setName(name);
-    }
-
-    @Override
-    public void setLSID(String lsid)
-    {
-        super.setLSID(lsid);
-    }
-
-    @Override
-    public void setLSID(Lsid lsid)
-    {
-        super.setLSID(lsid);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
When attempting to resolve a `TableInfo` from a `Domain` for the `AssayDomainKind` we currently iterate over all the assay definitions in a container and for each provider we call `provider.createProtocolSchema()` and then hydrate full `TableInfo` instances until we find a match.

This refactors the approach to first resolve the singularly desired provider and only induce the `provider.createProtocolSchema()` call for that provider to then resolve the `TableInfo`.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1645
- https://github.com/LabKey/labkey-ui-premium/pull/599
- https://github.com/LabKey/platform/pull/6057
- https://github.com/LabKey/limsModules/pull/919
- https://github.com/LabKey/commonAssays/pull/822

#### Changes
- Refactor away `AssayManager.getTableInfoForDomainId()` by directly resolving the assay protocol/provider in `AssayDomainKind.getTableInfo()` and then instantiating a new schema for only that assay.
- Separate `AbstractAssayProvider.getDomains()` into `getDomains()` and `getDomainsAndDefaultValues()` to make `getDomains()` more clear in its role and what it will return (i.e. a `List<Domain>` rather than a `List<Pair<Domain, Map<DomainProperty, Object>>>`)
- Update `assay-assayList.api` matching on protocol "name" and provider "type" to be case-insensitive.
- Add null checks
