### PR TITLE
Avoid returning FK metadata for a malformed TableInfo

### DIFF
--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -329,7 +329,7 @@ public class JsonWriter
         TableDescription lookupTable = columnInfo.getFkTableDescription();
         if (null != fk
                 && null != lookupTable
-                && (!(fk instanceof RowIdForeignKey) || !(((RowIdForeignKey)fk).getOriginalColumn().equals(columnInfo))))
+                && (!(fk instanceof RowIdForeignKey rfk) || !(rfk.getOriginalColumn().equals(columnInfo))))
         {
             JSONObject lookupInfo = new JSONObject();
             if (null != fk.getLookupContainer())
@@ -353,6 +353,12 @@ public class JsonWriter
                 queryName = lookupTable.getPublicName();
             else
                 queryName = lookupTable.getName();
+
+            if (queryName == null || schemaName == null)
+            {
+                // Bail out if something went wrong with creating the lookup target
+                return null;
+            }
 
             // Duplicate info with different property names for backwards compatibility
             lookupInfo.put("queryName", queryName);
@@ -408,7 +414,7 @@ public class JsonWriter
 
             if (key == null)
             {
-                if (null != pks && pks.size() > 0)
+                if (null != pks && !pks.isEmpty())
                     key = pks.get(0);
                 if (null != pks && pks.size() == 2 && ("container".equalsIgnoreCase(key) || "containerid".equalsIgnoreCase(key)))
                     key = pks.get(1);

--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -354,12 +354,6 @@ public class JsonWriter
             else
                 queryName = lookupTable.getName();
 
-            if (queryName == null || schemaName == null)
-            {
-                // Bail out if something went wrong with creating the lookup target
-                return null;
-            }
-
             // Duplicate info with different property names for backwards compatibility
             lookupInfo.put("queryName", queryName);
             lookupInfo.put("table", queryName);

--- a/api/src/org/labkey/api/data/ReportingWriter.java
+++ b/api/src/org/labkey/api/data/ReportingWriter.java
@@ -251,7 +251,7 @@ public class ReportingWriter
         TableInfo lookupTable = columnInfo.getFkTableInfo();
         if (null != fk
                 && null != lookupTable
-                && (!(fk instanceof RowIdForeignKey) || !(((RowIdForeignKey)fk).getOriginalColumn().equals(columnInfo))))
+                && (!(fk instanceof RowIdForeignKey rfk) || !(rfk.getOriginalColumn().equals(columnInfo))))
         {
             Map<String, Object> lookupInfo = new HashMap<>();
             if (null != fk.getLookupContainer())
@@ -289,6 +289,13 @@ public class ReportingWriter
                     LOG.debug("userSchema for non-public lookup table " + queryName + " was null on column " + columnInfo.getName() + " in table " + parentTable.getPublicSchemaName() + "." + parentTable.getPublicName() + ". Using " + lookupTable.getSchema().getName());
                 }
             }
+
+            if (queryName == null || schemaName == null)
+            {
+                // Bail out if something went wrong with creating the lookup target
+                return null;
+            }
+
             lookupInfo.put("queryName", queryName);
             lookupInfo.put("schemaName", schemaName);
 
@@ -305,7 +312,7 @@ public class ReportingWriter
             }
             String key = null;
             List<String> pks = lookupTable.getPkColumnNames();
-            if (null != pks && pks.size() > 0)
+            if (null != pks && !pks.isEmpty())
                 key = pks.get(0);
             if (null != pks && pks.size() == 2 && ("container".equalsIgnoreCase(key) || "containerid".equalsIgnoreCase(key)))
                 key = pks.get(1);

--- a/api/src/org/labkey/api/data/ReportingWriter.java
+++ b/api/src/org/labkey/api/data/ReportingWriter.java
@@ -290,12 +290,6 @@ public class ReportingWriter
                 }
             }
 
-            if (queryName == null || schemaName == null)
-            {
-                // Bail out if something went wrong with creating the lookup target
-                return null;
-            }
-
             lookupInfo.put("queryName", queryName);
             lookupInfo.put("schemaName", schemaName);
 

--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -823,7 +823,12 @@ public class QueryManager
 
         boolean isPublic = o.getBoolean("isPublic");
         SchemaKey schemaPath = SchemaKey.fromString(o.optString("schemaName"));
-        String queryName = o.getString("queryName");
+        String queryName = o.optString("queryName");
+        if (queryName == null)
+        {
+            // Likely a lookup that targets something not exposed via a UserSchema. Bail out without further validation
+            return true;
+        }
         String displayColumn = o.optString("displayColumn");
         String keyColumn = o.optString("keyColumn");
         String containerPath = o.optString("containerPath");


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=39156

```
Stack Trace	
org.json.JSONException: JSONObject["queryName"] not found.
	at org.json.JSONObject.get(JSONObject.java:596)
	at org.json.JSONObject.getString(JSONObject.java:883)
	at org.labkey.query.persist.QueryManager.validateFk(QueryManager.java:826)
	at org.labkey.query.persist.QueryManager.validateColumn(QueryManager.java:768)
	at org.labkey.query.persist.QueryManager.validateQueryMetadata(QueryManager.java:749)
	at org.labkey.query.controllers.QueryController$ValidateQueryMetadataAction.execute(QueryController.java:7338)
	at org.labkey.query.controllers.QueryController$ValidateQueryMetadataAction.execute(QueryController.java:7299)
	at org.labkey.api.action.BaseApiAction.handlePost(BaseApiAction.java:239)
	at org.labkey.api.action.ReadOnlyApiAction.handleGet(ReadOnlyApiAction.java:34)
```

#### Changes
- Bail out if we have a null query or schema name