### PR TITLE
Add null check to password reset error view

### DIFF
--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1998,10 +1998,17 @@ public class SecurityController extends SpringActionController
         @Override
         public ModelAndView getFailView(UserForm form, BindException errors)
         {
-            HtmlStringBuilder builder = HtmlStringBuilder.of()
-                .unsafeAppend("<p>")
-                .append(form.getUser(true).getEmail() + ": Password " + (_loginExists ? "reset" : "created") + ".")
-                .unsafeAppend("</p><p>")
+            HtmlStringBuilder builder = HtmlStringBuilder.of();
+
+            User user = form.getUser();
+            if (user != null)
+            {
+                builder.unsafeAppend("<p>")
+                    .append(user.getEmail() + ": Password " + (_loginExists ? "reset" : "created") + ".")
+                    .unsafeAppend("</p>");
+            }
+
+            builder.unsafeAppend("<p>")
                 .append(getErrorMessage(errors))
                 .unsafeAppend("</p>")
                 .append(PageFlowUtil.button("Done").href(form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL())));


### PR DESCRIPTION
#### Rationale
`AdminResetPasswordAction.getFailView` can't handle non-existent user.

```
ERROR ExceptionUtil            2024-12-07T20:49:29,456     http-nio-8111-exec-8 : Unhandled exception: User not found
java.lang.IllegalStateException: User not found
	at org.labkey.core.security.SecurityController$UserForm.getUser(SecurityController.java:1825) ~[core-25.1-SNAPSHOT.jar:?]
	at org.labkey.core.security.SecurityController$AdminResetPasswordAction.getFailView(SecurityController.java:2003) ~[core-25.1-SNAPSHOT.jar:?]
	at org.labkey.core.security.SecurityController$AdminResetPasswordAction.getFailView(SecurityController.java:1943) ~[core-25.1-SNAPSHOT.jar:?]
	at org.labkey.api.action.ConfirmAction.handleRequest(ConfirmAction.java:104) ~[api-25.1-SNAPSHOT.jar:?]
```

#### Related Pull Requests
- #6021 

#### Changes
- Add null check to password reset error view
