### PR TITLE
Issue 51904: Strict-Transport-Security header when HTTPS is required

### DIFF
--- a/api/src/org/labkey/api/security/AuthFilter.java
+++ b/api/src/org/labkey/api/security/AuthFilter.java
@@ -125,49 +125,51 @@ public class AuthFilter implements Filter
             }
         }
 
-        // No startup failure, so check for SSL redirection
-        boolean sslRequired = AppProps.getInstance().isSSLRequired();
-        if (!req.getScheme().equalsIgnoreCase("https") && sslRequired)
+        if (AppProps.getInstance().isSSLRequired())
         {
-            // We can't redirect posts (we'll lose the post body), so return an error code
-            if ("post".equalsIgnoreCase(req.getMethod()))
+            // No startup failure, so check for SSL redirection
+            if (!req.getScheme().equalsIgnoreCase("https"))
             {
-                resp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Can't POST to an http URL; POSTs to this server require https");
+                // We can't redirect posts (we'll lose the post body), so return an error code
+                if ("post".equalsIgnoreCase(req.getMethod()))
+                {
+                    resp.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "Can't POST to an http URL; POSTs to this server require https");
+                    return;
+                }
+
+                StringBuffer originalURL = req.getRequestURL();
+                if (!StringUtils.isBlank(req.getQueryString()))
+                {
+                    originalURL.append("?");
+                    originalURL.append(req.getQueryString());
+                }
+                URL url = new URL(originalURL.toString());
+                int port = AppProps.getInstance().getSSLPort();
+
+                // Check the SSL configuration if this is the first time doing an SSL redirect. Note: The redirect and check must
+                // happen before ensureFirstRequestHandled() so AppProps gets initialized with the SSL scheme & port. That means
+                // this check can't be handled in a FirstRequestListener.
+                if (!_sslChecked)
+                {
+                    HttpsUtil.checkSslRedirectConfiguration(req, port);
+                    _sslChecked = true;
+                }
+
+                if (port == 443)
+                {
+                    port = -1;
+                }
+                url = new URL("https", url.getHost(), port, url.getFile());
+                // Use 301 redirect instead of a 302 to indicate it's a permanent move
+                resp.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+                resp.setHeader("Location", resp.encodeRedirectURL(url.toString()));
                 return;
             }
-
-            StringBuffer originalURL = req.getRequestURL();
-            if (!StringUtils.isBlank(req.getQueryString()))
+            else if (!AppProps.getInstance().isDevMode())
             {
-                originalURL.append("?");
-                originalURL.append(req.getQueryString());
+                // Issue 51904: Strict-Transport-Security header when HTTPS is required
+                resp.setHeader("Strict-Transport-Security", "max-age=31536000");
             }
-            URL url = new URL(originalURL.toString());
-            int port = AppProps.getInstance().getSSLPort();
-
-            // Check the SSL configuration if this is the first time doing an SSL redirect. Note: The redirect and check must
-            // happen before ensureFirstRequestHandled() so AppProps gets initialized with the SSL scheme & port. That means
-            // this check can't be handled in a FirstRequestListener.
-            if (!_sslChecked)
-            {
-                HttpsUtil.checkSslRedirectConfiguration(req, port);
-                _sslChecked = true;
-            }
-
-            if (port == 443)
-            {
-                port = -1;
-            }
-            url = new URL("https", url.getHost(), port, url.getFile());
-            // Use 301 redirect instead of a 302 to indicate it's a permanent move
-            resp.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
-            resp.setHeader("Location", resp.encodeRedirectURL(url.toString()));
-            return;
-        }
-
-        if (sslRequired)
-        {
-            resp.setHeader("Strict-Transport-Security", "max-age=31536000");
         }
 
         // allow CSRFUtil early access to req/resp if it wants to write cookies

--- a/api/src/org/labkey/api/security/AuthFilter.java
+++ b/api/src/org/labkey/api/security/AuthFilter.java
@@ -126,7 +126,8 @@ public class AuthFilter implements Filter
         }
 
         // No startup failure, so check for SSL redirection
-        if (!req.getScheme().equalsIgnoreCase("https") && AppProps.getInstance().isSSLRequired())
+        boolean sslRequired = AppProps.getInstance().isSSLRequired();
+        if (!req.getScheme().equalsIgnoreCase("https") && sslRequired)
         {
             // We can't redirect posts (we'll lose the post body), so return an error code
             if ("post".equalsIgnoreCase(req.getMethod()))
@@ -162,6 +163,11 @@ public class AuthFilter implements Filter
             resp.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
             resp.setHeader("Location", resp.encodeRedirectURL(url.toString()));
             return;
+        }
+
+        if (sslRequired)
+        {
+            resp.setHeader("Strict-Transport-Security", "max-age=31536000");
         }
 
         // allow CSRFUtil early access to req/resp if it wants to write cookies

--- a/api/src/org/labkey/api/security/AuthFilter.java
+++ b/api/src/org/labkey/api/security/AuthFilter.java
@@ -168,6 +168,7 @@ public class AuthFilter implements Filter
             else if (!AppProps.getInstance().isDevMode())
             {
                 // Issue 51904: Strict-Transport-Security header when HTTPS is required
+                // Avoid setting when in dev mode to make it easier to toggle HTTPS on and off again for local deployments
                 resp.setHeader("Strict-Transport-Security", "max-age=31536000");
             }
         }


### PR DESCRIPTION
#### Rationale
We have many protections in place already to ensure that traffic is always over HTTPS. We can set this header to catch an edge case for an initial http:// request on a third-party link.

#### Changes
- Set a long-lived `Strict-Transport-Security` header when the server is already requiring HTTPS connections