### PR TITLE
Set TLD override earlier

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -142,8 +142,9 @@ import org.labkey.api.security.ValidEmail;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.AppPropsTestCase;
-import org.labkey.api.settings.LookAndFeelProperties;
+import org.labkey.api.settings.BaseServerProperties;
 import org.labkey.api.settings.LookAndFeelFolderPropertiesTest;
+import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.settings.OptionalFeatureStartupListener;
 import org.labkey.api.settings.WriteableLookAndFeelProperties;
@@ -358,6 +359,7 @@ public class ApiModule extends CodeOnlyModule
             Aggregate.TestCase.class,
             ApiXmlWriter.TestCase.class,
             ArrayListMap.TestCase.class,
+            BaseServerProperties.TestCase.class,
             BooleanFormat.TestCase.class,
             BuilderObjectFactory.TestCase.class,
             CachingDataIterator.ScrollTestCase.class,

--- a/api/src/org/labkey/api/settings/BaseServerProperties.java
+++ b/api/src/org/labkey/api/settings/BaseServerProperties.java
@@ -16,16 +16,13 @@
 package org.labkey.api.settings;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.validator.routines.DomainValidator;
 import org.apache.commons.validator.routines.UrlValidator;
-import org.apache.logging.log4j.LogManager;
+import org.junit.Assert;
+import org.junit.Test;
 import org.labkey.api.util.URLHelper;
 
 import java.net.URISyntaxException;
 
-/**
- * Created by adam on 11/24/2015.
- */
 public class BaseServerProperties
 {
     private final String _scheme;
@@ -96,17 +93,12 @@ public class BaseServerProperties
         }
         else
         {
-            switch (scheme)
+            serverPort = switch (scheme)
             {
-                case "http":
-                    serverPort = 80;
-                    break;
-                case "https":
-                    serverPort = 443;
-                    break;
-                default:
-                    serverPort = -1;
-            }
+                case "http" -> 80;
+                case "https" -> 443;
+                default -> -1;
+            };
         }
 
         return new BaseServerProperties(scheme, serverName, serverPort);
@@ -138,5 +130,26 @@ public class BaseServerProperties
     public int getServerPort()
     {
         return _serverPort;
+    }
+
+
+    public static class TestCase extends Assert
+    {
+        @Test
+        public void validateLocalDomains()
+        {
+            UrlValidator validator = new UrlValidator(new String[]{"http", "https"}, UrlValidator.ALLOW_LOCAL_URLS);
+            validate(validator, "http://www.foo.local");
+            validate(validator, "https://www.foo.local");
+            validate(validator, "http://localhost");
+            validate(validator, "https://localhost");
+            validate(validator, "http://localhost:8080");
+            validate(validator, "https://localhost:8080");
+        }
+
+        private void validate(UrlValidator validator, String url)
+        {
+            assertTrue(url + " was not valid!", validator.isValid(url));
+        }
     }
 }

--- a/api/src/org/labkey/api/settings/BaseServerProperties.java
+++ b/api/src/org/labkey/api/settings/BaseServerProperties.java
@@ -29,22 +29,6 @@ public class BaseServerProperties
     private final String _serverName;
     private final int _serverPort;
 
-    static
-    {
-        try
-        {
-            // Adds non-standard TLDs to allowable values for Apache Commons Validator. See Issue 25041.
-
-            // We've received an exception report that indicates (but does not definitively prove) this call may fail
-            // on some servers. Shouldn't be fatal if it doesn't work.
-            DomainValidator.updateTLDOverride(DomainValidator.ArrayType.GENERIC_PLUS, new String[]{"local"});
-        }
-        catch (Throwable e)
-        {
-            LogManager.getLogger(BaseServerProperties.class).error("Failed to enable .local domains in URL validation", e);
-        }
-    }
-
     // Validate and parse, returning properties
     public static BaseServerProperties parseAndValidate(String baseServerUrl) throws URISyntaxException
     {
@@ -58,7 +42,7 @@ public class BaseServerProperties
         // Divide up the parts and validate some more
         URLHelper url = new URLHelper(baseServerUrl);
 
-        if (url.getParsedPath().size() > 0)
+        if (!url.getParsedPath().isEmpty())
             throw new URISyntaxException(baseServerUrl, "Too many path parts");
 
         BaseServerProperties props = parse(baseServerUrl);

--- a/api/src/org/labkey/api/util/ContextListener.java
+++ b/api/src/org/labkey/api/util/ContextListener.java
@@ -19,6 +19,7 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 import org.apache.commons.logging.LogFactory;
+import org.apache.commons.validator.routines.DomainValidator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -57,6 +58,13 @@ public class ContextListener implements ServletContextListener
             // Set this only if the user hasn't overridden it
             System.setProperty(LogHelper.LOG_HOME_PROPERTY_NAME, System.getProperty("catalina.base") + "/logs");
         }
+
+        // Adds non-standard TLDs to allowable values for Apache Commons Validator. See Issue 25041. Since this
+        // is set statically, it must be called very early, before any reference to UrlValidator occurs. Any
+        // reference to that class, including its constants or classes that might extend it, results in
+        // UrlValidator statically constructing a default UrlValidator, which causes any subsequent call to
+        // updateTLDOverride() to throw.
+        DomainValidator.updateTLDOverride(DomainValidator.ArrayType.GENERIC_PLUS, "local");
     }
 
     private static final List<ShutdownListener> _shutdownListeners = new CopyOnWriteArrayList<>();

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -29,7 +29,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;


### PR DESCRIPTION
#### Rationale
Related PR added a usage of `UrlValidator` that executed before `BaseServerProperties` was able to set its override that allows ".local" domains. This resulted in an `IllegalStateException` when the override call was attempted. I tried more elegant solutions (e.g., create and use our own subclass of UrlValidator that statically sets the override), but unfortunately, any reference UrlValidator (including the constants it defines or touching any subclass) results in UrlValidator constructing a static default instance before we can call our override. So, just make the override call in `ContextListener` and move on.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6043