### PR TITLE
Set the FilePathRoot on moved run

### DIFF
--- a/api/src/org/labkey/api/exp/XarSource.java
+++ b/api/src/org/labkey/api/exp/XarSource.java
@@ -84,6 +84,8 @@ public abstract class XarSource implements Serializable
 
     public abstract Path getRootPath();
 
+    public Path getJobRootPath() { return getRootPath(); }
+
     /**
      * Should be true if this was uploaded XML that was not part of a full XAR
      */

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -1109,7 +1109,8 @@ public class XarReader extends AbstractXarImporter
             vals.setProtocolLSID(protocol.getLSID());
             vals.setComments(trimString(a.getComments()));
 
-            vals.setFilePathRoot(FileUtil.getAbsolutePath(_xarSource.getRootPath()));     //  FileUtil.getAbsolutePath(runContext.getContainer(), _job.getPipeRoot().getRootNioPath()));
+            // vals.setFilePathRoot(FileUtil.getAbsolutePath(_xarSource.getRootPath()));     //  FileUtil.getAbsolutePath(runContext.getContainer(), _job.getPipeRoot().getRootNioPath()));
+            vals.setFilePathRoot(FileUtil.getAbsolutePath(runContext.getContainer(), _job.getPipeRoot().getRootNioPath()));
             vals.setContainer(getContainer());
             String workflowTaskLSID = a.getWorkflowTaskLSID();
 

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -1110,7 +1110,7 @@ public class XarReader extends AbstractXarImporter
             vals.setComments(trimString(a.getComments()));
 
             // vals.setFilePathRoot(FileUtil.getAbsolutePath(_xarSource.getRootPath()));     //  FileUtil.getAbsolutePath(runContext.getContainer(), _job.getPipeRoot().getRootNioPath()));
-            vals.setFilePathRoot(FileUtil.getAbsolutePath(runContext.getContainer(), _job.getPipeRoot().getRootNioPath()));
+            vals.setFilePathRoot(FileUtil.getAbsolutePath(_xarSource.getJobRootPath()));
             vals.setContainer(getContainer());
             String workflowTaskLSID = a.getWorkflowTaskLSID();
 

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -1109,7 +1109,6 @@ public class XarReader extends AbstractXarImporter
             vals.setProtocolLSID(protocol.getLSID());
             vals.setComments(trimString(a.getComments()));
 
-            // vals.setFilePathRoot(FileUtil.getAbsolutePath(_xarSource.getRootPath()));     //  FileUtil.getAbsolutePath(runContext.getContainer(), _job.getPipeRoot().getRootNioPath()));
             vals.setFilePathRoot(FileUtil.getAbsolutePath(_xarSource.getJobRootPath()));
             vals.setContainer(getContainer());
             String workflowTaskLSID = a.getWorkflowTaskLSID();

--- a/experiment/src/org/labkey/experiment/pipeline/MoveRunsTask.java
+++ b/experiment/src/org/labkey/experiment/pipeline/MoveRunsTask.java
@@ -225,8 +225,8 @@ public class MoveRunsTask extends PipelineJob.Task<MoveRunsTaskFactory>
         {
             var pipelineJob = getXarContext().getJob();
             return pipelineJob != null
-                    ? FileUtil.stringToPath(getXarContext().getContainer(), pipelineJob.getPipeRoot().getRootFileLike().toNioPathForRead().toString())
-                    : getRootPath();
+                    ? pipelineJob.getPipeRoot().getRootFileLike().toNioPathForRead()
+                    : super.getJobRootPath();
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/pipeline/MoveRunsTask.java
+++ b/experiment/src/org/labkey/experiment/pipeline/MoveRunsTask.java
@@ -221,6 +221,15 @@ public class MoveRunsTask extends PipelineJob.Task<MoveRunsTaskFactory>
         }
 
         @Override
+        public Path getJobRootPath()
+        {
+            var pipelineJob = getXarContext().getJob();
+            return pipelineJob != null
+                    ? FileUtil.stringToPath(getXarContext().getContainer(), pipelineJob.getPipeRoot().getRootFileLike().toNioPathForRead().toString())
+                    : getRootPath();
+        }
+
+        @Override
         public boolean shouldIgnoreDataFiles()
         {
             return true;


### PR DESCRIPTION
#### Rationale
When a Skyline document is moved to another folder, FilePathRoot on the moved ExpRun continues to point to the source container. 
- FilePathRoot gets set incorrectly in `XarReader`:
`vals.setFilePathRoot(FileUtil.getAbsolutePath(_xarSource.getRootPath()))`
- `getRootPath() `method in `MoveRunsXarSource` returns the root path in the source container. 

#### Related Pull Requests
- https://github.com/LabKey/MacCossLabModules/pull/502
- https://github.com/LabKey/targetedms/pull/1007
