### PR TITLE
Issue 51710: Remove replaced assay runs from the search index

### DIFF
--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -136,6 +136,8 @@ public interface AssayService
 
     void deindexAssays(@NotNull Collection<? extends ExpProtocol> expProtocols);
 
+    void deindexAssayRuns(Collection<? extends ExpRun> expRuns);
+
     /**
      * Creates a run, but does not persist it to the database. Creates the run only, no protocol applications, etc.
      */

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -134,7 +134,7 @@ public interface AssayService
     void indexAssay(SearchService.IndexTask task, Container c, ExpProtocol protocol);
     void indexAssays(SearchService.IndexTask task, Container c);
 
-    void indexAssayRun(int expRunRowId, boolean forceIndex);
+    void indexAssayRun(int expRunRowId);
 
     void deindexAssays(@NotNull Collection<? extends ExpProtocol> expProtocols);
 

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -134,7 +134,7 @@ public interface AssayService
     void indexAssay(SearchService.IndexTask task, Container c, ExpProtocol protocol);
     void indexAssays(SearchService.IndexTask task, Container c);
 
-    void indexAssayRun(int expRunRowId);
+    void indexAssayRun(int expRunRowId, boolean forceIndex);
 
     void deindexAssays(@NotNull Collection<? extends ExpProtocol> expProtocols);
 

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -134,6 +134,8 @@ public interface AssayService
     void indexAssay(SearchService.IndexTask task, Container c, ExpProtocol protocol);
     void indexAssays(SearchService.IndexTask task, Container c);
 
+    void indexAssayRun(int expRunRowId);
+
     void deindexAssays(@NotNull Collection<? extends ExpProtocol> expProtocols);
 
     void deindexAssayRuns(Collection<? extends ExpRun> expRuns);

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -400,6 +400,7 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
                 ExperimentService.get().auditRunEvent(context.getUser(), context.getProtocol(), replacedRun, null, auditMessage, context.getAuditUserComment());
 
                 transaction.addCommitTask(() -> replacedRun.archiveDataFiles(context.getUser()), DbScope.CommitTaskOption.POSTCOMMIT);
+                transaction.addCommitTask(() -> AssayService.get().deindexAssayRuns(List.of(replacedRun)), DbScope.CommitTaskOption.POSTCOMMIT);
             }
 
             AssayService.get().ensureUniqueBatchName(batch, context.getProtocol(), context.getUser());

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -400,6 +400,7 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
                 ExperimentService.get().auditRunEvent(context.getUser(), context.getProtocol(), replacedRun, null, auditMessage, context.getAuditUserComment());
 
                 transaction.addCommitTask(() -> replacedRun.archiveDataFiles(context.getUser()), DbScope.CommitTaskOption.POSTCOMMIT);
+                // Issue 51710: Remove replaced assay runs from the search index
                 transaction.addCommitTask(() -> AssayService.get().deindexAssayRuns(List.of(replacedRun)), DbScope.CommitTaskOption.POSTCOMMIT);
             }
 

--- a/assay/src/org/labkey/assay/AssayExperimentListener.java
+++ b/assay/src/org/labkey/assay/AssayExperimentListener.java
@@ -32,6 +32,6 @@ public class AssayExperimentListener implements ExperimentListener
     @Override
     public void afterRunSaved(Container container, User user, ExpProtocol protocol, ExpRun run)
     {
-        AssayManager.get().indexAssayRun(run.getRowId(), false);
+        AssayManager.get().indexAssayRun(run.getRowId());
     }
 }

--- a/assay/src/org/labkey/assay/AssayExperimentListener.java
+++ b/assay/src/org/labkey/assay/AssayExperimentListener.java
@@ -32,6 +32,6 @@ public class AssayExperimentListener implements ExperimentListener
     @Override
     public void afterRunSaved(Container container, User user, ExpProtocol protocol, ExpRun run)
     {
-        AssayManager.get().indexAssayRun(run.getRowId());
+        AssayManager.get().indexAssayRun(run.getRowId(), false);
     }
 }

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -708,7 +708,7 @@ public class AssayManager implements AssayService
      */
     private boolean shouldIndexRun(ExpRun expRun)
     {
-        return getProvider(expRun) != null && expRun.getReplacedByRun() == null;
+        return expRun != null && getProvider(expRun) != null && expRun.getReplacedByRun() == null;
     }
 
     public void indexAssayBatch(int expRunRowId)

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -704,11 +704,11 @@ public class AssayManager implements AssayService
     }
 
     /**
-     * Only index runs that have an associated assay provider
+     * Only index runs that have an associated assay provider and that have not been replaced
      */
     private boolean shouldIndexRun(ExpRun expRun)
     {
-        return getProvider(expRun) != null;
+        return getProvider(expRun) != null && expRun.getReplacedByRun() == null;
     }
 
     public void indexAssayBatch(int expRunRowId)
@@ -800,6 +800,7 @@ public class AssayManager implements AssayService
             ss.deleteResource(protocol.getDocumentId());
     }
 
+    @Override
     public void deindexAssayRuns(Collection<? extends ExpRun> expRuns)
     {
         if (expRuns == null || expRuns.isEmpty())

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -767,7 +767,7 @@ public class AssayManager implements AssayService
     }
 
     @Override
-    public void indexAssayRun(int expRunRowId)
+    public void indexAssayRun(int expRunRowId, boolean forceIndex)
     {
         SearchService ss = SearchService.get();
         if (ss == null)
@@ -777,7 +777,7 @@ public class AssayManager implements AssayService
         if (expRun == null)
             return;
         
-        if (shouldIndexRun(expRun))
+        if (shouldIndexRun(expRun) || forceIndex)
             indexAssayRun(ss.defaultTask(), ExperimentService.get().getExpRun(expRunRowId));
     }
 

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -766,6 +766,7 @@ public class AssayManager implements AssayService
                 ).forEach(r -> indexAssayRun(task, r));
     }
 
+    @Override
     public void indexAssayRun(int expRunRowId)
     {
         SearchService ss = SearchService.get();

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -767,7 +767,7 @@ public class AssayManager implements AssayService
     }
 
     @Override
-    public void indexAssayRun(int expRunRowId, boolean forceIndex)
+    public void indexAssayRun(int expRunRowId)
     {
         SearchService ss = SearchService.get();
         if (ss == null)
@@ -777,7 +777,7 @@ public class AssayManager implements AssayService
         if (expRun == null)
             return;
         
-        if (shouldIndexRun(expRun) || forceIndex)
+        if (shouldIndexRun(expRun))
             indexAssayRun(ss.defaultTask(), ExperimentService.get().getExpRun(expRunRowId));
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4350,14 +4350,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 // Re-index replaced run if replacing run is deleted
                 if (run.getReplacesRuns() != null)
                 {
-                    transaction.addCommitTask(() ->
-                                    run.getReplacesRuns().forEach(replacedRun ->
-                                            AssayService.get().indexAssayRun(replacedRun.getRowId())
-                                    ),
-                            DbScope.CommitTaskOption.POSTCOMMIT
+                    run.getReplacesRuns().forEach(replacedRun ->
+                            AssayService.get().indexAssayRun(replacedRun.getRowId(), true)
                     );
                 }
-                deleteRun(run, datasToDelete, user, userComment); // here, replacesRuns is intact
+                deleteRun(run, datasToDelete, user, userComment);
 
                 for (ExpData data : datasToDelete)
                 {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4350,8 +4350,12 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 // Re-index replaced run if replacing run is deleted
                 if (run.getReplacesRuns() != null)
                 {
-                    run.getReplacesRuns().forEach(replacedRun ->
-                            AssayService.get().indexAssayRun(replacedRun.getRowId(), true)
+                    List<ExpRunImpl> replacedRuns = run.getReplacesRuns();
+                    transaction.addCommitTask(() ->
+                        replacedRuns.forEach(replacedRun ->
+                                AssayService.get().indexAssayRun(replacedRun.getRowId())
+                        ),
+                        DbScope.CommitTaskOption.POSTCOMMIT
                     );
                 }
                 deleteRun(run, datasToDelete, user, userComment);

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4347,8 +4347,17 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 // Archive all data files prior to deleting
                 //  ideally this would be transacted as a commit task but we decided against it due to complications
                 run.archiveDataFiles(user);
-
-                deleteRun(run, datasToDelete, user, userComment);
+                // Re-index replaced run if replacing run is deleted
+                if (run.getReplacesRuns() != null)
+                {
+                    transaction.addCommitTask(() ->
+                                    run.getReplacesRuns().forEach(replacedRun ->
+                                            AssayService.get().indexAssayRun(replacedRun.getRowId())
+                                    ),
+                            DbScope.CommitTaskOption.POSTCOMMIT
+                    );
+                }
+                deleteRun(run, datasToDelete, user, userComment); // here, replacesRuns is intact
 
                 for (ExpData data : datasToDelete)
                 {


### PR DESCRIPTION
#### Rationale
See issue [here](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51710).

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6262
- https://github.com/LabKey/limsModules/pull/1118

#### Changes
- Upon successful run replacement de-index the run
- When a run is deleted that has replaced a former run, then index the former run to ensure it appears in search results
- Ensure replaced runs are not indexed in the future (skip indexing them)
