### PR TITLE
Retry after race condition killing job's queries

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1175,10 +1175,10 @@ public class DbScope
             log(() -> 1 == _refCount ? "Releasing connection [1]: " + conn.toString() : "Attempting to decrease count of connection [" + _refCount + "]: " + conn.toString());
 
             if (_conn == null)
-                throw new ConnectionAlreadyReleaseException("Connection has already been nulled out, but was passed: " + conn);
+                throw new ConnectionAlreadyReleasedException("Connection has already been nulled out, but was passed: " + conn);
 
             if (_conn != conn)
-                throw new IllegalStateException("Incorrect Connection: " + conn + " vs. " + _conn);
+                throw new DifferentConnectionException("Incorrect Connection: " + conn + " vs. " + _conn);
 
             if (_refCount <= 0)
                 throw new IllegalStateException("Reference count is too low (" + _refCount + ") for " + _conn);
@@ -1195,13 +1195,25 @@ public class DbScope
     }
 
     /**
-     * Special case for when the connection being closed doesn't match the expected
-     * connection for this thread, to help scenarios that are prone to race conditions
-     * (like killing pipeline jobs) ignore it.
+     * Special case for when the connection that we expected to close has already been closed.
+     * Makes it easier to ignore this error for scenarios that are prone to race conditions, like killing pipeline jobs.
      */
-    public static class ConnectionAlreadyReleaseException extends IllegalStateException implements SkipMothershipLogging
+    public static class ConnectionAlreadyReleasedException extends IllegalStateException implements SkipMothershipLogging
     {
-        public ConnectionAlreadyReleaseException(String s)
+        public ConnectionAlreadyReleasedException(String s)
+        {
+            super(s);
+        }
+    }
+
+    /**
+     * Special case for when the connection that we expected to close already been closed and another connection
+     * is in use instead.
+     * Makes it easier to retry in cases that are prone to race conditions, like killing pipeline jobs.
+     */
+    public static class DifferentConnectionException extends IllegalStateException implements SkipMothershipLogging
+    {
+        public DifferentConnectionException(String s)
         {
             super(s);
         }
@@ -2153,7 +2165,7 @@ public class DbScope
                     LOG.warn("Forcing close of still-pending transaction object started at ", t._creation);
                     t.close();
                 }
-                catch (ConnectionAlreadyReleaseException ignored)
+                catch (ConnectionAlreadyReleasedException ignored)
                 {
                     // The code in another thread has already released the connection
                 }

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -1207,7 +1207,8 @@ public class DbScope
     }
 
     /**
-     * Special case for when the connection that we expected to close already been closed and another connection
+     * Special case for when the connection that we expected to close has already been closed and another connection
+
      * is in use instead.
      * Makes it easier to retry in cases that are prone to race conditions, like killing pipeline jobs.
      */

--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -664,7 +664,7 @@ public class ExceptionUtil
                 return true;
             }
 
-            if (ex instanceof AbortedRequestException || ex instanceof DbScope.ConnectionAlreadyReleaseException)
+            if (ex instanceof AbortedRequestException || ex instanceof DbScope.ConnectionAlreadyReleasedException)
             {
                 return true;
             }

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -295,7 +295,29 @@ public class PipelineJobServiceImpl implements PipelineJobService
             // Piggyback on the job thread so we can shut down open connections on its behalf
             try (DbScope.ConnectionSharingCloseable ignored = DbScope.shareConnections(jobThread, Thread.currentThread()))
             {
-                DbScope.closeConnectionsForCurrentThreadWithoutReleasingLocks();
+                DbScope.DifferentConnectionException lastException;
+                int retry = 0;
+                do
+                {
+                    try
+                    {
+                        DbScope.closeConnectionsForCurrentThreadWithoutReleasingLocks();
+                        lastException = null;
+                    }
+                    catch (DbScope.DifferentConnectionException e)
+                    {
+                        // The connection we tried to close has already been closed and the thread has already
+                        // started using a different connection. Try again
+                        lastException = e;
+                        retry++;
+                    }
+                }
+                while (lastException != null && retry < 3);
+
+                if (lastException != null)
+                {
+                    throw lastException;
+                }
             }
         }
     }


### PR DESCRIPTION
#### Rationale
We get occasional errors when cancelling a pipeline job and try slamming its DB connections shut.

```
ERROR ExceptionUtil            2024-12-03T00:01:59,196     http-nio-8111-exec-4 : Unhandled exception: Incorrect Connection: Connection wrapper 65590 for SPID 42919, originally allocated to thread JobThread-2.5 at 12/3/24, 12:01:59 AM, real connection: 1747365834 - class org.apache.tomcat.dbcp.dbcp2.PoolingDataSource$PoolGuardConnectionWrapper vs. Connection wrapper 65592 for SPID 42919, originally allocated to thread JobThread-2.5 at 12/3/24, 12:01:59 AM, real connection: 1714434544 - class org.apache.tomcat.dbcp.dbcp2.PoolingDataSource$PoolGuardConnectionWrapper
java.lang.IllegalStateException: Incorrect Connection: Connection wrapper 65590 for SPID 42919, originally allocated to thread JobThread-2.5 at 12/3/24, 12:01:59 AM, real connection: 1747365834 - class org.apache.tomcat.dbcp.dbcp2.PoolingDataSource$PoolGuardConnectionWrapper vs. Connection wrapper 65592 for SPID 42919, originally allocated to thread JobThread-2.5 at 12/3/24, 12:01:59 AM, real connection: 1714434544 - class org.apache.tomcat.dbcp.dbcp2.PoolingDataSource$PoolGuardConnectionWrapper
	at org.labkey.api.data.DbScope$ConnectionHolder.release(DbScope.java:1181) ~[api-25.1-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScope$ConnectionType$2.close(DbScope.java:1131) ~[api-25.1-SNAPSHOT.jar:?]
	at org.labkey.api.data.ConnectionWrapper.internalClose(ConnectionWrapper.java:439) ~[api-25.1-SNAPSHOT.jar:?]
	at org.labkey.api.data.ConnectionWrapper.close(ConnectionWrapper.java:432) ~[api-25.1-SNAPSHOT.jar:?]
	at org.labkey.api.data.ConnectionWrapper.closeConnections(ConnectionWrapper.java:233) ~[api-25.1-SNAPSHOT.jar:?]
	at org.labkey.api.data.DbScope.closeConnectionsForCurrentThreadWithoutReleasingLocks(DbScope.java:2124) ~[api-25.1-SNAPSHOT.jar:?]
	at org.labkey.pipeline.api.PipelineJobServiceImpl.cancelForJob(PipelineJobServiceImpl.java:298) ~[pipeline-25.1-SNAPSHOT.jar:?]
	at org.labkey.api.pipeline.PipelineJob.interrupt(PipelineJob.java:1736) ~[api-25.1-SNAPSHOT.jar:?]
	at org.labkey.pipeline.api.PipelineQueueImpl.cancelJob(PipelineQueueImpl.java:219) ~[pipeline-25.1-SNAPSHOT.jar:?]
	at org.labkey.pipeline.api.PipelineStatusManager.cancelStatus(PipelineStatusManager.java:944) ~[pipeline-25.1-SNAPSHOT.jar:?]
```

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres/3292893?buildTab=overview&expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true

#### Changes
- Create a specific exception type for this scenario and retry a couple of times
- Fix typo in existing class name