### PR TITLE
Issue 51815: Fully enable FileRootMaintenanceTask for S3-backed folders

### DIFF
--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -1607,8 +1607,14 @@ public class FileContentServiceImpl implements FileContentService, WarningProvid
 
     public static void throwIfPathNotFile(java.nio.file.Path path, Container container)
     {
-        if (null == path || FileUtil.hasCloudScheme(path))
+        if (null == path)
+        {
+            throw new RuntimeException("No path to evaluate in " + container.getPath());
+        }
+        if (FileUtil.hasCloudScheme(path))
+        {
             throw new RuntimeException("Cannot get File object from Cloud File Root in " + container.getPath());
+        }
     }
 
     private boolean containsUrlOrVariation(List<String> existingUrls, java.nio.file.Path path)

--- a/filecontent/src/org/labkey/filecontent/FileRootMaintenanceTask.java
+++ b/filecontent/src/org/labkey/filecontent/FileRootMaintenanceTask.java
@@ -69,8 +69,6 @@ public class FileRootMaintenanceTask implements MaintenanceTask
                     Container c = ContainerManager.getForId(record.entityId());
                     if (c != null)
                     {
-                        if (service.isCloudRoot(c))
-                            return;
                         Path root = service.getFileRootPath(c);
                         try
                         {


### PR DESCRIPTION
#### Rationale
The previous fix handled null (misconfigured) file roots but didn't actually enable calculating file sizes for S3-backed folders.

#### Changes
- Remove the check for cloud now that we're using `Path`