### PR TITLE
Lsid.parseLsid() return null when argument is null

### DIFF
--- a/api/src/org/labkey/api/exp/Lsid.java
+++ b/api/src/org/labkey/api/exp/Lsid.java
@@ -125,6 +125,8 @@ public class Lsid
     @Nullable
     private static String[] parseLsid(String s)
     {
+        if (s == null)
+            return null;
         String[] parts = StringUtils.split(s,':');
         if (parts.length < 5 || parts.length > 6)
             return null;

--- a/api/src/org/labkey/api/exp/Lsid.java
+++ b/api/src/org/labkey/api/exp/Lsid.java
@@ -123,7 +123,7 @@ public class Lsid
      */
 
     @Nullable
-    private static String[] parseLsid(String s)
+    private static String[] parseLsid(@Nullable String s)
     {
         if (s == null)
             return null;


### PR DESCRIPTION
#### Rationale
The `Lsid.parseLsid()` method (which is called more often than can be calculated) throws an NPE if the argument is null due to a dereferencing of a null `String[] parts`. This adds a check to avoid the NPE and return null. Returning null here is safe since callers are expected to handle null. This resolves [Issue 52157](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52157). 

#### Changes
- Add null check on argument to `Lsid.parseLsid()`.
