### PR TITLE
Issue 52037: Quote header fields if necessary to protect special characters

### DIFF
--- a/api/src/org/labkey/api/data/TSVWriter.java
+++ b/api/src/org/labkey/api/data/TSVWriter.java
@@ -39,7 +39,7 @@ public abstract class TSVWriter extends TextWriter
     protected char _chDelimiter = '\t';
     protected char _chQuote = '"';
     protected String _rowSeparator = "\n";
-    protected String _escapeChar = "\\\\";
+    protected char _escapeChar = '\\';
 
     protected List<String> _fileHeader = null;
     protected boolean _headerRowVisible = true;

--- a/api/src/org/labkey/api/data/TSVWriter.java
+++ b/api/src/org/labkey/api/data/TSVWriter.java
@@ -39,6 +39,7 @@ public abstract class TSVWriter extends TextWriter
     protected char _chDelimiter = '\t';
     protected char _chQuote = '"';
     protected String _rowSeparator = "\n";
+    protected String _escapeChar = "\\\\";
 
     protected List<String> _fileHeader = null;
     protected boolean _headerRowVisible = true;
@@ -200,7 +201,7 @@ public abstract class TSVWriter extends TextWriter
         {
             // NOTE: Excel always includes comma in the list of characters that will be quoted,
             // but we will only quote comma if it is the delimiter character.
-            _escapedCharsString = "\r\n" + _rowSeparator + _chDelimiter + _chQuote;
+            _escapedCharsString = "\r\n" + _rowSeparator + _chDelimiter + _chQuote + _escapeChar;
         }
 
 

--- a/api/src/org/labkey/api/query/QueryKey.java
+++ b/api/src/org/labkey/api/query/QueryKey.java
@@ -116,7 +116,7 @@ import java.util.Objects;
         return StringUtils.replaceEach(str, REPLACEMENT, ILLEGAL);
     }
 
-    private static final String[] ILLEGAL = {"$", "/", "&", "}", "~", ",", "."};
+    public static final String[] ILLEGAL = {"$", "/", "&", "}", "~", ",", "."};
     private static final String[] REPLACEMENT = {"$D", "$S", "$A", "$B", "$T", "$C", "$P"};
 
     /**

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2914,7 +2914,7 @@ public class ExpDataIterators
                 String name = colInfo.getName();
 
                 fieldIndexes.add(i);
-                header.add(name);
+                header.add(_tsvWriter.quoteValue(name));
             }
 
             File dataFile = FileUtil.createTempFile("~importSplit-", container.getRowId() + dataClass.getName() + ".tsv");
@@ -2964,12 +2964,12 @@ public class ExpDataIterators
                 if (validFields.contains(name))
                 {
                     fieldIndexes.add(i);
-                    header.add(name);
+                    header.add(_tsvWriter.quoteValue(name));
                 }
                 if (lcName.startsWith(MATERIAL_INPUTS_PREFIX_LC))
                 {
                     fieldIndexes.add(i);
-                    header.add(name);
+                    header.add(_tsvWriter.quoteValue(name));
                     // no dependencies to register if the names of samples are not being provided in the file.
                     if (_dataIdIndex != -1)
                     {
@@ -2981,12 +2981,12 @@ public class ExpDataIterators
                 else if (lcName.startsWith(DATA_INPUTS_PREFIX_LC))
                 {
                     fieldIndexes.add(i);
-                    header.add(name);
+                    header.add(_tsvWriter.quoteValue(name));
                 }
                 else if (lcName.startsWith(INPUTS_PREFIX_LC))
                 {
                     fieldIndexes.add(i);
-                    header.add(name);
+                    header.add(_tsvWriter.quoteValue(name));
                     if (_dataIdIndex != -1)
                         dependencyIndexes.put(i, name.replaceAll("(?i)" + INPUTS_PREFIX_LC, ""));
                 }


### PR DESCRIPTION
#### Rationale
Issue [52037](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=52037): When splitting an input Excel file into separate TSV files for cross-type or cross-container import, we need to be sure to preserve and special characters in the field names that won't naturally get recognized when parsing a TSV file. The `shouldQuote` method within `TSVWriter` does not account for the need to quote the backslash (escape) character.


#### Changes
- Use `quoteValue` to quote headers when writing out TSV files for splitting an input file in to many 
- Add the backslash (\) character to the set of characters that should trigger quoting.