### PR TITLE
Restore Dataset.createMutable()

### DIFF
--- a/api/src/org/labkey/api/study/Dataset.java
+++ b/api/src/org/labkey/api/study/Dataset.java
@@ -311,6 +311,8 @@ public interface Dataset extends StudyEntity
 
     void setKeyPropertyName(String name);
 
+    Dataset createMutable(); // See Issue 52211
+
     void save(User user) throws SQLException;
 
     boolean isQueryDataset();


### PR DESCRIPTION
#### Rationale
In the related PR, interface `Dataset` was changed to no longer extend `StudyCachable`, which meant it no longer provided `createMutable()`. This was fine for all code in LabKey repositories, but client code was relying on this method. (Client worked around the removal using reflection, but better to actually expose the method.) There's no compelling reason not to offer createMutable(), especially since Dataset offers `setUseTimeKeyField()`, `setKeyPropertyName()`, (and other mutating setters), plus `save()`.

I chose not to extend `StudyCachable` since other generics changes in the refactor made this challenging. Just adding the method was sufficient here.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52211

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5633