### PR TITLE
Update the stateTypeEnum

### DIFF
--- a/api/schemas/qcStates.xsd
+++ b/api/schemas/qcStates.xsd
@@ -111,6 +111,7 @@
             <xs:enumeration value="Available"/>
             <xs:enumeration value="Consumed"/>
             <xs:enumeration value="Locked"/>
+            <xs:enumeration value="Excluded"/>
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
#### Rationale
This was causing an exception during folder export of a Biologics folder type. A new state type was introduced in `24.12`.