### PR TITLE
Issue 51749: Site validator fails on some wikis

### DIFF
--- a/api/src/org/labkey/api/view/Portal.java
+++ b/api/src/org/labkey/api/view/Portal.java
@@ -1702,10 +1702,9 @@ public class Portal implements ModuleChangeListener
         }
         catch(Throwable t)
         {
-            WebPartView errorView;
             int status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
             String message = "An unexpected error occurred";
-            errorView = ExceptionUtil.getErrorWebPartView(status, message, t, portalCtx.getRequest());
+            WebPartView<?> errorView = ExceptionUtil.getErrorWebPartView(status, message, t, portalCtx.getRequest());
             errorView.setTitle(webPart.getName());
             errorView.setWebPart(webPart);
             return errorView;

--- a/core/src/org/labkey/core/admin/sitevalidation/SiteValidationJob.java
+++ b/core/src/org/labkey/core/admin/sitevalidation/SiteValidationJob.java
@@ -6,6 +6,7 @@ import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.PipelineStatusFile;
+import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.URLHelper;
@@ -60,7 +61,11 @@ public class SiteValidationJob extends PipelineJob
             setStatus(s);
         });
         JspTemplate<SiteValidationForm> template = new JspTemplate<>("/org/labkey/core/admin/sitevalidation/siteValidation.jsp", _form);
-        ViewContext context = new ViewContext(getInfo());
+        // Issue 51749 - ensure we have a URL for wiki validation
+        ViewBackgroundInfo info = new ViewBackgroundInfo(getInfo().getContainer(),
+                getInfo().getUser(),
+                getInfo().getURL() == null ? AppProps.getInstance().getHomePageActionURL() : getInfo().getURL());
+        ViewContext context = new ViewContext(info);
         template.setViewContext(context);
         File results = FileUtil.appendName(getPipeRoot().getLogDirectory(), getResultsFileName());
 


### PR DESCRIPTION
#### Rationale
Some Wikis need the current URL to render. We have to supply a fake one for site validation that's happening in a pipeline job.

#### Changes
- Supply a dummy URL