### PR TITLE
Issue 51776: LKSM: Updating a sample type name and only changing casing errors

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -7812,7 +7812,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     ) throws ExperimentException
     {
         name = StringUtils.trimToNull(name);
-        validateDataClassName(c, u, name);
+        validateDataClassName(c, u, name, false);
         validateDataClassOptions(c, u, options);
 
         Lsid lsid = getDataClassLsid(c);
@@ -7934,7 +7934,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             newName = StringUtils.trimToNull(options.getName());
             if (!oldDataClassName.equals(newName))
             {
-                validateDataClassName(c, u, newName);
+                validateDataClassName(c, u, newName, oldDataClassName.equalsIgnoreCase(newName));
                 hasNameChange = true;
                 dataClass.setName(newName);
             }
@@ -8001,7 +8001,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return errors;
     }
 
-    private void validateDataClassName(@NotNull Container c, @NotNull User u, String name) throws IllegalArgumentException
+    private void validateDataClassName(@NotNull Container c, @NotNull User u, String name, boolean skipExisting) throws IllegalArgumentException
     {
         if (name == null)
             throw new ApiUsageException("DataClass name is required.");
@@ -8011,9 +8011,12 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (name.length() > nameMax)
             throw new ApiUsageException("DataClass name may not exceed " + nameMax + " characters.");
 
-        ExpDataClass existing = getDataClass(c, u, name);
-        if (existing != null)
-            throw new ApiUsageException("DataClass '" + existing.getName() + "' already exists.");
+        if (!skipExisting)
+        {
+            ExpDataClass existing = getDataClass(c, u, name);
+            if (existing != null)
+                throw new ApiUsageException("DataClass '" + existing.getName() + "' already exists.");
+        }
 
         // Issue 51321: check reserved data class name: First, All
         if ("First".equalsIgnoreCase(name) || "All".equalsIgnoreCase(name))

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -707,7 +707,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                                               @Nullable List<String> excludedContainerIds, @Nullable List<String> excludedDashboardContainerIds)
         throws ExperimentException
     {
-        validateSampleTypeName(c, u, name);
+        validateSampleTypeName(c, u, name, false);
 
         if (properties == null || properties.isEmpty())
             throw new ApiUsageException("At least one property is required");
@@ -966,7 +966,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         };
     }
 
-    private void validateSampleTypeName(Container container, User user, String name)
+    private void validateSampleTypeName(Container container, User user, String name, boolean skipExistingCheck)
     {
         if (name == null || StringUtils.isBlank(name))
             throw new ApiUsageException("Sample Type name is required.");
@@ -976,8 +976,11 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         if (name.length() > nameMax)
             throw new ApiUsageException("Sample Type name may not exceed " + nameMax + " characters.");
 
-        if (getSampleType(container, user, name) != null)
-            throw new ApiUsageException("A Sample Type with name '" + name + "' already exists.");
+        if (!skipExistingCheck)
+        {
+            if (getSampleType(container, user, name) != null)
+                throw new ApiUsageException("A Sample Type with name '" + name + "' already exists.");
+        }
 
         // Issue 51321: check reserved sample type name: First
         if ("First".equalsIgnoreCase(name) || "All".equalsIgnoreCase(name))
@@ -996,7 +999,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         boolean hasNameChange = false;
         if (!oldSampleTypeName.equals(newName))
         {
-            validateSampleTypeName(container, user, newName);
+            validateSampleTypeName(container, user, newName, oldSampleTypeName.equalsIgnoreCase(newName));
             hasNameChange = true;
             st.setName(newName);
         }


### PR DESCRIPTION
#### Rationale
Issue [51776](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51776)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6175
- https://github.com/LabKey/limsModules/pull/1032

#### Changes
- By pass existing dataclass/sample type check during renaming when only changing casing
