### PR TITLE
Move StatusCake sync code into mothership module system maintenance task

### DIFF
--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -16,7 +16,6 @@
 
 package org.labkey.mothership;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.InetAddressValidator;
@@ -301,11 +300,13 @@ public class MothershipController extends SpringActionController
         {
             UpgradeMessageForm form = new UpgradeMessageForm();
 
-            form.setCurrentBuildDate(MothershipManager.get().getCurrentBuildDate(getContainer()));
-            form.setMessage(MothershipManager.get().getUpgradeMessage(getContainer()));
-            form.setCreateIssueURL(MothershipManager.get().getCreateIssueURL(getContainer()));
-            form.setIssuesContainer(MothershipManager.get().getIssuesContainer(getContainer()));
-            form.setMarketingMessage(MothershipManager.get().getMarketingMessage(getContainer()));
+            form.setCurrentBuildDate(MothershipManager.get().getCurrentBuildDate());
+            form.setMessage(MothershipManager.get().getUpgradeMessage());
+            form.setCreateIssueURL(MothershipManager.get().getCreateIssueURL());
+            form.setIssuesContainer(MothershipManager.get().getIssuesContainer());
+            form.setMarketingMessage(MothershipManager.get().getMarketingMessage());
+            form.setStatusCakeApiKey(StringUtils.trimToNull(MothershipManager.get().getStatusCakeApiKey()));
+            form.setUptimeContainer(MothershipManager.get().getUptimeContainer());
 
             return new VBox(new LinkBar(), new JspView<>("/org/labkey/mothership/editUpgradeMessage.jsp", form));
         }
@@ -329,11 +330,18 @@ public class MothershipController extends SpringActionController
         @Override
         public boolean handlePost(UpgradeMessageForm form, BindException errors)
         {
-            MothershipManager.get().setCurrentBuildDate(getContainer(), form.getCurrentBuildDate());
-            MothershipManager.get().setUpgradeMessage(getContainer(), form.getMessage());
-            MothershipManager.get().setCreateIssueURL(getContainer(), form.getCreateIssueURL());
-            MothershipManager.get().setIssuesContainer(getContainer(), form.getIssuesContainer());
-            MothershipManager.get().setMarketingMessage(getContainer(), form.getMarketingMessage());
+            MothershipManager.get().setCurrentBuildDate(form.getCurrentBuildDate());
+            MothershipManager.get().setUpgradeMessage(form.getMessage());
+            MothershipManager.get().setCreateIssueURL(form.getCreateIssueURL());
+            MothershipManager.get().setIssuesContainer(form.getIssuesContainer());
+            MothershipManager.get().setMarketingMessage(form.getMarketingMessage());
+            MothershipManager.get().setUptimeContainer(form.getUptimeContainer());
+
+            if (form.getStatusCakeApiKey() != null)
+            {
+                MothershipManager.get().setStatusCakeApiKey(form.getStatusCakeApiKey());
+            }
+
             return true;
         }
 
@@ -509,7 +517,7 @@ public class MothershipController extends SpringActionController
             }
             cifModel.put("body", body.toString());
             cifModel.put("title", title.toString());
-            cifModel.put("action", MothershipManager.get().getCreateIssueURL(getContainer()));
+            cifModel.put("action", MothershipManager.get().getCreateIssueURL());
 
             return new JspView<>("/org/labkey/mothership/view/createIssue.jsp", cifModel);
         }
@@ -757,7 +765,7 @@ public class MothershipController extends SpringActionController
                 {
                     JSONObject response = new JSONObject();
                     response.put("upgradeMessage", getUpgradeMessage(sessionAndRelease.second));
-                    response.put("marketingUpdate", MothershipManager.get().getMarketingMessage(getContainer()));
+                    response.put("marketingUpdate", MothershipManager.get().getMarketingMessage());
 
                     return success(response);
                 }
@@ -906,12 +914,12 @@ public class MothershipController extends SpringActionController
 
     private String getUpgradeMessage(@NotNull SoftwareRelease release)
     {
-        Date currentBuildDate = MothershipManager.get().getCurrentBuildDate(getContainer());
+        Date currentBuildDate = MothershipManager.get().getCurrentBuildDate();
         Date reportedBuildDate = release.getBuildTime();
 
         if (reportedBuildDate != null && currentBuildDate != null && reportedBuildDate.before(currentBuildDate))
         {
-            return MothershipManager.get().getUpgradeMessage(getContainer());
+            return MothershipManager.get().getUpgradeMessage();
         }
         return "";
     }
@@ -1865,6 +1873,8 @@ public class MothershipController extends SpringActionController
         private String _createIssueURL;
         private String _issuesContainer;
         private String _marketingMessage;
+        private String _statusCakeApiKey;
+        private String _uptimeContainer;
 
         public Date getCurrentBuildDate()
         {
@@ -1914,6 +1924,26 @@ public class MothershipController extends SpringActionController
         public void setMarketingMessage(String marketingMessage)
         {
             _marketingMessage = marketingMessage;
+        }
+
+        public String getStatusCakeApiKey()
+        {
+            return _statusCakeApiKey;
+        }
+
+        public void setStatusCakeApiKey(String statusCakeApiKey)
+        {
+            _statusCakeApiKey = statusCakeApiKey;
+        }
+
+        public String getUptimeContainer()
+        {
+            return _uptimeContainer;
+        }
+
+        public void setUptimeContainer(String uptimeContainer)
+        {
+            _uptimeContainer = uptimeContainer;
         }
     }
 }

--- a/mothership/src/org/labkey/mothership/MothershipManager.java
+++ b/mothership/src/org/labkey/mothership/MothershipManager.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
@@ -62,11 +63,14 @@ public class MothershipManager
     private static final MothershipManager INSTANCE = new MothershipManager();
     private static final String SCHEMA_NAME = "mothership";
     private static final String UPGRADE_MESSAGE_PROPERTY_CATEGORY = "upgradeMessage";
+    private static final String MOTHERSHIP_SECURE_CATEGORY = "mothershipSecure";
     private static final String CURRENT_BUILD_DATE_PROP = "currentBuildDate";
     private static final String UPGRADE_MESSAGE_PROP = "upgradeMessage";
     private static final String CREATE_ISSUE_URL_PROP = "createIssueURL";
     private static final String ISSUES_CONTAINER_PROP = "issuesContainer";
     private static final String MARKETING_MESSAGE_PROP = "marketingMessage";
+    private static final String UPTIME_CONTAINER_PROP = "uptimeContainer";
+    private static final String STATUS_CAKE_API_KEY_PROP = "statusCakeApiKey";
     private static final ReentrantLock INSERT_EXCEPTION_LOCK = new ReentrantLockWithName(MothershipManager.class, "INSERT_EXCEPTION_LOCK");
 
     private static final Logger log = LogHelper.getLogger(MothershipManager.class, "Persists mothership records like sessions and installs");
@@ -462,26 +466,50 @@ public class MothershipManager
         return getSchema().getSqlDialect();
     }
 
-    private WritablePropertyMap getWritableProperties(Container c)
+    private WritablePropertyMap getWritableProperties(Container c, boolean secure)
     {
-        return PropertyManager.getWritableProperties(c, UPGRADE_MESSAGE_PROPERTY_CATEGORY, true);
+        if (secure)
+        {
+            return PropertyManager.getEncryptedStore().getWritableProperties(c, MOTHERSHIP_SECURE_CATEGORY, true);
+        }
+        else
+        {
+            return PropertyManager.getWritableProperties(c, UPGRADE_MESSAGE_PROPERTY_CATEGORY, true);
+        }
     }
 
-    private @NotNull Map<String, String> getProperties(Container c)
+    private @NotNull Map<String, String> getProperties(boolean secure)
     {
-        return PropertyManager.getProperties(c, UPGRADE_MESSAGE_PROPERTY_CATEGORY);
+        if (secure)
+        {
+            return PropertyManager.getEncryptedStore().getProperties(getContainer(), MOTHERSHIP_SECURE_CATEGORY);
+        }
+        else
+        {
+            return PropertyManager.getProperties(getContainer(), UPGRADE_MESSAGE_PROPERTY_CATEGORY);
+        }
     }
 
-    public Date getCurrentBuildDate(Container c)
+    private static Container getContainer()
     {
-        Map<String, String> props = getProperties(c);
+        return ContainerManager.getForPath(MothershipReport.CONTAINER_PATH);
+    }
+
+    public Date getCurrentBuildDate()
+    {
+        Map<String, String> props = getProperties(false);
         String buildDate = props.get(CURRENT_BUILD_DATE_PROP);
         return  null == buildDate ? null : new Date(DateUtil.parseISODateTime(buildDate));
     }
 
-    private String getStringProperty(Container c, String name)
+    private String getStringProperty(String name)
     {
-        Map<String, String> props = getProperties(c);
+        return getStringProperty(name, false);
+    }
+
+    private String getStringProperty(String name, boolean secure)
+    {
+        Map<String, String> props = getProperties(secure);
         String message = props.get(name);
         if (message == null)
         {
@@ -490,46 +518,51 @@ public class MothershipManager
         return message;
     }
 
-    public String getUpgradeMessage(Container c)
+    public String getUpgradeMessage()
     {
-        return getStringProperty(c, UPGRADE_MESSAGE_PROP);
+        return getStringProperty(UPGRADE_MESSAGE_PROP);
     }
 
-    public String getMarketingMessage(Container c)
+    public String getMarketingMessage()
     {
-        return getStringProperty(c, MARKETING_MESSAGE_PROP);
+        return getStringProperty(MARKETING_MESSAGE_PROP);
     }
 
-    private void saveProperty(Container c, String name, String value)
+    private void saveProperty(String name, String value)
     {
-        WritablePropertyMap props = getWritableProperties(c);
+        saveProperty(name, value, false);
+    }
+
+    private void saveProperty(String name, String value, boolean secure)
+    {
+        WritablePropertyMap props = getWritableProperties(getContainer(), secure);
         props.put(name, value);
         props.save();
     }
 
-    public void setCurrentBuildDate(Container c, Date buildDate)
+    public void setCurrentBuildDate(Date buildDate)
     {
-        saveProperty(c, CURRENT_BUILD_DATE_PROP, DateUtil.formatIsoDateShortTime(buildDate));
+        saveProperty(CURRENT_BUILD_DATE_PROP, DateUtil.formatIsoDateShortTime(buildDate));
     }
 
-    public void setUpgradeMessage(Container c, String message)
+    public void setUpgradeMessage(String message)
     {
-        saveProperty(c, UPGRADE_MESSAGE_PROP, message);
+        saveProperty(UPGRADE_MESSAGE_PROP, message);
     }
 
-    public void setMarketingMessage(Container c, String message)
+    public void setMarketingMessage(String message)
     {
-        saveProperty(c, MARKETING_MESSAGE_PROP, message);
+        saveProperty(MARKETING_MESSAGE_PROP, message);
     }
 
-    public String getCreateIssueURL(Container c)
+    public String getCreateIssueURL()
     {
-        return getStringProperty(c, CREATE_ISSUE_URL_PROP);
+        return getStringProperty(CREATE_ISSUE_URL_PROP);
     }
 
-    public void setCreateIssueURL(Container c, String url)
+    public void setCreateIssueURL(String url)
     {
-        saveProperty(c, CREATE_ISSUE_URL_PROP, url);
+        saveProperty(CREATE_ISSUE_URL_PROP, url);
     }
 
     public void updateExceptionStackTrace(ExceptionStackTrace stackTrace, User user)
@@ -537,14 +570,34 @@ public class MothershipManager
         Table.update(user, getTableInfoExceptionStackTrace(), stackTrace, stackTrace.getExceptionStackTraceId());
     }
 
-    public String getIssuesContainer(Container c)
+    public String getIssuesContainer()
     {
-        return getStringProperty(c, ISSUES_CONTAINER_PROP);
+        return getStringProperty(ISSUES_CONTAINER_PROP);
     }
 
-    public void setIssuesContainer(Container c, String container)
+    public void setIssuesContainer(String container)
     {
-        saveProperty(c, ISSUES_CONTAINER_PROP, container);
+        saveProperty(ISSUES_CONTAINER_PROP, container);
+    }
+
+    public String getUptimeContainer()
+    {
+        return getStringProperty(UPTIME_CONTAINER_PROP);
+    }
+
+    public void setUptimeContainer(String uptimeContainer)
+    {
+        saveProperty(UPTIME_CONTAINER_PROP, uptimeContainer);
+    }
+
+    public String getStatusCakeApiKey()
+    {
+        return getStringProperty(STATUS_CAKE_API_KEY_PROP, true);
+    }
+
+    public void setStatusCakeApiKey(String statusCakeApiKey)
+    {
+        saveProperty(STATUS_CAKE_API_KEY_PROP, statusCakeApiKey, true);
     }
 
     public void updateSoftwareRelease(Container container, User user, SoftwareRelease bean)

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -26,12 +26,14 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.util.MothershipReport;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.SystemMaintenance;
 import org.labkey.api.view.BaseWebPartFactory;
 import org.labkey.api.view.Portal;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.api.view.WebPartView;
 import org.labkey.mothership.query.MothershipSchema;
+import org.labkey.mothership.statuscake.StatusCakeMaintenanceTask;
 import org.labkey.mothership.view.ExceptionListWebPart;
 
 import java.util.Collection;
@@ -136,5 +138,7 @@ public class MothershipModule extends DefaultModule
                 MothershipManager.get().deleteForUser(user);
             }
         });
+
+        SystemMaintenance.addTask(new StatusCakeMaintenanceTask());
     }
 }

--- a/mothership/src/org/labkey/mothership/editUpgradeMessage.jsp
+++ b/mothership/src/org/labkey/mothership/editUpgradeMessage.jsp
@@ -25,7 +25,7 @@
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    JspView<UpgradeMessageForm> me = (JspView<UpgradeMessageForm>) HttpView.currentView();
+    JspView<UpgradeMessageForm> me = HttpView.currentView();
     UpgradeMessageForm form = me.getModelBean();
 %>
 
@@ -33,7 +33,7 @@
     <table>
         <tr>
             <td>
-                Current build date:
+                <label for="currentBuildDateInput">Current build date:</label>
             </td>
             <%
                 Date buildDate = DateUtil.getDateOnly(form.getCurrentBuildDate());
@@ -41,39 +41,55 @@
                 String strDate = null != buildDate ? sdf.format(buildDate) : "";
             %>
             <td>
-                <input type="date" size="6" name="currentBuildDate" value="<%= h(strDate) %>"/>
+                <input type="date" size="6" id="currentBuildDateInput" name="currentBuildDate" value="<%= h(strDate) %>"/>
             </td>
         </tr>
         <tr>
             <td>
-                Upgrade message (HTML allowed):
+                <label for="messageInput">Upgrade message (HTML allowed):</label>
             </td>
             <td>
-                <textarea rows="5" cols="50" name="message"><%=h(form.getMessage())%></textarea>
-            </td>
-        </tr>
-        <tr>
-            <td>
-                Create issue URL:
-            </td>
-            <td>
-                <input type="text" size="50" name="createIssueURL" value="<%=h(form.getCreateIssueURL())%>"/>
+                <textarea rows="5" cols="50" id="messageInput" name="message"><%=h(form.getMessage())%></textarea>
             </td>
         </tr>
         <tr>
             <td>
-                Issues container path:
+                <label for="createIssueURLInput">Create issue URL:</label>
             </td>
             <td>
-                <input type="text" size="50" name="issuesContainer" value="<%=h(form.getIssuesContainer())%>"/>
+                <input type="text" size="50" id="createIssueURLInput" name="createIssueURL" value="<%=h(form.getCreateIssueURL())%>"/>
             </td>
         </tr>
         <tr>
             <td>
-                Marketing message (HTML allowed):
+                <label for="issuesContainerInput">Issues container path:</label>
             </td>
             <td>
-                <textarea rows="5" cols="50" name="marketingMessage"><%=h(form.getMarketingMessage())%></textarea>
+                <input type="text" size="50" id="issuesContainerInput" name="issuesContainer" value="<%=h(form.getIssuesContainer())%>"/>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <label for="marketingMessageInput">Marketing message (HTML allowed):</label>
+            </td>
+            <td>
+                <textarea rows="5" cols="50" id="marketingMessageInput" name="marketingMessage"><%=h(form.getMarketingMessage())%></textarea>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <label for="statusCakeApiKeyInput">StatusCake API Key:</label>
+            </td>
+            <td>
+                <input type="text" size="50" id="statusCakeApiKeyInput" name="statusCakeApiKey" <% if(form.getStatusCakeApiKey() != null) { %>placeholder="API key set. Overwrite with new value" <% } %>/>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <label for="uptimeContainerInput">Container with uptime lists:</label>
+            </td>
+            <td>
+                <input type="text" size="50" id="uptimeContainerInput" name="uptimeContainer"  value="<%=h(form.getUptimeContainer())%>"/>
             </td>
         </tr>
         <tr>

--- a/mothership/src/org/labkey/mothership/query/MothershipSchema.java
+++ b/mothership/src/org/labkey/mothership/query/MothershipSchema.java
@@ -356,7 +356,7 @@ public class MothershipSchema extends UserSchema
         result.wrapAllColumns(true);
         result.getMutableColumnOrThrow("StackTrace").setDisplayColumnFactory(StackTraceDisplayColumn::new);
 
-        String path = MothershipManager.get().getIssuesContainer(getContainer());
+        String path = MothershipManager.get().getIssuesContainer();
         ActionURL issueURL = PageFlowUtil.urlProvider(IssuesUrls.class).getDetailsURL(ContainerManager.getForPath(path));
         issueURL.addParameter("issueId", "${BugNumber}");
         result.getMutableColumnOrThrow("BugNumber").setURL(StringExpressionFactory.createURL(issueURL));

--- a/mothership/src/org/labkey/mothership/statuscake/History.java
+++ b/mothership/src/org/labkey/mothership/statuscake/History.java
@@ -1,0 +1,33 @@
+package org.labkey.mothership.statuscake;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+
+public record History(Server s, LocalDateTime start, LocalDateTime end) {
+    public long getDuration() {
+        if (end == null) {
+            return -1;
+        }
+        ZoneId zoneId = ZoneId.systemDefault(); // You can use any ZoneId
+        Instant instant1 = start.atZone(zoneId).toInstant();
+        Instant instant2 = end.atZone(zoneId).toInstant();
+
+        // Calculate the duration between the two Instants
+        Duration duration = Duration.between(instant1, instant2);
+
+        // Get the difference in seconds
+        return duration.toSeconds();
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("serverId", s.getId());
+        result.put("start", start);
+        result.put("duration", getDuration());
+        return result;
+    }
+}

--- a/mothership/src/org/labkey/mothership/statuscake/Server.java
+++ b/mothership/src/org/labkey/mothership/statuscake/Server.java
@@ -1,0 +1,43 @@
+package org.labkey.mothership.statuscake;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class Server {
+    private final String _id;
+    private final String _name;
+    private final List<String> _tags;
+    private LocalDateTime _firstUse;
+
+    public Server(String id, String name, List<String> tags) {
+        _id = id;
+        _name = name;
+        _tags = tags;
+    }
+
+    public void checkFirstUse(LocalDateTime time) {
+        if (_firstUse == null || time.isBefore(_firstUse)) {
+            _firstUse = time;
+        }
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> result = new HashMap<>();
+        result.put("id", _id);
+        result.put("name", _name);
+        result.put("tags", String.join(", ", _tags));
+        result.put("firstUse", _firstUse);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Server: " + _name;
+    }
+
+    public String getId() {
+        return _id;
+    }
+}

--- a/mothership/src/org/labkey/mothership/statuscake/StatusCakeMaintenanceTask.java
+++ b/mothership/src/org/labkey/mothership/statuscake/StatusCakeMaintenanceTask.java
@@ -1,0 +1,287 @@
+package org.labkey.mothership.statuscake;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.DuplicateKeyException;
+import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QueryUpdateServiceException;
+import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.User;
+import org.labkey.api.util.SystemMaintenance;
+import org.labkey.api.util.UnexpectedException;
+import org.labkey.mothership.MothershipManager;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.ResolverStyle;
+import java.time.temporal.ChronoField;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.labkey.api.query.QueryUpdateService.ConfigParameters.BulkLoad;
+
+/**
+ * Pulls info from StatusCake via their API to populate three lists. Calculates monthly percent uptimes for each server.
+ */
+public class StatusCakeMaintenanceTask implements SystemMaintenance.MaintenanceTask
+{
+    @Override
+    public String getDescription()
+    {
+        return "Pull data from StatusCake API to populate lists that track server uptime";
+    }
+
+    @Override
+    public String getName()
+    {
+        return "StatusCake";
+    }
+
+    @Override
+    public boolean isEnabledByDefault()
+    {
+        return false;
+    }
+
+    static final DateTimeFormatter yearMonthParser = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(ChronoField.YEAR, 4)
+            .appendLiteral('-')
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2).toFormatter();
+
+    static final DateTimeFormatter rfc3339Parser = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendValue(ChronoField.YEAR, 4)
+            .appendLiteral('-')
+            .appendValue(ChronoField.MONTH_OF_YEAR, 2)
+            .appendLiteral('-')
+            .appendValue(ChronoField.DAY_OF_MONTH, 2)
+            .appendLiteral('T')
+            .appendValue(ChronoField.HOUR_OF_DAY, 2)
+            .appendLiteral(':')
+            .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+            .appendLiteral(':')
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+            .optionalStart()
+            .appendFraction(ChronoField.NANO_OF_SECOND, 2, 9, true) //2nd parameter: 2 for JRE (8, 11 LTS), 1 for JRE (17 LTS)
+            .optionalEnd()
+            .appendOffset("+HH:MM","Z")
+            .toFormatter()
+            .withResolverStyle(ResolverStyle.STRICT)
+            .withChronology(IsoChronology.INSTANCE);
+
+    @Override
+    public void run(Logger log)
+    {
+        String statusCakeAPIKey = MothershipManager.get().getStatusCakeApiKey();
+        if (statusCakeAPIKey == null)
+        {
+            log.error("No StatusCake API key set");
+            return;
+        }
+
+        String containerPath = MothershipManager.get().getUptimeContainer();
+
+        if (containerPath == null)
+        {
+            log.error("No target container path set for StatusCake maintenance task");
+            return;
+        }
+
+        Container targetContainer = ContainerManager.getForPath(containerPath);
+        if (targetContainer == null)
+        {
+            log.error("No such target container " + containerPath + " found for StatusCake maintenance task");
+            return;
+        }
+
+        User user = User.getAdminServiceUser();
+        UserSchema listSchema = QueryService.get().getUserSchema(user, targetContainer, "lists");
+        TableInfo serversTable = listSchema.getTable("StatusCakeServers");
+        if (serversTable == null)
+        {
+            log.error("No StatusCakeServers table");
+            return;
+        }
+        TableInfo downtimeTable = listSchema.getTable("StatusCakeDowntime");
+        if (downtimeTable == null)
+        {
+            log.error("No StatusCakeDowntime table");
+            return;
+        }
+        TableInfo yearMonthsTable = listSchema.getTable("StatusCakeYearMonths");
+        if (yearMonthsTable == null)
+        {
+            log.error("No StatusCakeYearMonths table");
+            return;
+        }
+
+        List<Map<String, Object>> serverRows = new ArrayList<>();
+        List<Map<String, Object>> historyRows = new ArrayList<>();
+
+        LocalDateTime since = LocalDateTime.of(2022, 1, 1, 0, 0, 0);
+
+        int limit = 100;
+        AtomicInteger rowsReturned = new AtomicInteger();
+        int page = 1;
+
+        do
+        {
+            try (CloseableHttpClient client = HttpClients.createDefault())
+            {
+                ClassicHttpRequest httpGet = ClassicRequestBuilder.get("https://api.statuscake.com/v1/uptime?limit=" + limit + "&page=" + page)
+                        .build();
+                httpGet.setHeader("Authorization", "Bearer " + statusCakeAPIKey);
+
+                page++;
+
+                client.execute(httpGet, response -> {
+                    final HttpEntity entity1 = response.getEntity();
+
+                    try (Reader reader = new InputStreamReader(entity1.getContent(), StandardCharsets.UTF_8))
+                    {
+                        JSONObject o = new JSONObject(new JSONTokener(reader));
+                        JSONArray data = o.getJSONArray("data");
+                        rowsReturned.set(data.length());
+                        for (int i = 0; i < data.length(); i++)
+                        {
+                            JSONObject check = data.getJSONObject(i);
+                            String id = check.getString("id");
+                            String name = check.getString("name");
+                            List tags = check.getJSONArray("tags").toList();
+                            Server s = new Server(id, name, tags);
+
+                            List<History> history = getUptime(s, client, since, statusCakeAPIKey);
+                            log.info("Fetched " + s + " with " + history.size() + " history rows");
+
+                            serverRows.add(s.toMap());
+                            historyRows.addAll(history.stream().map(History::toMap).toList());
+                        }
+                    }
+                    EntityUtils.consume(entity1);
+                    return null;
+                });
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+        while (limit == rowsReturned.get());
+
+        try
+        {
+            log.info("Truncating lists");
+            serversTable.getUpdateService().truncateRows(user, targetContainer, null, null);
+            downtimeTable.getUpdateService().truncateRows(user, targetContainer, null, null);
+            yearMonthsTable.getUpdateService().truncateRows(user, targetContainer, null, null);
+
+            insertRows(log, serversTable, user, targetContainer, serverRows);
+            insertRows(log, downtimeTable, user, targetContainer, historyRows);
+            insertRows(log, yearMonthsTable, user, targetContainer, createYearMonthRows(since));
+        }
+        catch (BatchValidationException | QueryUpdateServiceException | SQLException | DuplicateKeyException e)
+        {
+            throw UnexpectedException.wrap(e);
+        }
+    }
+
+    private static @NotNull List<Map<String, Object>> createYearMonthRows(LocalDateTime since)
+    {
+        List<Map<String, Object>> yearMonthRows = new ArrayList<>();
+        LocalDateTime month = since;
+        int monthIndex = 1;
+        while (month.isBefore(LocalDateTime.now()))
+        {
+            yearMonthRows.add(Map.of("YearMonth", yearMonthParser.format(month), "MonthIndex", monthIndex++));
+            month = month.plusMonths(1);
+        }
+        return yearMonthRows;
+    }
+
+    private void insertRows(Logger log, TableInfo table, User user, Container targetContainer, List<Map<String, Object>> rows) throws DuplicateKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
+    {
+        log.info("Populating " + table.getName() + " with " + rows.size() + " rows");
+        BatchValidationException errors = new BatchValidationException();
+        // Skip detailed audit via BulkLoad
+        table.getUpdateService().insertRows(user, targetContainer, rows, errors, Map.of(BulkLoad, true), null);
+        if (errors.hasErrors())
+        {
+            throw errors;
+        }
+    }
+
+    private static List<History> getUptime(Server server, CloseableHttpClient client, LocalDateTime since, String statusCakeAPIKey) throws IOException
+    {
+        Instant instant = since.toInstant(ZoneOffset.UTC);
+
+        int limit = 100;
+
+        // Limit to data from 2022 and later
+        ClassicHttpRequest httpGet = ClassicRequestBuilder.get("https://api.statuscake.com/v1/uptime/" + server.getId() + "/periods?limit=" + limit + "&after=" + (instant.toEpochMilli() / 1000))
+                .build();
+        httpGet.setHeader("Authorization", "Bearer " + statusCakeAPIKey);
+
+        List<History> result = new ArrayList<>();
+
+        client.execute(httpGet, response -> {
+            final HttpEntity entity1 = response.getEntity();
+            if (response.getCode() != 200)
+            {
+                throw new RuntimeException("Bad response " + response.getCode() + " for " + httpGet.getPath());
+            }
+
+            try (Reader reader = new InputStreamReader(entity1.getContent(), StandardCharsets.UTF_8))
+            {
+                JSONObject o = new JSONObject(new JSONTokener(reader));
+                JSONArray data = o.getJSONArray("data");
+                for (int i = 0; i < data.length(); i++)
+                {
+                    JSONObject check = data.getJSONObject(i);
+                    String status = check.getString("status");
+                    LocalDateTime start = LocalDateTime.parse(check.getString("created_at"), rfc3339Parser);
+                    LocalDateTime end = check.has("ended_at") ? LocalDateTime.parse(check.getString("ended_at"), rfc3339Parser) : null;
+                    server.checkFirstUse(start);
+                    if ("down".equalsIgnoreCase(status))
+                    {
+                        History history = new History(server, start, end);
+                        result.add(history);
+                    }
+                }
+            }
+            return null;
+        });
+
+        if (result.size() == limit)
+        {
+            History h = result.get(result.size() - 1);
+            result.addAll(getUptime(server, client, h.end(), statusCakeAPIKey));
+        }
+
+        return result;
+    }
+}

--- a/mothership/src/org/labkey/mothership/statuscake/StatusCakeMaintenanceTask.java
+++ b/mothership/src/org/labkey/mothership/statuscake/StatusCakeMaintenanceTask.java
@@ -143,6 +143,7 @@ public class StatusCakeMaintenanceTask implements SystemMaintenance.MaintenanceT
         List<Map<String, Object>> serverRows = new ArrayList<>();
         List<Map<String, Object>> historyRows = new ArrayList<>();
 
+        // Limit to data from 2022 and later
         LocalDateTime since = LocalDateTime.of(2022, 1, 1, 0, 0, 0);
 
         int limit = 100;
@@ -241,7 +242,6 @@ public class StatusCakeMaintenanceTask implements SystemMaintenance.MaintenanceT
 
         int limit = 100;
 
-        // Limit to data from 2022 and later
         ClassicHttpRequest httpGet = ClassicRequestBuilder.get("https://api.statuscake.com/v1/uptime/" + server.getId() + "/periods?limit=" + limit + "&after=" + (instant.toEpochMilli() / 1000))
                 .build();
         httpGet.setHeader("Authorization", "Bearer " + statusCakeAPIKey);


### PR DESCRIPTION
#### Rationale
Instead of using a standalone script that has to be run manually, it'll be more convenient to have a nightly sync of uptime data from StatusCake to labkey.org. As a system maintenance task, it can also be run on demand.

#### Changes
- New maintenance task that extracts data from StatusCake and inserts into three lists
- API key and target container via the existing Mothership config page