### PR TITLE
Fix some date compare clauses

### DIFF
--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -1653,15 +1653,10 @@ public abstract class CompareType
         @Override
         String toWhereClause(SqlDialect dialect, String alias)
         {
+            // See Issue 51472
             return dialect.isSqlServer() ?
-                dialect.getColumnSelectName(alias) + getSqlServerComparison() :
+                dialect.getColumnSelectName(alias) + _comparison.getSql().replace("?", SS_CAST) :
                 super.toWhereClause(dialect, alias);
-        }
-
-        // See Issue 51472
-        protected String getSqlServerComparison()
-        {
-            throw new IllegalStateException("Must override either toWhereClause() or getSqlServerComparison()");
         }
 
         @Override
@@ -1777,12 +1772,6 @@ public abstract class CompareType
         }
 
         @Override
-        protected String getSqlServerComparison()
-        {
-            return " > " + SS_CAST;
-        }
-
-        @Override
         protected boolean meetsCriteria(ColumnRenderProperties col, Object value)
         {
             if (value == null)
@@ -1804,12 +1793,6 @@ public abstract class CompareType
         DateGteCompareClause(FieldKey fieldKey, Object rawFilterValue, Calendar startValue)
         {
             super(fieldKey, DATE_GTE, " >= ", rawFilterValue, startValue);
-        }
-
-        @Override
-        protected String getSqlServerComparison()
-        {
-            return " >= " + SS_CAST;
         }
 
         @Override
@@ -1837,12 +1820,6 @@ public abstract class CompareType
         }
 
         @Override
-        protected String getSqlServerComparison()
-        {
-            return " < " + SS_CAST;
-        }
-
-        @Override
         protected boolean meetsCriteria(ColumnRenderProperties col, Object value)
         {
             if (value == null)
@@ -1864,12 +1841,6 @@ public abstract class CompareType
         DateLteCompareClause(FieldKey fieldKey, Object rawFilterValue, Calendar startValue)
         {
             super(fieldKey, DATE_LTE, " <= ", rawFilterValue, addOneDay(startValue));
-        }
-
-        @Override
-        protected String getSqlServerComparison()
-        {
-            return " <= " + SS_CAST;
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
Previous fix to make date comparisons work consistently on non-US SQL Server duplicated the comparison SQL into each SQL Server override. Two of the duplicated comparisons were correct and two were incorrect, surprising no one. Switch to using the canonical `CompareType` SQL on all databases, substituting the necessary CAST in the SQL Server case.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5987
- https://github.com/LabKey/platform/pull/6107