### PR TITLE
Plates: Replicate Groups

### DIFF
--- a/assay/resources/schemas/dbscripts/postgresql/assay-25.000-25.001.sql
+++ b/assay/resources/schemas/dbscripts/postgresql/assay-25.000-25.001.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('migrateReplicateGroups');

--- a/assay/resources/schemas/dbscripts/sqlserver/assay-25.000-25.001.sql
+++ b/assay/resources/schemas/dbscripts/sqlserver/assay-25.000-25.001.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'migrateReplicateGroups';

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -118,7 +118,7 @@ public class AssayModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 25.000;
+        return 25.001;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -1,5 +1,6 @@
 package org.labkey.assay;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
@@ -9,6 +10,7 @@ import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.plate.PlateDataStateManager;
 import org.labkey.api.assay.plate.PlateService;
 import org.labkey.api.assay.plate.PlateSet;
+import org.labkey.api.assay.plate.Position;
 import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
@@ -42,12 +44,16 @@ import org.labkey.api.exp.property.Lookup;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.query.SchemaKey;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
+import org.labkey.api.util.Pair;
+import org.labkey.assay.plate.PlateImpl;
 import org.labkey.assay.plate.PlateManager;
 import org.labkey.assay.plate.PlateMetadataDomainKind;
 import org.labkey.assay.plate.TsvPlateLayoutHandler;
 import org.labkey.assay.plate.model.PlateSetLineage;
 import org.labkey.assay.plate.query.PlateTable;
+import org.labkey.assay.plate.query.WellTable;
 import org.labkey.assay.query.AssayDbSchema;
 
 import java.sql.SQLException;
@@ -366,11 +372,11 @@ public class AssayUpgradeCode implements UpgradeCode
 
         // Determine all containers that have a Plate where Samples are specified in wells
         SQLFragment sql = new SQLFragment("""
-                    SELECT DISTINCT P.Container
-                    FROM assay.Well AS W
-                    INNER JOIN assay.Plate AS P ON P.RowId = W.PlateId
-                    WHERE P.AssayType = ? AND W.SampleId IS NOT NULL
-                """).add(TsvPlateLayoutHandler.TYPE);
+            SELECT DISTINCT P.Container
+            FROM assay.Well AS W
+            INNER JOIN assay.Plate AS P ON P.RowId = W.PlateId
+            WHERE P.AssayType = ? AND W.SampleId IS NOT NULL
+        """).add(TsvPlateLayoutHandler.TYPE);
         List<String> containerIds = new SqlSelector(scope, sql).getArrayList(String.class);
 
         for (String containerId : containerIds)
@@ -390,17 +396,16 @@ public class AssayUpgradeCode implements UpgradeCode
 
             _log.info(String.format("Populating plate well types in \"%s\".", container.getPath()));
 
-
             try (DbScope.Transaction tx = scope.ensureTransaction())
             {
                 SQLFragment wellSql = new SQLFragment("""
-                            SELECT W.RowId, W.PlateId
-                            FROM assay.Well AS W
-                            INNER JOIN assay.Plate AS P ON P.RowId = W.PlateId
-                            WHERE P.Container = ? AND P.AssayType = ? AND W.SampleId IS NOT NULL AND W.RowId NOT IN (
-                                SELECT WellId FROM assay.WellGroupPositions AS WGP WHERE WGP.WellId = W.RowId
-                            )
-                        """).add(containerId).add(TsvPlateLayoutHandler.TYPE);
+                    SELECT W.RowId, W.PlateId
+                    FROM assay.Well AS W
+                    INNER JOIN assay.Plate AS P ON P.RowId = W.PlateId
+                    WHERE P.Container = ? AND P.AssayType = ? AND W.SampleId IS NOT NULL AND W.RowId NOT IN (
+                        SELECT WellId FROM assay.WellGroupPositions AS WGP WHERE WGP.WellId = W.RowId
+                    )
+                """).add(containerId).add(TsvPlateLayoutHandler.TYPE);
 
                 Map<Integer, Map<Integer, PlateManager.WellGroupChange>> wellGroupChanges = new HashMap<>();
                 Collection<Map<String, Object>> sampleWellRows = new SqlSelector(scope, wellSql).getMapCollection();
@@ -408,7 +413,7 @@ public class AssayUpgradeCode implements UpgradeCode
                 {
                     Integer plateRowId = (Integer) sampleWellRow.get("PlateId");
                     Integer wellRowId = (Integer) sampleWellRow.get("RowId");
-                    PlateManager.WellGroupChange change = new PlateManager.WellGroupChange(plateRowId, wellRowId, WellGroup.Type.SAMPLE.name(), null);
+                    PlateManager.WellGroupChange change = new PlateManager.WellGroupChange(plateRowId, wellRowId, WellGroup.Type.SAMPLE.name(), null, null);
 
                     wellGroupChanges.computeIfAbsent(plateRowId, HashMap::new).put(wellRowId, change);
                 }
@@ -420,11 +425,86 @@ public class AssayUpgradeCode implements UpgradeCode
                 }
 
                 _log.info(String.format("Updating \"%d\" well groups across \"%d\" plates in \"%s\".", sampleWellRows.size(), wellGroupChanges.entrySet().size(), container.getPath()));
-                PlateManager.get().computeWellGroups(container, User.getAdminServiceUser(), wellGroupChanges);
+                computeWellGroups(container, User.getAdminServiceUser(), wellGroupChanges);
                 _log.info(String.format("Completed well group update in \"%s\".", container.getPath()));
 
                 tx.commit();
             }
+        }
+    }
+
+    // This is a functional copy of PlateManager.computeWellGroups() prior to the replicates refactor
+    // to represent replicates with the "Replicate Groups" column. When this is removed the methods called on
+    // PlateManager should be once again made private if possible.
+    private static void computeWellGroups(
+        Container container,
+        User user,
+        Map<Integer, Map<Integer, PlateManager.WellGroupChange>> wellGroupChanges
+    ) throws Exception
+    {
+        for (var entry : wellGroupChanges.entrySet())
+        {
+            var plate = (PlateImpl) PlateManager.get().requirePlate(container, entry.getKey(), "Failed to update well groups.");
+            if (!TsvPlateLayoutHandler.TYPE.equalsIgnoreCase(plate.getAssayType()))
+                continue;
+
+            var wellChanges = entry.getValue();
+            Map<Pair<WellGroup.Type, String>, List<Position>> wellGroupings = new HashMap<>();
+
+            for (var wellData : PlateManager.get().getWellData(container, user, plate.getRowId(), false, false))
+            {
+                WellGroup.Type type = wellData.getType();
+                String wellGroup = wellData.getWellGroup();
+
+                Integer wellRowId = wellData.getRowId();
+                var wellChange = wellChanges.get(wellRowId);
+                if (wellChange != null)
+                {
+                    if (wellChange.type() != null)
+                    {
+                        String typeStr = StringUtils.trimToNull(wellChange.type());
+                        if (typeStr != null)
+                            type = WellGroup.Type.valueOf(typeStr);
+                        else
+                            type = null;
+                    }
+                    if (wellChange.group() != null)
+                        wellGroup = StringUtils.trimToNull(wellChange.group());
+                }
+
+                // Type/Group are not set and are not being updated
+                if (type == null && wellGroup == null)
+                    continue;
+
+                var position = plate.getPosition(wellData.getRow(), wellData.getCol());
+
+                // Specifying a group requires that a type is also specified
+                if (type == null)
+                {
+                    throw new ValidationException(String.format(
+                        "Well %s must specify a \"%s\" when a \"%s\" is specified.",
+                        position.getDescription(),
+                        WellTable.Column.Type.name(),
+                        WellTable.Column.WellGroup.name()
+                    ));
+                }
+
+                var wellGroupKey = Pair.of(type, wellGroup);
+                wellGroupings.computeIfAbsent(wellGroupKey, k -> new ArrayList<>()).add(position);
+            }
+
+            // Mark pre-existing well groups on this plate for deletion
+            for (WellGroup existingWellGroup : plate.getWellGroups())
+                plate.markWellGroupForDeletion(existingWellGroup);
+
+            // Create new well groups for this plate
+            for (var wellGrouping : wellGroupings.entrySet())
+            {
+                var typeGroup = wellGrouping.getKey();
+                plate.addWellGroup(typeGroup.second, typeGroup.first, wellGrouping.getValue());
+            }
+
+            PlateManager.get().savePlateImpl(container, user, plate);
         }
     }
 

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -56,6 +56,7 @@ import org.labkey.assay.plate.query.PlateTable;
 import org.labkey.assay.plate.query.WellTable;
 import org.labkey.assay.query.AssayDbSchema;
 
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -809,5 +810,133 @@ public class AssayUpgradeCode implements UpgradeCode
 
             tx.commit();
         }
+    }
+
+    /**
+     * Called from assay-25.000-25.001.sql
+     * Migrate replicate well groups to be represented via the "Replicate Group" column.
+     */
+    @SuppressWarnings({"UnusedDeclaration"})
+    public static void migrateReplicateGroups(ModuleContext ctx) throws Exception
+    {
+        if (ctx.isNewInstall())
+            return;
+
+        DbScope scope = AssayDbSchema.getInstance().getSchema().getScope();
+
+        // - For all "Standard" plates that have a "REPLICATE" well group:
+        //   - If the plate does not contain a "SAMPLE" zone, then create one
+        //   - For each "REPLICATE" well group:
+        //     - Get all the wells that are in the group
+        //     - Add those wells to the "SAMPLE" zone. This will be done in the assay.WellGroupPositions table
+
+        try (DbScope.Transaction tx = scope.ensureTransaction())
+        {
+            long numPlatesWithReplicates;
+            {
+                SQLFragment plateRowIdsSql = new SQLFragment("""
+                    SELECT DISTINCT P.RowId
+                    FROM assay.Plate AS P
+                    INNER JOIN assay.WellGroup AS WG ON WG.PlateId = P.RowId
+                    WHERE P.AssayType = ? AND WG.TypeName = ?
+                """)
+                .add("Standard")   // TsvPlateLayoutHandler.TYPE
+                .add("REPLICATE"); // WellGroup.Type.REPLICATE
+
+                numPlatesWithReplicates = new SqlSelector(scope, plateRowIdsSql).getRowCount();
+            }
+
+            if (numPlatesWithReplicates > 0)
+            {
+                ensureSampleZoneWellGroups(scope);
+
+                // Insert missing well positions into the "SAMPLE" well groups where name is NULL
+                {
+                    SQLFragment sql = new SQLFragment("""
+                        INSERT INTO assay.WellGroupPositions (wellGroupId, wellId)
+                        SELECT sampleWG.RowId AS wellGroupId, replicateWGP.wellId
+                        FROM assay.WellGroup AS replicateWG
+                        INNER JOIN assay.WellGroupPositions AS replicateWGP ON replicateWG.RowId = replicateWGP.wellGroupId
+                        INNER JOIN assay.WellGroup AS sampleWG ON sampleWG.PlateId = replicateWG.PlateId
+                        INNER JOIN assay.Plate AS P ON P.RowId = replicateWG.PlateId
+                        LEFT JOIN assay.WellGroupPositions AS sampleWGP ON sampleWG.RowId = sampleWGP.wellGroupId AND replicateWGP.wellId = sampleWGP.wellId
+                        WHERE P.AssayType = ? AND replicateWG.TypeName = ? AND sampleWG.TypeName = ? AND sampleWG.Name IS NULL AND sampleWGP.wellId IS NULL
+                    """)
+                    .add("Standard")  // TsvPlateLayoutHandler.TYPE
+                    .add("REPLICATE") // WellGroup.Type.REPLICATE;
+                    .add("SAMPLE");   // WellGroup.Type.SAMPLE;
+
+                    new SqlExecutor(scope).execute(sql);
+                }
+            }
+
+            // Display the ReplicateGroup column by default on each plate set where WellGroup is currently displayed
+            {
+                SQLFragment sql = new SQLFragment("""
+                    INSERT INTO assay.PlateSetProperty (PlateSetId, FieldKey)
+                    SELECT DISTINCT PSP.PlateSetId, ? AS FieldKey
+                    FROM assay.PlateSetProperty AS PSP WHERE PSP.FieldKey = ?
+                """)
+                .add("ReplicateGroup") // WellTable.Column.ReplicateGroup
+                .add("WellGroup");     // WellTable.Column.WellGroup
+
+                new SqlExecutor(scope).execute(sql);
+            }
+
+            tx.commit();
+        }
+    }
+
+    private static void ensureSampleZoneWellGroups(DbScope scope) throws Exception
+    {
+        List<List<?>> sampleZoneRowValues = new ArrayList<>();
+
+        // Determine the set of plates that do not yet have a "SAMPLE" well group that does not have a name (a.k.a. "Sample zone").
+        SQLFragment needSampleZoneSql = new SQLFragment("""
+            SELECT DISTINCT P.RowId, P.Container, WG.Template
+            FROM assay.Plate AS P
+            INNER JOIN assay.WellGroup AS WG ON WG.PlateId = P.RowId
+            WHERE P.AssayType = ? AND WG.TypeName = ?
+            AND P.RowId NOT IN (
+                SELECT PP.RowId
+                FROM assay.Plate AS PP
+                INNER JOIN assay.WellGroup AS WGG ON WGG.PlateId = PP.RowId
+                WHERE PP.AssayType = ? AND WGG.TypeName = ? AND WGG.Name IS NULL
+            )
+            ORDER BY P.RowId
+        """)
+        .add("Standard")  // TsvPlateLayoutHandler.TYPE
+        .add("REPLICATE") // WellGroup.Type.REPLICATE;
+        .add("Standard")  // TsvPlateLayoutHandler.TYPE
+        .add("SAMPLE");   // WellGroup.Type.SAMPLE;
+
+        try (ResultSet rs = new SqlSelector(scope, needSampleZoneSql).getResultSet())
+        {
+            Map<String, Container> containers = new HashMap<>();
+            while (rs.next())
+            {
+                int plateRowId = rs.getInt("RowId");
+                String containerId = rs.getString("Container");
+                boolean template = rs.getBoolean("Template");
+
+                Container container = containers.computeIfAbsent(containerId, ContainerManager::getForId);
+                if (container == null)
+                {
+                    // This is never expected to occur due to schema constraint of foreign key assay.WellGroup.Container -> core.Containers
+                    throw new IllegalStateException(String.format("Unable to resolve container with entityId \"%s\" for plate rowId (%d).", containerId, plateRowId));
+                }
+
+                Lsid lsid = PlateManager.get().getLsid(WellGroup.class, container);
+                sampleZoneRowValues.add(List.of(plateRowId, lsid.toString(), container.getEntityId(), template, "SAMPLE")); // WellGroup.Type.SAMPLE;
+            }
+        }
+
+        if (!sampleZoneRowValues.isEmpty())
+        {
+            String insertSql = "INSERT INTO assay.WellGroup (PlateId, LSID, Container, Template, TypeName) VALUES (?, ?, ?, ?, ?)";
+            Table.batchExecute(AssayDbSchema.getInstance().getSchema(), insertSql, sampleZoneRowValues);
+        }
+
+        _log.info("Inserted {} new \"sample zone\" well groups.", sampleZoneRowValues.size());
     }
 }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -4798,6 +4798,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
             d.setMetadata(wellData.getMetadata());
             d.setWellGroup(wellData.getWellGroup());
+            d.setReplicateGroup(wellData.getReplicateGroup());
             d.setType(wellData.getType());
 
             targetWellData.add(d.getData());

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3582,16 +3582,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     {
         for (WellData wellData : wellDataList)
         {
-            boolean isSampleWell = wellData.isSample();
-            boolean isReplicateWell = wellData.isReplicate();
-            boolean isSampleOrReplicate = isSampleWell || isReplicateWell;
-
-            Pair<WellGroup.Type, String> groupKey = null;
-            if (isSampleOrReplicate && wellData.getWellGroup() != null)
-            {
-                WellGroup.Type type = isSampleWell ? WellGroup.Type.SAMPLE : WellGroup.Type.REPLICATE;
-                groupKey = Pair.of(type, wellData.getWellGroup());
-            }
+            boolean isSampleOrReplicate = wellData.isSampleOrReplicate();
+            Pair<WellGroup.Type, String> groupKey = wellData.getGroupKey();
 
             if (counter >= sampleIds.size())
             {
@@ -4091,7 +4083,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     private long getReplicateGroupCount(@NotNull UserSchema plateSchema, @NotNull Integer plateSetRowId)
     {
         String labkeySql = String.format("""
-            SELECT DISTINCT Type, WellGroup
+            SELECT DISTINCT ReplicateGroup
             FROM plate.Well WHERE PlateId.PlateSet.RowId = %s AND ReplicateGroup IS NOT NULL
         """, plateSetRowId);
 
@@ -4109,7 +4101,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             WellTable.Column.PlateId.name(),
             WellTable.Column.Position.name(),
             WellTable.Column.Row.name(),
-            WellTable.Column.RowId.name()
+            WellTable.Column.RowId.name(),
+            WellTable.Column.WellGroup.name()
         );
 
         columnNames.removeAll(excludedColumns);
@@ -4704,6 +4697,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                     {
                         d.setPosition(p.getDescription());
                         d.setWellGroup(wellData.getWellGroup());
+                        d.setReplicateGroup(wellData.getReplicateGroup());
                         d.setType(wellData.getType());
                     }
                     else
@@ -4756,6 +4750,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                         {
                             d.setMetadata(wellData.getMetadata());
                             d.setWellGroup(wellData.getWellGroup());
+                            d.setReplicateGroup(wellData.getReplicateGroup());
                             d.setType(wellData.getType());
                         }
 

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -448,7 +448,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
     public List<FieldKey> getMetadataColumns(@NotNull PlateSet plateSet, Container c, User user, ContainerFilter cf)
     {
-        Set<FieldKey> includedMetadataCols = new HashSet<>();
+        // Using a LinkedHashSet to retain plate ordering of custom fields
+        Set<FieldKey> includedMetadataCols = new LinkedHashSet<>();
         for (Plate plate : plateSet.getPlates())
         {
             QueryView plateQueryView = getPlateQueryView(c, user, cf, plate, false);
@@ -469,7 +470,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             }
         }
 
-        return includedMetadataCols.stream().sorted(Comparator.comparing(k -> k.getName().toLowerCase())).toList();
+        return List.copyOf(includedMetadataCols);
     }
 
     @NotNull
@@ -2531,7 +2532,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         order.put(WellTable.Column.WellGroup.fieldKey(), 1);
         order.put(WellTable.Column.ReplicateGroup.fieldKey(), 2);
         order.put(WellTable.Column.SampleID.fieldKey(), 3);
-        Comparator<PlateCustomField> nameComparator = Comparator.comparing(PlateCustomField::getName, Comparator.nullsLast(String::compareTo));
+        Comparator<PlateCustomField> nameComparator = Comparator.comparing((k) -> k.getName().toLowerCase(), Comparator.nullsLast(String::compareTo));
 
         fields.sort((f1, f2) -> {
             if (f1.isBuiltIn() && f2.isBuiltIn())

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -4100,7 +4100,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     private long getReplicateGroupCount(@NotNull UserSchema plateSchema, @NotNull Integer plateSetRowId)
     {
         String labkeySql = String.format("""
-            SELECT DISTINCT ReplicateGroup
+            SELECT DISTINCT WellGroup, ReplicateGroup
             FROM plate.Well WHERE PlateId.PlateSet.RowId = %s AND ReplicateGroup IS NOT NULL
         """, plateSetRowId);
 
@@ -4118,8 +4118,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             WellTable.Column.PlateId.name(),
             WellTable.Column.Position.name(),
             WellTable.Column.Row.name(),
-            WellTable.Column.RowId.name(),
-            WellTable.Column.WellGroup.name()
+            WellTable.Column.RowId.name()
         );
 
         columnNames.removeAll(excludedColumns);

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1935,13 +1935,18 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         {
             // Copy the plate
             PlateImpl newPlate = new PlateImpl(container, name, null, sourcePlate.getAssayType(), sourcePlate.getPlateType());
-            newPlate.setCustomFields(sourcePlate.getCustomFields());
-            newPlate.setDescription(description);
+            List<PlateCustomField> newFields = new ArrayList<>(sourcePlate.getCustomFields());
 
             if (copyAsTemplate)
+            {
                 newPlate.setTemplate(true);
+                newFields.removeIf((f) -> WellTable.Column.SampleID.fieldKey().equals(f.getFieldKey()));
+            }
             else
                 newPlate.setPlateSet(destinationPlateSet);
+
+            newPlate.setCustomFields(newFields);
+            newPlate.setDescription(description);
 
             copyProperties(sourcePlate, newPlate);
             copyWellGroups(sourcePlate, newPlate);

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -350,6 +350,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         List<PlateCustomField> templateFields = new ArrayList<>();
         templateFields.add(new PlateCustomField(WellTable.Column.Type.fieldKey()));
         templateFields.add(new PlateCustomField(WellTable.Column.WellGroup.fieldKey()));
+        templateFields.add(new PlateCustomField(WellTable.Column.ReplicateGroup.fieldKey()));
 
         if (plateSet == null || plateSet.isAssay())
         {
@@ -360,6 +361,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             {
                 fields.add(new PlateCustomField(WellTable.Column.Type.fieldKey()));
                 fields.add(new PlateCustomField(WellTable.Column.WellGroup.fieldKey()));
+                fields.add(new PlateCustomField(WellTable.Column.ReplicateGroup.fieldKey()));
                 fields.add(new PlateCustomField(WellTable.Column.SampleID.fieldKey()));
             }
         }
@@ -814,7 +816,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         throw new ValidationException(error);
     }
 
-    private @NotNull Plate requirePlate(Container container, int plateRowId, @Nullable String errorPrefix) throws ValidationException
+    public @NotNull Plate requirePlate(Container container, int plateRowId, @Nullable String errorPrefix) throws ValidationException
     {
         return (Plate) require(getPlate(container, plateRowId), "Plate id \"" + plateRowId + "\" not found.", errorPrefix);
     }
@@ -1083,7 +1085,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return AssayDbSchema.getInstance().getSchema().getScope().ensureTransaction(locks);
     }
 
-    private int savePlateImpl(Container container, User user, @NotNull PlateImpl plate) throws Exception
+    public int savePlateImpl(Container container, User user, @NotNull PlateImpl plate) throws Exception
     {
         return savePlateImpl(container, user, plate, false);
     }
@@ -2384,6 +2386,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             TableInfo wellTable = getWellTable(container, user);
             fields.add(new PlateCustomField(wellTable.getColumn(WellTable.Column.Type.fieldKey())));
             fields.add(new PlateCustomField(wellTable.getColumn(WellTable.Column.WellGroup.fieldKey())));
+            fields.add(new PlateCustomField(wellTable.getColumn(WellTable.Column.ReplicateGroup.fieldKey())));
             fields.add(new PlateCustomField(wellTable.getColumn(WellTable.Column.SampleID.fieldKey())));
         }
 
@@ -2526,7 +2529,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         Map<FieldKey, Integer> order = new HashMap<>();
         order.put(WellTable.Column.Type.fieldKey(), 0);
         order.put(WellTable.Column.WellGroup.fieldKey(), 1);
-        order.put(WellTable.Column.SampleID.fieldKey(), 2);
+        order.put(WellTable.Column.ReplicateGroup.fieldKey(), 2);
+        order.put(WellTable.Column.SampleID.fieldKey(), 3);
         Comparator<PlateCustomField> nameComparator = Comparator.comparing(PlateCustomField::getName, Comparator.nullsLast(String::compareTo));
 
         fields.sort((f1, f2) -> {
@@ -3784,6 +3788,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         columns.add(WellTable.Column.RowId.name());
         columns.add(WellTable.Column.Type.name());
         columns.add(WellTable.Column.WellGroup.name());
+        columns.add(WellTable.Column.ReplicateGroup.name());
         if (includeSamples)
             columns.add(WellTable.Column.SampleID.name());
 
@@ -3837,10 +3842,10 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return wellDataList;
     }
 
-    public record WellGroupChange(Integer plateRowId, Integer wellRowId, String type, String group) {}
+    public record WellGroupChange(Integer plateRowId, Integer wellRowId, String type, String group, String replicateGroup) {}
 
     /**
-     * Computes the well groups based on changes (updates) made to the well "Type" and "Group".
+     * Computes the well groups based on changes (updates) made to the well "Type", "WellGroup", and "ReplicateGroup".
      * This is invoked whenever rows are inserted or updated in the assay.Well table.
      */
     public void computeWellGroups(
@@ -3867,6 +3872,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             {
                 WellGroup.Type type = wellData.getType();
                 String wellGroup = wellData.getWellGroup();
+                String replicateGroup = wellData.getReplicateGroup();
 
                 Integer wellRowId = wellData.getRowId();
                 var wellChange = wellChanges.get(wellRowId);
@@ -3882,27 +3888,44 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                     }
                     if (wellChange.group != null)
                         wellGroup = StringUtils.trimToNull(wellChange.group);
+                    if (wellChange.replicateGroup != null)
+                        replicateGroup = StringUtils.trimToNull(wellChange.replicateGroup);
                 }
 
-                // Type/Group are not set and are not being updated
-                if (type == null && wellGroup == null)
+                // Type/Group/ReplicateGroup are not set and are not being updated
+                if (type == null && wellGroup == null && replicateGroup == null)
                     continue;
 
                 var position = plate.getPosition(wellData.getRow(), wellData.getCol());
 
-                // Specifying a group requires that a type is also specified
+                // Specifying a group or replicate group requires that a type is also specified
                 if (type == null)
                 {
                     throw new ValidationException(String.format(
                         "Well %s must specify a \"%s\" when a \"%s\" is specified.",
                         position.getDescription(),
                         WellTable.Column.Type.name(),
-                        WellTable.Column.WellGroup.name()
+                        wellGroup != null ? WellTable.Column.WellGroup.name() : WellTable.Column.ReplicateGroup.name()
+                    ));
+                }
+
+                if (WellGroup.Type.REPLICATE.equals(type))
+                {
+                    throw new ValidationException(String.format(
+                        "Type \"%s\" is not supported for well %s. Specify a \"ReplicateGroup\" instead.",
+                        WellGroup.Type.REPLICATE.getLabel(),
+                        position.getDescription()
                     ));
                 }
 
                 var wellGroupKey = Pair.of(type, wellGroup);
                 wellGroupings.computeIfAbsent(wellGroupKey, k -> new ArrayList<>()).add(position);
+
+                if (replicateGroup != null)
+                {
+                    var replicateGroupKey = Pair.of(WellGroup.Type.REPLICATE, replicateGroup);
+                    wellGroupings.computeIfAbsent(replicateGroupKey, k -> new ArrayList<>()).add(position);
+                }
             }
 
             // Mark pre-existing well groups on this plate for deletion
@@ -3945,7 +3968,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 {
                     case REPLICATE -> {
                         if (wellGroup.isZone())
-                            throw new ValidationException(String.format("Replicates must specify a \"%s\".", WellTable.Column.WellGroup.name()));
+                            throw new ValidationException(String.format("Replicates must specify a \"%s\".", WellTable.Column.ReplicateGroup.name()));
 
                         var plateSet = plate.getPlateSet();
                         if (plateSet != null)
@@ -4010,10 +4033,11 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 ));
             }
 
-            if (wellGroups.size() > 1)
+            // TODO: Can perform more precise checks here
+            if (wellGroups.size() > 2)
             {
                 throw new ValidationException(String.format(
-                    "Well %s is included in more than one well group. This is not supported for assay type \"%s\" plate \"%s\".",
+                    "Well %s is included in more than two well groups. This is not supported for assay type \"%s\" plate \"%s\".",
                     position.getDescription(),
                     TsvPlateLayoutHandler.TYPE,
                     plate.getName()
@@ -4068,8 +4092,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     {
         String labkeySql = String.format("""
             SELECT DISTINCT Type, WellGroup
-            FROM plate.Well WHERE PlateId.PlateSet.RowId = %s AND Type = %s
-        """, plateSetRowId, LabKeySql.quoteString(WellGroup.Type.REPLICATE.name()));
+            FROM plate.Well WHERE PlateId.PlateSet.RowId = %s AND ReplicateGroup IS NOT NULL
+        """, plateSetRowId);
 
         return QueryService.get().getSelectBuilder(plateSchema, labkeySql).buildSqlSelector(null).getRowCount();
     }
@@ -4104,10 +4128,10 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             SELECT
             %s
             FROM plate.Well
-            WHERE PlateId.PlateSet.RowId = %s AND Type = %s
+            WHERE PlateId.PlateSet.RowId = %s AND ReplicateGroup IS NOT NULL
             GROUP BY
             %s
-        """, columnsSql, plateSetRowId, LabKeySql.quoteString(WellGroup.Type.REPLICATE.name()), columnsSql);
+        """, columnsSql, plateSetRowId, columnsSql);
     }
 
     private void validatePlateSetReplicates(Container container, User user, @NotNull Integer plateSetRowId) throws ValidationException
@@ -4128,7 +4152,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             Set<String> groups = new HashSet<>();
             while (results.next())
             {
-                String groupName = StringUtils.trimToNull(results.getString(WellTable.Column.WellGroup.name()));
+                String groupName = StringUtils.trimToNull(results.getString(WellTable.Column.ReplicateGroup.name()));
                 if (groupName == null)
                     continue;
 

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3703,7 +3703,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return fieldKeys;
     }
 
-    public QueryView getPlateQueryView(Container container, User user, ContainerFilter cf, Plate plate, boolean isMapView)
+    private QueryView getPlateQueryView(Container container, User user, ContainerFilter cf, Plate plate, boolean isMapView)
     {
         UserSchema userSchema = QueryService.get().getUserSchema(user, container, PlateSchema.SCHEMA_NAME);
         List<FieldKey> fieldKeys = getPlateExportFieldKeys(plate, isMapView);
@@ -3748,8 +3748,9 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 QueryView plateQueryView = getPlateQueryView(c, user, cf, plate, false);
                 List<DisplayColumn> displayColumns = getPlateDisplayColumns(plateQueryView);
                 PlateFileBytes plateFileBytes = new PlateFileBytes(plate.getName(), new ByteArrayOutputStream());
+                FieldKey sampleIdNameFieldKey = FieldKey.fromParts(WellTable.Column.SampleID.name(), "Name");
 
-                try (TSVGridWriter writer = new TSVGridWriter(plateQueryView::getResults, displayColumns, Collections.singletonMap("SampleId/Name", "Sample ID")))
+                try (TSVGridWriter writer = new TSVGridWriter(plateQueryView::getResults, displayColumns, Collections.singletonMap(sampleIdNameFieldKey.toString(), "Sample ID")))
                 {
                     writer.setDelimiterCharacter(delim);
                     writer.setColumnHeaderType(ColumnHeaderType.FieldKey);

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3669,7 +3669,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
     private List<FieldKey> getPlateExportFieldKeys(Plate plate, boolean isMapView)
     {
-        List<FieldKey> fieldKeys = new ArrayList<>(List.of(FieldKey.fromParts("SampleId", "Name")));
+        List<FieldKey> fieldKeys = new ArrayList<>();
+        fieldKeys.add(FieldKey.fromParts(WellTable.Column.SampleID.name(), "Name"));
 
         if (isMapView)
         {
@@ -3681,14 +3682,23 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             // For non-map export view we always want "position" first
             fieldKeys.add(0, WellTable.Column.Position.fieldKey());
         }
-        Set<String> excludedColumns = new HashSet<>(Arrays.asList("SampleID", "Type", "WellGroup"));
-        List<PlateCustomField> customFields = isMapView
-                ? plate.getCustomFields().stream().filter(field -> !excludedColumns.contains(field.getFieldKey() == null ? null : field.getFieldKey().getName())).toList()
-                : plate.getCustomFields();
-        for (PlateCustomField customField : customFields)
+
+        List<PlateCustomField> customFields = plate.getCustomFields();
+
+        if (isMapView)
         {
-            fieldKeys.add(FieldKey.fromParts(customField.getName()));
+            Set<FieldKey> excludedColumns = Set.of(
+                WellTable.Column.SampleID.fieldKey(),
+                WellTable.Column.Type.fieldKey(),
+                WellTable.Column.WellGroup.fieldKey(),
+                WellTable.Column.ReplicateGroup.fieldKey()
+            );
+
+            customFields = customFields.stream().filter(field -> field.getFieldKey() == null || !excludedColumns.contains(field.getFieldKey())).toList();
         }
+
+        for (PlateCustomField customField : customFields)
+            fieldKeys.add(FieldKey.fromParts(customField.getName()));
 
         return fieldKeys;
     }

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -1633,13 +1633,27 @@ public final class PlateManagerTest
             }
         }
 
-        // Verify update validation
         var wellA3 = getWellRow(newPlate.getRowId(), "A3");
-        wellA3.put(PlateMetadataFields.barcode.name(), null);
 
-        var errors = updateWells(List.of(wellA3), true);
-        assertTrue(errors.hasErrors());
-        assertEquals(expectedMessage, errors.getMessage());
+        // Verify update validation
+        {
+            wellA3.put(PlateMetadataFields.barcode.name(), null);
+
+            var errors = updateWells(List.of(wellA3), true);
+            assertTrue(errors.hasErrors());
+            assertEquals(expectedMessage, errors.getMessage());
+        }
+
+        // Verify update only changing well metadata
+        {
+            var wellMetadataA3 = new CaseInsensitiveHashMap<>();
+            wellMetadataA3.put("RowId", wellA3.get("RowId"));
+            wellMetadataA3.put(PlateMetadataFields.barcode.name(), null);
+
+            var errors = updateWells(List.of(wellMetadataA3), true);
+            assertTrue(errors.hasErrors());
+            assertEquals(expectedMessage, errors.getMessage());
+        }
     }
 
     @Test

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -434,8 +434,8 @@ public final class PlateManagerTest
         // remove amount and amountUnits metadata fields
         fields = PlateManager.get().removeFields(container, user, plateId, List.of(fields.get(0), fields.get(1)));
         assertEquals("Unexpected number of custom fields", 9, fields.size());
-        assertEquals("Expected Concentration custom field", "Concentration", fields.get(3).getName());
-        assertEquals("Expected ConcentrationUnits custom field", "ConcentrationUnits", fields.get(4).getName());
+        assertEquals("Expected Concentration custom field", "Concentration", fields.get(4).getName());
+        assertEquals("Expected ConcentrationUnits custom field", "ConcentrationUnits", fields.get(5).getName());
 
         // select wells
         SimpleFilter filter = SimpleFilter.createContainerFilter(container);
@@ -604,14 +604,14 @@ public final class PlateManagerTest
         List<Object[]> result = PlateManager.get().getInstrumentInstructions(plateSet.getRowId(), includedMetadataCols, container, user);
 
         // Assert
-        Object[] valuesRow1 = new Object[]{"myPlate", plate.getBarcode(), "A1", 96, sample1.getName(), "B1234", "2.25", null, "SAMPLE", null};
+        Object[] valuesRow1 = new Object[]{"myPlate", plate.getBarcode(), "A1", 96, sample1.getName(), "SAMPLE", null, null, "B1234", "2.25"};
         assertArrayEquals(valuesRow1, result.get(0));
 
-        Object[] valuesRow2 = new Object[]{"myPlate", plate.getBarcode(), "A2", 96, sample2.getName(), "B5678", "1.25", null, "SAMPLE", null};
+        Object[] valuesRow2 = new Object[]{"myPlate", plate.getBarcode(), "A2", 96, sample2.getName(), "SAMPLE", null, null, "B5678", "1.25"};
         assertArrayEquals(valuesRow2, result.get(1));
     }
 
-    private void assertWorklistThrows(String message, Integer sourceRowId, Integer destinationRowId, List<FieldKey> sourceIncludedMetadataCols, List<FieldKey> destinationIncludedMetadataCols) throws Exception
+    private void assertWorklistThrows(String message, Integer sourceRowId, Integer destinationRowId, List<FieldKey> sourceIncludedMetadataCols, List<FieldKey> destinationIncludedMetadataCols)
     {
         try
         {
@@ -655,13 +655,13 @@ public final class PlateManagerTest
         List<Object[]> plateDataRows = PlateManager.get().getWorklist(plateSource.getPlateSet().getRowId(), plateDestination.getPlateSet().getRowId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, container, user);
 
         // Assert
-        Object[] valuesRow1 = new Object[]{"myPlate1-1", plateSource.getBarcode(), "A1", 96, sample1.getName(), "B1234", "2.25", null, "SAMPLE", null, "myPlate2-1", plateDestination.getBarcode(), "A2", 96, null, "SAMPLE", null};
+        Object[] valuesRow1 = new Object[]{"myPlate1-1", plateSource.getBarcode(), "A1", 96, sample1.getName(), "SAMPLE", null, null, "B1234", "2.25", "myPlate2-1", plateDestination.getBarcode(), "A2", 96, "SAMPLE", null, null};
         assertArrayEquals(valuesRow1, plateDataRows.get(0));
 
-        Object[] valuesRow2 = new Object[]{"myPlate1-1", plateSource.getBarcode(),"A2", 96, sample2.getName(), "B5678", "1.25", null, "SAMPLE", null, "myPlate2-1", plateDestination.getBarcode(), "A1", 96, null, "SAMPLE", null};
+        Object[] valuesRow2 = new Object[]{"myPlate1-1", plateSource.getBarcode(),"A2", 96, sample2.getName(), "SAMPLE", null, null, "B5678", "1.25", "myPlate2-1", plateDestination.getBarcode(), "A1", 96, "SAMPLE", null, null};
         assertArrayEquals(valuesRow2, plateDataRows.get(1));
 
-        Object[] valuesRow3 = new Object[]{"myPlate1-1", plateSource.getBarcode(),"A2", 96, sample2.getName(), "B5678", "1.25", null, "SAMPLE", null, "myPlate2-1", plateDestination.getBarcode(), "A3", 96, null, "SAMPLE", null};
+        Object[] valuesRow3 = new Object[]{"myPlate1-1", plateSource.getBarcode(),"A2", 96, sample2.getName(), "SAMPLE", null, null, "B5678", "1.25", "myPlate2-1", plateDestination.getBarcode(), "A3", 96, "SAMPLE", null, null};
         assertArrayEquals(valuesRow3, plateDataRows.get(2));
     }
 
@@ -690,10 +690,10 @@ public final class PlateManagerTest
         List<Object[]> plateDataRows = PlateManager.get().getWorklist(plateSource.getPlateSet().getRowId(), plateDestination.getPlateSet().getRowId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, container, user);
 
         // Assert
-        Object[] valuesRow1 = new Object[]{"myPlate1-2", plateSource.getBarcode(), "A1", 96, sample1.getName(), "B1234", "2.25", null, "SAMPLE", null, null, null, null, null, null, null, null};
+        Object[] valuesRow1 = new Object[]{"myPlate1-2", plateSource.getBarcode(), "A1", 96, sample1.getName(), "SAMPLE", null, null, "B1234", "2.25", null, null, null, null, null, null, null};
         assertArrayEquals(valuesRow1, plateDataRows.get(0));
 
-        Object[] valuesRow2 = new Object[]{"myPlate1-2", plateSource.getBarcode(),"A2", 96, sample2.getName(), "B5678", "1.25", null, "SAMPLE", null, "myPlate2-2", plateDestination.getBarcode(), "A1", 96, null, "SAMPLE", null};
+        Object[] valuesRow2 = new Object[]{"myPlate1-2", plateSource.getBarcode(),"A2", 96, sample2.getName(), "SAMPLE", null, null, "B5678", "1.25", "myPlate2-2", plateDestination.getBarcode(), "A1", 96, "SAMPLE", null, null};
         assertArrayEquals(valuesRow2, plateDataRows.get(1));
     }
 
@@ -752,13 +752,13 @@ public final class PlateManagerTest
         List<Object[]> plateDataRows = PlateManager.get().getWorklist(plateSource.getPlateSet().getRowId(), plateDestination.getPlateSet().getRowId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, container, user);
 
         // Assert
-        Object[] valuesRow1 = new Object[]{"myPlate1-4", plateSource.getBarcode(), "A1", 96, sample.getName(), "B1234", "2.25", null, "SAMPLE", null, "myPlate2-4", plateDestination.getBarcode(), "A2", 96, null, "SAMPLE", null};
+        Object[] valuesRow1 = new Object[]{"myPlate1-4", plateSource.getBarcode(), "A1", 96, sample.getName(), "SAMPLE", null, null, "B1234", "2.25", "myPlate2-4", plateDestination.getBarcode(), "A2", 96, "SAMPLE", null, null};
         assertArrayEquals(valuesRow1, plateDataRows.get(0));
 
-        Object[] valuesRow2 = new Object[]{"myPlate1-4", plateSource.getBarcode(),"A2", 96, sample.getName(), "B5678", "1.25", null, "SAMPLE", null, "myPlate2-4", plateDestination.getBarcode(), "A3", 96, null, "SAMPLE", null};
+        Object[] valuesRow2 = new Object[]{"myPlate1-4", plateSource.getBarcode(),"A2", 96, sample.getName(), "SAMPLE", null, null, "B5678", "1.25", "myPlate2-4", plateDestination.getBarcode(), "A3", 96, "SAMPLE", null, null};
         assertArrayEquals(valuesRow2, plateDataRows.get(1));
 
-        Object[] valuesRow3 = new Object[]{"myPlate1-4", plateSource.getBarcode(),"A3", 96, sample.getName(), "B910", "1.0", null, "SAMPLE", null, "myPlate2-4", plateDestination.getBarcode(), "A4", 96, null, "SAMPLE", null};
+        Object[] valuesRow3 = new Object[]{"myPlate1-4", plateSource.getBarcode(),"A3", 96, sample.getName(), "SAMPLE", null, null, "B910", "1.0", "myPlate2-4", plateDestination.getBarcode(), "A4", 96, "SAMPLE", null, null};
         assertArrayEquals(valuesRow3, plateDataRows.get(2));
     }
 
@@ -787,13 +787,13 @@ public final class PlateManagerTest
         List<Object[]> plateDataRows = PlateManager.get().getWorklist(plateSource.getPlateSet().getRowId(), plateDestination.getPlateSet().getRowId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, container, user);
 
         // Assert
-        Object[] valuesRow1 = new Object[]{"myPlate1-5", plateSource.getBarcode(), "A1", 96, sample.getName(), "B1234", "2.25", null, "SAMPLE", null, "myPlate2-5", plateDestination.getBarcode(), "A2", 96, null, "SAMPLE", null};
+        Object[] valuesRow1 = new Object[]{"myPlate1-5", plateSource.getBarcode(), "A1", 96, sample.getName(), "SAMPLE", null, null, "B1234", "2.25", "myPlate2-5", plateDestination.getBarcode(), "A2", 96, "SAMPLE", null, null};
         assertArrayEquals(valuesRow1, plateDataRows.get(0));
 
-        Object[] valuesRow2 = new Object[]{"myPlate1-5", plateSource.getBarcode(),"A1", 96, sample.getName(), "B1234", "2.25", null, "SAMPLE", null, "myPlate2-5", plateDestination.getBarcode(), "A3", 96, null, "SAMPLE", null};
+        Object[] valuesRow2 = new Object[]{"myPlate1-5", plateSource.getBarcode(),"A1", 96, sample.getName(), "SAMPLE", null, null, "B1234", "2.25", "myPlate2-5", plateDestination.getBarcode(), "A3", 96, "SAMPLE", null, null};
         assertArrayEquals(valuesRow2, plateDataRows.get(1));
 
-        Object[] valuesRow3 = new Object[]{"myPlate1-5", plateSource.getBarcode(),"A1", 96, sample.getName(), "B1234", "2.25", null, "SAMPLE", null, "myPlate2-5", plateDestination.getBarcode(), "A4", 96, null, "SAMPLE", null};
+        Object[] valuesRow3 = new Object[]{"myPlate1-5", plateSource.getBarcode(),"A1", 96, sample.getName(), "SAMPLE", null, null, "B1234", "2.25", "myPlate2-5", plateDestination.getBarcode(), "A4", 96, "SAMPLE", null, null};
         assertArrayEquals(valuesRow3, plateDataRows.get(2));
     }
 

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -428,13 +429,13 @@ public final class PlateManagerTest
         }
 
         // assign custom fields to the plate
-        assertEquals("Expected custom fields to be added to the plate", 10, PlateManager.get().addFields(container, user, plateId, fields).size());
+        assertEquals("Expected custom fields to be added to the plate", 11, PlateManager.get().addFields(container, user, plateId, fields).size());
 
         // remove amount and amountUnits metadata fields
         fields = PlateManager.get().removeFields(container, user, plateId, List.of(fields.get(0), fields.get(1)));
-        assertEquals("Unexpected number of custom fields", 8, fields.size());
-        assertEquals("Expected Concentration custom field", "Concentration", fields.get(2).getName());
-        assertEquals("Expected ConcentrationUnits custom field", "ConcentrationUnits", fields.get(3).getName());
+        assertEquals("Unexpected number of custom fields", 9, fields.size());
+        assertEquals("Expected Concentration custom field", "Concentration", fields.get(3).getName());
+        assertEquals("Expected ConcentrationUnits custom field", "ConcentrationUnits", fields.get(4).getName());
 
         // select wells
         SimpleFilter filter = SimpleFilter.createContainerFilter(container);
@@ -497,20 +498,12 @@ public final class PlateManagerTest
     {
         // Act
         List<Map<String, Object>> rows = List.of(
-            CaseInsensitiveHashMap.of(
-                "wellLocation", "A1",
-                "concentration", 2.25,
-                    PlateMetadataFields.barcode.name(), "B1234"
-            ),
-            CaseInsensitiveHashMap.of(
-                "wellLocation", "A2",
-                "concentration", 1.25,
-                    PlateMetadataFields.barcode.name(), "B5678"
-            )
+            wellWithMetdata(createWellRow("A1", null, null), 2.25, "B1234"),
+            wellWithMetdata(createWellRow("A2", null, null), 1.25, "B5678")
         );
 
         Plate plate = createPlate(PLATE_TYPE_96_WELLS, "hit selection plate", null, rows);
-        assertEquals("Unexpected number of plate custom fields", 5, plate.getCustomFields().size());
+        assertEquals("Unexpected number of plate custom fields", 6, plate.getCustomFields().size());
 
         TableInfo wellTable = getWellTable();
         FieldKey fkConcentration = FieldKey.fromParts("concentration");
@@ -556,7 +549,7 @@ public final class PlateManagerTest
         Pair<Integer, List<Map<String, Object>>> wellSampleDataFilledPartial = PlateManager.get().getWellSampleData(container, sampleIds, 2, 3, 6, null);
 
         // Assert
-        assertEquals(wellSampleDataFilledFull.first, 6, 0);
+        assertEquals(6, wellSampleDataFilledFull.first, 0);
         List<String> wellLocations = List.of("A1", "A2", "A3", "B1", "B2", "B3");
         for (int i = 0; i < wellSampleDataFilledFull.second.size(); i++)
         {
@@ -565,7 +558,7 @@ public final class PlateManagerTest
             assertEquals(well.get("wellLocation"), wellLocations.get(i));
         }
 
-        assertEquals(wellSampleDataFilledPartial.first, 11, 0);
+        assertEquals(11, wellSampleDataFilledPartial.first, 0);
         for (int i = 0; i < wellSampleDataFilledPartial.second.size(); i++)
         {
             Map<String, Object> well = wellSampleDataFilledPartial.second.get(i);
@@ -594,20 +587,8 @@ public final class PlateManagerTest
         ExpMaterial sample2 = samples.get(1);
 
         List<Map<String, Object>> rows = List.of(
-            CaseInsensitiveHashMap.of(
-                "wellLocation", "A1",
-                "sampleId", sample1.getRowId(),
-                "type", "SAMPLE",
-                "concentration", 2.25,
-                    PlateMetadataFields.barcode.name(), "B1234"
-            ),
-            CaseInsensitiveHashMap.of(
-                "wellLocation", "A2",
-                "sampleId", sample2.getRowId(),
-                "type", "SAMPLE",
-                "concentration", 1.25,
-                    PlateMetadataFields.barcode.name(), "B5678"
-            )
+            wellWithMetdata(createWellRow("A1", "SAMPLE", sample1.getRowId()), 2.25, "B1234"),
+            wellWithMetdata(createWellRow("A2", "SAMPLE", sample2.getRowId()), 1.25, "B5678")
         );
         Plate plate = createPlate(PLATE_TYPE_96_WELLS, "myPlate", null, rows);
         PlateSet plateSet = plate.getPlateSet();
@@ -623,15 +604,11 @@ public final class PlateManagerTest
         List<Object[]> result = PlateManager.get().getInstrumentInstructions(plateSet.getRowId(), includedMetadataCols, container, user);
 
         // Assert
-        Object[] row1 = result.get(0);
-        String[] valuesRow1 = new String[]{"myPlate", plate.getBarcode(), "A1", "96", sample1.getName(), "B1234", "2.25", "SAMPLE", null};
-        for (int i = 0; i < row1.length; i++)
-            assertEquals(row1[i] == null ? null : row1[i].toString(), valuesRow1[i]);
+        Object[] valuesRow1 = new Object[]{"myPlate", plate.getBarcode(), "A1", 96, sample1.getName(), "B1234", "2.25", null, "SAMPLE", null};
+        assertArrayEquals(valuesRow1, result.get(0));
 
-        Object[] row2 = result.get(1);
-        String[] valuesRow2 = new String[]{"myPlate", plate.getBarcode(), "A2", "96", sample2.getName(), "B5678", "1.25", "SAMPLE", null};
-        for (int i = 0; i < row1.length; i++)
-            assertEquals(row2[i] == null ? null : row2[i].toString(), valuesRow2[i]);
+        Object[] valuesRow2 = new Object[]{"myPlate", plate.getBarcode(), "A2", 96, sample2.getName(), "B5678", "1.25", null, "SAMPLE", null};
+        assertArrayEquals(valuesRow2, result.get(1));
     }
 
     private void assertWorklistThrows(String message, Integer sourceRowId, Integer destinationRowId, List<FieldKey> sourceIncludedMetadataCols, List<FieldKey> destinationIncludedMetadataCols) throws Exception
@@ -659,42 +636,18 @@ public final class PlateManagerTest
         ExpMaterial sample1 = samples.get(0);
         ExpMaterial sample2 = samples.get(1);
 
-        List<Map<String, Object>> rows1 = List.of(
-            CaseInsensitiveHashMap.of(
-                "wellLocation", "A1",
-                "sampleId", sample1.getRowId(),
-                "type", "SAMPLE",
-                "concentration", 2.25,
-                    PlateMetadataFields.barcode.name(), "B1234"
-            ),
-            CaseInsensitiveHashMap.of(
-                "wellLocation", "A2",
-                "sampleId", sample2.getRowId(),
-                "type", "SAMPLE",
-                "concentration", 1.25,
-                    PlateMetadataFields.barcode.name(), "B5678"
-            )
+        List<Map<String, Object>> sourceWells = List.of(
+            wellWithMetdata(createWellRow("A1", "SAMPLE", sample1.getRowId()), 2.25, "B1234"),
+            wellWithMetdata(createWellRow("A2", "SAMPLE", sample2.getRowId()), 1.25, "B5678")
         );
-        Plate plateSource = createPlate(PLATE_TYPE_96_WELLS, "myPlate1-1", null, rows1);
+        Plate plateSource = createPlate(PLATE_TYPE_96_WELLS, "myPlate1-1", null, sourceWells);
 
-        List<Map<String, Object>> rows2 = List.of(
-            CaseInsensitiveHashMap.of(
-                "wellLocation", "A1",
-                "type", "SAMPLE",
-                "sampleId", sample2.getRowId()
-            ),
-            CaseInsensitiveHashMap.of(
-                "wellLocation", "A2",
-                "type", "SAMPLE",
-                "sampleId", sample1.getRowId()
-            ),
-            CaseInsensitiveHashMap.of(
-                "wellLocation", "A3",
-                "type", "SAMPLE",
-                "sampleId", sample2.getRowId()
-            )
+        List<Map<String, Object>> destinationWells = List.of(
+            createWellRow("A1", "SAMPLE", sample2.getRowId()),
+            createWellRow("A2", "SAMPLE", sample1.getRowId()),
+            createWellRow("A3", "SAMPLE", sample2.getRowId())
         );
-        Plate plateDestination = createPlate(PLATE_TYPE_96_WELLS, "myPlate2-1", null, rows2);
+        Plate plateDestination = createPlate(PLATE_TYPE_96_WELLS, "myPlate2-1", null, destinationWells);
 
         // Act
         List<FieldKey> sourceIncludedMetadataCols = PlateManager.get().getMetadataColumns(plateSource.getPlateSet(), container, user, cf);
@@ -702,20 +655,14 @@ public final class PlateManagerTest
         List<Object[]> plateDataRows = PlateManager.get().getWorklist(plateSource.getPlateSet().getRowId(), plateDestination.getPlateSet().getRowId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, container, user);
 
         // Assert
-        Object[] row1 = plateDataRows.get(0);
-        String[] valuesRow1 = new String[]{"myPlate1-1", plateSource.getBarcode(), "A1", "96", sample1.getName(), "B1234", "2.25", "SAMPLE", null, "myPlate2-1", plateDestination.getBarcode(), "A2", "96", "SAMPLE", null};
-        for (int i = 0; i < row1.length; i++)
-            assertEquals(row1[i] == null ? null : row1[i].toString(), valuesRow1[i]);
+        Object[] valuesRow1 = new Object[]{"myPlate1-1", plateSource.getBarcode(), "A1", 96, sample1.getName(), "B1234", "2.25", null, "SAMPLE", null, "myPlate2-1", plateDestination.getBarcode(), "A2", 96, null, "SAMPLE", null};
+        assertArrayEquals(valuesRow1, plateDataRows.get(0));
 
-        Object[] row2 = plateDataRows.get(1);
-        String[] valuesRow2 = new String[]{"myPlate1-1", plateSource.getBarcode(),"A2", "96", sample2.getName(), "B5678", "1.25", "SAMPLE", null, "myPlate2-1", plateDestination.getBarcode(), "A1", "96", "SAMPLE", null};
-        for (int i = 0; i < row2.length; i++)
-            assertEquals(row2[i] == null ? null : row2[i].toString(), valuesRow2[i]);
+        Object[] valuesRow2 = new Object[]{"myPlate1-1", plateSource.getBarcode(),"A2", 96, sample2.getName(), "B5678", "1.25", null, "SAMPLE", null, "myPlate2-1", plateDestination.getBarcode(), "A1", 96, null, "SAMPLE", null};
+        assertArrayEquals(valuesRow2, plateDataRows.get(1));
 
-        Object[] row3 = plateDataRows.get(2);
-        String[] valuesRow3 = new String[]{"myPlate1-1", plateSource.getBarcode(),"A2", "96", sample2.getName(), "B5678", "1.25", "SAMPLE", null, "myPlate2-1", plateDestination.getBarcode(), "A3", "96", "SAMPLE", null};
-        for (int i = 0; i < row3.length; i++)
-            assertEquals(row3[i] == null ? null : row3[i].toString(), valuesRow3[i]);
+        Object[] valuesRow3 = new Object[]{"myPlate1-1", plateSource.getBarcode(),"A2", 96, sample2.getName(), "B5678", "1.25", null, "SAMPLE", null, "myPlate2-1", plateDestination.getBarcode(), "A3", 96, null, "SAMPLE", null};
+        assertArrayEquals(valuesRow3, plateDataRows.get(2));
     }
 
     @Test
@@ -729,30 +676,12 @@ public final class PlateManagerTest
         ExpMaterial sample2 = samples.get(1);
 
         List<Map<String, Object>> rows1 = List.of(
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A1",
-                        "sampleId", sample1.getRowId(),
-                        "type", "SAMPLE",
-                        "concentration", 2.25,
-                        PlateMetadataFields.barcode.name(), "B1234"
-                ),
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A2",
-                        "sampleId", sample2.getRowId(),
-                        "type", "SAMPLE",
-                        "concentration", 1.25,
-                        PlateMetadataFields.barcode.name(), "B5678"
-                )
+            wellWithMetdata(createWellRow("A1", "SAMPLE", sample1.getRowId()), 2.25, "B1234"),
+            wellWithMetdata(createWellRow("A2", "SAMPLE", sample2.getRowId()), 1.25, "B5678")
         );
         Plate plateSource = createPlate(PLATE_TYPE_96_WELLS, "myPlate1-2", null, rows1);
 
-        List<Map<String, Object>> rows2 = List.of(
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A1",
-                        "type", "SAMPLE",
-                        "sampleId", sample2.getRowId()
-                )
-        );
+        List<Map<String, Object>> rows2 = List.of(createWellRow("A1", "SAMPLE", sample2.getRowId()));
         Plate plateDestination = createPlate(PLATE_TYPE_96_WELLS, "myPlate2-2", null, rows2);
 
         // Act
@@ -761,15 +690,11 @@ public final class PlateManagerTest
         List<Object[]> plateDataRows = PlateManager.get().getWorklist(plateSource.getPlateSet().getRowId(), plateDestination.getPlateSet().getRowId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, container, user);
 
         // Assert
-        Object[] row1 = plateDataRows.get(0);
-        String[] valuesRow1 = new String[]{"myPlate1-2", plateSource.getBarcode(), "A1", "96", sample1.getName(), "B1234", "2.25", "SAMPLE", null, null, null, null, null, null, null};
-        for (int i = 0; i < row1.length; i++)
-            assertEquals(row1[i] == null ? null : row1[i].toString(), valuesRow1[i]);
+        Object[] valuesRow1 = new Object[]{"myPlate1-2", plateSource.getBarcode(), "A1", 96, sample1.getName(), "B1234", "2.25", null, "SAMPLE", null, null, null, null, null, null, null, null};
+        assertArrayEquals(valuesRow1, plateDataRows.get(0));
 
-        Object[] row2 = plateDataRows.get(1);
-        String[] valuesRow2 = new String[]{"myPlate1-2", plateSource.getBarcode(),"A2", "96", sample2.getName(), "B5678", "1.25", "SAMPLE", null, "myPlate2-2", plateDestination.getBarcode(), "A1", "96", "SAMPLE", null};
-        for (int i = 0; i < row2.length; i++)
-            assertEquals(row2[i] == null ? null : row2[i].toString(), valuesRow2[i]);
+        Object[] valuesRow2 = new Object[]{"myPlate1-2", plateSource.getBarcode(),"A2", 96, sample2.getName(), "B5678", "1.25", null, "SAMPLE", null, "myPlate2-2", plateDestination.getBarcode(), "A1", 96, null, "SAMPLE", null};
+        assertArrayEquals(valuesRow2, plateDataRows.get(1));
     }
 
     @Test
@@ -780,41 +705,15 @@ public final class PlateManagerTest
         ExpMaterial sample = createSamples(1).get(0);
 
         List<Map<String, Object>> rows1 = List.of(
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A1",
-                        "sampleId", sample.getRowId(),
-                        "type", "SAMPLE",
-                        "concentration", 2.25,
-                        PlateMetadataFields.barcode.name(), "B1234"
-                ),
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A2",
-                        "sampleId", sample.getRowId(),
-                        "type", "SAMPLE",
-                        "concentration", 1.25,
-                        PlateMetadataFields.barcode.name(), "B5678"
-                ),
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A3",
-                        "sampleId", sample.getRowId(),
-                        "type", "SAMPLE",
-                        "concentration", 1.00,
-                        PlateMetadataFields.barcode.name(), "B910"
-                )
+            wellWithMetdata(createWellRow("A1", "SAMPLE", sample.getRowId()), 2.25, "B1234"),
+            wellWithMetdata(createWellRow("A2", "SAMPLE", sample.getRowId()), 1.25, "B5678"),
+            wellWithMetdata(createWellRow("A3", "SAMPLE", sample.getRowId()), 1.00, "B910")
         );
         Plate plateSource = createPlate(PLATE_TYPE_96_WELLS, "myPlate1-3", null, rows1);
 
         List<Map<String, Object>> rows2 = List.of(
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A1",
-                        "type", "SAMPLE",
-                        "sampleId", sample.getRowId()
-                ),
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A2",
-                        "type", "SAMPLE",
-                        "sampleId", sample.getRowId()
-                )
+            createWellRow("A1", "SAMPLE", sample.getRowId()),
+            createWellRow("A2", "SAMPLE", sample.getRowId())
         );
         Plate plateDestination = createPlate(PLATE_TYPE_96_WELLS, "myPlate2-3", null, rows2);
 
@@ -834,46 +733,16 @@ public final class PlateManagerTest
         ExpMaterial sample = createSamples(3).get(0);
 
         List<Map<String, Object>> rows1 = List.of(
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A1",
-                        "sampleId", sample.getRowId(),
-                        "type", "SAMPLE",
-                        "concentration", 2.25,
-                        PlateMetadataFields.barcode.name(), "B1234"
-                ),
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A2",
-                        "sampleId", sample.getRowId(),
-                        "type", "SAMPLE",
-                        "concentration", 1.25,
-                        PlateMetadataFields.barcode.name(), "B5678"
-                ),
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A3",
-                        "sampleId", sample.getRowId(),
-                        "type", "SAMPLE",
-                        "concentration", 1.00,
-                        PlateMetadataFields.barcode.name(), "B910"
-                )
+            wellWithMetdata(createWellRow("A1", "SAMPLE", sample.getRowId()), 2.25, "B1234"),
+            wellWithMetdata(createWellRow("A2", "SAMPLE", sample.getRowId()), 1.25, "B5678"),
+            wellWithMetdata(createWellRow("A3", "SAMPLE", sample.getRowId()), 1.00, "B910")
         );
         Plate plateSource = createPlate(PLATE_TYPE_96_WELLS, "myPlate1-4", null, rows1);
 
         List<Map<String, Object>> rows2 = List.of(
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A2",
-                        "type", "SAMPLE",
-                        "sampleId", sample.getRowId()
-                ),
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A3",
-                        "type", "SAMPLE",
-                        "sampleId", sample.getRowId()
-                ),
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A4",
-                        "type", "SAMPLE",
-                        "sampleId", sample.getRowId()
-                )
+            createWellRow("A2", "SAMPLE", sample.getRowId()),
+            createWellRow("A3", "SAMPLE", sample.getRowId()),
+            createWellRow("A4", "SAMPLE", sample.getRowId())
         );
         Plate plateDestination = createPlate(PLATE_TYPE_96_WELLS, "myPlate2-4", null, rows2);
 
@@ -883,20 +752,14 @@ public final class PlateManagerTest
         List<Object[]> plateDataRows = PlateManager.get().getWorklist(plateSource.getPlateSet().getRowId(), plateDestination.getPlateSet().getRowId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, container, user);
 
         // Assert
-        Object[] row1 = plateDataRows.get(0);
-        String[] valuesRow1 = new String[]{"myPlate1-4", plateSource.getBarcode(), "A1", "96", sample.getName(), "B1234", "2.25", "SAMPLE", null, "myPlate2-4", plateDestination.getBarcode(), "A2", "96", "SAMPLE", null};
-        for (int i = 0; i < row1.length; i++)
-            assertEquals(row1[i] == null ? null : row1[i].toString(), valuesRow1[i]);
+        Object[] valuesRow1 = new Object[]{"myPlate1-4", plateSource.getBarcode(), "A1", 96, sample.getName(), "B1234", "2.25", null, "SAMPLE", null, "myPlate2-4", plateDestination.getBarcode(), "A2", 96, null, "SAMPLE", null};
+        assertArrayEquals(valuesRow1, plateDataRows.get(0));
 
-        Object[] row2 = plateDataRows.get(1);
-        String[] valuesRow2 = new String[]{"myPlate1-4", plateSource.getBarcode(),"A2", "96", sample.getName(), "B5678", "1.25", "SAMPLE", null, "myPlate2-4", plateDestination.getBarcode(), "A3", "96", "SAMPLE", null};
-        for (int i = 0; i < row2.length; i++)
-            assertEquals(row2[i] == null ? null : row2[i].toString(), valuesRow2[i]);
+        Object[] valuesRow2 = new Object[]{"myPlate1-4", plateSource.getBarcode(),"A2", 96, sample.getName(), "B5678", "1.25", null, "SAMPLE", null, "myPlate2-4", plateDestination.getBarcode(), "A3", 96, null, "SAMPLE", null};
+        assertArrayEquals(valuesRow2, plateDataRows.get(1));
 
-        Object[] row3 = plateDataRows.get(2);
-        String[] valuesRow3 = new String[]{"myPlate1-4", plateSource.getBarcode(),"A3", "96", sample.getName(), "B910", "1.0", "SAMPLE", null, "myPlate2-4", plateDestination.getBarcode(), "A4", "96", "SAMPLE", null};
-        for (int i = 0; i < row3.length; i++)
-            assertEquals(row3[i] == null ? null : row3[i].toString(), valuesRow3[i]);
+        Object[] valuesRow3 = new Object[]{"myPlate1-4", plateSource.getBarcode(),"A3", 96, sample.getName(), "B910", "1.0", null, "SAMPLE", null, "myPlate2-4", plateDestination.getBarcode(), "A4", 96, null, "SAMPLE", null};
+        assertArrayEquals(valuesRow3, plateDataRows.get(2));
     }
 
     @Test
@@ -907,32 +770,14 @@ public final class PlateManagerTest
         ExpMaterial sample = createSamples(3).get(0);
 
         List<Map<String, Object>> rows1 = List.of(
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A1",
-                        "sampleId", sample.getRowId(),
-                        "type", "SAMPLE",
-                        "concentration", 2.25,
-                        PlateMetadataFields.barcode.name(), "B1234"
-                )
+            wellWithMetdata(createWellRow("A1", "SAMPLE", sample.getRowId()), 2.25, "B1234")
         );
         Plate plateSource = createPlate(PLATE_TYPE_96_WELLS, "myPlate1-5", null, rows1);
 
         List<Map<String, Object>> rows2 = List.of(
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A2",
-                        "type", "SAMPLE",
-                        "sampleId", sample.getRowId()
-                ),
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A3",
-                        "type", "SAMPLE",
-                        "sampleId", sample.getRowId()
-                ),
-                CaseInsensitiveHashMap.of(
-                        "wellLocation", "A4",
-                        "type", "SAMPLE",
-                        "sampleId", sample.getRowId()
-                )
+            createWellRow("A2", "SAMPLE", sample.getRowId()),
+            createWellRow("A3", "SAMPLE", sample.getRowId()),
+            createWellRow("A4", "SAMPLE", sample.getRowId())
         );
         Plate plateDestination = createPlate(PLATE_TYPE_96_WELLS, "myPlate2-5", null, rows2);
 
@@ -942,20 +787,14 @@ public final class PlateManagerTest
         List<Object[]> plateDataRows = PlateManager.get().getWorklist(plateSource.getPlateSet().getRowId(), plateDestination.getPlateSet().getRowId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, container, user);
 
         // Assert
-        Object[] row1 = plateDataRows.get(0);
-        String[] valuesRow1 = new String[]{"myPlate1-5", plateSource.getBarcode(), "A1", "96", sample.getName(), "B1234", "2.25", "SAMPLE", null, "myPlate2-5", plateDestination.getBarcode(), "A2", "96", "SAMPLE", null};
-        for (int i = 0; i < row1.length; i++)
-            assertEquals(row1[i] == null ? null : row1[i].toString(), valuesRow1[i]);
+        Object[] valuesRow1 = new Object[]{"myPlate1-5", plateSource.getBarcode(), "A1", 96, sample.getName(), "B1234", "2.25", null, "SAMPLE", null, "myPlate2-5", plateDestination.getBarcode(), "A2", 96, null, "SAMPLE", null};
+        assertArrayEquals(valuesRow1, plateDataRows.get(0));
 
-        Object[] row2 = plateDataRows.get(1);
-        String[] valuesRow2 = new String[]{"myPlate1-5", plateSource.getBarcode(),"A1", "96", sample.getName(), "B1234", "2.25", "SAMPLE", null, "myPlate2-5", plateDestination.getBarcode(), "A3", "96", "SAMPLE", null};
-        for (int i = 0; i < row2.length; i++)
-            assertEquals(row2[i] == null ? null : row2[i].toString(), valuesRow2[i]);
+        Object[] valuesRow2 = new Object[]{"myPlate1-5", plateSource.getBarcode(),"A1", 96, sample.getName(), "B1234", "2.25", null, "SAMPLE", null, "myPlate2-5", plateDestination.getBarcode(), "A3", 96, null, "SAMPLE", null};
+        assertArrayEquals(valuesRow2, plateDataRows.get(1));
 
-        Object[] row3 = plateDataRows.get(2);
-        String[] valuesRow3 = new String[]{"myPlate1-5", plateSource.getBarcode(),"A1", "96", sample.getName(), "B1234", "2.25", "SAMPLE", null, "myPlate2-5", plateDestination.getBarcode(), "A4", "96", "SAMPLE", null};
-        for (int i = 0; i < row3.length; i++)
-            assertEquals(row3[i] == null ? null : row3[i].toString(), valuesRow3[i]);
+        Object[] valuesRow3 = new Object[]{"myPlate1-5", plateSource.getBarcode(),"A1", 96, sample.getName(), "B1234", "2.25", null, "SAMPLE", null, "myPlate2-5", plateDestination.getBarcode(), "A4", 96, null, "SAMPLE", null};
+        assertArrayEquals(valuesRow3, plateDataRows.get(2));
     }
 
     private void assertReformatThrows(String message, ReformatOptions options)
@@ -1392,10 +1231,10 @@ public final class PlateManagerTest
                 CaseInsensitiveHashMap.of("wellLocation", "A2", "sampleId", sampleRowIds.get(1), "type", "SAMPLE"),
                 CaseInsensitiveHashMap.of("wellLocation", "A3", "sampleId", sampleRowIds.get(2), "type", "SAMPLE"),
                 CaseInsensitiveHashMap.of("wellLocation", "A4", "sampleId", sampleRowIds.get(3), "type", "SAMPLE"),
-                CaseInsensitiveHashMap.of("wellLocation", "B1", "sampleId", sampleRowIds.get(4), "type", "REPLICATE", "wellGroup", "RB1"),
-                CaseInsensitiveHashMap.of("wellLocation", "B2", "sampleId", sampleRowIds.get(4), "type", "REPLICATE", "wellGroup", "RB1"),
-                CaseInsensitiveHashMap.of("wellLocation", "B3", "sampleId", sampleRowIds.get(5), "type", "REPLICATE", "wellGroup", "RB2"),
-                CaseInsensitiveHashMap.of("wellLocation", "B4", "sampleId", sampleRowIds.get(5), "type", "REPLICATE", "wellGroup", "RB2"),
+                CaseInsensitiveHashMap.of("wellLocation", "B1", "sampleId", sampleRowIds.get(4), "type", "SAMPLE", "replicateGroup", "RB1"),
+                CaseInsensitiveHashMap.of("wellLocation", "B2", "sampleId", sampleRowIds.get(4), "type", "SAMPLE", "replicateGroup", "RB1"),
+                CaseInsensitiveHashMap.of("wellLocation", "B3", "sampleId", sampleRowIds.get(5), "type", "SAMPLE", "replicateGroup", "RB2"),
+                CaseInsensitiveHashMap.of("wellLocation", "B4", "sampleId", sampleRowIds.get(5), "type", "SAMPLE", "replicateGroup", "RB2"),
                 CaseInsensitiveHashMap.of("wellLocation", "C1", "sampleId", controlRowIds.get(0), "type", "CONTROL"),
                 CaseInsensitiveHashMap.of("wellLocation", "C2", "sampleId", sampleRowIds.get(6), "type", "SAMPLE"),
                 CaseInsensitiveHashMap.of("wellLocation", "C3", "sampleId", controlRowIds.get(1), "type", "CONTROL"),
@@ -1410,7 +1249,7 @@ public final class PlateManagerTest
         // 96-well source plate
         {
             List<Map<String, Object>> sourcePlateData = List.of(
-                CaseInsensitiveHashMap.of("wellLocation", "A1", "sampleId", sampleRowIds.get(4), "type", "REPLICATE", "wellGroup", "RB1"),
+                CaseInsensitiveHashMap.of("wellLocation", "A1", "sampleId", sampleRowIds.get(4), "type", "SAMPLE", "replicateGroup", "RB1"),
                 CaseInsensitiveHashMap.of("wellLocation", "A12", "sampleId", sampleRowIds.get(0), "type", "SAMPLE", "wellGroup", "S1"),
                 CaseInsensitiveHashMap.of("wellLocation", "D6", "sampleId", sampleRowIds.get(8), "type", "SAMPLE"),
                 CaseInsensitiveHashMap.of("wellLocation", "E6", "sampleId", sampleRowIds.get(9), "type", "SAMPLE"),
@@ -1418,7 +1257,7 @@ public final class PlateManagerTest
                 CaseInsensitiveHashMap.of("wellLocation", "H2", "sampleId", sampleRowIds.get(10), "type", "SAMPLE"),
                 CaseInsensitiveHashMap.of("wellLocation", "H3", "sampleId", sampleRowIds.get(11), "type", "SAMPLE"),
                 CaseInsensitiveHashMap.of("wellLocation", "H4", "sampleId", sampleRowIds.get(12), "type", "SAMPLE"),
-                CaseInsensitiveHashMap.of("wellLocation", "H12", "sampleId", sampleRowIds.get(5), "type", "REPLICATE", "wellGroup", "RB2")
+                CaseInsensitiveHashMap.of("wellLocation", "H12", "sampleId", sampleRowIds.get(5), "type", "SAMPLE", "replicateGroup", "RB2")
             );
             sourcePlates.add(createPlate(PLATE_TYPE_96_WELLS, null, targetPlateSetId, sourcePlateData));
         }
@@ -1571,10 +1410,10 @@ public final class PlateManagerTest
             CaseInsensitiveHashMap.of("wellLocation", "A2", "type", "SAMPLE", PlateMetadataFields.barcode.name(), "BC-A2"),
             CaseInsensitiveHashMap.of("wellLocation", "A3", "type", "SAMPLE", PlateMetadataFields.barcode.name(), "BC-A3"),
             CaseInsensitiveHashMap.of("wellLocation", "A4", "type", "SAMPLE", PlateMetadataFields.barcode.name(), "BC-A4"),
-            CaseInsensitiveHashMap.of("wellLocation", "B1", "type", "REPLICATE", "wellGroup", "RBT1", PlateMetadataFields.barcode.name(), "BC-RB1"),
-            CaseInsensitiveHashMap.of("wellLocation", "B2", "type", "REPLICATE", "wellGroup", "RBT1", PlateMetadataFields.barcode.name(), "BC-RB1"),
-            CaseInsensitiveHashMap.of("wellLocation", "B3", "type", "REPLICATE", "wellGroup", "RBT2", PlateMetadataFields.barcode.name(), "BC-RB2"),
-            CaseInsensitiveHashMap.of("wellLocation", "B4", "type", "REPLICATE", "wellGroup", "RBT2", PlateMetadataFields.barcode.name(), "BC-RB2"),
+            CaseInsensitiveHashMap.of("wellLocation", "B1", "type", "SAMPLE", "replicateGroup", "RBT1", PlateMetadataFields.barcode.name(), "BC-RB1"),
+            CaseInsensitiveHashMap.of("wellLocation", "B2", "type", "SAMPLE", "replicateGroup", "RBT1", PlateMetadataFields.barcode.name(), "BC-RB1"),
+            CaseInsensitiveHashMap.of("wellLocation", "B3", "type", "SAMPLE", "replicateGroup", "RBT2", PlateMetadataFields.barcode.name(), "BC-RB2"),
+            CaseInsensitiveHashMap.of("wellLocation", "B4", "type", "SAMPLE", "replicateGroup", "RBT2", PlateMetadataFields.barcode.name(), "BC-RB2"),
             CaseInsensitiveHashMap.of("wellLocation", "C1", "type", "CONTROL", PlateMetadataFields.barcode.name(), "BC-C1"),
             CaseInsensitiveHashMap.of("wellLocation", "C2", "type", "SAMPLE", PlateMetadataFields.barcode.name(), "BC-C2"),
             CaseInsensitiveHashMap.of("wellLocation", "C3", "type", "CONTROL", PlateMetadataFields.barcode.name(), "BC-C3"),
@@ -1706,7 +1545,7 @@ public final class PlateManagerTest
     {
         // Arrange
         String plateName = "testReplicateZoneValidation";
-        String expectedErrorMessage = "Replicates must specify a \"WellGroup\".";
+        String expectedErrorMessage = "Type \"Replicate\" is not supported for well %s. Specify a \"ReplicateGroup\" instead.";
         List<Map<String, Object>> sourcePlateData = new ArrayList<>();
         for (int i = 0; i < 5; i++)
         {
@@ -1718,21 +1557,24 @@ public final class PlateManagerTest
         }
 
         // Act / Assert
-        assertCreatePlateThrows(expectedErrorMessage, PLATE_TYPE_96_WELLS, plateName, null, sourcePlateData);
+        assertCreatePlateThrows(String.format(expectedErrorMessage, "A1"), PLATE_TYPE_96_WELLS, plateName, null, sourcePlateData);
 
         // Fixup rows by making all rows specify the same well group and resubmit
-        sourcePlateData.forEach(row -> row.put("wellGroup", "Group A"));
+        sourcePlateData.forEach(row -> {
+            row.put("type", "SAMPLE");
+            row.put("replicateGroup", "Group A");
+        });
 
         // Act (expect no errors)
         var newPlate = createPlate(PLATE_TYPE_96_WELLS, plateName, null, sourcePlateData);
 
         // Verify update validation
-        var wellA1 = getWellRow(newPlate.getRowId(), "A1");
-        wellA1.put("wellGroup", null);
+        var wellA3 = getWellRow(newPlate.getRowId(), "A3");
+        wellA3.put("type", "REPLICATE");
 
-        var errors = updateWells(List.of(wellA1), true);
+        var errors = updateWells(List.of(wellA3), true);
         assertTrue(errors.hasErrors());
-        assertEquals(expectedErrorMessage, errors.getMessage());
+        assertEquals(String.format(expectedErrorMessage, "A3"), errors.getMessage());
     }
 
     @Test
@@ -1744,8 +1586,8 @@ public final class PlateManagerTest
         List<String> filledPositions = new ArrayList<>();
 
         Map<String, Object> commonWellValues = new CaseInsensitiveHashMap<>();
-        commonWellValues.put("type", "REPLICATE");
-        commonWellValues.put("wellGroup", "R1");
+        commonWellValues.put("type", "SAMPLE");
+        commonWellValues.put("replicateGroup", "R1");
         commonWellValues.put("concentration", 12.0);
         commonWellValues.put(PlateMetadataFields.barcode.name(), "BC-122");
         commonWellValues.put(PlateMetadataFields.opacity.name(), 3.14);
@@ -1758,13 +1600,13 @@ public final class PlateManagerTest
             filledPositions.add(position);
 
             // All rows are the same except for wellLocation and sampleId
-            var row = createWellRow(position, (String) commonWellValues.get("type"), (String) commonWellValues.get("wellGroup"), sampleRowIds.get(i));
+            var row = createWellRow(position, (String) commonWellValues.get("type"), sampleRowIds.get(i), null, (String) commonWellValues.get("replicateGroup"));
             row.putAll(commonWellValues);
             sourcePlateData.add(row);
         }
 
         // Act / Assert
-        var expectedMessage = String.format("Replicate group \"%s\" contains mismatched well data. Ensure all data aligns for the replicates declared in these wells.", commonWellValues.get("wellGroup"));
+        var expectedMessage = String.format("Replicate group \"%s\" contains mismatched well data. Ensure all data aligns for the replicates declared in these wells.", commonWellValues.get("replicateGroup"));
         assertCreatePlateThrows(expectedMessage, PLATE_TYPE_96_WELLS, plateName, null, sourcePlateData);
 
         // Fixup rows by making all rows the same and resubmit
@@ -1810,19 +1652,19 @@ public final class PlateManagerTest
         List<Integer> sampleRowIds = createSamples(2).stream().map(ExpObject::getRowId).sorted().toList();
 
         List<Map<String, Object>> plate1Data = new ArrayList<>();
-        plate1Data.add(createWellRow("A1", "REPLICATE", "R1", sampleRowIds.get(0)));
-        plate1Data.add(createWellRow("A2", "REPLICATE", "R1", sampleRowIds.get(0)));
-        plate1Data.add(createWellRow("A3", "REPLICATE", "R1", sampleRowIds.get(0)));
+        plate1Data.add(createWellRow("A1", "SAMPLE", sampleRowIds.get(0), null, "R1"));
+        plate1Data.add(createWellRow("A2", "SAMPLE", sampleRowIds.get(0), null, "R1"));
+        plate1Data.add(createWellRow("A3", "SAMPLE", sampleRowIds.get(0), null, "R1"));
 
         List<Map<String, Object>> plate2Data = new ArrayList<>();
-        plate2Data.add(createWellRow("B1", "REPLICATE", "R1", sampleRowIds.get(1)));
-        plate2Data.add(createWellRow("B2", "REPLICATE", "R1", sampleRowIds.get(1)));
-        plate2Data.add(createWellRow("B3", "REPLICATE", "R1", sampleRowIds.get(1)));
+        plate2Data.add(createWellRow("B1", "SAMPLE", sampleRowIds.get(1), null, "R1"));
+        plate2Data.add(createWellRow("B2", "SAMPLE", sampleRowIds.get(1), null, "R1"));
+        plate2Data.add(createWellRow("B3", "SAMPLE", sampleRowIds.get(1), null, "R1"));
 
         List<Map<String, Object>> plate3Data = new ArrayList<>();
-        plate2Data.add(createWellRow("C1", "REPLICATE", "R2", sampleRowIds.get(0)));
-        plate2Data.add(createWellRow("C2", "REPLICATE", "R2", sampleRowIds.get(0)));
-        plate2Data.add(createWellRow("C3", "REPLICATE", "R2", sampleRowIds.get(0)));
+        plate2Data.add(createWellRow("C1", "SAMPLE", sampleRowIds.get(0), null, "R2"));
+        plate2Data.add(createWellRow("C2", "SAMPLE", sampleRowIds.get(0), null, "R2"));
+        plate2Data.add(createWellRow("C3", "SAMPLE", sampleRowIds.get(0), null, "R2"));
 
         var plateData = List.of(
             new PlateManager.PlateData(null, plateType.getRowId(), null, null, plate1Data),
@@ -1854,15 +1696,16 @@ public final class PlateManagerTest
         plateSetImpl.setType(PlateSetType.primary);
         PlateType plateType = PLATE_TYPE_12_WELLS;
 
-        List<Map<String, Object>> PS1Data = new ArrayList<>();
-        PS1Data.add(createWellRow("A1", "SAMPLE", null, sampleRowIds.get(0)));
-        PS1Data.add(createWellRow("A2", "SAMPLE", null, sampleRowIds.get(1)));
-        PS1Data.add(createWellRow("A3", "SAMPLE", null, sampleRowIds.get(2)));
+        List<Map<String, Object>> PS1Data = List.of(
+            createWellRow("A1", "SAMPLE", sampleRowIds.get(0)),
+            createWellRow("A2", "SAMPLE", sampleRowIds.get(1)),
+            createWellRow("A3", "SAMPLE", sampleRowIds.get(2))
+        );
 
         var plateData1 = List.of(new PlateManager.PlateData("PS1", plateType.getRowId(), null, null, PS1Data));
         PlateSet plateSet1 = createPlateSet(plateSetImpl, plateData1, null);
 
-        List<Map<String, Object>> dataPS2 = Arrays.asList(createWellRow("A1", "POSITIVE_CONTROL", null, sampleRowIds.get(0)));
+        List<Map<String, Object>> dataPS2 = Arrays.asList(createWellRow("A1", "POSITIVE_CONTROL", sampleRowIds.get(0)));
         var plateData2 = List.of(new PlateManager.PlateData("PS2", plateType.getRowId(), null, null, dataPS2));
 
         // Act / Assert
@@ -1871,7 +1714,7 @@ public final class PlateManagerTest
         assertCreatePlateSetThrows(errorMsg, plateSetImpl, plateData2, plateSet1.getRowId());
 
         // Assert (expect no errors)
-        List<Map<String, Object>> newDataPS2 = Arrays.asList(createWellRow("A1", "POSITIVE_CONTROL", null, sampleRowIds.get(3)));
+        List<Map<String, Object>> newDataPS2 = Arrays.asList(createWellRow("A1", "POSITIVE_CONTROL", sampleRowIds.get(3)));
         plateData2 = List.of(new PlateManager.PlateData("PS2", plateType.getRowId(), null, null, newDataPS2));
         createPlateSet(plateSetImpl, plateData2, plateSet1.getRowId());
     }
@@ -1893,22 +1736,24 @@ public final class PlateManagerTest
         Plate templatePS = createPlateTemplate(PLATE_TYPE_384_WELLS, "PT", null);
 
         // Act
-        List<PlateCustomField> one = PlateManager.get().getFields(container, PPSPlate.getRowId());
-        List<PlateCustomField> two = PlateManager.get().getFields(container, APSPlate.getRowId());
-        List<PlateCustomField> three = PlateManager.get().getFields(container, templatePS.getRowId());
+        List<PlateCustomField> PPSPlateFields = PlateManager.get().getFields(container, PPSPlate.getRowId());
+        List<PlateCustomField> APSPlateFields = PlateManager.get().getFields(container, APSPlate.getRowId());
+        List<PlateCustomField> templatePlateFields = PlateManager.get().getFields(container, templatePS.getRowId());
 
         // Assert
-        assertEquals(one.size(), 1);
-        assertEquals(one.get(0).getName(), "SampleID");
+        assertEquals(1, PPSPlateFields.size());
+        assertEquals("SampleID", PPSPlateFields.get(0).getName());
 
-        assertEquals(two.size(), 3);
-        assertEquals(two.get(0).getName(), "Type");
-        assertEquals(two.get(1).getName(), "WellGroup");
-        assertEquals(two.get(2).getName(), "SampleID");
+        assertEquals(4, APSPlateFields.size());
+        assertEquals("Type", APSPlateFields.get(0).getName());
+        assertEquals("WellGroup", APSPlateFields.get(1).getName());
+        assertEquals("ReplicateGroup", APSPlateFields.get(2).getName());
+        assertEquals("SampleID", APSPlateFields.get(3).getName());
 
-        assertEquals(three.size(), 2);
-        assertEquals(two.get(0).getName(), "Type");
-        assertEquals(two.get(1).getName(), "WellGroup");
+        assertEquals(3, templatePlateFields.size());
+        assertEquals("Type", APSPlateFields.get(0).getName());
+        assertEquals("WellGroup", APSPlateFields.get(1).getName());
+        assertEquals("ReplicateGroup", APSPlateFields.get(2).getName());
     }
 
     @Test
@@ -1919,8 +1764,8 @@ public final class PlateManagerTest
         List<Integer> sampleRowIds = samples.stream().map(ExpObject::getRowId).sorted().toList();
 
         List<Map<String, Object>> data = List.of(
-                CaseInsensitiveHashMap.of("wellLocation", "A1", "sampleId", sampleRowIds.get(0), "type", "CONTROL"),
-                CaseInsensitiveHashMap.of("wellLocation", "A2", "sampleId", sampleRowIds.get(1), "type", "")
+            createWellRow("A1", "CONTROL", sampleRowIds.get(0)),
+            createWellRow("A2", "", sampleRowIds.get(1))
         );
 
         // Act
@@ -1947,7 +1792,7 @@ public final class PlateManagerTest
         List<Integer> sampleRowIds = samples.stream().map(ExpObject::getRowId).sorted().toList();
 
         List<Map<String, Object>> data = List.of(
-                CaseInsensitiveHashMap.of("wellLocation", "A1", "sampleId", sampleRowIds.get(0), "type", "CONTROL")
+            createWellRow("A1", "CONTROL", sampleRowIds.get(0))
         );
 
         // Act
@@ -1961,7 +1806,7 @@ public final class PlateManagerTest
         {
             r.next();
             var type = r.getString(FieldKey.fromParts("type"));
-            assertEquals(type, "CONTROL");
+            assertEquals("CONTROL", type);
         }
     }
 
@@ -2078,7 +1923,8 @@ public final class PlateManagerTest
             FieldKey.fromParts("rowId"),
             FieldKey.fromParts("sampleId"),
             FieldKey.fromParts("type"),
-            FieldKey.fromParts("wellGroup")
+            FieldKey.fromParts("wellGroup"),
+            FieldKey.fromParts("replicateGroup")
         ));
     }
 
@@ -2134,13 +1980,36 @@ public final class PlateManagerTest
         return errors;
     }
 
-    private Map<String, Object> createWellRow(String position, String type, String wellGroup, Integer sampleId)
+    private Map<String, Object> createWellRow(String position, String type, Integer sampleId)
+    {
+        return createWellRow(position, type, sampleId, null, null);
+    }
+
+    private Map<String, Object> createWellRow(
+        String position,
+        String type,
+        Integer sampleId,
+        @Nullable String wellGroup,
+        @Nullable String replicateGroup
+    )
     {
         Map<String, Object> row = new CaseInsensitiveHashMap<>();
         row.put("wellLocation", position);
         row.put("type", type);
-        row.put("wellGroup", wellGroup);
+        if (wellGroup != null)
+            row.put("wellGroup", wellGroup);
+        if (replicateGroup != null)
+            row.put("replicateGroup", replicateGroup);
         row.put("sampleId", sampleId);
         return row;
+    }
+
+    private Map<String, Object> wellWithMetdata(Map<String, Object> well, @Nullable Object concentration, @Nullable String barcode)
+    {
+        if (concentration != null)
+            well.put("concentration", concentration);
+        if (barcode != null)
+            well.put(PlateMetadataFields.barcode.name(), barcode);
+        return well;
     }
 }

--- a/assay/src/org/labkey/assay/plate/PlateMetricsProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateMetricsProvider.java
@@ -4,6 +4,7 @@ import org.labkey.api.assay.AssayProtocolSchema;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.plate.PlateSetType;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
@@ -79,15 +80,29 @@ public class PlateMetricsProvider implements UsageMetricsProvider
         return new SqlSelector(schema, sql).getObject(Long.class);
     }
 
-    private Long plateTypeCount(DbSchema schema, TableInfo plateTable, TableInfo plateTypeTable, int cols, int rows)
+    private Long plateTypeCount(DbSchema schema, TableInfo plateTable, TableInfo plateTypeTable, int cols, int rows, boolean template)
     {
         SQLFragment sql = new SQLFragment("SELECT COUNT(*) FROM ")
                 .append(plateTable, "p")
                 .append(" JOIN ").append(plateTypeTable, "pt")
                 .append(" ON p.plateType = pt.rowId")
-                .append(" WHERE pt.columns = ? AND pt.rows = ?")
+                .append(" WHERE p.archived = ? AND p.template = ? AND pt.columns = ? AND pt.rows = ?")
+                .add(false)
+                .add(template)
                 .add(cols)
                 .add(rows);
+        return new SqlSelector(schema, sql).getObject(Long.class);
+    }
+
+    private Long plateWellGroupCount(DbSchema schema, TableInfo plateTable, TableInfo wellGroupTable, boolean template, WellGroup.Type wellGroupType)
+    {
+        SQLFragment sql = new SQLFragment("SELECT COUNT(DISTINCT wg.plateId) FROM ")
+                .append(wellGroupTable, "wg")
+                .append(" INNER JOIN ").append(plateTable, "p").append(" ON p.rowId = wg.plateId ")
+                .append(" WHERE p.archived = ? AND p.template = ? AND wg.typename = ?")
+                .add(false)
+                .add(template)
+                .add(wellGroupType);
         return new SqlSelector(schema, sql).getObject(Long.class);
     }
 
@@ -178,63 +193,87 @@ public class PlateMetricsProvider implements UsageMetricsProvider
     {
         var plateMetrics = new HashMap<String, Object>();
         var schema = AssayDbSchema.getInstance();
+        var dbSchema = schema.getSchema();
         TableInfo plateSetTable = schema.getTableInfoPlateSet();
         TableInfo plateTable = schema.getTableInfoPlate();
-        Long plateSetCount = plateSetCount(schema.getSchema(), plateSetTable, false);
-        Long archivedPlateSetCount = plateSetCount(schema.getSchema(), plateSetTable, true);
-        Long primaryPlateSetCount = new SqlSelector(schema.getSchema(), new SQLFragment("SELECT COUNT(*) FROM ").append(plateSetTable, "ps").append(" WHERE type = ?").add(PlateSetType.primary)).getObject(Long.class);
-        Long assayPlateSetCount = new SqlSelector(schema.getSchema(), new SQLFragment("SELECT COUNT(*) FROM ").append(plateSetTable, "ps").append(" WHERE type = ?").add(PlateSetType.assay)).getObject(Long.class);
-        Long standAlonePlateSetCount = new SqlSelector(schema.getSchema(), new SQLFragment("SELECT COUNT(*) FROM ").append(plateSetTable, "ps").append(" WHERE type = ?").add(PlateSetType.assay).append(" AND rootPlateSetId IS NULL")).getObject(Long.class);
-        Long plateSetNoPlatesCount = plateSetPlatesCount(schema.getSchema(), plateSetTable, plateTable, 0);
-        Long plateSetOnePlateCount = plateSetPlatesCount(schema.getSchema(), plateSetTable, plateTable, 1);
-        SQLFragment maxPlatesSql = new SQLFragment("SELECT MAX(plateCount) FROM (").append(plateSetPlatesSQL(plateSetTable, plateTable)).append(") x");
-        Long maxPlatesCount = new SqlSelector(schema.getSchema(), maxPlatesSql).getObject(Long.class);
-
-        Map<String, Long> plateSets = new HashMap<>();
-        plateSets.put("archivedPlateSetCount", archivedPlateSetCount);
-        plateSets.put("plateSetCount", plateSetCount);
-        plateSets.put("primaryPlateSetCount", primaryPlateSetCount);
-        plateSets.put("assayPlateSetCount", assayPlateSetCount);
-        plateSets.put("standAloneAssayPlateSetCount", standAlonePlateSetCount);
-        plateSets.put("plateSetsWithNoPlatesCount", plateSetNoPlatesCount);
-        plateSets.put("plateSetsWithOnePlateCount", plateSetOnePlateCount);
-        plateSets.put("maximumPlatesInPlateSet", maxPlatesCount);
-        plateSets.put("plateSetsWith1To10PlatesCount", plateSetPlatesCountBetween(schema.getSchema(), plateSetTable, plateTable, 0, 11));
-        plateSets.put("plateSetsWith11to30PlatesCount", plateSetPlatesCountBetween(schema.getSchema(), plateSetTable, plateTable, 10, 31));
-        plateSets.put("plateSetsWith31to60PlatesCount", plateSetPlatesCountBetween(schema.getSchema(), plateSetTable, plateTable, 30, 61));
-        plateMetrics.put("plateSets", plateSets);
-
-        Long platesCount = plateCount(schema.getSchema(), plateTable, false, false);
-        Long archivedPlatesCount = plateCount(schema.getSchema(), plateTable, false, true);
-        Long plateTemplateCount = plateCount(schema.getSchema(), plateTable, true, false);
-        Long archivedPlateTemplates = plateCount(schema.getSchema(), plateTable, true, true);
         TableInfo plateTypeTable = schema.getTableInfoPlateType();
-        TableInfo wellTable = schema.getTableInfoWell();
-        plateMetrics.put("plates", Map.of(
-            "platesCount", platesCount,
-            "archivedPlatesCount", archivedPlatesCount,
-            "plateTemplateCount", plateTemplateCount,
-            "archivedTemplatesCount", archivedPlateTemplates,
-            "distinctPlatedSamples", new SqlSelector(schema.getSchema(), new SQLFragment("SELECT COUNT(*) FROM (SELECT DISTINCT sampleId FROM ").append(wellTable, "w").append(" WHERE sampleId IS NOT NULL) as ds")).getObject(Long.class),
-            "12WellCount", plateTypeCount(schema.getSchema(), plateTable, plateTypeTable, 4, 3),
-            "24WellCount", plateTypeCount(schema.getSchema(), plateTable, plateTypeTable, 6, 4),
-            "48WellCount", plateTypeCount(schema.getSchema(), plateTable, plateTypeTable, 8, 6),
-            "96WellCount", plateTypeCount(schema.getSchema(), plateTable, plateTypeTable, 12, 8),
-            "384WellCount", plateTypeCount(schema.getSchema(), plateTable, plateTypeTable, 24, 16)
-        ));
+        TableInfo wellGroupTable = schema.getTableInfoWellGroup();
 
-        TableInfo hitTable = schema.getTableInfoHit();
-        TableInfo filterCriteriaTable = schema.getTableInfoFilterCriteria();
-        List<ExpProtocol> plateEnabledProtocols = getPlateEnabledAssayProtocols();
-        plateMetrics.put("assays", Map.of(
-            "hitCount", new SqlSelector(schema.getSchema(), new SQLFragment("SELECT COUNT(*) FROM ").append(hitTable, "h")).getObject(Long.class),
-            "plateSetsWithHits", new SqlSelector(schema.getSchema(), new SQLFragment("SELECT COUNT(DISTINCT plateSetPath) FROM ").append(hitTable, "h")).getObject(Long.class),
-            "assaysWithPlateMetadataEnabled", plateEnabledProtocols.size(),
-            "assayRunsCount", getPlateBasedAssayRunsCount(plateEnabledProtocols),
-            "assayResultsCount", getPlateBasedAssayResultsCount(plateEnabledProtocols),
-            "domainsWithFilterCriteriaConfigured", new SqlSelector(schema.getSchema(), new SQLFragment("SELECT COUNT(DISTINCT domainId) FROM ").append(filterCriteriaTable, "fc")).getObject(Long.class),
-            "columnsWithFilterCriteria", new SqlSelector(schema.getSchema(), new SQLFragment("SELECT COUNT(DISTINCT propertyId) FROM ").append(filterCriteriaTable, "fc")).getObject(Long.class)
-        ));
+        // plateSets
+        {
+            Map<String, Long> plateSets = new HashMap<>();
+            plateSets.put("archivedPlateSetCount", plateSetCount(dbSchema, plateSetTable, true));
+            plateSets.put("plateSetCount", plateSetCount(dbSchema, plateSetTable, false));
+            plateSets.put("primaryPlateSetCount", new SqlSelector(dbSchema, new SQLFragment("SELECT COUNT(*) FROM ").append(plateSetTable, "ps").append(" WHERE type = ?").add(PlateSetType.primary)).getObject(Long.class));
+            plateSets.put("assayPlateSetCount", new SqlSelector(dbSchema, new SQLFragment("SELECT COUNT(*) FROM ").append(plateSetTable, "ps").append(" WHERE type = ?").add(PlateSetType.assay)).getObject(Long.class));
+            plateSets.put("standAloneAssayPlateSetCount", new SqlSelector(dbSchema, new SQLFragment("SELECT COUNT(*) FROM ").append(plateSetTable, "ps").append(" WHERE type = ?").add(PlateSetType.assay).append(" AND rootPlateSetId IS NULL")).getObject(Long.class));
+            plateSets.put("plateSetsWithNoPlatesCount", plateSetPlatesCount(dbSchema, plateSetTable, plateTable, 0));
+            plateSets.put("plateSetsWithOnePlateCount", plateSetPlatesCount(dbSchema, plateSetTable, plateTable, 1));
+            plateSets.put("maximumPlatesInPlateSet", new SqlSelector(dbSchema, new SQLFragment("SELECT MAX(plateCount) FROM (").append(plateSetPlatesSQL(plateSetTable, plateTable)).append(") x")).getObject(Long.class));
+            plateSets.put("plateSetsWith1To10PlatesCount", plateSetPlatesCountBetween(dbSchema, plateSetTable, plateTable, 0, 11));
+            plateSets.put("plateSetsWith11to30PlatesCount", plateSetPlatesCountBetween(dbSchema, plateSetTable, plateTable, 10, 31));
+            plateSets.put("plateSetsWith31to60PlatesCount", plateSetPlatesCountBetween(dbSchema, plateSetTable, plateTable, 30, 61));
+            plateMetrics.put("plateSets", plateSets);
+        }
+
+        // plates
+        {
+            TableInfo wellTable = schema.getTableInfoWell();
+            Map<String, Long> plates = new HashMap<>();
+            plates.put("platesCount", plateCount(dbSchema, plateTable, false, false));
+            plates.put("archivedPlatesCount", plateCount(dbSchema, plateTable, false, true));
+            plates.put("distinctPlatedSamples", new SqlSelector(dbSchema, new SQLFragment("SELECT COUNT(*) FROM (SELECT DISTINCT sampleId FROM ").append(wellTable, "w").append(" WHERE sampleId IS NOT NULL) as ds")).getObject(Long.class));
+            plates.put("12WellCount", plateTypeCount(dbSchema, plateTable, plateTypeTable, 4, 3, false));
+            plates.put("24WellCount", plateTypeCount(dbSchema, plateTable, plateTypeTable, 6, 4, false));
+            plates.put("48WellCount", plateTypeCount(dbSchema, plateTable, plateTypeTable, 8, 6, false));
+            plates.put("96WellCount", plateTypeCount(dbSchema, plateTable, plateTypeTable, 12, 8, false));
+            plates.put("384WellCount", plateTypeCount(dbSchema, plateTable, plateTypeTable, 24, 16, false));
+            plates.put("platesWithNegativeControlGroups", plateWellGroupCount(dbSchema, plateTable, wellGroupTable, false, WellGroup.Type.NEGATIVE_CONTROL));
+            plates.put("platesWithPositiveControlGroups", plateWellGroupCount(dbSchema, plateTable, wellGroupTable, false, WellGroup.Type.POSITIVE_CONTROL));
+            plates.put("platesWithReplicateGroups", plateWellGroupCount(dbSchema, plateTable, wellGroupTable, false, WellGroup.Type.REPLICATE));
+            plateMetrics.put("plates", plates);
+        }
+
+        // templates
+        {
+            Map<String, Long> templates = new HashMap<>();
+            templates.put("plateTemplateCount", plateCount(dbSchema, plateTable, true, false));
+            templates.put("archivedTemplatesCount", plateCount(dbSchema, plateTable, true, true));
+            templates.put("12WellCount", plateTypeCount(dbSchema, plateTable, plateTypeTable, 4, 3, true));
+            templates.put("24WellCount", plateTypeCount(dbSchema, plateTable, plateTypeTable, 6, 4, true));
+            templates.put("48WellCount", plateTypeCount(dbSchema, plateTable, plateTypeTable, 8, 6, true));
+            templates.put("96WellCount", plateTypeCount(dbSchema, plateTable, plateTypeTable, 12, 8, true));
+            templates.put("384WellCount", plateTypeCount(dbSchema, plateTable, plateTypeTable, 24, 16, true));
+            templates.put("templatesWithNegativeControlGroups", plateWellGroupCount(dbSchema, plateTable, wellGroupTable, true, WellGroup.Type.NEGATIVE_CONTROL));
+            templates.put("templatesWithPositiveControlGroups", plateWellGroupCount(dbSchema, plateTable, wellGroupTable, true, WellGroup.Type.POSITIVE_CONTROL));
+            templates.put("templatesWithReplicateGroups", plateWellGroupCount(dbSchema, plateTable, wellGroupTable, true, WellGroup.Type.REPLICATE));
+            plateMetrics.put("templates", templates);
+        }
+
+        // assays
+        {
+            TableInfo hitTable = schema.getTableInfoHit();
+            TableInfo filterCriteriaTable = schema.getTableInfoFilterCriteria();
+            List<ExpProtocol> plateEnabledProtocols = getPlateEnabledAssayProtocols();
+            plateMetrics.put("assays", Map.of(
+                "hitCount", new SqlSelector(dbSchema, new SQLFragment("SELECT COUNT(*) FROM ").append(hitTable, "h")).getObject(Long.class),
+                "plateSetsWithHits", new SqlSelector(dbSchema, new SQLFragment("SELECT COUNT(DISTINCT plateSetPath) FROM ").append(hitTable, "h")).getObject(Long.class),
+                "assaysWithPlateMetadataEnabled", plateEnabledProtocols.size(),
+                "assayRunsCount", getPlateBasedAssayRunsCount(plateEnabledProtocols),
+                "assayResultsCount", getPlateBasedAssayResultsCount(plateEnabledProtocols),
+                "domainsWithFilterCriteriaConfigured", new SqlSelector(dbSchema, new SQLFragment("SELECT COUNT(DISTINCT domainId) FROM ").append(filterCriteriaTable, "fc")).getObject(Long.class),
+                "columnsWithFilterCriteria", new SqlSelector(dbSchema, new SQLFragment("SELECT COUNT(DISTINCT propertyId) FROM ").append(filterCriteriaTable, "fc")).getObject(Long.class)
+            ));
+        }
+
+        // wells
+        {
+            TableInfo wellTable = schema.getTableInfoWell();
+            Map<String, Long> wells = new HashMap<>();
+            wells.put("wellCount", new SqlSelector(dbSchema, new SQLFragment("SELECT COUNT(*) FROM ").append(wellTable, "w")).getObject(Long.class));
+            wells.put("wellsWithSamples", new SqlSelector(dbSchema, new SQLFragment("SELECT COUNT(*) FROM ").append(wellTable, "w").append(" WHERE sampleId IS NOT NULL")).getObject(Long.class));
+            plateMetrics.put("wells", wells);
+        }
 
         plateMetrics.put("metadata", Map.of(
             "fieldsCount", getMetadataFieldsCount()

--- a/assay/src/org/labkey/assay/plate/data/WellData.java
+++ b/assay/src/org/labkey/assay/plate/data/WellData.java
@@ -1,9 +1,11 @@
 package org.labkey.assay.plate.data;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
+import org.labkey.api.util.Pair;
 import org.labkey.assay.plate.PlateManager;
 import org.labkey.assay.plate.query.WellTable;
 
@@ -66,12 +68,17 @@ public class WellData
 
     public boolean isReplicate()
     {
-        return WellGroup.Type.REPLICATE.equals(getType());
+        return _replicateGroup != null;
     }
 
     public boolean isSample()
     {
         return WellGroup.Type.SAMPLE.equals(getType());
+    }
+
+    public boolean isSampleOrReplicate()
+    {
+        return isSample() || isReplicate();
     }
 
     public Integer getCol()
@@ -82,6 +89,19 @@ public class WellData
     public void setCol(Integer col)
     {
         _col = col;
+    }
+
+    public @Nullable Pair<WellGroup.Type, String> getGroupKey()
+    {
+        if (isSample() || isReplicate())
+        {
+            if (isReplicate())
+                return Pair.of(WellGroup.Type.REPLICATE, _replicateGroup);
+            else if (_wellGroup != null)
+                return Pair.of(WellGroup.Type.SAMPLE, _wellGroup);
+        }
+
+        return null;
     }
 
     public String getLsid()

--- a/assay/src/org/labkey/assay/plate/data/WellData.java
+++ b/assay/src/org/labkey/assay/plate/data/WellData.java
@@ -50,6 +50,8 @@ public class WellData
             data.put(WellTable.Column.Type.name(), _type.name());
         if (_wellGroup != null)
             data.put(WellTable.Column.WellGroup.name(), _wellGroup);
+        if (_replicateGroup != null)
+            data.put(WellTable.Column.ReplicateGroup.name(), _replicateGroup);
 
         for (var entry : getMetadata().entrySet())
         {
@@ -95,10 +97,11 @@ public class WellData
     {
         if (isSample() || isReplicate())
         {
+            if (_wellGroup != null)
+                return Pair.of(WellGroup.Type.SAMPLE, _wellGroup);
+
             if (isReplicate())
                 return Pair.of(WellGroup.Type.REPLICATE, _replicateGroup);
-            else if (_wellGroup != null)
-                return Pair.of(WellGroup.Type.SAMPLE, _wellGroup);
         }
 
         return null;

--- a/assay/src/org/labkey/assay/plate/data/WellData.java
+++ b/assay/src/org/labkey/assay/plate/data/WellData.java
@@ -18,6 +18,7 @@ public class WellData
     private String _lsid;
     private Map<String, Object> _metadata;
     private String _position;
+    private String _replicateGroup;
     private Integer _row;
     private Integer _rowId;
     private Integer _sampleId;
@@ -111,6 +112,16 @@ public class WellData
     public void setPosition(String position)
     {
         _position = position;
+    }
+
+    public String getReplicateGroup()
+    {
+        return _replicateGroup;
+    }
+
+    public void setReplicateGroup(String replicateGroup)
+    {
+        _replicateGroup = replicateGroup;
     }
 
     public Integer getRow()

--- a/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
@@ -188,8 +188,11 @@ public final class WellTriggerFactory implements TriggerFactory
     {
         private final Map<Integer, Map<Integer, PlateManager.WellGroupChange>> wellGroupChanges = new HashMap<>();
         private final Set<Integer> modifiedPlates = new HashSet<>();
+        private final Map<Integer, Map<Integer, String>> wellReplicateGroupMap = new HashMap<>();
 
         private void checkForChanges(
+            Container container,
+            User user,
             @Nullable Map<String, Object> newRow,
             @Nullable Map<String, Object> oldRow,
             ValidationException errors,
@@ -236,7 +239,7 @@ public final class WellTriggerFactory implements TriggerFactory
 
             // If the sample, type, or any data on a replicate well has been updated,
             // then mark the plate as modified and subsequently validate the well groups.
-            if (!hasSampleChange && !hasTypeGroupReplicateChange)
+            if (!hasSampleChange && !hasTypeGroupReplicateChange && !hasReplicateChange(container, user, plateRowId, wellRowId))
                 return;
 
             modifiedPlates.add(plateRowId);
@@ -266,6 +269,13 @@ public final class WellTriggerFactory implements TriggerFactory
             }
 
             return value;
+        }
+
+        private boolean hasReplicateChange(Container container, User user, @NotNull Integer plateRowId, @NotNull Integer wellRowId)
+        {
+            var wellMap = wellReplicateGroupMap.computeIfAbsent(plateRowId, (pid) -> getWellReplicateGroups(container, user, pid));
+
+            return wellMap.get(wellRowId) != null;
         }
 
         private boolean hasSampleChange(@Nullable Map<String, Object> row)
@@ -319,7 +329,7 @@ public final class WellTriggerFactory implements TriggerFactory
             if (errors.hasErrors())
                 return;
 
-            checkForChanges(newRow, null, errors, extraContext);
+            checkForChanges(c, user, newRow, null, errors, extraContext);
         }
 
         @Override
@@ -336,7 +346,7 @@ public final class WellTriggerFactory implements TriggerFactory
             if (errors.hasErrors())
                 return;
 
-            checkForChanges(newRow, oldRow, errors, extraContext);
+            checkForChanges(c, user, newRow, oldRow, errors, extraContext);
         }
     }
 
@@ -349,6 +359,18 @@ public final class WellTriggerFactory implements TriggerFactory
         QueryService.get().getSelectBuilder(schema, sql.toDebugString())
                 .buildSqlSelector(null)
                 .forEach(r -> map.put(r.getInt(WellTable.Column.RowId.name()), r.getString(WellTable.Column.Type.name())));
+
+        return map;
+    }
+
+    private Map<Integer, String> getWellReplicateGroups(Container container, User user, int plateRowId)
+    {
+        var map = new HashMap<Integer, String>();
+        UserSchema schema = QueryService.get().getUserSchema(user, container, "plate");
+        SQLFragment sql = new SQLFragment("SELECT RowId, ReplicateGroup FROM plate.Well WHERE PlateId = ?").add(plateRowId);
+        QueryService.get().getSelectBuilder(schema, sql.toDebugString())
+                .buildSqlSelector(null)
+                .forEach(r -> map.put(r.getInt(WellTable.Column.RowId.name()), r.getString(WellTable.Column.ReplicateGroup.name())));
 
         return map;
     }

--- a/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/data/WellTriggerFactory.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class WellTriggerFactory implements TriggerFactory
+public final class WellTriggerFactory implements TriggerFactory
 {
     @Override
     public @NotNull Collection<Trigger> createTrigger(@Nullable Container c, TableInfo table, Map<String, Object> extraContext)
@@ -40,7 +40,7 @@ public class WellTriggerFactory implements TriggerFactory
     }
 
     // When no "Type" is given but "SampleId" is populated, provide 'Sample' as the type
-    protected class EnsureSampleWellTypeTrigger implements Trigger
+    private class EnsureSampleWellTypeTrigger implements Trigger
     {
         private final Map<Integer, String> wellTypeMap = new LRUMap<>(PlateSet.MAX_PLATE_SET_WELLS);
 
@@ -121,7 +121,8 @@ public class WellTriggerFactory implements TriggerFactory
         }
     }
 
-    protected class ValidatePrimaryPlateSetUniqueSamplesTrigger implements Trigger
+    @SuppressWarnings("InnerClassMayBeStatic")
+    private class ValidatePrimaryPlateSetUniqueSamplesTrigger implements Trigger
     {
         private final HashSet<Integer> mutatedWellRowIds = new HashSet<>();
 
@@ -182,15 +183,13 @@ public class WellTriggerFactory implements TriggerFactory
         }
     }
 
-    protected class ComputeWellGroupsTrigger implements Trigger
+    @SuppressWarnings("InnerClassMayBeStatic")
+    private class ComputeWellGroupsTrigger implements Trigger
     {
         private final Map<Integer, Map<Integer, PlateManager.WellGroupChange>> wellGroupChanges = new HashMap<>();
         private final Set<Integer> modifiedPlates = new HashSet<>();
-        private final Map<Integer, Map<Integer, String>> wellTypeMap = new HashMap<>();
 
         private void checkForChanges(
-            Container container,
-            User user,
             @Nullable Map<String, Object> newRow,
             @Nullable Map<String, Object> oldRow,
             ValidationException errors,
@@ -202,12 +201,18 @@ public class WellTriggerFactory implements TriggerFactory
                 return;
 
             var hasSampleChange = hasSampleChange(newRow);
-            var hasTypeGroupChange = hasTypeGroupChange(newRow);
+            var hasTypeGroupReplicateChange = hasTypeGroupReplicateChange(newRow);
 
             // If this is an insertion (newRow != null && oldRow == null),
-            // then verify further to ignore when type and group are present but are set to null.
-            if (hasTypeGroupChange && oldRow == null)
-                hasTypeGroupChange = newRow.get(WellTable.Column.Type.name()) != null || newRow.get(WellTable.Column.WellGroup.name()) != null;
+            // then verify further to ignore when type, group, and replicateGroup are present but are set to null.
+            if (hasTypeGroupReplicateChange && oldRow == null)
+            {
+                hasTypeGroupReplicateChange = (
+                    newRow.get(WellTable.Column.Type.name()) != null ||
+                    newRow.get(WellTable.Column.WellGroup.name()) != null ||
+                    newRow.get(WellTable.Column.ReplicateGroup.name()) != null
+                );
+            }
 
             var wellRowId = (Integer) newRow.get(WellTable.Column.RowId.name());
             if (wellRowId == null)
@@ -231,42 +236,36 @@ public class WellTriggerFactory implements TriggerFactory
 
             // If the sample, type, or any data on a replicate well has been updated,
             // then mark the plate as modified and subsequently validate the well groups.
-            if (!hasSampleChange && !hasTypeGroupChange && !hasReplicateChange(container, user, plateRowId, wellRowId))
+            if (!hasSampleChange && !hasTypeGroupReplicateChange)
                 return;
 
             modifiedPlates.add(plateRowId);
 
-            if (hasTypeGroupChange)
+            if (hasTypeGroupReplicateChange)
             {
-                String type = null;
-                String group = null;
-
                 // If the row does contain the key, then it is treated as an explicit change.
                 // In this case we set the value to the empty string.
-                if (newRow.containsKey(WellTable.Column.Type.name()))
-                {
-                    type = (String) newRow.get(WellTable.Column.Type.name());
-                    if (StringUtils.trimToNull(type) == null)
-                        type = "";
-                }
-                if (newRow.containsKey(WellTable.Column.WellGroup.name()))
-                {
-                    group = (String) newRow.get(WellTable.Column.WellGroup.name());
-                    if (StringUtils.trimToNull(group) == null)
-                        group = "";
-                }
-
-                var change = new PlateManager.WellGroupChange(plateRowId, wellRowId, type, group);
+                var type = getStringValue(WellTable.Column.Type, newRow);
+                var group = getStringValue(WellTable.Column.WellGroup, newRow);
+                var replicateGroup = getStringValue(WellTable.Column.ReplicateGroup, newRow);
+                var change = new PlateManager.WellGroupChange(plateRowId, wellRowId, type, group, replicateGroup);
 
                 wellGroupChanges.computeIfAbsent(plateRowId, HashMap::new).put(wellRowId, change);
             }
         }
 
-        private boolean hasReplicateChange(Container container, User user, @NotNull Integer plateRowId, @NotNull Integer wellRowId)
+        private @Nullable String getStringValue(WellTable.Column column, @NotNull Map<String, Object> row)
         {
-            var wellMap = wellTypeMap.computeIfAbsent(plateRowId, (pid) -> getWellTypes(container, user, pid));
+            String value = null;
 
-            return WellGroup.Type.REPLICATE.name().equals(wellMap.get(wellRowId));
+            if (row.containsKey(column.name()))
+            {
+                value = (String) row.get(column.name());
+                if (StringUtils.trimToNull(value) == null)
+                    value = "";
+            }
+
+            return value;
         }
 
         private boolean hasSampleChange(@Nullable Map<String, Object> row)
@@ -274,9 +273,13 @@ public class WellTriggerFactory implements TriggerFactory
             return row != null && row.containsKey(WellTable.Column.SampleID.name());
         }
 
-        private boolean hasTypeGroupChange(@Nullable Map<String, Object> row)
+        private boolean hasTypeGroupReplicateChange(@Nullable Map<String, Object> row)
         {
-            return row != null && (row.containsKey(WellTable.Column.Type.name()) || row.containsKey(WellTable.Column.WellGroup.name()));
+            return row != null && (
+                row.containsKey(WellTable.Column.Type.name()) ||
+                row.containsKey(WellTable.Column.WellGroup.name()) ||
+                row.containsKey(WellTable.Column.ReplicateGroup.name())
+            );
         }
 
         @Override
@@ -316,7 +319,7 @@ public class WellTriggerFactory implements TriggerFactory
             if (errors.hasErrors())
                 return;
 
-            checkForChanges(c, user, newRow, null, errors, extraContext);
+            checkForChanges(newRow, null, errors, extraContext);
         }
 
         @Override
@@ -333,7 +336,7 @@ public class WellTriggerFactory implements TriggerFactory
             if (errors.hasErrors())
                 return;
 
-            checkForChanges(c, user, newRow, oldRow, errors, extraContext);
+            checkForChanges(newRow, oldRow, errors, extraContext);
         }
     }
 

--- a/assay/src/org/labkey/assay/plate/layout/ArrayOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/ArrayOperation.java
@@ -364,14 +364,10 @@ public class ArrayOperation implements LayoutOperation
             if (sampleId == null)
                 continue;
 
-            boolean isSampleWell = wellData.isSample();
-            boolean isReplicateWell = wellData.isReplicate();
-            boolean isSampleOrReplicate = isSampleWell || isReplicateWell;
-
-            if (isSampleOrReplicate && wellData.getWellGroup() != null)
+            Pair<WellGroup.Type, String> groupKey = wellData.getGroupKey();
+            if (groupKey != null)
             {
-                WellGroup.Type type = isSampleWell ? WellGroup.Type.SAMPLE : WellGroup.Type.REPLICATE;
-                groupSampleMap.put(Pair.of(type, wellData.getWellGroup()), sampleId);
+                groupSampleMap.put(groupKey, sampleId);
                 sampleWells.putIfAbsent(sampleId, new WellLayout.Well(-1, -1, plate.getRowId(), wellData.getRow(), wellData.getCol(), sampleId));
             }
         }
@@ -412,7 +408,7 @@ public class ArrayOperation implements LayoutOperation
             for (WellData wellData : context.wellDataCache().getData(sourceRowId, true, false))
             {
                 Integer wellSampleId = wellData.getSampleId();
-                if (wellSampleId != null && !sampleWells.containsKey(wellSampleId) && (wellData.isSample() || wellData.isReplicate()))
+                if (wellSampleId != null && !sampleWells.containsKey(wellSampleId) && wellData.isSampleOrReplicate())
                 {
                     sampleWells.put(wellSampleId, new WellLayout.Well(-1, -1, sourceRowId, wellData.getRow(), wellData.getCol(), null));
                 }

--- a/assay/src/org/labkey/assay/plate/layout/ArrayOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/ArrayOperation.java
@@ -308,16 +308,8 @@ public class ArrayOperation implements LayoutOperation
     {
         for (WellData wellData : context.wellDataCache().getData(target.getTargetTemplateId(), false, false))
         {
-            boolean isSampleWell = wellData.isSample();
-            boolean isReplicateWell = wellData.isReplicate();
-            boolean isSampleOrReplicate = isSampleWell || isReplicateWell;
-
-            Pair<WellGroup.Type, String> groupKey = null;
-            if (isSampleOrReplicate && wellData.getWellGroup() != null)
-            {
-                WellGroup.Type type = isSampleWell ? WellGroup.Type.SAMPLE : WellGroup.Type.REPLICATE;
-                groupKey = Pair.of(type, wellData.getWellGroup());
-            }
+            boolean isSampleOrReplicate = wellData.isSampleOrReplicate();
+            Pair<WellGroup.Type, String> groupKey = wellData.getGroupKey();
 
             if (sampleIndex >= sampleIds.size())
             {

--- a/assay/src/org/labkey/assay/plate/layout/ArrayOperation.java
+++ b/assay/src/org/labkey/assay/plate/layout/ArrayOperation.java
@@ -244,16 +244,8 @@ public class ArrayOperation implements LayoutOperation
                 Integer wellSampleId = wellData.getSampleId();
                 if (wellSampleId == null)
                 {
-                    boolean isSampleWell = wellData.isSample();
-                    boolean isReplicateWell = wellData.isReplicate();
-                    boolean isSampleOrReplicate = isSampleWell || isReplicateWell;
-
-                    Pair<WellGroup.Type, String> groupKey = null;
-                    if (isSampleOrReplicate && wellData.getWellGroup() != null)
-                    {
-                        WellGroup.Type type = isSampleWell ? WellGroup.Type.SAMPLE : WellGroup.Type.REPLICATE;
-                        groupKey = Pair.of(type, wellData.getWellGroup());
-                    }
+                    boolean isSampleOrReplicate = wellData.isSampleOrReplicate();
+                    Pair<WellGroup.Type, String> groupKey = wellData.getGroupKey();
 
                     if (sampleIndex >= sampleIds.size())
                     {

--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -157,6 +157,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
         column.setLabel("Sample Group");
         column.setUserEditable(true);
         column.setShownInInsertView(true);
+        column.setShownInUpdateView(true);
         column.setDescription("Identifies the sample group to which the well belongs.");
         addColumn(column);
     }
@@ -167,6 +168,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
         column.setLabel("Replicate Group");
         column.setUserEditable(true);
         column.setShownInInsertView(true);
+        column.setShownInUpdateView(true);
         column.setDescription("Identifies the replicate group to which the well belongs.");
         addColumn(column);
     }
@@ -213,6 +215,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
         column.setFk(new QueryForeignKey(getUserSchema().getTable(WellGroupTypeTable.NAME), null, null));
         column.setUserEditable(true);
         column.setShownInInsertView(true);
+        column.setShownInUpdateView(true);
         column.setDescription("Specifies the type of well.");
         addColumn(column);
     }

--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -7,6 +7,7 @@ import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PositionImpl;
 import org.labkey.api.assay.plate.Well;
+import org.labkey.api.assay.plate.WellGroup;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
@@ -78,6 +79,7 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
         Lsid,
         PlateId,
         Position,
+        ReplicateGroup,
         Row,
         RowId,
         SampleID,
@@ -121,13 +123,14 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
     public void addColumns()
     {
         super.addColumns();
-        addWellGroupColumn();
+        addSampleGroupColumn();
         addPositionColumn();
         addWellMetadataColumns();
         addTypeColumn();
+        addReplicateGroupColumn();
     }
 
-    private void addWellGroupColumn()
+    private SQLFragment wellGroupSql(boolean forReplicateGroup)
     {
         SQLFragment groupSql = new SQLFragment("SELECT WG.Name FROM ")
                 .append(AssayDbSchema.getInstance().getTableInfoWellGroupPositions(), "WGP")
@@ -137,18 +140,34 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
                 .append(" INNER JOIN ")
                 .append(AssayDbSchema.getInstance().getTableInfoPlate(), "P")
                 .append(" ON P.RowId = WG.PlateId ")
-                .append(" WHERE P.AssayType = ? AND WGP.WellId = " + STR_TABLE_ALIAS + ".RowId")
-                .add(TsvPlateLayoutHandler.TYPE);
+                .append(" WHERE P.AssayType = ?")
+                .add(TsvPlateLayoutHandler.TYPE)
+                .append(" AND WGP.WellId = " + STR_TABLE_ALIAS + ".RowId")
+                .append(" AND WG.TypeName ").append(forReplicateGroup ? "=" : "!=").append(" ?")
+                .add(WellGroup.Type.REPLICATE.name());
 
         // The underlying schema allows for multiple well groups per well, however, as a "well group" column
         // we do not support having multiple values. Here we limit the query to return a single result.
-        groupSql = new SQLFragment("(").append(getSqlDialect().limitRows(groupSql, 1)).append(")");
+        return new SQLFragment("(").append(getSqlDialect().limitRows(groupSql, 1)).append(")");
+    }
 
-        var column = new ExprColumn(this, Column.WellGroup.fieldKey(), groupSql, JdbcType.VARCHAR);
-        column.setLabel("Group");
+    private void addSampleGroupColumn()
+    {
+        var column = new ExprColumn(this, Column.WellGroup.fieldKey(), wellGroupSql(false), JdbcType.VARCHAR);
+        column.setLabel("Sample Group");
         column.setUserEditable(true);
         column.setShownInInsertView(true);
-        column.setDescription("Identifies the group to which the well belongs.");
+        column.setDescription("Identifies the sample group to which the well belongs.");
+        addColumn(column);
+    }
+
+    private void addReplicateGroupColumn()
+    {
+        var column = new ExprColumn(this, Column.ReplicateGroup.fieldKey(), wellGroupSql(true), JdbcType.VARCHAR);
+        column.setLabel("Replicate Group");
+        column.setUserEditable(true);
+        column.setShownInInsertView(true);
+        column.setDescription("Identifies the replicate group to which the well belongs.");
         addColumn(column);
     }
 
@@ -182,8 +201,9 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
                 .append(" INNER JOIN ")
                 .append(AssayDbSchema.getInstance().getTableInfoPlate(), "P")
                 .append(" ON P.RowId = WG.PlateId ")
-                .append(" WHERE P.AssayType = ? AND WGP.WellId = " + STR_TABLE_ALIAS + ".RowId")
-                .add(TsvPlateLayoutHandler.TYPE);
+                .append(" WHERE P.AssayType = ? AND WG.TypeName != ? AND WGP.WellId = " + STR_TABLE_ALIAS + ".RowId")
+                .add(TsvPlateLayoutHandler.TYPE)
+                .add(WellGroup.Type.REPLICATE);
 
         // The underlying schema allows for multiple well groups per well, however, as a "well type" column
         // we do not support having multiple values. Here we limit the query to return a single result.


### PR DESCRIPTION
#### Rationale
This changes how replicates are modeled in assay plates for application users so that we can support more advanced plating scenarios.

1. Plate wells now allow for specification of a "Replicate Group". This is another dimension/layer for wells in addititon to "Sample Group"
2. Instead of specifying the type of a well as "Replicate" the well is marked as a "Sample" and a replicate group is specified. Specifying a well as type "Replicate" is no longer allowed.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/654
- https://github.com/LabKey/limsModules/pull/1096
- https://github.com/LabKey/platform/pull/6251

#### Changes
- Introduce new "Replicate Group" expression column on plate.Well table.
- Re-label "Group" as "Sample Group".
- Plate wells can no longer be marked as type "Replicate", instead they must specify a "Replicate Group".
- Schema upgrade to overlap REPLICATE well groups with SAMPLE "zone" well groups. This ensures wells formerly marked as "Replicate" are now marked as "Sample".
- Update well triggers and validation to align to new expectations of a "Replicate Group" value instead of a "Replicate" type column.
- Ensure worklists, instrument instructions, and plate data exports have consistent handling of built-in columns.
- Update `PlateManagerTest` coverage for existing replicate functionality.
