### PR TITLE
AuthenticationProvider refactor

### DIFF
--- a/api/src/org/labkey/api/audit/query/AbstractAuditDomainKind.java
+++ b/api/src/org/labkey/api/audit/query/AbstractAuditDomainKind.java
@@ -294,12 +294,6 @@ public abstract class AbstractAuditDomainKind extends DomainKind<JSONObject>
     }
 
     @Override
-    public DbSchemaType getSchemaType()
-    {
-        return DbSchemaType.Provisioned;
-    }
-
-    @Override
     public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> names = new HashSet<>();

--- a/api/src/org/labkey/api/exp/property/AbstractDomainKind.java
+++ b/api/src/org/labkey/api/exp/property/AbstractDomainKind.java
@@ -202,8 +202,8 @@ public abstract class AbstractDomainKind<T> extends DomainKind<T>
         if (domain.getStorageTableName() != null)
         {
             String table = domain.getStorageTableName();
-            allRowsSQL.append("SELECT * FROM " + getStorageSchemaName() + "." + table);
-            nonBlankRowsSQL.append("SELECT * FROM " + getStorageSchemaName() + "." + table + " x WHERE ");
+            allRowsSQL.append("SELECT * FROM ").append(getStorageSchemaName()).append(".").append(table);
+            nonBlankRowsSQL.append("SELECT * FROM ").append(getStorageSchemaName()).append(".").append(table).append(" x WHERE ");
             SqlDialect dialect = CoreSchema.getInstance().getSqlDialect();
             // Issue 17183 - Postgres uses lower case column names when quoting is required
             nonBlankRowsSQL.append("x.");

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -59,7 +59,7 @@ abstract public class DomainKind<T> implements Handler<String>
 
     /**
      * Return a class of DomainKind's bean which carries domain specific properties.
-     * This class will used when marshalling/unmarshalling via Jackson during Create and Save/Update Domain
+     * This class will be used when marshalling/unmarshalling via Jackson during Create and Save/Update Domain
      * @return Class of DomainKind's bean with domain specific properties
      */
     abstract public Class<? extends T> getTypeClass();

--- a/api/src/org/labkey/api/exp/property/TestDomainKind.java
+++ b/api/src/org/labkey/api/exp/property/TestDomainKind.java
@@ -40,11 +40,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
- * User: tgaluhn
- * Date: 1/30/2017
- *
  * For the StorageProvisioner integration tests, when the Study module is not present.
- *
  */
 public class TestDomainKind extends DomainKind<JSONObject>
 {
@@ -197,12 +193,6 @@ public class TestDomainKind extends DomainKind<JSONObject>
     public Set<PropertyStorageSpec.ForeignKey> getPropertyForeignKeys(Container container)
     {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public DbSchemaType getSchemaType()
-    {
-        return DbSchemaType.Provisioned;
     }
 
     @Override

--- a/api/src/org/labkey/api/issues/AbstractIssuesListDefDomainKind.java
+++ b/api/src/org/labkey/api/issues/AbstractIssuesListDefDomainKind.java
@@ -173,12 +173,6 @@ public abstract class AbstractIssuesListDefDomainKind extends AbstractDomainKind
     }
 
     @Override
-    public DbSchemaType getSchemaType()
-    {
-        return DbSchemaType.Provisioned;
-    }
-
-    @Override
     public String getStorageSchemaName()
     {
         return IssuesSchema.ISSUE_DEF_SCHEMA_NAME;

--- a/api/src/org/labkey/api/security/AuthenticationConfiguration.java
+++ b/api/src/org/labkey/api/security/AuthenticationConfiguration.java
@@ -2,7 +2,6 @@ package org.labkey.api.security;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -23,6 +22,7 @@ import org.labkey.api.security.permissions.RequireSecondaryAuthenticationPermiss
 import org.labkey.api.settings.WriteableAppProps;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
 
@@ -39,7 +39,7 @@ import static org.labkey.api.security.SsoSaveConfigurationAction.logLogoAction;
 
 public interface AuthenticationConfiguration<AP extends AuthenticationProvider> extends AttachmentParent
 {
-    Logger LOG = LogManager.getLogger(AuthenticationConfiguration.class);
+    Logger LOG = LogHelper.getLogger(AuthenticationConfiguration.class, "Authentication configuration loading and saving issues");
 
     // All the AuthenticationProvider interfaces. This list is used by AuthenticationProviderCache to filter collections of providers.
     List<Class<? extends AuthenticationConfiguration>> ALL_CONFIGURATION_INTERFACES = Arrays.asList(

--- a/api/src/org/labkey/api/security/AuthenticationConfigurationCache.java
+++ b/api/src/org/labkey/api/security/AuthenticationConfigurationCache.java
@@ -13,6 +13,7 @@ import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.security.AuthenticationConfiguration.PrimaryAuthenticationConfiguration;
+import org.labkey.api.security.AuthenticationProvider.ConfigurableAuthenticationProvider;
 import org.labkey.api.util.logging.LogHelper;
 
 import java.util.ArrayList;
@@ -105,14 +106,14 @@ public class AuthenticationConfigurationCache
             if (null == provider)
             {
                 String description = (String)map.get("Description");
-                LOG.warn("A saved authentication configuration requires the \"" + providerName + "\" authentication provider, but that provider is not present in this deployment. Authentication via " + (null != description ? "\"" + description + "\"" : "this mechanism") + " will not be available.");
+                LOG.warn("A saved authentication configuration requires the \"{}\" authentication provider, but that provider is not present in this deployment. Authentication via {} will not be available.", providerName, null != description ? "\"" + description + "\"" : "this mechanism");
                 return null;
             }
 
-            if (!(provider instanceof AuthenticationConfigurationFactory))
-                throw new IllegalStateException("AuthenticationProvider does not implement AuthenticationConfigurationFactory: " + provider.getClass().getName());
+            if (!(provider instanceof ConfigurableAuthenticationProvider<?> configurable))
+                throw new IllegalStateException("AuthenticationProvider does not implement ConfigurableAuthenticationProvider: " + provider.getClass().getName());
 
-            return ((AuthenticationConfigurationFactory<?>)provider).getAuthenticationConfiguration(new ConfigurationSettings(map));
+            return configurable.getAuthenticationConfiguration(new ConfigurationSettings(map));
         }
 
         private void addConfiguration(AuthenticationConfiguration<?> configuration)

--- a/api/src/org/labkey/api/security/AuthenticationConfigurationFactory.java
+++ b/api/src/org/labkey/api/security/AuthenticationConfigurationFactory.java
@@ -1,9 +1,0 @@
-package org.labkey.api.security;
-
-import org.jetbrains.annotations.NotNull;
-
-public interface AuthenticationConfigurationFactory<AC extends AuthenticationConfiguration<?>>
-{
-    // Translate a single ConfigurationSettings into an AuthenticationConfiguration
-    AC getAuthenticationConfiguration(@NotNull ConfigurationSettings cs);
-}

--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -118,85 +118,93 @@ public interface AuthenticationProvider
         return "Description of this " + name + " configuration. Providing a description is required to update an existing configuration and strongly recommended when creating a new configuration.";
     }
 
-    // Retrieves all the startup properties in the specified categories, populates them into a form, and saves the form
-    default <FORM extends SaveConfigurationForm, AC extends AuthenticationConfiguration, T extends Enum<T> & StartupProperty> void saveStartupProperties(String category, Class<FORM> formClass, Class<AC> configurationClass, Class<T> type)
+    interface ConfigurableAuthenticationProvider<AC extends AuthenticationConfiguration<?>> extends AuthenticationProvider
     {
-        assert Arrays.stream(type.getEnumConstants()).filter(c -> c.name().equals("Description") || c.name().equals("Enabled")).count() == 2 :
-            type.getName() + " does not define required Description and Enabled constants!";
+        Class<AC> getConfigurationClass();
 
-        ModuleLoader.getInstance().handleStartupProperties(new StandardStartupPropertyHandler<>(category, type)
+        // Translates a single ConfigurationSettings into the appropriate AuthenticationConfiguration
+        AC getAuthenticationConfiguration(@NotNull ConfigurationSettings cs);
+
+        // Retrieves all the startup properties in the specified categories, populates them into a form, and saves the form
+        default <FORM extends SaveConfigurationForm, T extends Enum<T> & StartupProperty> void saveStartupProperties(String category, Class<FORM> formClass, Class<T> type)
         {
-            @Override
-            public void handle(Map<T, StartupPropertyEntry> properties)
+            assert Arrays.stream(type.getEnumConstants()).filter(c -> c.name().equals("Description") || c.name().equals("Enabled")).count() == 2 :
+                type.getName() + " does not define required Description and Enabled constants!";
+
+            ModuleLoader.getInstance().handleStartupProperties(new StandardStartupPropertyHandler<>(category, type)
             {
-                if (!properties.isEmpty())
+                @Override
+                public void handle(Map<T, StartupPropertyEntry> properties)
                 {
-                    Map<String, String> map = properties.entrySet().stream()
-                        .collect(Collectors.toMap(e-> e.getKey().getPropertyName(), e->e.getValue().getValue()));
-
-                    ObjectFactory<FORM> factory = ObjectFactory.Registry.getFactory(formClass);
-                    FORM form = factory.fromMap(map);
-
-                    // If description is provided in the startup properties file and an existing configuration for this provider
-                    // matches that description then update the existing configuration. If not, create a new configuration. #39474
-                    final String description;
-
-                    if (null != form.getDescription())
+                    if (!properties.isEmpty())
                     {
-                        description = form.getDescription();
-                    }
-                    else
-                    {
-                        description = getName() + " Configuration";
-                        form.setDescription(description);
-                        LOG.info("No description property was provided for " + getName() + " configuration; using generic description \"" + description + "\".");
-                    }
+                        Map<String, String> map = properties.entrySet().stream()
+                            .collect(Collectors.toMap(e-> e.getKey().getPropertyName(), e->e.getValue().getValue()));
 
-                    List<String> existingDescriptions = AuthenticationConfigurationCache.getConfigurations(configurationClass).stream()
-                        .map(AuthenticationConfiguration::getDescription)
-                        .toList();
+                        ObjectFactory<FORM> factory = ObjectFactory.Registry.getFactory(formClass);
+                        FORM form = factory.fromMap(map);
 
-                    if (!existingDescriptions.isEmpty())
-                        LOG.info("Descriptions of existing " + getName() + " configurations: " + existingDescriptions);
+                        // If description is provided in the startup properties file and an existing configuration for this provider
+                        // matches that description then update the existing configuration. If not, create a new configuration. #39474
+                        final String description;
 
-                    AuthenticationConfigurationCache.getConfigurations(configurationClass).stream()
-                        .filter(ac -> ac.getDescription().equals(description))
-                        .map(AuthenticationConfiguration::getRowId)
-                        .findFirst()
-                        .ifPresentOrElse(rowId ->
+                        if (null != form.getDescription())
                         {
-                            form.setRowId(rowId);
-                            LOG.info("Updating existing " + getName() + " configuration with description \"" + description + "\"");
-                        }, () ->
-                            LOG.info("Did not find an existing " + getName() + " configuration with description \"" + description + "\". Creating a new configuration using the specified properties."));
+                            description = form.getDescription();
+                        }
+                        else
+                        {
+                            description = getName() + " Configuration";
+                            form.setDescription(description);
+                            LOG.info("No description property was provided for {} configuration; using generic description \"{}\".", getName(), description);
+                        }
 
-                    AuthenticationConfiguration<?> configuration = SaveConfigurationAction.saveForm(form, null);
-                    configuration.handleStartupProperties(map);
+                        List<String> existingDescriptions = AuthenticationConfigurationCache.getConfigurations(getConfigurationClass()).stream()
+                            .map(AuthenticationConfiguration::getDescription)
+                            .toList();
+
+                        if (!existingDescriptions.isEmpty())
+                            LOG.info("Descriptions of existing {} configurations: {}", getName(), existingDescriptions);
+
+                        AuthenticationConfigurationCache.getConfigurations(getConfigurationClass()).stream()
+                            .filter(ac -> ac.getDescription().equals(description))
+                            .map(AuthenticationConfiguration::getRowId)
+                            .findFirst()
+                            .ifPresentOrElse(rowId ->
+                            {
+                                form.setRowId(rowId);
+                                LOG.info("Updating existing {} configuration with description \"{}\"", getName(), description);
+                            }, () ->
+                                LOG.info("Did not find an existing {} configuration with description \"{}\". Creating a new configuration using the specified properties.", getName(), description));
+
+                        AuthenticationConfiguration<?> configuration = SaveConfigurationAction.saveForm(form, null);
+                        configuration.handleStartupProperties(map);
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
-    interface PrimaryAuthenticationProvider<AC extends PrimaryAuthenticationConfiguration<?>> extends AuthenticationProvider, AuthenticationConfigurationFactory<AC>
+    interface PrimaryAuthenticationProvider<AC extends PrimaryAuthenticationConfiguration<? extends PrimaryAuthenticationProvider<?>>> extends ConfigurableAuthenticationProvider<AC>
     {
     }
 
-    interface LoginFormAuthenticationProvider<AC extends LoginFormAuthenticationConfiguration<?>> extends PrimaryAuthenticationProvider<AC>, AuthenticationConfigurationFactory<AC>
+    interface LoginFormAuthenticationProvider<AC extends LoginFormAuthenticationConfiguration<?>> extends PrimaryAuthenticationProvider<AC>
     {
         // id and password will not be blank (not null, not empty, not whitespace only)
         @NotNull AuthenticationResponse authenticate(AC configuration, @NotNull String id, @NotNull String password, URLHelper returnURL) throws InvalidEmailException;
     }
 
-    interface SSOAuthenticationProvider<SSO extends SSOAuthenticationConfiguration<?>> extends PrimaryAuthenticationProvider<SSO>, AuthenticationConfigurationFactory<SSO>
+    interface SSOAuthenticationProvider<SSO extends SSOAuthenticationConfiguration<? extends SSOAuthenticationProvider<SSO>>> extends PrimaryAuthenticationProvider<SSO>
     {
         @Override
-        default <FORM extends SaveConfigurationForm, AC extends AuthenticationConfiguration, T extends Enum<T> & StartupProperty> void saveStartupProperties(String category, Class<FORM> formClass, Class<AC> configurationClass, Class<T> type)
+        default <FORM extends SaveConfigurationForm, T extends Enum<T> & StartupProperty> void saveStartupProperties(String category, Class<FORM> formClass, Class<T> type)
         {
             // SSO authentication provider StartupProperty enums must define AutoRedirect, HeaderLogo, and LoginPageLogo constants
             assert Arrays.stream(type.getEnumConstants()).filter(c -> c.name().equals("AutoRedirect") || c.name().equals("HeaderLogo") || c.name().equals("LoginPageLogo")).count() == 3 :
                 type.getName() + " does not define required AutoRedirect, HeaderLogo, and LoginPageLogo constants!";
 
-            PrimaryAuthenticationProvider.super.saveStartupProperties(category, formClass, configurationClass, type);
+            PrimaryAuthenticationProvider.super.saveStartupProperties(category, formClass, type);
         }
 
         static String getStartupLogoDescription(String type, String name)
@@ -207,7 +215,7 @@ public interface AuthenticationProvider
         }
     }
 
-    interface RequestAuthenticationProvider extends PrimaryAuthenticationProvider
+    interface RequestAuthenticationProvider<AC extends PrimaryAuthenticationConfiguration<?>> extends PrimaryAuthenticationProvider<AC>
     {
         @NotNull AuthenticationResponse authenticate(@NotNull HttpServletRequest request);
     }
@@ -228,7 +236,7 @@ public interface AuthenticationProvider
         @Nullable SecurityMessage getAPIResetPasswordMessage(User user, boolean isAdminCopy);
     }
 
-    interface SecondaryAuthenticationProvider<SAC extends SecondaryAuthenticationConfiguration<?>> extends AuthenticationProvider, AuthenticationConfigurationFactory<SAC>
+    interface SecondaryAuthenticationProvider<SAC extends SecondaryAuthenticationConfiguration<?>> extends ConfigurableAuthenticationProvider<SAC>
     {
         String REQUIRED_FOR = "requiredFor";
 
@@ -249,13 +257,21 @@ public interface AuthenticationProvider
         }
 
         @Override
-        default <FORM extends SaveConfigurationForm, AC extends AuthenticationConfiguration, T extends Enum<T> & StartupProperty> void saveStartupProperties(String category, Class<FORM> formClass, Class<AC> configurationClass, Class<T> type)
+        default <FORM extends SaveConfigurationForm, T extends Enum<T> & StartupProperty> void saveStartupProperties(String category, Class<FORM> formClass, Class<T> type)
         {
             // Secondary authentication provider StartupProperty enums must define RequiredFor constant
             assert Arrays.stream(type.getEnumConstants()).filter(c -> c.name().equals(REQUIRED_FOR)).count() == 1 :
                 type.getName() + " does not define requiredFor constant!";
 
-            AuthenticationProvider.super.saveStartupProperties(category, formClass, configurationClass, type);
+            ConfigurableAuthenticationProvider.super.saveStartupProperties(category, formClass, type);
+        }
+
+        @Override
+        default boolean allowInsert()
+        {
+            // For all current secondary providers, it makes no sense to have more than one configuration, so prevent
+            // insert if there's already a configuration in place.
+            return AuthenticationConfigurationCache.getConfigurations(getConfigurationClass()).isEmpty();
         }
     }
 
@@ -270,11 +286,6 @@ public interface AuthenticationProvider
          */
         long getUserDelay(String id) throws LoginDisabledException;
 
-        /**
-         * @param request
-         * @param id
-         * @param addCount
-         */
         void addUserDelay(HttpServletRequest request, String id, int addCount);
 
         void resetUserDelay(String id);

--- a/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
@@ -18,7 +18,6 @@ package org.labkey.api.assay;
 
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PropertyStorageSpec;
@@ -116,12 +115,6 @@ public class AssayResultDomainKind extends AssayDomainKind
     public DbSchema getSchema()
     {
         return DbSchema.get(getStorageSchemaName(), getSchemaType());
-    }
-
-    @Override
-    public DbSchemaType getSchemaType()
-    {
-        return DbSchemaType.Provisioned;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/PlateReplicateStatsDomainKind.java
+++ b/assay/src/org/labkey/assay/plate/PlateReplicateStatsDomainKind.java
@@ -6,7 +6,6 @@ import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PropertyStorageSpec;
@@ -80,12 +79,6 @@ public class PlateReplicateStatsDomainKind extends AssayDomainKind
     private DbSchema getSchema()
     {
         return DbSchema.get(getStorageSchemaName(), getSchemaType());
-    }
-
-    @Override
-    public DbSchemaType getSchemaType()
-    {
-        return DbSchemaType.Provisioned;
     }
 
     @Override

--- a/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
+++ b/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
@@ -59,6 +59,12 @@ import static org.labkey.core.login.DbLoginManager.DATABASE_AUTHENTICATION_CATEG
 public class DbLoginAuthenticationProvider implements LoginFormAuthenticationProvider<DbLoginConfiguration>
 {
     @Override
+    public Class<DbLoginConfiguration> getConfigurationClass()
+    {
+        return DbLoginConfiguration.class;
+    }
+
+    @Override
     public DbLoginConfiguration getAuthenticationConfiguration(@NotNull ConfigurationSettings ignored)
     {
         Map<String, Object> properties = Map.of(

--- a/core/src/org/labkey/core/query/ModulesTableInfo.java
+++ b/core/src/org/labkey/core/query/ModulesTableInfo.java
@@ -98,6 +98,7 @@ public class ModulesTableInfo extends SimpleUserSchema.SimpleTable<CoreQuerySche
         addTextColumn("LicenseURL").setHidden(true);
         addTextColumn("VcsRevision");
         addTextColumn("VcsURL");
+        addTextColumn("SourcePath");
         addTextColumn("Dependencies");
         addTextColumn("SupportedDatabases");
 
@@ -200,6 +201,7 @@ public class ModulesTableInfo extends SimpleUserSchema.SimpleTable<CoreQuerySche
             appendStringLiteral(h, cte,",",module.getLicenseUrl());
             appendStringLiteral(h, cte,",",module.getVcsRevision());
             appendStringLiteral(h, cte,",",module.getVcsUrl());
+            appendStringLiteral(h, cte,",",module.getSourcePath());
             appendStringLiteral(h, cte,",",StringUtils.join(module.getModuleDependenciesAsSet(), ", "));
             appendStringLiteral(h, cte,",",module.getSupportedDatabasesSet().toString());
             cte.append(")");
@@ -216,6 +218,7 @@ public class ModulesTableInfo extends SimpleUserSchema.SimpleTable<CoreQuerySche
         cte.append(",Organization, OrganizationURL");
         cte.append(",License, LicenseURL");
         cte.append(",VcsRevision, VcsURL");
+        cte.append(",SourcePath");
         cte.append(",Dependencies, SupportedDatabases");
         cte.append(")\n");
 

--- a/devtools/src/org/labkey/devtools/authentication/TestSecondaryProvider.java
+++ b/devtools/src/org/labkey/devtools/authentication/TestSecondaryProvider.java
@@ -29,6 +29,12 @@ public class TestSecondaryProvider implements SecondaryAuthenticationProvider<Te
     public static final String NAME = "TestSecondary";
 
     @Override
+    public Class<TestSecondaryConfiguration> getConfigurationClass()
+    {
+        return TestSecondaryConfiguration.class;
+    }
+
+    @Override
     public TestSecondaryConfiguration getAuthenticationConfiguration(@NotNull ConfigurationSettings cs)
     {
         return new TestSecondaryConfiguration(this, cs.getStandardSettings(), cs.getProperties());

--- a/devtools/src/org/labkey/devtools/authentication/TestSsoProvider.java
+++ b/devtools/src/org/labkey/devtools/authentication/TestSsoProvider.java
@@ -32,6 +32,12 @@ public class TestSsoProvider implements SSOAuthenticationProvider<TestSsoConfigu
     public static final String NAME = "TestSSO";
 
     @Override
+    public Class<TestSsoConfiguration> getConfigurationClass()
+    {
+        return TestSsoConfiguration.class;
+    }
+
+    @Override
     public TestSsoConfiguration getAuthenticationConfiguration(@NotNull ConfigurationSettings cs)
     {
         return new TestSsoConfiguration(this, cs.getStandardSettings(), cs.getProperties());

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -57,7 +57,6 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DesignDataClassPermission;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
@@ -77,8 +76,6 @@ import java.util.stream.Collectors;
 
 /**
  * DomainKind implementation for data classes, allowing customizable fields to be attached to the based set of columns.
- * User: kevink
- * Date: 9/15/15
  */
 public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindProperties>
 {
@@ -103,7 +100,7 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
 
 
         RESERVED_NAMES = new CaseInsensitiveHashSet(BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()));
-        RESERVED_NAMES.addAll(Arrays.asList(ExpDataClassDataTable.Column.values()).stream().map(ExpDataClassDataTable.Column::name).collect(Collectors.toList()));
+        RESERVED_NAMES.addAll(Arrays.stream(ExpDataClassDataTable.Column.values()).map(ExpDataClassDataTable.Column::name).toList());
         RESERVED_NAMES.add("Container");
         RESERVED_NAMES.add("RunId"); // Issue 50461
 
@@ -252,12 +249,6 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
     }
 
     @Override
-    public DbSchemaType getSchemaType()
-    {
-        return DbSchemaType.Provisioned;
-    }
-
-    @Override
     public String getStorageSchemaName()
     {
         return PROVISIONED_SCHEMA_NAME;
@@ -350,7 +341,7 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
         }
 
         Map<String, String> aliasMap = options.getImportAliasesMap();
-        if (aliasMap != null && aliasMap.size() > 0)
+        if (aliasMap != null && !aliasMap.isEmpty())
         {
             ExpDataClass dataClass = options.getRowId() >= 0 ? ExperimentService.get().getDataClass(options.getRowId()) : null;
             Domain stDomain = dataClass != null ? dataClass.getDomain() : null;

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -17,6 +17,7 @@ package org.labkey.list.model;
 
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.attachments.AttachmentService;
@@ -26,7 +27,6 @@ import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PropertyStorageSpec;
@@ -328,12 +328,6 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
     }
 
     @Override
-    public DbSchemaType getSchemaType()
-    {
-        return DbSchemaType.Provisioned;
-    }
-
-    @Override
     public TableInfo getTableInfo(User user, Container container, String name, @Nullable ContainerFilter cf)
     {
         return new ListQuerySchema(user, container).createTable(name, cf);
@@ -465,8 +459,8 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
     }
 
     @Override
-    public ValidationException updateDomain(GWTDomain<? extends GWTPropertyDescriptor> original, GWTDomain<? extends GWTPropertyDescriptor> update,
-                                            ListDomainKindProperties listProperties, Container container, User user, boolean includeWarnings)
+    public @NotNull ValidationException updateDomain(GWTDomain<? extends GWTPropertyDescriptor> original, GWTDomain<? extends GWTPropertyDescriptor> update,
+                                                     ListDomainKindProperties listProperties, Container container, User user, boolean includeWarnings)
     {
         ValidationException exception;
 

--- a/study/api-src/org/labkey/api/specimen/model/AbstractSpecimenDomainKind.java
+++ b/study/api-src/org/labkey/api/specimen/model/AbstractSpecimenDomainKind.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.data.SQLFragment;
@@ -122,12 +121,6 @@ public abstract class AbstractSpecimenDomainKind extends BaseAbstractDomainKind
     public String getStorageSchemaName()
     {
         return SpecimenTablesProvider.SCHEMA_NAME;
-    }
-
-    @Override
-    public DbSchemaType getSchemaType()
-    {
-        return DbSchemaType.Provisioned;
     }
 
     @Override

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -18,6 +18,7 @@ package org.labkey.study.model;
 
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.compliance.ComplianceService;
@@ -25,7 +26,6 @@ import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PropertyStorageSpec;
@@ -66,7 +66,6 @@ import org.labkey.api.writer.ContainerUser;
 import org.labkey.study.StudySchema;
 import org.labkey.study.assay.StudyPublishManager;
 import org.labkey.study.controllers.StudyController;
-import org.labkey.study.query.DatasetFactory;
 import org.labkey.study.query.StudyQuerySchema;
 
 import java.util.ArrayList;
@@ -83,11 +82,6 @@ import java.util.stream.Collectors;
 
 import static org.labkey.study.model.DatasetDomainKindProperties.TIME_KEY_FIELD_KEY;
 
-/**
- * User: matthewb
- * Date: May 4, 2007
- * Time: 1:01:43 PM
- */
 public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomainKindProperties>
 {
     public final static String LSID_PREFIX = "StudyDataset";
@@ -223,7 +217,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
     public static String generateDomainURI(String name, String id, Container container)
     {
         String objectid = name == null ? "" : name;
-        if (null != objectid && null != id)
+        if (null != id)
         {
             // normalize the object id
             objectid += "-" + id.toLowerCase();
@@ -342,12 +336,6 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
     public String getStorageSchemaName()
     {
         return StudySchema.getInstance().getDatasetSchemaName();
-    }
-
-    @Override
-    public DbSchemaType getSchemaType()
-    {
-        return DbSchemaType.Provisioned;
     }
 
     @Override
@@ -726,8 +714,8 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
     }
 
     @Override
-    public ValidationException updateDomain(GWTDomain<? extends GWTPropertyDescriptor> original, GWTDomain<? extends GWTPropertyDescriptor> update,
-                                            DatasetDomainKindProperties datasetProperties, Container container, User user, boolean includeWarnings)
+    public @NotNull ValidationException updateDomain(GWTDomain<? extends GWTPropertyDescriptor> original, GWTDomain<? extends GWTPropertyDescriptor> update,
+                                                     DatasetDomainKindProperties datasetProperties, Container container, User user, boolean includeWarnings)
     {
         assert original.getDomainURI().equals(update.getDomainURI());
         StudyImpl study = StudyManager.getInstance().getStudy(container);


### PR DESCRIPTION
#### Rationale
Introduce `ConfigurableAuthenticationProvider`, a common interface that `PrimaryAuthenticationProvider` and `SecondaryAuthenticationProvider` extend. This replaces side interface `AuthenticationConfigurationFactory` and provides an appropriate home for `saveStartupProperties()`. It also provides `getConfigurationClass()`, used by saveStartupProperties() and `allowInsert()`. This also cleans up some generics handling.
