### PR TITLE
Ability to Edit Sample IDs in the Grid

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -71,6 +71,7 @@ import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExpRunItem;
 import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.NameExpressionOptionService;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.api.SimpleRunRecord;
 import org.labkey.api.exp.property.PropertyService;
@@ -2373,6 +2374,9 @@ public class ExpDataIterators
             if (!isMergeOrUpdate)
                 keyColumns.add(ExpDataTable.Column.LSID.toString());
 
+            NameExpressionOptionService svc = NameExpressionOptionService.get();
+            boolean canUpdateNames = svc.getAllowUserSpecificNamesValue(_container);
+
             if (isSample)
             {
                 if (isMergeOrUpdate)
@@ -2380,6 +2384,8 @@ public class ExpDataIterators
                     if (isUpdateUsingLsid)
                     {
                         keyColumns.add(ExpDataTable.Column.LSID.toString());
+                        if (!canUpdateNames)
+                            dontUpdate.add("name");
                     }
                     else
                     {
@@ -2401,6 +2407,8 @@ public class ExpDataIterators
                 if (isUpdateUsingLsid)
                 {
                     keyColumns.add(ExpDataTable.Column.LSID.toString());
+                    if (!canUpdateNames)
+                        dontUpdate.add("name");
                 }
                 else
                 {

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3502,10 +3502,12 @@ public class ExperimentController extends SpringActionController
                     notPermittedIds.add(expData.getRowId());
             }
 
+            NameExpressionOptionService svc = NameExpressionOptionService.get();
             response.put("containers", containers.stream().map(c -> Map.of(
                     "id", c.getEntityId(),
                     "path", (Object) c.getPath(),
-                    "permitted", permClass == null || c.hasPermission(getUser(), permClass)
+                    "permitted", permClass == null || c.hasPermission(getUser(), permClass),
+                    "canEditName", svc.getAllowUserSpecificNamesValue(c)
             )).toList());
 
             response.put("notPermitted", notPermittedIds.stream().map(id -> Map.of("RowId", (Object) id)).toList());
@@ -3573,10 +3575,13 @@ public class ExperimentController extends SpringActionController
                     notPermittedIds.add(material.getRowId());
             }
 
+            NameExpressionOptionService svc = NameExpressionOptionService.get();
+
             response.put("containers", containers.stream().map(c -> Map.of(
                     "id", c.getEntityId(),
                     "path", (Object) c.getPath(),
-                    "permitted", permClass == null || c.hasPermission(getUser(), permClass)
+                    "permitted", permClass == null || c.hasPermission(getUser(), permClass),
+                    "canEditName", svc.getAllowUserSpecificNamesValue(c)
             )).toList());
 
             response.put("notPermitted", notPermittedIds.stream().map(id -> Map.of("RowId", (Object) id)).toList());


### PR DESCRIPTION
#### Rationale
getOperationConfirmation apis are used to check if a collection of selected data can be edited based on their status and permission, which is used during cross folder edit. In order to determine if data name can be editable, canEditName has been added to to flag a container as configured to support user provided names.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1695
- https://github.com/LabKey/labkey-ui-premium/pull/649
- https://github.com/LabKey/platform/pull/6240
- https://github.com/LabKey/limsModules/pull/1087

#### Changes
- include 1canEditName` info based on container's AllowUserSpecificNamesValue for GetMaterialOperationConfirmationDataAction and GetDataOperationConfirmationDataAction
