### PR TITLE
Issue 51908: Increase precision for display and storage of stored amounts to nanoliters and nanograms

### DIFF
--- a/api/src/org/labkey/api/data/measurement/AmountDataColumn.java
+++ b/api/src/org/labkey/api/data/measurement/AmountDataColumn.java
@@ -14,6 +14,7 @@ import org.labkey.api.util.HtmlString;
 
 import java.util.Set;
 
+import static org.labkey.api.data.measurement.Measurement.DEFAULT_PRECISION_SCALE;
 import static org.labkey.api.data.measurement.UnitsDataColumn.DEFAULT_UNITS_FIELD_PROPERTY_NAME;
 import static org.labkey.api.data.measurement.UnitsDataColumn.UNITS_FIELD_PROPERTY_NAME;
 import static org.labkey.api.data.measurement.UnitsDataColumn.getFieldKey;
@@ -87,7 +88,10 @@ public class AmountDataColumn extends DataColumn
             return null;
 
         if (ctx.get(_unitsField) == null)
-            return Precision.round(storedAmount, 6);
+        {
+            int scale = sampleTypeUnit == null ? DEFAULT_PRECISION_SCALE : sampleTypeUnit.getKind().getPrecisionScale();
+            return Precision.round(storedAmount, scale);
+        }
 
         try
         {

--- a/api/src/org/labkey/api/data/measurement/AmountDataColumn.java
+++ b/api/src/org/labkey/api/data/measurement/AmountDataColumn.java
@@ -89,7 +89,7 @@ public class AmountDataColumn extends DataColumn
 
         if (ctx.get(_unitsField) == null)
         {
-            int scale = sampleTypeUnit == null ? DEFAULT_PRECISION_SCALE : sampleTypeUnit.getKind().getPrecisionScale();
+            int scale = sampleTypeUnit == null ? DEFAULT_PRECISION_SCALE : sampleTypeUnit.getPrecisionScale();
             return Precision.round(storedAmount, scale);
         }
 

--- a/api/src/org/labkey/api/data/measurement/Measurement.java
+++ b/api/src/org/labkey/api/data/measurement/Measurement.java
@@ -13,6 +13,8 @@ import java.util.regex.Pattern;
 
 public class Measurement
 {
+    public static final int DEFAULT_PRECISION_SCALE = 6;
+
     private static final String NUMBER_REGEX = "[+\\-]?\\d+(?:\\.\\d+)?(?:[Ee][+\\-]\\d+)?";
     private static final Pattern AMOUNT_AND_UNITS_PATTERN = Pattern.compile("\\s*(?<amount>" + NUMBER_REGEX + ")?\\s*(?<units>\\S*)\\s*");
     private Unit _units;
@@ -21,9 +23,21 @@ public class Measurement
 
     public enum Kind
     {
-        Mass,
-        Volume,
-        Count
+        Mass(12),
+        Volume(9),
+        Count(2);
+
+        private final int _precisionScale;
+
+        Kind(int precisionScale)
+        {
+            _precisionScale = precisionScale;
+        }
+
+        public int getPrecisionScale()
+        {
+            return _precisionScale;
+        }
     }
 
     public enum Unit
@@ -120,7 +134,7 @@ public class Measurement
             if (converted == null)
                 return null;
 
-            return Precision.round(converted, 6);
+            return Precision.round(converted, targetUnit == null ? DEFAULT_PRECISION_SCALE : targetUnit.getKind().getPrecisionScale());
         }
 
         public Double convertAmount(@Nullable Double amount, @Nullable Measurement.Unit targetUnit)

--- a/api/src/org/labkey/api/data/measurement/Measurement.java
+++ b/api/src/org/labkey/api/data/measurement/Measurement.java
@@ -23,49 +23,39 @@ public class Measurement
 
     public enum Kind
     {
-        Mass(12),
-        Volume(9),
-        Count(2);
-
-        private final int _precisionScale;
-
-        Kind(int precisionScale)
-        {
-            _precisionScale = precisionScale;
-        }
-
-        public int getPrecisionScale()
-        {
-            return _precisionScale;
-        }
+        Mass,
+        Volume,
+        Count;
     }
 
     public enum Unit
     {
-        g("grams", Kind.Mass, 1),
-        mg("milligrams", Kind.Mass, 0.001),
-        kg("kilograms", Kind.Mass, 1000),
-        mL("milliliters", Kind.Volume, 1),
-        uL("microliters", Kind.Volume, 0.001, "μL"),
-        L("liters", Kind.Volume, 1000),
-        kL("kiloliters", Kind.Volume, 100000),
-        unit("units", Kind.Count, 1);
+        g("grams", Kind.Mass, 1, 9),
+        mg("milligrams", Kind.Mass, 0.001, 6),
+        kg("kilograms", Kind.Mass, 1000, 12),
+        mL("milliliters", Kind.Volume, 1, 6),
+        uL("microliters", Kind.Volume, 0.001, 3, "μL"),
+        L("liters", Kind.Volume, 1000, 9),
+        kL("kiloliters", Kind.Volume, 100000, 12),
+        unit("units", Kind.Count, 1, 2);
 
         private final String _longLabel;
         private final Kind _kind;
         private final double _ratio;
         private final String _alternateName;
+        private final int _precisionScale;
 
-        Unit(String longLabel, Kind kind, double ratio)
+        Unit(String longLabel, Kind kind, double ratio, int precisionScale)
         {
-           this(longLabel, kind, ratio, null);
+           this(longLabel, kind, ratio, precisionScale, null);
         }
 
-        Unit(String longLabel, Kind kind, double ratio, String alternateName)
+        Unit(String longLabel, Kind kind, double ratio, int precisionScale, String alternateName)
         {
             _longLabel = longLabel;
             _kind = kind;
             _ratio = ratio;
+            _precisionScale = precisionScale;
             _alternateName = alternateName;
         }
 
@@ -87,6 +77,11 @@ public class Measurement
         public String getAlternateName()
         {
             return _alternateName;
+        }
+
+        public int getPrecisionScale()
+        {
+            return _precisionScale;
         }
 
         public boolean isCompatible(Unit otherUnit)
@@ -134,7 +129,7 @@ public class Measurement
             if (converted == null)
                 return null;
 
-            return Precision.round(converted, targetUnit == null ? DEFAULT_PRECISION_SCALE : targetUnit.getKind().getPrecisionScale());
+            return Precision.round(converted, targetUnit == null ? DEFAULT_PRECISION_SCALE : targetUnit.getPrecisionScale());
         }
 
         public Double convertAmount(@Nullable Double amount, @Nullable Measurement.Unit targetUnit)
@@ -169,6 +164,7 @@ public class Measurement
                 return false;
 
             return unitA.getKind() == unitB.getKind();
+
         }
 
         public static class TestCase extends Assert

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1557,6 +1557,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
         Double totalVolume = 0.0;
         Double totalAvailableVolume = 0.0;
+        Measurement.Kind unitKind = null;
 
         for (AliquotAmountUnitResult volumeUnit : volumeUnits)
         {
@@ -1570,6 +1571,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 try
                 {
                     unit = StringUtils.isEmpty(aliquotUnit) ? totalDisplayUnit : Measurement.Unit.valueOf(aliquotUnit);
+                    unitKind = unit.getKind();
                 }
                 catch (IllegalArgumentException ignore)
                 {
@@ -1596,9 +1598,9 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
             }
         }
-
-        totalVolume = Precision.round(totalVolume, 6);
-        totalAvailableVolume = Precision.round(totalAvailableVolume, 6);
+        int scale = unitKind == null ? Measurement.DEFAULT_PRECISION_SCALE : unitKind.getPrecisionScale();
+        totalVolume = Precision.round(totalVolume, scale);
+        totalAvailableVolume = Precision.round(totalAvailableVolume, scale);
 
         if (Double.compare(totalVolume, 0.0) == 0)
             totalDisplayUnit = null;

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1555,9 +1555,8 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             }
         }
 
-        Double totalVolume = 0.0;
-        Double totalAvailableVolume = 0.0;
-        Measurement.Kind unitKind = null;
+        double totalVolume = 0.0;
+        double totalAvailableVolume = 0.0;
 
         for (AliquotAmountUnitResult volumeUnit : volumeUnits)
         {
@@ -1571,8 +1570,6 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 try
                 {
                     unit = StringUtils.isEmpty(aliquotUnit) ? totalDisplayUnit : Measurement.Unit.valueOf(aliquotUnit);
-                    if (unitKind == null)
-                        unitKind = unit != null ? unit.getKind() : null;
                 }
                 catch (IllegalArgumentException ignore)
                 {
@@ -1599,7 +1596,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
             }
         }
-        int scale = unitKind == null ? Measurement.DEFAULT_PRECISION_SCALE : unitKind.getPrecisionScale();
+        int scale = totalDisplayUnit == null ? Measurement.DEFAULT_PRECISION_SCALE : totalDisplayUnit.getPrecisionScale();
         totalVolume = Precision.round(totalVolume, scale);
         totalAvailableVolume = Precision.round(totalAvailableVolume, scale);
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1571,7 +1571,8 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 try
                 {
                     unit = StringUtils.isEmpty(aliquotUnit) ? totalDisplayUnit : Measurement.Unit.valueOf(aliquotUnit);
-                    unitKind = unit.getKind();
+                    if (unitKind == null)
+                        unitKind = unit != null ? unit.getKind() : null;
                 }
                 catch (IllegalArgumentException ignore)
                 {


### PR DESCRIPTION
#### Rationale
Issue [51908](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51908): The request here is to allow values to be stored with a precision of nanoliter or nanogram, but not to add these as explicit unit types (yet).

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1690
- https://github.com/LabKey/labkey-ui-premium/pull/644
- https://github.com/LabKey/limsModules/pull/1076

#### Changes
- Add a precision scale for the different unit kinds
- Use precision scale from unit kind when available
