### PR TITLE
Fix SM Starter Postgres Tests

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -787,7 +787,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         }
         else
         {
-            sql = new SQLFragment("SELECT NULL");
+            sql = new SQLFragment("(SELECT NULL)");
         }
         var col = new ExprColumn(this, Column.IsPlated.name(), sql, JdbcType.VARCHAR);
         col.setDescription("Whether the sample that has been plated, if plating is supported.");


### PR DESCRIPTION
#### Rationale
Invalid SQL was executed in the select null case.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6166

#### Changes
- Add parens
