### PR TITLE
Issue 51367: When designer creates a domain, exclude folders they don't have read access to

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -1047,6 +1047,8 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     void ensureDataTypeContainerExclusions(@NotNull DataTypeForExclusion dataType, @Nullable Collection<String> excludedContainerIds, @NotNull Integer dataTypeId, User user);
 
+    void ensureDataTypeContainerExclusionsNonAdmin(@NotNull DataTypeForExclusion dataType, @NotNull Integer dataTypeId, Container container, User user);
+
     String getDisabledDataTypeAuditMsg(ExperimentService.DataTypeForExclusion type, List<Integer> ids, boolean isUpdate);
 
     void registerRunInputsViewProvider(QueryViewProvider<ExpRun> provider);

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -608,6 +608,8 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
 
                 if (assay.getExcludedContainerIds() != null && (!isNew || !assay.getExcludedContainerIds().isEmpty()))
                     ExperimentService.get().ensureDataTypeContainerExclusions(ExperimentService.DataTypeForExclusion.AssayDesign, assay.getExcludedContainerIds(), protocol.getRowId(), getUser());
+                else
+                    ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(ExperimentService.DataTypeForExclusion.AssayDesign, protocol.getRowId(), getContainer(), getUser());
 
                 QueryService.get().updateLastModified();
                 transaction.commit();

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -201,10 +201,12 @@ import org.labkey.api.query.SimpleValidationError;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchService;
+import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.roles.ProjectAdminRole;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.ParticipantVisit;
@@ -7903,6 +7905,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
             if (options != null && options.getExcludedContainerIds() != null && !options.getExcludedContainerIds().isEmpty())
                 ExperimentService.get().ensureDataTypeContainerExclusions(DataTypeForExclusion.DataClass, options.getExcludedContainerIds(), impl.getRowId(), u);
+            else
+                ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(DataTypeForExclusion.DataClass, impl.getRowId(), c, u);
 
             tx.addCommitTask(() -> clearDataClassCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
             tx.commit();
@@ -8841,6 +8845,33 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             }
         }
     }
+
+    @Override
+    public void ensureDataTypeContainerExclusionsNonAdmin(@NotNull DataTypeForExclusion dataType, @NotNull Integer dataTypeId, Container container, User user)
+    {
+        var isAdmin = user.hasApplicationAdminPermission() || container.hasPermission(user, AdminPermission.class);
+
+        if (!isAdmin)
+        {
+            // get the full container list for this project
+            Set<String> folderIds = ContainerManager.getAllChildren(container.getProject(), new LimitedUser(user, ProjectAdminRole.class))
+                    .stream()
+                    .map(Container::getId)
+                    .collect(toSet());
+            // get the set of containers this user has permission to see
+            Set<String> userFolderIds = ContainerManager.getAllChildren(container.getProject(), user)
+                    .stream()
+                    .map(Container::getId)
+                    .collect(toSet());
+            // exclude the containers this user does not have permission to
+            if (folderIds.removeAll(userFolderIds))
+            {
+                ExperimentService.get().ensureDataTypeContainerExclusions(dataType, folderIds, dataTypeId, user);
+            }
+
+        }
+    }
+
 
     private void addAuditEventForDataTypeContainerUpdate(DataTypeForExclusion type, String containerId, User user)
     {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -883,8 +883,12 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                     DefaultValueService.get().setDefaultValues(domain.getContainer(), defaultValues);
                     if (excludedContainerIds != null && !excludedContainerIds.isEmpty())
                         ExperimentService.get().ensureDataTypeContainerExclusions(ExperimentService.DataTypeForExclusion.SampleType, excludedContainerIds, st.getRowId(), u);
+                    else
+                        ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(ExperimentService.DataTypeForExclusion.SampleType, st.getRowId(), c, u);
                     if (excludedDashboardContainerIds != null && !excludedDashboardContainerIds.isEmpty())
                         ExperimentService.get().ensureDataTypeContainerExclusions(ExperimentService.DataTypeForExclusion.DashboardSampleType, excludedDashboardContainerIds, st.getRowId(), u);
+                    else
+                        ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(ExperimentService.DataTypeForExclusion.DashboardSampleType, st.getRowId(), c, u);
                     transaction.addCommitTask(() -> clearMaterialSourceCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
                     return st;
                 }


### PR DESCRIPTION
#### Rationale
Issue [51367](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51367) - Non-admin users that are in one of the designer roles can create sample types, source types, and/or assay designs, and currently these new designs show up in all folders, even the ones these users don't have read access to. It is a little unexpected to have this "side effect" and the users without admin permissions can't change the visibility so the new types may be seen to pollute the spaces that the users don't have access to. We change the logic to exclude the new types from folders the non-admin user doesn't have read access to.  Since non-admin users are not presented with a UI for folder exclusion, the changes here are only for the initial creation of the domains, not for updates.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1077

#### Changes
- Add method `ensureDataTypeContainerExclusionsNonAdmin` to `ExperimentService` and use it when creating new types that can have exclusions.
