### PR TITLE
Fix deleting existing templates

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -8413,13 +8413,10 @@ public class QueryController extends SpringActionController
                     xmlTable.setTableDbType("NOT_IN_DB");
                 }
 
-                xmlImportTemplates = xmlTable.getImportTemplates();
-                if (xmlImportTemplates == null)
-                    xmlImportTemplates = xmlTable.addNewImportTemplates();
-
                 // remove existing templates
-                for (int i = 0; i < xmlImportTemplates.getTemplateArray().length; i++)
-                    xmlImportTemplates.removeTemplate(i);
+                if (xmlTable.isSetImportTemplates())
+                    xmlTable.unsetImportTemplates();
+                xmlImportTemplates = xmlTable.addNewImportTemplates();
 
                 // set new templates
                 if (!updatedTemplates.isEmpty())


### PR DESCRIPTION
#### Rationale
On import template updates, the existing templates arrays are deleted and the new template are written to the query xml. The code that deletes the existing templates is problematic since it deletes based on index of the array being mutated. Changes made to properly reset importTemplates during update.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1678
- https://github.com/LabKey/labkey-ui-premium/pull/632
- https://github.com/LabKey/platform/pull/6188
- https://github.com/LabKey/testAutomation/pull/2214
- https://github.com/LabKey/limsModules/pull/1041

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
