### PR TITLE
Issue 51752: LKSM: Using a period in entity name and making it a required parent errors

### DIFF
--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -226,12 +226,12 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
     }
 
     /**
-     * @return a Map<columnName, alternativeColumnName> of additionally required fields during import.
+     * @return a List<Set<String>> a list of additionally required fields during import, each field can have a Set of alternative field keys
      * Example usage is specifying the set of required lineage columns during sample/dataclass data creation.
      */
-    @NotNull default Map<String, String> getAdditionalRequiredInsertColumns()
+    @NotNull default List<Set<String>> getAdditionalRequiredInsertColumns()
     {
-        return Collections.emptyMap();
+        return Collections.emptyList();
     }
 
     ColumnInfo getVersionColumn();

--- a/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
@@ -38,6 +38,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -245,7 +246,7 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
         //
         // check for unbound columns that are required
         //
-        Map<String, String> additionalRequiredColumns = _target.getAdditionalRequiredInsertColumns();
+        List<Set<String>> additionalRequiredInsertColumns = _target.getAdditionalRequiredInsertColumns();
         if (_validate && !context.getConfigParameterBoolean(QueryUpdateService.ConfigParameters.SkipRequiredFieldValidation) && !context.getInsertOption().updateOnly)
         {
             for (TranslateHelper pair : unusedCols.values())
@@ -256,15 +257,13 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
 
             if (!context.getConfigParameterBoolean(ExperimentService.QueryOptions.DeferRequiredLineageValidation))
             {
-                if (!additionalRequiredColumns.isEmpty())
+                if (!additionalRequiredInsertColumns.isEmpty())
                 {
                     Set<String> allColumns = new CaseInsensitiveHashSet(convert.getColumnNameMap().keySet());
-                    for (Map.Entry<String, String> entry : additionalRequiredColumns.entrySet())
+                    for (Set<String> requiredColumnSet : additionalRequiredInsertColumns)
                     {
-                        if (!allColumns.contains(entry.getKey()) && !allColumns.contains(entry.getValue()))
-                        {
-                            setupError.addGlobalError("Data does not contain required field: " + entry.getValue());
-                        }
+                        if (Collections.disjoint(allColumns, new CaseInsensitiveHashSet(requiredColumnSet)))
+                            setupError.addGlobalError("Data does not contain required field: " + requiredColumnSet.iterator().next());
                     }
                 }
             }
@@ -302,8 +301,8 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
             Set<String> additionalRequiredCols = new CaseInsensitiveHashSet();
             if (!context.getConfigParameterBoolean(ExperimentService.QueryOptions.DeferRequiredLineageValidation))
             {
-                additionalRequiredCols.addAll(additionalRequiredColumns.keySet());
-                additionalRequiredCols.addAll(additionalRequiredColumns.values());
+                for (Set<String> requiredFields : additionalRequiredInsertColumns)
+                    additionalRequiredCols.addAll(requiredFields);
             }
             ValidatorIterator validate = getValidatorIterator(validateInput, context, translateHelperMap, _c, _user);
 

--- a/api/src/org/labkey/api/util/SubstitutionFormat.java
+++ b/api/src/org/labkey/api/util/SubstitutionFormat.java
@@ -223,6 +223,12 @@ public class SubstitutionFormat
             Collection<?> c = (Collection)value;
             return c.stream().skip(1).collect(Collectors.toList());
         }
+
+        @Override
+        public int argumentCount()
+        {
+            return 0;
+        }
     };
 
     static final SubstitutionFormat last = new SubstitutionFormat("last")

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -894,20 +894,18 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
     @Override
     @NotNull
-    public Map<String, String> getAdditionalRequiredInsertColumns()
+    public List<Set<String>> getAdditionalRequiredInsertColumns()
     {
         if (getDataClass() == null)
-            return Collections.emptyMap();
+            return Collections.emptyList();
 
-        Map<String, String> required = new CaseInsensitiveHashMap<>();
         try
         {
-            required.putAll(getDataClass().getRequiredImportAliases());
-            return required;
+            return getRequiredParentImportFields(getDataClass().getRequiredImportAliases());
         }
         catch (IOException e)
         {
-            return Collections.emptyMap();
+            return Collections.emptyList();
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1513,20 +1513,18 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
     @Override
     @NotNull
-    public Map<String, String> getAdditionalRequiredInsertColumns()
+    public List<Set<String>> getAdditionalRequiredInsertColumns()
     {
         if (getSampleType() == null)
-            return Collections.emptyMap();
+            return Collections.emptyList();
 
-        Map<String, String> required = new CaseInsensitiveHashMap<>();
         try
         {
-            required.putAll(getSampleType().getRequiredImportAliases());
-            return required;
+            return getRequiredParentImportFields(getSampleType().getRequiredImportAliases());
         }
         catch (IOException e)
         {
-            return Collections.emptyMap();
+            return Collections.emptyList();
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
@@ -47,6 +47,7 @@ import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -321,7 +322,7 @@ public abstract class ExpRunItemTableImpl<C extends Enum> extends ExpTableImpl<C
         List<Set<String>> required = new ArrayList<>();
         for (Map.Entry<String, String> importAlias : requiredImportAliases.entrySet())
         {
-            Set<String> fields = new HashSet<>();
+            Set<String> fields = new LinkedHashSet<>();
             String dataType = importAlias.getValue();
             boolean isParentSamples = dataType.toLowerCase().startsWith(MATERIAL_INPUTS_ALIAS_PREFIX.toLowerCase());
             String prefix = isParentSamples ? MATERIAL_INPUTS_ALIAS_PREFIX : DATA_INPUTS_ALIAS_PREFIX;

--- a/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
@@ -35,6 +35,7 @@ import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.LookupForeignKey;
+import org.labkey.api.query.QueryKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
@@ -44,12 +45,16 @@ import org.labkey.experiment.lineage.LineageForeignKey;
 
 import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.labkey.api.data.UpdateableTableInfo.ObjectUriType.schemaColumn;
+import static org.labkey.api.exp.api.ExperimentJSONConverter.DATA_INPUTS_ALIAS_PREFIX;
+import static org.labkey.api.exp.api.ExperimentJSONConverter.MATERIAL_INPUTS_ALIAS_PREFIX;
 
 public abstract class ExpRunItemTableImpl<C extends Enum> extends ExpTableImpl<C> implements UpdateableTableInfo
 {
@@ -306,5 +311,27 @@ public abstract class ExpRunItemTableImpl<C extends Enum> extends ExpTableImpl<C
         }
 
         return hasProvisionedCol;
+    }
+
+    protected List<Set<String>> getRequiredParentImportFields(@Nullable Map<String, String> requiredImportAliases)
+    {
+        if (requiredImportAliases == null || requiredImportAliases.isEmpty())
+            return Collections.emptyList();
+
+        List<Set<String>> required = new ArrayList<>();
+        for (Map.Entry<String, String> importAlias : requiredImportAliases.entrySet())
+        {
+            Set<String> fields = new HashSet<>();
+            String dataType = importAlias.getValue();
+            boolean isParentSamples = dataType.toLowerCase().startsWith(MATERIAL_INPUTS_ALIAS_PREFIX.toLowerCase());
+            String prefix = isParentSamples ? MATERIAL_INPUTS_ALIAS_PREFIX : DATA_INPUTS_ALIAS_PREFIX;
+            String dataTypeName = dataType.substring(prefix.length());
+            String encoded = prefix + QueryKey.encodePart(dataTypeName);
+            fields.add(dataType); // MaterialInputs/Sample.Type1
+            fields.add(importAlias.getKey()); // pAlias
+            fields.add(encoded); // MaterialInputs/Sample$PType1
+            required.add(fields);
+        }
+        return required;
     }
 }


### PR DESCRIPTION
#### Rationale
When a parent data type is supplied as a column input, its query encoded since the data type name is a query name. The required field check currently checks for the decoded form only. Changes made to accept encoded parent input during validation.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1585
- https://github.com/LabKey/labkey-ui-premium/pull/539
- https://github.com/LabKey/platform/pull/5872
- https://github.com/LabKey/limsModules/pull/730
- https://github.com/LabKey/testAutomation/pull/2072

- https://github.com/LabKey/limsModules/pull/952

#### Changes
- check encoded parent fields during required field validation
