### PR TITLE
Issue 51770: Enable "Missing files count" metric by default

### DIFF
--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -578,8 +578,6 @@ public class ExperimentModule extends SpringModule
 
         SystemMaintenance.addTask(new FileLinkMetricsMaintenanceTask());
 
-        FileLinkMetricsMaintenanceTask.populateStartupProperties();
-
         UsageMetricsService svc = UsageMetricsService.get();
         if (null != svc)
         {

--- a/experiment/src/org/labkey/experiment/FileLinkMetricsMaintenanceTask.java
+++ b/experiment/src/org/labkey/experiment/FileLinkMetricsMaintenanceTask.java
@@ -44,13 +44,6 @@ public class FileLinkMetricsMaintenanceTask implements SystemMaintenance.Mainten
     }
 
     @Override
-    public boolean isEnabledByDefault()
-    {
-        return false;
-    }
-
-
-    @Override
     public void run(Logger log)
     {
         try
@@ -90,31 +83,4 @@ public class FileLinkMetricsMaintenanceTask implements SystemMaintenance.Mainten
         }
     }
 
-    private enum StartupProperties implements StartupProperty
-    {
-        EnableFileLinkMetricsTask
-                {
-                    @Override
-                    public String getDescription()
-                    {
-                        return "Enable the system maintenance task to calculate metrics for valid and missing files for File fields.";
-                    }
-                }
-    }
-
-    public static void populateStartupProperties()
-    {
-        // Looking for startup.properties value of FileLinkMetrics.EnableFileLinkMetricsTask = true
-        ModuleLoader.getInstance().handleStartupProperties(new StandardStartupPropertyHandler<>(STARTUP_SCOPE, StartupProperties.class)
-        {
-            @Override
-            public void handle(Map<StartupProperties, StartupPropertyEntry> map)
-            {
-                StartupPropertyEntry entry = map.get(StartupProperties.EnableFileLinkMetricsTask);
-                if (null != entry && Boolean.valueOf(entry.getValue()))
-                    SystemMaintenance.enableTask(FileLinkMetricsMaintenanceTask.NAME);
-            }
-        });
-
-    }
 }


### PR DESCRIPTION
#### Rationale
"Missing files count" metric was implemented as a system maintenance task that's disabled by default, that can be enabled from UI or as a startup property. This PR enables the task by default and drops the related startup property.

#### Related Pull Requests
[platform#5531](https://github.com/LabKey/platform/pull/5531)
[Dockerfile#100](https://github.com/LabKey/Dockerfile/pull/100)

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
