### PR TITLE
Fix issue where importing from the pipeline root doesn't properly process flow files

### DIFF
--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -242,8 +242,10 @@ public class XarReader extends AbstractXarImporter
                 ExperimentRunType a = _experimentArchive.getExperimentRuns().getExperimentRunArray(0);
                 a.setCreateNewIfDuplicate(false);
                 a.setGenerateDataFromStepRecord(false);
-                for (int i = a.getExperimentLog().getExperimentLogEntryArray().length - 1; i >= 0; i--)
-                    a.getExperimentLog().removeExperimentLogEntry(i);
+                
+                if (a.isSetExperimentLog())
+                    for (int i = a.getExperimentLog().getExperimentLogEntryArray().length - 1; i >= 0; i--)
+                        a.getExperimentLog().removeExperimentLogEntry(i);
 
                 try (OutputStream fos = Files.newOutputStream(expDir.resolve("experiment.xar.xml")))
                 {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51706
Importing Flow files directly from the root aren't processed as expected

#### Related Pull Requests
- https://github.com/LabKey/commonAssays/pull/825

#### Changes
- Add a check to make sure archive log is actually present to prevent NPE
