### PR TITLE
Relax related issue rules for restricted issues

### DIFF
--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -187,6 +187,18 @@ public class IssueManager
     @Nullable
     public static IssueObject getIssue(@Nullable Container c, User user, int issueId)
     {
+        return getIssue(c, user, issueId, true);
+    }
+
+    @Nullable
+    public static IssueObject getIssue(
+            @Nullable Container c,
+            User user,
+            int issueId,
+            boolean throwOnRestrictedFailure        // controls whether we throw on a RestrictedIssueProvider failure
+                                                    // or just return null
+    )
+    {
         IssueObject issue = _getIssue(c, user, issueId);
 
         // check permissions for a restricted issue list
@@ -206,12 +218,17 @@ public class IssueManager
 
             if (!provider.hasPermission(user, issue, relatedIssues, errors))
             {
-                StringBuilder msg = new StringBuilder(errors.isEmpty() ? "Access denied" : "");
-                for (ValidationError ve : errors)
+                if (throwOnRestrictedFailure)
                 {
-                    msg.append(ve.getMessage()).append("\n");
+                    StringBuilder msg = new StringBuilder(errors.isEmpty() ? "Access denied" : "");
+                    for (ValidationError ve : errors)
+                    {
+                        msg.append(ve.getMessage()).append("\n");
+                    }
+                    throw new UnauthorizedException(msg.toString());
                 }
-                throw new UnauthorizedException(msg.toString());
+                else
+                    return null;
             }
         }
         return issue;
@@ -280,7 +297,7 @@ public class IssueManager
         for (Integer relatedIssueInt : relatedIssues)
         {
             // only add related issues that the user has permission to see
-            IssueObject relatedIssue = IssueManager.getIssue(null, user, relatedIssueInt);
+            IssueObject relatedIssue = IssueManager.getIssue(null, user, relatedIssueInt, false);
             if (relatedIssue != null)
             {
                 boolean hasReadPermission = ContainerManager.getForId(relatedIssue.getContainerId()).hasPermission(user, ReadPermission.class);
@@ -315,7 +332,7 @@ public class IssueManager
     {
         for (Integer relatedIssueInt : issue.getRelatedIssues())
         {
-            IssueObject relatedIssue = IssueManager.getIssue(null, user, relatedIssueInt);
+            IssueObject relatedIssue = IssueManager.getIssue(null, user, relatedIssueInt, false);
             if (relatedIssue != null && relatedIssue.getCommentObjects().size() > 0)
             {
                 boolean hasReadPermission = ContainerManager.getForId(relatedIssue.getContainerId()).hasPermission(user, ReadPermission.class);

--- a/issues/src/org/labkey/issue/model/IssuePage.java
+++ b/issues/src/org/labkey/issue/model/IssuePage.java
@@ -674,7 +674,7 @@ public class IssuePage implements DataRegionSelection.DataSelectionKeyForm
 
     public String renderIssueIdLink(Integer id)
     {
-        IssueObject issue = IssueManager.getIssue(null, _user, id);
+        IssueObject issue = IssueManager.getIssue(null, _user, id, false);
         Container c = issue != null ? issue.lookupContainer() : null;
         if (c != null && c.hasPermission(_user, ReadPermission.class))
         {

--- a/issues/src/org/labkey/issue/view/RelatedIssuesView.java
+++ b/issues/src/org/labkey/issue/view/RelatedIssuesView.java
@@ -37,6 +37,7 @@ import org.labkey.api.view.VBox;
 import org.labkey.api.view.ViewContext;
 import org.labkey.issue.model.IssueListDef;
 import org.labkey.issue.model.IssueManager;
+import org.labkey.issue.model.IssueObject;
 import org.labkey.issue.query.IssuesQuerySchema;
 import org.springframework.validation.BindException;
 
@@ -67,11 +68,16 @@ public class RelatedIssuesView extends VBox
             Integer issueId = (Integer)m.get("issueId");
             String containerId = (String)m.get("container");
             Container c = ContainerManager.getForId(containerId);
+
             if (c == null || !c.hasPermission(getViewContext().getUser(), ReadPermission.class))
                 return;
 
             IssueListDef d = IssueManager.getIssueListDef(c, issueDefId);
             if (d == null)
+                return;
+
+            IssueObject issue = IssueManager.getIssue(null, context.getUser(), issueId, false);
+            if (issue == null)
                 return;
 
             // If the user doesn't have ReadPermission to the domain container, we won't be able to create a query


### PR DESCRIPTION
#### Rationale
This changes how related issues are handled for restricted issues. Previously, a user was required to have access to all related issues in order to view an issues details. With this change, related issues will behave equivalently to those in an unrestricted list. A user will still be able to view the details of an issue but will not see any related issues they do not have access to (other than the ID of said related issue(s)).

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6302
- https://github.com/LabKey/onprcEHRModules/pull/1249
- https://github.com/LabKey/testAutomation/pull/2264
