### PR TITLE
Issue 52036: Don't translate slashes in field name as lookup separators

### DIFF
--- a/api/src/org/labkey/api/data/ColumnHeaderType.java
+++ b/api/src/org/labkey/api/data/ColumnHeaderType.java
@@ -68,7 +68,11 @@ public enum ColumnHeaderType
             if (columnInfo != null)
             {
                 name = columnInfo.getName();
-                org.labkey.api.query.FieldKey fieldKey = org.labkey.api.query.FieldKey.fromString(name);
+                org.labkey.api.query.FieldKey fieldKey;
+                if (columnInfo.isLookup())
+                    fieldKey = org.labkey.api.query.FieldKey.fromString(name);
+                else
+                    fieldKey = org.labkey.api.query.FieldKey.fromParts(name);
 
                 fieldKey = fixMissingValueIndicator(columnInfo, fieldKey);
                 name = fieldKey.toDisplayString();
@@ -90,9 +94,15 @@ public enum ColumnHeaderType
             String name;
             if (columnInfo != null)
             {
+                name = columnInfo.getName();
                 org.labkey.api.query.FieldKey fieldKey = columnInfo.getFieldKey();
                 if (fieldKey == null)
-                    fieldKey = org.labkey.api.query.FieldKey.fromString(columnInfo.getName());
+                {
+                    if (columnInfo.isLookup())
+                        fieldKey = org.labkey.api.query.FieldKey.fromString(name);
+                    else
+                        fieldKey = org.labkey.api.query.FieldKey.fromParts(name);
+                }
 
                 fieldKey = fixMissingValueIndicator(columnInfo, fieldKey);
                 name = fieldKey.toString();

--- a/api/src/org/labkey/api/data/ColumnHeaderType.java
+++ b/api/src/org/labkey/api/data/ColumnHeaderType.java
@@ -69,8 +69,10 @@ public enum ColumnHeaderType
             {
                 name = columnInfo.getName();
                 org.labkey.api.query.FieldKey fieldKey;
-                if (columnInfo.isLookup())
+                if (columnInfo.isLookup()) // Issue 52036: FIXME if it is a lookup and the field it looks up to has a slash, what do we do?
+                {
                     fieldKey = org.labkey.api.query.FieldKey.fromString(name);
+                }
                 else
                     fieldKey = org.labkey.api.query.FieldKey.fromParts(name);
 


### PR DESCRIPTION
#### Rationale
Issue [52036](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52036): This is a partial fix for this issue. When a field name contains a slash, don't interpret that slash as a lookup separator for the `DisplayFieldKey` column header type. The fix here will work except for cases where the field is a lookup and the name also includes a slash. I need to understand when the name of the field might actually include the lookup path in order to work out a fix for that case. For now a partial fix seems better than none (if for no other reason than we have tests that are failing).

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1093

#### Changes
- Update `ColumnHeaderType.DisplayFieldKey.getText` to simply use name if the column is not a lookup
