### PR TITLE
Result level exclusions for plate based assays

### DIFF
--- a/api/src/org/labkey/api/assay/plate/PlateDataStateManager.java
+++ b/api/src/org/labkey/api/assay/plate/PlateDataStateManager.java
@@ -1,0 +1,154 @@
+package org.labkey.api.assay.plate;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
+import org.labkey.api.qc.AbstractManageDataStatesForm;
+import org.labkey.api.qc.DataState;
+import org.labkey.api.qc.DataStateHandler;
+import org.labkey.api.qc.DataStateManager;
+import org.labkey.api.security.User;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class PlateDataStateManager implements DataStateHandler
+{
+    public static final String HANDLER_NAME = "PlateDataStateHandler";
+    private static PlateDataStateManager _instance = new PlateDataStateManager();
+
+    /**
+     * Maps to DataStates for plate related operations. Initially, there is only a single data state
+     * supported, but plans are to add more over time.
+     */
+    public enum StateType
+    {
+        Excluded("Excludes data rows from certain operations.",
+                Collections.emptySet());
+
+        final Set<DataOperation> _permittedOps;
+        final String _description;
+
+        StateType(String description, Set<DataOperation> permittedOps)
+        {
+            _description = description;
+            _permittedOps = permittedOps;
+        }
+
+        public Set<DataOperation> getPermittedOps()
+        {
+            return _permittedOps;
+        }
+
+        @Nullable
+        static StateType getType(String typeName)
+        {
+            for (StateType type : StateType.values())
+            {
+                if (type.name().equals(typeName))
+                    return type;
+            }
+            return null;
+        }
+    }
+
+    /**
+     * The operation that might be performed for an associated DataState
+     */
+    public enum DataOperation
+    {
+        analysis("included for any data or statistical analysis, curve fitting etc");
+
+        final String _description;
+
+        DataOperation(String description)
+        {
+            _description = description;
+        }
+    }
+
+    private PlateDataStateManager(){}
+
+    public static PlateDataStateManager get()
+    {
+        return _instance;
+    }
+
+    public boolean isOperationPermitted(@Nullable DataState state, DataOperation operation)
+    {
+        if (state == null)
+            return true;
+
+        StateType stateType = StateType.getType(state.getStateType());
+        return stateType != null && stateType.getPermittedOps().contains(operation);
+    }
+
+    public void ensureDefaultStates(Container container, User user)
+    {
+        Set<String> typeNames = getStates(container).stream().map(DataState::getStateType).collect(Collectors.toSet());
+        for (StateType type : StateType.values())
+        {
+            if (!typeNames.contains(type.name()))
+            {
+                DataState state = new DataState();
+                state.setContainer(container);
+                state.setStateType(type.name());
+                state.setLabel(type.name());
+                state.setDescription(type._description);
+
+                DataStateManager.getInstance().insertState(user, state);
+            }
+        }
+    }
+
+    @Override
+    public String getHandlerType()
+    {
+        return HANDLER_NAME;
+    }
+
+    @Override
+    public List<DataState> getStates(Container container)
+    {
+        return DataStateManager.getInstance().getStates(container).stream()
+                .filter(state -> StateType.getType(state.getStateType()) != null)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean isStateInUse(Container container, DataState state)
+    {
+        // for now, we won't allow removal of the default plate data states
+        return true;
+    }
+
+    @Override
+    public boolean isBlankStatePublic(Container container)
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isRequireCommentOnQCStateChange(Container container)
+    {
+        return false;
+    }
+
+    @Override
+    public @Nullable String getStateChangeError(Container container, DataState state, Map rowUpdates)
+    {
+        // no changes allowed for now
+        if (StateType.getType(state.getStateType()) != null)
+            return "Data State for '" + state.getLabel() + "' cannot be changed.";
+
+        return null;
+    }
+
+    @Override
+    public void updateState(Container container, AbstractManageDataStatesForm form, User user)
+    {
+        // nothing to do, this state handler isn't on the end of the manage action
+    }
+}

--- a/api/src/org/labkey/api/assay/plate/PlateDataStateManager.java
+++ b/api/src/org/labkey/api/assay/plate/PlateDataStateManager.java
@@ -43,7 +43,7 @@ public class PlateDataStateManager implements DataStateHandler
         }
 
         @Nullable
-        static StateType getType(String typeName)
+        public static StateType getType(String typeName)
         {
             for (StateType type : StateType.values())
             {
@@ -136,7 +136,7 @@ public class PlateDataStateManager implements DataStateHandler
     public boolean isStateInUse(Container container, DataState state)
     {
         // for now, we won't allow removal of the default plate data states
-        return true;
+        return StateType.getType(state.getStateType()) != null;
     }
 
     @Override

--- a/api/src/org/labkey/api/assay/plate/PlateDataStateManager.java
+++ b/api/src/org/labkey/api/assay/plate/PlateDataStateManager.java
@@ -87,13 +87,14 @@ public class PlateDataStateManager implements DataStateHandler
 
     public void ensureDefaultStates(Container container, User user)
     {
-        Set<String> typeNames = getStates(container).stream().map(DataState::getStateType).collect(Collectors.toSet());
+        Container c = getDataStateContainer(container);
+        Set<String> typeNames = getStates(c).stream().map(DataState::getStateType).collect(Collectors.toSet());
         for (StateType type : StateType.values())
         {
             if (!typeNames.contains(type.name()))
             {
                 DataState state = new DataState();
-                state.setContainer(container);
+                state.setContainer(c);
                 state.setStateType(type.name());
                 state.setLabel(type.name());
                 state.setDescription(type._description);
@@ -101,6 +102,20 @@ public class PlateDataStateManager implements DataStateHandler
                 DataStateManager.getInstance().insertState(user, state);
             }
         }
+    }
+
+    @Nullable
+    public DataState getStateForRowId(Container container, Integer rowId)
+    {
+        return DataStateManager.getInstance().getStateForRowId(getDataStateContainer(container), rowId);
+    }
+
+    private Container getDataStateContainer(Container container)
+    {
+        // scope the data state container to the project
+        if (container.isRoot())
+            return container;
+        return container.isProject() ? container : container.getProject();
     }
 
     @Override

--- a/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
@@ -43,6 +43,7 @@ public class AssayResultDomainKind extends AssayDomainKind
     public static final String WELL_LOCATION_COLUMN_NAME = "WellLocation";
     public static final String WELL_LSID_COLUMN_NAME = "WellLsid";
     public static final String REPLICATE_LSID_COLUMN_NAME = "ReplicateLsid";
+    public static final String STATE_COLUMN_NAME = "State";
 
     public AssayResultDomainKind()
     {
@@ -138,6 +139,7 @@ public class AssayResultDomainKind extends AssayDomainKind
                     mandatoryNames.add(WELL_LOCATION_COLUMN_NAME);
                     mandatoryNames.add(WELL_LSID_COLUMN_NAME);
                     mandatoryNames.add(REPLICATE_LSID_COLUMN_NAME);
+                    mandatoryNames.add(STATE_COLUMN_NAME);
                 }
             }
         }

--- a/assay/resources/schemas/dbscripts/postgresql/assay-24.013-24.014.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-24.013-24.014.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('initializeWellExclusions');

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-24.013-24.014.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-24.013-24.014.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'initializeWellExclusions';

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -117,7 +117,7 @@ public class AssayModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 24.013;
+        return 24.014;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -31,6 +31,7 @@ import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.assay.TsvDataHandler;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
+import org.labkey.api.assay.plate.PlateDataStateManager;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.PlateUtils;
 import org.labkey.api.assay.plate.PositionImpl;
@@ -50,6 +51,7 @@ import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.SpringModule;
 import org.labkey.api.pipeline.PipelineJobService;
+import org.labkey.api.qc.DataStateManager;
 import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reports.report.r.ParamReplacementSvc;
@@ -95,7 +97,6 @@ import org.labkey.pipeline.xml.AssayImportRunTaskType;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -146,6 +147,8 @@ public class AssayModule extends SpringModule
         AssayService.setInstance(new AssayManager());
         PlateService.setInstance(new PlateManager());
         AssayPlateMetadataService.setInstance(new AssayPlateMetadataServiceImpl());
+        DataStateManager.getInstance().registerDataStateHandler(PlateDataStateManager.get());
+
         addController("assay", AssayController.class);
         addController("plate", PlateController.class);
         PlateSchema.register(this);

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -472,10 +472,10 @@ public class AssayUpgradeCode implements UpgradeCode
                 if (!plateSetsToHits.containsKey(plateSetRowId))
                 {
                     PlateSetLineage lineage = PlateManager.get().getPlateSetLineage(
-                        ContainerManager.getRoot(),
-                        User.getAdminServiceUser(),
-                        plateSetRowId,
-                        ContainerFilter.EVERYTHING
+                            ContainerManager.getRoot(),
+                            User.getAdminServiceUser(),
+                            plateSetRowId,
+                            ContainerFilter.EVERYTHING
                     );
                     String lineagePath = lineage.getSeedPath();
 
@@ -518,11 +518,11 @@ public class AssayUpgradeCode implements UpgradeCode
 
         // Determine all containers that have a Plate where Samples are specified in wells
         SQLFragment sql = new SQLFragment("""
-                SELECT DISTINCT P.Container
-                FROM assay.Well AS W
-                INNER JOIN assay.Plate AS P ON P.RowId = W.PlateId
-                WHERE P.AssayType = ? AND W.SampleId IS NOT NULL
-            """).add(TsvPlateLayoutHandler.TYPE);
+                    SELECT DISTINCT P.Container
+                    FROM assay.Well AS W
+                    INNER JOIN assay.Plate AS P ON P.RowId = W.PlateId
+                    WHERE P.AssayType = ? AND W.SampleId IS NOT NULL
+                """).add(TsvPlateLayoutHandler.TYPE);
         List<String> containerIds = new SqlSelector(scope, sql).getArrayList(String.class);
 
         for (String containerId : containerIds)
@@ -546,13 +546,13 @@ public class AssayUpgradeCode implements UpgradeCode
             try (DbScope.Transaction tx = scope.ensureTransaction())
             {
                 SQLFragment wellSql = new SQLFragment("""
-                    SELECT W.RowId, W.PlateId
-                    FROM assay.Well AS W
-                    INNER JOIN assay.Plate AS P ON P.RowId = W.PlateId
-                    WHERE P.Container = ? AND P.AssayType = ? AND W.SampleId IS NOT NULL AND W.RowId NOT IN (
-                        SELECT WellId FROM assay.WellGroupPositions AS WGP WHERE WGP.WellId = W.RowId
-                    )
-                """).add(containerId).add(TsvPlateLayoutHandler.TYPE);
+                            SELECT W.RowId, W.PlateId
+                            FROM assay.Well AS W
+                            INNER JOIN assay.Plate AS P ON P.RowId = W.PlateId
+                            WHERE P.Container = ? AND P.AssayType = ? AND W.SampleId IS NOT NULL AND W.RowId NOT IN (
+                                SELECT WellId FROM assay.WellGroupPositions AS WGP WHERE WGP.WellId = W.RowId
+                            )
+                        """).add(containerId).add(TsvPlateLayoutHandler.TYPE);
 
                 Map<Integer, Map<Integer, PlateManager.WellGroupChange>> wellGroupChanges = new HashMap<>();
                 Collection<Map<String, Object>> sampleWellRows = new SqlSelector(scope, wellSql).getMapCollection();
@@ -644,6 +644,7 @@ public class AssayUpgradeCode implements UpgradeCode
     }
 
     private static final String METADATA_RENAME_SUFFIX = "_PREV";
+
     private static String ensureNewName(DomainProperty dp, Domain domain)
     {
         String newName = dp.getName() + METADATA_RENAME_SUFFIX;

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -2,15 +2,14 @@ package org.labkey.assay;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayResultDomainKind;
-import org.labkey.api.assay.AssaySchema;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.plate.AbstractPlateBasedAssayProvider;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateBasedAssayProvider;
+import org.labkey.api.assay.plate.PlateDataStateManager;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.WellGroup;
@@ -20,11 +19,13 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DbSequence;
 import org.labkey.api.data.DbSequenceManager;
 import org.labkey.api.data.DeferredUpgrade;
+import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.NameGenerator;
 import org.labkey.api.data.ObjectFactory;
 import org.labkey.api.data.PropertyStorageSpec;
@@ -46,14 +47,15 @@ import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.exp.property.Lookup;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.module.ModuleContext;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.roles.SiteAdminRole;
 import org.labkey.api.util.Pair;
-import org.labkey.assay.plate.PlateCache;
 import org.labkey.assay.plate.PlateManager;
 import org.labkey.assay.plate.PlateMetadataDomainKind;
 import org.labkey.assay.plate.PlateSetImpl;
@@ -752,5 +754,55 @@ public class AssayUpgradeCode implements UpgradeCode
     private static boolean isBiologicsFolder(Container container)
     {
         return container != null && "Biologics".equals(ContainerManager.getFolderTypeName(container));
+    }
+
+    /**
+     * Called from assay-24.013-24.014.sql, in order to support row level exclusions for plate enabled assays.
+     * The upgrade ensures the default assay plate data states as well as creates the result domain qc state field.
+     */
+    public static void initializeWellExclusions(ModuleContext ctx) throws Exception
+    {
+        if (ctx.isNewInstall())
+            return;
+
+        DbScope scope = AssayDbSchema.getInstance().getSchema().getScope();
+        try (DbScope.Transaction tx = scope.ensureTransaction())
+        {
+            Set<ExpProtocol> protocols = new HashSet<>();
+            for (Container container : ContainerManager.getAllChildren(ContainerManager.getRoot()))
+            {
+                if (isBiologicsFolder(container))
+                {
+                    PlateDataStateManager.get().ensureDefaultStates(container, User.getAdminServiceUser());
+                    protocols.addAll(AssayService.get().getAssayProtocols(container));
+                }
+            }
+
+            for (ExpProtocol protocol : protocols)
+            {
+                AssayProvider provider = AssayService.get().getProvider(protocol);
+                if (provider != null)
+                {
+                    if (provider.isPlateMetadataEnabled(protocol))
+                    {
+                        // ensure the QC state column exists in the result domain
+                        Domain resultDomain = provider.getResultsDomain(protocol);
+                        if (resultDomain.getPropertyByName(AssayResultDomainKind.STATE_COLUMN_NAME) == null)
+                        {
+                            _log.info(String.format("Adding the %s field to the results domain for assay : %s", AssayResultDomainKind.STATE_COLUMN_NAME, protocol.getName()));
+                            DomainProperty dp = resultDomain.addProperty(new PropertyStorageSpec(AssayResultDomainKind.STATE_COLUMN_NAME, JdbcType.INTEGER));
+                            dp.setLabel("QC State");
+                            dp.setImportAliasSet(Set.of("QCState", "QC State"));
+                            dp.setLookup(new Lookup(null, SchemaKey.fromParts(CoreSchema.getInstance().getSchemaName()), CoreSchema.DATA_STATES_TABLE_NAME));
+                            dp.setShownInInsertView(false);
+                            dp.setShownInUpdateView(false);
+
+                            resultDomain.save(User.getAdminServiceUser());
+                        }
+                    }
+                }
+            }
+            tx.commit();
+        }
     }
 }

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -760,6 +760,7 @@ public class AssayUpgradeCode implements UpgradeCode
      * Called from assay-24.013-24.014.sql, in order to support row level exclusions for plate enabled assays.
      * The upgrade ensures the default assay plate data states as well as creates the result domain qc state field.
      */
+    @DeferredUpgrade
     public static void initializeWellExclusions(ModuleContext ctx) throws Exception
     {
         if (ctx.isNewInstall())

--- a/assay/src/org/labkey/assay/TsvAssayProvider.java
+++ b/assay/src/org/labkey/assay/TsvAssayProvider.java
@@ -43,6 +43,7 @@ import org.labkey.api.assay.actions.AssayRunUploadForm;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbSequence;
 import org.labkey.api.data.DbSequenceManager;
 import org.labkey.api.data.SimpleFilter;
@@ -477,6 +478,20 @@ public class TsvAssayProvider extends AbstractTsvAssayProvider
                     replicateLsid.setHidden(true);
 
                     newFields.add(replicateLsid);
+                }
+
+                if (!existingFields.contains(AssayResultDomainKind.STATE_COLUMN_NAME))
+                {
+                    GWTPropertyDescriptor qcState = new GWTPropertyDescriptor(AssayResultDomainKind.STATE_COLUMN_NAME, PropertyType.INTEGER.getTypeUri());
+                    qcState.setLabel("QC State");
+                    qcState.setImportAliases("QCState,\"QC State\"");
+                    qcState.setLookupSchema(CoreSchema.getInstance().getSchemaName());
+                    qcState.setLookupQuery(CoreSchema.DATA_STATES_TABLE_NAME);
+                    qcState.setLookupContainer(null);
+                    qcState.setShownInInsertView(false);
+                    qcState.setShownInUpdateView(false);
+
+                    newFields.add(qcState);
                 }
 
                 if (!newFields.isEmpty())

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -1069,7 +1069,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                 {
                     if (entry.getValue() instanceof Integer stateRowId)
                     {
-                        return DataStateManager.getInstance().getStateForRowId(container, stateRowId);
+                        return PlateDataStateManager.get().getStateForRowId(container, stateRowId);
                     }
                 }
             }

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -73,7 +73,6 @@ import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.qc.DataLoaderSettings;
 import org.labkey.api.qc.DataState;
-import org.labkey.api.qc.DataStateManager;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
@@ -983,8 +982,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         if (measures.isEmpty())
             return;
 
-        DomainProperty qcStateProp = resultDomain.getProperties().stream().filter(dp -> AssayResultDomainKind.STATE_COLUMN_NAME.equalsIgnoreCase(dp.getName()))
-                .findFirst().orElse(null);
+        DomainProperty qcStateProp = getAssayStateProp(resultDomain);
 
         List<Map<String, Object>> replicates = new ArrayList<>();
         List<Map<String, Object>> keys = new ArrayList<>();
@@ -1057,24 +1055,61 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
     }
 
     @Nullable
-    private DataState getStateFromRow(Container container, Map<String, Object> row, @Nullable DomainProperty qcState)
+    private static DataState getStateFromRow(Container container, Map<String, Object> row, @Nullable DomainProperty stateProp) throws ExperimentException
     {
-        if (qcState != null)
+        if (stateProp != null)
         {
-            Set<String> importAlias = new CaseInsensitiveHashSet(qcState.getName());
-            importAlias.addAll(qcState.getImportAliasSet());
+            Set<String> importAlias = new CaseInsensitiveHashSet(stateProp.getName());
+            importAlias.addAll(stateProp.getImportAliasSet());
             for (Map.Entry<String, Object> entry : row.entrySet())
             {
                 if (importAlias.contains(entry.getKey()))
                 {
                     if (entry.getValue() instanceof Integer stateRowId)
                     {
-                        return PlateDataStateManager.get().getStateForRowId(container, stateRowId);
+                        DataState state = PlateDataStateManager.get().getStateForRowId(container, stateRowId);
+                        if (state == null)
+                            throw new ExperimentException(String.format("No data states for the rowID : %d was found", stateRowId));
+
+                        return state;
                     }
                 }
             }
         }
         return null;
+    }
+
+    @Nullable
+    public static DomainProperty getAssayStateProp(Domain resultDomain)
+    {
+        if (resultDomain == null)
+            return null;
+
+        return resultDomain.getProperties().stream().filter(dp -> AssayResultDomainKind.STATE_COLUMN_NAME.equalsIgnoreCase(dp.getName()))
+                .findFirst().orElse(null);
+    }
+
+    /**
+     * Ensure the data state value in the row represents a data state in scope and is a valid state for plate based
+     * assays.
+     */
+    public static void validateRowDataStates(Container container, Map<String, Object> row, DomainProperty stateProp) throws ValidationException
+    {
+        try
+        {
+            DataState state = getStateFromRow(container, row, stateProp);
+            if (state != null)
+            {
+                if (PlateDataStateManager.StateType.getType(state.getStateType()) == null)
+                {
+                    throw new ValidationException(String.format("The data state : %s is not valid for this assay", state.getStateType()));
+                }
+            }
+        }
+        catch (ExperimentException e)
+        {
+            throw UnexpectedException.wrap(e);
+        }
     }
 
     private @NotNull AssayProvider requireProvider(ExpProtocol protocol) throws ExperimentException
@@ -1176,6 +1211,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 
             Domain runDomain = _provider.getRunDomain(_protocol);
             Domain resultDomain = _provider.getResultsDomain(_protocol);
+            DomainProperty stateProp = AssayPlateMetadataServiceImpl.getAssayStateProp(resultDomain);
             DomainProperty plateSetProperty = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_SET_COLUMN_NAME);
             DomainProperty plateProperty = resultDomain.getPropertyByName(AssayResultDomainKind.PLATE_COLUMN_NAME);
             DomainProperty wellLocationProperty = resultDomain.getPropertyByName(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME);
@@ -1244,6 +1280,9 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                     _replicateRows.computeIfAbsent(lsid, k -> new ArrayList<>()).add(map);
                 }
             }
+
+            // validate any data state values on the row
+            validateRowDataStates(_container, map, stateProp);
         }
 
         @Override

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -1069,7 +1069,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                     {
                         DataState state = PlateDataStateManager.get().getStateForRowId(container, stateRowId);
                         if (state == null)
-                            throw new ExperimentException(String.format("No data states for the rowID : %d was found", stateRowId));
+                            throw new ExperimentException(String.format("No data states for the rowID %d was found.", stateRowId));
 
                         return state;
                     }

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -1102,7 +1102,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             {
                 if (PlateDataStateManager.StateType.getType(state.getStateType()) == null)
                 {
-                    throw new ValidationException(String.format("The data state : %s is not valid for this assay", state.getStateType()));
+                    throw new ValidationException(String.format("The data state '%s' is not valid for this assay.", state.getLabel()));
                 }
             }
         }

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -21,6 +21,7 @@ import org.labkey.api.assay.TsvDataHandler;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.assay.plate.ExcelPlateReader;
 import org.labkey.api.assay.plate.Plate;
+import org.labkey.api.assay.plate.PlateDataStateManager;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateType;
@@ -71,6 +72,8 @@ import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.qc.DataLoaderSettings;
+import org.labkey.api.qc.DataState;
+import org.labkey.api.qc.DataStateManager;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
@@ -972,6 +975,9 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         if (measures.isEmpty())
             return;
 
+        DomainProperty qcStateProp = resultDomain.getProperties().stream().filter(dp -> AssayResultDomainKind.STATE_COLUMN_NAME.equalsIgnoreCase(dp.getName()))
+                .findFirst().orElse(null);
+
         List<Map<String, Object>> replicates = new ArrayList<>();
         List<Map<String, Object>> keys = new ArrayList<>();
 
@@ -985,6 +991,11 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                 // organize values for each replicate well group by measure
                 for (Map<String, Object> row : entry.getValue())
                 {
+                    // check whether this data row should be included for calculations
+                    DataState state = getStateFromRow(container, row, qcStateProp);
+                    if (!PlateDataStateManager.get().isOperationPermitted(state, PlateDataStateManager.DataOperation.analysis))
+                        continue;
+
                     for (Map.Entry<String, Object> col : row.entrySet())
                     {
                         if (measures.containsKey(col.getKey()) && col.getValue() != null)
@@ -1035,6 +1046,27 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         {
             throw UnexpectedException.wrap(e);
         }
+    }
+
+    @Nullable
+    private DataState getStateFromRow(Container container, Map<String, Object> row, @Nullable DomainProperty qcState)
+    {
+        if (qcState != null)
+        {
+            Set<String> importAlias = new CaseInsensitiveHashSet(qcState.getName());
+            importAlias.addAll(qcState.getImportAliasSet());
+            for (Map.Entry<String, Object> entry : row.entrySet())
+            {
+                if (importAlias.contains(entry.getKey()))
+                {
+                    if (entry.getValue() instanceof Integer stateRowId)
+                    {
+                        return DataStateManager.getInstance().getStateForRowId(container, stateRowId);
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     private @NotNull AssayProvider requireProvider(ExpProtocol protocol) throws ExperimentException

--- a/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
@@ -2,7 +2,9 @@ package org.labkey.assay.plate;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayResultDomainKind;
+import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -15,6 +17,7 @@ import org.labkey.api.data.triggers.TriggerFactory;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.ValidationException;
@@ -31,17 +34,26 @@ import java.util.Map;
 public class AssayPlateTriggerFactory implements TriggerFactory
 {
     private final ExpProtocol _protocol;
+    private DomainProperty _qcStateProp;
 
     public AssayPlateTriggerFactory(ExpProtocol protocol)
     {
         _protocol = protocol;
+
+        if (_protocol != null)
+        {
+            AssayProvider provider = AssayService.get().getProvider(_protocol);
+            if (provider != null)
+                _qcStateProp = AssayPlateMetadataServiceImpl.getAssayStateProp(provider.getResultsDomain(_protocol));
+        }
     }
 
     @Override
     public @NotNull Collection<Trigger> createTrigger(@Nullable Container c, TableInfo table, Map<String, Object> extraContext)
     {
         return List.of(
-            new ReplicateStatsTrigger()
+            new ReplicateStatsTrigger(),
+            new DataStateTrigger()
         );
     }
 
@@ -118,6 +130,20 @@ public class AssayPlateTriggerFactory implements TriggerFactory
             {
                 throw UnexpectedException.wrap(e);
             }
+        }
+    }
+
+    /**
+     * Trigger to help validate state values on update. Inserts will be handled on assay
+     * run creation.
+     */
+    private class DataStateTrigger implements Trigger
+    {
+        @Override
+        public void beforeUpdate(TableInfo table, Container c, User user, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, ValidationException errors, Map<String, Object> extraContext) throws ValidationException
+        {
+            if (newRow != null && _qcStateProp != null)
+                AssayPlateMetadataServiceImpl.validateRowDataStates(c, newRow, _qcStateProp);
         }
     }
 }

--- a/core/src/org/labkey/core/query/CoreQuerySchema.java
+++ b/core/src/org/labkey/core/query/CoreQuerySchema.java
@@ -163,9 +163,9 @@ public class CoreQuerySchema extends UserSchema
         if (FILES_TABLE_NAME.equalsIgnoreCase(name))
             return getFilesTable();
         if (QCSTATE_TABLE_NAME.equalsIgnoreCase(name))
-           return getQCStatesTable();
+           return getQCStatesTable(cf);
         if (DATA_STATES_TABLE_NAME.equalsIgnoreCase(name))
-            return getDataStatesTable();
+            return getDataStatesTable(cf);
         if (API_KEYS_TABLE_NAME.equalsIgnoreCase(name) && getUser().hasRootPermission(UserManagementPermission.class))
             return new ApiKeysTableInfo(this);
         if (USER_API_KEYS_TABLE_NAME.equalsIgnoreCase(name))
@@ -632,9 +632,9 @@ public class CoreQuerySchema extends UserSchema
         return new FileListTableInfo(this);
     }
 
-    protected TableInfo getDataStatesTable()
+    protected TableInfo getDataStatesTable(ContainerFilter cf)
     {
-        return new DataStatesTableInfo(this);
+        return new DataStatesTableInfo(this, cf);
     }
 
     protected TableInfo getMVIndicatorTable(ContainerFilter cf)
@@ -652,9 +652,9 @@ public class CoreQuerySchema extends UserSchema
         return result;
     }
 
-    public TableInfo getQCStatesTable()
+    public TableInfo getQCStatesTable(ContainerFilter cf)
     {
-        TableInfo dataStatesTable = getDataStatesTable();
+        TableInfo dataStatesTable = getDataStatesTable(cf);
         FilteredTable table = new FilteredTable<>(dataStatesTable, this);
         SQLFragment sql = new SQLFragment("(stateType IS NULL)");
         table.setName(QCSTATE_TABLE_NAME);

--- a/core/src/org/labkey/core/query/DataStatesTableInfo.java
+++ b/core/src/org/labkey/core/query/DataStatesTableInfo.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.qc.DataState;
@@ -45,9 +46,9 @@ import java.util.Map;
  */
 public class DataStatesTableInfo extends FilteredTable<CoreQuerySchema>
 {
-    public DataStatesTableInfo(CoreQuerySchema schema)
+    public DataStatesTableInfo(CoreQuerySchema schema, ContainerFilter cf)
     {
-        super(CoreSchema.getInstance().getTableInfoDataStates(), schema);
+        super(CoreSchema.getInstance().getTableInfoDataStates(), schema, cf);
         for (ColumnInfo baseColumn : _rootTable.getColumns())
         {
             String name = baseColumn.getName();


### PR DESCRIPTION
#### Rationale
Adds initial support to exclude wells from certain operations for plate enabled assays. Assay results will include a `state` field which can be set to a value in the `core.DataState` table. The data state will determine what operations are allowed for values in that row. Initially only a single `excluded` data state will be supported but others can be added later. Also, currently the excluded state will prevent the well from participating in any replicate statistical calculations.

Data states will be scoped to the project level. An upgrade script was added to update the result domain for any plate enabled assays in a LKB folder.

#### Related Pull Requests
https://github.com/LabKey/limsModules/pull/925