### PR TITLE
Address NPE in set password workflows

### DIFF
--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -91,7 +91,7 @@ public abstract class PostgreSql91Dialect extends SqlDialect
 {
     public static final int TEMPTABLE_GENERATOR_MINSIZE = 1000;
     public static final String PRODUCT_NAME = "PostgreSQL";
-    public static final String RECOMMENDED = PRODUCT_NAME + " 16.x is the recommended version.";
+    public static final String RECOMMENDED = PRODUCT_NAME + " 17.x is the recommended version.";
 
     private final Map<String, Integer> _domainScaleMap = new CopyOnWriteHashMap<>();
     private final AtomicBoolean _arraySortFunctionExists = new AtomicBoolean(false);

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -133,6 +133,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.labkey.api.security.AuthenticationManager.AUTO_CREATE_ACCOUNTS_KEY;
@@ -1606,7 +1607,7 @@ public class LoginController extends SpringActionController
             NamedObjectList passwordInputs = getPasswordInputs(form);
             String buttonText = getButtonText();
             SetPasswordBean bean = new SetPasswordBean(
-                    form, getEmailForForm(form), _unrecoverableError, getMessage(form),
+                    form, getEmailForForm(form), _unrecoverableError, getSuccessMessageSupplier(form),
                     nonPasswordInputs, passwordInputs, getClass(), isCancellable(form),
                     buttonText, getTitle()
             );
@@ -1675,7 +1676,7 @@ public class LoginController extends SpringActionController
         }
 
         protected abstract void verify(SetPasswordForm form, Errors errors);
-        protected abstract String getMessage(SetPasswordForm form);
+        protected abstract Supplier<String> getSuccessMessageSupplier(SetPasswordForm form);
         protected abstract NamedObjectList getPasswordInputs(SetPasswordForm form);
         protected boolean clearVerification()
         {
@@ -1709,9 +1710,9 @@ public class LoginController extends SpringActionController
         }
 
         @Override
-        protected String getMessage(SetPasswordForm form)
+        protected Supplier<String> getSuccessMessageSupplier(SetPasswordForm form)
         {
-            return "Your email address (" + _user.getEmail() + ") has been verified! Create an account password below.";
+            return () -> "Your email address (" + _user.getEmail() + ") has been verified! Create an account password below.";
         }
 
         @Override
@@ -1766,12 +1767,12 @@ public class LoginController extends SpringActionController
         User user = LoginManager.verify(verification);
         boolean isVerified = user != null;
 
-        LoginController.checkVerificationErrors(isVerified, user, errors);
+        LoginController.checkVerificationErrors(isVerified, user, verification, errors);
 
         return isVerified && !errors.hasErrors() ? user : null;
     }
 
-    public static void checkVerificationErrors(boolean isVerified, User user, Errors errors)
+    public static void checkVerificationErrors(boolean isVerified, User user, String verification, Errors errors)
     {
         if (isVerified)
         {
@@ -1783,10 +1784,13 @@ public class LoginController extends SpringActionController
         }
         else
         {
-            // Verification string wasn't found. User might have already verified, they don't have a login (should be
-            // using LDAP or SSO), or the link got mangled. Don't provide detailed guidance since that could reveal
-            // information about existing users.
-            errors.reject("setPassword", "Verification failed. Make sure you've copied the entire link into your browser's address bar.");
+            // Verification failed. Inspect the verification token to provide a bit of guidance.
+            if (null == verification)
+                errors.reject("setPassword", "Verification failed. The verification parameter is missing. Make sure you've copied the entire link into your browser's address bar.");
+            else if (verification.length() < LoginManager.TEMP_PASSWORD_LENGTH)
+                errors.reject("setPassword", "Verification failed. The verification parameter is shorter than expected. Make sure you've copied the entire link into your browser's address bar.");
+            else
+                errors.reject("setPassword", "Verification failed. You may have already verified.");
         }
     }
 
@@ -1811,9 +1815,9 @@ public class LoginController extends SpringActionController
         }
 
         @Override
-        protected String getMessage(SetPasswordForm form)
+        protected Supplier<String> getSuccessMessageSupplier(SetPasswordForm form)
         {
-            return "Welcome! We see that this is your first time logging in. This wizard will guide you through " +
+            return () -> "Welcome! We see that this is your first time logging in. This wizard will guide you through " +
                     "creating a Site Administrator account that has full control over this server, installing the modules " +
                     "required to use LabKey Server, and setting some basic configuration.";
         }
@@ -1967,9 +1971,9 @@ public class LoginController extends SpringActionController
         }
 
         @Override
-        protected String getMessage(SetPasswordForm form)
+        protected Supplier<String> getSuccessMessageSupplier(SetPasswordForm form)
         {
-            return form.getMessage();
+            return () -> form.getMessage();
         }
 
         @Override
@@ -2044,7 +2048,7 @@ public class LoginController extends SpringActionController
         public final String email;
         public final SetPasswordForm form;
         public final boolean unrecoverableError;
-        public final String message;
+        public final Supplier<String> successMessageSupplier;
         public final NamedObjectList nonPasswordInputs;
         public final NamedObjectList passwordInputs;
         public final Class<? extends AbstractSetPasswordAction> action;
@@ -2054,14 +2058,14 @@ public class LoginController extends SpringActionController
 
         // TODO switch to builder pattern
         private SetPasswordBean(SetPasswordForm form, @Nullable String emailForForm, boolean unrecoverableError,
-                                String message, NamedObjectList nonPasswordInputs, NamedObjectList passwordInputs,
+                                Supplier<String> successMessageSupplier, NamedObjectList nonPasswordInputs, NamedObjectList passwordInputs,
                                 Class<? extends AbstractSetPasswordAction> clazz, boolean cancellable,
                                 String buttonText, String title)
         {
             this.form = form;
             this.email = emailForForm;
             this.unrecoverableError = unrecoverableError;
-            this.message = message;
+            this.successMessageSupplier = successMessageSupplier;
             this.nonPasswordInputs = nonPasswordInputs;
             this.passwordInputs = passwordInputs;
             this.action = clazz;

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -64,7 +64,7 @@
 
     <div class="auth-form-body">
     <% if (!bean.unrecoverableError) { %>
-        <p><%=h(bean.message)%></p>
+        <p><%=h(bean.successMessageSupplier.get())%></p>
 
         <%
             for (NamedObject input : bean.nonPasswordInputs)

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -1902,7 +1902,7 @@ public class UserController extends SpringActionController
                     String requestedEmail = verifyEmail.requestedEmail();
                     String verificationToken = form.getVerificationToken();
                     boolean isVerified = verifyEmail.isVerified(verificationToken);
-                    LoginController.checkVerificationErrors(isVerified, loggedInUser, errors);
+                    LoginController.checkVerificationErrors(isVerified, loggedInUser, verificationToken, errors);
 
                     if (!errors.hasErrors())  // verified and active
                     {


### PR DESCRIPTION
#### Rationale
Users are clicking their emailed verification links long after they've verified. A recent refactor caused this case to NPE.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6021

#### Changes
- Ensure that no attempt is made to generate a success message when there's an unrecoverable error (e.g., verification failed, so no user)
- In the verification failure case, inspect the token to provide slightly more specific guidance
- Also, recommend PostgreSQL 17.x