### PR TITLE
Make ExcelLoader.getSheet public

### DIFF
--- a/api/src/org/labkey/api/reader/ExcelLoader.java
+++ b/api/src/org/labkey/api/reader/ExcelLoader.java
@@ -303,7 +303,7 @@ public class ExcelLoader extends DataLoader
     }
 
 
-    private Sheet getSheet() throws IOException
+    public Sheet getSheet() throws IOException
     {
         try
         {


### PR DESCRIPTION
#### Rationale
Make getSheet() available for handling of .xls files beyond what getFirstNLinesXLS offers.

#### Changes
- Make ExcelLoader.getSheet public
