### PR TITLE
Ignore blank PrimaryTsvColumnName

### DIFF
--- a/specimen/src/org/labkey/specimen/importer/SpecimenImporter.java
+++ b/specimen/src/org/labkey/specimen/importer/SpecimenImporter.java
@@ -2072,7 +2072,8 @@ public class SpecimenImporter extends SpecimenTableManager
         for (var c : importColumns)
             c.getImportAliases().forEach(n -> map.put(n, c));
         for (var c : importColumns)
-            map.put(c.getPrimaryTsvColumnName(), c);
+            if (StringUtils.isNotBlank(c.getPrimaryTsvColumnName()))
+                map.put(c.getPrimaryTsvColumnName(), c);
         return map;
     }
 
@@ -2110,7 +2111,10 @@ public class SpecimenImporter extends SpecimenTableManager
         for (int i=1 ; i<=in.getColumnCount() ; i++)
         {
             ImportableColumn c = importMap.get(in.getColumnInfo(i).getName());
-            names.add(c == null ? null : c.getPrimaryTsvColumnName());
+            String alias = c == null ? null : c.getPrimaryTsvColumnName();
+            if (StringUtils.isBlank(alias))
+                alias = null;
+            names.add(alias);
         }
         return AliasDataIterator.wrap(in, context, names);
     }

--- a/specimen/src/org/labkey/specimen/pipeline/SampleMindedTransformTask.java
+++ b/specimen/src/org/labkey/specimen/pipeline/SampleMindedTransformTask.java
@@ -342,7 +342,8 @@ public class SampleMindedTransformTask extends AbstractSpecimenTransformTask
         outputRow.put("global_unique_specimen_id", barcode);
         String ptid = removeNonNullValue(outputRow, "participantid");
         outputRow.put("ptid", ptid);
-        outputRow.put("tube_type", outputRow.get("vesseldomaintype"));  // specimenevent
+        // NOTE: SpecimenImporter.AliasDataIterator seems to map tubetype and type_type to the same column
+        // Including both leads to AliasDataIterator outputting two colums named "tube_type"
         outputRow.put("tubetype", outputRow.get("vesseldomaintype"));   // missing specimen
         // Fix up the visit number
         String visit = removeNonNullValue(outputRow, "visitname");


### PR DESCRIPTION
#### Rationale
A blank tsv column name results in columns in the dataiterator named ""

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
