### PR TITLE
ParameterCurveFit algorithm update for 3PL fit to use a smaller slopeRadiansStep 

### DIFF
--- a/core/src/org/labkey/core/statistics/ParameterCurveFit.java
+++ b/core/src/org/labkey/core/statistics/ParameterCurveFit.java
@@ -252,6 +252,10 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
         if (is3Parameter() || is4Parameter())
             parameters.asymmetry = 1;
 
+        double slopeRadiansSteps = Math.PI / 30;
+        if (is3Parameter())
+            slopeRadiansSteps = Math.PI / 180;
+
         // try reasonable variants of max and min, in case there's a better fit.  We'll keep going past "reasonable" if
         // we haven't found a single bestFit option, but we need to bail out at some point.  We currently quit once max
         // reaches 200 or min reaches -100, since these values don't seem biologically reasonable.
@@ -266,7 +270,7 @@ public class ParameterCurveFit extends DefaultCurveFit<ParameterCurveFit.Sigmoid
                 {
                     parameters.max = getAsymptoteMax() != null ? getAsymptoteMax() : max;
                     parameters.inflection = relativeEC50;
-                    for (double slopeRadians = 0; slopeRadians < Math.PI; slopeRadians += Math.PI / 30)
+                    for (double slopeRadians = 0; slopeRadians < Math.PI; slopeRadians += slopeRadiansSteps)
                     {
                         parameters.slope = Math.tan(slopeRadians);
                         switch (_fitType)

--- a/core/src/org/labkey/core/statistics/StatsServiceImpl.java
+++ b/core/src/org/labkey/core/statistics/StatsServiceImpl.java
@@ -140,8 +140,8 @@ public class StatsServiceImpl implements StatsService
             CurveValidation v2 = new CurveValidation(new double[]{93.28, 88.65, 74.12, 46.16, 28.34, 17.41, 6.17, -1.79});
             v2.setResults(CurveFitType.POLYNOMIAL, new CurveResults(5.4, .414, .424));
             v2.setResults(CurveFitType.FOUR_PARAMETER_SIMPLEX, new CurveResults(.994, .419, .419));
-            v2.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(3.45, .414, .414));
-            v2.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(3.45, .414, .414));
+            v2.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(2.93, .414, .414));
+            v2.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(2.93, .414, .414));
             v2.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(3.4, .403, .403));
             v2.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(3.1, .420, .420));
             v2.setResults(CurveFitType.LINEAR, new CurveResults(36.8, .553, .553));
@@ -160,8 +160,8 @@ public class StatsServiceImpl implements StatsService
             CurveValidation v4 = new CurveValidation(new double[]{75.94, 58.52, 39.42, 28.84, 19.37, 9.91, 6.04, -7.35});
             v4.setResults(CurveFitType.POLYNOMIAL, new CurveResults(2.4, .259, .273));
             v4.setResults(CurveFitType.FOUR_PARAMETER_SIMPLEX, new CurveResults(.994, .258, .271));
-            v4.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(4.34, .280, .280));
-            v4.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(4.34, .280, .280));
+            v4.setResults(CurveFitType.THREE_PARAMETER, new CurveResults(4.05, .265, .265));
+            v4.setResults(CurveFitType.THREE_PARAMETER_ALT, new CurveResults(4.05, .265, .265));
             v4.setResults(CurveFitType.FOUR_PARAMETER, new CurveResults(4.5, .226, .247));
             v4.setResults(CurveFitType.FIVE_PARAMETER, new CurveResults(3.7, .245, .262));
             v4.setResults(CurveFitType.LINEAR, new CurveResults(27.5, .374, .374));
@@ -290,17 +290,17 @@ public class StatsServiceImpl implements StatsService
             assertEquals(-1.667, fit.rSquared(fit.getParameters()), delta);
             fit = service.getCurveFit(CurveFitType.THREE_PARAMETER, data1, 0.0, 4.0);
             fit.setLogXScale(true);
-            verifySigmoidalParameters(fit, 0.0, 4.0, 1.376, 0.095, 1.0);
-            assertEquals(0.974, fit.rSquared(fit.getParameters()), delta);
+            verifySigmoidalParameters(fit, 0.0, 4.0, 1.540, 0.095, 1.0);
+            assertEquals(0.980, fit.rSquared(fit.getParameters()), delta);
 
             fit = service.getCurveFit(CurveFitType.THREE_PARAMETER_ALT, data1);
             fit.setLogXScale(false);
-            verifySigmoidalParameters(fit, 0.0, 3.17, -1.732, 0.096, 1.0);
+            verifySigmoidalParameters(fit, 0.0, 3.17, -1.963, 0.096, 1.0);
             assertEquals(0.786, fit.rSquared(fit.getParameters()), delta);
             fit = service.getCurveFit(CurveFitType.THREE_PARAMETER_ALT, data1, 0.0, 4.0);
             fit.setLogXScale(true);
-            verifySigmoidalParameters(fit, 0.0, 4.0, -1.376, 0.095, 1.0);
-            assertEquals(0.974, fit.rSquared(fit.getParameters()), delta);
+            verifySigmoidalParameters(fit, 0.0, 4.0, -1.540, 0.095, 1.0);
+            assertEquals(0.980, fit.rSquared(fit.getParameters()), delta);
 
             fit = service.getCurveFit(CurveFitType.FOUR_PARAMETER, data1);
             fit.setLogXScale(false);
@@ -367,14 +367,14 @@ public class StatsServiceImpl implements StatsService
 
             fit = service.getCurveFit(CurveFitType.THREE_PARAMETER, data1);
             fit.setLogXScale(true);
-            verifySigmoidalParameters(fit, 0.0, 103.0, -0.445, 6.907, 1.0);
-            assertEquals(3.631, fit.getFitError(), delta);
+            verifySigmoidalParameters(fit, 0.0, 103.0, -0.384, 6.907, 1.0);
+            assertEquals(2.960, fit.getFitError(), delta);
             assertEquals(0.989, fit.rSquared(fit.getParameters()), delta);
 
             fit = service.getCurveFit(CurveFitType.THREE_PARAMETER_ALT, data1);
             fit.setLogXScale(true);
-            verifySigmoidalParameters(fit, 0.0, 103.0, 0.445, 6.907, 1.0);
-            assertEquals(3.631, fit.getFitError(), delta);
+            verifySigmoidalParameters(fit, 0.0, 103.0, 0.384, 6.907, 1.0);
+            assertEquals(2.960, fit.getFitError(), delta);
             assertEquals(0.989, fit.rSquared(fit.getParameters()), delta);
         }
 


### PR DESCRIPTION
#### Rationale
After review of the new 3PL curve fit calculation with the client who requested it, it was noticed that the slope parameter calculation was off by ~0.2 from the values we were using for comparison in the test data. It looks like if we use a smaller slopeRadians step interval in the calculation algorithm, the calculated values are closer without the execution time taking too much longer. Note that I targeted this change to only affect the 3PL fit so there should be no change for 4PL and 5PL fits.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/976

#### Changes
- Update ParameterCurveFit algorithm for 3PL fit to use a smaller slopeRadiansStep for more accurate calculation
