### PR TITLE
Issue 52020: Add subquery alias for PlateManager.getRunCountUsingPlateInResults()

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -645,7 +645,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             unionSql.append(fragment);
         }
 
-        SQLFragment sql = new SQLFragment("SELECT SUM(RunCount) AS RunCountSum FROM (").append(unionSql).append(")");
+        SQLFragment sql = new SQLFragment("SELECT SUM(RunCount) AS RunCountSum FROM (").append(unionSql).append(") AS RunCountTable");
 
         return ((BigDecimal) new SqlSelector(ExperimentService.get().getSchema(), sql).getMap().get("RunCountSum")).intValueExact();
     }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52020

This issue was also seen on nightly when trying to view Plate Set details. Looks to only repro on PG DB versions < 16 (nightly is on PG 15.7).

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6202

#### Changes
- add subquery alias
