### PR TITLE
Fb issue 51208

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -713,7 +713,7 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
                 assert null != indexPtidOutput || hasErrors();
 
                 String ptid = null == indexPtidOutput ? "" : getOutputString(indexPtidOutput);
-                sb.append(ptid);
+                sb.append(ptid.trim());
 
                 if (!_datasetDefinition.isDemographicData())
                 {


### PR DESCRIPTION
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51208)

#### Rationale
The repro is to import a CSV where the participant ID has either leading (or trailing) whitespace. The value should be quoted.