### PR TITLE
Don't allow sample type creation for 'name' and 'id' capture groups.

### DIFF
--- a/experiment/src/org/labkey/experiment/pipeline/SampleReloadTask.java
+++ b/experiment/src/org/labkey/experiment/pipeline/SampleReloadTask.java
@@ -118,7 +118,10 @@ public class SampleReloadTask extends PipelineJob.Task<SampleReloadTask.Factory>
             if (sampleType != null)
                 log.info("Sample Type matching the 'name' capture group was resolved : " + sampleName);
             else
-                log.info("Sample Type matching the 'name' capture group was not resolved : " + sampleName);
+            {
+                log.error("Sample Type matching the 'name' capture group was not resolved : " + sampleName);
+                return new RecordedActionSet();
+            }
         }
         else if (params.containsKey(SAMPLE_ID_KEY))
         {
@@ -127,7 +130,10 @@ public class SampleReloadTask extends PipelineJob.Task<SampleReloadTask.Factory>
             if (sampleType != null)
                 log.info("Sample Type matching the 'id' capture group was resolved : " + sampleType.getName());
             else
-                log.info("Sample Type matching the 'id' capture group was not resolved : " + params.get(SAMPLE_ID_KEY));
+            {
+                log.error("Sample Type matching the 'id' capture group was not resolved : " + params.get(SAMPLE_ID_KEY));
+                return new RecordedActionSet();
+            }
         }
 
         if (sampleType == null)


### PR DESCRIPTION
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51269)

#### Rationale
This change brings the sample type file watcher behavior in line with our [documentation](https://www.labkey.org/Documentation/Archive/24.3/wiki-page.view?name=fileWatchTasks#samples). Prior to this change if we couldn't resolve either the specified name or ID to an existing sample type, we would go ahead and create the sample type anyway. This is undesirable for clients when their users make an error with the uploaded file name and force the administrators to clean up sample types inadvertently created.
