### PR TITLE
Fix AssayExportImportTests

### DIFF
--- a/api/gwtsrc/org/labkey/api/gwt/client/assay/model/GWTProtocol.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/assay/model/GWTProtocol.java
@@ -197,9 +197,8 @@ public class GWTProtocol implements IsSerializable
         return _protocolTransformScripts;
     }
 
-    public void setProtocolTransformScripts(List<Map<String, Object>> protocolTransformScripts)
+    private void handleMapTransformScripts(List<Map<String, Object>> protocolTransformScripts)
     {
-        _protocolTransformScripts = new ArrayList<>(protocolTransformScripts.size());
         for (Map<String, Object> map : protocolTransformScripts)
         {
             _protocolTransformScripts.add(Map.of(
@@ -207,6 +206,34 @@ public class GWTProtocol implements IsSerializable
                     "runOnEdit", map.get("runOnEdit"),
                     "runOnImport", map.get("runOnImport")
             ));
+        }
+    }
+
+    private void handleStringTransformScripts(List<String> protocolTransformScripts)
+    {
+        List<Map<String, Object>> transformedScripts = new ArrayList<>(protocolTransformScripts.size());
+        for (String script : protocolTransformScripts)
+        {
+            transformedScripts.add(Map.of(
+                    "scriptPath", script.trim(),
+                    "runOnEdit", false,
+                    "runOnImport", true
+            ));
+        }
+        handleMapTransformScripts(transformedScripts);
+    }
+
+    public void setProtocolTransformScripts(List<?> protocolTransformScripts)
+    {
+        if (!protocolTransformScripts.isEmpty()) {
+            Object first = protocolTransformScripts.get(0);
+            if (first instanceof Map) {
+                handleMapTransformScripts((List<Map<String, Object>>) protocolTransformScripts);
+            } else if (first instanceof String) {
+                handleStringTransformScripts((List<String>) protocolTransformScripts);
+            } else {
+                throw new IllegalArgumentException("Unsupported type: " + first.getClass().getName());
+            }
         }
     }
 


### PR DESCRIPTION
#### Rationale
Previously, the type of protocolTransformScripts was changed. To maintain backwards compatibility with the current java api which expects protocolTransformScripts to be a list of strings, we are adjusting to handle recieving both a list of maps and a list of strings.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6229

#### Changes
- Add handleMapTransformScripts and handleStringTransformScripts, call them from setProtocolTransformScripts
