### PR TITLE
Query dataset error handling updates

### DIFF
--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -64,7 +64,7 @@ import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.attachments.BaseDownloadAction;
 import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
-import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
@@ -4871,18 +4871,14 @@ public class StudyController extends BaseStudyController
                 else
                 {
                     TableInfo ti = QueryService.get().getUserSchema(getUser(), getContainer(), form.getSchemaName()).getTable(form.getQueryName());
-                    var colNames = new CaseInsensitiveHashSet();
-                    for (ColumnInfo column : ti.getColumns())
-                    {
-                        colNames.add(column.getName());
-                    }
+                    Set<String> colNames = ti.getColumns().stream().map(ColumnInfo::getName).collect(LabKeyCollectors.toCaseInsensitiveHashSet());
 
                     List<String> notFound = Arrays.stream(QueryDatasetTable.REQUIRED_COLUMNS)
-                            .filter(value -> !colNames.contains(value.toLowerCase()))
+                            .filter(value -> !colNames.contains(value))
                             .toList();
 
                     if (!notFound.isEmpty())
-                        errors.reject("snapshotQuery.error", "The source query is missing the following required columns for a query based snapshot: " + String.join(", ", notFound));
+                        errors.reject("snapshotQuery.error", "The source query is missing the following required columns for a query backed dataset: " + String.join(", ", notFound));
                 }
             }
 

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -64,6 +64,7 @@ import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.attachments.BaseDownloadAction;
 import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
@@ -298,7 +299,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static org.labkey.study.model.QCStateSet.PUBLIC_STATES_LABEL;
 import static org.labkey.study.model.QCStateSet.getQCStateFilteredURL;
@@ -4871,7 +4871,11 @@ public class StudyController extends BaseStudyController
                 else
                 {
                     TableInfo ti = QueryService.get().getUserSchema(getUser(), getContainer(), form.getSchemaName()).getTable(form.getQueryName());
-                    Set<String> colNames = ti.getColumns().stream().map(column -> column.getName().toLowerCase()).collect(Collectors.toSet());
+                    var colNames = new CaseInsensitiveHashSet();
+                    for (ColumnInfo column : ti.getColumns())
+                    {
+                        colNames.add(column.getName());
+                    }
 
                     List<String> notFound = Arrays.stream(QueryDatasetTable.REQUIRED_COLUMNS)
                             .filter(value -> !colNames.contains(value.toLowerCase()))

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -262,6 +262,7 @@ import org.labkey.study.query.DatasetQuerySettings;
 import org.labkey.study.query.DatasetQueryView;
 import org.labkey.study.query.LocationTable;
 import org.labkey.study.query.PublishedRecordQueryView;
+import org.labkey.study.query.QueryDatasetTable;
 import org.labkey.study.query.StudyQuerySchema;
 import org.labkey.study.query.StudyQueryView;
 import org.labkey.study.reports.ReportManager;
@@ -281,6 +282,7 @@ import java.io.Writer;
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -296,6 +298,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.labkey.study.model.QCStateSet.PUBLIC_STATES_LABEL;
 import static org.labkey.study.model.QCStateSet.getQCStateFilteredURL;
@@ -4859,8 +4862,25 @@ public class StudyController extends BaseStudyController
             if (null == study)
                 throw new NotFoundException("No study in this folder");
 
-            if (form.getQueryDataset() != null && study.getTimepointType() != TimepointType.CONTINUOUS)
-                errors.reject("snapshotQuery.error", "Query based snapshot is only available for continuous studies");
+            if (form.getQueryDataset() != null)
+            {
+                if (study.getTimepointType() != TimepointType.CONTINUOUS)
+                {
+                    errors.reject("snapshotQuery.error", "Query based snapshot is only available for continuous studies");
+                }
+                else
+                {
+                    TableInfo ti = QueryService.get().getUserSchema(getUser(), getContainer(), form.getSchemaName()).getTable(form.getQueryName());
+                    Set<String> colNames = ti.getColumns().stream().map(column -> column.getName().toLowerCase()).collect(Collectors.toSet());
+
+                    List<String> notFound = Arrays.stream(QueryDatasetTable.REQUIRED_COLUMNS)
+                            .filter(value -> !colNames.contains(value.toLowerCase()))
+                            .toList();
+
+                    if (!notFound.isEmpty())
+                        errors.reject("snapshotQuery.error", "The source query is missing the following required columns for a query based snapshot: " + String.join(", ", notFound));
+                }
+            }
 
             String name = StringUtils.trimToNull(form.getSnapshotName());
 

--- a/study/src/org/labkey/study/model/QueryDataset.java
+++ b/study/src/org/labkey/study/model/QueryDataset.java
@@ -10,6 +10,7 @@ import org.labkey.api.data.SchemaTableInfo;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.VirtualTable;
 import org.labkey.api.query.ExprColumn;
+import org.labkey.api.query.MetadataParseException;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.LimitedUser;
@@ -30,13 +31,13 @@ public class QueryDataset extends VirtualTable<UserSchema>
         UserSchema us = QueryService.get().getUserSchema(new LimitedUser(User.guest, ProjectAdminRole.class), def.getSourceQueryContainer(), def.getSourceQuerySchema());
         if (us == null)
         {
-            throw new IllegalArgumentException("QueryDataset requires a valid schema");
+            throw new MetadataParseException("QueryDataset requires a valid schema");
         }
 
         TableInfo ti = us.getTable(def.getSourceQueryName());
         if (ti == null)
         {
-            throw new IllegalArgumentException("QueryDataset requires a valid query");
+            throw new MetadataParseException("QueryDataset requires a valid query");
         }
 
         _inner = new QuerySchemaTableInfo(ti);
@@ -95,57 +96,47 @@ public class QueryDataset extends VirtualTable<UserSchema>
             wrapAllColumns(ti.getColumns());
 
             // Key
-            if (getColumn("Key") != null)
+            if (getColumn(DatasetDomainKind._KEY) == null)
             {
-                addColumn(new ExprColumn(this, "_Key", getColumn("Key").getValueSql(ExprColumn.STR_TABLE_ALIAS), JdbcType.VARCHAR));
-            }
-            else
-            {
-                throw new IllegalArgumentException("QueryDataset requires a query with a unique Key column");
+                throw new MetadataParseException("A query dataset requires a source query with a unique _Key column");
             }
 
             // ParticipantId
             if (!ensureParticipantIdCol(ti))
             {
-                throw new IllegalArgumentException("QueryDataset requires a query with a ParticipantId, SubjectId, or Id column");
+                throw new MetadataParseException("A query dataset requires a source query with a ParticipantId, SubjectId, or Id column");
             }
 
             // Date
-            if (getColumn("Date") == null)
+            if (getColumn(DatasetDomainKind.DATE) == null)
             {
-                throw new IllegalArgumentException("QueryDataset requires a query with a Date column");
+                throw new MetadataParseException("A query dataset requires a source query with a Date column");
             }
 
             // QCState
             // could consider looking up the "Completed" state and filling that in automatically if found
-            if (getColumn("QCState") == null)
+            if (getColumn(DatasetDomainKind.QCSTATE) == null)
             {
-                throw new IllegalArgumentException("QueryDataset requires a query with a QCState column");
+                throw new MetadataParseException("A query dataset requires a source query with a QCState column");
             }
 
             // LSID
-            if (getColumn("lsid") == null)
+            if (getColumn(DatasetDomainKind.LSID) == null)
             {
-                throw new IllegalArgumentException("QueryDataset requires a query with a LSID column");
+                throw new MetadataParseException("A query dataset requires a source query with a LSID column");
             }
 
             // SequenceNum
-            if (getColumn("SequenceNum") == null)
+            if (getColumn(DatasetDomainKind.SEQUENCENUM) == null)
             {
-                ExprColumn sequenceNumCol = new ExprColumn(this, "SequenceNum", new SQLFragment(StudyUtils.sequenceNumFromDateSQL("Date")), JdbcType.DECIMAL);
+                ExprColumn sequenceNumCol = new ExprColumn(this, DatasetDomainKind.SEQUENCENUM, new SQLFragment(StudyUtils.sequenceNumFromDateSQL(DatasetDomainKind.DATE)), JdbcType.DECIMAL);
                 addColumn(sequenceNumCol);
             }
 
             // SourceLSID
-            if (getColumn("SourceLSID") == null)
+            if (getColumn(DatasetDomainKind.SOURCELSID) == null)
             {
-                addColumn(new ExprColumn(this, "SourceLSID", new SQLFragment("NULL"), JdbcType.VARCHAR));
-            }
-
-            // SourceLSID
-            if (getColumn("SourceLSID") == null)
-            {
-                addColumn(new ExprColumn(this, "SourceLSID", new SQLFragment("NULL"), JdbcType.VARCHAR));
+                addColumn(new ExprColumn(this, DatasetDomainKind.SOURCELSID, new SQLFragment("NULL"), JdbcType.VARCHAR));
             }
         }
 
@@ -160,7 +151,7 @@ public class QueryDataset extends VirtualTable<UserSchema>
 
         private boolean ensureParticipantIdCol(TableInfo ti)
         {
-            if (getColumn("ParticipantId") != null)
+            if (getColumn(DatasetDomainKind.PARTICIPANTID) != null)
             {
                 return true;
             }
@@ -168,13 +159,13 @@ public class QueryDataset extends VirtualTable<UserSchema>
             if (ti.getColumn("SubjectId") != null)
             {
                 ColumnInfo subjectIdCol = ti.getColumn("SubjectId");
-                addColumn(new ExprColumn(this, "ParticipantId", subjectIdCol.getValueSql(ExprColumn.STR_TABLE_ALIAS), subjectIdCol.getJdbcType()));
+                addColumn(new ExprColumn(this, DatasetDomainKind.PARTICIPANTID, subjectIdCol.getValueSql(ExprColumn.STR_TABLE_ALIAS), subjectIdCol.getJdbcType()));
                 return true;
             }
             else if (ti.getColumn("Id") != null)
             {
                 ColumnInfo idCol = ti.getColumn("Id");
-                addColumn(new ExprColumn(this, "ParticipantId", idCol.getValueSql(ExprColumn.STR_TABLE_ALIAS), idCol.getJdbcType()));
+                addColumn(new ExprColumn(this, DatasetDomainKind.PARTICIPANTID, idCol.getValueSql(ExprColumn.STR_TABLE_ALIAS), idCol.getJdbcType()));
                 return true;
             }
 

--- a/study/src/org/labkey/study/query/QueryDatasetTable.java
+++ b/study/src/org/labkey/study/query/QueryDatasetTable.java
@@ -7,6 +7,7 @@ import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.util.Pair;
 import org.labkey.study.model.DatasetDefinition;
+import org.labkey.study.model.DatasetDomainKind;
 
 import java.util.Collections;
 import java.util.List;
@@ -14,6 +15,14 @@ import java.util.Map;
 
 public class QueryDatasetTable extends DatasetTableImpl
 {
+    public static final String[] REQUIRED_COLUMNS = new String[]{
+            DatasetDomainKind._KEY,
+            DatasetDomainKind.DATE,
+            DatasetDomainKind.QCSTATE,
+            DatasetDomainKind.LSID,
+            DatasetDomainKind.PARTICIPANTID
+    };
+
     QueryDatasetTable(@NotNull StudyQuerySchema schema, ContainerFilter cf, @NotNull DatasetDefinition dsd)
     {
         super(schema, cf, dsd);


### PR DESCRIPTION
#### Rationale
Need to make creating query based snapshot a little easier. First check for required columns on creation and return error if not all there. Second, throw a type of exception if there are issues that doesn't freeze up the schema browser.

#### Changes
- Check required columns on creation
- Use defined dataset col names
- Use MetadataParseExceptions
