### PR TITLE
Minor fixes to various study features

### DIFF
--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -467,6 +467,23 @@ public class StringUtilsLabKey
         return combined;
     }
 
+    /**
+     * @return the indefinite article to use with the passed in noun. Returns "a" for words starting with most
+     * consonants, "an" for words starting with a vowel, and "a(n)" for words starting with "h". This isn't perfect
+     * since it's not distinguishing voiced vs. unvoiced "h", acronyms that are spelled out, and other pronunciation
+     * quirks.
+     */
+    public static String getArticleForNoun(String noun)
+    {
+        char firstChar = noun.charAt(0);
+        return switch (firstChar)
+        {
+            case 'h', 'H' -> "a(n)";
+            case 'a', 'e', 'i', 'o', 'u' -> "an";
+            default -> "a";
+        };
+    }
+
     public static class TestCase extends Assert
     {
         @Test

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -288,7 +288,6 @@ import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -6745,13 +6744,13 @@ public class StudyController extends BaseStudyController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class ManageAlternateIdsAction extends SimpleViewAction<Object>
+    public class ManageParticipantsAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object form, BindException errors)
         {
             ChangeAlternateIdsForm changeAlternateIdsForm = getChangeAlternateIdForm(getStudyRedirectIfNull());
-            return new JspView<>("/org/labkey/study/view/manageAlternateIds.jsp", changeAlternateIdsForm);
+            return new JspView<>("/org/labkey/study/view/manageParticipants.jsp", changeAlternateIdsForm);
         }
 
         @Override
@@ -6759,8 +6758,8 @@ public class StudyController extends BaseStudyController
         {
             setHelpTopic("alternateIDs");
             _addManageStudy(root);
-            String subjectNoun = getStudyRedirectIfNull().getSubjectNounSingular();
-            root.addChild("Manage Alternate " + subjectNoun + " IDs and " + subjectNoun + " Aliases");
+            String pluralNoun = getStudyRedirectIfNull().getSubjectNounPlural();
+            root.addChild("Manage " + pluralNoun, new ActionURL(ManageParticipantsAction.class, getContainer()));
         }
     }
 
@@ -6776,14 +6775,19 @@ public class StudyController extends BaseStudyController
         @Override
         public void addNavTrail(NavTree root)
         {
-            _addManageStudy(root);
+            // Add Manage Participants nav trail
+            ManageParticipantsAction manageParticipantsAction = new ManageParticipantsAction();
+            manageParticipantsAction.setViewContext(getViewContext());
+            manageParticipantsAction.setPageConfig(new PageConfig(getViewContext().getRequest()));
+            manageParticipantsAction.addNavTrail(root);
+
             String subjectColumnName = getStudyRedirectIfNull().getSubjectColumnName();
-            root.addChild("Merge " + subjectColumnName + "s");
+            root.addChild("Change or Merge " + subjectColumnName + "s");
           }
     }
 
     @RequiresPermission(ReadPermission.class)
-    public static class SubjectListAction extends SimpleViewAction
+    public static class SubjectListAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -7448,8 +7452,7 @@ public class StudyController extends BaseStudyController
         @Override
         protected ActionURL getSuccessURL(IdForm form)
         {
-            ActionURL actionURL = new ActionURL(ManageAlternateIdsAction.class, getContainer());
-            return actionURL;
+            return new ActionURL(ManageParticipantsAction.class, getContainer());
         }
     }
 

--- a/study/src/org/labkey/study/query/LocationQueryView.java
+++ b/study/src/org/labkey/study/query/LocationQueryView.java
@@ -82,10 +82,6 @@ public class LocationQueryView extends QueryView
 
         List<String> recordSelectorColumns = view.getDataRegion().getRecordSelectorValueColumns();
         bar.add(createExportButton(recordSelectorColumns));
-
-        ActionButton b = createPrintButton();
-        if (null != b)
-            bar.add(createPrintButton());
     }
 
     @Override

--- a/study/src/org/labkey/study/query/LocationTable.java
+++ b/study/src/org/labkey/study/query/LocationTable.java
@@ -126,7 +126,7 @@ public class LocationTable extends BaseStudyTable
         return "Label";
     }
 
-    private class LocationQueryUpdateService extends DefaultQueryUpdateService
+    private static class LocationQueryUpdateService extends DefaultQueryUpdateService
     {
         public LocationQueryUpdateService(TableInfo queryTable, TableInfo dbTable)
         {

--- a/study/src/org/labkey/study/view/manageParticipants.jsp
+++ b/study/src/org/labkey/study/view/manageParticipants.jsp
@@ -17,7 +17,8 @@
 %>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.study.Study" %>
-<%@ page import="org.labkey.api.view.ActionURL"%>
+<%@ page import="org.labkey.api.util.HtmlString"%>
+<%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
@@ -32,46 +33,53 @@
     }
 %>
 <%
-    JspView<StudyController.ChangeAlternateIdsForm> me = (JspView<StudyController.ChangeAlternateIdsForm>) HttpView.currentView();
+    JspView<StudyController.ChangeAlternateIdsForm> me = HttpView.currentView();
     StudyController.ChangeAlternateIdsForm bean = me.getModelBean();
     Container c = getContainer();
     Study s = StudyManager.getInstance().getStudy(c);
-    String subjectNounSingular = s.getSubjectNounSingular();
-    String subjectNounPlural = s.getSubjectNounPlural();
+    String subjectNounSingularTitleString = s.getSubjectNounSingular();
+    HtmlString subjectNounSingularTitle = h(subjectNounSingularTitleString);
+    HtmlString subjectNounSingular = h(s.getSubjectNounSingular().toLowerCase());
+    HtmlString subjectNounPlural = h(s.getSubjectNounPlural().toLowerCase());
     String subjectNounColName = s.getSubjectColumnName();
     int aliasDatasetId = bean.getAliasDatasetId();
     String aliasColumn = bean.getAliasColumn();
     String sourceColumn = bean.getSourceColumn();
-//    boolean isAdmin = c.hasPermission(getUser(), AdminPermission.class);
     Integer numberOfDigits = bean.getNumDigits() > 0 ? bean.getNumDigits() : 6;
 %>
 <div style="max-width: 1000px">
-<h2>Alternate <%= h(subjectNounSingular)%> IDs</h2>
-<p>Alternate <%= h(subjectNounSingular) %> IDs allow you to publish and export a study with all <%= h(subjectNounSingular.toLowerCase()) %> IDs
-    replaced by randomly generated alternate IDs or by IDs you specify. Alternate IDs must be unique. The Change Alternate IDs button clears all alternate IDs, whether you had specified them or not.
-    Random alternate IDs will then be generated automatically for all <%= h(subjectNounPlural.toLowerCase()) %> using
+<h2>Alternate <%=subjectNounSingularTitle%> IDs for Masking</h2>
+<p>Alternate <%=subjectNounSingular%> IDs allow you to publish and export a study with all <%=subjectNounSingular%> IDs
+    replaced by masked IDs that either you specify or the system generates randomly. Alternate IDs must be unique. The Change Alternate IDs button clears all
+    alternate IDs, whether you had specified them or not. Random alternate IDs will then be generated automatically for all <%=subjectNounPlural%> using
     the prefix and the number of digits specified below.
 </p>
 <p>
-    Every <%= h(subjectNounSingular.toLowerCase()) %> is also given a date offset that is used when you publish or export a study, if you request date shifting. Date offsets never change.
-    The Export button exports a TSV that contains the alternate ID and date offset for each <%= h(subjectNounSingular.toLowerCase()) %>.
-    The Import button imports a TSV that contains an alternate ID and/or date offset for some or all <%= h(subjectNounPlural.toLowerCase()) %>.
+    Every <%=subjectNounSingular%> is also given a date offset that is used when you publish or export a study, if you request date shifting. Date offsets never change.
+    The Export button exports a TSV that contains the alternate ID and date offset for each <%=subjectNounSingular%>.
+    The Import button imports a TSV that contains an alternate ID and/or date offset for some or all <%=subjectNounPlural%>.
 </p>
 </div>
 <div id="alternateIdsPanel"></div>
 
 <div style="max-width: 1000px">
-<h2><%= h(subjectNounSingular)%> Aliases</h2>
-<p>You may link <%= h(subjectNounPlural.toLowerCase())%> in this study with <%= h(subjectNounPlural.toLowerCase())%> from another source
-    by specifying a dataset that contains aliases for each <%= h(subjectNounSingular.toLowerCase())%>.
+    <h2>Change or Merge <%=subjectNounSingularTitle%> IDs</h2>
+    Click the button below to change a <%=subjectNounSingular%> ID or merge data from multiple <%=subjectNounSingular%> IDs to a single <%=subjectNounSingular%> ID.
+</div>
+<div id="changeOrMergePanel"></div>
+
+<div style="max-width: 1000px">
+<h2><%=subjectNounSingularTitle%> Aliases</h2>
+<p>You may link <%=subjectNounPlural%> in this study with <%=subjectNounPlural%> from another source
+    by specifying a dataset that contains aliases for each <%=subjectNounSingular%>.
     You must also specify which dataset columns contain the aliases and source organization names that use the aliases.
 </p>
 </div>
 <div id="datasetMappingPanel"></div>
 
 <div style="max-width: 1000px">
-    <h2>Delete <%= h(subjectNounSingular)%> </h2>
-    <p>Select <%= h(subjectNounSingular.toLowerCase())%> you want to delete from this study.
+    <h2>Delete <%=subjectNounSingularTitle%> </h2>
+    <p>Select <%=subjectNounSingular%> you want to delete from this study.
     </p>
 </div>
 <div id="deleteParticipantPanel"></div>
@@ -138,10 +146,6 @@
                         xtype: 'button',
                         text: 'Import',
                         handler: function() {window.location = <%= q(new ActionURL(StudyController.ImportAlternateIdMappingAction.class, getContainer()))%>;}
-                    },{
-                        xtype: 'button',
-                        text: 'Change or Merge ' + <%= q(subjectNounColName) %>,
-                        handler: function() {window.location = <%= q(new ActionURL(StudyController.MergeParticipantsAction.class, getContainer()))%>;}
                     }]
                 }]
             });
@@ -162,7 +166,7 @@
                     buttons: Ext4.MessageBox.OKCANCEL,
                     icon: Ext4.MessageBox.WARNING,
                     fn : function(buttonID) {
-                        if (buttonID == 'ok')
+                        if (buttonID === 'ok')
                         {
                             var preVal = prefixField.getValue();
                             var digVal = digitsField.getValue();
@@ -197,7 +201,7 @@
                     dock: 'bottom',
                     ui : 'footer',
                     style : 'background: none',
-                    height : 30,
+                    height : 31,
                     items: [{
                         xtype: 'button',
                         text: 'Done',
@@ -209,7 +213,7 @@
             //Alias mapping components start here
 
             var aliasDatasetId = <%=aliasDatasetId%>;
-            var previousValue = (aliasDatasetId != -1);
+            var previousValue = (aliasDatasetId !== -1);
             Ext4.define('datasetModel',{
                 extend : 'Ext.data.Model',
                 fields : [
@@ -222,7 +226,6 @@
                 model : 'datasetModel',
                 sorters : {property : 'Label', direction : 'ASC'}
             });
-//
 
             var dataCombo = Ext4.create('Ext.form.field.ComboBox',{
                 name : 'datasetCombo',
@@ -235,21 +238,21 @@
                 fieldLabel : 'Dataset Containing Aliases',
                 editable: false,
                 listeners : {
-                     select : function(cb){
-                            aliasCombo.clearValue();
-                            sourceCombo.clearValue();
-                            populateOtherBoxes(cb.getRawValue());
-                            aliasCombo.setDisabled(false);
-                            sourceCombo.setDisabled(false);
+                    select : function(cb){
+                        aliasCombo.clearValue();
+                        sourceCombo.clearValue();
+                        populateOtherBoxes(cb.getRawValue());
+                        aliasCombo.setDisabled(false);
+                        sourceCombo.setDisabled(false);
 
-                     },
-                     setup : function(cb){
+                    },
+                    setup : function(cb){
                          aliasCombo.clearValue();
                          sourceCombo.clearValue();
                          populateOtherBoxes(cb.getRawValue(), true);
                          aliasCombo.setDisabled(false);
                          sourceCombo.setDisabled(false);
-                     }
+                    }
                 }
             });
 
@@ -317,10 +320,10 @@
                         {
                             var field = details.metaData.fields[i];
                             // Filter out irrelevant columns based on type
-                            if (field.jsonType == 'string' || field.jsonType == 'int')
+                            if (field.jsonType === 'string' || field.jsonType === 'int')
                             {
                                 // Filter out some built-in columns
-                                if (field.name != 'lsid' && field.name != <%= q(subjectNounColName)%>)
+                                if (field.name !== 'lsid' && field.name !== <%= q(subjectNounColName)%>)
                                 {
                                     filteredFields.push({ name: field.name });
                                 }
@@ -330,11 +333,11 @@
                         aliasCombo.fireEvent('dataloaded', aliasCombo);
                         sourceCombo.fireEvent('dataloaded', sourceCombo);
                         if(setup){
-                            if('<%=h(aliasColumn)%>' != "")
+                            if('<%=h(aliasColumn)%>' !== "")
                             {
                                 aliasCombo.select(aliasCombo.findRecord('name', '<%=h(aliasColumn)%>'));
                             }
-                            if('<%=h(sourceColumn)%>' != "")
+                            if('<%=h(sourceColumn)%>' !== "")
                             {
                                 sourceCombo.select(sourceCombo.findRecord('name', '<%=h(sourceColumn)%>'));
                             }
@@ -374,12 +377,12 @@
                         method : 'POST',
 
                         success: function(details){
-                            if(datasetId != -1)
-                                displayDoneChangingMessage("Save Alias Settings", <%=q(subjectNounSingular)%> + " alias settings saved successfully.");
+                            if (datasetId !== -1)
+                                displayDoneChangingMessage("Save Alias Settings", <%=q(subjectNounSingularTitleString)%> + " alias settings saved successfully.");
                             else
-                                displayDoneChangingMessage("Clear Alias Settings", <%=q(subjectNounSingular)%> + " alias settings cleared.")
+                                displayDoneChangingMessage("Clear Alias Settings", <%=q(subjectNounSingularTitleString)%> + " alias settings cleared.")
                             aliasDatasetId = datasetId;
-                            if(datasetId != -1)
+                            if (datasetId !== -1)
                                 importButton.setDisabled(false);
 
                         },
@@ -392,9 +395,8 @@
                     });
                 }
                 else {
-                        displayBadFormMessage();
+                    displayBadFormMessage();
                 }
-
             };
 
             var saveButton = Ext4.create('Ext.button.Button', {
@@ -429,7 +431,7 @@
                     style : 'background: none',
                     dock : 'bottom',
                     ui : 'footer',
-                    height: 30,
+                    height: 31,
                     items: [saveButton, clearButton, importButton, manageButton]
                  }
 
@@ -457,14 +459,14 @@
                     },
                     extraParams: {
                         schemaName: 'study',
-                        queryName: <%=q(subjectNounSingular)%>
+                        queryName: <%=q(subjectNounSingularTitleString)%>
                     }
                 },
             });
 
             var viewParticipantDataLink = Ext4.create('Ext.Component', {
                 tpl: new Ext4.XTemplate(
-                        '<a class="labkey-text-link" href="{[this.getURL(values)]}" target="_blank">View ' + <%=q(h(subjectNounSingular))%> + ' Data</a>',
+                        '<a class="labkey-text-link" href="{[this.getURL(values)]}" target="_blank">View ' + <%=q(subjectNounSingularTitle)%> + ' Data</a>',
                         {
                             getURL : function(values){
                                 return LABKEY.ActionURL.buildURL('study', 'participant.view', null, { 'participantId': values.participantId })
@@ -483,7 +485,7 @@
                 displayField : <%=q(subjectNounColName)%>,
                 labelWidth : 120,
                 labelSeparator: '',
-                fieldLabel : (<%=q(subjectNounSingular)%> + " ID"),
+                fieldLabel : (<%=q(subjectNounSingularTitleString)%> + " ID"),
                 editable: true,
                 queryMode: 'remote',
                 minChars: 2,
@@ -508,7 +510,7 @@
             var deleteParticipant = function(participantIdToDelete) {
                 Ext4.Msg.show({
                     title   : 'Confirmation',
-                    msg     : "Are you sure you want to delete " + <%=q(h(subjectNounSingular.toLowerCase()))%> + " '" + participantIdToDelete + "'?",
+                    msg     : "Are you sure you want to delete " + <%=q(subjectNounSingular)%> + " '" + participantIdToDelete + "'?",
                     buttons : Ext4.MessageBox.YESNO,
                     icon    : Ext4.MessageBox.QUESTION,
                     fn      : function(id){
@@ -522,14 +524,14 @@
                                 scope: this,
                                 success: function() {
                                     Ext4.getBody().unmask();
-                                    displayDoneChangingMessage("Success", "Successfully deleted " +  <%=q(h(subjectNounSingular))%> + " " + participantIdToDelete + '.');
+                                    displayDoneChangingMessage("Success", "Successfully deleted " +  <%=q(subjectNounSingular)%> + " " + participantIdToDelete + '.');
                                     // Refresh the ComboBox store after deletion
                                     participantCombo.setValue(null);
                                     participantCombo.getStore().load();
                                 },
                                 failure: function(response, options){
                                     Ext4.getBody().unmask();
-                                    LABKEY.Utils.displayAjaxErrorResponse(response, options, false, "Failed to delete " + <%=q(h(subjectNounSingular))%> + " " + participantIdToDelete + ": " + response.responseText);
+                                    LABKEY.Utils.displayAjaxErrorResponse(response, options, false, "Failed to delete " + <%=q(subjectNounSingular)%> + " " + participantIdToDelete + ": " + response.responseText);
                                 },
                             });
                         }
@@ -551,9 +553,31 @@
                     style : 'background: none',
                     dock : 'bottom',
                     ui : 'footer',
-                    height: 30,
+                    height: 31,
                     items: [deleteButton, viewParticipantDataLink]
                 }
+            });
+
+            var changeOrMergePanel = Ext4.create('Ext.form.FormPanel', {
+                renderTo: 'changeOrMergePanel',
+                bodyPadding: 10,
+                bodyStyle: 'background: none',
+                frame: false,
+                border: false,
+                width: 600,
+                buttonAlign : 'left',
+                dockedItems: [{
+                    xtype: 'toolbar',
+                    dock: 'bottom',
+                    ui : 'footer',
+                    style : 'background: none',
+                    height : 31,
+                    items: [{
+                        xtype: 'button',
+                        text: 'Change or Merge ' + <%=q(subjectNounSingularTitleString)%> + ' IDs',
+                        handler: function() {window.location = <%=q(new ActionURL(StudyController.MergeParticipantsAction.class, getContainer()))%>;}
+                    }]
+                }]
             });
         };
 

--- a/study/src/org/labkey/study/view/manageStudy.jsp
+++ b/study/src/org/labkey/study/view/manageStudy.jsp
@@ -44,10 +44,10 @@
 <%@ page import="org.labkey.study.controllers.StudyController.ConfigureMasterPatientSettingsAction" %>
 <%@ page import="org.labkey.study.controllers.StudyController.DeleteStudyAction" %>
 <%@ page import="org.labkey.study.controllers.StudyController.DemoModeAction" %>
-<%@ page import="org.labkey.study.controllers.StudyController.ManageAlternateIdsAction" %>
 <%@ page import="org.labkey.study.controllers.StudyController.ManageExternalReloadAction" %>
 <%@ page import="org.labkey.study.controllers.StudyController.ManageLocationsAction" %>
 <%@ page import="org.labkey.study.controllers.StudyController.ManageParticipantCategoriesAction" %>
+<%@ page import="org.labkey.study.controllers.StudyController.ManageParticipantsAction" %>
 <%@ page import="org.labkey.study.controllers.StudyController.ManageQCStatesAction" %>
 <%@ page import="org.labkey.study.controllers.StudyController.ManageStudyPropertiesAction" %>
 <%@ page import="org.labkey.study.controllers.StudyController.ManageTypesAction" %>
@@ -235,8 +235,8 @@
                     </tr>
                     <tr>
                         <td class="lk-study-prop-label"><%= h(subjectNounPlural) %></td>
-                        <td class="lk-study-prop-desc">Delete participants and configure <%= h(subjectNounSingle.toLowerCase()) %> IDs</td>
-                        <td><%= link("Manage " + subjectNounPlural, ManageAlternateIdsAction.class) %></td>
+                        <td class="lk-study-prop-desc">Delete <%= h(subjectNounPlural.toLowerCase()) %>  and configure <%= h(subjectNounSingle.toLowerCase()) %> IDs</td>
+                        <td><%= link("Manage " + subjectNounPlural, ManageParticipantsAction.class) %></td>
                     </tr>
                     <tr>
                         <td class="lk-study-prop-label">Security</td>

--- a/study/src/org/labkey/study/view/manageStudyPropertiesExt.jsp
+++ b/study/src/org/labkey/study/view/manageStudyPropertiesExt.jsp
@@ -557,6 +557,7 @@ function renderFormPanel(data, editable){
             dock: 'bottom',
             ui: 'footer',
             style : 'background-color: transparent;',
+            height: 31,
             items: buttons
         }],
         renderTo : 'formDiv',

--- a/study/src/org/labkey/study/view/mergeParticipants.jsp
+++ b/study/src/org/labkey/study/view/mergeParticipants.jsp
@@ -25,6 +25,7 @@
 <%@ page import="org.labkey.study.model.DatasetDefinition" %>
 <%@ page import="org.labkey.study.model.StudyImpl" %>
 <%@ page import="org.labkey.study.model.StudyManager" %>
+<%@ page import="org.labkey.api.util.StringUtilsLabKey" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
     @Override
@@ -36,7 +37,7 @@
 <%
     Container c = getContainer();
     StudyImpl s = StudyManager.getInstance().getStudy(c);
-    String subjectNounSingular = s.getSubjectNounSingular();
+    String subjectNounSingular = s.getSubjectNounSingular().toLowerCase();
     String subjectNounColumnName = s.getSubjectColumnName();
     Integer aliasDatasetId = s.getParticipantAliasDatasetId();
     String aliasDatasetName = null;
@@ -57,9 +58,10 @@
 %>
 <div style="max-width: 1000px">
     <p>
-        If a(n) <%= h(subjectNounSingular) %>  in your study has been loaded with an incorrect <%= h(subjectNounColumnName) %>,
-        you can change the identifier. If you change the <%= h(subjectNounColumnName) %> to one that is already in the study,
-        data will be merged into a single <%= h(subjectNounSingular) %>.
+        If <%=h(StringUtilsLabKey.getArticleForNoun(subjectNounSingular))%> <%=h(subjectNounSingular)%> in your study
+        has been loaded with an incorrect <%= h(subjectNounColumnName) %>, you can change the identifier. If you change
+        the <%= h(subjectNounColumnName) %> to one that already exists in the study, the data associated with the
+        incorrect <%= h(subjectNounColumnName) %> will be merged to the existing <%= h(subjectNounColumnName) %>.
     </p>
 </div>
 <div id="mergeParticipantsPanel-div"></div>

--- a/study/test/src/org/labkey/test/tests/study/StudyMergeParticipantsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyMergeParticipantsTest.java
@@ -174,7 +174,7 @@ public class StudyMergeParticipantsTest extends StudyBaseTest
         clickButton("Submit", "Dataset: " + ALIAS_DATASET);
 
         // Configure new dataset as the alias dataset
-        goToManageAlternateIds();
+        goToManageParticipants();
         _ext4Helper.selectComboBoxItem("Dataset Containing Aliases", ALIAS_DATASET);
         _ext4Helper.selectComboBoxItem("Alias Column", ALIAS_COLUMN);
         _ext4Helper.selectComboBoxItem("Source Column", SOURCE_COLUMN);
@@ -201,7 +201,7 @@ public class StudyMergeParticipantsTest extends StudyBaseTest
         return BrowserType.CHROME;
     }
 
-    private void goToManageAlternateIds()
+    private void goToManageParticipants()
     {
         goToManageStudy();
         clickAndWait(Locator.linkContainingText("Manage Participants"));
@@ -209,7 +209,7 @@ public class StudyMergeParticipantsTest extends StudyBaseTest
 
     private void goToMergeParticipants()
     {
-        goToManageAlternateIds();
-        clickButton("Change or Merge " + SUBJECT_COLUMN);
+        goToManageParticipants();
+        clickButton("Change or Merge " + SUBJECT_NOUN + " IDs");
     }
 }

--- a/study/test/src/org/labkey/test/tests/study/StudyPHIExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPHIExportTest.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.tests.study;
 
-import org.junit.Assert;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
@@ -103,7 +102,7 @@ public class StudyPHIExportTest extends StudyExportTest
         assertEquals("unexpected number of rows for cohort 2", 2, drt.getDataRowCount());
     }
 
-    private void verifyStatsDoNotMatch(Map originalFirstMouseStats, Map alteredFirstMouseStats)
+    private void verifyStatsDoNotMatch(Map<String, String> originalFirstMouseStats, Map<String, String> alteredFirstMouseStats)
     {
         for(String columnName : defaultStatsToCollect)
         {
@@ -111,7 +110,7 @@ public class StudyPHIExportTest extends StudyExportTest
         }
     }
 
-    private void verifyStatsMatch(Map originalFirstMouseStats, Map alteredFirstMouseStats)
+    private void verifyStatsMatch(Map<String, String> originalFirstMouseStats, Map<String, String> alteredFirstMouseStats)
     {
         for(String columnName : defaultStatsToCollect)
         {
@@ -198,7 +197,7 @@ public class StudyPHIExportTest extends StudyExportTest
         selectQuery("study", "Location");
         waitAndClickAndWait(Locator.linkWithText("view data"));
         DataRegionTable query = new DataRegionTable("query", this);
-        Assert.assertTrue("Lab Code column should not be in default view", query.getColumnIndex("LabwareLabCode") == -1);
+        assertEquals("Lab Code column should not be in default view", -1, query.getColumnIndex("LabwareLabCode"));
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.addColumn("LabwareLabCode");
         _customizeViewsHelper.applyCustomView();
@@ -225,7 +224,7 @@ public class StudyPHIExportTest extends StudyExportTest
         }
         assertEquals("Unexpected number of clinics", clinicCount, foundClinics);
 
-// Redundent because schema browser "view data" of study/locations and "manage Locations" link to the same table.
+// Redundant because schema browser "view data" of study/locations and "manage Locations" link to the same table.
 //
 //        clickTab("Manage");
 //        clickAndWait(Locator.linkWithText("Manage Locations"));
@@ -281,45 +280,50 @@ public class StudyPHIExportTest extends StudyExportTest
         goToDatasets();
         clickAndWait(Locator.linkContainingText("DEM-1"));
         DataRegionTable drt = new DataRegionTable("Dataset", this);
-        Map stats = new HashMap();
+        Map<String, String> stats = new HashMap<>();
 
-
-        for(int i = 0; i <defaultStatsToCollect.length; i++)
+        for (String s : defaultStatsToCollect)
         {
-            stats.put(defaultStatsToCollect[i], drt.getDataAsText(0, defaultStatsToCollect[i]));
+            stats.put(s, drt.getDataAsText(0, s));
         }
 
         return stats;
     }
 
     private static final String BAD_ALTERNATEID_MAPPING =
-            "ParticipantId\tAlternateId\tDateOffset\n" +
-                    "999320582\tNEWALT_32\t0\n" +
-                    "999320638\tNEWALT_32\t1";
+            """
+                    ParticipantId\tAlternateId\tDateOffset
+                    999320582\tNEWALT_32\t0
+                    999320638\tNEWALT_32\t1""";
 
     private static final String ALTERNATEID_MAPPING =
-            "ParticipantId\tAlternateId\tDateOffset\n" +
-                    "999320582\tNEWALT_32\t0\n" +
-                    "999320638\tNEWALT_33\t1";
+            """
+                    ParticipantId\tAlternateId\tDateOffset
+                    999320582\tNEWALT_32\t0
+                    999320638\tNEWALT_33\t1""";
 
     private static final String BAD_ALTERNATEID_MAPPING_2 =
-            "ParticipantId\tAlternateId\tDateOffset\n" +
-                    "999320533\tNEWALT_32\t0\n" +
-                    "999320638\tNEWALT_33\t1";
+            """
+                    ParticipantId\tAlternateId\tDateOffset
+                    999320533\tNEWALT_32\t0
+                    999320638\tNEWALT_33\t1""";
 
     private static final String BAD_ALTERNATEID_MAPPING_3 =
-            "ParticipantId\tAlternateId\tDateOffset\n" +
-                    "999320582\n" +
-                    "999320638\tNEWALT_13\t1";
+            """
+                    ParticipantId\tAlternateId\tDateOffset
+                    999320582
+                    999320638\tNEWALT_13\t1""";
 
     private static final String BAD_ALTERNATEID_MAPPING_4 =
-                    "999320582\tNEWALT_12\t0\n" +
-                    "999320638\tNEWALT_13\t1";
+            """
+                    999320582\tNEWALT_12\t0
+                    999320638\tNEWALT_13\t1""";
 
     private static final String ALTERNATEID_MAPPING_2 =
-            "AlternateId\tParticipantId\tDateOffset\n" +
-                    "NEWALT_32AB9\t999320582\t0\n" +
-                    "NEWALT_333Q\t999320638\t1";
+            """
+                    AlternateId\tParticipantId\tDateOffset
+                    NEWALT_32AB9\t999320582\t0
+                    NEWALT_333Q\t999320638\t1""";
 
     @LogMethod
     private void verifyImportingAlternateIds()
@@ -353,7 +357,7 @@ public class StudyPHIExportTest extends StudyExportTest
         importDataPage.setText(ALTERNATEID_MAPPING_2);
         importDataPage.submit();
 
-        assertTextPresent("Manage Alternate", "Aliases");
+        assertTextPresent("Manage Mice", "Alternate", "Aliases");
         clickButton("Done");
     }
 }


### PR DESCRIPTION
#### Rationale
Fixing confusing UI, bad wording & formatting, incomplete navtrails, clipped buttons, double print buttons, etc.

#### Changes
- Manage Participants
  - Rename `ManageAlternateIdsAction` --> `ManageParticipantsAction`, since it's evolved significantly over time. Same with its JSP.
  - Reference the participant noun (not hard-coded "participant") consistently in the "manage participants" link description
  - Clarify that an "Alternate ID" is used for masking
  - Move "Change and Merge <Participant> ID" button out of the "Alternate IDs" section into its own section since it has nothing to do with Alternate IDs
  - Use subject noun more consistently
- Fix vertically clipped Ext4 buttons on a couple pages
- Improve merge participants page's navtrail and wording
- [Issue 51865: Data Region on Manage Location page for a Study has two print buttons](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51865)
