### PR TITLE
Add restrictions on names of domains

### DIFF
--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -11,6 +11,7 @@ import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.gwt.client.AuditBehaviorType;
+import org.labkey.api.query.QueryKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
@@ -72,11 +73,21 @@ public interface AuditHandler
                     .orElse(key);
             String lcName = nameFromAlias.toLowerCase();
             // Preserve casing of inputs so we can show the names properly
-            if (!lcName.startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase()) && !lcName.startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase()))
+            boolean isExpInput = false;
+            if (lcName.startsWith(ExpData.DATA_INPUTS_PREFIX.toLowerCase()) || lcName.startsWith(ExpMaterial.MATERIAL_INPUTS_PREFIX.toLowerCase()))
+            {
+                String[] parts = nameFromAlias.split("/", 2);
+                String prefix = parts[0];
+                String dataType = parts[1];
+                // MaterialInputs/datypeTypeEncoded
+                if (row.containsKey(prefix + "/" + QueryKey.encodePart(dataType)))
+                    isExpInput = true;
+            }
+            else
                 nameFromAlias = lcName;
 
             boolean isExtraAuditField = extraFieldsToInclude != null && extraFieldsToInclude.contains(nameFromAlias);
-            if (!excludedFromDetailDiff.contains(nameFromAlias) && row.containsKey(nameFromAlias))
+            if (!excludedFromDetailDiff.contains(nameFromAlias) && (row.containsKey(nameFromAlias) || isExpInput))
             {
                 Object oldValue = entry.getValue();
                 Object newValue = row.get(nameFromAlias);

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -462,7 +462,7 @@ public class NameGenerator
         for (SubstitutionValue subValue : SubstitutionValue.values())
         {
             if (subValue.getKey().equalsIgnoreCase(fieldKey))
-                return fieldKey + " is a reserved name.";
+                return "'" + fieldKey + "' is a reserved name.";
         }
 
         return null;

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -747,7 +747,7 @@ public class NameGenerator
 
     public static boolean isParentInput(Object token, @Nullable Map<String, String> importAliases, @Nullable String currentDataTypeName, Container container, User user)
     {
-        return isParentInputToken(token, importAliases, false) || isParentInputWithDataType(token.toString().split("/"), currentDataTypeName, false, container, user);
+        return isParentInputToken(token, importAliases, false) || isParentInputWithDataType(token.toString().split("/", 2), currentDataTypeName, false, container, user);
     }
 
     public static boolean isParentLookup(List<String> fieldParts, @Nullable Map<String, String> importAliases, @Nullable String currentDataTypeName, Container container, User user)
@@ -1167,7 +1167,7 @@ public class NameGenerator
                             if (!isAncestorSearch)
                                 parentLookupFields.computeIfAbsent(dataTypeToken, (s) -> new ArrayList<>()).add(fieldParts.get(1));
 
-                            String[] inputParts = dataTypeToken.split("/");
+                            String[] inputParts = dataTypeToken.split("/", 2);
                             lookupValuePreview = getParentLookupTokenPreview(_currentDataTypeName, fkTok, inputParts[0], inputParts[1], ancestorPartOption, lookupField, user, dataClassNames, sampleTypeNames);
                         }
                         else if (!isParentAlias && fieldParts.size() <= 3)

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -823,7 +823,7 @@ public class NameGenerator
                 return false;
             inputToken = inputToken.substring(1); // remove leading ~
         }
-        String dataType = parts[1];
+        String dataType = QueryKey.decodePart(parts[1]); // If data type contains special characters
 
         boolean isInput = INPUT_PARENT.equalsIgnoreCase(inputToken);
         boolean isData = ExpData.DATA_INPUT_PARENT.equalsIgnoreCase(inputToken);
@@ -847,8 +847,20 @@ public class NameGenerator
         return ExperimentService.get().getDataClass(container, user, dataType) != null;
     }
 
+    static String getEncodedDataTypeInExpression(String expression)
+    {
+        return expression.replaceAll("/", "\\$S");
+    }
+
+    static String getDecodedDataTypeInExpression(String expression)
+    {
+        return QueryKey.decodePart(expression);
+    }
+
     private Object getParentLookupTokenPreview(String currentDataType, FieldKey fkTok, String inputPrefix, @Nullable String inputDataType, @Nullable NameExpressionAncestorPartOption ancestorPartOption, String lookupField, User user, Map<String, String> dataClassNames, Map<String, String> sampleTypeNames)
     {
+        if (inputDataType != null)
+            inputDataType = getDecodedDataTypeInExpression(inputDataType);
         String inputPrefixLc = inputPrefix.toLowerCase();
         boolean isMaterial = inputPrefixLc.startsWith("materialinputs") || inputPrefixLc.startsWith("inputs");
         boolean isData = inputPrefixLc.startsWith("datainputs") || inputPrefixLc.startsWith("inputs");
@@ -1063,13 +1075,14 @@ public class NameGenerator
                         hasDateBasedSampleCounterFormat = true;
                 }
 
-                String sTok = QueryKey.decodePart(token.toString()).toLowerCase();
+                String sTok = QueryKey.decodePart(token.toString());
                 if (isParentInput(sTok, importAliases, _currentDataTypeName, _container, user))
                 {
                     isParentPart = true;
                     hasParentInputs = true;
                 }
 
+                String sTokLc = sTok.toLowerCase();
                 if (token instanceof FieldKey fkTok)
                 {
                     int previousErrorCount = _syntaxErrors.size();
@@ -1211,8 +1224,8 @@ public class NameGenerator
 
                     if (isParentPart)
                     {
-                        boolean isInput = sTok.startsWith(INPUT_PARENT.toLowerCase());
-                        boolean isMaterial = sTok.startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase());
+                        boolean isInput = sTokLc.startsWith(INPUT_PARENT.toLowerCase());
+                        boolean isMaterial = sTokLc.startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase());
                         Object preview = isInput ? SubstitutionValue.Inputs.getPreviewValue() : (isMaterial ? SubstitutionValue.MaterialInputs.getPreviewValue() : SubstitutionValue.DataInputs.getPreviewValue());
                         previewCtx.put(fkTok.toString(), preview);
                     }
@@ -1381,7 +1394,7 @@ public class NameGenerator
             {
                 if (fieldParts.size() == 1)
                     fieldParts.add("Name");
-                String[] inputs = importAliases.get(alias.substring(1)).split("/");
+                String[] inputs = importAliases.get(alias.substring(1)).split("/", 2);
                 isMaterialStr = inputs[0];
                 typeStr = inputs[1];
             }
@@ -1907,10 +1920,13 @@ public class NameGenerator
         {
             String inputType = isMaterialParent ? ExpMaterial.MATERIAL_INPUT_PARENT : ExpData.DATA_INPUT_PARENT;
             String inputCol = inputType + "/" + parentTypeName;
+            String inputColEncoded = inputType + "/" + getEncodedDataTypeInExpression(parentTypeName);
 
-            List<String> fieldNames = new ArrayList<>();
+            Set<String> fieldNames = new HashSet<>();
             if (_expParentLookupFields.containsKey(inputCol))
                 fieldNames.addAll(_expParentLookupFields.get(inputCol));
+            if (_expParentLookupFields.containsKey(inputColEncoded))
+                fieldNames.addAll(_expParentLookupFields.get(inputColEncoded));
             if (_expParentLookupFields.containsKey(inputType))
                 fieldNames.addAll(_expParentLookupFields.get(inputType));
             if (_expParentLookupFields.containsKey(INPUT_PARENT))
@@ -1939,6 +1955,8 @@ public class NameGenerator
                 inputLookupValues.computeIfAbsent(inputType + "/" + fieldName, (s) -> new ArrayList<>()).add(lookupValue);
                 // add to <Type>Inputs/<TypeName>/<LookupField>
                 inputLookupValues.computeIfAbsent(inputCol + "/" + fieldName, (s) -> new ArrayList<>()).add(lookupValue);
+                if (!inputColEncoded.equalsIgnoreCase(inputCol))
+                    inputLookupValues.computeIfAbsent(inputColEncoded + "/" + fieldName, (s) -> new ArrayList<>()).add(lookupValue);
             }
         }
 
@@ -2030,7 +2048,7 @@ public class NameGenerator
 
         }
 
-        private void addParentLookupContext(String parentTypeName,
+        private void addParentLookupContext(String parentTypeName/* already decoded */,
                                             String parentName,
                                             boolean isMaterialParent,
                                             @Nullable Map<String, String> parentImportAliases,
@@ -2043,11 +2061,14 @@ public class NameGenerator
 
             if (!hasTypeLookup)
             {
+                String parentTypeNameEncoded = getEncodedDataTypeInExpression(parentTypeName);
                 if (isMaterialParent)
                 {
                     if (_expParentLookupFields.containsKey(ExpMaterial.MATERIAL_INPUT_PARENT))
                         hasTypeLookup = true;
                     else if (_expParentLookupFields.containsKey(ExpMaterial.MATERIAL_INPUT_PARENT + "/" + parentTypeName))
+                        hasTypeLookup = true;
+                    else if (_expParentLookupFields.containsKey(ExpMaterial.MATERIAL_INPUT_PARENT + "/" + parentTypeNameEncoded))
                         hasTypeLookup = true;
                 }
                 else
@@ -2055,6 +2076,8 @@ public class NameGenerator
                     if (_expParentLookupFields.containsKey(ExpData.DATA_INPUT_PARENT))
                         hasTypeLookup = true;
                     else if (_expParentLookupFields.containsKey(ExpData.DATA_INPUT_PARENT + "/" + parentTypeName))
+                        hasTypeLookup = true;
+                    else if (_expParentLookupFields.containsKey(ExpData.DATA_INPUT_PARENT + "/" + parentTypeNameEncoded))
                         hasTypeLookup = true;
                 }
             }
@@ -2171,24 +2194,10 @@ public class NameGenerator
                     if (value == null)
                         continue;
 
-                    String[] parts = colName.split("/", 2);
-
-                    if (parts.length == 2)
-                    {
-                        if (_expressionSummary.hasParentInputs)
-                            addInputs(parts, colName, value, inputs, parentImportAliases);
-                        if (_expressionSummary.hasParentLookup)
-                            addParentLookupInput(parts, colName, value, parentImportAliases, inputLookupValues);
-                    }
-                    else if (parentImportAliases != null && parentImportAliases.containsKey(colName))
-                    {
-                        String colNameForAlias = parentImportAliases.get(colName);
-                        parts = colNameForAlias.split("/", 2);
-                        if (_expressionSummary.hasParentInputs)
-                            addInputs(parts, colNameForAlias, value, inputs, parentImportAliases);
-                        if (_expressionSummary.hasParentLookup)
-                            addParentLookupInput(parts, colName, value, parentImportAliases, inputLookupValues);
-                    }
+                    if (_expressionSummary.hasParentInputs)
+                        addInputs(colName, value, inputs, parentImportAliases);
+                    if (_expressionSummary.hasParentLookup)
+                        addParentLookupInput(colName, value, parentImportAliases, inputLookupValues);
                 }
 
                 // if a single input or lookup is found, return the object, not the list
@@ -2277,18 +2286,24 @@ public class NameGenerator
             return ctx;
         }
 
-        private void addParentLookupInput(String[] parts,
-                                          String colName,
+        private void addParentLookupInput(String colName,
                                           Object value,
                                           @Nullable Map<String, String> parentImportAliases,
                                           Map<String, ArrayList<Object>> inputLookupValues)
         {
-            boolean isMaterialParent = parts[0].equalsIgnoreCase(ExpMaterial.MATERIAL_INPUT_PARENT);
-            boolean isDataParent = parts[0].equalsIgnoreCase(ExpData.DATA_INPUT_PARENT);
-            if (isMaterialParent || isDataParent)
+            String[] parts = colName.split("/", 2);
+            if (parentImportAliases != null && parentImportAliases.containsKey(colName))
+                parts = parentImportAliases.get(colName).split("/", 2);
+
+            if (parts.length == 2)
             {
-                for (String parent : parentNames(value, colName))
-                    addParentLookupContext(QueryKey.decodePart(parts[1]), parent, isMaterialParent, parentImportAliases, inputLookupValues);
+                boolean isMaterialParent = parts[0].equalsIgnoreCase(ExpMaterial.MATERIAL_INPUT_PARENT);
+                boolean isDataParent = parts[0].equalsIgnoreCase(ExpData.DATA_INPUT_PARENT);
+                if (isMaterialParent || isDataParent)
+                {
+                    for (String parent : parentNames(value, colName))
+                        addParentLookupContext(QueryKey.decodePart(parts[1]), parent, isMaterialParent, parentImportAliases, inputLookupValues);
+                }
             }
         }
 
@@ -2297,12 +2312,19 @@ public class NameGenerator
             return NameGenerator.parentNames(value, parentColName).collect(Collectors.toList());
         }
 
-        private void addInputs(String[] parts,
-                               String colName,
+        private void addInputs(String colName,
                                Object value,
                                Map<String, Set<String>> inputs,
                                @Nullable Map<String, String> parentImportAliases)
         {
+            String[] parts = colName.split("/", 2);
+            boolean isParentAliasInput = false;
+            if (parts.length == 1 && parentImportAliases != null && parentImportAliases.containsKey(colName))
+            {
+                isParentAliasInput = true;
+                parts = parentImportAliases.get(colName).split("/", 2);
+            }
+
             if (parts.length == 2)
             {
                 String inputsCategory = null;
@@ -2312,21 +2334,30 @@ public class NameGenerator
                     inputsCategory = ExpMaterial.MATERIAL_INPUT_PARENT;
                 if (inputsCategory != null)
                 {
+                    String dataType = parts[1];
+                    String decodedDataType = QueryKey.decodePart(dataType); // data might come in as encoded or decoded
                     Collection<String> parents = parentNames(value, colName);
                     inputs.get(INPUT_PARENT).addAll(parents);
-                    inputs.computeIfAbsent(INPUT_PARENT + "/" + parts[1],  (s) -> new LinkedHashSet<>()).addAll(parents); // add Inputs/SampleType1
                     inputs.get(inputsCategory).addAll(parents);
+
+                    Set<String> dataTypeAltNames = new HashSet<>();
+                    dataTypeAltNames.add(decodedDataType);
+                    dataTypeAltNames.add(getEncodedDataTypeInExpression(decodedDataType));
+                    for (String dataTypeAltName : dataTypeAltNames)
+                    {
+                        inputs.computeIfAbsent(INPUT_PARENT + "/" + dataTypeAltName,  (s) -> new LinkedHashSet<>()).addAll(parents); // add Inputs/SampleType1
+                        if (!parents.isEmpty()) // convert "parent1,parent2" to [parent1, parent2]
+                            inputs.computeIfAbsent(parts[0] + "/" + dataTypeAltName,  (s) -> new LinkedHashSet<>()).addAll(parents);
+                    }
+
                     // if import aliases are defined, also add in the inputs under the aliases in case those are used in the name expression
-                    if (parentImportAliases != null)
+                    if (parentImportAliases != null && !isParentAliasInput)
                     {
                         Optional<Map.Entry<String, String>> aliasEntry = parentImportAliases.entrySet().stream().filter(entry -> entry.getValue().equalsIgnoreCase(colName)).findFirst();
                         aliasEntry.ifPresent(entry -> {
                             inputs.computeIfAbsent(entry.getKey(),  (s) -> new LinkedHashSet<>()).addAll(parents);
                         });
                     }
-
-                    if (!parents.isEmpty()) // convert "parent1,parent2" to [parent1, parent2]
-                        inputs.computeIfAbsent(parts[0] + "/" + parts[1],  (s) -> new LinkedHashSet<>()).addAll(parents);
                 }
             }
         }

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -2350,6 +2350,8 @@ public class NameGenerator
                     // if import aliases are defined, also add in the inputs under the aliases in case those are used in the name expression
                     if (parentImportAliases != null)
                     {
+                        if (parentImportAliases.containsKey(colName))
+                            inputs.computeIfAbsent(colName,  (s) -> new LinkedHashSet<>()).addAll(parents);
                         Optional<Map.Entry<String, String>> aliasEntry = parentImportAliases.entrySet().stream().filter(entry -> entry.getValue().equalsIgnoreCase(colName)).findFirst();
                         aliasEntry.ifPresent(entry -> {
                             inputs.computeIfAbsent(entry.getKey(),  (s) -> new LinkedHashSet<>()).addAll(parents);

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -2335,7 +2335,6 @@ public class NameGenerator
                     Collection<String> parents = parentNames(value, colName);
                     inputs.get(INPUT_PARENT).addAll(parents);
                     inputs.get(inputsCategory).addAll(parents);
-                    // TODO, parents broken
 
                     Set<String> dataTypeAltNames = new HashSet<>();
                     dataTypeAltNames.add(decodedDataType);

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -2318,12 +2318,8 @@ public class NameGenerator
                                @Nullable Map<String, String> parentImportAliases)
         {
             String[] parts = colName.split("/", 2);
-            boolean isParentAliasInput = false;
             if (parts.length == 1 && parentImportAliases != null && parentImportAliases.containsKey(colName))
-            {
-                isParentAliasInput = true;
                 parts = parentImportAliases.get(colName).split("/", 2);
-            }
 
             if (parts.length == 2)
             {
@@ -2339,6 +2335,7 @@ public class NameGenerator
                     Collection<String> parents = parentNames(value, colName);
                     inputs.get(INPUT_PARENT).addAll(parents);
                     inputs.get(inputsCategory).addAll(parents);
+                    // TODO, parents broken
 
                     Set<String> dataTypeAltNames = new HashSet<>();
                     dataTypeAltNames.add(decodedDataType);
@@ -2351,7 +2348,7 @@ public class NameGenerator
                     }
 
                     // if import aliases are defined, also add in the inputs under the aliases in case those are used in the name expression
-                    if (parentImportAliases != null && !isParentAliasInput)
+                    if (parentImportAliases != null)
                     {
                         Optional<Map.Entry<String, String>> aliasEntry = parentImportAliases.entrySet().stream().filter(entry -> entry.getValue().equalsIgnoreCase(colName)).findFirst();
                         aliasEntry.ifPresent(entry -> {

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -445,6 +445,29 @@ public class NameGenerator
 
     }
 
+    public static String validateFieldKeyConflict(String fieldKey)
+    {
+        String fieldKeyLc = fieldKey.toLowerCase();
+
+        Set<String> formatNames = new HashSet<>(SubstitutionFormat.getFormatNames());
+        formatNames.add(SubstitutionValue.withCounter.name());
+        for (String formatName : formatNames)
+        {
+            String lcFormatName = ":" + formatName.toLowerCase();
+            int matchInd = fieldKeyLc.indexOf(lcFormatName);
+            if (matchInd > -1)
+                return "'" + fieldKey.substring(matchInd, matchInd + lcFormatName.length()) + "' is a reserved pattern.";
+        }
+
+        for (SubstitutionValue subValue : SubstitutionValue.values())
+        {
+            if (subValue.getKey().equalsIgnoreCase(fieldKey))
+                return fieldKey + " is a reserved name.";
+        }
+
+        return null;
+    }
+
     static Pair<List<String>, List<String>> getReservedFieldValidationResults(String nameExpression)
     {
         // For each substitution format, find its location in the string

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -26,6 +26,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
+import org.labkey.api.data.NameGenerator;
 import org.labkey.api.data.RemapCache;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
@@ -75,6 +76,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewBackgroundInfo;
@@ -117,6 +119,8 @@ public interface ExperimentService extends ExperimentRunTypeSource
     String LSID_COUNTER_DB_SEQUENCE_PREFIX = "LsidCounter-";
 
     String LINEAGE_DEFAULT_MAXIMUM_DEPTH_PROPERTY_NAME = "lineageDefaultMaximumDepth";
+
+    String ILLEGAL_PARENT_ALIAS_CHARSET = "/:<>$[]{};,`\"~!@#$%^*=|?\\";
 
     int SIMPLE_PROTOCOL_FIRST_STEP_SEQUENCE = 1;
     int SIMPLE_PROTOCOL_CORE_STEP_SEQUENCE = 10;
@@ -538,6 +542,14 @@ public interface ExperimentService extends ExperimentRunTypeSource
             {
                 throw new IllegalArgumentException(String.format("Duplicate parent alias header found: %1$s", trimmedKey));
             }
+
+            String legalCharacterCheck = StringUtilsLabKey.validateLegalNames(trimmedKey, ILLEGAL_PARENT_ALIAS_CHARSET, "Parent alias");
+            if (legalCharacterCheck != null)
+                throw new IllegalArgumentException(legalCharacterCheck);
+
+            String nameSyntaxError = NameGenerator.validateFieldKeyConflict(trimmedKey);
+            if (nameSyntaxError != null)
+                throw new IllegalArgumentException("Invalid Parent alias '" + trimmedKey + "'. " + nameSyntaxError);
 
             //Check if parent alias has correct format MaterialInput/<name> or NEW_SAMPLE_TYPE_ALIAS_VALUE, or DataInput/<name> or NEW_DATA_CLASS_ALIAS_VALUE
             if (!ExperimentService.parentAliasHasCorrectFormat(trimmedValue))

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -671,4 +671,10 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
     {
         return ComplianceService.get().isComplianceSupported();
     }
+
+    @Override
+    public boolean supportNamingPattern()
+    {
+        return true;
+    }
 }

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -673,7 +673,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
     }
 
     @Override
-    public boolean supportNamingPattern()
+    public boolean supportsNamingPattern()
     {
         return true;
     }

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -410,4 +410,9 @@ abstract public class DomainKind<T> implements Handler<String>
     {
         return false;
     }
+
+    public boolean supportNamingPattern()
+    {
+        return false;
+    }
 }

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -411,7 +411,7 @@ abstract public class DomainKind<T> implements Handler<String>
         return false;
     }
 
-    public boolean supportNamingPattern()
+    public boolean supportsNamingPattern()
     {
         return false;
     }

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -32,6 +32,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ContainerService;
+import org.labkey.api.data.NameGenerator;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.SchemaTableInfo;
 import org.labkey.api.data.SimpleFilter;
@@ -76,6 +77,7 @@ import org.labkey.api.util.JdbcUtil;
 import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.data.xml.ColumnType;
 import org.labkey.data.xml.ConditionalFormatFilterType;
@@ -104,6 +106,8 @@ import static org.labkey.api.util.StringExpressionFactory.SUBSTITUTION_EXP_PATTE
 public class DomainUtil
 {
     private static final Logger LOG = LogManager.getLogger(DomainUtil.class);
+    private static final String ILLEGAL_CHARSET = "<>$[]{};,`\"~!@#$%^*=|?\\";
+
     private DomainUtil()
     {
     }
@@ -688,10 +692,6 @@ public class DomainUtil
     {
         // Create a copy of the GWTDomain to ensure the template's Domain is not modified
         domain = new GWTDomain(domain);
-        if (domainName != null)
-        {
-            domain.setName(domainName);
-        }
 
         DomainKind kind = PropertyService.get().getDomainKindByName(kindName);
         if (kind == null)
@@ -699,6 +699,17 @@ public class DomainUtil
 
         if (!kind.canCreateDefinition(user, container))
             throw new UnauthorizedException("You don't have permission to create a new domain");
+
+
+        if (domainName != null)
+            domain.setName(domainName);
+
+        if (domain.getName() != null)
+        {
+            String domainNameError = validateDomainName(domain.getName(), kind.supportNamingPattern());
+            if (!StringUtils.isEmpty(domainNameError))
+                throw new IllegalArgumentException(domainNameError);
+        }
 
         // Issue 48810: if not creating from templateInfo, validate reserved field names based on domainKind
         boolean strictFieldValidation = arguments != null ? (Boolean) arguments.getOrDefault("strictFieldValidation", true) : true;
@@ -754,10 +765,17 @@ public class DomainUtil
             return validationException;
         }
 
-        if (updateDomainName && !d.getName().equals(update.getName()))
+        String updatedName = update.getName();
+        if (updateDomainName && !d.getName().equals(updatedName))
         {
+            String domainNameError = validateDomainName(updatedName, kind.supportNamingPattern());
+            if (!StringUtils.isEmpty(domainNameError))
+            {
+                validationException.addError(new SimpleValidationError(domainNameError));
+                return validationException;
+            }
             DefaultValueService.get().clearDefaultValues(d.getContainer(), d); // default values exp.objects will be re-created
-            d.setName(update.getName());
+            d.setName(updatedName);
         }
 
         d.setDisabledSystemFields(kind.getDisabledSystemFields(update.getDisabledSystemFields()));
@@ -915,6 +933,23 @@ public class DomainUtil
         }
 
         return validationException;
+    }
+
+    private static @Nullable String validateDomainName(@NotNull String domainName, boolean supportNamingPattern)
+    {
+        //final String legalChars = " -_()&/.:";
+        String legalCharacterCheck = StringUtilsLabKey.validateLegalNames(domainName, ILLEGAL_CHARSET, "Domain name");
+        if (legalCharacterCheck != null)
+            return legalCharacterCheck;
+
+        char start = domainName.charAt(0);
+        if (!Character.isLetterOrDigit(start))
+            return "Domain name must start with a letter or a number character.";
+
+        if (supportNamingPattern)
+            return NameGenerator.validateFieldKeyConflict(domainName);
+        
+        return null;
     }
 
     private static String getMissingMandatoryField(List<? extends GWTPropertyDescriptor> updatedFields,
@@ -1331,6 +1366,16 @@ public class DomainUtil
                     exception.addFieldError(name, getDomainErrorMessage(updates,("'" + name + "' is a reserved field name in '" + updates.getName() + "'.")));
                 }
                 continue;
+            }
+
+            if (domainKind != null && domainKind.supportNamingPattern())
+            {
+                String nameSyntaxError = NameGenerator.validateFieldKeyConflict(name);
+                if (nameSyntaxError != null)
+                {
+                    exception.addFieldError(name, nameSyntaxError);
+                    continue;
+                }
             }
 
             if (namePropertyIdMap.containsKey(name))

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -106,7 +106,7 @@ import static org.labkey.api.util.StringExpressionFactory.SUBSTITUTION_EXP_PATTE
 public class DomainUtil
 {
     private static final Logger LOG = LogManager.getLogger(DomainUtil.class);
-    private static final String ILLEGAL_CHARSET = "<>$[]{};,`\"~!@#$%^*=|?\\";
+    private static final String ILLEGAL_CHARSET = "<>[]{};,`\"~!@#$%^*=|?\\";
 
     private DomainUtil()
     {
@@ -706,7 +706,7 @@ public class DomainUtil
 
         if (domain.getName() != null)
         {
-            String domainNameError = validateDomainName(domain.getName(), kind.supportNamingPattern());
+            String domainNameError = validateDomainName(domain.getName(), kind);
             if (!StringUtils.isEmpty(domainNameError))
                 throw new IllegalArgumentException(domainNameError);
         }
@@ -768,7 +768,7 @@ public class DomainUtil
         String updatedName = update.getName();
         if (updateDomainName && !d.getName().equals(updatedName))
         {
-            String domainNameError = validateDomainName(updatedName, kind.supportNamingPattern());
+            String domainNameError = validateDomainName(updatedName, kind);
             if (!StringUtils.isEmpty(domainNameError))
             {
                 validationException.addError(new SimpleValidationError(domainNameError));
@@ -935,20 +935,25 @@ public class DomainUtil
         return validationException;
     }
 
-    private static @Nullable String validateDomainName(@NotNull String domainName, boolean supportNamingPattern)
+    private static @Nullable String validateDomainName(@NotNull String domainName, DomainKind kind)
     {
+        String prefix = "Invalid " + kind.getKindName() + " name. ";
         //final String legalChars = " -_()&/.:";
         String legalCharacterCheck = StringUtilsLabKey.validateLegalNames(domainName, ILLEGAL_CHARSET, "Domain name");
         if (legalCharacterCheck != null)
-            return legalCharacterCheck;
+            return prefix + legalCharacterCheck;
 
         char start = domainName.charAt(0);
         if (!Character.isLetterOrDigit(start))
-            return "Domain name must start with a letter or a number character.";
+            return prefix + "Domain name must start with a letter or a number character.";
 
-        if (supportNamingPattern)
-            return NameGenerator.validateFieldKeyConflict(domainName);
-        
+        if (kind.supportNamingPattern())
+        {
+            String invalidPattenError = NameGenerator.validateFieldKeyConflict(domainName);
+            if (invalidPattenError != null)
+                return prefix + invalidPattenError;
+        }
+
         return null;
     }
 

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -106,7 +106,7 @@ import static org.labkey.api.util.StringExpressionFactory.SUBSTITUTION_EXP_PATTE
 public class DomainUtil
 {
     private static final Logger LOG = LogManager.getLogger(DomainUtil.class);
-    private static final String ILLEGAL_CHARSET = "<>[]{};,`\"~!@#$%^*=|?\\";
+    public static final String ILLEGAL_DOMAIN_NAME_CHARSET = "<>[]{};,`\"~!@#$%^*=|?\\";
 
     private DomainUtil()
     {
@@ -706,7 +706,7 @@ public class DomainUtil
 
         if (domain.getName() != null)
         {
-            String domainNameError = validateDomainName(domain.getName(), kind);
+            String domainNameError = validateDomainName(domain.getName(), kind.getKindName(), kind.supportNamingPattern());
             if (!StringUtils.isEmpty(domainNameError))
                 throw new IllegalArgumentException(domainNameError);
         }
@@ -768,7 +768,7 @@ public class DomainUtil
         String updatedName = update.getName();
         if (updateDomainName && !d.getName().equals(updatedName))
         {
-            String domainNameError = validateDomainName(updatedName, kind);
+            String domainNameError = validateDomainName(updatedName, kind.getKindName(), kind.supportNamingPattern());
             if (!StringUtils.isEmpty(domainNameError))
             {
                 validationException.addError(new SimpleValidationError(domainNameError));
@@ -935,19 +935,23 @@ public class DomainUtil
         return validationException;
     }
 
-    private static @Nullable String validateDomainName(@NotNull String domainName, DomainKind kind)
+    public static @Nullable String validateDomainName(@NotNull String domainName, String kindName, boolean supportNamingPattern)
     {
-        String prefix = "Invalid " + kind.getKindName() + " name. ";
-        //final String legalChars = " -_()&/.:";
-        String legalCharacterCheck = StringUtilsLabKey.validateLegalNames(domainName, ILLEGAL_CHARSET, "Domain name");
-        if (legalCharacterCheck != null)
-            return prefix + legalCharacterCheck;
+        String prefix = "Invalid " + kindName + " name. ";
+
+        if (StringUtils.isBlank(domainName))
+            return "Domain name must not be blank";
 
         char start = domainName.charAt(0);
         if (!Character.isLetterOrDigit(start))
             return prefix + "Domain name must start with a letter or a number character.";
 
-        if (kind.supportNamingPattern())
+        //final String legalChars = " -_()&/.:";
+        String legalCharacterCheck = StringUtilsLabKey.validateLegalNames(domainName, ILLEGAL_DOMAIN_NAME_CHARSET, "Domain name");
+        if (legalCharacterCheck != null)
+            return prefix + legalCharacterCheck;
+
+        if (supportNamingPattern)
         {
             String invalidPattenError = NameGenerator.validateFieldKeyConflict(domainName);
             if (invalidPattenError != null)

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -706,7 +706,7 @@ public class DomainUtil
 
         if (domain.getName() != null)
         {
-            String domainNameError = validateDomainName(domain.getName(), kind.getKindName(), kind.supportNamingPattern());
+            String domainNameError = validateDomainName(domain.getName(), kind.getKindName(), kind.supportsNamingPattern());
             if (!StringUtils.isEmpty(domainNameError))
                 throw new IllegalArgumentException(domainNameError);
         }
@@ -768,7 +768,7 @@ public class DomainUtil
         String updatedName = update.getName();
         if (updateDomainName && !d.getName().equals(updatedName))
         {
-            String domainNameError = validateDomainName(updatedName, kind.getKindName(), kind.supportNamingPattern());
+            String domainNameError = validateDomainName(updatedName, kind.getKindName(), kind.supportsNamingPattern());
             if (!StringUtils.isEmpty(domainNameError))
             {
                 validationException.addError(new SimpleValidationError(domainNameError));
@@ -935,23 +935,22 @@ public class DomainUtil
         return validationException;
     }
 
-    public static @Nullable String validateDomainName(@NotNull String domainName, String kindName, boolean supportNamingPattern)
+    public static @Nullable String validateDomainName(@NotNull String domainName, String kindName, boolean supportsNamingPattern)
     {
-        String prefix = "Invalid " + kindName + " name. ";
+        String prefix = "Invalid " + kindName + " name \"" + domainName + "\". ";
 
         if (StringUtils.isBlank(domainName))
-            return "Domain name must not be blank";
+            return kindName + " name must not be blank.";
 
         char start = domainName.charAt(0);
         if (!Character.isLetterOrDigit(start))
-            return prefix + "Domain name must start with a letter or a number character.";
+            return prefix + kindName + " name must start with a letter or a number.";
 
-        //final String legalChars = " -_()&/.:";
-        String legalCharacterCheck = StringUtilsLabKey.validateLegalNames(domainName, ILLEGAL_DOMAIN_NAME_CHARSET, "Domain name");
+        String legalCharacterCheck = StringUtilsLabKey.validateLegalNames(domainName, ILLEGAL_DOMAIN_NAME_CHARSET, kindName + " name");
         if (legalCharacterCheck != null)
             return prefix + legalCharacterCheck;
 
-        if (supportNamingPattern)
+        if (supportsNamingPattern)
         {
             String invalidPattenError = NameGenerator.validateFieldKeyConflict(domainName);
             if (invalidPattenError != null)
@@ -1377,7 +1376,7 @@ public class DomainUtil
                 continue;
             }
 
-            if (domainKind != null && domainKind.supportNamingPattern())
+            if (domainKind != null && domainKind.supportsNamingPattern())
             {
                 String nameSyntaxError = NameGenerator.validateFieldKeyConflict(name);
                 if (nameSyntaxError != null)

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -334,20 +334,7 @@ public class FileUtil
 
     private static @Nullable String validateFileName(String s)
     {
-        if (StringUtils.isBlank(s))
-            return "Filename must not be blank";
-        if (!ViewServlet.validChars(s))
-            return "Filename must contain only valid unicode characters.";
-        if (StringUtils.containsAny(s, restrictedPrintable))
-            return "Filename may not contain any of these characters: " + restrictedPrintable;
-        if (StringUtils.containsAny(s, "\t\n\r"))
-            return "Filename may not contain 'tab', 'new line', or 'return' characters.";
-        if (StringUtils.contains("-$", s.charAt(0)))
-            return "Filename may not begin with any of these characters: -$";
-        if (Pattern.matches("(.*\\s--[^ ].*)|(.*\\s-[^- ].*)", s))
-            return "Filename may not contain space followed by dash.";
-
-        return null;
+        return StringUtilsLabKey.validateLegalNames(s, restrictedPrintable, "Filename");
     }
 
     private static String checkExtension(String filename, AppProps appProps)

--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -25,6 +25,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.Identifiable;
+import org.labkey.api.view.ViewServlet;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -51,6 +52,26 @@ public class StringUtilsLabKey
 
     private static final Random RANDOM = new Random();
     private static final int MAX_LONG_LENGTH = String.valueOf(Long.MAX_VALUE).length() - 1;
+
+
+
+    public static @Nullable String validateLegalNames(String s, @NotNull String illegalCharset, String type)
+    {
+        if (StringUtils.isBlank(s))
+            return type + " must not be blank";
+        if (!ViewServlet.validChars(s))
+            return type + " must contain only valid unicode characters.";
+        if (StringUtils.containsAny(s, illegalCharset))
+            return type + " may not contain any of these characters: " + illegalCharset;
+        if (StringUtils.containsAny(s, "\t\n\r"))
+            return type + " may not contain 'tab', 'new line', or 'return' characters.";
+        if (StringUtils.contains("-$", s.charAt(0)))
+            return type + " may not begin with any of these characters: -$";
+        if (Pattern.matches("(.*\\s--[^ ].*)|(.*\\s-[^- ].*)", s))
+            return type + " may not contain space followed by dash.";
+
+        return null;
+    }
 
     public static void append(StringBuilder sb, @Nullable Identifiable identifiable)
     {

--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -58,7 +58,7 @@ public class StringUtilsLabKey
     public static @Nullable String validateLegalNames(String s, @NotNull String illegalCharset, String type)
     {
         if (StringUtils.isBlank(s))
-            return type + " must not be blank";
+            return type + " must not be blank.";
         if (!ViewServlet.validChars(s))
             return type + " must contain only valid unicode characters.";
         if (StringUtils.containsAny(s, illegalCharset))

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -392,6 +392,10 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                     if (AssayManager.get().getAssayProtocolByName(getContainer(), assay.getName()) != null)
                         throw new ValidationException("Assay protocol already exists for this name.");
 
+                    String nameError = DomainUtil.validateDomainName(assay.getName(), "Assay Design", false);
+                    if (nameError != null)
+                        throw new ValidationException(nameError);
+
                     XarContext context = new XarContext("Domains", getContainer(), getUser());
                     context.addSubstitution("AssayName", PageFlowUtil.encode(assay.getName()));
 
@@ -437,6 +441,12 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                                 "This assay was created in folder " + protocol.getContainer().getPath());
                     oldAssayName = protocol.getName();
                     hasNameChange = !assay.getName().equals(oldAssayName);
+                    if (hasNameChange)
+                    {
+                        String nameError = DomainUtil.validateDomainName(assay.getName(), "Assay Design", false);
+                        if (nameError != null)
+                            throw new ValidationException(nameError);
+                    }
                     protocol.setName(assay.getName());
                     protocol.setProtocolDescription(assay.getDescription());
                     if (assay.getStatus() != null)

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.5.2-fb-domainNameValidation.1",
+        "@labkey/components": "6.5.3-fb-domainNameValidation.1",
         "@labkey/themes": "1.4.0"
       },
       "devDependencies": {
@@ -3058,9 +3058,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.5.2-fb-domainNameValidation.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.2-fb-domainNameValidation.1.tgz",
-      "integrity": "sha512-ttc2hu8RcYroBRfQbgy1mFGXGsX71wgtENfpwevwd2YY4ciaHLpRk/IC7iyo/HW1Rwu1lpcuX615ETUu2gOdWA==",
+      "version": "6.5.3-fb-domainNameValidation.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.3-fb-domainNameValidation.1.tgz",
+      "integrity": "sha512-UUuJYcBlzTrzo3faghKz6lk/zT6xFaSC2pxymIMrpOiXLJVNtlL0BoWZafboU/JUNU8Ac5JI5MDf873n04iCLw==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.36.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.5.1-fb-domainNameValidation.1",
+        "@labkey/components": "6.5.2-fb-domainNameValidation.1",
         "@labkey/themes": "1.4.0"
       },
       "devDependencies": {
@@ -3058,9 +3058,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.5.1-fb-domainNameValidation.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.1-fb-domainNameValidation.1.tgz",
-      "integrity": "sha512-BuoM0l57Giy8JjjA4iRvJh3hdN/nkz2eB6a1Wkweyj+XDuG0+6IPfUiCM5TOqbbCUNvfbJE09YcY9ON9EUoBmQ==",
+      "version": "6.5.2-fb-domainNameValidation.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.2-fb-domainNameValidation.1.tgz",
+      "integrity": "sha512-ttc2hu8RcYroBRfQbgy1mFGXGsX71wgtENfpwevwd2YY4ciaHLpRk/IC7iyo/HW1Rwu1lpcuX615ETUu2gOdWA==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.36.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.5.3-fb-domainNameValidation.1",
+        "@labkey/components": "6.5.3",
         "@labkey/themes": "1.4.0"
       },
       "devDependencies": {
@@ -3058,9 +3058,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.5.3-fb-domainNameValidation.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.3-fb-domainNameValidation.1.tgz",
-      "integrity": "sha512-UUuJYcBlzTrzo3faghKz6lk/zT6xFaSC2pxymIMrpOiXLJVNtlL0BoWZafboU/JUNU8Ac5JI5MDf873n04iCLw==",
+      "version": "6.5.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.3.tgz",
+      "integrity": "sha512-7kQ9VegwEysB2BFJ4W8sKim0Ld9mXLZq3PC23gcqWEKvhok/jL0aId6x2uQUxhu+8q1BX+6shfBj0j8RLA9uLQ==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.36.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.4.0",
+        "@labkey/components": "6.5.1-fb-domainNameValidation.1",
         "@labkey/themes": "1.4.0"
       },
       "devDependencies": {
@@ -3058,9 +3058,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.4.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.4.0.tgz",
-      "integrity": "sha512-S3HX8kc7yL9PXNmeAbn6hWrz/6Jl1xGNwdqpFrmvCvb/aQ8g+ydZFSBQd73EcxZsCsPUlewZbrOQ7gqRTADH7g==",
+      "version": "6.5.1-fb-domainNameValidation.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.1-fb-domainNameValidation.1.tgz",
+      "integrity": "sha512-BuoM0l57Giy8JjjA4iRvJh3hdN/nkz2eB6a1Wkweyj+XDuG0+6IPfUiCM5TOqbbCUNvfbJE09YcY9ON9EUoBmQ==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.36.0",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.4.0",
+    "@labkey/components": "6.5.1-fb-domainNameValidation.1",
     "@labkey/themes": "1.4.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.5.2-fb-domainNameValidation.1",
+    "@labkey/components": "6.5.3-fb-domainNameValidation.1",
     "@labkey/themes": "1.4.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.5.1-fb-domainNameValidation.1",
+    "@labkey/components": "6.5.2-fb-domainNameValidation.1",
     "@labkey/themes": "1.4.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.5.3-fb-domainNameValidation.1",
+    "@labkey/components": "6.5.3",
     "@labkey/themes": "1.4.0"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.5.1-fb-domainNameValidation.1"
+        "@labkey/components": "6.5.2-fb-domainNameValidation.1"
       },
       "devDependencies": {
         "@labkey/build": "8.3.0",
@@ -2864,9 +2864,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.5.1-fb-domainNameValidation.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.1-fb-domainNameValidation.1.tgz",
-      "integrity": "sha512-BuoM0l57Giy8JjjA4iRvJh3hdN/nkz2eB6a1Wkweyj+XDuG0+6IPfUiCM5TOqbbCUNvfbJE09YcY9ON9EUoBmQ==",
+      "version": "6.5.2-fb-domainNameValidation.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.2-fb-domainNameValidation.1.tgz",
+      "integrity": "sha512-ttc2hu8RcYroBRfQbgy1mFGXGsX71wgtENfpwevwd2YY4ciaHLpRk/IC7iyo/HW1Rwu1lpcuX615ETUu2gOdWA==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.36.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.4.0"
+        "@labkey/components": "6.5.1-fb-domainNameValidation.1"
       },
       "devDependencies": {
         "@labkey/build": "8.3.0",
@@ -2864,9 +2864,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.4.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.4.0.tgz",
-      "integrity": "sha512-S3HX8kc7yL9PXNmeAbn6hWrz/6Jl1xGNwdqpFrmvCvb/aQ8g+ydZFSBQd73EcxZsCsPUlewZbrOQ7gqRTADH7g==",
+      "version": "6.5.1-fb-domainNameValidation.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.1-fb-domainNameValidation.1.tgz",
+      "integrity": "sha512-BuoM0l57Giy8JjjA4iRvJh3hdN/nkz2eB6a1Wkweyj+XDuG0+6IPfUiCM5TOqbbCUNvfbJE09YcY9ON9EUoBmQ==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.36.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.5.2-fb-domainNameValidation.1"
+        "@labkey/components": "6.5.3-fb-domainNameValidation.1"
       },
       "devDependencies": {
         "@labkey/build": "8.3.0",
@@ -2864,9 +2864,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.5.2-fb-domainNameValidation.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.2-fb-domainNameValidation.1.tgz",
-      "integrity": "sha512-ttc2hu8RcYroBRfQbgy1mFGXGsX71wgtENfpwevwd2YY4ciaHLpRk/IC7iyo/HW1Rwu1lpcuX615ETUu2gOdWA==",
+      "version": "6.5.3-fb-domainNameValidation.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.3-fb-domainNameValidation.1.tgz",
+      "integrity": "sha512-UUuJYcBlzTrzo3faghKz6lk/zT6xFaSC2pxymIMrpOiXLJVNtlL0BoWZafboU/JUNU8Ac5JI5MDf873n04iCLw==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.36.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.5.3-fb-domainNameValidation.1"
+        "@labkey/components": "6.5.3"
       },
       "devDependencies": {
         "@labkey/build": "8.3.0",
@@ -2864,9 +2864,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.5.3-fb-domainNameValidation.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.3-fb-domainNameValidation.1.tgz",
-      "integrity": "sha512-UUuJYcBlzTrzo3faghKz6lk/zT6xFaSC2pxymIMrpOiXLJVNtlL0BoWZafboU/JUNU8Ac5JI5MDf873n04iCLw==",
+      "version": "6.5.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.5.3.tgz",
+      "integrity": "sha512-7kQ9VegwEysB2BFJ4W8sKim0Ld9mXLZq3PC23gcqWEKvhok/jL0aId6x2uQUxhu+8q1BX+6shfBj0j8RLA9uLQ==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.36.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.5.3-fb-domainNameValidation.1"
+    "@labkey/components": "6.5.3"
   },
   "devDependencies": {
     "@labkey/build": "8.3.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.5.1-fb-domainNameValidation.1"
+    "@labkey/components": "6.5.2-fb-domainNameValidation.1"
   },
   "devDependencies": {
     "@labkey/build": "8.3.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.4.0"
+    "@labkey/components": "6.5.1-fb-domainNameValidation.1"
   },
   "devDependencies": {
     "@labkey/build": "8.3.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.5.2-fb-domainNameValidation.1"
+    "@labkey/components": "6.5.3-fb-domainNameValidation.1"
   },
   "devDependencies": {
     "@labkey/build": "8.3.0",

--- a/experiment/src/client/test/integration/AssayDesignCrud.ispec.ts
+++ b/experiment/src/client/test/integration/AssayDesignCrud.ispec.ts
@@ -1,10 +1,12 @@
-import { hookServer, RequestOptions, successfulResponse } from '@labkey/test';
+import { hookServer, RequestOptions, selectRandomN, successfulResponse } from '@labkey/test';
 import mock from 'mock-fs';
 
 import {
     deleteAssayDesign,
     getAssayDesignPayload,
-    getAssayDesignRowIdByName, importRun,
+    getAssayDesignRowIdByName,
+    ILLEGAL_DOMAIN_CHARSET,
+    importRun,
     initProject
 } from './utils';
 import { ASSAY_DESIGNER_ROLE } from '@labkey/components';
@@ -91,75 +93,150 @@ describe('Assay Designer - Permissions', () => {
 
     });
 
+    async function verifyAssayDesignCreateFailure(badDomainName: string, error: string) {
+        let exception = null;
+        const badDomainNameResp = await server.post(
+            'assay',
+            'saveProtocol.api',
+            getAssayDesignPayload(badDomainName, [], []),
+            {...topFolderOptions, ...designerReaderOptions}
+        ).expect((resp) => {
+            exception = JSON.parse(resp.text).exception;
+        })
+
+        if (exception !== error)
+            console.log(badDomainName);
+
+        expect(exception).toBe(error);
+    }
+
+    async function verifyAssayDesignUpdateFailure(payload: any, badDomainName: string, error: string) {
+        let exception = null;
+        payload['name'] = badDomainName;
+        const badDomainNameResp = await server.post(
+            'assay',
+            'saveProtocol.api',
+            payload,
+            {...topFolderOptions, ...designerReaderOptions}
+        ).expect((resp) => {
+            exception = JSON.parse(resp.text).exception;
+        })
+
+        if (exception !== error)
+            console.log(badDomainName);
+
+        expect(exception).toBe(error);
+    }
+
+    it('Assay design name validation', async () => {
+        const badNames = {
+            '': 'Domain name must not be blank',
+            ' ': 'Domain name must not be blank',
+            'with\0nullCharacter': `Invalid Assay Design name. Domain name must contain only valid unicode characters.`,
+            'with\tnewLines': `Invalid Assay Design name. Domain name may not contain 'tab', 'new line', or 'return' characters.`,
+            '.startWithDot': `Invalid Assay Design name. Domain name must start with a letter or a number character.`,
+            ['c' + selectRandomN(ILLEGAL_DOMAIN_CHARSET.split(''), 2).join('')]: `Invalid Assay Design name. Domain name may not contain any of these characters: ` + ILLEGAL_DOMAIN_CHARSET,
+            'a -b': `Invalid Assay Design name. Domain name may not contain space followed by dash.`
+        };
+
+        let badNameKeys = Object.keys(badNames);
+        for (let i = 0; i < badNameKeys.length; i++)
+            await verifyAssayDesignCreateFailure(badNameKeys[i], badNames[badNameKeys[i]]);
+        
+        let assayDesignPayload = getAssayDesignPayload('good', [], []);
+
+        await server.post(
+            'assay',
+            'saveProtocol.api',
+            assayDesignPayload,
+            {...topFolderOptions, ...designerReaderOptions}
+        ).expect((res) => {
+            const result = JSON.parse(res.text);
+            assayDesignPayload.protocolId = result.data.protocolId;
+            const domains = result.data.domains;
+            assayDesignPayload.domains[0].domainId = domains[0].domainId;
+            assayDesignPayload.domains[0].domainURI = domains[0].domainURI;
+            assayDesignPayload.domains[1].domainId = domains[1].domainId;
+            assayDesignPayload.domains[1].domainURI = domains[1].domainURI;
+            assayDesignPayload.domains[2].domainId = domains[2].domainId;
+            assayDesignPayload.domains[2].domainURI = domains[2].domainURI;
+            return true;
+        });
+
+        for (let i = 0; i < badNameKeys.length; i++)
+            await verifyAssayDesignUpdateFailure(assayDesignPayload, badNameKeys[i], badNames[badNameKeys[i]]);
+
+    });
+
     describe('Create/update/delete designs', () => {
         it('Designer can create, update and delete empty design, reader and editors cannot create/update/delete design.', async () => {
             const dataType = "ToBeDeleted";
-            const assayDesignPaylod = getAssayDesignPayload(dataType, [], []);
+            const assayDesignPayload = getAssayDesignPayload(dataType, [], []);
 
             await server.post(
                 'assay',
                 'saveProtocol.api',
-                assayDesignPaylod,
+                assayDesignPayload,
                 {...topFolderOptions, ...readerUserOptions}
             ).expect(403);
 
             await server.post(
                 'assay',
                 'saveProtocol.api',
-                assayDesignPaylod,
+                assayDesignPayload,
                 {...topFolderOptions, ...editorUserOptions}
             ).expect(403);
 
             await server.post(
                 'assay',
                 'saveProtocol.api',
-                assayDesignPaylod,
+                assayDesignPayload,
                 {...topFolderOptions, ...designerReaderOptions}
             ).expect((res) => {
                 const result = JSON.parse(res.text);
-                assayDesignPaylod.protocolId = result.data.protocolId;
+                assayDesignPayload.protocolId = result.data.protocolId;
                 const domains = result.data.domains;
-                assayDesignPaylod.domains[0].domainId = domains[0].domainId;
-                assayDesignPaylod.domains[0].domainURI = domains[0].domainURI;
-                assayDesignPaylod.domains[1].domainId = domains[1].domainId;
-                assayDesignPaylod.domains[1].domainURI = domains[1].domainURI;
-                assayDesignPaylod.domains[2].domainId = domains[2].domainId;
-                assayDesignPaylod.domains[2].domainURI = domains[2].domainURI;
+                assayDesignPayload.domains[0].domainId = domains[0].domainId;
+                assayDesignPayload.domains[0].domainURI = domains[0].domainURI;
+                assayDesignPayload.domains[1].domainId = domains[1].domainId;
+                assayDesignPayload.domains[1].domainURI = domains[1].domainURI;
+                assayDesignPayload.domains[2].domainId = domains[2].domainId;
+                assayDesignPayload.domains[2].domainURI = domains[2].domainURI;
                 return true;
             });
 
-            assayDesignPaylod.domains[2].fields = [resultPropField];
+            assayDesignPayload.domains[2].fields = [resultPropField];
 
             await server.post(
                 'assay',
                 'saveProtocol.api',
-                assayDesignPaylod,
+                assayDesignPayload,
                 {...topFolderOptions, ...readerUserOptions}
             ).expect(403);
 
             await server.post(
                 'assay',
                 'saveProtocol.api',
-                assayDesignPaylod,
+                assayDesignPayload,
                 {...topFolderOptions, ...editorUserOptions}
             ).expect(403);
 
             await server.post(
                 'assay',
                 'saveProtocol.api',
-                assayDesignPaylod,
+                assayDesignPayload,
                 {...topFolderOptions, ...designerReaderOptions}
             ).expect(successfulResponse);
 
             const dataTypeRowId = await getAssayDesignRowIdByName(server, dataType, topFolderOptions);
-            expect(dataTypeRowId).toBe(assayDesignPaylod.protocolId);
+            expect(dataTypeRowId).toBe(assayDesignPayload.protocolId);
 
-            let deleteResult = await deleteAssayDesign(server, assayDesignPaylod.protocolId, topFolderOptions, readerUserOptions);
+            let deleteResult = await deleteAssayDesign(server, assayDesignPayload.protocolId, topFolderOptions, readerUserOptions);
             expect(deleteResult.status).toEqual(403);
-            deleteResult = await deleteAssayDesign(server, assayDesignPaylod.protocolId, topFolderOptions, editorUserOptions);
+            deleteResult = await deleteAssayDesign(server, assayDesignPayload.protocolId, topFolderOptions, editorUserOptions);
             expect(deleteResult.status).toEqual(403);
 
-            deleteResult = await deleteAssayDesign(server, assayDesignPaylod.protocolId, topFolderOptions, designerReaderOptions);
+            deleteResult = await deleteAssayDesign(server, assayDesignPayload.protocolId, topFolderOptions, designerReaderOptions);
             expect(deleteResult.status).toEqual(200);
 
             const removeddataType = await getAssayDesignRowIdByName(server, dataType, topFolderOptions);
@@ -168,7 +245,7 @@ describe('Assay Designer - Permissions', () => {
         //
         it('Designer can update non-empty design but cannot delete non-empty design, admin can delete non-empty design', async () => {
             const dataType = "FailedDelete";
-            const assayDesignPaylod = getAssayDesignPayload(dataType, [], []);
+            const assayDesignPayload = getAssayDesignPayload(dataType, [], []);
             await server.post(
                 'assay',
                 'saveProtocol.api',
@@ -176,57 +253,57 @@ describe('Assay Designer - Permissions', () => {
                 {...topFolderOptions, ...designerReaderOptions}
             ).expect((res) => {
                 const result = JSON.parse(res.text);
-                assayDesignPaylod.protocolId = result.data.protocolId;
+                assayDesignPayload.protocolId = result.data.protocolId;
                 const domains = result.data.domains;
-                assayDesignPaylod.domains[0].domainId = domains[0].domainId;
-                assayDesignPaylod.domains[0].domainURI = domains[0].domainURI;
-                assayDesignPaylod.domains[1].domainId = domains[1].domainId;
-                assayDesignPaylod.domains[1].domainURI = domains[1].domainURI;
-                assayDesignPaylod.domains[2].domainId = domains[2].domainId;
-                assayDesignPaylod.domains[2].domainURI = domains[2].domainURI;
+                assayDesignPayload.domains[0].domainId = domains[0].domainId;
+                assayDesignPayload.domains[0].domainURI = domains[0].domainURI;
+                assayDesignPayload.domains[1].domainId = domains[1].domainId;
+                assayDesignPayload.domains[1].domainURI = domains[1].domainURI;
+                assayDesignPayload.domains[2].domainId = domains[2].domainId;
+                assayDesignPayload.domains[2].domainURI = domains[2].domainURI;
                 return true;
             });
 
-            assayDesignPaylod.domains[2].fields = [resultPropField];
+            assayDesignPayload.domains[2].fields = [resultPropField];
 
             // create run in child folder
-            const { runId } = await importRun(server, assayDesignPaylod.protocolId, 'ChildRun', [{"Prop":"ABC"}], subfolder1Options, editorUserOptions);
+            const { runId } = await importRun(server, assayDesignPayload.protocolId, 'ChildRun', [{"Prop":"ABC"}], subfolder1Options, editorUserOptions);
             expect(runId > 0).toBeTruthy();
 
             await server.post(
                 'assay',
                 'saveProtocol.api',
-                assayDesignPaylod,
+                assayDesignPayload,
                 {...topFolderOptions, ...designerReaderOptions}
             ).expect(successfulResponse);
 
             // verify data exist in child prevent designer from delete design
-            let deleteResult = await deleteAssayDesign(server, assayDesignPaylod.protocolId, topFolderOptions, designerReaderOptions);
+            let deleteResult = await deleteAssayDesign(server, assayDesignPayload.protocolId, topFolderOptions, designerReaderOptions);
             expect(deleteResult.status).toEqual(403);
-            deleteResult = await deleteAssayDesign(server, assayDesignPaylod.protocolId, topFolderOptions, readerUserOptions);
+            deleteResult = await deleteAssayDesign(server, assayDesignPayload.protocolId, topFolderOptions, readerUserOptions);
             expect(deleteResult.status).toEqual(403);
-            deleteResult = await deleteAssayDesign(server, assayDesignPaylod.protocolId, topFolderOptions, editorUserOptions);
+            deleteResult = await deleteAssayDesign(server, assayDesignPayload.protocolId, topFolderOptions, editorUserOptions);
             expect(deleteResult.status).toEqual(403);
 
             let failedRemoveddataType = await getAssayDesignRowIdByName(server, dataType, topFolderOptions);
-            expect(failedRemoveddataType).toEqual(assayDesignPaylod.protocolId);
+            expect(failedRemoveddataType).toEqual(assayDesignPayload.protocolId);
 
             // create another run in top folder
-            await importRun(server, assayDesignPaylod.protocolId, 'TopRun', [{"Prop":"EFG"}], topFolderOptions, editorUserOptions);
+            await importRun(server, assayDesignPayload.protocolId, 'TopRun', [{"Prop":"EFG"}], topFolderOptions, editorUserOptions);
 
             // verify data exist in Top prevent designer from delete design
-            deleteResult = await deleteAssayDesign(server, assayDesignPaylod.protocolId, topFolderOptions, designerEditorOptions);
+            deleteResult = await deleteAssayDesign(server, assayDesignPayload.protocolId, topFolderOptions, designerEditorOptions);
             expect(deleteResult.status).toEqual(403);
-            deleteResult = await deleteAssayDesign(server, assayDesignPaylod.protocolId, topFolderOptions, readerUserOptions);
+            deleteResult = await deleteAssayDesign(server, assayDesignPayload.protocolId, topFolderOptions, readerUserOptions);
             expect(deleteResult.status).toEqual(403);
-            deleteResult = await deleteAssayDesign(server, assayDesignPaylod.protocolId, topFolderOptions, editorUserOptions);
+            deleteResult = await deleteAssayDesign(server, assayDesignPayload.protocolId, topFolderOptions, editorUserOptions);
             expect(deleteResult.status).toEqual(403);
 
             failedRemoveddataType = await getAssayDesignRowIdByName(server, dataType, topFolderOptions);
-            expect(failedRemoveddataType).toEqual(assayDesignPaylod.protocolId);
+            expect(failedRemoveddataType).toEqual(assayDesignPayload.protocolId);
 
             //admin can delete design with data
-            deleteResult = await deleteAssayDesign(server, assayDesignPaylod.protocolId, topFolderOptions, adminOptions);
+            deleteResult = await deleteAssayDesign(server, assayDesignPayload.protocolId, topFolderOptions, adminOptions);
             expect(deleteResult.status).toEqual(200);
 
             const removedDataType = await getAssayDesignRowIdByName(server, dataType, topFolderOptions);

--- a/experiment/src/client/test/integration/AssayDesignCrud.ispec.ts
+++ b/experiment/src/client/test/integration/AssayDesignCrud.ispec.ts
@@ -107,7 +107,7 @@ describe('Assay Designer - Permissions', () => {
         if (exception !== error)
             console.log(badDomainName);
 
-        expect(exception).toBe(error);
+        expect(exception).toBe(error.replace("REPLACE", badDomainName));
     }
 
     async function verifyAssayDesignUpdateFailure(payload: any, badDomainName: string, error: string) {
@@ -125,18 +125,18 @@ describe('Assay Designer - Permissions', () => {
         if (exception !== error)
             console.log(badDomainName);
 
-        expect(exception).toBe(error);
+        expect(exception).toBe(error.replace("REPLACE", badDomainName));
     }
 
     it('Assay design name validation', async () => {
         const badNames = {
-            '': 'Domain name must not be blank',
-            ' ': 'Domain name must not be blank',
-            'with\0nullCharacter': `Invalid Assay Design name. Domain name must contain only valid unicode characters.`,
-            'with\tnewLines': `Invalid Assay Design name. Domain name may not contain 'tab', 'new line', or 'return' characters.`,
-            '.startWithDot': `Invalid Assay Design name. Domain name must start with a letter or a number character.`,
-            ['c' + selectRandomN(ILLEGAL_DOMAIN_CHARSET.split(''), 2).join('')]: `Invalid Assay Design name. Domain name may not contain any of these characters: ` + ILLEGAL_DOMAIN_CHARSET,
-            'a -b': `Invalid Assay Design name. Domain name may not contain space followed by dash.`
+            '': 'Assay Design name must not be blank',
+            ' ': 'Assay Design name must not be blank',
+            'with\0nullCharacter': `Invalid Assay Design name "REPLACE". Assay Design name must contain only valid unicode characters.`,
+            'with\tnewLines': `Invalid Assay Design name "REPLACE". Assay Design name may not contain 'tab', 'new line', or 'return' characters.`,
+            '.startWithDot': `Invalid Assay Design name "REPLACE". Assay Design name must start with a letter or a number.`,
+            ['c' + selectRandomN(ILLEGAL_DOMAIN_CHARSET.split(''), 2).join('')]: `Invalid Assay Design name "REPLACE". Assay Design name may not contain any of these characters: ` + ILLEGAL_DOMAIN_CHARSET,
+            'a -b': `Invalid Assay Design name "REPLACE". Assay Design name may not contain space followed by dash.`
         };
 
         let badNameKeys = Object.keys(badNames);

--- a/experiment/src/client/test/integration/AssayDesignCrud.ispec.ts
+++ b/experiment/src/client/test/integration/AssayDesignCrud.ispec.ts
@@ -122,16 +122,13 @@ describe('Assay Designer - Permissions', () => {
             exception = JSON.parse(resp.text).exception;
         })
 
-        if (exception !== error)
-            console.log(badDomainName);
-
         expect(exception).toBe(error.replace("REPLACE", badDomainName));
     }
 
     it('Assay design name validation', async () => {
         const badNames = {
-            '': 'Assay Design name must not be blank',
-            ' ': 'Assay Design name must not be blank',
+            '': 'Assay Design name must not be blank.',
+            ' ': 'Assay Design name must not be blank.',
             'with\0nullCharacter': `Invalid Assay Design name "REPLACE". Assay Design name must contain only valid unicode characters.`,
             'with\tnewLines': `Invalid Assay Design name "REPLACE". Assay Design name may not contain 'tab', 'new line', or 'return' characters.`,
             '.startWithDot': `Invalid Assay Design name "REPLACE". Assay Design name must start with a letter or a number.`,

--- a/experiment/src/client/test/integration/DataClassCrud.ispec.ts
+++ b/experiment/src/client/test/integration/DataClassCrud.ispec.ts
@@ -1,6 +1,7 @@
 import { hookServer, RequestOptions, successfulResponse } from '@labkey/test';
 import mock from 'mock-fs';
 import {
+    checkDomainName,
     checkLackDesignerOrReaderPerm,
     createSource,
     deleteSourceType,
@@ -68,9 +69,13 @@ afterEach(() => {
     mock.restore();
 });
 
-describe('Data Class Designer - Permissions', () => {
+describe('Data Class Designer', () => {
     it('Lack designer or Reader permission', async () => {
         await checkLackDesignerOrReaderPerm(server, 'DataClass', topFolderOptions, readerUserOptions, editorUserOptions, designerOptions);
+    });
+
+    it('Data class name validation', async () => {
+        await checkDomainName(server, 'DataClass', true, topFolderOptions, designerReaderOptions);
     });
 
     describe('Create/update/delete designs', () => {

--- a/experiment/src/client/test/integration/SampleTypeCrud.ispec.ts
+++ b/experiment/src/client/test/integration/SampleTypeCrud.ispec.ts
@@ -1,6 +1,7 @@
 import { ExperimentCRUDUtils, hookServer, RequestOptions, successfulResponse } from '@labkey/test';
 import mock from 'mock-fs';
 import {
+    checkDomainName,
     checkLackDesignerOrReaderPerm,
     createSample,
     deleteSampleType,
@@ -136,12 +137,16 @@ afterEach(() => {
     mock.restore();
 });
 
-describe('Sample Type Designer - Permissions', () => {
+describe('Sample Type Designer', () => {
     it('Lack designer or Reader permission', async () => {
         await checkLackDesignerOrReaderPerm(server, 'SampleSet', topFolderOptions, readerUserOptions, editorUserOptions, designerOptions);
     });
 
     describe('Create/update/delete designs', () => {
+        it('Sample type name validation', async () => {
+            await checkDomainName(server, 'SampleSet', true, topFolderOptions, designerReaderOptions);
+        });
+
         it('Designer can create, update and delete empty design, reader and editors cannot create/update/delete design', async () => {
             const sampleType = "ToDelete";
             let domainId = -1, domainURI = '';

--- a/experiment/src/client/test/integration/utils.ts
+++ b/experiment/src/client/test/integration/utils.ts
@@ -360,8 +360,8 @@ const LEGAL_CHARSET = [' ', '+', '-', '_', '.', ':', '', '&', '(', ')', '/'];
 const alphaNumeric = ['a', 'A', '1', '0'];
 export async function checkDomainName(server: IntegrationTestServer, domainType: string, supportNameExpression: boolean, folderOptions: RequestOptions, userOptions: RequestOptions) {
     const badNames = {
-        '': `${domainType} name must not be blank.`,
-        ' ': `${domainType} name must not be blank.`,
+        '': domainType === 'SampleSet' ? 'You must supply a name for the sample type.' : `${domainType} name must not be blank.`,
+        ' ': domainType === 'SampleSet' ? 'You must supply a name for the sample type.' : `${domainType} name must not be blank.`,
         'with\0nullCharacter': `Invalid ${domainType} name "REPLACE". ${domainType} name must contain only valid unicode characters.`,
         'with\tnewLines': `Invalid ${domainType} name "REPLACE". ${domainType} name may not contain 'tab', 'new line', or 'return' characters.`,
         '.startWithDot': `Invalid ${domainType} name "REPLACE". ${domainType} name must start with a letter or a number.`,
@@ -390,6 +390,8 @@ export async function checkDomainName(server: IntegrationTestServer, domainType:
     let dataTypeRowId = 0;
     if (domainType !== 'SampleSet')
         dataTypeRowId = await getDataClassRowIdByName(server, domainName, folderOptions);
+    badNames[''] = `${domainType} name must not be blank.`;
+    badNames[' '] = `${domainType} name must not be blank.`;
     for (let i = 0; i < badNameKeys.length; i++){
         await verifyDomainUpdateFailure(server, domainId, domainURI, dataTypeRowId, badNameKeys[i], badNames[badNameKeys[i]], folderOptions, userOptions);
     }

--- a/experiment/src/client/test/integration/utils.ts
+++ b/experiment/src/client/test/integration/utils.ts
@@ -1,4 +1,10 @@
-import { ExperimentCRUDUtils, IntegrationTestServer, RequestOptions, successfulResponse } from '@labkey/test';
+import {
+    ExperimentCRUDUtils,
+    IntegrationTestServer,
+    RequestOptions,
+    selectRandomN,
+    successfulResponse
+} from '@labkey/test';
 import { caseInsensitive, SAMPLE_TYPE_DESIGNER_ROLE } from '@labkey/components';
 import { PermissionRoles } from '@labkey/api';
 
@@ -299,6 +305,98 @@ export async function initProject(server: IntegrationTestServer, projectName: st
     }
 }
 
+async function verifyDomainCreateFailure(server: IntegrationTestServer, domainType: string, badDomainName: string, error: string, folderOptions: RequestOptions, userOptions: RequestOptions) {
+    const field = domainType === 'SampleSet' ? { name: 'Name' } : { name: 'Prop' };
+    const badDomainNameResp = await server.post('property', 'createDomain', {
+        kind: domainType,
+        domainDesign: { name: badDomainName, fields: [field] },
+        options: {
+            name: badDomainName,
+        }
+    }, {...folderOptions, ...userOptions});
+
+    expect(badDomainNameResp['body']['success']).toBeFalsy();
+    expect(badDomainNameResp['body']['exception']).toBe(error);
+}
+
+async function verifyDomainUpdateFailure(server: IntegrationTestServer, domainId: number, domainURI: string, dataTypeRowId/*needed for updating dataclass*/: number, badDomainName: string, error: string, folderOptions: RequestOptions, userOptions: RequestOptions) {
+    const options = {
+        name: badDomainName
+    }
+    if (dataTypeRowId)
+        options['rowId'] = dataTypeRowId;
+    const updatedDomainPayload = {
+        domainId,
+        domainDesign: {name: badDomainName, domainId, domainURI},
+        options
+    };
+
+    const badDomainNameResp = await server.post('property', 'saveDomain', updatedDomainPayload, {...folderOptions, ...userOptions});
+
+    expect(badDomainNameResp['body']['success']).toBeFalsy();
+    expect(badDomainNameResp['body']['exception']).toBe(error);
+}
+
+async function verifyDomainCreateSuccess(server: IntegrationTestServer, domainType: string, domainName: string, folderOptions: RequestOptions, userOptions: RequestOptions) {
+    let domainId, domainURI;
+    const field = domainType === 'SampleSet' ? { name: 'Name' } : { name: 'Prop' };
+    await server.post('property', 'createDomain', {
+        kind: domainType,
+        domainDesign: { name: domainName, fields: [field] },
+        options: {
+            name: domainName,
+        }
+    }, {...folderOptions, ...userOptions}).expect((result) => {
+        const domain = JSON.parse(result.text);
+        domainId = domain.domainId;
+        domainURI = domain.domainURI;
+        return true;
+    });
+    return {domainId, domainURI};
+}
+
+const EMPTY_DOMAIN_NAME_MSG = 'Domain name must not be blank';
+export const ILLEGAL_DOMAIN_CHARSET = "<>[]{};,`\"~!@#$%^*=|?\\";
+const LEGAL_CHARSET = [' ', '+', '-', '_', '.', ':', '', '&', '(', ')', '/'];
+const alphaNumeric = ['a', 'A', '1', '0'];
+export async function checkDomainName(server: IntegrationTestServer, domainType: string, supportNameExpression: boolean, folderOptions: RequestOptions, userOptions: RequestOptions) {
+    const badNames = {
+        '': EMPTY_DOMAIN_NAME_MSG,
+        ' ': EMPTY_DOMAIN_NAME_MSG,
+        'with\0nullCharacter': `Invalid ${domainType} name. Domain name must contain only valid unicode characters.`,
+        'with\tnewLines': `Invalid ${domainType} name. Domain name may not contain 'tab', 'new line', or 'return' characters.`,
+        '.startWithDot': `Invalid ${domainType} name. Domain name must start with a letter or a number character.`,
+        ' startWithSpace': `Invalid ${domainType} name. Domain name must start with a letter or a number character.`,
+        ['c' + selectRandomN(ILLEGAL_DOMAIN_CHARSET.split(''), 2).join('')]: `Invalid ${domainType} name. Domain name may not contain any of these characters: ` + ILLEGAL_DOMAIN_CHARSET,
+        'a -b': `Invalid ${domainType} name. Domain name may not contain space followed by dash.`
+    };
+    if (supportNameExpression) {
+        badNames['withCounter'] = `Invalid ${domainType} name. 'withCounter' is a reserved name.`;
+        badNames['int:withCounter'] = `Invalid ${domainType} name. ':withCounter' is a reserved pattern.`;
+        badNames['drawdate:first'] = `Invalid ${domainType} name. ':first' is a reserved pattern.`;
+    }
+
+    let badNameKeys = Object.keys(badNames);
+    for (let i = 0; i < badNameKeys.length; i++)
+        await verifyDomainCreateFailure(server, domainType, badNameKeys[i], badNames[badNameKeys[i]], folderOptions, userOptions);
+
+    if (!supportNameExpression)
+    {
+        await verifyDomainCreateSuccess(server, domainType, 'withCounter', folderOptions, userOptions);
+    }
+
+    const domainName = selectRandomN(alphaNumeric, 2).join('') + selectRandomN(LEGAL_CHARSET, 5).join('');
+    const { domainId, domainURI } = await verifyDomainCreateSuccess(server, domainType, domainName, folderOptions, userOptions);
+
+    let dataTypeRowId = 0;
+    if (domainType !== 'SampleSet')
+        dataTypeRowId = await getDataClassRowIdByName(server, domainName, folderOptions);
+    for (let i = 0; i < badNameKeys.length; i++){
+        await verifyDomainUpdateFailure(server, domainId, domainURI, dataTypeRowId, badNameKeys[i], badNames[badNameKeys[i]], folderOptions, userOptions);
+    }
+
+}
+
 export async function checkLackDesignerOrReaderPerm(server: IntegrationTestServer, domainType: string, topFolderOptions: RequestOptions, readerUserOptions: RequestOptions, editorUserOptions: RequestOptions, designerOptions: RequestOptions) {
     await server.post('property', 'createDomain', {
         kind: domainType,
@@ -582,7 +680,7 @@ export const getAssayDesignPayload = (name: string, runFields: any[], resultFiel
         "domains": [
             {
                 "name": "Batch Fields",
-                "domainURI": "urn:lsid:${LSIDAuthority}:AssayDomain-Batch.Folder-${Container.RowId}:${AssayName}",
+                "domainURI": "urn:lsid:${LSIDAuthority}:AssayDomain-Batch.Folder-${Container.RowId}:${GpatAssayDBSeq}",
                 "domainId": 0,
                 "fields": [],
                 "indices": [],
@@ -591,7 +689,7 @@ export const getAssayDesignPayload = (name: string, runFields: any[], resultFiel
             },
             {
                 "name": "Run Fields",
-                "domainURI": "urn:lsid:${LSIDAuthority}:AssayDomain-Run.Folder-${Container.RowId}:${AssayName}",
+                "domainURI": "urn:lsid:${LSIDAuthority}:AssayDomain-Run.Folder-${Container.RowId}:${GpatAssayDBSeq}",
                 "domainId": 0,
                 "fields": runFields,
                 "indices": [],
@@ -600,7 +698,7 @@ export const getAssayDesignPayload = (name: string, runFields: any[], resultFiel
             },
             {
                 "name": "Data Fields",
-                "domainURI": "urn:lsid:${LSIDAuthority}:AssayDomain-Data.Folder-${Container.RowId}:${AssayName}",
+                "domainURI": "urn:lsid:${LSIDAuthority}:AssayDomain-Data.Folder-${Container.RowId}:${GpatAssayDBSeq}",
                 "domainId": 0,
                 "fields": resultFields,
                 "indices": [],

--- a/experiment/src/client/test/integration/utils.ts
+++ b/experiment/src/client/test/integration/utils.ts
@@ -316,7 +316,7 @@ async function verifyDomainCreateFailure(server: IntegrationTestServer, domainTy
     }, {...folderOptions, ...userOptions});
 
     expect(badDomainNameResp['body']['success']).toBeFalsy();
-    expect(badDomainNameResp['body']['exception']).toBe(error);
+    expect(badDomainNameResp['body']['exception']).toBe(error.replace("REPLACE", badDomainName));
 }
 
 async function verifyDomainUpdateFailure(server: IntegrationTestServer, domainId: number, domainURI: string, dataTypeRowId/*needed for updating dataclass*/: number, badDomainName: string, error: string, folderOptions: RequestOptions, userOptions: RequestOptions) {
@@ -334,7 +334,7 @@ async function verifyDomainUpdateFailure(server: IntegrationTestServer, domainId
     const badDomainNameResp = await server.post('property', 'saveDomain', updatedDomainPayload, {...folderOptions, ...userOptions});
 
     expect(badDomainNameResp['body']['success']).toBeFalsy();
-    expect(badDomainNameResp['body']['exception']).toBe(error);
+    expect(badDomainNameResp['body']['exception']).toBe(error.replace("REPLACE", badDomainName));
 }
 
 async function verifyDomainCreateSuccess(server: IntegrationTestServer, domainType: string, domainName: string, folderOptions: RequestOptions, userOptions: RequestOptions) {
@@ -355,25 +355,24 @@ async function verifyDomainCreateSuccess(server: IntegrationTestServer, domainTy
     return {domainId, domainURI};
 }
 
-const EMPTY_DOMAIN_NAME_MSG = 'Domain name must not be blank';
 export const ILLEGAL_DOMAIN_CHARSET = "<>[]{};,`\"~!@#$%^*=|?\\";
 const LEGAL_CHARSET = [' ', '+', '-', '_', '.', ':', '', '&', '(', ')', '/'];
 const alphaNumeric = ['a', 'A', '1', '0'];
 export async function checkDomainName(server: IntegrationTestServer, domainType: string, supportNameExpression: boolean, folderOptions: RequestOptions, userOptions: RequestOptions) {
     const badNames = {
-        '': EMPTY_DOMAIN_NAME_MSG,
-        ' ': EMPTY_DOMAIN_NAME_MSG,
-        'with\0nullCharacter': `Invalid ${domainType} name. Domain name must contain only valid unicode characters.`,
-        'with\tnewLines': `Invalid ${domainType} name. Domain name may not contain 'tab', 'new line', or 'return' characters.`,
-        '.startWithDot': `Invalid ${domainType} name. Domain name must start with a letter or a number character.`,
-        ' startWithSpace': `Invalid ${domainType} name. Domain name must start with a letter or a number character.`,
-        ['c' + selectRandomN(ILLEGAL_DOMAIN_CHARSET.split(''), 2).join('')]: `Invalid ${domainType} name. Domain name may not contain any of these characters: ` + ILLEGAL_DOMAIN_CHARSET,
-        'a -b': `Invalid ${domainType} name. Domain name may not contain space followed by dash.`
+        '': `${domainType} name must not be blank.`,
+        ' ': `${domainType} name must not be blank.`,
+        'with\0nullCharacter': `Invalid ${domainType} name "REPLACE". ${domainType} name must contain only valid unicode characters.`,
+        'with\tnewLines': `Invalid ${domainType} name "REPLACE". ${domainType} name may not contain 'tab', 'new line', or 'return' characters.`,
+        '.startWithDot': `Invalid ${domainType} name "REPLACE". ${domainType} name must start with a letter or a number.`,
+        ' startWithSpace': `Invalid ${domainType} name "REPLACE". ${domainType} name must start with a letter or a number.`,
+        ['c' + selectRandomN(ILLEGAL_DOMAIN_CHARSET.split(''), 2).join('')]: `Invalid ${domainType} name "REPLACE". ${domainType} name may not contain any of these characters: ` + ILLEGAL_DOMAIN_CHARSET,
+        'a -b': `Invalid ${domainType} name "REPLACE". ${domainType} name may not contain space followed by dash.`
     };
     if (supportNameExpression) {
-        badNames['withCounter'] = `Invalid ${domainType} name. 'withCounter' is a reserved name.`;
-        badNames['int:withCounter'] = `Invalid ${domainType} name. ':withCounter' is a reserved pattern.`;
-        badNames['drawdate:first'] = `Invalid ${domainType} name. ':first' is a reserved pattern.`;
+        badNames['withCounter'] = `Invalid ${domainType} name "REPLACE". 'withCounter' is a reserved name.`;
+        badNames['int:withCounter'] = `Invalid ${domainType} name "REPLACE". ':withCounter' is a reserved pattern.`;
+        badNames['drawdate:first'] = `Invalid ${domainType} name "REPLACE". ':first' is a reserved pattern.`;
     }
 
     let badNameKeys = Object.keys(badNames);

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2962,7 +2962,7 @@ public class ExpDataIterators
                 header.add(name);
             }
 
-            File dataFile = FileUtil.createTempFile("~importSplit-", container.getRowId() + dataClass.getName() + ".tsv");
+            File dataFile = FileUtil.createTempFile("~importSplit-", container.getRowId() + FileUtil.makeLegalName(dataClass.getName()) + ".tsv");
 
             List<String> dataRows = new ArrayList<String>();
             dataRows.add(StringUtils.join(header, "\t"));
@@ -2980,7 +2980,7 @@ public class ExpDataIterators
                 _context.getErrors().addRowError(new ValidationException("Table for sample type '" + sampleType.getName() + "' not found."));
                 return null;
             }
-            File dataFile = FileUtil.createTempFile("~importSplit-", container.getRowId() + sampleType.getName() + ".tsv");
+            File dataFile = FileUtil.createTempFile("~importSplit-", container.getRowId() + FileUtil.makeLegalName(sampleType.getName()) + ".tsv");
             Set<String> validFields = new CaseInsensitiveHashSet();
             samplesTable.getColumns().forEach(column -> {
                 if (!IGNORED_FIELD_NAMES.contains(column.getName()))

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -496,7 +496,7 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
     }
 
     @Override
-    public boolean supportNamingPattern()
+    public boolean supportsNamingPattern()
     {
         return true;
     }

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -494,4 +494,10 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
     {
         return ComplianceService.get().isComplianceSupported();
     }
+
+    @Override
+    public boolean supportNamingPattern()
+    {
+        return true;
+    }
 }

--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -1475,7 +1475,7 @@ public class PropertyController extends SpringActionController
         if (!kind.canEditDefinition(user, domain))
             throw new UnauthorizedException("You don't have permission to edit this domain.");
 
-        if (original.getName() != null && !original.getName().equals(update.getName()))
+        if (original.getName() != null && update.getName() != null && !original.getName().equals(update.getName()))
         {
             String domainNameError = DomainUtil.validateDomainName(update.getName(), kind.getKindName(), kind.supportNamingPattern());
             if (domainNameError != null)

--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -1475,6 +1475,13 @@ public class PropertyController extends SpringActionController
         if (!kind.canEditDefinition(user, domain))
             throw new UnauthorizedException("You don't have permission to edit this domain.");
 
+        if (original.getName() != null && !original.getName().equals(update.getName()))
+        {
+            String domainNameError = DomainUtil.validateDomainName(update.getName(), kind.getKindName(), kind.supportNamingPattern());
+            if (domainNameError != null)
+                throw new IllegalArgumentException(domainNameError);
+        }
+
         if (JSONObject.class == kind.getTypeClass())
         {
             return kind.updateDomain(original, update, options, container, user, includeWarnings);

--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -1477,7 +1477,7 @@ public class PropertyController extends SpringActionController
 
         if (original.getName() != null && update.getName() != null && !original.getName().equals(update.getName()))
         {
-            String domainNameError = DomainUtil.validateDomainName(update.getName(), kind.getKindName(), kind.supportNamingPattern());
+            String domainNameError = DomainUtil.validateDomainName(update.getName(), kind.getKindName(), kind.supportsNamingPattern());
             if (domainNameError != null)
                 throw new IllegalArgumentException(domainNameError);
         }

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -583,6 +583,10 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
             // Now check standard study tables
             if (schema.getTableNames().contains(name))
                 throw new IllegalArgumentException("A study table exists with the name \"" + name + "\".");
+
+            String datasetNameError = DomainUtil.validateDomainName(name, getKindName(), false);
+            if (datasetNameError != null)
+                throw new IllegalArgumentException(datasetNameError);
         }
 
         // Label related exceptions

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -37,6 +37,7 @@ import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.TestDataGenerator;
 import org.openqa.selenium.WebElement;
 
 import java.util.ArrayList;
@@ -135,18 +136,26 @@ public class StudyDatasetsTest extends BaseWebDriverTest
     @Test
     public void testDatasets()
     {
-        createDataset("A");
-        renameDataset("A", "Original A", "A", "Original A", "XTest", "YTest", "ZTest");
-        createDataset("A");
-        deleteFields("A");
+        createDataset(TestDataGenerator.randomInvalidDomainName(5), "Invalid StudyDatasetVisit name. Domain name must start with a letter or a number character.");
 
-        checkFieldsPresent("Original A", "YTest", "ZTest");
+        String datasetA = TestDataGenerator.randomDomainName();
+        createDataset(datasetA, null);
+
+        String badDataSetName = TestDataGenerator.randomInvalidDomainName(5);
+        renameDataset("Invalid StudyDatasetVisit name. Domain name must start with a letter or a number character.", datasetA, badDataSetName, datasetA, badDataSetName, "XTest", "YTest", "ZTest");
+
+        String datasetAUpdated = TestDataGenerator.randomDomainName();
+        renameDataset(null, datasetA, datasetAUpdated, datasetA, datasetAUpdated, "XTest", "YTest", "ZTest");
+        createDataset(datasetA, null);
+        deleteFields(datasetA);
+
+        checkFieldsPresent(datasetAUpdated, "YTest", "ZTest");
 
         verifySideFilter();
 
         verifyReportAndViewDatasetReferences();
 
-        createDataset("B");
+        createDataset("B", null);
         importDatasetData("B", DATASET_HEADER, DATASET_B_DATA, "All data");
         checkDataElementsPresent("B",  DATASET_B_DATA.split("\t|\n"));
 
@@ -199,7 +208,7 @@ public class StudyDatasetsTest extends BaseWebDriverTest
     }
 
     @LogMethod
-    protected void createDataset(@LoggedParam String name)
+    protected void createDataset(@LoggedParam String name, @Nullable String error)
     {
         DatasetDesignerPage definitionPage = _studyHelper.goToManageDatasets()
             .clickCreateNewDataset()
@@ -209,11 +218,17 @@ public class StudyDatasetsTest extends BaseWebDriverTest
         panel.manuallyDefineFields("XTest");
         panel.addField("YTest");
         panel.addField("ZTest");
-        definitionPage.clickSave();
+        if (error == null)
+            definitionPage.clickSave();
+        else
+        {
+            definitionPage.saveExpectFail(error);
+            definitionPage.clickCancel();
+        }
     }
 
     @LogMethod
-    protected void renameDataset(String orgName, String newName, String orgLabel, String newLabel, String... fieldNames)
+    protected void renameDataset(String error, String orgName, String newName, String orgLabel, String newLabel, String... fieldNames)
     {
         DatasetDesignerPage editDatasetPage = _studyHelper.goToManageDatasets()
             .selectDatasetByName(orgName)
@@ -228,7 +243,14 @@ public class StudyDatasetsTest extends BaseWebDriverTest
             assertTextPresent(fieldName);
         }
 
-        editDatasetPage.clickSave();
+        if (error == null)
+            editDatasetPage.clickSave();
+        else
+        {
+            editDatasetPage.saveExpectFail(error);
+            editDatasetPage.clickCancel();
+            return;
+        }
 
         // fix dataset label references in report and view mappings
         for (Map.Entry<String, String> entry : EXPECTED_REPORTS.entrySet())
@@ -442,10 +464,10 @@ public class StudyDatasetsTest extends BaseWebDriverTest
         verifyCustomViewWithDatasetJoins("CPS-1: Screening Chemistry Panel", CUSTOM_VIEW_PRIVATE, false, false, "DataSets/DEM-1/DEMbdt", "DataSets/DEM-1/DEMsex");
 
         // rename and relabel the datasets related to these reports and views
-        renameDataset("DEM-1", "demo", "DEM-1: Demographics", "Demographics");
-        renameDataset("APX-1", "abbrphy", "APX-1: Abbreviated Physical Exam", "Abbreviated Physical Exam");
-        renameDataset("ECI-1", "eligcrit", "ECI-1: Eligibility Criteria", "Eligibility Criteria");
-        renameDataset("CPS-1", "scrchem", "CPS-1: Screening Chemistry Panel", "Screening Chemistry Panel");
+        renameDataset(null, "DEM-1", "demo", "DEM-1: Demographics", "Demographics");
+        renameDataset(null, "APX-1", "abbrphy", "APX-1: Abbreviated Physical Exam", "Abbreviated Physical Exam");
+        renameDataset(null, "ECI-1", "eligcrit", "ECI-1: Eligibility Criteria", "Eligibility Criteria");
+        renameDataset(null, "CPS-1", "scrchem", "CPS-1: Screening Chemistry Panel", "Screening Chemistry Panel");
 
         // verify the reports and views dataset label/name references after dataset rename and relabel
         //verifyExpectedReportsAndViewsExist();

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -136,13 +136,13 @@ public class StudyDatasetsTest extends BaseWebDriverTest
     @Test
     public void testDatasets()
     {
-        createDataset(TestDataGenerator.randomInvalidDomainName(5), "Invalid StudyDatasetVisit name. Domain name must start with a letter or a number character.");
+        String badDataSetName = TestDataGenerator.randomInvalidDomainName(5);
+        createDataset(badDataSetName, "Invalid StudyDatasetVisit name \"" + badDataSetName + "\". StudyDatasetVisit name must start with a letter or a number.");
 
         String datasetA = TestDataGenerator.randomDomainName();
         createDataset(datasetA, null);
 
-        String badDataSetName = TestDataGenerator.randomInvalidDomainName(5);
-        renameDataset("Invalid StudyDatasetVisit name. Domain name must start with a letter or a number character.", datasetA, badDataSetName, datasetA, badDataSetName, "XTest", "YTest", "ZTest");
+        renameDataset("Invalid StudyDatasetVisit name \"" + badDataSetName + "\". StudyDatasetVisit name must start with a letter or a number.", datasetA, badDataSetName, datasetA, badDataSetName, "XTest", "YTest", "ZTest");
 
         String datasetAUpdated = TestDataGenerator.randomDomainName();
         renameDataset(null, datasetA, datasetAUpdated, datasetA, datasetAUpdated, "XTest", "YTest", "ZTest");
@@ -228,7 +228,7 @@ public class StudyDatasetsTest extends BaseWebDriverTest
     }
 
     @LogMethod
-    protected void renameDataset(String error, String orgName, String newName, String orgLabel, String newLabel, String... fieldNames)
+    protected void renameDataset(@Nullable String error, String orgName, String newName, String orgLabel, String newLabel, String... fieldNames)
     {
         DatasetDesignerPage editDatasetPage = _studyHelper.goToManageDatasets()
             .selectDatasetByName(orgName)


### PR DESCRIPTION
#### Rationale
This set of PRs implement a set of rules what characters / patterns can be used as domain (sample, data class, list, etc) names for new domains as well as existing domains when they are re-named.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1662
- https://github.com/LabKey/labkey-ui-premium/pull/616
- https://github.com/LabKey/limsModules/pull/984
- https://github.com/LabKey/platform/pull/6140
- https://github.com/LabKey/testAutomation/pull/2189
- https://github.com/LabKey/commonAssays/pull/826

#### Changes
- Add DomainUtil.validateDomainName and wire up domain name validation during creation and update
- Validate parentAlias to avoid conflict with naming pattern syntax
- Support parent and ancestor naming pattern for parent type that contains /, in the form of $S
- fix detailed audit with special names
- Add jest integration test for validating domain names
- Update / Add selenium tests for domain names with special characters
