### PR TITLE
trendlineField.js for loop change to fix JS error

### DIFF
--- a/visualization/resources/web/vis/chartWizard/chartTypeDialog/trendlineField.js
+++ b/visualization/resources/web/vis/chartWizard/chartTypeDialog/trendlineField.js
@@ -24,9 +24,11 @@ Ext4.define('LABKEY.vis.TrendlineField', {
     getTrendlineTypeStore: function() {
         if (!this.trendlineTypeStore) {
             const data = [];
-            for (let value in this.options) {
-                const option = LABKEY.vis.GenericChartHelper.TRENDLINE_OPTIONS[this.options[value]];
-                data.push([option.value, option.label, option.showMin, option.showMax, option.schemaPrefix]);
+            for (let i = 0; i < this.options.length; i++) {
+                const option = LABKEY.vis.GenericChartHelper.TRENDLINE_OPTIONS[this.options[i]];
+                if (option) {
+                    data.push([option.value, option.label, option.showMin, option.showMax, option.schemaPrefix]);
+                }
             }
 
             this.trendlineTypeStore = Ext4.create('Ext.data.ArrayStore', {


### PR DESCRIPTION
#### Rationale
Nightly is showing a JS error when viewing line charts because of a for loop in the trendlineField.js code. It is iterating over the array "object" keys instead of the array element. 

#### Changes
- convert for loop to iterate over array elements
