### PR TITLE
Stop double encoding button tooltips

### DIFF
--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -482,11 +482,6 @@ public abstract class JspBase extends JspContext implements HasViewContext
         return new ButtonBuilder(text);
     }
 
-    public ButtonBuilder button(Renderable html)
-    {
-        return new ButtonBuilder(html);
-    }
-
     public SelectBuilder select()
     {
         return new SelectBuilder();

--- a/api/src/org/labkey/api/query/import.jsp
+++ b/api/src/org/labkey/api/query/import.jsp
@@ -20,12 +20,11 @@
 <%@ page import="org.labkey.api.query.AbstractQueryImportAction" %>
 <%@ page import="org.labkey.api.query.QueryUpdateService" %>
 <%@ page import="org.labkey.api.util.HelpTopic" %>
+<%@ page import="org.labkey.api.util.JavaScriptFragment" %>
 <%@ page import="org.labkey.api.util.JsonUtil" %>
 <%@ page import="org.labkey.api.util.Pair" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
-<%@ page import="static org.labkey.api.util.HtmlString.NDASH" %>
-<%@ page import="org.labkey.api.util.JavaScriptFragment" %>
 <%@ page extends="org.labkey.api.jsp.JspBase"%>
 <%!
     @Override
@@ -53,8 +52,7 @@
             extraFormFields += o.toString() + ",\n";
     }
 
-
-    if (bean.urlExcelTemplates != null && bean.urlExcelTemplates.size() > 0)
+    if (bean.urlExcelTemplates != null && !bean.urlExcelTemplates.isEmpty())
     {
         if (bean.urlExcelTemplates.size() == 1)
         {
@@ -72,7 +70,12 @@
             <%= button("Download").onClick("window.location = document.getElementById('importTemplate').value;") %><br>&nbsp;<br>
             <%
         }
-    }%>
+    }
+
+    // We really want an en dash here; ignore IntelliJ which tries to replace this with a simple short dash.
+    //noinspection UnnecessaryUnicodeEscape
+    String ndash = "\u2013";
+%>
 
 <style>
     .lk-import-expando .labkey-button {
@@ -102,7 +105,7 @@
     <div class="panel-heading">
         <h3 class="panel-title pull-left">Copy/paste text</h3>
         <span class="lk-import-expando pull-right">
-            <%=button(NDASH).id(copyPasteDivId + "Expando") %>
+            <%=button(ndash).id(copyPasteDivId + "Expando") %>
         </span>
         <div class="clearfix"></div>
     </div>
@@ -136,7 +139,7 @@
 
     function toggleExpanded(toggleButton, toggleDiv, collapseButton, collapseDiv)
     {
-        var collapsed = -1 !== toggleButton.dom.innerHTML.indexOf("+");
+        const collapsed = -1 !== toggleButton.dom.innerHTML.indexOf("+");
         toggleButton.dom.innerHTML = collapsed ? "&ndash;" : "+";
         toggleDiv.parent().setStyle("display",collapsed?"block":"none");
 

--- a/api/src/org/labkey/api/util/Button.java
+++ b/api/src/org/labkey/api/util/Button.java
@@ -18,7 +18,6 @@ package org.labkey.api.util;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.RenderContext;
-import org.labkey.api.util.DOM.Renderable;
 import org.labkey.api.view.DisplayElement;
 import org.labkey.api.view.HttpView;
 
@@ -53,7 +52,7 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
     // Composable members
     private final String cssClass;
     private final String iconCls;
-    private final Renderable html; // required
+    private final String caption; // required
     private final String href;
     private final String onClick;
     private final String id;
@@ -75,7 +74,7 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
     {
         this.cssClass = builder.cssClass;
         this.dropdown = builder.dropdown;
-        this.html     = builder.html;
+        this.caption = builder.caption;
         this.href = builder.href;
         this.onClick = builder.onClick;
         this.iconCls = builder.iconCls;
@@ -235,7 +234,7 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
         boolean iconOnly = getIconCls() != null;
         String submitId = page.makeId("submit_");
         // In the icon-only button case, use caption as tooltip. This avoids having to set both caption and tooltip
-        final Renderable tip = (null != tooltip ? HtmlString.of(tooltip) : (!iconOnly ? null : html));
+        final String tip = (null != tooltip ? tooltip : (iconOnly ? caption : null));
         String clickHandler = generateOnClick();
 
         var attrs = at(attributes)
@@ -257,13 +256,13 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
         return createHtmlFragment(
             isSubmit() ?
             INPUT(at(type,"submit",tabindex,"-1",Attribute.style,"position:absolute;left:-9999px;width:1px;height:1px;",Attribute.id,submitId)) : null,
-            A(attrs, iconOnly ? FA(getIconCls()) : SPAN(html))
+            A(attrs, iconOnly ? FA(getIconCls()) : SPAN(caption))
         );
     }
 
     public static class ButtonBuilder extends DisplayElementBuilder<Button, ButtonBuilder>
     {
-        private final Renderable html;
+        private final String caption;
 
         private String typeCls;
         private boolean disableOnClick;
@@ -271,14 +270,9 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
         private boolean enabled = true;
         private boolean submit;
 
-        public ButtonBuilder(@NotNull String text)
+        public ButtonBuilder(@NotNull String caption)
         {
-            this.html = HtmlString.of(text);
-        }
-
-        public ButtonBuilder(@NotNull Renderable html)
-        {
-            this.html = html;
+            this.caption = caption;
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
Primary concern: tooltips on buttons were getting double encoded. For example, the "Clone Permissions" button on the user details page:

![double encoded tooltip](https://github.com/user-attachments/assets/ec4fb25b-df2a-466c-b1f4-407697f1fb44)

Secondary concern: tooltip and caption handling was more complicated than it needed to be, especially for icons. Let's call the caption `caption` and stop accepting HTML captions, which nobody needs and won't work for tooltips.