### PR TITLE
Clear hit selections for excluded rows

### DIFF
--- a/api/src/org/labkey/api/assay/plate/PlateDataStateManager.java
+++ b/api/src/org/labkey/api/assay/plate/PlateDataStateManager.java
@@ -64,7 +64,8 @@ public class PlateDataStateManager implements DataStateHandler
      */
     public enum DataOperation
     {
-        analysis("included for any data or statistical analysis, curve fitting etc");
+        analysis("included for any data or statistical analysis, curve fitting etc"),
+        hitSelection("can mark data for hit selection");
 
         final String _description;
 

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -1182,7 +1182,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         private final ExpProtocol _protocol;
         private final AssayProvider _provider;
         private final AssayRunUploadContext<?> _context;
-        private final Set<Integer> _excludedRows;
+        private DomainProperty _stateProp;
 
         public PlateMetadataImportHelper(
             ExpData data,
@@ -1205,7 +1205,6 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             _protocol = protocol;
             _provider = provider;
             _context = context;
-            _excludedRows = new HashSet<>();
         }
 
         @Override
@@ -1215,7 +1214,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 
             Domain runDomain = _provider.getRunDomain(_protocol);
             Domain resultDomain = _provider.getResultsDomain(_protocol);
-            DomainProperty stateProp = AssayPlateMetadataServiceImpl.getAssayStateProp(resultDomain);
+            _stateProp = AssayPlateMetadataServiceImpl.getAssayStateProp(resultDomain);
             DomainProperty plateSetProperty = runDomain.getPropertyByName(AssayPlateMetadataService.PLATE_SET_COLUMN_NAME);
             DomainProperty plateProperty = resultDomain.getPropertyByName(AssayResultDomainKind.PLATE_COLUMN_NAME);
             DomainProperty wellLocationProperty = resultDomain.getPropertyByName(AssayResultDomainKind.WELL_LOCATION_COLUMN_NAME);
@@ -1285,14 +1284,18 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                 }
             }
 
-            // validate any data state values on the row
-            DataState state = validateRowDataStates(_container, map, stateProp);
-            if (!PlateDataStateManager.get().isOperationPermitted(state, PlateDataStateManager.DataOperation.hitSelection))
-            {
-                Object o = map.get("RowId");
-                if (o instanceof Integer rowId)
-                    _excludedRows.add(rowId);
-            }
+            // Validate any data state values on the row. No hit selection / data state processing is done on import
+            // because at this time transform script hit selection is not supported nor is there any intersection
+            // in the re-import case yet.
+            validateRowDataStates(_container, map, _stateProp);
+        }
+
+        /**
+         * Is data being added to a previous run
+         */
+        private boolean isExistingRun()
+        {
+            return _context.getReImportOption() == AssayRunUploadContext.ReImportOption.MERGE_DATA && _context.getReRunId() != null;
         }
 
         @Override
@@ -1304,7 +1307,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                 AssayPlateMetadataService.get().insertReplicateStats(_container, _user, _protocol, _run, _replicateRows);
 
                 // re-select any hits that were present in the previous run
-                if (_context.getReImportOption() == AssayRunUploadContext.ReImportOption.MERGE_DATA && _context.getReRunId() != null)
+                if (isExistingRun())
                 {
                     ExpRun prevRun = ExperimentService.get().getExpRun(_context.getReRunId());
                     if (prevRun != null)
@@ -1320,8 +1323,6 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                                 .append(" WHERE HT.runId = ? ").add(prevRun.getRowId())
                                 .append(" AND ED.runId = ? ").add(_run.getRowId());
                         List<Integer> rowIds = new SqlSelector(AssayDbSchema.getInstance().getScope(), sql).getArrayList(Integer.class);
-                        // omit excluded rows from being re-selected as hits
-                        rowIds.removeAll(_excludedRows);
                         if (!rowIds.isEmpty())
                             PlateManager.get().markHits(_container, _user, _protocol.getRowId(), true, rowIds, null);
 

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -1093,7 +1093,8 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
      * Ensure the data state value in the row represents a data state in scope and is a valid state for plate based
      * assays.
      */
-    public static void validateRowDataStates(Container container, Map<String, Object> row, DomainProperty stateProp) throws ValidationException
+    @Nullable
+    public static DataState validateRowDataStates(Container container, Map<String, Object> row, DomainProperty stateProp) throws ValidationException
     {
         try
         {
@@ -1105,6 +1106,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                     throw new ValidationException(String.format("The data state '%s' is not valid for this assay.", state.getLabel()));
                 }
             }
+            return state;
         }
         catch (ExperimentException e)
         {
@@ -1180,6 +1182,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         private final ExpProtocol _protocol;
         private final AssayProvider _provider;
         private final AssayRunUploadContext<?> _context;
+        private final Set<Integer> _excludedRows;
 
         public PlateMetadataImportHelper(
             ExpData data,
@@ -1202,6 +1205,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             _protocol = protocol;
             _provider = provider;
             _context = context;
+            _excludedRows = new HashSet<>();
         }
 
         @Override
@@ -1282,7 +1286,13 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             }
 
             // validate any data state values on the row
-            validateRowDataStates(_container, map, stateProp);
+            DataState state = validateRowDataStates(_container, map, stateProp);
+            if (!PlateDataStateManager.get().isOperationPermitted(state, PlateDataStateManager.DataOperation.hitSelection))
+            {
+                Object o = map.get("RowId");
+                if (o instanceof Integer rowId)
+                    _excludedRows.add(rowId);
+            }
         }
 
         @Override
@@ -1310,6 +1320,8 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                                 .append(" WHERE HT.runId = ? ").add(prevRun.getRowId())
                                 .append(" AND ED.runId = ? ").add(_run.getRowId());
                         List<Integer> rowIds = new SqlSelector(AssayDbSchema.getInstance().getScope(), sql).getArrayList(Integer.class);
+                        // omit excluded rows from being re-selected as hits
+                        rowIds.removeAll(_excludedRows);
                         if (!rowIds.isEmpty())
                             PlateManager.get().markHits(_container, _user, _protocol.getRowId(), true, rowIds, null);
 

--- a/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
@@ -6,6 +6,7 @@ import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayResultDomainKind;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
+import org.labkey.api.assay.plate.PlateDataStateManager;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
@@ -18,6 +19,7 @@ import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.qc.DataState;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.ValidationException;
@@ -28,8 +30,10 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class AssayPlateTriggerFactory implements TriggerFactory
 {
@@ -139,11 +143,29 @@ public class AssayPlateTriggerFactory implements TriggerFactory
      */
     private class DataStateTrigger implements Trigger
     {
+        Set<Integer> _excludedRows = new HashSet<>();
+
         @Override
         public void beforeUpdate(TableInfo table, Container c, User user, @Nullable Map<String, Object> newRow, @Nullable Map<String, Object> oldRow, ValidationException errors, Map<String, Object> extraContext) throws ValidationException
         {
             if (newRow != null && _qcStateProp != null)
-                AssayPlateMetadataServiceImpl.validateRowDataStates(c, newRow, _qcStateProp);
+            {
+                DataState state = AssayPlateMetadataServiceImpl.validateRowDataStates(c, newRow, _qcStateProp);
+                if (!PlateDataStateManager.get().isOperationPermitted(state, PlateDataStateManager.DataOperation.hitSelection))
+                {
+                    Object o = oldRow.get("RowId");
+                    if (o instanceof Integer rowId)
+                        _excludedRows.add(rowId);
+                }
+            }
+        }
+
+        @Override
+        public void complete(TableInfo table, Container c, User user, TableInfo.TriggerType event, BatchValidationException errors, Map<String, Object> extraContext)
+        {
+            // clear out hit selections for exclusions which don't allow the operation
+            if (!_excludedRows.isEmpty())
+                PlateManager.get().deleteHits(_protocol.getRowId(), _excludedRows);
         }
     }
 }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -32,6 +32,7 @@ import org.labkey.api.assay.plate.AbstractPlateLayoutHandler;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateCustomField;
+import org.labkey.api.assay.plate.PlateDataStateManager;
 import org.labkey.api.assay.plate.PlateLayoutHandler;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.PlateSet;
@@ -95,6 +96,7 @@ import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
+import org.labkey.api.qc.DataState;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
@@ -2991,6 +2993,10 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
             if (markAsHit)
             {
+                // Validate that none of the selected rows have exclusions
+                if (!isOperationPermittedOnResults(container, user, protocol, rowIds, PlateDataStateManager.DataOperation.hitSelection))
+                    throw new ValidationException("Failed to mark hits, some of the rows have QC states which prevent the operation.");
+
                 // Exclude preexisting hits
                 {
                     SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("ResultId"), rowIds, CompareType.IN);
@@ -3060,6 +3066,33 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
             tx.commit();
         }
+    }
+
+    /**
+     * Checks whether the specified data operation is permitted on the existing assay result rows.
+     */
+    private boolean isOperationPermittedOnResults(Container container, User user, @NotNull ExpProtocol protocol, Collection<Integer> rowIds, PlateDataStateManager.DataOperation operation)
+    {
+        AssayProvider provider = AssayService.get().getProvider(protocol);
+        Domain resultDomain = provider.getResultsDomain(protocol);
+        DomainProperty stateProp = AssayPlateMetadataServiceImpl.getAssayStateProp(resultDomain);
+        if (stateProp != null)
+        {
+            AssayProtocolSchema schema = provider.createProtocolSchema(user, container, protocol, null);
+            TableInfo resultsTable = schema.createDataTable(null, false);
+
+            SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("RowId"), rowIds, CompareType.IN);
+            Set<Integer> dataStates = new HashSet<>(new TableSelector(resultsTable, Collections.singleton(stateProp.getName()), filter, null).getArrayList(Integer.class));
+            for (Integer state : dataStates)
+            {
+                DataState dataState = PlateDataStateManager.get().getStateForRowId(container, state);
+                if (dataState != null && !PlateDataStateManager.get().isOperationPermitted(dataState, operation))
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     private void deleteHits(SimpleFilter filter)

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3086,7 +3086,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             for (Integer state : dataStates)
             {
                 DataState dataState = PlateDataStateManager.get().getStateForRowId(container, state);
-                if (dataState != null && !PlateDataStateManager.get().isOperationPermitted(dataState, operation))
+                if (!PlateDataStateManager.get().isOperationPermitted(dataState, operation))
                 {
                     return false;
                 }


### PR DESCRIPTION

#### Rationale
This adds validation to hit selections that will prevent marking rows as hits that are currently QC excluded. Additionally, any rows that are excluded will have any hit selections removed.