### PR TITLE
Issue 52037: Update TSVWriter to make escaping of backslashes optional

### DIFF
--- a/api/src/org/labkey/api/data/TSVWriter.java
+++ b/api/src/org/labkey/api/data/TSVWriter.java
@@ -44,7 +44,7 @@ public abstract class TSVWriter extends TextWriter
     protected List<String> _fileHeader = null;
     protected boolean _headerRowVisible = true;
     protected boolean _preserveEmptyString = false;
-    private String _additionalEscapeChars = null;
+    private String _additionalQuotedChars = null;
 
     public enum DELIM
     {
@@ -144,9 +144,9 @@ public abstract class TSVWriter extends TextWriter
         _preserveEmptyString = preserveEmptyString;
     }
 
-    public void setAdditionalEscapeChars(String additionalEscapeChars)
+    public void setAdditionalQuotedChars(String additionalQuotedChars)
     {
-        _additionalEscapeChars = additionalEscapeChars;
+        _additionalQuotedChars = additionalQuotedChars;
     }
 
     protected String _escapedCharsString = null;
@@ -218,7 +218,7 @@ public abstract class TSVWriter extends TextWriter
         char lastCh = value.charAt(len-1);
         if (Character.isSpaceChar(firstCh) || Character.isSpaceChar(lastCh))
             return true;
-        if (StringUtils.containsAny(value, _additionalEscapeChars))
+        if (StringUtils.containsAny(value, _additionalQuotedChars))
             return true;
         return StringUtils.containsAny(value,_escapedCharsString);
     }

--- a/api/src/org/labkey/api/data/TSVWriter.java
+++ b/api/src/org/labkey/api/data/TSVWriter.java
@@ -39,11 +39,12 @@ public abstract class TSVWriter extends TextWriter
     protected char _chDelimiter = '\t';
     protected char _chQuote = '"';
     protected String _rowSeparator = "\n";
-    protected char _escapeChar = '\\';
+    public static final String BACKSLASH_CHAR_STRING = "\\";
 
     protected List<String> _fileHeader = null;
     protected boolean _headerRowVisible = true;
     protected boolean _preserveEmptyString = false;
+    private String _additionalEscapeChars = null;
 
     public enum DELIM
     {
@@ -143,6 +144,11 @@ public abstract class TSVWriter extends TextWriter
         _preserveEmptyString = preserveEmptyString;
     }
 
+    public void setAdditionalEscapeChars(String additionalEscapeChars)
+    {
+        _additionalEscapeChars = additionalEscapeChars;
+    }
+
     protected String _escapedCharsString = null;
 
     /**
@@ -201,7 +207,7 @@ public abstract class TSVWriter extends TextWriter
         {
             // NOTE: Excel always includes comma in the list of characters that will be quoted,
             // but we will only quote comma if it is the delimiter character.
-            _escapedCharsString = "\r\n" + _rowSeparator + _chDelimiter + _chQuote + _escapeChar;
+            _escapedCharsString = "\r\n" + _rowSeparator + _chDelimiter + _chQuote;
         }
 
 
@@ -211,6 +217,8 @@ public abstract class TSVWriter extends TextWriter
         char firstCh = value.charAt(0);
         char lastCh = value.charAt(len-1);
         if (Character.isSpaceChar(firstCh) || Character.isSpaceChar(lastCh))
+            return true;
+        if (StringUtils.containsAny(value, _additionalEscapeChars))
             return true;
         return StringUtils.containsAny(value,_escapedCharsString);
     }

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -955,7 +955,7 @@ public class ExpDataIterators
                     throw new UnsupportedOperationException();
                 }
             };
-            _tsvWriter.setAdditionalEscapeChars(TSVWriter.BACKSLASH_CHAR_STRING);
+            _tsvWriter.setAdditionalQuotedChars(TSVWriter.BACKSLASH_CHAR_STRING);
 
         }
 
@@ -2490,7 +2490,7 @@ public class ExpDataIterators
                     throw new UnsupportedOperationException();
                 }
             };
-            _tsvWriter.setAdditionalEscapeChars(TSVWriter.BACKSLASH_CHAR_STRING);
+            _tsvWriter.setAdditionalQuotedChars(TSVWriter.BACKSLASH_CHAR_STRING);
 
             _isCrossFolderUpdate = isCrossFolder && context.getInsertOption().updateOnly;
 

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -955,8 +955,6 @@ public class ExpDataIterators
                     throw new UnsupportedOperationException();
                 }
             };
-            _tsvWriter.setAdditionalQuotedChars(TSVWriter.BACKSLASH_CHAR_STRING);
-
         }
 
         private BatchValidationException getErrors()

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -955,6 +955,7 @@ public class ExpDataIterators
                     throw new UnsupportedOperationException();
                 }
             };
+            _tsvWriter.setAdditionalEscapeChars(TSVWriter.BACKSLASH_CHAR_STRING);
 
         }
 
@@ -2489,6 +2490,7 @@ public class ExpDataIterators
                     throw new UnsupportedOperationException();
                 }
             };
+            _tsvWriter.setAdditionalEscapeChars(TSVWriter.BACKSLASH_CHAR_STRING);
 
             _isCrossFolderUpdate = isCrossFolder && context.getInsertOption().updateOnly;
 


### PR DESCRIPTION
#### Rationale
Issue [52037](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=52037) The initial fix for this issue introduced a problem with a usage of TSVWriter that is writing out file paths on Windows (in `TsvDataExchangeHandler` specifically, but perhaps elsewhere as well). These paths have backslashes in them but the values are not expected to be quoted. 

#### Related Pull Requests
- #6246 

#### Changes
- Add new field and constant in `TSVWriter` to allow quoting of backslashes in particular but possibly other troubling characters in the future.
