### PR TITLE
Experiment: bump @labkey/test

### DIFF
--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@labkey/build": "8.2.0",
-        "@labkey/test": "1.6.2",
+        "@labkey/test": "1.6.3",
         "@types/jest": "29.5.12",
         "@types/react": "16.14.60",
         "@types/react-dom": "16.9.24",
@@ -3327,9 +3327,9 @@
       }
     },
     "node_modules/@labkey/test": {
-      "version": "1.6.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.6.2.tgz",
-      "integrity": "sha512-wLrkbjayoZpEkxNwt/+r8D6WyKEL1XPtMgHrmQpDEO+juXxU04zlFenFJroEZfVlkaayn/0+Ot/gWrEOO00EQg==",
+      "version": "1.6.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.6.3.tgz",
+      "integrity": "sha512-9wJYxIy8trWy3bLmhFgmSBUfiPa1V3GWe4G5OVDmlKxwcSHQeN0iEN7ZWAGn5HViiAy3s3ssesAiETQxzN+zig==",
       "dev": true,
       "dependencies": {
         "properties-reader": "2.3.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@labkey/build": "8.2.0",
-    "@labkey/test": "1.6.2",
+    "@labkey/test": "1.6.3",
     "@types/jest": "29.5.12",
     "@types/react": "16.14.60",
     "@types/react-dom": "16.9.24",


### PR DESCRIPTION
#### Rationale
This updates the experiment module dependency on `@labkey/test` to the latest version correlated with v24.11. This is done primarily to get the experiment endpoint tests passing again in CI.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1639
- #6021

#### Changes
- Bump `@labkey/test`
