### PR TITLE
setRibbonMessage.api

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1506,6 +1506,55 @@ public class AdminController extends SpringActionController
         }
     }
 
+    public static class SetRibbonMessageForm
+    {
+        private Boolean _show = null;
+        private String _message = null;
+
+        public Boolean isShow()
+        {
+            return _show;
+        }
+
+        public void setShow(Boolean show)
+        {
+            _show = show;
+        }
+
+        public String getMessage()
+        {
+            return _message;
+        }
+
+        public void setMessage(String message)
+        {
+            _message = message;
+        }
+    }
+
+    @RequiresPermission(AdminOperationsPermission.class)
+    public static class SetRibbonMessageAction extends MutatingApiAction<SetRibbonMessageForm>
+    {
+        @Override
+        public Object execute(SetRibbonMessageForm form, BindException errors) throws Exception
+        {
+            if (form.isShow() != null || form.getMessage() != null)
+            {
+                WriteableAppProps props = AppProps.getWriteableInstance();
+
+                if (form.isShow() != null)
+                    props.setShowRibbonMessage(form.isShow());
+
+                if (form.getMessage() != null)
+                    props.setRibbonMessage(form.getMessage());
+
+                props.save(getViewContext().getUser());
+            }
+
+            return null;
+        }
+    }
+
     @RequiresPermission(AdminPermission.class)
     public class ConfigureSiteValidationAction extends SimpleViewAction<Object>
     {


### PR DESCRIPTION
#### Rationale
New API action to set the ribbon message and turn it on/off. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51843

Examples:

- Set the ribbon message and turn it on: `admin-setRibbonMessage.api?message=System maintenance will start at 4PM&show=1`
- Turn off the ribbon message: `admin-setRibbonMessage.api?show=0`
- Turn on the ribbon message showing whatever message was previously set: `admin-setRibbonMessage.api?show=1`

All invocations require site administrator role plus a CSRF parameter. If invoking via a LabKey client library, the library should handle the CSRF token automatically. If invoking from the command line (e.g., `curl`), specify both an `X-LABKEY-CSRF` header and a `X-LABKEY-CSRF` parameter with the same value.