### PR TITLE
Issue 40987: Notify list swaps users when display name matches email

### DIFF
--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -1181,10 +1181,16 @@ public class UserManager
         {
             if (null == (name = StringUtils.trimToNull(name)))
                 continue;
-            User u = null;
-            try { u = getUser(new ValidEmail(name)); } catch (ValidEmail.InvalidEmailException ignored) {}
-            if (null == u)
-                u = getUserByDisplayName(name);
+            // First try by display name. See issue 40987
+            User u = getUserByDisplayName(name);
+            if (u == null)
+            {
+                try
+                {
+                    u = getUser(new ValidEmail(name));
+                }
+                catch (ValidEmail.InvalidEmailException ignored) {}
+            }
             parsed.add(null == u ? name : String.valueOf(u.getUserId()));
         }
         return parsed;


### PR DESCRIPTION
#### Rationale
We don't want to swap out users on the notify list when nobody is trying to edit them

#### Changes
- Resolve by display name before attempting by email