### PR TITLE
Mark modules that support both databases

### DIFF
--- a/announcements/module.properties
+++ b/announcements/module.properties
@@ -13,3 +13,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/api/module.properties
+++ b/api/module.properties
@@ -7,3 +7,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/assay/module.properties
+++ b/assay/module.properties
@@ -5,3 +5,4 @@ Description: Provides services and other APIs that assay modules call to impleme
 URL: https://www.labkey.org/Documentation/wiki-page.view?name=instrumentData
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/audit/module.properties
+++ b/audit/module.properties
@@ -5,3 +5,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/core/module.properties
+++ b/core/module.properties
@@ -9,3 +9,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/devtools/module.properties
+++ b/devtools/module.properties
@@ -3,3 +3,4 @@ Label: Developer tools and tests
 Description: For use during development, not intended for production
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/experiment/module.properties
+++ b/experiment/module.properties
@@ -12,3 +12,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/filecontent/module.properties
+++ b/filecontent/module.properties
@@ -7,3 +7,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/issues/module.properties
+++ b/issues/module.properties
@@ -10,3 +10,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/list/module.properties
+++ b/list/module.properties
@@ -13,3 +13,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/pipeline/module.properties
+++ b/pipeline/module.properties
@@ -11,3 +11,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/query/module.properties
+++ b/query/module.properties
@@ -5,3 +5,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/search/module.properties
+++ b/search/module.properties
@@ -7,3 +7,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/specimen/module.properties
+++ b/specimen/module.properties
@@ -5,3 +5,4 @@ Description: A system for tracking specimens as part of a study. \
 URL: https://www.labkey.com/products-services/sample-management-software/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/study/module.properties
+++ b/study/module.properties
@@ -7,3 +7,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/survey/module.properties
+++ b/survey/module.properties
@@ -8,3 +8,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 
+SupportedDatabases: mssql, pgsql

--- a/timeline/module.properties
+++ b/timeline/module.properties
@@ -5,3 +5,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/visualization/module.properties
+++ b/visualization/module.properties
@@ -7,3 +7,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/wiki/module.properties
+++ b/wiki/module.properties
@@ -8,3 +8,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql


### PR DESCRIPTION
#### Rationale
Need to explicitly declare support for SQL Server since we're about to change the default to PostgreSQL-only