### PR TITLE
Issue 51300: on assay run import, don't keep the primary file if the new run failed to save

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -448,12 +448,30 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
             AssayResultsFileWriter<?> resultsFileWriter = new AssayResultsFileWriter<>(context.getProtocol(), run, null);
             resultsFileWriter.cleanupPostedFiles(context.getContainer(), false);
 
+            cleanPrimaryFile(context);
+
             if (e instanceof ExperimentException)
                 throw (ExperimentException)e;
             else
                 throw new ExperimentException(e);
         }
         catch (BatchValidationException e)
+        {
+            throw new ExperimentException(e);
+        }
+    }
+
+    private void cleanPrimaryFile(AssayRunUploadContext<ProviderType> context) throws ExperimentException
+    {
+        try
+        {
+            // Issue 51300: don't keep the primary file if the new run failed to save
+            boolean isReRun = context.getReRunId() != null;
+            FileLike primaryFile = context.getUploadedData().get(AssayDataCollector.PRIMARY_FILE);
+            if (!isReRun && primaryFile != null && primaryFile.exists())
+                primaryFile.delete();
+        }
+        catch (IOException e)
         {
             throw new ExperimentException(e);
         }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51300

When an assay import fails, we leave around the uploaded primary data file in the assaydata dir. We have code that cleans up any posted assay results files. This PR adds to that so that we clean up the primary file as well. Note that if the run is a re-run we do not do this cleanup as we don't want to remove a file that was already used in an existing run.

#### Changes
- saveExperimentRun catch update to delete primary file 
