### PR TITLE
Give a stronger error when referencing an invalid config

### DIFF
--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -1522,7 +1522,7 @@ public class PipelineController extends SpringActionController
                 }
                 else
                 {
-                    errors.reject(ERROR_MSG, "Form with id " + rowId + " could not be found");
+                    throw new NotFoundException("Pipeline trigger with id " + rowId + " could not be found");
                 }
             }
 


### PR DESCRIPTION
#### Rationale
Today, if you try to view a file watcher that doesn't exist in the current container scope, the code tries to give you an error. But it just loads a broken edit form instead, ignoring the helpful error message.

#### Changes
- Throw a NotFoundException to make it clear there's a problem