### PR TITLE
Bump documentation version to 25.3

### DIFF
--- a/api/src/org/labkey/api/Constants.java
+++ b/api/src/org/labkey/api/Constants.java
@@ -56,7 +56,7 @@ public class Constants
      */
     public static String getDocumentationVersion()
     {
-        return "24.11";
+        return "25.3";
     }
 
     /**


### PR DESCRIPTION
#### Rationale
`Constants$TestCase` is failing, complaining that it's time to bump the documentation version to 25.3