### PR TITLE
Add startup properties to enable/disable system maintenance tasks

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -143,8 +143,8 @@ import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.AdminConsole.OptionalFeatureFlag;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.AppPropsTestCase;
-import org.labkey.api.settings.FolderSettingsCache;
 import org.labkey.api.settings.BaseServerProperties;
+import org.labkey.api.settings.FolderSettingsCache;
 import org.labkey.api.settings.LookAndFeelFolderPropertiesTest;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.settings.OptionalFeatureService.FeatureType;
@@ -176,6 +176,7 @@ import org.labkey.api.util.SessionHelper;
 import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.SystemMaintenance;
+import org.labkey.api.util.SystemMaintenanceStartupListener;
 import org.labkey.api.util.URIUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.emailTemplate.EmailTemplate;
@@ -255,8 +256,10 @@ public class ApiModule extends CodeOnlyModule
         AuthenticationManager.registerMetricsProvider();
         ApiKeyManager.get().handleStartupProperties();
         MailHelper.init();
-        // Handle optional feature startup properties as late as possible; we want all optional features to be registered first
+        // Handle optional feature and system maintenance startup properties as late as possible; we want all optional
+        // features and system maintenance tasks to be registered first
         ContextListener.addStartupListener(new OptionalFeatureStartupListener());
+        ContextListener.addStartupListener(new SystemMaintenanceStartupListener());
         ContextListener.addStartupListener(new StartupPropertyStartupListener());
     }
 

--- a/api/src/org/labkey/api/settings/AdminConsole.java
+++ b/api/src/org/labkey/api/settings/AdminConsole.java
@@ -232,5 +232,4 @@ public class AdminConsole
             return getFlag();
         }
     }
-
 }

--- a/api/src/org/labkey/api/settings/StartupProperty.java
+++ b/api/src/org/labkey/api/settings/StartupProperty.java
@@ -7,7 +7,7 @@ public interface StartupProperty
     // As a convenience for enum implementations, where getPropertyName() simply returns Enum.name()
     default String name()
     {
-        throw new IllegalStateException("Must override getStartupProp()");
+        throw new IllegalStateException("Must override getPropertyName()");
     }
 
     // Implementations can override this to use an alternative property name (not name()) or to filter out specific

--- a/api/src/org/labkey/api/settings/StartupPropertyHandler.java
+++ b/api/src/org/labkey/api/settings/StartupPropertyHandler.java
@@ -2,9 +2,12 @@ package org.labkey.api.settings;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.util.DOM;
 
 import java.util.Collection;
 import java.util.Map;
+
+import static org.labkey.api.util.DOM.STRONG;
 
 public abstract class StartupPropertyHandler<T extends StartupProperty>
 {
@@ -22,6 +25,12 @@ public abstract class StartupPropertyHandler<T extends StartupProperty>
     public String getScope()
     {
         return _scope;
+    }
+
+    // Override to provide more detailed scope-wide guidance on the Startup Properties page
+    public DOM.Renderable getScopeDescription()
+    {
+        return STRONG(getScope());
     }
 
     public String getStartupPropertyClassName()

--- a/api/src/org/labkey/api/util/SystemMaintenance.java
+++ b/api/src/org/labkey/api/util/SystemMaintenance.java
@@ -22,6 +22,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.PropertyManager;
 import org.labkey.api.data.PropertyManager.WritablePropertyMap;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.settings.StartupProperty;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
@@ -45,8 +47,6 @@ import java.util.stream.Collectors;
 
 /**
  * Manages scheduling and queuing system maintenance tasks.
- * User: adam
- * Date: Sep 29, 2006
  */
 public class SystemMaintenance
 {
@@ -140,6 +140,8 @@ public class SystemMaintenance
     {
         if (task.getName().contains(","))
             throw new IllegalStateException("System maintenance task " + task.getClass().getSimpleName() + " has a comma in its name (" + task.getName() + ")");
+        if (ModuleLoader.getInstance().isStartupComplete())
+            throw new IllegalStateException("System maintenance task " + task.getClass().getSimpleName() + " was added after startup was complete");
         TASKS.add(task);
     }
 
@@ -170,6 +172,7 @@ public class SystemMaintenance
         return new SystemMaintenanceProperties(props);
     }
 
+    // For all tasks that can be disabled, set the enabledTasks to enabled and set the rest to disabled
     public static void setProperties(Set<String> enabledTasks, String time)
     {
         WritablePropertyMap writableProps = PropertyManager.getWritableProperties(SET_NAME, true);
@@ -188,25 +191,31 @@ public class SystemMaintenance
         setTimer();
     }
 
-    public static void enableTask(String taskToEnable)
+    // Enable all tasksToEnable, disable all tasksToDisable, and don't modify the enabled property for all other tasks
+    public static void ensureTaskProperties(Set<String> tasksToEnable, Set<String> tasksToDisable)
     {
         WritablePropertyMap writableProps = PropertyManager.getWritableProperties(SET_NAME, true);
         String disabled = writableProps.get(DISABLED_TASKS_PROPERTY_NAME);
         String enabled = writableProps.get(ENABLED_TASKS_PROPERTY_NAME);
 
-        Set<String> disabledTasks = new HashSet<>();
-        Set<String> enabledTasks = new HashSet<>();
-        if (disabled != null)
-            disabledTasks.addAll(Arrays.asList(disabled.split(",")));
-        if (enabled != null)
-            enabledTasks.addAll(Arrays.asList(enabled.split(",")));
+        Set<String> disabledTasks = StringUtils.isEmpty(disabled) ? new HashSet<>() : new HashSet<>(Arrays.asList(disabled.split(",")));
+        Set<String> enabledTasks = StringUtils.isEmpty(enabled) ? new HashSet<>() : new HashSet<>(Arrays.asList(enabled.split(",")));
 
-        disabledTasks.remove(taskToEnable);
-        enabledTasks.add(taskToEnable);
+        disabledTasks.removeAll(tasksToEnable);
+        disabledTasks.addAll(tasksToDisable);
+        enabledTasks.removeAll(tasksToDisable);
+        enabledTasks.addAll(tasksToEnable);
 
         writableProps.put(DISABLED_TASKS_PROPERTY_NAME, StringUtils.join(disabledTasks, ","));
         writableProps.put(ENABLED_TASKS_PROPERTY_NAME, StringUtils.join(enabledTasks, ","));
 
+        writableProps.save();
+    }
+
+    public static void clearProperties()
+    {
+        WritablePropertyMap writableProps = PropertyManager.getWritableProperties(SET_NAME, true);
+        writableProps.clear();
         writableProps.save();
     }
 
@@ -251,9 +260,10 @@ public class SystemMaintenance
     /**
      * A specific piece of maintenance to be run as part of the overall {@link MaintenancePipelineJob}.
      */
-    public interface MaintenanceTask
+    public interface MaintenanceTask extends StartupProperty
     {
         /** Description used in logging and UI */
+        @Override
         String getDescription();
 
         /**
@@ -300,6 +310,16 @@ public class SystemMaintenance
         default boolean isRecurring()
         {
             return true;
+        }
+
+        /**
+         * For StartupProperty implementation
+         */
+        @Override
+        @NotNull
+        default String getPropertyName()
+        {
+            return getName();
         }
     }
 }

--- a/api/src/org/labkey/api/util/SystemMaintenanceStartupListener.java
+++ b/api/src/org/labkey/api/util/SystemMaintenanceStartupListener.java
@@ -1,0 +1,60 @@
+package org.labkey.api.util;
+
+import jakarta.servlet.ServletContext;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.settings.MapBasedStartupPropertyHandler;
+import org.labkey.api.settings.StartupPropertyEntry;
+import org.labkey.api.util.SystemMaintenance.MaintenanceTask;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.labkey.api.util.DOM.SPAN;
+import static org.labkey.api.util.DOM.STRONG;
+
+public class SystemMaintenanceStartupListener implements StartupListener
+{
+    @Override
+    public String getName()
+    {
+        return "System maintenance task startup property handler";
+    }
+
+    @Override
+    public void moduleStartupComplete(ServletContext servletContext)
+    {
+        ModuleLoader.getInstance().handleStartupProperties(new SystemMaintenanceStartupPropertyHandler());
+    }
+
+    private static class SystemMaintenanceStartupPropertyHandler extends MapBasedStartupPropertyHandler<MaintenanceTask>
+    {
+        public SystemMaintenanceStartupPropertyHandler()
+        {
+            super(
+                "SystemMaintenance",
+                MaintenanceTask.class.getName(),
+                SystemMaintenance.getTasks().stream()
+                    .filter(MaintenanceTask::canDisable)
+                    .sorted(Comparator.comparing(MaintenanceTask::getPropertyName, String.CASE_INSENSITIVE_ORDER))
+            );
+        }
+
+        @Override
+        public DOM.Renderable getScopeDescription()
+        {
+            return SPAN(STRONG(getScope()), " - set these properties to true/false to enable/disable the corresponding task");
+        }
+
+        @Override
+        public void handle(Map<MaintenanceTask, StartupPropertyEntry> properties)
+        {
+            Map<Boolean, Set<String>> map = properties.values().stream()
+                .collect(
+                    Collectors.partitioningBy(prop -> Boolean.valueOf(prop.getValue()), Collectors.mapping(StartupPropertyEntry::getName, Collectors.toSet()))
+                );
+            SystemMaintenance.ensureTaskProperties(map.get(true), map.get(false));
+        }
+    }
+}

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -3366,6 +3366,28 @@ public class AdminController extends SpringActionController
         }
     }
 
+    @AdminConsoleAction(AdminOperationsPermission.class)
+    public static class ResetSystemMaintenanceAction extends FormHandlerAction<Object>
+    {
+        @Override
+        public void validateCommand(Object target, Errors errors)
+        {
+        }
+
+        @Override
+        public boolean handlePost(Object o, BindException errors) throws Exception
+        {
+            SystemMaintenance.clearProperties();
+            return true;
+        }
+
+        @Override
+        public URLHelper getSuccessURL(Object o)
+        {
+            return new AdminUrlsImpl().getAdminConsoleURL();
+        }
+    }
+
     public static class SystemMaintenanceForm
     {
         private String _taskName;

--- a/core/src/org/labkey/core/admin/systemMaintenance.jsp
+++ b/core/src/org/labkey/core/admin/systemMaintenance.jsp
@@ -27,6 +27,7 @@
 <%@ page import="org.labkey.api.util.SystemMaintenance.MaintenanceTask" %>
 <%@ page import="org.labkey.api.util.SystemMaintenance.SystemMaintenanceProperties" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.labkey.core.admin.AdminController" %>
 <%@ page import="org.labkey.core.admin.AdminController.AdminUrlsImpl" %>
 <%@ page import="org.labkey.core.admin.AdminController.SystemMaintenanceAction" %>
 <%@ page import="java.util.ArrayList" %>
@@ -146,6 +147,7 @@
             <tr>
                 <td style="padding-top: 10px;">
                     <%= hasAdminOpsPerms ? button("Save").submit(true).onClick("return validateForm();") : HtmlString.EMPTY_STRING %>
+                    <%= hasAdminOpsPerms ? button("Reset to Defaults").href(AdminController.ResetSystemMaintenanceAction.class, getContainer()).usePost() : HtmlString.EMPTY_STRING %>
                     <%= button(!hasAdminOpsPerms ? "Done" : "Cancel").href(new AdminUrlsImpl().getAdminConsoleURL()) %>
                 </td>
             </tr>


### PR DESCRIPTION
#### Rationale
Adding enable/disable startup properties for all configurable system maintenance tasks was straightforward and may be useful.

Also, add "Reset to Defaults" button to system maintenance page and ability to add scope-wide guidance to startup properties page.

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/136