### PR TITLE
Migrate <permissionClasses> -> <requiresPermissions>

### DIFF
--- a/core/resources/views/ModulePropertyAdmin.view.xml
+++ b/core/resources/views/ModulePropertyAdmin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.UpdatePermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4"/>
         <dependency path="ModulePropertiesAdminPanel.js"/>

--- a/query/resources/views/importData.view.xml
+++ b/query/resources/views/importData.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Import Data">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4ClientApi"/>
         <dependency path="/extWidgets/ExcelUploadPanel.js"/>

--- a/query/resources/views/importWizard.view.xml
+++ b/query/resources/views/importWizard.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Import Data">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4ClientApi"/>
         <dependency path="/extWidgets/ImportWizard.js"/>

--- a/query/resources/views/manageRecord.view.xml
+++ b/query/resources/views/manageRecord.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Manage Record" frame="portal">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4ClientApi"/>
     </dependencies>

--- a/query/resources/views/recordDetails.view.xml
+++ b/query/resources/views/recordDetails.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" frame="portal">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4ClientApi"/>
         <dependency path="/extWidgets/DetailsPanel.js"/>

--- a/query/resources/views/rowCounts.view.xml
+++ b/query/resources/views/rowCounts.view.xml
@@ -1,5 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Query Row Counts" frame="none">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
 </view>


### PR DESCRIPTION
#### Rationale
We recommend `<requiresPermissions>` since it matches the other elements and action annotations; use what we document so we propagate the recommended element. `<permissionsClasses>` remains a valid synonym.