### PR TITLE
Change 'sessionKey' query parameter name

### DIFF
--- a/api/src/org/labkey/api/reports/report/r/view/DownloadOutputView.java
+++ b/api/src/org/labkey/api/reports/report/r/view/DownloadOutputView.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.attachments.AttachmentParent;
 import org.labkey.api.reports.report.ReportUrls;
 import org.labkey.api.reports.report.r.ParamReplacement;
-import org.labkey.api.util.GUID;
+import org.labkey.api.util.ImageUtil;
 import org.labkey.api.util.PageFlowUtil;
 
 import java.io.File;
@@ -64,10 +64,12 @@ public abstract class DownloadOutputView extends ROutputView
         {
             File newFile = moveToTemp(file, "RReportPdf");
             // file hasn't been saved yet
-            String key = "temp:" + GUID.makeGUID();
-            getViewContext().getRequest().getSession(true).setAttribute(key, newFile);
+            String key = ImageUtil.setFileInSession(getViewContext().getRequest(), newFile);
             downloadUrl = PageFlowUtil.urlProvider(ReportUrls.class).urlStreamFile(getViewContext().getContainer()).
-                    addParameters(PageFlowUtil.map("sessionKey", key, "deleteFile", "false", "attachment", "true")).getLocalURIString();
+                    addParameters(PageFlowUtil.map(
+                            ImageUtil.FILE_SESSION_PARAM, key,
+                            ImageUtil.DELETE_FILE_PARAM, "false",
+                            ImageUtil.ATTACHMENT_PARAM, "true")).getLocalURIString();
         }
         return downloadUrl;
     }

--- a/api/src/org/labkey/api/reports/report/r/view/ImageOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/ImageOutput.java
@@ -18,16 +18,15 @@ package org.labkey.api.reports.report.r.view;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.labkey.api.reports.Report;
-import org.labkey.api.reports.report.r.RReport;
 import org.labkey.api.reports.report.ReportDescriptor;
 import org.labkey.api.reports.report.ReportUrls;
 import org.labkey.api.reports.report.ScriptOutput;
 import org.labkey.api.reports.report.ScriptReportDescriptor;
 import org.labkey.api.reports.report.r.AbstractParamReplacement;
 import org.labkey.api.reports.report.r.ParamReplacement;
+import org.labkey.api.reports.report.r.RReport;
 import org.labkey.api.thumbnail.Thumbnail;
 import org.labkey.api.util.FileUtil;
-import org.labkey.api.util.GUID;
 import org.labkey.api.util.ImageUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
@@ -133,10 +132,9 @@ public class ImageOutput extends AbstractParamReplacement
 
                 if (imgFile != null)
                 {
-                    String key = "temp:" + GUID.makeGUID();
-                    getViewContext().getRequest().getSession(true).setAttribute(key, imgFile);
+                    String key = ImageUtil.setFileInSession(getViewContext().getRequest(), imgFile);
                     ActionURL url = PageFlowUtil.urlProvider(ReportUrls.class).urlStreamFile(getViewContext().getContainer());
-                    url.addParameters(PageFlowUtil.map("sessionKey", key, "deleteFile", Boolean.toString(_deleteFile), "cacheFile", "true"));
+                    url.addParameters(PageFlowUtil.map(ImageUtil.FILE_SESSION_PARAM, key, ImageUtil.DELETE_FILE_PARAM, Boolean.toString(_deleteFile), ImageUtil.CACHE_FILE_PARAM, "true"));
                     imgUrl = url.getLocalURIString();
                 }
             }

--- a/api/src/org/labkey/api/util/ImageUtil.java
+++ b/api/src/org/labkey/api/util/ImageUtil.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.util;
 
+import jakarta.servlet.http.HttpServletRequest;
 import net.coobird.thumbnailator.Thumbnails;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.hc.core5.http.ParseException;
@@ -53,6 +54,10 @@ import java.util.logging.Level;
 public class ImageUtil
 {
     private static Logger LOG = LogManager.getLogger(ImageUtil.class);
+    public static final String FILE_SESSION_PARAM = "fileCacheKey";
+    public static final String DELETE_FILE_PARAM = "deleteFile";
+    public static final String CACHE_FILE_PARAM = "cacheFile";
+    public static final String ATTACHMENT_PARAM = "attachment";
 
     static
     {
@@ -248,6 +253,35 @@ public class ImageUtil
         }
     }
 
+    /**
+     * Retrieves a file cached in the session
+     */
+    @Nullable
+    public static File getFileFromSession(HttpServletRequest request, String key)
+    {
+        Object o = request.getSession().getAttribute(key);
+        if (o instanceof File file && file.exists())
+            return file;
+
+        return null;
+    }
+
+    /**
+     * Adds a file to the request session and returns the generated session attribute key.
+     */
+    @Nullable
+    public static String setFileInSession(HttpServletRequest request, File file)
+    {
+        if (file != null && file.exists())
+        {
+            String key = "temp:" + GUID.makeGUID();
+            request.getSession(true).setAttribute(key, file);
+
+            return key;
+        }
+        return null;
+    }
+
     // LabKey user agent is used to resolve image resources (or others if required in the future) using the
     // same session as the incoming request.  Right now this occurs when we are generating a thumbnail for a Knitr
     // R report
@@ -262,7 +296,7 @@ public class ImageUtil
         }
 
         @Override
-        public org.xhtmlrenderer.resource.ImageResource getImageResource(java.lang.String uri)
+        public ImageResource getImageResource(String uri)
         {
             ImageResource ir;
             String uriResolved = resolveURI(uri);
@@ -276,10 +310,11 @@ public class ImageUtil
                 try
                 {
                     URLHelper helper = new URLHelper(uriResolved);
-                    String sessionKey = helper.getParameter("sessionKey");
-                    String deleteFile = helper.getParameter("deleteFile");
-                    File file = (File) _context.getRequest().getSession().getAttribute(sessionKey);
-                    if (file != null && file.exists())
+                    String sessionKey = helper.getParameter(FILE_SESSION_PARAM);
+                    String deleteFile = helper.getParameter(DELETE_FILE_PARAM);
+
+                    File file = getFileFromSession(_context.getRequest(), sessionKey);
+                    if (file != null)
                     {
                         try
                         {

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -132,6 +132,7 @@ import org.labkey.api.thumbnail.ThumbnailService.ImageType;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
+import org.labkey.api.util.ImageUtil;
 import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.PageFlowUtil;
@@ -1523,14 +1524,14 @@ public class ReportsController extends SpringActionController
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
         {
-            String sessionKey = (String) getViewContext().get("sessionKey");
-            String deleteFile = (String) getViewContext().get("deleteFile");
-            String attachment = (String) getViewContext().get("attachment");
-            String cacheFile = (String) getViewContext().get("cacheFile");
+            String sessionKey = (String) getViewContext().get(ImageUtil.FILE_SESSION_PARAM);
+            String deleteFile = (String) getViewContext().get(ImageUtil.DELETE_FILE_PARAM);
+            String attachment = (String) getViewContext().get(ImageUtil.ATTACHMENT_PARAM);
+            String cacheFile = (String) getViewContext().get(ImageUtil.CACHE_FILE_PARAM);
             if (sessionKey != null)
             {
-                File file = (File) getViewContext().getRequest().getSession().getAttribute(sessionKey);
-                if (file != null && file.isFile())
+                File file = ImageUtil.getFileFromSession(getViewContext().getRequest(), sessionKey);
+                if (file != null)
                 {
                     Map<String, String> responseHeaders = Collections.emptyMap();
                     if (BooleanUtils.toBoolean(cacheFile))

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -19,7 +19,6 @@ package org.labkey.study.controllers.reports;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -33,7 +32,6 @@ import org.labkey.api.action.FormHandlerAction;
 import org.labkey.api.action.FormViewAction;
 import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.ReadOnlyApiAction;
-import org.labkey.api.action.ReturnUrlForm;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.ColumnInfo;
@@ -68,10 +66,10 @@ import org.labkey.api.study.StudyService;
 import org.labkey.api.study.Visit;
 import org.labkey.api.study.reports.CrosstabReport;
 import org.labkey.api.study.reports.CrosstabReportDescriptor;
+import org.labkey.api.util.ImageUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.UniqueID;
-import org.labkey.api.util.element.CsrfInput;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
@@ -100,7 +98,6 @@ import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.io.File;
-import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -152,15 +149,15 @@ public class ReportsController extends BaseStudyController
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
         {
-            String sessionKey = (String) getViewContext().get("sessionKey");
+            String sessionKey = (String) getViewContext().get(ImageUtil.FILE_SESSION_PARAM);
             if (null == sessionKey)
             {
                 //TODO: Return a GIF that says not found??
                 return null;
             }
 
-            File file = (File) getViewContext().getRequest().getSession().getAttribute(sessionKey);
-            if (file.exists())
+            File file = ImageUtil.getFileFromSession(getViewContext().getRequest(), sessionKey);
+            if (file != null)
             {
                 PageFlowUtil.streamFile(getViewContext().getResponse(), file.toPath(), false);
                 file.delete();


### PR DESCRIPTION
[tracking issue](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51715)

#### Rationale
While not a security concern, rename the `sessionKey` parameter and consolidate the code which uses this method to stash and retrieve files from the session.