### PR TITLE
don't duplicate rowNumber column in ListOfMapsDataIterator constructor

### DIFF
--- a/api/src/org/labkey/api/data/ResultsImpl.java
+++ b/api/src/org/labkey/api/data/ResultsImpl.java
@@ -70,7 +70,7 @@ public class ResultsImpl implements Results, DataIterator
             _fieldMap = new LinkedHashMap<>(count * 2);
             _fieldIndexMap = new HashMap<>(count * 2);
             _columnInfoList = new ArrayList<>(count+1);
-            _columnInfoList.add(new BaseColumnInfo("_rowNumber", JdbcType.INTEGER));
+            _columnInfoList.add(new BaseColumnInfo(ROWNUMBER_COLUMNNAME, JdbcType.INTEGER));
 
             for (int i = 1; i <= count; i++)
             {
@@ -95,7 +95,7 @@ public class ResultsImpl implements Results, DataIterator
         _fieldMap = new LinkedHashMap<>(cols.size() * 2);
         _fieldIndexMap = new HashMap<>(cols.size() * 2);
         _columnInfoList = new ArrayList<>(cols.size()+1);
-        _columnInfoList.add(new BaseColumnInfo("_rowNumber", JdbcType.INTEGER));
+        _columnInfoList.add(new BaseColumnInfo(ROWNUMBER_COLUMNNAME, JdbcType.INTEGER));
 
         for (ColumnInfo col : cols)
         {
@@ -123,7 +123,7 @@ public class ResultsImpl implements Results, DataIterator
         _fieldMap = null == fieldMap ? Collections.emptyMap() : fieldMap;
         _fieldIndexMap = new HashMap<>(_fieldMap.size() * 2);
         _columnInfoList = new ArrayList<>(fieldMap.size()+1);
-        _columnInfoList.add(new BaseColumnInfo("_rowNumber", JdbcType.INTEGER));
+        _columnInfoList.add(new BaseColumnInfo(ROWNUMBER_COLUMNNAME, JdbcType.INTEGER));
 
         FieldKey fk = null;
         try

--- a/api/src/org/labkey/api/dataiterator/AbstractMapDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/AbstractMapDataIterator.java
@@ -135,9 +135,12 @@ public abstract class AbstractMapDataIterator extends AbstractDataIterator imple
                     set.addAll(row.keySet());
                 colNames = set;
             }
-            colNames.remove(ROWNUMBER_COLUMNNAME);
             for (String name : colNames)
+            {
+                if (ROWNUMBER_COLUMNNAME.equals(name))
+                    continue;
                 _cols.add(new BaseColumnInfo(name, JdbcType.OTHER));
+            }
             _rows = initRows(rows);
         }
 

--- a/api/src/org/labkey/api/dataiterator/AbstractMapDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/AbstractMapDataIterator.java
@@ -135,6 +135,7 @@ public abstract class AbstractMapDataIterator extends AbstractDataIterator imple
                     set.addAll(row.keySet());
                 colNames = set;
             }
+            colNames.remove(ROWNUMBER_COLUMNNAME);
             for (String name : colNames)
                 _cols.add(new BaseColumnInfo(name, JdbcType.OTHER));
             _rows = initRows(rows);

--- a/api/src/org/labkey/api/dataiterator/BeanDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/BeanDataIterator.java
@@ -40,7 +40,7 @@ public class BeanDataIterator<K> extends AbstractDataIterator implements DataIte
         super(context);
 
         _class = cls;
-        _cols.add(new BaseColumnInfo("_rowNumber", JdbcType.INTEGER));
+        _cols.add(new BaseColumnInfo(ROWNUMBER_COLUMNNAME, JdbcType.INTEGER));
         _readMethods.add(null);
         K bean = rows.isEmpty() ? null : rows.get(0);
 

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -136,11 +136,17 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         }
     };
 
+    private void outputColumnsAdd(ColumnInfo c, Supplier s)
+    {
+        _outputColumns.add(new Pair<>(c,s));
+    }
+
+
     public SimpleTranslator(DataIterator source, DataIteratorContext context)
     {
         super(context);
         _data = source;
-        _outputColumns.add(new Pair<>(new BaseColumnInfo(source.getColumnInfo(0)), new PassthroughColumn(0)));
+        outputColumnsAdd(new BaseColumnInfo(source.getColumnInfo(0)), new PassthroughColumn(0));
     }
 
     protected DataIterator getInput()
@@ -1158,13 +1164,13 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                 throw new RuntimeException(x);
             }
         };
-        _outputColumns.add(new Pair<>(col, s));
+        outputColumnsAdd(col, s);
         return _outputColumns.size()-1;
     }
 
     public int addColumn(ColumnInfo col, Supplier call)
     {
-        _outputColumns.add(new Pair<>(col, call));
+        outputColumnsAdd(col, call);
         return _outputColumns.size()-1;
     }
 
@@ -1553,7 +1559,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             }
             else
             {
-                _outputColumns.add(new Pair<>(new BaseColumnInfo(name, e.type), c));
+                outputColumnsAdd(new BaseColumnInfo(name, e.type), c);
                 return _outputColumns.size()-1;
             }
         }

--- a/api/src/org/labkey/api/dataiterator/StringTestIterator.java
+++ b/api/src/org/labkey/api/dataiterator/StringTestIterator.java
@@ -51,7 +51,7 @@ class StringTestIterator extends AbstractDataIterator implements ScrollableDataI
     public ColumnInfo getColumnInfo(int i)
     {
         if (i==0)
-            return new BaseColumnInfo("_rownumber", JdbcType.INTEGER);
+            return new BaseColumnInfo(ROWNUMBER_COLUMNNAME, JdbcType.INTEGER);
         return new BaseColumnInfo(columns.get(i-1),JdbcType.VARCHAR);
     }
 

--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -1001,7 +1001,7 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
         public ColumnInfo getColumnInfo(int i)
         {
             if (i == 0)
-                return new BaseColumnInfo("_rowNumber", JdbcType.INTEGER);
+                return new BaseColumnInfo(ROWNUMBER_COLUMNNAME, JdbcType.INTEGER);
             ColumnDescriptor d = _columns[i-1];
             JdbcType type = JdbcType.valueOf(d.clazz);
             if (null == type)

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -3184,7 +3184,7 @@ public class ExpDataIterators
                 "Modified",
                 "ModifiedBy",
                 "Created",
-                "_rowNumber",
+                ROWNUMBER_COLUMNNAME,
                 RowId.name(),
                 "genId",
                 AliquotedFromLSID.name(),


### PR DESCRIPTION
#### Rationale
don't duplicate rowNumber column in ListOfMapsDataIterator constructor
use ROWNUMBER_COLUMNNAME in more places
fix JHU_Test

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
