### PR TITLE
Ignore null attribute names for HTML generation

### DIFF
--- a/api/src/org/labkey/api/util/DOM.java
+++ b/api/src/org/labkey/api/util/DOM.java
@@ -917,22 +917,29 @@ public class DOM
                 for (var entry : attrs)
                 {
                     Object key = entry.getKey();
-                    if (key instanceof DOM.Attribute)
-                        ((DOM.Attribute) key).render(builder, entry.getValue());
-                    else if (key instanceof String)
+                    if (key instanceof DOM.Attribute a)
+                       a.render(builder, entry.getValue());
+                    else if (key instanceof String s)
                     {
-                        appendAttribute(builder, (String) key, entry.getValue());
+                        appendAttribute(builder, s, entry.getValue());
+                    }
+                    else if (key == null)
+                    {
+                        if (entry.getValue() != null)
+                        {
+                            throw new IllegalArgumentException("Cannot have a null attribute name with a non-null value: " + entry.getValue());
+                        }
                     }
                     else
                     {
-                        throw new IllegalArgumentException(String.valueOf(key));
+                        throw new IllegalArgumentException("Invalid attribute key '" + key + "' of type " + key.getClass().getName());
                     }
                 }
                 // TODO again horrible hack, make this go away
-                if (attrs instanceof _Attributes && null != ((_Attributes) attrs).callback)
+                if (attrs instanceof _Attributes a && null != a.callback)
                 {
                     builder.append(" ");
-                    ((_Attributes) attrs).callback.accept(builder);
+                    a.callback.accept(builder);
                 }
             }
             if (selfClosing)

--- a/api/src/org/labkey/api/util/DomTestCase.java
+++ b/api/src/org/labkey/api/util/DomTestCase.java
@@ -7,11 +7,14 @@ import java.util.Arrays;
 
 import static org.labkey.api.util.DOM.Attribute.id;
 import static org.labkey.api.util.DOM.Attribute.method;
+import static org.labkey.api.util.DOM.Attribute.name;
 import static org.labkey.api.util.DOM.Attribute.selected;
+import static org.labkey.api.util.DOM.Attribute.type;
 import static org.labkey.api.util.DOM.DIV;
 import static org.labkey.api.util.DOM.Element;
 import static org.labkey.api.util.DOM.H1;
 import static org.labkey.api.util.DOM.H2;
+import static org.labkey.api.util.DOM.INPUT;
 import static org.labkey.api.util.DOM.LK;
 import static org.labkey.api.util.DOM.OPTION;
 import static org.labkey.api.util.DOM.SELECT;
@@ -82,6 +85,10 @@ public class DomTestCase extends Assert
                         DIV("I don't care if they equal"),
                         1 != 2 ? "1 does not equal 2" : null));
         assertEquals("<div><div>I don&#039;t care if they equal</div>1 does not equal 2</div>", h.toString());
+
+        HtmlString h2 = createHtml(
+                INPUT(at(name, "myName", type, "text", /* checked */null, null)));
+        assertEquals("<input name=\"myName\" type=\"text\" />", h2.toString());
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Other parts of our DOM generation API ignore nulls. It makes it easier to write concise generation code if we can do the same with attributes.

#### Changes
- Ignore null attribute names