### PR TITLE
Issue 51618: Start tracking queries before execution

### DIFF
--- a/api/src/org/labkey/api/data/dialect/StatementWrapper.java
+++ b/api/src/org/labkey/api/data/dialect/StatementWrapper.java
@@ -2909,7 +2909,8 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
 
     private @Nullable List<Object> translateParametersForQueryTracking()
     {
-        // Make a copy of the parameters list (it gets modified below) and switch to zero-based list (_parameters is a one-based list)
+        // Make a copy of the parameters list (it gets modified by callers) and switch to zero-based list (_parameters is a one-based list)
+
         List<Object> zeroBasedList;
 
         if (null != _parameters)

--- a/api/src/org/labkey/api/data/dialect/StatementWrapper.java
+++ b/api/src/org/labkey/api/data/dialect/StatementWrapper.java
@@ -27,6 +27,7 @@ import org.labkey.api.data.ConnectionWrapper;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.QueryLogging;
 import org.labkey.api.data.ResultSetWrapper;
+import org.labkey.api.data.queryprofiler.Query;
 import org.labkey.api.data.queryprofiler.QueryProfiler;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.DateUtil;
@@ -1237,7 +1238,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public ResultSet executeQuery()
             throws SQLException
     {
-        beforeExecute();
+        Query preQuery = beforeExecute(_debugSql);
         SQLException ex = null;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(_debugSql))
         {
@@ -1255,7 +1256,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
         finally
         {
-            afterExecute(_debugSql, ex, -1);
+            afterExecute(preQuery, ex, -1);
         }
     }
 
@@ -1263,7 +1264,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public int executeUpdate()
             throws SQLException
     {
-        beforeExecute();
+        Query preQuery = beforeExecute(_debugSql);
         SQLException ex = null;
         int rows = -1;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(_debugSql))
@@ -1277,7 +1278,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
         finally
         {
-            afterExecute(_debugSql, ex, rows);
+            afterExecute(preQuery, ex, rows);
         }
     }
 
@@ -1610,7 +1611,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public boolean execute()
             throws SQLException
     {
-        beforeExecute();
+        Query preQuery = beforeExecute(_debugSql);
         SQLException ex = null;
         Boolean ret=null;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(_debugSql))
@@ -1626,7 +1627,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         finally
         {
             int rows = (ret==Boolean.FALSE) ? _stmt.getUpdateCount() : -1;
-            afterExecute(_debugSql, ex, rows);
+            afterExecute(preQuery, ex, rows);
         }
     }
 
@@ -1827,7 +1828,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public ResultSet executeQuery(String sql)
             throws SQLException
     {
-        beforeExecute(sql);
+        Query preQuery = beforeExecute(sql);
         SQLException ex = null;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(_debugSql))
         {
@@ -1842,7 +1843,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
         finally
         {
-            afterExecute(_debugSql, ex, -1);
+            afterExecute(preQuery, ex, -1);
         }
     }
 
@@ -1850,7 +1851,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public int executeUpdate(String sql)
             throws SQLException
     {
-        beforeExecute(sql);
+        Query preQuery = beforeExecute(sql);
         int rows = -1;
         SQLException ex = null;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(_debugSql))
@@ -1864,7 +1865,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
         finally
         {
-            afterExecute(sql, ex, rows);
+            afterExecute(preQuery, ex, rows);
         }
     }
 
@@ -2045,7 +2046,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public boolean execute(String sql)
             throws SQLException
     {
-        beforeExecute(sql);
+        Query preQuery = beforeExecute(sql);
         SQLException ex = null;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(sql))
         {
@@ -2058,7 +2059,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
         finally
         {
-            afterExecute(sql, ex, -1);
+            afterExecute(preQuery, ex, -1);
         }
     }
 
@@ -2224,7 +2225,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public int[] executeBatch()
             throws SQLException
     {
-        beforeExecute();
+        Query preQuery = beforeExecute(_debugSql);
         SQLException ex = null;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(_debugSql))
         {
@@ -2237,7 +2238,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
         finally
         {
-            afterExecute(_debugSql, ex, -1);
+            afterExecute(preQuery, ex, -1);
         }
     }
 
@@ -2281,7 +2282,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public int executeUpdate(String sql, int autoGeneratedKeys)
             throws SQLException
     {
-        beforeExecute(sql);
+        Query preQuery = beforeExecute(sql);
         int rows = -1;
         SQLException ex = null;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(_debugSql))
@@ -2295,7 +2296,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
         finally
         {
-            afterExecute(sql, ex, rows);
+            afterExecute(preQuery, ex, rows);
         }
     }
 
@@ -2303,7 +2304,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public int executeUpdate(String sql, int[] columnIndexes)
             throws SQLException
     {
-        beforeExecute(sql);
+        Query preQuery = beforeExecute(sql);
         int rows = -1;
         SQLException ex = null;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(_debugSql))
@@ -2317,7 +2318,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
         finally
         {
-            afterExecute(sql, ex, rows);
+            afterExecute(preQuery, ex, rows);
         }
     }
 
@@ -2325,7 +2326,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public int executeUpdate(String sql, String[] columnNames)
             throws SQLException
     {
-        beforeExecute(sql);
+        Query preQuery = beforeExecute(sql);
         int rows = -1;
         SQLException ex = null;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(_debugSql))
@@ -2339,7 +2340,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
         finally
         {
-            afterExecute(sql, ex, rows);
+            afterExecute(preQuery, ex, rows);
         }
     }
 
@@ -2347,7 +2348,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public boolean execute(String sql, int autoGeneratedKeys)
             throws SQLException
     {
-        beforeExecute(sql);
+        Query preQuery = beforeExecute(sql);
         SQLException ex = null;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(sql))
         {
@@ -2360,7 +2361,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
         finally
         {
-            afterExecute(sql, ex, -1);
+            afterExecute(preQuery, ex, -1);
         }
     }
 
@@ -2368,7 +2369,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public boolean execute(String sql, int[] columnIndexes)
             throws SQLException
     {
-        beforeExecute(sql);
+        Query preQuery = beforeExecute(sql);
         SQLException ex = null;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(sql))
         {
@@ -2381,7 +2382,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
         finally
         {
-            afterExecute(sql, ex, -1);
+            afterExecute(preQuery, ex, -1);
         }
     }
 
@@ -2389,7 +2390,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
     public boolean execute(String sql, String[] columnNames)
             throws SQLException
     {
-        beforeExecute(sql);
+        Query preQuery = beforeExecute(sql);
         SQLException ex = null;
         try (var ignore = DebugInfoDumper.pushThreadDumpContext(sql))
         {
@@ -2402,7 +2403,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         }
         finally
         {
-            afterExecute(sql, ex, -1);
+            afterExecute(preQuery, ex, -1);
         }
     }
 
@@ -2793,36 +2794,34 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         throw new UnsupportedOperationException();
     }
 
-    private void beforeExecute(String sql)
+    private Query beforeExecute(String sql)
     {
         _debugSql = sql;
-        beforeExecute();
-    }
-
-    private void beforeExecute()
-    {
         // Crawler.java and BaseWebDriverTest.java use "8(" as attempted injection string
         if (_debugSql.contains("\"8(\"") && !_debugSql.contains("\"\"8(\"\"")) // 18196
             throw new IllegalArgumentException("SQL injection test failed: " + _debugSql);
         _msStart = System.currentTimeMillis();
+
+        List<Object> zeroBasedList = translateParametersForQueryTracking();
+        return QueryProfiler.getInstance().preTrack(_conn.getScope(), sql, zeroBasedList, _stackTrace, isRequestThread());
     }
 
 
-    private void afterExecute(String sql, @Nullable SQLException x, int rowsAffected)
+    private void afterExecute(Query query, @Nullable SQLException x, int rowsAffected)
     {
         if (null != x)
         {
-            ExceptionUtil.decorateException(x, ExceptionUtil.ExceptionInfo.DialectSQL, sql, true);
+            ExceptionUtil.decorateException(x, ExceptionUtil.ExceptionInfo.DialectSQL, query.getOriginalSql(), true);
             if (SqlDialect.isConfigurationException(x))
             {
                 ExceptionUtil.decorateException(x, ExceptionUtil.ExceptionInfo.SkipMothershipLogging, "true", true);
             }
         }
-        _logStatement(sql, x, rowsAffected, getQueryLogging());
+        _logStatement(query.getOriginalSql(), x, rowsAffected, getQueryLogging());
     }
     
 
-    private static final Package _java_lang = java.lang.String.class.getPackage();
+    private static final Package JAVA_LANG = java.lang.String.class.getPackage();
 
     private void _logStatement(String sql, @Nullable SQLException x, int rowsAffected, QueryLogging queryLogging)
     {
@@ -2833,40 +2832,8 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         if (isAssertEnabled && AppProps.getInstance().isDevMode() && isMutatingSql(sql))
             SpringActionController.executingMutatingSql(sql);
 
-        // Make a copy of the parameters list (it gets modified below) and switch to zero-based list (_parameters is a one-based list)
-        List<Object> zeroBasedList;
-
-        if (null != _parameters)
-        {
-            zeroBasedList = new ArrayList<>(_parameters.size());
-
-            // Translate parameters that can't be cached (for now, just JDBC arrays). I'd rather stash the original parameters and send
-            // those to the query profiler, but this would require one or more non-standard methods on StatementWrapper. See #24314.
-            for (Object o : _parameters)
-            {
-                if (o instanceof Array a)
-                {
-                    try
-                    {
-                        o = a.getArray();
-                    }
-                    catch (Exception e)
-                    {
-                        _log.error("Could not retrieve array", e);
-                        o = null;
-                    }
-                }
-
-                zeroBasedList.add(o);
-            }
-        }
-        else
-        {
-            zeroBasedList = null;
-        }
-
         // Hold on to this stack trace so that we can reuse it later (if collection has been enabled)
-        StackTraceElement[] stack = QueryProfiler.getInstance().track(_conn.getScope(), sql, zeroBasedList, elapsed, _stackTrace, isRequestThread(), queryLogging);
+        Query query = QueryProfiler.getInstance().track(_conn.getScope(), sql, translateParametersForQueryTracking(), elapsed, _stackTrace, isRequestThread(), queryLogging);
 
         if (x != null)
         {
@@ -2914,14 +2881,13 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
                     logEntry.append(value);
                     Class<?> c = null==o ? null : o.getClass();
                     if (null != c && c != String.class && c != Integer.class)
-                        logEntry.append(" :").append(c.getPackage() == _java_lang ? c.getSimpleName() : c.getName());
+                        logEntry.append(" :").append(c.getPackage() == JAVA_LANG ? c.getSimpleName() : c.getName());
                 }
                 catch (Exception ex)
                 {
                     /* */
                 }
             }
-            _parameters.clear();
         }
         _parameters = null;
 
@@ -2929,7 +2895,7 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
             logEntry.append("\n    cancelled by user");
         if (null != x)
             logEntry.append("\n    ").append(x);
-        _appendTableStackTrace(logEntry, 5, stack);
+        _appendTableStackTrace(logEntry, 5, query.getStackTraceElements());
 
         final String logString = logEntry.toString();
         _log.log(Level.DEBUG, logString);
@@ -2939,6 +2905,42 @@ public class StatementWrapper implements Statement, PreparedStatement, CallableS
         {
             DebugInfoDumper.dumpThreads(_log);
         }
+    }
+
+    private @Nullable List<Object> translateParametersForQueryTracking()
+    {
+        // Make a copy of the parameters list (it gets modified below) and switch to zero-based list (_parameters is a one-based list)
+        List<Object> zeroBasedList;
+
+        if (null != _parameters)
+        {
+            zeroBasedList = new ArrayList<>(_parameters.size());
+
+            // Translate parameters that can't be cached (for now, just JDBC arrays). I'd rather stash the original parameters and send
+            // those to the query profiler, but this would require one or more non-standard methods on StatementWrapper. See #24314.
+            for (Object o : _parameters)
+            {
+                if (o instanceof Array a)
+                {
+                    try
+                    {
+                        o = a.getArray();
+                    }
+                    catch (Exception e)
+                    {
+                        _log.error("Could not retrieve array", e);
+                        o = null;
+                    }
+                }
+
+                zeroBasedList.add(o);
+            }
+        }
+        else
+        {
+            zeroBasedList = null;
+        }
+        return zeroBasedList;
     }
 
     private boolean isMutatingSql(String sql)

--- a/api/src/org/labkey/api/data/queryprofiler/Query.java
+++ b/api/src/org/labkey/api/data/queryprofiler/Query.java
@@ -39,8 +39,7 @@ public class Query
     DbScope _scope;
     private final String _sql;
     private boolean _truncated;
-    private final @Nullable
-    List<Object> _parameters;
+    private final @Nullable List<Object> _parameters;
     private final long _elapsed;
     private final StackTraceElement[] _stackTrace;
     private final boolean _isRequestThread;
@@ -60,6 +59,11 @@ public class Query
     public DbScope getScope()
     {
         return _scope;
+    }
+
+    public String getOriginalSql()
+    {
+        return _sql;
     }
 
     public String getSql()
@@ -85,6 +89,11 @@ public class Query
     public long getElapsed()
     {
         return _elapsed;
+    }
+
+    public StackTraceElement[] getStackTraceElements()
+    {
+        return _stackTrace;
     }
 
     public String getStackTrace()

--- a/api/src/org/labkey/api/data/queryprofiler/QueryProfiler.java
+++ b/api/src/org/labkey/api/data/queryprofiler/QueryProfiler.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -96,6 +97,7 @@ public class QueryProfiler
     private boolean _hasBeenReset = false;
 
     private final List<DatabaseQueryListener> _listeners = new CopyOnWriteArrayList<>();
+    private int _droppedQueries;
 
     public static QueryProfiler getInstance()
     {
@@ -202,8 +204,21 @@ public class QueryProfiler
         _listeners.add(listener);
     }
 
-    @Nullable
-    public StackTraceElement[] track(@Nullable DbScope scope, String sql, @Nullable List<Object> parameters, long elapsed,
+    @NotNull
+    public Query preTrack(@Nullable DbScope scope, String sql, @Nullable List<Object> parameters,
+                          @Nullable StackTraceElement[] stackTrace, boolean requestThread)
+    {
+        // Don't block if queue is full
+        Query query = new Query(scope, sql, parameters, -1, stackTrace, requestThread);
+        if (!_queue.offer(query))
+        {
+            _droppedQueries++;
+        }
+        return query;
+    }
+
+    @NotNull
+    public Query track(@Nullable DbScope scope, String sql, @Nullable List<Object> parameters, long elapsed,
           @Nullable StackTraceElement[] stackTrace, boolean requestThread, QueryLogging queryLogging)
     {
         if (null == stackTrace)
@@ -222,8 +237,12 @@ public class QueryProfiler
         MiniProfiler.addQuery(elapsed, sql, stackTrace);
 
         // Don't block if queue is full
-        _queue.offer(new Query(scope, sql, parameters, elapsed, stackTrace, requestThread));
-        return stackTrace;
+        Query query = new Query(scope, sql, parameters, elapsed, stackTrace, requestThread);
+        if (!_queue.offer(query))
+        {
+            _droppedQueries++;
+        }
+        return query;
     }
 
     public void resetAllStatistics()
@@ -310,10 +329,10 @@ public class QueryProfiler
                         out.println("  <tr><td style=\"border-top:1px solid\" colspan=5>&nbsp;</td></tr>");
                         out.println("  <tr><td colspan=5>&nbsp;</td></tr>");
 
-                        out.println("  <tr><td>Total Unique Queries");
+                        out.print("  <tr><td>Total Unique Queries");
 
                         if (_uniqueQueryCountEstimate > QueryTrackerSet.STANDARD_LIMIT)
-                            out.println(" (Estimate)");
+                            out.print(" (Estimate)");
 
                         out.println(":</td><td style=\"text-align:right\">" + Formats.commaf0.format(_uniqueQueryCountEstimate) + "</td>");
                         out.println("<td style=\"width:10px\">&nbsp;</td>");
@@ -326,6 +345,7 @@ public class QueryProfiler
                             out.println("<td>" + (_hasBeenReset ? "Elapsed Time Since Last Reset" : "Server Uptime") + ":</td><td style=\"text-align:right\">" + DateUtil.formatDuration(upTime) + "</td>");
                         }
                         out.println("</tr>");
+                        out.println("<tr><td>Dropped Due to Throttling:</td><td style=\"text-align:right\">" + Formats.commaf0.format(_droppedQueries) + "</td></tr>");
                         out.println("</table><br><br>");
 
                         out.println("<table>");
@@ -526,23 +546,36 @@ public class QueryProfiler
         {
             try
             {
-                //noinspection InfiniteLoopStatement
                 while (!interrupted())
                 {
                     Query query = _queue.take();
+
+                    boolean preTrack = query.getElapsed() < 0;
 
                     // Don't update or add while we're rendering the report or vice versa
                     synchronized (_lock)
                     {
                         if (query.isRequestThread())
                         {
-                            _requestQueryCount++;
-                            _requestQueryTime += query.getElapsed();
+                            if (preTrack)
+                            {
+                                _requestQueryCount++;
+                            }
+                            else
+                            {
+                                _requestQueryTime += query.getElapsed();
+                            }
                         }
                         else
                         {
-                            _backgroundQueryCount++;
-                            _backgroundQueryTime += query.getElapsed();
+                            if (preTrack)
+                            {
+                                _backgroundQueryCount++;
+                            }
+                            else
+                            {
+                                _backgroundQueryTime += query.getElapsed();
+                            }
                         }
 
                         String sql = query.getSql();
@@ -567,7 +600,7 @@ public class QueryProfiler
 
                             _queries.put(hash, tracker);
                         }
-                        else
+                        else if (!preTrack)
                         {
                             for (QueryTrackerSet set : getTrackerSets())
                                 set.beforeUpdate(tracker);

--- a/api/src/org/labkey/api/data/queryprofiler/QueryTracker.java
+++ b/api/src/org/labkey/api/data/queryprofiler/QueryTracker.java
@@ -74,8 +74,6 @@ class QueryTracker
         _validSql = validSql;
         _firstInvocation = System.currentTimeMillis();
         _truncated = truncated;
-
-        addInvocation(elapsed, stackTrace);
     }
 
     public void addInvocation(long elapsed, String stackTrace)
@@ -174,7 +172,7 @@ class QueryTracker
 
     public long getAverage()
     {
-        return _cumulative / _count;
+        return _count == 0 ? 0 : _cumulative / _count;
     }
 
     public int getStackTraceCount()

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -3911,10 +3911,10 @@ public class AdminController extends SpringActionController
                 {
                     divisor = getDivisor(Math.max(usage.getInit(), Math.max(usage.getUsed(), Math.max(usage.getCommitted(), usage.getMax()))));
 
-                    types.add(new MemoryCategory("Init", usage.getInit() / divisor.first));
-                    types.add(new MemoryCategory("Used", usage.getUsed() / divisor.first));
-                    types.add(new MemoryCategory("Committed", usage.getCommitted() / divisor.first));
-                    types.add(new MemoryCategory("Max", usage.getMax() / divisor.first));
+                    types.add(new MemoryCategory("Init", (double) usage.getInit() / divisor.first));
+                    types.add(new MemoryCategory("Used", (double) usage.getUsed() / divisor.first));
+                    types.add(new MemoryCategory("Committed", (double) usage.getCommitted() / divisor.first));
+                    types.add(new MemoryCategory("Max", (double) usage.getMax() / divisor.first));
                 }
             }
 
@@ -4532,7 +4532,7 @@ public class AdminController extends SpringActionController
         public void export(DataCheckForm form, HttpServletResponse response, BindException errors) throws Exception
         {
             String fullyQualifiedSchemaName = form.getDbSchema();
-            if (null == fullyQualifiedSchemaName || fullyQualifiedSchemaName.length() == 0)
+            if (null == fullyQualifiedSchemaName || fullyQualifiedSchemaName.isEmpty())
             {
                 throw new NotFoundException("Must specify dbSchema parameter");
             }


### PR DESCRIPTION
#### Rationale
When a query is very slow, it's helpful to capture and expose its SQL in the query tracker before it completes

#### Changes
- Start tracking queries before they're executed
- Update their runtime stats when they're complete
- Show whether we've dropped any executions based on throttling the number of queries in the queue
- Minor code cleanup