### PR TITLE
Add ManageVersion property to all module.properties files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -274,7 +274,6 @@ api/src/org/labkey/api/assay/AssayWarningsDisplayColumn.java -text
 api/src/org/labkey/api/assay/AssayWellExclusionService.java -text
 api/src/org/labkey/api/assay/bulkPropertiesInput.jsp -text
 api/src/org/labkey/api/assay/DefaultAssayRunCreator.java -text
-api/src/org/labkey/api/assay/DefaultDataTransformer.java -text
 api/src/org/labkey/api/assay/fileUpload.jsp -text
 api/src/org/labkey/api/assay/FileUploadDataCollector.java -text
 api/src/org/labkey/api/assay/pipeline/AssayRunAsyncContext.java -text
@@ -932,12 +931,7 @@ api/src/org/labkey/api/pipeline/WorkDirFactory.java -text
 api/src/org/labkey/api/pipeline/XMLBeanTaskFactoryFactory.java -text
 api/src/org/labkey/api/portal/ProjectUrls.java -text
 api/src/org/labkey/api/premium/AntiVirusService.java -text
-api/src/org/labkey/api/qc/DataExchangeHandler.java -text
 api/src/org/labkey/api/qc/DataLoaderSettings.java -text
-api/src/org/labkey/api/qc/DataTransformer.java -text
-api/src/org/labkey/api/qc/DefaultTransformResult.java -text
-api/src/org/labkey/api/qc/TransformDataHandler.java -text
-api/src/org/labkey/api/qc/TransformResult.java -text
 api/src/org/labkey/api/qc/TsvDataExchangeHandler.java -text
 api/src/org/labkey/api/qc/TsvDataSerializer.java -text
 api/src/org/labkey/api/qc/ValidationDataHandler.java -text
@@ -1248,7 +1242,6 @@ api/src/org/labkey/api/security/SecurityUrls.java -text
 api/src/org/labkey/api/security/SessionApiKeyManager.java -text
 api/src/org/labkey/api/security/SessionKeyManager.java -text
 api/src/org/labkey/api/security/SessionReplacingRequest.java -text
-api/src/org/labkey/api/security/TokenAuthenticationManager.java -text
 api/src/org/labkey/api/security/UserCache.java -text
 api/src/org/labkey/api/security/UserManager.java -text
 api/src/org/labkey/api/security/UserPrincipal.java -text
@@ -2836,7 +2829,6 @@ study/src/org/labkey/study/query/VisitUpdateService.java -text
 study/src/org/labkey/study/reports/AssayProgressReport.java -text
 study/src/org/labkey/study/reports/BaseStudyView.java -text
 study/src/org/labkey/study/reports/DefaultAssayProgressSource.java -text
-study/src/org/labkey/study/reports/ExternalReport.java -text
 study/src/org/labkey/study/reports/ParticipantReport.java -text
 study/src/org/labkey/study/reports/ParticipantReportDescriptor.java -text
 study/src/org/labkey/study/reports/QueryAssayProgressSource.java -text
@@ -2881,7 +2873,6 @@ study/src/org/labkey/study/view/dataspace_studyfilter.jsp -text
 study/src/org/labkey/study/view/demoMode.jsp -text
 study/src/org/labkey/study/view/editSnapshot.jsp -text
 study/src/org/labkey/study/view/editVisit.jsp -text
-study/src/org/labkey/study/view/externalReportDesigner.jsp -text
 study/src/org/labkey/study/view/importStudyBatch.jsp -text
 study/src/org/labkey/study/view/importVisitAliases.jsp -text
 study/src/org/labkey/study/view/importVisitMap.jsp -text
@@ -3013,7 +3004,6 @@ study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java -text
 study/test/src/org/labkey/test/tests/study/StudyTest.java -text
 study/test/src/org/labkey/test/tests/study/StudyVisitManagementTest.java -text
 study/test/src/org/labkey/test/tests/study/StudyVisitTagTest.java -text
-study/test/src/org/labkey/test/tests/study/VaccineProtocolTest.java -text
 study/webapp/study/MeasurePicker.js -text
 study/webapp/study/ParticipantFilterPanel.js -text
 study/webapp/study/ParticipantGroup.js -text

--- a/announcements/module.properties
+++ b/announcements/module.properties
@@ -14,3 +14,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/api/module.properties
+++ b/api/module.properties
@@ -8,3 +8,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/assay/module.properties
+++ b/assay/module.properties
@@ -6,3 +6,4 @@ URL: https://www.labkey.org/Documentation/wiki-page.view?name=instrumentData
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/audit/module.properties
+++ b/audit/module.properties
@@ -6,3 +6,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/core/module.properties
+++ b/core/module.properties
@@ -10,3 +10,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/devtools/module.properties
+++ b/devtools/module.properties
@@ -4,3 +4,4 @@ Description: For use during development, not intended for production
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/experiment/module.properties
+++ b/experiment/module.properties
@@ -13,3 +13,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/filecontent/module.properties
+++ b/filecontent/module.properties
@@ -8,3 +8,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/issues/module.properties
+++ b/issues/module.properties
@@ -11,3 +11,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/list/module.properties
+++ b/list/module.properties
@@ -14,3 +14,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/mothership/module.properties
+++ b/mothership/module.properties
@@ -5,3 +5,4 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+ManageVersion: true

--- a/pipeline/module.properties
+++ b/pipeline/module.properties
@@ -12,3 +12,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/query/module.properties
+++ b/query/module.properties
@@ -6,3 +6,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/search/module.properties
+++ b/search/module.properties
@@ -8,3 +8,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/specimen/module.properties
+++ b/specimen/module.properties
@@ -6,3 +6,4 @@ URL: https://www.labkey.com/products-services/sample-management-software/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/study/module.properties
+++ b/study/module.properties
@@ -8,3 +8,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/survey/module.properties
+++ b/survey/module.properties
@@ -7,5 +7,5 @@ Organization: LabKey
 OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
-
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/timeline/module.properties
+++ b/timeline/module.properties
@@ -6,3 +6,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/visualization/module.properties
+++ b/visualization/module.properties
@@ -8,3 +8,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/wiki/module.properties
+++ b/wiki/module.properties
@@ -9,3 +9,4 @@ OrganizationURL: https://www.labkey.com/
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true


### PR DESCRIPTION
#### Rationale
We want every LabKey-managed module to specify the `ManageVersion` property. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47369
