### PR TITLE
ContainerFactory resilience for recently added columns

### DIFF
--- a/api/src/org/labkey/api/collections/ResultSetRowMapFactory.java
+++ b/api/src/org/labkey/api/collections/ResultSetRowMapFactory.java
@@ -19,7 +19,6 @@ import org.labkey.api.data.CachedResultSet;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.util.ResultSetUtil;
 
-import java.beans.Introspector;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.sql.Clob;
@@ -27,7 +26,6 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Map;
 
 public class ResultSetRowMapFactory extends RowMapFactory<Object> implements Serializable
 {
@@ -64,21 +62,8 @@ public class ResultSetRowMapFactory extends RowMapFactory<Object> implements Ser
     {
         super(md.getColumnCount() + 1);
 
-        int count = md.getColumnCount();
-        Map<String, Integer> findMap = getFindMap();
-        findMap.put("_row", 0);  // We're going to stuff the current row index at index 0
-
-        for (int i = 1; i <= count; i++)
-        {
-            String propName = md.getColumnLabel(i);
-
-            if (!propName.isEmpty() && Character.isUpperCase(propName.charAt(0)))
-                propName = Introspector.decapitalize(propName);
-
-            findMap.put(propName, i);
-        }
+        ResultSetUtil.populateFindMap(md, getFindMap());
     }
-
 
     public void setConvertBigDecimalToDouble(boolean b)
     {

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -89,6 +89,7 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.QuietCloser;
 import org.labkey.api.util.ReentrantLockWithName;
+import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
@@ -3103,8 +3104,13 @@ public class ContainerManager
             LockState lockState = null != lockStateString ? Enums.getIfPresent(LockState.class, lockStateString).or(LockState.Unlocked) : LockState.Unlocked;
 
             LocalDate expirationDate = rs.getObject("ExpirationDate", LocalDate.class);
-            Long fileRootSize = (Long)rs.getObject("FileRootSize");  // getObject() and cast because getLong() returns 0 for null
-            LocalDateTime fileRootLastCrawled = rs.getObject("FileRootLastCrawled", LocalDateTime.class);
+
+            // Could be running upgrade code before these recent columns have been added to the table. Use a find map
+            // to determine if they are present. Issue 51692. These checks could be removed after creation of these
+            // columns is incorporated into the bootstrap scripts.
+            Map<String, Integer> findMap = ResultSetUtil.getFindMap(rs.getMetaData());
+            Long fileRootSize = findMap.containsKey("FileRootSize") ? (Long)rs.getObject("FileRootSize") : null;  // getObject() and cast because getLong() returns 0 for null
+            LocalDateTime fileRootLastCrawled = findMap.containsKey("FileRootLastCrawled") ? rs.getObject("FileRootLastCrawled", LocalDateTime.class) : null;
 
             Container dirParent = null;
             if (null != parentId)

--- a/api/src/org/labkey/api/util/ResultSetUtil.java
+++ b/api/src/org/labkey/api/util/ResultSetUtil.java
@@ -20,6 +20,8 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.collections.ArrayListMap;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.ResultSetRowMapFactory;
 import org.labkey.api.data.CachedResultSet;
 import org.labkey.api.data.CachedResultSets;
@@ -28,6 +30,7 @@ import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.util.logging.LogHelper;
 
+import java.beans.Introspector;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -108,6 +111,27 @@ public class ResultSetUtil
         return factory.getRowMap(rs);
     }
 
+    public static Map<String, Integer> populateFindMap(ResultSetMetaData md, Map<String, Integer> findMap) throws SQLException
+    {
+        findMap.put("_row", 0);  // We're going to stuff the current row index at index 0
+
+        for (int i = 1; i <= md.getColumnCount(); i++)
+        {
+            String propName = md.getColumnLabel(i);
+
+            if (!propName.isEmpty() && Character.isUpperCase(propName.charAt(0)))
+                propName = Introspector.decapitalize(propName);
+
+            findMap.put(propName, i);
+        }
+
+        return findMap;
+    }
+
+    public static Map<String, Integer> getFindMap(ResultSetMetaData md) throws SQLException
+    {
+        return populateFindMap(md, new ArrayListMap.FindMap<>(new CaseInsensitiveHashMap<>()));
+    }
 
     // Just for testing purposes... splats ResultSet metadata to log
     @SuppressWarnings("unused")


### PR DESCRIPTION
#### Rationale
Upgrading a <= 24.2 database to 24.11 can fail in `CoreUpgradeCode.makeWithCounterCaseInsensitive()` because the `ContainerFactory` is expecting `core.Containers` columns that haven't been added to the table yet. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51692

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5952