### PR TITLE
Issue 51933: Assure we remove all invisible characters from header text

### DIFF
--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -430,7 +430,8 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
         {
             String[] headers = lineFields[_skipLines - 1];
             for (int f = 0; f < nCols; f++)
-                colDescs[f].name = (f >= headers.length || StringUtils.isBlank(headers[f])) ? getDefaultColumnName(f) : headers[f].trim().replaceAll("[\\t\\n\\r]+"," ");
+                // Issue 51933: the trim() method does not trim off any non-breaking spaces, so we'll do a replacement using the larger regex class of invisible characters
+                colDescs[f].name = (f >= headers.length || StringUtils.isBlank(headers[f])) ? getDefaultColumnName(f) : headers[f].replaceAll("[\\p{Z}]+", " ").trim();
         }
         else
         {

--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -431,7 +431,7 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
             String[] headers = lineFields[_skipLines - 1];
             for (int f = 0; f < nCols; f++)
                 // Issue 51933: the trim() method does not trim off any non-breaking spaces, so we'll do a replacement using the larger regex class of invisible characters
-                colDescs[f].name = (f >= headers.length || StringUtils.isBlank(headers[f])) ? getDefaultColumnName(f) : headers[f].replaceAll("[\\p{Z}]+", " ").trim();
+                colDescs[f].name = (f >= headers.length || StringUtils.isBlank(headers[f])) ? getDefaultColumnName(f) : headers[f].replaceAll("[\\p{Z}\\t\\n\\r]+", " ").trim();
         }
         else
         {

--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -336,7 +336,7 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
                     if (f < lineFields[0].length)
                     {
                         String name = lineFields[0][f];
-                        name = name.replaceAll("[\\t\\n\\r]+"," ");
+                        name = name.replaceAll("[\\p{Z}\\t\\n\\r]+"," ").trim();
                         if (_columnInfoMap.containsKey(name))
                         {
                             //preferentially use this class if it matches

--- a/api/src/org/labkey/api/reader/ExcelLoader.java
+++ b/api/src/org/labkey/api/reader/ExcelLoader.java
@@ -786,7 +786,7 @@ public class ExcelLoader extends DataLoader
 
     public static class ExcelLoaderTestCase extends Assert
     {
-        String[] line0 = new String[] { "date", "scan", "time", "mz", "accurateMZ", "mass", "intensity", "charge", "chargeStates", "kl", "background", "median", "peaks", "scan\nFirst", "scanLast", "scanCount", "totalIntensity", "description" };
+        String[] line0 = new String[] { "date", "scan", "time", "mz", "accurateMZ", "mass", "intensity", "charge", "chargeStates", "kl", "background", "median", "peaks", "scan\nFirst\u00A0 \u00A0 ", "scanLast", "scanCount", "totalIntensity", "description" };
         String[] line1Xlsx = new String[] { "2006-01-02 00:00:00", "96", "1543.3400999999999", "858.32460000000003", "false", "1714.6346000000001", "2029.6295", "2", "1", "0.19630893999999999", "26.471083", "12.982442000000001", "4", "92", "100", "9", "20248.761999999999", "description" };
         String[] line1Xls = new String[] { "2006-01-02 00:00", "96.0", "1543.3401", "858.3246", "false", "1714.6346", "2029.6295", "2.0", "1.0", "0.19630894", "26.471083", "12.982442", "4.0", "92.0", "100.0", "9.0", "20248.762", "description"
         };


### PR DESCRIPTION
#### Rationale
Issue [51933](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51933)  the `trim()` method does not remove non-breaking spaces and some other invisible characters, but these characters are not (or should not be) used as characters in the names of fields. We replace a larger set of invisible characters with a space, and then trim the resulting string.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2229

#### Changes
- Update `DataLoader`'s handling of whitespace characters.
