### PR TITLE
Don't short-circuit the process for loading ExtJS

### DIFF
--- a/core/webapp/labkey.js
+++ b/core/webapp/labkey.js
@@ -474,14 +474,7 @@ if (typeof LABKEY == "undefined")
 
             checkCallback('requiresExt3', callback);
 
-            if (window.Ext)
-            {
-                handle(callback, scope);
-            }
-            else
-            {
-                requiresLib('Ext3', callback, scope);
-            }
+            requiresLib('Ext3', callback, scope);
         };
 
         var requiresExt3ClientAPI = function(callback, scope)
@@ -529,14 +522,7 @@ if (typeof LABKEY == "undefined")
 
             checkCallback('requiresExt4Sandbox', callback);
 
-            if (window.Ext4)
-            {
-                handle(callback, scope);
-            }
-            else
-            {
-                requiresLib('Ext4', callback, scope);
-            }
+            requiresLib('Ext4', callback, scope);
         };
 
         var requiresLib = function(lib, callback, scope)


### PR DESCRIPTION
#### Rationale
`window.Ext4` is defined before our patches are applied. If multiple components call `LABKEY.requiresExt4Sandbox`, this check for `window.Ext4` might cause the second component to not wait for the patches to get loaded.
The same goes for Ext3.

#### Related Pull Requests
- N/A

#### Changes
- Remove short-circuiting for loading Ext
