### PR TITLE
Configure Markdown renderer to escape and sanitize

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -802,7 +802,7 @@ public class AnnouncementsController extends SpringActionController
             List<AttachmentFile> files = getAttachmentFileList();
 
             AnnouncementModel insert = form.getBean();
-            if (null == insert.getParent() || 0 == insert.getParent().length())
+            if (null == insert.getParent() || insert.getParent().isEmpty())
                 insert.setParent(form.getParentId());
 
             try

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -522,7 +522,7 @@ public class AnnouncementManager
 
                 body = PageFlowUtil.validateHtml(body, validateErrors, hasDeveloperPermission);
 
-                if (validateErrors.size() > 0)
+                if (!validateErrors.isEmpty())
                     throw new RuntimeValidationException("Invalid HTML markup. " + String.join("\n", validateErrors));
 
                 // side-effect

--- a/api/src/org/labkey/api/dataiterator/DataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorBuilder.java
@@ -16,12 +16,6 @@
 
 package org.labkey.api.dataiterator;
 
-/**
- * User: matthewb
- * Date: 2011-05-17
- * Time: 1:47 PM
- */
-
 public interface DataIteratorBuilder
 {
     DataIterator getDataIterator(DataIteratorContext context);

--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -68,12 +68,6 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-/**
- * User: jgarms
- * Date: Oct 22, 2008
- * Time: 11:26:37 AM
- */
-
 // Abstract class for loading columnar data from file sources: TSVs, Excel files, etc.
 public abstract class DataLoader implements Iterable<Map<String, Object>>, Loader, DataIteratorBuilder, Closeable
 {

--- a/api/src/org/labkey/api/reader/Loader.java
+++ b/api/src/org/labkey/api/reader/Loader.java
@@ -23,8 +23,6 @@ import java.util.Map;
 
 /**
  * A loader of columnar data.
- * User: adam
- * Date: Aug 8, 2010
  */
 public interface Loader
 {

--- a/api/src/org/labkey/api/reports/report/r/ParamReplacement.java
+++ b/api/src/org/labkey/api/reports/report/r/ParamReplacement.java
@@ -31,9 +31,6 @@ import java.util.Map;
 /**
  * Handles substitution parameters for R reports by mapping symbolic names to
  * files on generation, as well as rendering the results.
- *
- * User: Karl Lum
- * Date: May 5, 2008
  */
 public interface ParamReplacement
 {

--- a/core/src/org/labkey/core/wiki/MarkdownServiceImpl.java
+++ b/core/src/org/labkey/core/wiki/MarkdownServiceImpl.java
@@ -53,6 +53,8 @@ public class MarkdownServiceImpl implements MarkdownService
             .build();
         _renderer = HtmlRenderer.builder()
             .softbreak("<br>\n")  // See Issue #34169
+            .sanitizeUrls(true)
+            .escapeHtml(true)
             .extensions(extensions)
             .build();
     }

--- a/core/src/org/labkey/core/wiki/MarkdownTestCase.java
+++ b/core/src/org/labkey/core/wiki/MarkdownTestCase.java
@@ -44,14 +44,14 @@ class MarkdownTestCase extends Assert
         MarkdownService markdownService = MarkdownService.get();
 
         String testMdText = "<h2>header</h2>";
-        String expectedHtmlText = "<div class=\"lk-markdown-container\"><h2>header</h2>\n</div>";
+        String expectedHtmlText = "<div class=\"lk-markdown-container\"><p>&lt;h2&gt;header&lt;/h2&gt;</p>\n</div>";
         String htmlText = markdownService.toHtml(testMdText);
-        assertEquals("The MarkdownService failed to correctly translate markdown with html tags.", expectedHtmlText, htmlText);
+        assertEquals("The MarkdownService failed to correctly escape html tags.", expectedHtmlText, htmlText);
 
         testMdText = "<script>alert()</script>";
-        expectedHtmlText = "<div class=\"lk-markdown-container\"><script>alert()</script>\n</div>";
+        expectedHtmlText = "<div class=\"lk-markdown-container\"><p>&lt;script&gt;alert()&lt;/script&gt;</p>\n</div>";
         htmlText = markdownService.toHtml(testMdText);
-        assertEquals("The MarkdownService failed to correctly translate markdown with html tags.", expectedHtmlText, htmlText);
+        assertEquals("The MarkdownService failed to correctly escape script tags.", expectedHtmlText, htmlText);
     }
 
     /**
@@ -195,9 +195,9 @@ class MarkdownTestCase extends Assert
         String expectedHtmlText = """
                 <div class="lk-markdown-container"><hr />
                 <ul>
-                <li><strong><a href="https://nodeca.github.io/pica/demo/">pica</a></strong> - high quality and fast image<br>
+                <li><strong><a rel="nofollow" href="https://nodeca.github.io/pica/demo/">pica</a></strong> - high quality and fast image<br>
                 resize in browser.</li>
-                <li><strong><a href="https://github.com/nodeca/babelfish/">babelfish</a></strong> - developer friendly<br>
+                <li><strong><a rel="nofollow" href="https://github.com/nodeca/babelfish/">babelfish</a></strong> - developer friendly<br>
                 i18n with plurals support and easy syntax.</li>
                 </ul>
                 <p>You will like those projects!</p>
@@ -333,10 +333,10 @@ class MarkdownTestCase extends Assert
                 </tbody>
                 </table>
                 <h2 id="links">Links</h2>
-                <p><a href="http://dev.nodeca.com">link text</a></p>
-                <p><a href="http://nodeca.github.io/pica/demo/" title="title text!">link with title</a></p>
-                <p>Autoconverted link <a href="https://github.com/nodeca/pica">https://github.com/nodeca/pica</a></p>
-                <p>Autoconverted email address <a href="mailto:markdown@labkey.test">markdown@labkey.test</a></p>
+                <p><a rel="nofollow" href="http://dev.nodeca.com">link text</a></p>
+                <p><a rel="nofollow" href="http://nodeca.github.io/pica/demo/" title="title text!">link with title</a></p>
+                <p>Autoconverted link <a rel="nofollow" href="https://github.com/nodeca/pica">https://github.com/nodeca/pica</a></p>
+                <p>Autoconverted email address <a rel="nofollow" href="mailto:markdown@labkey.test">markdown@labkey.test</a></p>
                 </div>""";
         String htmlText = markdownService.toHtml(testMdText);
         assertEquals("The MarkdownService failed to correctly translate complex markdown text to html.", expectedHtmlText, htmlText);

--- a/wiki/src/org/labkey/wiki/WikiController.java
+++ b/wiki/src/org/labkey/wiki/WikiController.java
@@ -2239,7 +2239,7 @@ public class WikiController extends SpringActionController
 
             //check to ensure that there is not an existing wiki with the same name
             //but different entity id (works for both insert and update case)
-            if (null != name && name.length() > 0)
+            if (null != name && !name.isEmpty())
             {
                 Wiki existingWiki = WikiSelectManager.getWiki(container, name);
                 if (null != existingWiki && (null == form.getEntityId() || !StringUtils.equalsIgnoreCase(existingWiki.getEntityId(), form.getEntityId().toString())))


### PR DESCRIPTION
#### Rationale
We don't want HTML tags in Markdown