### PR TITLE
Avoid NPE when connection is cut when rendering assay QC warnings

### DIFF
--- a/api/src/org/labkey/api/assay/AssayProtocolSchema.java
+++ b/api/src/org/labkey/api/assay/AssayProtocolSchema.java
@@ -89,6 +89,7 @@ import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.StringExpressionFactory;
+import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
 import org.labkey.api.view.NotFoundException;
@@ -746,13 +747,17 @@ public abstract class AssayProtocolSchema extends AssaySchema implements UserSch
                                     }
                                     catch(IOException e)
                                     {
-                                        throw new RuntimeException(e);
+                                        throw UnexpectedException.wrap(e);
                                     }
                                 });
                             }
                         }
                         catch (SQLException | IOException e)
                         {
+                            if (errors == null)
+                            {
+                                throw UnexpectedException.wrap(e);
+                            }
                             errors.reject(SpringActionController.ERROR_MSG, e.getMessage());
                         }
                     }


### PR DESCRIPTION
#### Rationale
```
java.lang.NullPointerException: Cannot invoke "org.springframework.validation.BindException.reject(String, String)" because "errors" is null
	at org.labkey.api.assay.AssayProtocolSchema$DataRegionDecorator.addQCWarningIndicator(AssayProtocolSchema.java:751)
	at org.labkey.api.assay.AssayProtocolSchema.createDataQueryView(AssayProtocolSchema.java:660)
	at org.labkey.api.assay.AssayResultsView.<init>(AssayResultsView.java:41)
	at org.labkey.assay.view.AssayResultsWebPartFactory.getWebPartView(AssayResultsWebPartFactory.java:49)
	at org.labkey.assay.view.AssayBaseWebPartFactory.getWebPartView(AssayBaseWebPartFactory.java:88)
	at org.labkey.api.view.Portal.getWebPartViewSafe(Portal.java:1668)
	at org.labkey.api.view.Portal.populatePortalView(Portal.java:1414)
	at org.labkey.api.view.Portal.populatePortalView(Portal.java:1370)
	at org.labkey.core.portal.ProjectController$BeginAction.getView(ProjectController.java:369)
	at org.labkey.core.portal.ProjectController$BeginAction.getView(ProjectController.java:313)
	at org.labkey.api.action.SimpleViewAction.handleRequest(SimpleViewAction.java:75)
	at org.labkey.api.action.BaseViewAction.handleRequest(BaseViewAction.java:193)
	at org.labkey.api.action.SpringActionController.handleRequest(SpringActionController.java:508)
```

#### Changes
- Rethrow exception in cases where a BindException isn't available