### PR TITLE
Populate LSID fix for pre-existing extensible column rows

### DIFF
--- a/api/src/org/labkey/api/exp/OntologyManager.java
+++ b/api/src/org/labkey/api/exp/OntologyManager.java
@@ -383,7 +383,11 @@ public class OntologyManager
                     throw new CancellationException();
 
                 assert before.start();
-                String lsid = helper.beforeImportObject(map);
+
+                Map<String, Object> modifiableMap = new HashMap<>(map);
+                String lsid = helper.beforeImportObject(modifiableMap);
+                map = Collections.unmodifiableMap(modifiableMap);
+
                 if (lsid == null)
                 {
                     throw new IllegalStateException("No LSID available");


### PR DESCRIPTION
#### Rationale
AbstractDataIterator.getMap() was converted to return an unmodifiableMap. This PR converts it to a modifiable map in OntologyManager.insertTabDelimited to allow extensible columns on pre-existing rows to be populated with an LSID.

[Ticket 51859](https://www.labkey.org/WNPRC/support%20tickets/issues-details.view?issueId=51859)

#### Changes
- Convert to unmodifiable map only for beforeImportObject in OntologyManager.insertTabDelimited
