### PR TITLE
Support long database names in PostgreSQL 17.x

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -368,6 +368,21 @@ public class DbScope
             _dialect = SqlDialectManager.getFromDriverClassname(_dsName, _driverClassName);
             MemTracker.get().remove(_dialect);
             _driverClass = initializeDriver();
+
+            if (_dialect.isPostgreSQL())
+            {
+                // Starting with PostgreSQL 17.x, we can't connect with a database name longer than 63 chars, so we have
+                // to truncate and replace the URL in the DataSource. Yuck. Issue #51676.
+                String url = _dsPropertyReader.getUrl();
+                String name = _dialect.getDatabaseName(url);
+                if (name.length() > _dialect.getIdentifierMaxLength())
+                {
+                    String truncated = StringUtils.truncate(name, _dialect.getIdentifierMaxLength());
+                    String newUrl = url.replace(name, truncated);
+                    _dsPropertyReader.setUrl(newUrl);
+                }
+            }
+
             _url = _dsPropertyReader.getUrl();
 
             // Validate that data source is using a supported connection pool

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -368,22 +368,19 @@ public class DbScope
             _dialect = SqlDialectManager.getFromDriverClassname(_dsName, _driverClassName);
             MemTracker.get().remove(_dialect);
             _driverClass = initializeDriver();
+            _url = _dsPropertyReader.getUrl();
 
             if (_dialect.isPostgreSQL())
             {
-                // Starting with PostgreSQL 17.x, we can't connect with a database name longer than 63 chars, so we have
-                // to truncate and replace the URL in the DataSource. Yuck. Issue #51676.
-                String url = _dsPropertyReader.getUrl();
-                String name = _dialect.getDatabaseName(url);
-                if (name.length() > _dialect.getIdentifierMaxLength())
-                {
-                    String truncated = StringUtils.truncate(name, _dialect.getIdentifierMaxLength());
-                    String newUrl = url.replace(name, truncated);
-                    _dsPropertyReader.setUrl(newUrl);
-                }
-            }
+                // Starting with 17.x, PostgreSQL won't connect to a database name longer than 63 chars, but it fails
+                // with a misleading message, so we proactively look for this and throw. Issue #51676.
+                String name = _dialect.getDatabaseName(_url);
 
-            _url = _dsPropertyReader.getUrl();
+                // This isn't ideal because the dialect isn't versioned to the database. But if we can't connect we
+                // don't know what database version is there.
+                if (name.length() > _dialect.getIdentifierMaxLength())
+                    throw new ConfigurationException("Database name \"" + name + "\" in DataSource \"" + dsName + "\" exceeds the maximum identifier length");
+            }
 
             // Validate that data source is using a supported connection pool
             validateConnectionPool();
@@ -1760,20 +1757,6 @@ public class DbScope
         // Attempt a connection three times before giving up
         for (int i = 0; i < 3; i++)
         {
-            if (i > 0)
-            {
-                LOG.warn("Retrying connection to \"{}\" at {} in 10 seconds", ds.getDsName(), ds.getUrl());
-
-                try
-                {
-                    Thread.sleep(10000);  // Wait 10 seconds before trying again
-                }
-                catch (InterruptedException e)
-                {
-                    LOG.warn("ensureDataBase", e);
-                }
-            }
-
             // Create non-pooled connection... don't want to pool a failed connection
             try (Connection conn = getRawConnection(ds.getUrl(), ds))
             {
@@ -1798,6 +1781,20 @@ public class DbScope
                     LOG.warn("Connection to \"{}\" at {} failed with the following error:", ds.getDsName(), ds.getUrl());
                     LOG.warn("Message: {} SQLState: {} ErrorCode: {}", e.getMessage(), e.getSQLState(), e.getErrorCode(), e);
                     lastException = e;
+
+                    if (i < 2)
+                    {
+                        LOG.warn("Retrying connection to \"{}\" at {} in 10 seconds", ds.getDsName(), ds.getUrl());
+
+                        try
+                        {
+                            Thread.sleep(10000);  // Wait 10 seconds before trying again
+                        }
+                        catch (InterruptedException ie)
+                        {
+                            LOG.warn("ensureDataBase", ie);
+                        }
+                    }
                 }
             }
             catch (Exception e)

--- a/api/src/org/labkey/api/data/LookupColumn.java
+++ b/api/src/org/labkey/api/data/LookupColumn.java
@@ -24,10 +24,8 @@ import org.labkey.api.query.RowIdForeignKey;
 import org.labkey.api.util.Pair;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A {@link org.labkey.api.data.ColumnInfo} that is part of a lookup target. This implementation knows
@@ -133,7 +131,7 @@ public class LookupColumn extends BaseColumnInfo
         _joinType = joinType;
         setSqlTypeName(lookupColumn.getSqlTypeName());
         String alias = foreignKey.getAlias() + "$" + lookupColumn.getAlias();
-        int maxLength = lookupColumn.getSqlDialect().getIdentifierMaxLength();
+        int maxLength = lookupColumn.getSqlDialect().getIdentifierMaxLength() - 3; // Leave room for "$" and possible suffixes
         if (alias.length() > maxLength)
             alias = AliasManager.truncate(foreignKey.getAlias(),maxLength/2) + "$" + AliasManager.truncate(lookupColumn.getAlias(),maxLength/2);
         setAlias(alias);
@@ -282,7 +280,7 @@ public class LookupColumn extends BaseColumnInfo
     {
         String alias = baseAlias + (baseAlias.endsWith("$")?"":"$") + fkAlias + "$";
 
-        alias = AliasManager.truncate(alias, dialect.getIdentifierMaxLength());
+        alias = AliasManager.truncate(alias, dialect.getIdentifierMaxLength() - 3 /* leave room for possible suffixes */);
         return alias;
     }
 

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -637,8 +637,7 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     {
         // This will handle both mixed case and special characters on PostgreSQL
         String legal = getSelectNameFromMetaDataName(dbName);
-        return "CREATE DATABASE " + legal + " WITH ENCODING 'UTF8';\n" +
-                "ALTER DATABASE " + legal + " SET default_with_oids TO OFF";
+        return "CREATE DATABASE " + legal + " WITH ENCODING 'UTF8'";
     }
 
     @Override

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -1346,20 +1346,6 @@ public abstract class SqlDialect
                 return null;
             }
         }
-
-        public void setUrl(String url) throws ServletException
-        {
-            String methodName = "setUrl";
-            try
-            {
-                Method method = _ds.getClass().getMethod(methodName, String.class);
-                method.invoke(_ds, url);
-            }
-            catch (Exception e)
-            {
-                throw new ServletException("Unable to set DataSource property via " + methodName, e);
-            }
-        }
     }
 
     // All statement creation passes through these two methods. We return our standard statement wrappers in most

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -958,11 +958,13 @@ public abstract class SqlDialect
             throw new IllegalStateException(getProductName() + " reserved words are not all in the keyword candidate list (sqlKeywords.txt). See log for details.");
     }
 
+    /**
+     * @return The absolute maximum length for this database. Callers are responsible for truncating generated names,
+     * handing suffixes, etc.
+     */
     public int getIdentifierMaxLength()
     {
-        // 63 probably works, but save 2 chars for appending chars to
-        // create aliases for extra tables used in the lookup (e.g. junctionAlias = getTableAlias() + "_j")
-        return 61;
+        return 63;
     }
 
     protected SQLFragment getIdentifierTestSql(String candidate)
@@ -1342,6 +1344,20 @@ public abstract class SqlDialect
             {
                 LOG.error("Could not extract connection properties from data source \"" + _dsName + "\"");
                 return null;
+            }
+        }
+
+        public void setUrl(String url) throws ServletException
+        {
+            String methodName = "setUrl";
+            try
+            {
+                Method method = _ds.getClass().getMethod(methodName, String.class);
+                method.invoke(_ds, url);
+            }
+            catch (Exception e)
+            {
+                throw new ServletException("Unable to set DataSource property via " + methodName, e);
             }
         }
     }

--- a/api/src/org/labkey/api/query/AliasManager.java
+++ b/api/src/org/labkey/api/query/AliasManager.java
@@ -208,7 +208,8 @@ public class AliasManager
 
     private static int getMaxLength(@Nullable SqlDialect dialect, boolean useLegacyMaxLength)
     {
-        // we use 28 here because Oracle has a limit or 30 characters, and that is likely the shortest restriction
+        // we use 28 here because Oracle has a limit of 30 characters, and that is likely the shortest restriction
+
         // But note: Oracle 12c raised the limit to 128 characters, so perhaps increase the fall-back length now?
         return useLegacyMaxLength ? 40 : (dialect == null ? 28 : dialect.getIdentifierMaxLength() - 3 /* leave room for possible suffixes */);
     }

--- a/api/src/org/labkey/api/query/AliasManager.java
+++ b/api/src/org/labkey/api/query/AliasManager.java
@@ -178,8 +178,7 @@ public class AliasManager
             ret = "X_";
         if (dialect != null)
             ret = dialect.makeLegalIdentifierName(ret);
-        // we use 28 here because Oracle has a limit or 30 characters, and that is likely the shortest restriction
-        int maxLength = useLegacyMaxLength ? 40 : (dialect == null ? 28 : dialect.getIdentifierMaxLength());
+        int maxLength = getMaxLength(dialect, useLegacyMaxLength);
         if (reserveCount > 0)
             maxLength -= reserveCount;
         if (maxLength < 5)
@@ -202,12 +201,17 @@ public class AliasManager
             sb.append(legalNameFromName(part));
             connector = "_";
         }
-        // we use 28 here because Oracle has a limit or 30 characters, and that is likely the shortest restriction
-        var ret = truncate(sb.toString(), useLegacyMaxLength ? 40 : (dialect == null ? 28 : dialect.getIdentifierMaxLength()));
+        var ret = truncate(sb.toString(), getMaxLength(dialect, useLegacyMaxLength));
         assert isLegalName(ret);
         return ret;
     }
 
+    private static int getMaxLength(@Nullable SqlDialect dialect, boolean useLegacyMaxLength)
+    {
+        // we use 28 here because Oracle has a limit or 30 characters, and that is likely the shortest restriction
+        // But note: Oracle 12c raised the limit to 128 characters, so perhaps increase the fall-back length now?
+        return useLegacyMaxLength ? 40 : (dialect == null ? 28 : dialect.getIdentifierMaxLength() - 3 /* leave room for possible suffixes */);
+    }
 
     public static String truncate(String str, int to)
     {
@@ -375,7 +379,7 @@ public class AliasManager
 
             assertEquals("select_", m.decideAlias("select"));
 
-            assertEquals(m._dialect.getIdentifierMaxLength(), m.decideAlias("This is a very long name for a column, but it happens! go figure.").length());
+            assertEquals(m._dialect.getIdentifierMaxLength() - 3, m.decideAlias("This is a very long name for a column, but it happens! go figure. " + StringUtils.repeat('x', 100)).length());
         }
     }
 }


### PR DESCRIPTION
#### Rationale
PostgreSQL used to accept database names longer than 63 characters, truncating them for all operations. As of 17.x, it allows creation but fails to connect when the database name is too long. Given the (intentional) inconsistent behavior and misleading exception on connection attempt, LabKey now throws a configuration exception if a too-long database name is detected. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51676

Also, change `getIdentifierMaxLength()` to report the database's actual limit. Previously, the dialect reported two or three characters less than the actual limit (it was inconsistent) in an attempt to help callers that might be adding suffixes. Now the dialect just reports the facts; callers are responsible for respecting the database-imposed limit.

And avoid an unnecessary 10-second sleep between creating the database and first connection. We need the timeout only if the initial connection failed.