### PR TITLE
Stop requiring a default parameters file

### DIFF
--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisJob.java
@@ -133,7 +133,9 @@ abstract public class AbstractFileAnalysisJob extends PipelineJob implements Fil
         else
             fileDefaults = protocol.getFactory().getDefaultParametersFile(root);
 
-        _parametersDefaults = getInputParameters(fileDefaults).getInputParameters();
+        _parametersDefaults = fileDefaults != null && Files.exists(fileDefaults) ?
+                getInputParameters(fileDefaults).getInputParameters() :
+                Collections.emptyMap();
 
         if (_log.isDebugEnabled())
         {


### PR DESCRIPTION
#### Rationale
Not all pipeline implementations have a useful default parameters file to merge with the job-specific parameters.

#### Changes
- If the default file isn't available, just use an empty set of parameters as defaults