### PR TITLE
Prevent import form from submitting twice

### DIFF
--- a/api/src/org/labkey/api/query/import.jsp
+++ b/api/src/org/labkey/api/query/import.jsp
@@ -184,6 +184,12 @@
         if (!form)
             return;
 
+        if (Ext4.getBody().isMasked())
+        {
+            console.warn("Form submission is already in progress");
+            return;
+        }
+
         Ext4.getBody().mask();
         errorDiv.update("&nbsp;");
 


### PR DESCRIPTION
#### Rationale
Rarely on TeamCity, this form submits data twice. An even less common subset of times, that double-submission triggers an "Ajax communication failed" error. Skipping additional submissions while the Ext mask is in place should prevent this problem.

#### Related Pull Requests
- N/A

#### Changes
- Prevent import form from submitting twice
