### PR TITLE
Fix naming pattern when parent input type contain & and parent name contains comma.

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -2346,6 +2346,7 @@ public class NameGenerator
                     Set<String> dataTypeAltNames = new HashSet<>();
                     dataTypeAltNames.add(decodedDataType);
                     dataTypeAltNames.add(getEncodedDataTypeInExpression(decodedDataType));
+                    dataTypeAltNames.add(QueryKey.encodePart(decodedDataType)); // add encoded form in case the original parents column in as encoded but parentValues needs to be updated (for example, strip quotes for comma)
                     for (String dataTypeAltName : dataTypeAltNames)
                     {
                         inputs.computeIfAbsent(INPUT_PARENT + "/" + dataTypeAltName,  (s) -> new LinkedHashSet<>()).addAll(parents); // add Inputs/SampleType1


### PR DESCRIPTION
#### Rationale
Fuzz [test](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_WorkflowEndpoints/3363672?buildTab=tests&expandedTest=build%3A%28id%3A3363672%29%2Cid%3A2000000019&logFilter=debug&logView=flowAware) revealed an issue using naming pattern when the sample type name contains "&" and the parent sample name contains comma. 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6268
- https://github.com/LabKey/limsModules/pull/1127

#### Changes
- Override name expression ctx map with converted parent name instead of original parent name 
