### PR TITLE
Retry after 500 error from StatusCake API

### DIFF
--- a/mothership/src/org/labkey/mothership/statuscake/StatusCakeMaintenanceTask.java
+++ b/mothership/src/org/labkey/mothership/statuscake/StatusCakeMaintenanceTask.java
@@ -40,6 +40,7 @@ import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.labkey.api.query.QueryUpdateService.ConfigParameters.BulkLoad;
@@ -176,7 +177,7 @@ public class StatusCakeMaintenanceTask implements SystemMaintenance.MaintenanceT
                             List tags = check.getJSONArray("tags").toList();
                             Server s = new Server(id, name, tags);
 
-                            List<History> history = getUptime(s, client, since, statusCakeAPIKey);
+                            List<History> history = getUptime(s, client, since, statusCakeAPIKey, log);
                             log.info("Fetched " + s + " with " + history.size() + " history rows");
 
                             serverRows.add(s.toMap());
@@ -236,7 +237,11 @@ public class StatusCakeMaintenanceTask implements SystemMaintenance.MaintenanceT
         }
     }
 
-    private static List<History> getUptime(Server server, CloseableHttpClient client, LocalDateTime since, String statusCakeAPIKey) throws IOException
+    private List<History> getUptime(Server server,
+                                           CloseableHttpClient client,
+                                           LocalDateTime since,
+                                           String statusCakeAPIKey,
+                                           Logger log) throws IOException
     {
         Instant instant = since.toInstant(ZoneOffset.UTC);
 
@@ -248,11 +253,58 @@ public class StatusCakeMaintenanceTask implements SystemMaintenance.MaintenanceT
 
         List<History> result = new ArrayList<>();
 
+        // StatusCake occasionally gives a 500 error on these requests. It doesn't seem to be rate-limiting, which
+        // should return a 429. Regardless, give it a few retries before failing
+        int attemptsRemaining = 3;
+        boolean success = false;
+        while (!success)
+        {
+            try
+            {
+                requestUptime(server, client, httpGet, result);
+                success = true;
+            }
+            catch (FailedRequestException e)
+            {
+                attemptsRemaining--;
+
+                if (attemptsRemaining == 0)
+                {
+                    throw e;
+                }
+                log.warn(e.getMessage());
+                try
+                {
+                    Thread.sleep(1000);
+                }
+                catch (InterruptedException ignored) {}
+            }
+        }
+
+        if (result.size() == limit)
+        {
+            History h = result.get(result.size() - 1);
+            result.addAll(getUptime(server, client, h.end(), statusCakeAPIKey ,log));
+        }
+
+        return result;
+    }
+
+    private static class FailedRequestException extends RuntimeException
+    {
+        public FailedRequestException(String message)
+        {
+            super(message);
+        }
+    }
+
+    private void requestUptime(Server server, CloseableHttpClient client, ClassicHttpRequest httpGet, List<History> result) throws IOException
+    {
         client.execute(httpGet, response -> {
             final HttpEntity entity1 = response.getEntity();
             if (response.getCode() != 200)
             {
-                throw new RuntimeException("Bad response " + response.getCode() + " for " + httpGet.getPath());
+                throw new FailedRequestException("Bad response " + response.getCode() + " for " + httpGet.getPath());
             }
 
             try (Reader reader = new InputStreamReader(entity1.getContent(), StandardCharsets.UTF_8))
@@ -275,13 +327,5 @@ public class StatusCakeMaintenanceTask implements SystemMaintenance.MaintenanceT
             }
             return null;
         });
-
-        if (result.size() == limit)
-        {
-            History h = result.get(result.size() - 1);
-            result.addAll(getUptime(server, client, h.end(), statusCakeAPIKey));
-        }
-
-        return result;
     }
 }


### PR DESCRIPTION
#### Rationale
When pulling data from StatusCake via their API, we sometimes get a 500 error. Attempt retries before failing.

```
java.lang.RuntimeException: Bad response 500 for /v1/uptime/3326826/periods?limit=100&after=1640995200
	at org.labkey.mothership.statuscake.StatusCakeMaintenanceTask.lambda$getUptime$1(StatusCakeMaintenanceTask.java:255) ~[mothership-25.1-SNAPSHOT.jar:?]
	at org.apache.hc.client5.http.impl.classic.CloseableHttpClient.execute(CloseableHttpClient.java:247) ~[httpclient5-5.4.1.jar:5.4.1]
	at org.apache.hc.client5.http.impl.classic.CloseableHttpClient.execute(CloseableHttpClient.java:188) ~[httpclient5-5.4.1.jar:5.4.1]
	at org.apache.hc.client5.http.impl.classic.CloseableHttpClient.execute(CloseableHttpClient.java:162) ~[httpclient5-5.4.1.jar:5.4.1]
	at org.labkey.mothership.statuscake.StatusCakeMaintenanceTask.getUptime(StatusCakeMaintenanceTask.java:251) ~[mothership-25.1-SNAPSHOT.jar:?]
	at org.labkey.mothership.statuscake.StatusCakeMaintenanceTask.lambda$run$0(StatusCakeMaintenanceTask.java:179) ~[mothership-25.1-SNAPSHOT.jar:?]
```

#### Changes
- Retry before giving up and rethrowing exception