### PR TITLE
Query Datasets

### DIFF
--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -205,6 +205,10 @@ abstract public class DomainKind<T>  implements Handler<String>
      */
     abstract public DbScope getScope();
     abstract public String getStorageSchemaName();
+    public boolean isProvisioned(Container container, String name)
+    {
+        return getStorageSchemaName() != null;
+    }
     abstract public Set<PropertyStorageSpec.Index> getPropertyIndices(Domain domain);
 
     /**

--- a/api/src/org/labkey/api/query/snapshot/QuerySnapshotService.java
+++ b/api/src/org/labkey/api/query/snapshot/QuerySnapshotService.java
@@ -118,6 +118,8 @@ public class QuerySnapshotService
         List<DisplayColumn> getDisplayColumns(QueryForm queryForm, BindException errors) throws Exception;
 
         TableInfo getTableInfoQuerySnapshotDef();
+
+        boolean isQueryDataset(Container container, String queryName);
     }
 
     public interface AutoUpdateable

--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -313,6 +313,8 @@ public interface Dataset extends StudyEntity
 
     void save(User user) throws SQLException;
 
+    boolean isQueryDataset();
+
     @Override
     boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm);
 

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -576,7 +576,7 @@ public class DomainImpl implements Domain
             List<DomainProperty> propsAdded = new ArrayList<>();
 
             DomainKind<?> kind = getDomainKind();
-            boolean hasProvisioner = null != kind && null != kind.getStorageSchemaName();
+            boolean hasProvisioner = null != kind && kind.isProvisioned(getContainer(), getName());
 
             // Certain provisioned table types (Lists and Datasets) get wiped when their fields are replaced via field Import
             if (hasProvisioner && isShouldDeleteAllData())

--- a/query/src/org/labkey/query/reports/view/ReportUIProvider.java
+++ b/query/src/org/labkey/query/reports/view/ReportUIProvider.java
@@ -187,7 +187,8 @@ public class ReportUIProvider extends DefaultReportUIProvider
         if (context.hasPermission(AdminPermission.class))
         {
             QuerySnapshotService.Provider provider = QuerySnapshotService.get(settings.getSchemaName());
-            if (provider != null && !QueryService.get().isQuerySnapshot(context.getContainer(), settings.getSchemaName(), settings.getQueryName()))
+            if (provider != null && !QueryService.get().isQuerySnapshot(context.getContainer(), settings.getSchemaName(), settings.getQueryName())
+                && !provider.isQueryDataset(context.getContainer(), settings.getQueryName()))
                 designers.add(new DesignerInfoImpl(QuerySnapshotService.TYPE, "Query Snapshot", null,
                         provider.getCreateWizardURL(settings, context), _getIconPath(QuerySnapshotService.TYPE), ReportService.DesignerType.DEFAULT, _getIconCls(QuerySnapshotService.TYPE)));
         }

--- a/study/resources/schemas/dbscripts/postgresql/study-25.000-25.001.sql
+++ b/study/resources/schemas/dbscripts/postgresql/study-25.000-25.001.sql
@@ -1,0 +1,4 @@
+
+ALTER TABLE study.DataSet ADD COLUMN SourceQueryName VARCHAR(200);
+ALTER TABLE study.DataSet ADD COLUMN SourceQuerySchema VARCHAR(200);
+ALTER TABLE study.DataSet ADD COLUMN SourceQueryContainer ENTITYID;

--- a/study/resources/schemas/dbscripts/sqlserver/study-25.000-25.001.sql
+++ b/study/resources/schemas/dbscripts/sqlserver/study-25.000-25.001.sql
@@ -1,0 +1,4 @@
+
+ALTER TABLE study.DataSet ADD SourceQueryName NVARCHAR(200);
+ALTER TABLE study.DataSet ADD SourceQuerySchema NVARCHAR(200);
+ALTER TABLE study.DataSet ADD SourceQueryContainer ENTITYID;

--- a/study/resources/schemas/study.xml
+++ b/study/resources/schemas/study.xml
@@ -400,6 +400,15 @@
       <column columnName="UseTimeKeyField">
         <description>Whether to use the time portion of the date field as a key field</description>
       </column>
+      <column columnName="SourceQueryName">
+        <description>Query name of a query backed dataset.</description>
+      </column>
+      <column columnName="SourceQuerySchema">
+        <description>Schema name of a query backed dataset.</description>
+      </column>
+      <column columnName="SourceQueryContainer">
+        <description>Container of a query backed dataset.</description>
+      </column>
     </columns>
   </table>
   <table tableName="SampleRequest" tableDbType="TABLE">

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -54,6 +54,7 @@ import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.qc.DataStateManager;
 import org.labkey.api.qc.export.DataStateImportExportHelper;
 import org.labkey.api.query.DefaultSchema;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.snapshot.QuerySnapshotService;
 import org.labkey.api.reports.ReportContentEmailManager;
 import org.labkey.api.reports.ReportService;
@@ -136,30 +137,12 @@ import org.labkey.study.dataset.DatasetSnapshotProvider;
 import org.labkey.study.dataset.DatasetViewProvider;
 import org.labkey.study.designer.view.StudyDesignsWebPart;
 import org.labkey.study.importer.StudyImporterFactory;
-import org.labkey.study.model.CohortDomainKind;
-import org.labkey.study.model.ContinuousDatasetDomainKind;
-import org.labkey.study.model.DatasetDefinition;
-import org.labkey.study.model.DateDatasetDomainKind;
-import org.labkey.study.model.GroupSecurityType;
-import org.labkey.study.model.ImportHelperServiceImpl;
-import org.labkey.study.model.Participant;
-import org.labkey.study.model.ParticipantGroupManager;
-import org.labkey.study.model.ParticipantGroupServiceImpl;
-import org.labkey.study.model.ParticipantIdImportHelper;
-import org.labkey.study.model.ProtocolDocumentType;
-import org.labkey.study.model.SequenceNumImportHelper;
-import org.labkey.study.model.StudyDomainKind;
-import org.labkey.study.model.StudyImpl;
-import org.labkey.study.model.StudyLsidHandler;
-import org.labkey.study.model.StudyManager;
-import org.labkey.study.model.TestDatasetDomainKind;
-import org.labkey.study.model.TreatmentManager;
-import org.labkey.study.model.VisitDatasetDomainKind;
-import org.labkey.study.model.VisitImpl;
+import org.labkey.study.model.*;
 import org.labkey.study.pipeline.StudyPipeline;
 import org.labkey.study.qc.StudyQCImportExportHelper;
 import org.labkey.study.qc.StudyQCStateHandler;
 import org.labkey.study.query.DatasetQueryView;
+import org.labkey.study.query.QueryDatasetQueryChangeListener;
 import org.labkey.study.query.StudyPersonnelDomainKind;
 import org.labkey.study.query.StudyQuerySchema;
 import org.labkey.study.query.StudySchemaProvider;
@@ -231,7 +214,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     @Override
     public Double getSchemaVersion()
     {
-        return 24.000;
+        return 25.001;
     }
 
     @Override
@@ -294,6 +277,8 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
 
         // Register so all administrators get this permission
         RoleManager.registerPermission(new ManageStudyPermission());
+
+        QueryService.get().addQueryListener(new QueryDatasetQueryChangeListener());
     }
 
     @Override
@@ -435,6 +420,11 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
             "Restore support for deprecated advanced reports",
             "This option and all support for advanced reports will be removed in LabKey Server v24.12.",
             true, false, FeatureType.Deprecated));
+
+        AdminConsole.addExperimentalFeatureFlag(DatasetQueryView.EXPERIMENTAL_QUERY_DATASETS,
+                "Allow query based dataset snapshots",
+                "Allow unprovisioned, query-based dataset snapshots to be created.",
+                false);
 
         ReportAndDatasetChangeDigestProvider.get().addNotificationInfoProvider(new DatasetNotificationInfoProvider());
 

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -547,6 +547,9 @@ public class StudyController extends BaseStudyController
             if (null == def)
                 throw new NotFoundException("No dataset found for datasetId " + form.getDatasetId() + ".");
 
+            if (def.isQueryDataset())
+                throw new UnsupportedOperationException("Query dataset definition cannot be edited. Update the source query to change definition.");
+
             if (!def.canUpdateDefinition(getUser()))
             {
                 ActionURL details = new ActionURL(DatasetDetailsAction.class,getContainer()).addParameter("id",def.getDatasetId());
@@ -4804,6 +4807,7 @@ public class StudyController extends BaseStudyController
     {
         private int _snapshotDatasetId = -1;
         private String _action;
+        private Boolean _queryDataset;
 
         public static final String EDIT_DATASET = "editDataset";
         public static final String CREATE_SNAPSHOT = "createSnapshot";
@@ -4817,6 +4821,16 @@ public class StudyController extends BaseStudyController
         public void setSnapshotDatasetId(int snapshotDatasetId)
         {
             _snapshotDatasetId = snapshotDatasetId;
+        }
+
+        public Boolean getQueryDataset()
+        {
+            return _queryDataset;
+        }
+
+        public void setQueryDataset(Boolean queryDataset)
+        {
+            _queryDataset = queryDataset;
         }
 
         public String getAction()
@@ -4844,6 +4858,9 @@ public class StudyController extends BaseStudyController
             Study study = StudyManager.getInstance().getStudy(getContainer());
             if (null == study)
                 throw new NotFoundException("No study in this folder");
+
+            if (form.getQueryDataset() != null && study.getTimepointType() != TimepointType.CONTINUOUS)
+                errors.reject("snapshotQuery.error", "Query based snapshot is only available for continuous studies");
 
             String name = StringUtils.trimToNull(form.getSnapshotName());
 
@@ -4942,11 +4959,24 @@ public class StudyController extends BaseStudyController
                         }
                     }
                 }
-                DatasetDefinition def = StudyPublishManager.getInstance().createDataset(getUser(), new DatasetDefinition.Builder(form.getSnapshotName())
+
+                DatasetDefinition.Builder builder = new DatasetDefinition.Builder(form.getSnapshotName())
                         .setStudy(study)
                         .setKeyPropertyName(additionalKey)
                         .setDemographicData(isDemographicData)
-                        .setUseTimeKeyField(useTimeKeyField));
+                        .setUseTimeKeyField(useTimeKeyField);
+
+
+                if (Boolean.TRUE.equals(form.getQueryDataset()))
+                {
+                    builder.setSourceQueryName(form.getQueryName())
+                            .setSourceQuerySchema(form.getSchemaName())
+                            .setSourceQueryContainer(getContainer())
+                            .setKeyPropertyName("Key");
+                }
+
+                DatasetDefinition def = StudyPublishManager.getInstance().createDataset(getUser(), builder);
+
                 form.setSnapshotDatasetId(def.getDatasetId());
                 if (keyManagementType != KeyManagementType.None)
                 {
@@ -4967,7 +4997,15 @@ public class StudyController extends BaseStudyController
                 }
 
                 // def may not be provisioned yet, create before we start adding properties
-                def.provisionTable();
+                if (def.isQueryDataset())
+                {
+                    def.provisionQueryDataset();
+                }
+                else
+                {
+                    def.provisionTable();
+                }
+
                 Domain d = def.getDomain();
 
                 for (ColumnInfo col : columnsToProvision)
@@ -5006,9 +5044,17 @@ public class StudyController extends BaseStudyController
                 }
                 else if (StudySnapshotForm.CREATE_SNAPSHOT.equals(form.getAction()))
                 {
-                    createDataset(form, errors);
+                    Dataset def = createDataset(form, errors);
                     if (!errors.hasErrors())
-                        _successURL = QuerySnapshotService.get(form.getSchemaName()).createSnapshot(form, errors);
+                        if (Boolean.TRUE.equals(form.getQueryDataset()))
+                        {
+                            _successURL = new ActionURL(StudyController.DatasetAction.class, getContainer()).
+                                    addParameter(Dataset.DATASET_KEY, def.getDatasetId());
+                        }
+                        else
+                        {
+                            _successURL = QuerySnapshotService.get(form.getSchemaName()).createSnapshot(form, errors);
+                        }
                 }
                 else if (StudySnapshotForm.CANCEL.equals(form.getAction()))
                 {

--- a/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
@@ -71,6 +71,7 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.study.StudySchema;
 import org.labkey.study.controllers.StudyController;
 import org.labkey.study.model.DatasetDefinition;
+import org.labkey.study.model.DatasetDomainKind;
 import org.labkey.study.model.DatasetManager;
 import org.labkey.study.model.ParticipantCategoryImpl;
 import org.labkey.study.model.ParticipantCategoryListener;
@@ -906,5 +907,11 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
                 QueryService.get().clearEnvironment();
             }
         }
+    }
+
+    @Override
+    public boolean isQueryDataset(Container container, String queryName)
+    {
+        return DatasetDomainKind.isQueryDataset(container, queryName);
     }
 }

--- a/study/src/org/labkey/study/model/ContinuousDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/ContinuousDatasetDomainKind.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.study.model;
 
-import org.labkey.api.data.Container;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.security.User;
 import org.labkey.api.study.TimepointType;
@@ -62,11 +61,5 @@ public class ContinuousDatasetDomainKind extends DatasetDomainKind
         fields.addAll(DatasetDefinition.DEFAULT_ABSOLUTE_DATE_FIELDS);
 
         return Collections.unmodifiableSet(fields);
-    }
-
-    @Override
-    public boolean isProvisioned(Container container, String name)
-    {
-        return !isQueryDataset(container, name);
     }
 }

--- a/study/src/org/labkey/study/model/ContinuousDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/ContinuousDatasetDomainKind.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.study.model;
 
+import org.labkey.api.data.Container;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.security.User;
 import org.labkey.api.study.TimepointType;
@@ -61,5 +62,11 @@ public class ContinuousDatasetDomainKind extends DatasetDomainKind
         fields.addAll(DatasetDefinition.DEFAULT_ABSOLUTE_DATE_FIELDS);
 
         return Collections.unmodifiableSet(fields);
+    }
+
+    @Override
+    public boolean isProvisioned(Container container, String name)
+    {
+        return !isQueryDataset(container, name);
     }
 }

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -35,37 +35,8 @@ import org.labkey.api.collections.ArrayListMap;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.Sets;
-import org.labkey.api.data.AuditConfigurable;
-import org.labkey.api.data.BaseColumnInfo;
-import org.labkey.api.data.BeanObjectFactory;
-import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.ConnectionWrapper;
-import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.DataColumn;
-import org.labkey.api.data.DatabaseCache;
-import org.labkey.api.data.DatabaseTableType;
-import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbScope;
+import org.labkey.api.data.*;
 import org.labkey.api.data.DbScope.Transaction;
-import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.DisplayColumnFactory;
-import org.labkey.api.data.ExceptionFramework;
-import org.labkey.api.data.JdbcType;
-import org.labkey.api.data.NullColumnInfo;
-import org.labkey.api.data.ObjectFactory;
-import org.labkey.api.data.PropertyManager;
-import org.labkey.api.data.RuntimeSQLException;
-import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.SchemaTableInfo;
-import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.SqlExecutor;
-import org.labkey.api.data.SqlSelector;
-import org.labkey.api.data.Table;
-import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableSelector;
-import org.labkey.api.data.Transient;
-import org.labkey.api.data.UpdateableTableInfo;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
@@ -203,6 +174,9 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
     private String _type = Dataset.TYPE_STANDARD;
     private DataSharing _datasharing = DataSharing.NONE;
     private boolean _useTimeKeyField = false;
+    private String _sourceQueryName;
+    private String _sourceQuerySchema;
+    private Container _sourceQueryContainer;
 
 
     private static final String[] BASE_DEFAULT_FIELD_NAMES_ARRAY = new String[]
@@ -771,24 +745,41 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
     {
         try (Transaction t = StudySchema.getInstance().getSchema().getScope().ensureTransaction(_lock))
         {
-            _domain = null;
-            if (null == getTypeURI())
-            {
-                DatasetDefinition d = createMutable();
-                d.setTypeURI(DatasetDomainKind.generateDomainURI(getName(), getEntityId(), getContainer()));
-                d.save(null);
-            }
-            ensureDomain();
+            ensureDomainDef();
             loadStorageTableInfo();
             StudyManager.getInstance().uncache(this);
             t.commit();
         }
     }
 
+    public void provisionQueryDataset()
+    {
+        try (Transaction t = StudySchema.getInstance().getSchema().getScope().ensureTransaction(_lock))
+        {
+            ensureDomainDef();
+            StudyManager.getInstance().uncache(this);
+            t.commit();
+        }
+    }
+
+    private void ensureDomainDef()
+    {
+        _domain = null;
+        if (null == getTypeURI())
+        {
+            DatasetDefinition d = createMutable();
+            d.setTypeURI(DatasetDomainKind.generateDomainURI(getName(), getEntityId(), getContainer()));
+            d.save(null);
+        }
+        ensureDomain();
+    }
 
     @Transient
     public TableInfo getStorageTableInfo() throws UnauthorizedException
     {
+        if (isQueryDataset())
+            return null;
+
         if (isInherited())
         {
             StudyImpl shared = getDefinitionStudy();
@@ -1227,6 +1218,41 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
         _keyPropertyName = keyPropertyName;
     }
 
+    @Override
+    public boolean isQueryDataset()
+    {
+        return _sourceQueryName != null && _sourceQuerySchema != null && _sourceQueryContainer != null;
+    }
+
+    public String getSourceQueryName()
+    {
+        return _sourceQueryName;
+    }
+
+    public void setSourceQueryName(String sourceQueryName)
+    {
+        _sourceQueryName = sourceQueryName;
+    }
+
+    public String getSourceQuerySchema()
+    {
+        return _sourceQuerySchema;
+    }
+
+    public void setSourceQuerySchema(String sourceQuerySchema)
+    {
+        _sourceQuerySchema = sourceQuerySchema;
+    }
+
+    public Container getSourceQueryContainer()
+    {
+        return _sourceQueryContainer;
+    }
+
+    public void setSourceQueryContainer(Container sourceQueryContainer)
+    {
+        _sourceQueryContainer = sourceQueryContainer;
+    }
 
     @Override
     public void save(User user)
@@ -1373,7 +1399,14 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
             _multiContainer = multiContainer;     /* true: don't preapply the container filter, let wrapper tableinfo handle it */
             Study study = StudyManager.getInstance().getStudy(_container);
 
-            _storage = def.getStorageTableInfo();
+            if (def.getSourceQueryName() != null && def.getSourceQuerySchema() != null && def.getSourceQueryContainer() != null)
+            {
+                _storage = new QueryDataset(getName(), def.getSourceQueryContainer(), def.getSourceQuerySchema(), def.getSourceQueryName());
+            }
+            else
+            {
+                _storage = def.getStorageTableInfo();
+            }
             _template = getTemplateTableInfo();
 
             // ParticipantId
@@ -2819,6 +2852,9 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
         private Boolean _useTimeKeyField = false;
         private Integer _datasetId;
         private StudyImpl _study;
+        private String _sourceQueryName;
+        private String _sourceQuerySchema;
+        private Container _sourceQueryContainer;
 
         public Builder(String name)
         {
@@ -2937,6 +2973,39 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
             return _study;
         }
 
+        public String getSourceQueryName()
+        {
+            return _sourceQueryName;
+        }
+
+        public Builder setSourceQueryName(String sourceQueryName)
+        {
+            _sourceQueryName = sourceQueryName;
+            return this;
+        }
+
+        public String getSourceQuerySchema()
+        {
+            return _sourceQuerySchema;
+        }
+
+        public Builder setSourceQuerySchema(String sourceQuerySchema)
+        {
+            _sourceQuerySchema = sourceQuerySchema;
+            return this;
+        }
+
+        public Container getSourceQueryContainer()
+        {
+            return _sourceQueryContainer;
+        }
+
+        public Builder setSourceQueryContainer(Container sourceQueryContainer)
+        {
+            _sourceQueryContainer = sourceQueryContainer;
+            return this;
+        }
+
         @Override
         public DatasetDefinition build()
         {
@@ -2962,6 +3031,15 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
             }
             if (_datasharing != null)
                 dsd.setDataSharing(_datasharing);
+
+            if (_sourceQueryName != null)
+                dsd.setSourceQueryName(_sourceQueryName);
+
+            if (_sourceQuerySchema != null)
+                dsd.setSourceQuerySchema(_sourceQuerySchema);
+
+            if (_sourceQueryContainer != null)
+                dsd.setSourceQueryContainer(_sourceQueryContainer);
 
             return dsd;
         }

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -1399,9 +1399,9 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
             _multiContainer = multiContainer;     /* true: don't preapply the container filter, let wrapper tableinfo handle it */
             Study study = StudyManager.getInstance().getStudy(_container);
 
-            if (def.getSourceQueryName() != null && def.getSourceQuerySchema() != null && def.getSourceQueryContainer() != null)
+            if (def.isQueryDataset())
             {
-                _storage = new QueryDataset(getName(), def.getSourceQueryContainer(), def.getSourceQuerySchema(), def.getSourceQueryName());
+                _storage = new QueryDataset(getName(), def);
             }
             else
             {

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -830,6 +830,12 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
         return ComplianceService.get().isComplianceSupported();
     }
 
+    @Override
+    public boolean isProvisioned(Container container, String name)
+    {
+        return super.isProvisioned(container, name) && !isQueryDataset(container, name);
+    }
+
     public static boolean isQueryDataset(Container container, String queryName)
     {
         StudyService ss = StudyService.get();

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -66,7 +66,6 @@ import org.labkey.api.writer.ContainerUser;
 import org.labkey.study.StudySchema;
 import org.labkey.study.assay.StudyPublishManager;
 import org.labkey.study.controllers.StudyController;
-import org.labkey.study.query.DatasetFactory;
 import org.labkey.study.query.StudyQuerySchema;
 
 import java.util.ArrayList;
@@ -829,5 +828,18 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
     public boolean supportsPhiLevel()
     {
         return ComplianceService.get().isComplianceSupported();
+    }
+
+    public static boolean isQueryDataset(Container container, String queryName)
+    {
+        StudyService ss = StudyService.get();
+        if (ss == null)
+            return false;
+
+        Dataset dt = ss.getDataset(container, ss.getDatasetIdByName(container, queryName));
+        if (dt == null)
+            return false;
+
+        return dt.isQueryDataset();
     }
 }

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -830,6 +830,7 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
         return ComplianceService.get().isComplianceSupported();
     }
 
+    // Query datasets don't have a domain kind, so check here if the dataset is a query dataset
     @Override
     public boolean isProvisioned(Container container, String name)
     {

--- a/study/src/org/labkey/study/model/QueryDataset.java
+++ b/study/src/org/labkey/study/model/QueryDataset.java
@@ -1,0 +1,204 @@
+package org.labkey.study.model;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.DatabaseTableType;
+import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SchemaTableInfo;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.VirtualTable;
+import org.labkey.api.query.ExprColumn;
+import org.labkey.api.query.QueryService;
+import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.LimitedUser;
+import org.labkey.api.security.User;
+import org.labkey.api.security.roles.ProjectAdminRole;
+import org.labkey.api.study.StudyUtils;
+import org.labkey.study.StudySchema;
+
+import java.util.List;
+
+public class QueryDataset extends VirtualTable<UserSchema>
+{
+    private final QuerySchemaTableInfo _inner;
+
+    public QueryDataset(@NotNull String name, @NotNull Container sourceContainer, @NotNull String sourceSchema, @NotNull String sourceQuery)
+    {
+        super(StudySchema.getInstance().getSchema(), name, null);
+        UserSchema us = QueryService.get().getUserSchema(new LimitedUser(User.guest, ProjectAdminRole.class), sourceContainer, sourceSchema);
+        if (us == null)
+        {
+            throw new IllegalArgumentException("QueryDataset requires a valid schema");
+        }
+
+        TableInfo ti = us.getTable(sourceQuery);
+        if (ti == null)
+        {
+            throw new IllegalArgumentException("QueryDataset requires a valid query");
+        }
+
+        _inner = new QuerySchemaTableInfo(ti);
+    }
+
+
+    @Override
+    public ColumnInfo getColumn(@NotNull String name, boolean resolveIfNeeded)
+    {
+        return _inner.getColumn(name);
+    }
+
+    @Override
+    public DatabaseTableType getTableType()
+    {
+        return _inner.getTableType();
+    }
+
+    @Override
+    public String getSelectName()
+    {
+        return _inner.getSelectName();
+    }
+
+    @Override
+    public @Nullable SQLFragment getSQLName()
+    {
+        return _inner.getSQLName();
+    }
+
+    @Nullable
+    @Override
+    public String getMetaDataName()
+    {
+        return _inner.getMetaDataName();
+    }
+
+    @NotNull
+    @Override
+    public SQLFragment getFromSQL(String alias)
+    {
+        return _inner.getFromSQL(alias);
+    }
+
+
+    private static class QuerySchemaTableInfo extends SchemaTableInfo
+    {
+        private static final String queryAlias = "QD";
+        SQLFragment _sql;
+
+        public QuerySchemaTableInfo(TableInfo ti)
+        {
+            super(ti.getSchema(), DatabaseTableType.NOT_IN_DB, ti.getName());
+            _sql = ti.getFromSQL(queryAlias);
+
+            wrapAllColumns(ti.getColumns());
+
+            // Key
+            if (getColumn("Key") != null)
+            {
+                addColumn(new ExprColumn(this, "_Key", getColumn("Key").getValueSql(ExprColumn.STR_TABLE_ALIAS), JdbcType.VARCHAR));
+            }
+            else
+            {
+                throw new IllegalArgumentException("QueryDataset requires a query with a unique Key column");
+            }
+
+            // ParticipantId
+            if (!ensureParticipantIdCol(ti))
+            {
+                throw new IllegalArgumentException("QueryDataset requires a query with a ParticipantId, SubjectId, or Id column");
+            }
+
+            // Date
+            if (getColumn("Date") == null)
+            {
+                throw new IllegalArgumentException("QueryDataset requires a query with a Date column");
+            }
+
+            // QCState
+            // could consider looking up the "Completed" state and filling that in automatically if found
+            if (getColumn("QCState") == null)
+            {
+                throw new IllegalArgumentException("QueryDataset requires a query with a QCState column");
+            }
+
+            // LSID
+            if (getColumn("lsid") == null)
+            {
+                throw new IllegalArgumentException("QueryDataset requires a query with a LSID column");
+            }
+
+            // SequenceNum
+            if (getColumn("SequenceNum") == null)
+            {
+                ExprColumn sequenceNumCol = new ExprColumn(this, "SequenceNum", new SQLFragment(StudyUtils.sequenceNumFromDateSQL("Date")), JdbcType.DECIMAL);
+                addColumn(sequenceNumCol);
+            }
+
+            // SourceLSID
+            if (getColumn("SourceLSID") == null)
+            {
+                addColumn(new ExprColumn(this, "SourceLSID", new SQLFragment("NULL"), JdbcType.VARCHAR));
+            }
+
+            // SourceLSID
+            if (getColumn("SourceLSID") == null)
+            {
+                addColumn(new ExprColumn(this, "SourceLSID", new SQLFragment("NULL"), JdbcType.VARCHAR));
+            }
+        }
+
+        public void wrapAllColumns(List<ColumnInfo> columns)
+        {
+            for (ColumnInfo col : columns)
+            {
+                ExprColumn to = new ExprColumn(this, col.getName(), col.getValueSql(ExprColumn.STR_TABLE_ALIAS), col.getJdbcType());
+                addColumn(to);
+            }
+        }
+
+        private boolean ensureParticipantIdCol(TableInfo ti)
+        {
+            if (getColumn("ParticipantId") != null)
+            {
+                return true;
+            }
+
+            if (ti.getColumn("SubjectId") != null)
+            {
+                ColumnInfo subjectIdCol = ti.getColumn("SubjectId");
+                addColumn(new ExprColumn(this, "ParticipantId", subjectIdCol.getValueSql(ExprColumn.STR_TABLE_ALIAS), subjectIdCol.getJdbcType()));
+                return true;
+            }
+            else if (ti.getColumn("Id") != null)
+            {
+                ColumnInfo idCol = ti.getColumn("Id");
+                addColumn(new ExprColumn(this, "ParticipantId", idCol.getValueSql(ExprColumn.STR_TABLE_ALIAS), idCol.getJdbcType()));
+                return true;
+            }
+
+            return false;
+        }
+
+        @Override
+        public @NotNull SQLFragment getFromSQL()
+        {
+            SQLFragment sql = new SQLFragment("(SELECT ").append(queryAlias).append(".* FROM ").append(_sql).append(")");
+            return sql;
+        }
+
+        @Override
+        public String getSelectName()
+        {
+            return null;
+        }
+
+        @Override
+        public @Nullable SQLFragment getSQLName()
+        {
+            return null;
+        }
+    }
+}

--- a/study/src/org/labkey/study/model/QueryDataset.java
+++ b/study/src/org/labkey/study/model/QueryDataset.java
@@ -3,7 +3,6 @@ package org.labkey.study.model;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.Container;
 import org.labkey.api.data.DatabaseTableType;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
@@ -25,16 +24,16 @@ public class QueryDataset extends VirtualTable<UserSchema>
 {
     private final QuerySchemaTableInfo _inner;
 
-    public QueryDataset(@NotNull String name, @NotNull Container sourceContainer, @NotNull String sourceSchema, @NotNull String sourceQuery)
+    public QueryDataset(@NotNull String name, @NotNull DatasetDefinition def)
     {
         super(StudySchema.getInstance().getSchema(), name, null);
-        UserSchema us = QueryService.get().getUserSchema(new LimitedUser(User.guest, ProjectAdminRole.class), sourceContainer, sourceSchema);
+        UserSchema us = QueryService.get().getUserSchema(new LimitedUser(User.guest, ProjectAdminRole.class), def.getSourceQueryContainer(), def.getSourceQuerySchema());
         if (us == null)
         {
             throw new IllegalArgumentException("QueryDataset requires a valid schema");
         }
 
-        TableInfo ti = us.getTable(sourceQuery);
+        TableInfo ti = us.getTable(def.getSourceQueryName());
         if (ti == null)
         {
             throw new IllegalArgumentException("QueryDataset requires a valid query");

--- a/study/src/org/labkey/study/query/DatasetFactory.java
+++ b/study/src/org/labkey/study/query/DatasetFactory.java
@@ -23,6 +23,10 @@ public class DatasetFactory
                 default -> throw new IllegalStateException("Unknown publish source type " + source);
             }
         }
+        else if (dsd.getSourceQueryName() != null)
+        {
+            return new QueryDatasetTable(schema, cf, dsd);
+        }
         else
             return new DatasetTableImpl(schema, cf, dsd);
     }

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -120,6 +120,7 @@ public class DatasetQueryView extends StudyQueryView
 {
     public static final String EXPERIMENTAL_LINKED_DATASET_CHECK = "LinkedDatasetCheck";
     public static final String EXPERIMENTAL_ALLOW_MERGE_WITH_MANAGED_KEYS = "MergeWithManagedDatasetKeys";
+    public static final String EXPERIMENTAL_QUERY_DATASETS = "queryBasedDatasets";
 
     private final DatasetDefinition _dataset;
     private final boolean _showSourceLinks;

--- a/study/src/org/labkey/study/query/QueryDatasetQueryChangeListener.java
+++ b/study/src/org/labkey/study/query/QueryDatasetQueryChangeListener.java
@@ -1,0 +1,90 @@
+package org.labkey.study.query;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryChangeListener;
+import org.labkey.api.query.SchemaKey;
+import org.labkey.api.security.User;
+import org.labkey.study.StudySchema;
+import org.labkey.study.model.DatasetDefinition;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+public class QueryDatasetQueryChangeListener implements QueryChangeListener
+{
+    @Override
+    public void queryCreated(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull Collection<String> queries)
+    {
+
+    }
+
+    @Override
+    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange> changes)
+    {
+        if (property.equals(QueryProperty.Name))
+        {
+            for (QueryPropertyChange change : changes)
+            {
+                String oldVal = (String)change.getOldValue();
+                String newVal = (String)change.getNewValue();
+
+                StudySchema ss = StudySchema.getInstance();
+
+                TableInfo table = ss.getTableInfoDataset();
+                SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("SourceQueryName"), oldVal);
+                filter.addCondition(FieldKey.fromParts("SourceQuerySchema"), schema.toString());
+                filter.addCondition(FieldKey.fromParts("SourceQueryContainer"), container.getId());
+
+                TableSelector ts = new TableSelector(table, filter, null);
+                ts.getArrayList(DatasetDefinition.class).forEach(_def ->
+                {
+                    _def.setSourceQueryName(newVal);
+                    _def.save(user);
+                });
+            }
+        }
+    }
+
+    @Override
+    public void queryDeleted(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull Collection<String> queries)
+    {
+        StudySchema ss = StudySchema.getInstance();
+        TableInfo table = ss.getTableInfoDataset();
+
+        for (String query : queries)
+        {
+            SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("SourceQueryName"), query);
+            filter.addCondition(FieldKey.fromParts("SourceQuerySchema"), schema.toString());
+            filter.addCondition(FieldKey.fromParts("SourceQueryContainer"), container.getId());
+
+            TableSelector ts = new TableSelector(table, filter, null);
+            ts.getArrayList(DatasetDefinition.class).forEach(_def -> _def.delete(user));
+        }
+    }
+
+    @Override
+    public Collection<String> queryDependents(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull Collection<String> queries)
+    {
+        StudySchema ss = StudySchema.getInstance();
+        TableInfo table = ss.getTableInfoDataset();
+        Collection<String> dependents = new HashSet<>();
+
+        for (String query : queries)
+        {
+            SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("SourceQueryName"), query);
+            filter.addCondition(FieldKey.fromParts("SourceQuerySchema"), schema.toString());
+            filter.addCondition(FieldKey.fromParts("SourceQueryContainer"), container.getId());
+
+            TableSelector ts = new TableSelector(table, filter, null);
+            ts.getArrayList(DatasetDefinition.class).forEach(_def -> dependents.add(_def.getName()));
+        }
+
+        return dependents;
+    }
+}

--- a/study/src/org/labkey/study/query/QueryDatasetTable.java
+++ b/study/src/org/labkey/study/query/QueryDatasetTable.java
@@ -1,0 +1,126 @@
+package org.labkey.study.query;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.MutableColumnInfo;
+import org.labkey.api.dataiterator.DataIteratorBuilder;
+import org.labkey.api.dataiterator.DataIteratorContext;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.InvalidKeyException;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.QueryUpdateServiceException;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.util.Pair;
+import org.labkey.study.model.DatasetDefinition;
+
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class QueryDatasetTable extends DatasetTableImpl
+{
+    QueryDatasetTable(@NotNull StudyQuerySchema schema, ContainerFilter cf, @NotNull DatasetDefinition dsd)
+    {
+        super(schema, cf, dsd);
+
+        setUpdateURL(null);
+        setInsertURL(null);
+        setImportURL(null);
+        setDeleteURL(null);
+
+        MutableColumnInfo ci = getMutableColumn("_key");
+        if (ci != null)
+        {
+            ci.setHidden(true);
+        }
+    }
+
+    @Override
+    public @NotNull Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
+    {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public QueryUpdateService getUpdateService()
+    {
+        User user = _userSchema.getUser();
+        if (!user.hasRootAdminPermission() && !hasPermission(user, ReadPermission.class))
+            return null;
+        return new QueryDatasetUpdateService(this);
+    }
+
+    private static class QueryDatasetUpdateService extends DatasetUpdateService
+    {
+        public QueryDatasetUpdateService(DatasetTableImpl table)
+        {
+            super(table);
+        }
+
+        @Override
+        public int mergeRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
+        {
+            throw new UnsupportedOperationException("Query datasets do not support importing rows.");
+        }
+
+        @Override
+        public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
+        {
+            throw new UnsupportedOperationException("Query datasets do not support importing rows.");
+        }
+
+        @Override
+        public int importRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors, Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
+        {
+            throw new UnsupportedOperationException("Query datasets do not support importing rows.");
+        }
+
+        @Override
+        public List<Map<String, Object>> insertRows(User user, Container container, List<Map<String, Object>> rows, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext) throws QueryUpdateServiceException
+        {
+            throw new UnsupportedOperationException("Query datasets do not support inserting rows.");
+        }
+
+        @Override
+        public List<Map<String, Object>> updateRows(User user, Container container, List<Map<String, Object>> rows, List<Map<String, Object>> oldKeys, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext) throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
+        {
+            throw new UnsupportedOperationException("Query datasets do not support updating rows.");
+        }
+
+        @Override
+        protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, @Nullable Map<Enum, Object> configParameters) throws InvalidKeyException, ValidationException, QueryUpdateServiceException
+        {
+            throw new UnsupportedOperationException("Query datasets do not support updating rows.");
+        }
+
+        @Override
+        public List<Map<String, Object>> deleteRows(User user, Container container, List<Map<String, Object>> keys, @Nullable Map<Enum, Object> configParameters, @Nullable Map<String, Object> extraScriptContext) throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
+        {
+            throw new UnsupportedOperationException("Query datasets do not support deleting rows.");
+        }
+
+        @Override
+        protected Map<String, Object> deleteRow(User user, Container container, Map<String, Object> oldRow) throws InvalidKeyException, QueryUpdateServiceException, ValidationException
+        {
+            throw new UnsupportedOperationException("Query datasets do not support deleting rows.");
+        }
+
+        @Override
+        protected int truncateRows(User user, Container container)
+        {
+            throw new UnsupportedOperationException("Query datasets do not support deleting rows.");
+        }
+
+        @Override
+        public int truncateRows(User user, Container container, @Nullable Map<Enum, Object> configParameters, @Nullable Map<String, Object> extraScriptContext) throws BatchValidationException, QueryUpdateServiceException, SQLException
+        {
+            throw new UnsupportedOperationException("Query datasets do not support deleting rows.");
+        }
+    }
+}

--- a/study/src/org/labkey/study/query/QueryDatasetTable.java
+++ b/study/src/org/labkey/study/query/QueryDatasetTable.java
@@ -1,24 +1,13 @@
 package org.labkey.study.query;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.MutableColumnInfo;
-import org.labkey.api.dataiterator.DataIteratorBuilder;
-import org.labkey.api.dataiterator.DataIteratorContext;
-import org.labkey.api.query.BatchValidationException;
-import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryUpdateService;
-import org.labkey.api.query.QueryUpdateServiceException;
-import org.labkey.api.query.ValidationException;
-import org.labkey.api.security.User;
-import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.Pair;
 import org.labkey.study.model.DatasetDefinition;
 
-import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -50,77 +39,6 @@ public class QueryDatasetTable extends DatasetTableImpl
     @Override
     public QueryUpdateService getUpdateService()
     {
-        User user = _userSchema.getUser();
-        if (!user.hasRootAdminPermission() && !hasPermission(user, ReadPermission.class))
-            return null;
-        return new QueryDatasetUpdateService(this);
-    }
-
-    private static class QueryDatasetUpdateService extends DatasetUpdateService
-    {
-        public QueryDatasetUpdateService(DatasetTableImpl table)
-        {
-            super(table);
-        }
-
-        @Override
-        public int mergeRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
-        {
-            throw new UnsupportedOperationException("Query datasets do not support importing rows.");
-        }
-
-        @Override
-        public int loadRows(User user, Container container, DataIteratorBuilder rows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
-        {
-            throw new UnsupportedOperationException("Query datasets do not support importing rows.");
-        }
-
-        @Override
-        public int importRows(User user, Container container, DataIteratorBuilder rows, BatchValidationException errors, Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
-        {
-            throw new UnsupportedOperationException("Query datasets do not support importing rows.");
-        }
-
-        @Override
-        public List<Map<String, Object>> insertRows(User user, Container container, List<Map<String, Object>> rows, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext) throws QueryUpdateServiceException
-        {
-            throw new UnsupportedOperationException("Query datasets do not support inserting rows.");
-        }
-
-        @Override
-        public List<Map<String, Object>> updateRows(User user, Container container, List<Map<String, Object>> rows, List<Map<String, Object>> oldKeys, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext) throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
-        {
-            throw new UnsupportedOperationException("Query datasets do not support updating rows.");
-        }
-
-        @Override
-        protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, @Nullable Map<Enum, Object> configParameters) throws InvalidKeyException, ValidationException, QueryUpdateServiceException
-        {
-            throw new UnsupportedOperationException("Query datasets do not support updating rows.");
-        }
-
-        @Override
-        public List<Map<String, Object>> deleteRows(User user, Container container, List<Map<String, Object>> keys, @Nullable Map<Enum, Object> configParameters, @Nullable Map<String, Object> extraScriptContext) throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
-        {
-            throw new UnsupportedOperationException("Query datasets do not support deleting rows.");
-        }
-
-        @Override
-        protected Map<String, Object> deleteRow(User user, Container container, Map<String, Object> oldRow) throws InvalidKeyException, QueryUpdateServiceException, ValidationException
-        {
-            throw new UnsupportedOperationException("Query datasets do not support deleting rows.");
-        }
-
-        @Override
-        protected int truncateRows(User user, Container container)
-        {
-            throw new UnsupportedOperationException("Query datasets do not support deleting rows.");
-        }
-
-        @Override
-        public int truncateRows(User user, Container container, @Nullable Map<Enum, Object> configParameters, @Nullable Map<String, Object> extraScriptContext) throws BatchValidationException, QueryUpdateServiceException, SQLException
-        {
-            throw new UnsupportedOperationException("Query datasets do not support deleting rows.");
-        }
+        return null;
     }
 }

--- a/study/src/org/labkey/study/view/createDatasetSnapshot.jsp
+++ b/study/src/org/labkey/study/view/createDatasetSnapshot.jsp
@@ -19,6 +19,7 @@
 <%@ page import="org.labkey.api.data.SimpleFilter" %>
 <%@ page import="org.labkey.api.query.QueryView" %>
 <%@ page import="org.labkey.api.query.snapshot.QuerySnapshotService" %>
+<%@ page import="org.labkey.api.settings.AppProps" %>
 <%@ page import="org.labkey.api.study.Dataset" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
@@ -26,6 +27,8 @@
 <%@ page import="org.labkey.study.controllers.StudyController" %>
 <%@ page import="java.util.LinkedHashMap" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="org.labkey.study.model.QueryDataset" %>
+<%@ page import="org.labkey.study.query.DatasetQueryView" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -93,12 +96,20 @@
                 </table>
             </td>
         </tr>
+        <% if (AppProps.getInstance().isOptionalFeatureEnabled(DatasetQueryView.EXPERIMENTAL_QUERY_DATASETS)) { %>
+            <tr><td class="labkey-form-label">Query Backed Dataset:</td>
+                <td>
+                    <% addHandler("queryDataset", "click", "onQueryDatasetChange();"); %>
+                    <input type=checkbox id="queryDataset" name="queryDataset">
+                </td>
+            </tr>
+        <% } %>
     </table>
     <br/>
         <%
             if (!bean.isEdit())
             {
-                out.println(button("Edit Dataset Definition").submit(true).onClick("this.form.action.value='" + StudyController.StudySnapshotForm.EDIT_DATASET + "'"));
+                out.println(button("Edit Dataset Definition").submit(true).onClick("this.form.action.value='" + StudyController.StudySnapshotForm.EDIT_DATASET + "'").id("editDataset"));
             }
 
             out.println(button(bean.isEdit() ? "Save" : "Create Snapshot").submit(true));
@@ -129,6 +140,33 @@
     {
         if (manualUpdate.checked)
             updateDelay.value = "0";
+    }
+
+    function onQueryDatasetChange()
+    {
+        const checked = document.getElementById('queryDataset').checked;
+        const manualUpdate = document.getElementById('manualUpdate');
+        const updateType = document.getElementById('updateType');
+        const updateDelay = document.getElementById('updateDelay');
+        const editDataset = document.getElementById('editDataset');
+
+        manualUpdate.disabled = checked;
+        updateType.disabled = checked;
+        if (updateDelay)
+            updateDelay.disabled = checked;
+
+        if (editDataset) {
+            if (checked) {
+                editDataset.style.color = 'gray';
+                editDataset.style.borderColor = 'gray';
+                editDataset.style.pointerEvents = 'none';
+            }
+            else {
+                editDataset.style.color = '';
+                editDataset.style.borderColor = '';
+                editDataset.style.pointerEvents = '';
+            }
+        }
     }
 
 </script>

--- a/study/src/org/labkey/study/writer/DatasetDefinitionWriter.java
+++ b/study/src/org/labkey/study/writer/DatasetDefinitionWriter.java
@@ -67,6 +67,9 @@ public class DatasetDefinitionWriter implements InternalStudyWriter
 
         for (DatasetDefinition def : datasets)
         {
+            if (def.isQueryDataset())
+                continue;
+
             DatasetsDocument.Datasets.Datasets2.Dataset datasetXml = datasets2Xml.addNewDataset();
             datasetXml.setName(def.getName());
             datasetXml.setId(def.getDatasetId());


### PR DESCRIPTION
#### Rationale
Live query snapshot datasets. Essentially an unprovisioned dataset backed by a live query.

#### Changes
- Create new dataset type that uses a LK query as it's data.
- Update dataset definition to save the required source query fields.
- Add virtual table backing the query dataset
- Update snapshot UI and add experimental flag.
- Update create snapshot API
- Add Query change listener
- Prevent any attempts to mutate this dataset
- Opt out of export
