### PR TITLE
Issue 52119: assay batch and run properties need to use column name instead of fieldKey for importRun.api

### DIFF
--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -612,21 +612,30 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
                 {
                     if (name.startsWith("properties["))
                     {
-                        String key = name.substring("properties[".length(), name.length() - 1);
-                        if (key.startsWith("'") && key.endsWith("'"))
-                            key = key.substring(1, key.length()-1);
+                        String key = parsePropertiesKey(name.substring("properties[".length(), name.length() - 1));
                         getProperties().put(key, pv.getValue());
                     }
                     else if (name.startsWith("batchProperties["))
                     {
-                        String key = name.substring("batchProperties[".length(), name.length()-1);
-                        if (key.startsWith("'") && key.endsWith("'"))
-                            key = key.substring(1, key.length()-1);
+                        String key = parsePropertiesKey(name.substring("batchProperties[".length(), name.length()-1));
                         getBatchProperties().put(key, pv.getValue());
                     }
                 }
             }
             return springBindParameters(this, "form", m);
+        }
+
+        private String parsePropertiesKey(String key)
+        {
+            if (key == null || key.isEmpty())
+                return key;
+
+            // Issue 52119: account for leading/trailing single quotes and decode double quotes
+            if (key.startsWith("'") && key.endsWith("'"))
+                key = key.substring(1, key.length()-1);
+            key = key.replaceAll("%22", "\"");
+
+            return key;
         }
     }
 }

--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -611,9 +611,19 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
                 if (name.endsWith("]"))
                 {
                     if (name.startsWith("properties["))
-                        getProperties().put(name.substring("properties[".length(), name.length()-1), pv.getValue());
+                    {
+                        String key = name.substring("properties[".length(), name.length() - 1);
+                        if (key.startsWith("'") && key.endsWith("'"))
+                            key = key.substring(1, key.length()-1);
+                        getProperties().put(key, pv.getValue());
+                    }
                     else if (name.startsWith("batchProperties["))
-                        getBatchProperties().put(name.substring("batchProperties[".length(), name.length()-1), pv.getValue());
+                    {
+                        String key = name.substring("batchProperties[".length(), name.length()-1);
+                        if (key.startsWith("'") && key.endsWith("'"))
+                            key = key.substring(1, key.length()-1);
+                        getBatchProperties().put(key, pv.getValue());
+                    }
                 }
             }
             return springBindParameters(this, "form", m);

--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -613,11 +613,13 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
                     if (name.startsWith("properties["))
                     {
                         String key = parsePropertiesKey(name.substring("properties[".length(), name.length() - 1));
-                        getProperties().put(key, pv.getValue());
+                        if (key != null)
+                            getProperties().put(key, pv.getValue());
                     }
                     else if (name.startsWith("batchProperties["))
                     {
                         String key = parsePropertiesKey(name.substring("batchProperties[".length(), name.length()-1));
+                        if (key != null)
                         getBatchProperties().put(key, pv.getValue());
                     }
                 }
@@ -628,7 +630,7 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
         private String parsePropertiesKey(String key)
         {
             if (key == null || key.isEmpty())
-                return key;
+                return null;
 
             // Issue 52119: account for leading/trailing single quotes and decode double quotes
             if (key.startsWith("'") && key.endsWith("'"))

--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -620,7 +620,7 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
                     {
                         String key = parsePropertiesKey(name.substring("batchProperties[".length(), name.length()-1));
                         if (key != null)
-                        getBatchProperties().put(key, pv.getValue());
+                            getBatchProperties().put(key, pv.getValue());
                     }
                 }
             }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52119

Server-side code expects column names to be sent when calling assay importRuns.api for the batchProperties and properties (i.e. run properties). We were passing column encoded fieldKeys instead of the names. This PR updates ImportRunApiAction bindParameters() to account for the single quotes around the properties key and to account for the url encoding of double quotes.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/658

#### Changes
- ImportRunApiAction bindParameters() to account for the single quotes around the properties key and to account for the url encoding of double quotes
