### PR TITLE
Issues 51894 and 51895: Treat import alias columns as strings

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -82,6 +82,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.labkey.api.action.SpringActionController.ERROR_GENERIC;
 import static org.labkey.api.query.AbstractQueryUpdateService.addTransactionAuditEvent;
@@ -569,6 +570,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
                                 .setSchemaName(schemaName)
                                 .setQueryName(queryName)
                                 .setRenamedColumns(getRenamedColumns())
+                                .setLineageImportAliases(getLineageImportAliases())
                                 .setInsertOption(_insertOption)
                                 .setAuditBehaviorType(behaviorType)
                                 .setAuditUserComment(_auditUserComment)
@@ -642,10 +644,10 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
 
     protected void configureLoader(DataLoader loader) throws IOException
     {
-        configureLoader(loader, _target, getRenamedColumns(), allowLineageColumns());
+        configureLoader(loader, _target, getRenamedColumns(), allowLineageColumns(), null);
     }
 
-    public static void configureLoader(DataLoader loader, @Nullable TableInfo target, @Nullable Map<String, String> renamedColumns, boolean allowLineageColumns) throws IOException
+    public static void configureLoader(DataLoader loader, @Nullable TableInfo target, @Nullable Map<String, String> renamedColumns, boolean allowLineageColumns, @Nullable Set<String> lineageAliasNames) throws IOException
     {
         //apply known columns so loader can do better type conversion
         if (loader != null && target != null)
@@ -675,7 +677,8 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
                     name.startsWith(ExpMaterial.MATERIAL_OUTPUT_CHILD.toLowerCase() + "/") ||
                     name.startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase() + "/") ||
                     name.startsWith(ExpData.DATA_OUTPUT_CHILD.toLowerCase() + "/") ||
-                    name.equalsIgnoreCase("Name") /* Issue 50710: Treat "Name" column as a string value for sample or data class import */)
+                    name.equalsIgnoreCase("Name") || /* Issue 50710: Treat "Name" column as a string value for sample or data class import */
+                    (lineageAliasNames != null && lineageAliasNames.contains(name)) )
                 {
                     col.clazz = String.class;
                     col.converter = TabLoader.noopConverter;
@@ -691,6 +694,11 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
     }
 
     protected Map<String, String> getRenamedColumns()
+    {
+        return null;
+    }
+
+    protected Set<String> getLineageImportAliases() throws IOException
     {
         return null;
     }

--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.query;
 
+import jakarta.servlet.ServletException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -38,8 +39,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.DetailedAuditLogDataIterator;
-import org.labkey.api.exp.api.ExpData;
-import org.labkey.api.exp.api.ExpMaterial;
+import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
@@ -74,7 +74,6 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.springframework.web.servlet.ModelAndView;
 
-import jakarta.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
@@ -673,10 +672,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
             for (ColumnDescriptor col : cols)
             {
                 String name = col.name.toLowerCase();
-                if (name.startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase() + "/") ||
-                    name.startsWith(ExpMaterial.MATERIAL_OUTPUT_CHILD.toLowerCase() + "/") ||
-                    name.startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase() + "/") ||
-                    name.startsWith(ExpData.DATA_OUTPUT_CHILD.toLowerCase() + "/") ||
+                if (ExperimentService.isInputOutputColumn(col.name) ||
                     name.equalsIgnoreCase("Name") || /* Issue 50710: Treat "Name" column as a string value for sample or data class import */
                     (lineageAliasNames != null && lineageAliasNames.contains(name)) )
                 {

--- a/api/src/org/labkey/api/query/QueryImportPipelineJob.java
+++ b/api/src/org/labkey/api/query/QueryImportPipelineJob.java
@@ -19,6 +19,7 @@ import org.labkey.api.view.ViewBackgroundInfo;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.labkey.api.query.AbstractQueryUpdateService.createTransactionAuditEvent;
 
@@ -52,6 +53,7 @@ public class QueryImportPipelineJob extends PipelineJob
         String _schemaName;
         String _queryName;
         Map<String, String> _renamedColumns;
+        Set<String> _lineageImportAliases;
 
         QueryUpdateService.InsertOption _insertOption= QueryUpdateService.InsertOption.INSERT;
         AuditBehaviorType _auditBehaviorType = null;
@@ -97,6 +99,8 @@ public class QueryImportPipelineJob extends PipelineJob
         {
             return _renamedColumns;
         }
+
+        public Set<String> getLineageImportAliases() { return _lineageImportAliases; }
 
         public QueryUpdateService.InsertOption getInsertOption()
         {
@@ -171,6 +175,12 @@ public class QueryImportPipelineJob extends PipelineJob
         public QueryImportAsyncContextBuilder setRenamedColumns(Map<String, String> renamedColumns)
         {
             _renamedColumns = renamedColumns;
+            return this;
+        }
+
+        public QueryImportAsyncContextBuilder setLineageImportAliases(Set<String> lineageImportAliases)
+        {
+            _lineageImportAliases = lineageImportAliases;
             return this;
         }
 
@@ -271,7 +281,7 @@ public class QueryImportPipelineJob extends PipelineJob
 
             loader = DataLoader.get().createLoader(_importContextBuilder.getPrimaryFile(), _importContextBuilder.getFileContentType(), _importContextBuilder.isHasColumnHeaders(), null, null);
 
-            AbstractQueryImportAction.configureLoader(loader, target, _importContextBuilder.getRenamedColumns(), _importContextBuilder.allowLineageColumns());
+            AbstractQueryImportAction.configureLoader(loader, target, _importContextBuilder.getRenamedColumns(), _importContextBuilder.allowLineageColumns(), _importContextBuilder.getLineageImportAliases());
 
             TransactionAuditProvider.TransactionAuditEvent auditEvent = null;
 

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2602,8 +2602,10 @@ public class ExpDataIterators
             {
                 try (DataLoader loader = DataLoader.get().createLoader(typeData.dataFile, "text/plain", true, null, null))
                 {
+                    ExpSampleTypeImpl sampleType = SampleTypeServiceImpl.get().getSampleType(typeData.container, _user, typeData.tableInfo.getName());
+                    Set<String> aliasNames = new CaseInsensitiveHashSet(sampleType.getImportAliases().keySet());
                     // We do not need to configure the loader for renamed columns as that has been taken care of when writing the file.
-                    configureLoader(loader, typeData.tableInfo, null, true);
+                    configureLoader(loader, typeData.tableInfo, null, true, aliasNames);
                     updateService.loadRows(_user, typeData.container, loader, _context, null);
                 }
                 catch (SQLException | IOException e)

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2602,15 +2602,18 @@ public class ExpDataIterators
             {
                 try (DataLoader loader = DataLoader.get().createLoader(typeData.dataFile, "text/plain", true, null, null))
                 {
-                    ExpSampleTypeImpl sampleType = SampleTypeServiceImpl.get().getSampleType(typeData.container, _user, typeData.tableInfo.getName());
-                    Set<String> aliasNames = new CaseInsensitiveHashSet(sampleType.getImportAliases().keySet());
+                    Set<String> aliasNames;
+                    if (_isSamples)
+                        aliasNames = new CaseInsensitiveHashSet(((ExpSampleType) typeData.dataType).getImportAliases().keySet());
+                    else
+                        aliasNames = new CaseInsensitiveHashSet(((ExpDataClass) typeData.dataType).getImportAliases().keySet());
                     // We do not need to configure the loader for renamed columns as that has been taken care of when writing the file.
                     configureLoader(loader, typeData.tableInfo, null, true, aliasNames);
                     updateService.loadRows(_user, typeData.container, loader, _context, null);
                 }
                 catch (SQLException | IOException e)
                 {
-                    String msg = "Problem importing data for sample type '" + typeData.dataType.getName() + "'. ";
+                    String msg = "Problem importing data for type '" + typeData.dataType.getName() + "'. ";
                     LOG.error(msg, e);
                     _context.getErrors().addRowError(new ValidationException(msg));
                 }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4123,6 +4123,18 @@ public class ExperimentController extends SpringActionController
         }
 
         @Override
+        protected @Nullable Set<String> getLineageImportAliases() throws IOException
+        {
+            boolean crossTypeImport = getOptionParamValue(AbstractQueryImportAction.Params.crossTypeImport);
+            if (!crossTypeImport)
+            {
+                ExpSampleTypeImpl sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), getUser(), _form.getQueryName());
+                return new CaseInsensitiveHashSet(sampleType.getImportAliases().keySet());
+            }
+            return null;
+        }
+
+        @Override
         protected int importData(
             DataLoader dl,
             FileStream file,
@@ -4188,6 +4200,12 @@ public class ExperimentController extends SpringActionController
             }
             return json;
         }
+
+        @Override
+        protected void configureLoader(DataLoader loader) throws IOException
+        {
+            configureLoader(loader, _target, getRenamedColumns(), allowLineageColumns(), getLineageImportAliases());
+        }
     }
 
     public abstract static class AbstractExpDataImportAction extends AbstractQueryImportAction<QueryForm>
@@ -4242,6 +4260,13 @@ public class ExperimentController extends SpringActionController
                 renameColumns.put(paramName.substring(renameParamPrefix.length()), (String) pv.getValue());
             }
             return renameColumns;
+        }
+
+        @Override
+        protected Set<String> getLineageImportAliases() throws IOException
+        {
+            ExpDataClass dataClass = ExperimentServiceImpl.get().getDataClass(getContainer(), getUser(), _form.getQueryName());
+            return new CaseInsensitiveHashSet(dataClass.getImportAliases().keySet());
         }
 
         protected void initContext(DataLoader dl, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, @Nullable String auditUserComment) throws IOException
@@ -4335,6 +4360,12 @@ public class ExperimentController extends SpringActionController
             if (_form.getQueryName() != null && url != null)
                 root.addChild(_form.getQueryName(), url);
             root.addChild("Import Data");
+        }
+
+        @Override
+        protected void configureLoader(DataLoader loader) throws IOException
+        {
+            configureLoader(loader, _target, getRenamedColumns(), allowLineageColumns(), getLineageImportAliases());
         }
 
     }


### PR DESCRIPTION
#### Rationale
Issues [51894](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51894) and [51895](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51895): When names of entities look like numbers, our type inference logic will convert them to numbers during a file import, which will strip off any leading zeros (and could convert names that look like scientific notation to integers or floats). We have logic to protect against this when the input columns begin with MaterialInputs or DataInputs and more obviously look like ancestor columns. This PR adds logic to check for lineage import alias names as well so we will treat these input columns as strings

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1034

#### Changes
- Add optional `lineageAliasNames` parameter to `configureLoader` and override the call to this method for data classes and sample types so they can provide their import aliases.