### PR TITLE
Handle unusual query encoding in link href

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyMergeParticipantsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyMergeParticipantsTest.java
@@ -135,8 +135,8 @@ public class StudyMergeParticipantsTest extends StudyBaseTest
 
         log("Check url's to are correctly constructed");
         final String url = WebTestHelper.buildRelativeUrl("study", PROJECT_NAME + "/" + FOLDER_NAME, "dataset",
-            Maps.of("datasetId", 5018,
-                "Dataset.ParticipantId~in", PTID_NO_ALIAS + ";" + PTID_NEW_2));
+            Maps.of("datasetId", 5018, "Dataset.ParticipantId~in", PTID_NO_ALIAS + ";" + PTID_NEW_2))
+            .replace("%7E", "~"); // '~' isn't encoded in href
         assertElementPresent(Locator.linkWithHref(url));
 
         log("Resolve conflicts and check for correct row retention");
@@ -148,8 +148,8 @@ public class StudyMergeParticipantsTest extends StudyBaseTest
         clickTab(SUBJECT_NOUN_PLURAL);
         waitAndClick(Locator.linkWithText(PTID_NEW_2));
         waitForElement(Locator.tag("th").containing("5008: Demographics"));
-        assertElementPresent(Locator.tag("td").containing("Start Date").append("/following-sibling::td['2008-04-27']")); //value from oldId demographic row
-        assertElementPresent(Locator.tag("td").containing("Genetic Consent").append("/following-sibling::td['false']")); //value from newId consent row
+        assertElementPresent(Locator.tag("td").containing("Start Date").followingSibling("td").withText("2008-04-27")); //value from oldId demographic row
+        assertElementPresent(Locator.tag("td").containing("Genetic Consent").followingSibling("td").withText("false")); //value from newId consent row
     }
 
     private void configureAliases()


### PR DESCRIPTION
#### Rationale
The link this test is checking doesn't encode a `~`. Need to adjust the expected `href` to account for this.
Also, fixing some invalid Locators that are used for validation here.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2169

#### Changes
- Handle unusual query encoding in href
- Fix invalid Locators
