### PR TITLE
Improve schema upgrade logging and version enforcement

### DIFF
--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -475,6 +475,15 @@ public class ModuleLoader implements MemTrackerListener
         }
     }
 
+    private record UpgradeInfo(String moduleName, double installedVersion)
+    {
+        @Override
+        public String toString()
+        {
+            return moduleName + " (from schema " + ModuleContext.formatVersion(installedVersion) + ")";
+        }
+    }
+
     /** Full web-server initialization */
     private void doInit(Execution execution) throws ServletException
     {
@@ -646,7 +655,7 @@ public class ModuleLoader implements MemTrackerListener
         upgradeLabKeySchemaInExternalDataSources();
 
         ModuleContext coreCtx;
-        List<String> modulesRequiringUpgrade = new LinkedList<>();
+        List<UpgradeInfo> modulesRequiringUpgrade = new LinkedList<>();
         List<String> additionalSchemasRequiringUpgrade = new LinkedList<>();
         List<String> downgradedModules = new LinkedList<>();
 
@@ -675,7 +684,7 @@ public class ModuleLoader implements MemTrackerListener
                     if (context.needsUpgrade(module.getSchemaVersion()))
                     {
                         context.setModuleState(ModuleState.InstallRequired);
-                        modulesRequiringUpgrade.add(context.getName());
+                        modulesRequiringUpgrade.add(new UpgradeInfo(context.getName(), context.getInstalledVersion()));
                         addModuleToLockFile(context.getName(), lockFile);
                     }
                     else

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -780,11 +780,11 @@ public class ModuleLoader implements MemTrackerListener
     /**
      * Does this module live in a repository that's managed by LabKey Corporation?
      * @param module a Module
-     * @return true if the module's VCS URL is non-null and starts with one of the GitHub organizations that LabKey manages
+     * @return true if the module's VCS URL is non-null and includes "github.com:LabKey/"
      */
     private boolean isFromLabKeyRepository(Module module)
     {
-        return StringUtils.startsWithAny(module.getVcsUrl(), "https://github.com/LabKey/");
+        return StringUtils.containsAny(module.getVcsUrl(), "github.com:LabKey/");
     }
 
     /**

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -480,7 +480,8 @@ public class ModuleLoader implements MemTrackerListener
         @Override
         public String toString()
         {
-            return moduleName + " (from schema " + ModuleContext.formatVersion(installedVersion) + ")";
+            return moduleName + " (from schema version " + ModuleContext.formatVersion(installedVersion) + ")";
+
         }
     }
 


### PR DESCRIPTION
#### Rationale
A recent failed upgrade of an older-than-supported DB pointed out some shortcomings

#### Changes
- Log the starting version for schemas needing upgrade
- Check for the way that GitHub VCS URLs are being captured as module properties