### PR TITLE
Don't encode parameters passed to WebTestHelper.buildUrl

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyMergeParticipantsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyMergeParticipantsTest.java
@@ -27,8 +27,6 @@ import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.Maps;
 
 import java.io.File;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 @Category(Daily.class)
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
@@ -138,7 +136,7 @@ public class StudyMergeParticipantsTest extends StudyBaseTest
         log("Check url's to are correctly constructed");
         final String url = WebTestHelper.buildRelativeUrl("study", PROJECT_NAME + "/" + FOLDER_NAME, "dataset",
             Maps.of("datasetId", 5018,
-                "Dataset.ParticipantId~in", PTID_NO_ALIAS + URLEncoder.encode(";", StandardCharsets.UTF_8) + PTID_NEW_2));
+                "Dataset.ParticipantId~in", PTID_NO_ALIAS + ";" + PTID_NEW_2));
         assertElementPresent(Locator.linkWithHref(url));
 
         log("Resolve conflicts and check for correct row retention");


### PR DESCRIPTION
#### Rationale
`WebTestHelper.buildUrl` and `buildRelativeUrl` now automatically encode parameters. No need for callers to do so.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2174

#### Changes
- Don't encode parameters passed to `WebTestHelper.buildUrl`