### PR TITLE
Issue 52154: LKSM/LKB: Unexpected "AliquotCount" error on Sample Import 

### DIFF
--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -92,6 +92,13 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
     private static final Set<PropertyStorageSpec.ForeignKey> FOREIGN_KEYS;
     private static final Set<String> FORCE_ENABLED_SYSTEM_FIELDS;
 
+    public static final String ALIQUOT_COUNT_LABEL = "Aliquots Created Count";
+    public static final String ALIQUOT_VOLUME_LABEL = "Aliquot Total Amount";
+    public static final String AVAILABLE_ALIQUOT_COUNT_LABEL = "Available Aliquot Count";
+    public static final String AVAILABLE_ALIQUOT_VOLUME_LABEL = "Available Aliquot Amount";
+
+    public static final Set<String> ALIQUOT_ROLLUP_FIELD_LABELS = CaseInsensitiveHashSet.of(ALIQUOT_COUNT_LABEL, ALIQUOT_VOLUME_LABEL, AVAILABLE_ALIQUOT_VOLUME_LABEL, AVAILABLE_ALIQUOT_COUNT_LABEL);
+
     static
     {
         BASE_PROPERTIES = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(
@@ -110,14 +117,11 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         RESERVED_NAMES.add("CpasType");
         RESERVED_NAMES.add("Is Aliquot");
         RESERVED_NAMES.add(ExpMaterial.ALIQUOTED_FROM_INPUT);
+        RESERVED_NAMES.addAll(ALIQUOT_ROLLUP_FIELD_LABELS);
+        RESERVED_NAMES.add("AliquotTotalVolume"); // Issue 52158: Sample Manager: data type reserved field name and label inconsistencies
         RESERVED_NAMES.add("Aliquoted From Parent");
-        RESERVED_NAMES.add("Available Aliquot Count");
-        RESERVED_NAMES.add("Available Aliquot Amount");
         RESERVED_NAMES.add("Root Material");
         RESERVED_NAMES.add("RecomputeRollup");
-        RESERVED_NAMES.add("AliquotTotalVolume");
-        RESERVED_NAMES.add("Aliquot Total Amount");
-        RESERVED_NAMES.add("Aliquots Created Count");
         RESERVED_NAMES.add("Aliquot Unit");
         RESERVED_NAMES.add("ExpirationDate");
         RESERVED_NAMES.add("Expiration Date");

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -111,6 +111,10 @@ import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 import static org.labkey.api.exp.api.SampleTypeDomainKind.SAMPLETYPE_FILE_DIRECTORY;
+import static org.labkey.api.exp.query.ExpMaterialTable.Column.AliquotCount;
+import static org.labkey.api.exp.query.ExpMaterialTable.Column.AliquotVolume;
+import static org.labkey.api.exp.query.ExpMaterialTable.Column.AvailableAliquotCount;
+import static org.labkey.api.exp.query.ExpMaterialTable.Column.AvailableAliquotVolume;
 import static org.labkey.api.util.StringExpressionFactory.AbstractStringExpression.NullValueBehavior.NullResult;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.*;
 
@@ -126,6 +130,12 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         MATERIAL_ALT_MERGE_KEYS = Set.of(Column.MaterialSourceId.name(), Column.Name.name());
         MATERIAL_ALT_UPDATE_KEYS = Set.of(Column.LSID.name());
     }
+
+    public static final String ALIQUOT_COUNT_LABEL = "Aliquots Created Count";
+    public static final String ALIQUOT_VOLUME_LABEL = "Aliquot Total Amount";
+    public static final String AVAILABLE_ALIQUOT_COUNT_LABEL = "Available Aliquot Count";
+    public static final String AVAILABLE_ALIQUOT_VOLUME_LABEL = "Available Aliquot Amount";
+
 
     public ExpMaterialTableImpl(UserSchema schema, ContainerFilter cf, @Nullable ExpSampleType sampleType)
     {
@@ -456,26 +466,26 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             }
             case AliquotCount ->
             {
-                var ret = wrapColumn(alias, _rootTable.getColumn("AliquotCount"));
-                ret.setLabel("Aliquots Created Count");
+                var ret = wrapColumn(alias, _rootTable.getColumn(AliquotCount.name()));
+                ret.setLabel(ALIQUOT_COUNT_LABEL);
                 return ret;
             }
             case AliquotVolume ->
             {
-                var ret = wrapColumn(alias, _rootTable.getColumn("AliquotVolume"));
-                ret.setLabel("Aliquot Total Amount");
+                var ret = wrapColumn(alias, _rootTable.getColumn(AliquotVolume.name()));
+                ret.setLabel(ALIQUOT_VOLUME_LABEL);
                 return ret;
             }
             case AvailableAliquotVolume ->
             {
-                var ret = wrapColumn(alias, _rootTable.getColumn("AvailableAliquotVolume"));
-                ret.setLabel("Available Aliquot Amount");
+                var ret = wrapColumn(alias, _rootTable.getColumn(AvailableAliquotVolume.name()));
+                ret.setLabel(AVAILABLE_ALIQUOT_VOLUME_LABEL);
                 return ret;
             }
             case AvailableAliquotCount ->
             {
-                var ret = wrapColumn(alias, _rootTable.getColumn("AvailableAliquotCount"));
-                ret.setLabel("Available Aliquot Count");
+                var ret = wrapColumn(alias, _rootTable.getColumn(AvailableAliquotCount.name()));
+                ret.setLabel(AVAILABLE_ALIQUOT_COUNT_LABEL);
                 return ret;
             }
             case AliquotUnit ->

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -110,6 +110,10 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
+import static org.labkey.api.exp.api.SampleTypeDomainKind.ALIQUOT_COUNT_LABEL;
+import static org.labkey.api.exp.api.SampleTypeDomainKind.ALIQUOT_VOLUME_LABEL;
+import static org.labkey.api.exp.api.SampleTypeDomainKind.AVAILABLE_ALIQUOT_COUNT_LABEL;
+import static org.labkey.api.exp.api.SampleTypeDomainKind.AVAILABLE_ALIQUOT_VOLUME_LABEL;
 import static org.labkey.api.exp.api.SampleTypeDomainKind.SAMPLETYPE_FILE_DIRECTORY;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.AliquotCount;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.AliquotVolume;
@@ -130,12 +134,6 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         MATERIAL_ALT_MERGE_KEYS = Set.of(Column.MaterialSourceId.name(), Column.Name.name());
         MATERIAL_ALT_UPDATE_KEYS = Set.of(Column.LSID.name());
     }
-
-    public static final String ALIQUOT_COUNT_LABEL = "Aliquots Created Count";
-    public static final String ALIQUOT_VOLUME_LABEL = "Aliquot Total Amount";
-    public static final String AVAILABLE_ALIQUOT_COUNT_LABEL = "Available Aliquot Count";
-    public static final String AVAILABLE_ALIQUOT_VOLUME_LABEL = "Available Aliquot Amount";
-
 
     public ExpMaterialTableImpl(UserSchema schema, ContainerFilter cf, @Nullable ExpSampleType sampleType)
     {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -132,6 +132,7 @@ import static org.labkey.api.data.TableSelector.ALL_COLUMNS;
 import static org.labkey.api.dataiterator.DetailedAuditLogDataIterator.AuditConfigs;
 import static org.labkey.api.dataiterator.SampleUpdateAddColumnsDataIterator.CURRENT_SAMPLE_STATUS_COLUMN_NAME;
 import static org.labkey.api.exp.api.ExpRunItem.PARENT_IMPORT_ALIAS_MAP_PROP;
+import static org.labkey.api.exp.api.SampleTypeDomainKind.ALIQUOT_ROLLUP_FIELD_LABELS;
 import static org.labkey.api.exp.api.SampleTypeService.ConfigParameters.SkipAliquotRollup;
 import static org.labkey.api.exp.api.SampleTypeService.ConfigParameters.SkipMaxSampleCounterFunction;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.AliquotCount;
@@ -147,10 +148,6 @@ import static org.labkey.api.exp.query.ExpMaterialTable.Column.SampleState;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.StoredAmount;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.Units;
 import static org.labkey.experiment.ExpDataIterators.incrementCounts;
-import static org.labkey.experiment.api.ExpMaterialTableImpl.ALIQUOT_COUNT_LABEL;
-import static org.labkey.experiment.api.ExpMaterialTableImpl.ALIQUOT_VOLUME_LABEL;
-import static org.labkey.experiment.api.ExpMaterialTableImpl.AVAILABLE_ALIQUOT_COUNT_LABEL;
-import static org.labkey.experiment.api.ExpMaterialTableImpl.AVAILABLE_ALIQUOT_VOLUME_LABEL;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.insert;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.rollup;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.update;
@@ -182,7 +179,6 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             AvailableAliquotVolume.toString(), JdbcType.DOUBLE
     );
 
-    private static final Set<String> ALIQUOT_ROLLUP_FIELD_LABELS = Set.of(ALIQUOT_COUNT_LABEL, ALIQUOT_VOLUME_LABEL, AVAILABLE_ALIQUOT_VOLUME_LABEL, AVAILABLE_ALIQUOT_COUNT_LABEL);
 
     static
     {
@@ -1600,18 +1596,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         private static boolean isAliquotRollupHeader(String name)
         {
-            for (String rollupField : ALIQUOT_ROLLUP_FIELDS.keySet())
-            {
-                if (rollupField.equalsIgnoreCase(name))
-                    return true;
-            }
-            for (String rollupLabel : ALIQUOT_ROLLUP_FIELD_LABELS)
-            {
-                if(rollupLabel.replaceAll("\\s+","").equalsIgnoreCase(name.replaceAll("\\s+","")))
-                    return true;
-            }
-
-            return false;
+            Set<String> rollupFields = new CaseInsensitiveHashSet();
+            rollupFields.addAll(ALIQUOT_ROLLUP_FIELDS.keySet());
+            rollupFields.addAll(ALIQUOT_ROLLUP_FIELD_LABELS);
+            return rollupFields.contains(name);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -147,6 +147,10 @@ import static org.labkey.api.exp.query.ExpMaterialTable.Column.SampleState;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.StoredAmount;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.Units;
 import static org.labkey.experiment.ExpDataIterators.incrementCounts;
+import static org.labkey.experiment.api.ExpMaterialTableImpl.ALIQUOT_COUNT_LABEL;
+import static org.labkey.experiment.api.ExpMaterialTableImpl.ALIQUOT_VOLUME_LABEL;
+import static org.labkey.experiment.api.ExpMaterialTableImpl.AVAILABLE_ALIQUOT_COUNT_LABEL;
+import static org.labkey.experiment.api.ExpMaterialTableImpl.AVAILABLE_ALIQUOT_VOLUME_LABEL;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.insert;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.rollup;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.update;
@@ -177,6 +181,8 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             AliquotVolume.toString(), JdbcType.DOUBLE,
             AvailableAliquotVolume.toString(), JdbcType.DOUBLE
     );
+
+    private static final Set<String> ALIQUOT_ROLLUP_FIELD_LABELS = Set.of(ALIQUOT_COUNT_LABEL, ALIQUOT_VOLUME_LABEL, AVAILABLE_ALIQUOT_VOLUME_LABEL, AVAILABLE_ALIQUOT_COUNT_LABEL);
 
     static
     {
@@ -1544,7 +1550,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                 if (isExpMaterialColumn(column, name))
                     return true;
             }
-            return false;
+            return isAliquotRollupHeader(name);
         }
 
         private static boolean isExpMaterialColumn(ExpMaterialTable.Column column, String name)
@@ -1590,6 +1596,22 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         public static boolean isUnitsHeader(String name)
         {
             return isExpMaterialColumn(ExpMaterialTable.Column.Units, name);
+        }
+
+        private static boolean isAliquotRollupHeader(String name)
+        {
+            for (String rollupField : ALIQUOT_ROLLUP_FIELDS.keySet())
+            {
+                if (rollupField.equalsIgnoreCase(name))
+                    return true;
+            }
+            for (String rollupLabel : ALIQUOT_ROLLUP_FIELD_LABELS)
+            {
+                if(rollupLabel.replaceAll("\\s+","").equalsIgnoreCase(name.replaceAll("\\s+","")))
+                    return true;
+            }
+
+            return false;
         }
     }
 


### PR DESCRIPTION
#### Rationale
Aliquot rollup columns are added to the data iterator during sample insert/import/merge so parent samples can have those values initialized to 0 while aliquot to null. When the import file also contains such columns, the import fails with "duplicate columns:" error.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6265
- https://github.com/LabKey/limsModules/pull/1120

#### Changes
- ignore provided aliquot rollup columns
