### PR TITLE
Issue 51894: Tests for cross-type and cross-folder import and fix issue

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -664,7 +664,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
             }
         }
 
-        // Issue 40302: Unable to use samples or data class with integer like names as material or data input
+        // Issue 40302: Unable to use samples or data class with integer-like names as material or data input
         // treat lineage columns as string values
         if (loader != null && allowLineageColumns)
         {

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4126,12 +4126,25 @@ public class ExperimentController extends SpringActionController
         protected @Nullable Set<String> getLineageImportAliases() throws IOException
         {
             boolean crossTypeImport = getOptionParamValue(AbstractQueryImportAction.Params.crossTypeImport);
-            if (!crossTypeImport)
+            // Issue 51894: We need to stop conversion to numbers for alias fields for all type
+            // If there are aliases defined for one type that are number fields in another type, this will prevent
+            // conversion to numbers during the initial partitioning, but the conversion will happen when the partition
+            // file is loaded.
+            if (crossTypeImport)
+            {
+                List<ExpSampleTypeImpl> sampleTypes = SampleTypeServiceImpl.get().getSampleTypes(getContainer(), getUser(), true);
+                Set<String> aliases = new CaseInsensitiveHashSet();
+                for (ExpSampleTypeImpl sampleType : sampleTypes)
+                {
+                    aliases.addAll(sampleType.getImportAliases().keySet());
+                }
+                return aliases;
+            }
+            else
             {
                 ExpSampleTypeImpl sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), getUser(), _form.getQueryName());
                 return new CaseInsensitiveHashSet(sampleType.getImportAliases().keySet());
             }
-            return null;
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
When doing a cross-type import, we need to make sure none of the lineage-related columns are converted to numbers for any of the sample types. This may result in some columns that are not aliases in all sample types being written as Strings in the partitioned files, but that should be handled properly when processing the individual files (and, in any case, is a bit of an edge case).

(Kind of makes me wonder if we'd just make everything map to a string type when splitting the files and do conversions when processing individual type files, but I'll leave this as is for the 25.1 change.)

#### Related Pull Requests
- #6179 
- https://github.com/LabKey/limsModules/pull/1038

#### Changes
- Pass through all sample type import aliases for cross-type import
