### PR TITLE
remove call to FileUtil.stringToPath()

### DIFF
--- a/filecontent/src/org/labkey/filecontent/FileContentController.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentController.java
@@ -1260,8 +1260,7 @@ public class FileContentController extends SpringActionController
                 Map<FieldKey, Object> data = result.getFieldKeyRowMap();
                 Map<String, Object> row = new HashMap<>();
 
-                java.nio.file.Path dataFilePath = FileUtil.stringToPath(getContainer(), (String) data.get(dataFileURLFieldKey));
-                row.put("dataFileUrl", null != dataFilePath ? FileUtil.pathToString(dataFilePath) : null);
+                row.put("dataFileUrl", data.get(dataFileURLFieldKey));
                 row.put("rowId", data.get(rowIdFieldKey));
                 row.put("name", data.get(nameFieldKey));
 


### PR DESCRIPTION
#### Rationale
FileUtil.stringToPath() is returning null on s3: urls.  I'm not sure why (because they don't have account name?).
This breaks extended properties in the file browser.

I'm not sure why we don't pass the dataFileUrl from exp.data as is? 

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
