### PR TITLE
Issue 51557: Fix folder deletion summary stats type casting

### DIFF
--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -889,10 +889,10 @@ public class ExperimentModule extends SpringModule
             columns.add(ExpDataClassTable.Column.Name.name());
             columns.add(ExpDataClassTable.Column.DataCount.name());
 
-            Map<String, Long> results = new TableSelector(table, columns).getValueMap();
+            Map<String, Integer> results = new TableSelector(table, columns).getValueMap();
             for (var entry : results.entrySet())
             {
-                long count = entry.getValue();
+                int count = entry.getValue();
                 if (count > 0)
                     summaries.add(new Summary(count, entry.getKey()));
             }
@@ -917,10 +917,10 @@ public class ExperimentModule extends SpringModule
             columns.add(ExpSampleTypeTable.Column.Name.name());
             columns.add(ExpSampleTypeTable.Column.SampleCount.name());
 
-            Map<String, Long> results = new TableSelector(table, columns).getValueMap();
+            Map<String, Integer> results = new TableSelector(table, columns).getValueMap();
             for (var entry : results.entrySet())
             {
-                long count = entry.getValue();
+                int count = entry.getValue();
                 if (count > 0)
                 {
                     String name = entry.getKey();


### PR DESCRIPTION
#### Rationale
This fixes a type casting issue that can appear on MSSQL instances that was introduced with #6005 as part of a fix for [Issue 51557](https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=51557).

#### Related Pull Requests
- #6005

#### Changes
- Use `Integer`/`int` instead of `Long`/`long`
