### PR TITLE
Make "create empty module" work on SQL Server

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -843,7 +843,8 @@ public class ModuleLoader implements MemTrackerListener
         Module core = getCoreModule();
 
         SupportedDatabase coreType = SupportedDatabase.get(CoreSchema.getInstance().getSqlDialect());
-        for (Module module : modules)
+        // Need to enumerate a copy of the list to avoid ConcurrentModificationException
+        for (Module module : new ArrayList<>(modules))
         {
             if (module == core)
                 continue;


### PR DESCRIPTION
#### Rationale
While investigating the issue fixed in the related PR, discovered a `ConcurrentModificationException` when removing modules

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/117