### PR TITLE
DataIteratorUtil createTableMap support for matching on encoded fieldKey for insert/update/save rows

### DIFF
--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -186,6 +186,13 @@ public class DataIteratorUtil
             }
         }
 
+        // Issue 52038: Add support for matching on encoded fieldKey
+        for (ColumnInfo col : cols)
+        {
+            if (null != col.getFieldKey())
+                targetAliasesMap.put(col.getFieldKey().toString(), new Pair<>(col, MatchType.alias));
+        }
+
         for (ColumnInfo col : cols)
         {
             String label = col.getLabel();


### PR DESCRIPTION
#### Rationale
One of the recent special characters issues that we fixed had to do with the app using fieldKeys instead of column names when posting the data from a Details form to the updateRows API. For those rows without any encoded special characters, this wasn't an issue but for those with the encoded special characters, the columns were not being resolved for the target table. In the data iterator code that handles this "column matching" we already support matching the column on name, label, uri, alias, among other things. This PR adds in the encoded fieldKey to the table column map that is used for this matching.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1697

#### Changes
- DataIteratorUtil createTableMap support for matching on column encoded fieldKey
