### PR TITLE
Skip "optimizing" remote URLs

### DIFF
--- a/api/src/org/labkey/api/view/PopupMenuView.java
+++ b/api/src/org/labkey/api/view/PopupMenuView.java
@@ -210,7 +210,7 @@ public class PopupMenuView extends HttpView<PopupMenu>
                 if (StringUtils.isNotEmpty(fragment))
                     dataQuery += "#" + fragment;
 
-                href = url.toString();
+                href = url.getURIString();
                 HttpView.currentPageConfig().addHandlerForQuerySelector(
                         "A.noFollowNavigate",
                         "click",

--- a/api/src/org/labkey/api/view/PopupMenuView.java
+++ b/api/src/org/labkey/api/view/PopupMenuView.java
@@ -195,31 +195,31 @@ public class PopupMenuView extends HttpView<PopupMenu>
         {
             try
             {
-                var context = HttpView.currentContext();
                 URLHelper url = new URLHelper(href);
+                boolean isLocal = null == url.getHost() && null == url.getScheme() && -1 == url.getPort();
+                if (isLocal)
+                {
+                    var context = HttpView.currentContext();
 
-                // separate the path (into href) and query/fragment (into dataQuery) portions of URL
-                var fragment = url.getFragment();
-                url.setFragment(null);
-                if (null != context && context.isRobot())
-                    url.addParameter(ActionURL.Param._noindex.name(), "1");
-                dataQuery = StringUtils.trimToEmpty(url.getRawQuery());
-                url.deleteParameters();
-                if (!dataQuery.isEmpty())
-                    dataQuery = "?" + dataQuery;
-                if (StringUtils.isNotEmpty(fragment))
-                    dataQuery += "#" + fragment;
+                    // separate the path (into href) and query/fragment (into dataQuery) portions of URL
+                    var fragment = url.getFragment();
+                    url.setFragment(null);
+                    if (null != context && context.isRobot())
+                        url.addParameter(ActionURL.Param._noindex.name(), "1");
+                    dataQuery = StringUtils.trimToEmpty(url.getRawQuery());
+                    url.deleteParameters();
+                    if (!dataQuery.isEmpty())
+                        dataQuery = "?" + dataQuery;
+                    if (StringUtils.isNotEmpty(fragment))
+                        dataQuery += "#" + fragment;
 
-                // URLHelper.getURIString() doesn't work with local paths (unlike ActionURL.getURIString())
-                if (null == url.getHost() && null == url.getScheme() && -1 == url.getPort())
                     href = url.getLocalURIString();
-                else
-                    href = url.getURIString();
-                HttpView.currentPageConfig().addHandlerForQuerySelector(
-                        "A.noFollowNavigate",
-                        "click",
-                        "window.location = this.href + this.dataset['query']; return false;");
-                cls = StringUtils.trimToEmpty(cls) + " noFollowNavigate";
+                    HttpView.currentPageConfig().addHandlerForQuerySelector(
+                            "A.noFollowNavigate",
+                            "click",
+                            "window.location = this.href + this.dataset['query']; return false;");
+                    cls = StringUtils.trimToEmpty(cls) + " noFollowNavigate";
+                }
             }
             catch (URISyntaxException e)
             {

--- a/api/src/org/labkey/api/view/PopupMenuView.java
+++ b/api/src/org/labkey/api/view/PopupMenuView.java
@@ -210,7 +210,11 @@ public class PopupMenuView extends HttpView<PopupMenu>
                 if (StringUtils.isNotEmpty(fragment))
                     dataQuery += "#" + fragment;
 
-                href = url.getURIString();
+                // URLHelper.getURIString() doesn't work with local paths (unlike ActionURL.getURIString())
+                if (null == url.getHost() && null == url.getScheme() && -1 == url.getPort())
+                    href = url.getLocalURIString();
+                else
+                    href = url.getURIString();
                 HttpView.currentPageConfig().addHandlerForQuerySelector(
                         "A.noFollowNavigate",
                         "click",


### PR DESCRIPTION
#### Rationale
Unfortunately, URLHelper.getURIString() is broken for local urls (?).  Fortunately, we don't care about optimizing remote URLs so we can just skip the tricky code.

PS: it's weird that a) URLHelper.toString() doesn't return a string somewhat like the string it parsed b) URLHelper.getLocalString() does not check that it is in fact a local string c) URLHelper.getURIString() returns a bogus URL for local urls (no host).  I guess we just we only use URLHelper in very specific ways.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
