### PR TITLE
Issue 51825: Improve logging when client dependency can't be found

### DIFF
--- a/api/src/org/labkey/api/view/template/ClientDependency.java
+++ b/api/src/org/labkey/api/view/template/ClientDependency.java
@@ -327,7 +327,14 @@ public abstract class ClientDependency
 
         if (path == null)
         {
-            LOG.error("Invalid client dependency path: " + requestedPath);
+            if (AppProps.getInstance().isDevMode())
+            {
+                LOG.error("Invalid client dependency path: {}", requestedPath);
+            }
+            else
+            {
+                LOG.debug("Invalid client dependency path: {}", requestedPath);
+            }
             return null;
         }
 


### PR DESCRIPTION
#### Rationale
If a client dependency can't be found in production mode, it's probably from a malicious bot making up URLs.

#### Changes
- Log in dev mode, shift to debug level for prod mode