### PR TITLE
Fix notebook data reference

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -633,7 +633,8 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         ExpDataClass dc = getDataClass(null);
         if (dc != null)
             dataClassName = dc.getName();
-        return "data:" + new Path(getContainer().getId(), dataClassName, Integer.toString(getRowId()));
+        // why not just data:rowId?
+        return "data:" + new Path(getContainer().getId(), dataClassName, Integer.toString(getRowId())).encode();
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
The documentId for dataclass data include the dataclass name. When the dataclass name contains special characters such as "/", the documentId cannot be parsed correctly. 

[SMProFolderExclusionTest.testExistingReferencesWithUpdatedExclusion](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_SampleManagerBPostgres/3311567?buildTab=tests&status=failed&name=SMProFolderExclusionTest.testExistingReferencesWithUpdatedExclusion)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6156
- https://github.com/LabKey/limsModules/pull/1007
- https://github.com/LabKey/testAutomation/pull/2200

#### Changes
- encode datatype name when generating documentid for search results
