### PR TITLE
Default SupportedDatabases property to PostgreSQL-only

### DIFF
--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -528,9 +528,9 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         return Collections.emptySet();
     }
 
-    protected static final Set<SupportedDatabase> ALL_DATABASES = Set.of(SupportedDatabase.mssql, SupportedDatabase.pgsql);
+    protected static final Set<SupportedDatabase> ONLY_POSTGRESQL = Set.of(SupportedDatabase.pgsql);
 
-    private Set<SupportedDatabase> _supportedDatabases = ALL_DATABASES;
+    private Set<SupportedDatabase> _supportedDatabases = ONLY_POSTGRESQL;
 
     @NotNull
     @Override

--- a/api/src/org/labkey/api/module/MockModule.java
+++ b/api/src/org/labkey/api/module/MockModule.java
@@ -470,7 +470,7 @@ public class MockModule implements Module
     @Override
     public Set<SupportedDatabase> getSupportedDatabasesSet()
     {
-        return DefaultModule.ALL_DATABASES;
+        return DefaultModule.ONLY_POSTGRESQL;
     }
 
     @Nullable

--- a/mothership/module.properties
+++ b/mothership/module.properties
@@ -5,4 +5,3 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
-SupportedDatabases: pgsql


### PR DESCRIPTION
#### Rationale
As we start moving away from SQL Server, we're changing the default supported databases to PostgreSQL-only