### PR TITLE
Limit special substitutions to HTML wikis only

### DIFF
--- a/announcements/src/org/labkey/announcements/model/AnnouncementModel.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementModel.java
@@ -249,7 +249,7 @@ public class AnnouncementModel extends Entity implements Serializable
         if (null == attachPrefix)
             return renderingService.getFormattedHtml(_rendererType, _body, sourceDescription);
         else
-            return renderingService.getFormattedHtml(_rendererType, _body, sourceDescription, attachPrefix, getAttachments());
+            return renderingService.getFormattedHtml(_rendererType, _body, sourceDescription, false, attachPrefix, getAttachments());
     }
 
     public String getStatus()

--- a/api/src/org/labkey/api/wiki/WikiRenderingService.java
+++ b/api/src/org/labkey/api/wiki/WikiRenderingService.java
@@ -41,12 +41,12 @@ public interface WikiRenderingService
      * @param sourceDescription info on where the text came from for debugging purposes. For example: Announcement 6654 in /MyContainer
      */
     HtmlString getFormattedHtml(WikiRendererType rendererType, String source, @Nullable String sourceDescription,
-                                String attachPrefix, Collection<? extends Attachment> attachments);
+                                boolean handleSubstitutions, String attachPrefix, Collection<? extends Attachment> attachments);
 
     /**
      * @param sourceDescription info on where the text came from for debugging purposes. For example: Announcement 6654 in /MyContainer
      */
-    WikiRenderer getRenderer(WikiRendererType rendererType, String hrefPrefix,
+    WikiRenderer getRenderer(WikiRendererType rendererType, boolean handleSubstitutions, String hrefPrefix,
                              String attachPrefix, Map<String, String> nameTitleMap,
                              Collection<? extends Attachment> attachments,
                              String sourceDescription);

--- a/api/src/org/labkey/api/wiki/WikiRenderingService.java
+++ b/api/src/org/labkey/api/wiki/WikiRenderingService.java
@@ -39,12 +39,14 @@ public interface WikiRenderingService
 
     /**
      * @param sourceDescription info on where the text came from for debugging purposes. For example: Announcement 6654 in /MyContainer
+     * @param handleSubstitutions allow webpart and dependency substitutions ({@code ${labkey.webPart}} and {@code ${labkey.dependency}})
      */
     HtmlString getFormattedHtml(WikiRendererType rendererType, String source, @Nullable String sourceDescription,
                                 boolean handleSubstitutions, String attachPrefix, Collection<? extends Attachment> attachments);
 
     /**
      * @param sourceDescription info on where the text came from for debugging purposes. For example: Announcement 6654 in /MyContainer
+     * @param handleSubstitutions allow webpart and dependency substitutions ({@code ${labkey.webPart}} and {@code ${labkey.dependency}})
      */
     WikiRenderer getRenderer(WikiRendererType rendererType, boolean handleSubstitutions, String hrefPrefix,
                              String attachPrefix, Map<String, String> nameTitleMap,

--- a/core/src/org/labkey/core/wiki/HtmlRenderer.java
+++ b/core/src/org/labkey/core/wiki/HtmlRenderer.java
@@ -62,7 +62,10 @@ public class HtmlRenderer implements WikiRenderer
         _substitutionHandlers.put("dependency", new ClientDependencySubstitutionHandler());
     }
 
-    // HTML wiki pages allow substitutions; HTML announcements and Markdown wikis (which are wrapped by this renderer) do not allow substitutions
+    /**
+     * HTML wiki pages allow webpart and dependency substitutions ({@code ${labkey.webPart}} and {@code ${labkey.dependency}});
+     * HTML announcements and Markdown wikis (which are wrapped by this renderer) do not allow substitutions
+     */
     public HtmlRenderer(boolean handleSubstitutions, String hrefPrefix, String attachPrefix, Map<String, String> nameTitleMap, @Nullable Collection<? extends Attachment> attachments)
     {
         _allowSubstitutions = handleSubstitutions;

--- a/core/src/org/labkey/core/wiki/HtmlRenderer.java
+++ b/core/src/org/labkey/core/wiki/HtmlRenderer.java
@@ -45,13 +45,9 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * User: Tamra Myers
- * Date: Aug 16, 2006
- * Time: 12:33:37 PM
- */
 public class HtmlRenderer implements WikiRenderer
 {
+    private final boolean _allowSubstitutions;
     private final String _hrefPrefix;
     private final String _attachPrefix;
     private final Map<String, String> _nameTitleMap;
@@ -66,9 +62,10 @@ public class HtmlRenderer implements WikiRenderer
         _substitutionHandlers.put("dependency", new ClientDependencySubstitutionHandler());
     }
 
-
-    public HtmlRenderer(String hrefPrefix, String attachPrefix, Map<String, String> nameTitleMap, @Nullable Collection<? extends Attachment> attachments)
+    // HTML wiki pages allow substitutions; HTML announcements and Markdown wikis (which are wrapped by this renderer) do not allow substitutions
+    public HtmlRenderer(boolean handleSubstitutions, String hrefPrefix, String attachPrefix, Map<String, String> nameTitleMap, @Nullable Collection<? extends Attachment> attachments)
     {
+        _allowSubstitutions = handleSubstitutions;
         _hrefPrefix = hrefPrefix;
         _attachPrefix = attachPrefix;
         _nameTitleMap = nameTitleMap == null ? new HashMap<>() : nameTitleMap;
@@ -237,97 +234,103 @@ public class HtmlRenderer implements WikiRenderer
     {
         if (text == null)
             return new FormattedHtml(HtmlString.EMPTY_STRING);
-        
-        // Find all substitution templates embedded in wiki text that have the form ${labkey.<type>(<any_stream of characters>)}.
-        Matcher webPartMatcher = _substitutionPattern.matcher(text);
 
-        // If we find none, return immediately
-        if (!webPartMatcher.find())
-            return new FormattedHtml(HtmlString.unsafe(text));
-
-        List<Definition> definitions = new ArrayList<>(10);
-        Map<Definition, List<String>> wikiErrors = new HashMap<>();
-        do
-        {
-            List<String> paramErrors = new ArrayList<>();
-            String substitutionType = webPartMatcher.group(1);          // type
-            String params = webPartMatcher.group(2).replace(",", "");
-            // Parse the parameters with the symbols in parseWith, they can be used in any order
-            // as long as they are the same symbol starts and completes a parameter value
-            List<String> paramList = new ArrayList<>();
-            paramList.add(params);
-            String[] parseWith = { "&#39;", "'" };
-            for (String parser : parseWith)
-            {
-                List<String> paramListTemp = new ArrayList<>();
-                for (String paramSection : paramList)
-                {
-                    String[] paramSplit = paramSection.split(parser);
-                    for (int i = 0; i < paramSplit.length; i+=2)
-                    {
-                        paramListTemp.add(paramSplit[i] + (paramSplit.length > i + 1 ? "'" + paramSplit[i+1]  + "'": ""));
-                    }
-                }
-                paramList = paramListTemp;
-            }
-
-            Map<String, String> paramMap = new HashMap<>(10);
-            for (String param : paramList)
-            {
-                Matcher paramMatcher = _paramPattern.matcher(param);
-
-                if (paramMatcher.matches())
-                {
-                    if (paramMap.containsKey(paramMatcher.group(1)))
-                        paramErrors.add(param.trim() + ", there are multiple parameters with this name");
-                    else
-                        paramMap.put(paramMatcher.group(1), paramMatcher.group(2));
-                }
-                else if (param.trim().length() > 0)
-                    paramErrors.add(param.trim());
-            }
-
-            // Stick new definition at beginning of list -- we want to replace them in reverse order
-            Definition definition = new Definition(substitutionType, webPartMatcher.start(), webPartMatcher.end(), paramMap);
-            definitions.add(0, definition);
-            wikiErrors.put(definition, paramErrors);
-        }
-        while(webPartMatcher.find());
-
-        StringBuilder sb = new StringBuilder(text);
         boolean volatilePage = false;
         LinkedHashSet<ClientDependency> cds = new LinkedHashSet<>();
 
-        // Get the corresponding substitution handler for each type and replace template with substitution
-        for (Definition definition : definitions)
+        if (_allowSubstitutions)
         {
-            SubstitutionHandler handler = _substitutionHandlers.get(definition.getType());
-            FormattedHtml substitution;
+            // Find all substitution templates embedded in wiki text that have the form ${labkey.<type>(<any_stream of characters>)}.
+            Matcher webPartMatcher = _substitutionPattern.matcher(text);
 
-            if (null != handler)
-                substitution = handler.getSubstitution(definition.getParams());
-            else
-                substitution = new FormattedHtml(HtmlString.unsafe("<br><font class='error' color='red'>Error: unknown type, \"labkey." + PageFlowUtil.filter(definition.getType()) + "\"</font>"));
+            // If we find none, return immediately
+            if (!webPartMatcher.find())
+                return new FormattedHtml(HtmlString.unsafe(text));
 
-            sb.replace(definition.getStart(), definition.getEnd(), substitution.getHtml().toString());
-
-            if (substitution.isVolatile())
-                volatilePage = true;
-
-            cds.addAll(substitution.getClientDependencies());
-
-            List<String> paramErrors = wikiErrors.get(definition);
-            if (paramErrors.size() > 0)
+            List<Definition> definitions = new ArrayList<>(10);
+            Map<Definition, List<String>> wikiErrors = new HashMap<>();
+            do
             {
-                String errorHTML = "<br>";
-                for (String error : paramErrors)
-                    errorHTML = errorHTML.concat("<font class='error' color='red'>Error with parameter " +
-                            error + " in " + definition.getType() + "</font><br><br>");
-                sb.insert(definition.getStart() + substitution.getHtml().toString().length(), errorHTML);
+                List<String> paramErrors = new ArrayList<>();
+                String substitutionType = webPartMatcher.group(1);          // type
+                String params = webPartMatcher.group(2).replace(",", "");
+                // Parse the parameters with the symbols in parseWith, they can be used in any order
+                // as long as they are the same symbol starts and completes a parameter value
+                List<String> paramList = new ArrayList<>();
+                paramList.add(params);
+                String[] parseWith = {"&#39;", "'"};
+                for (String parser : parseWith)
+                {
+                    List<String> paramListTemp = new ArrayList<>();
+                    for (String paramSection : paramList)
+                    {
+                        String[] paramSplit = paramSection.split(parser);
+                        for (int i = 0; i < paramSplit.length; i += 2)
+                        {
+                            paramListTemp.add(paramSplit[i] + (paramSplit.length > i + 1 ? "'" + paramSplit[i + 1] + "'" : ""));
+                        }
+                    }
+                    paramList = paramListTemp;
+                }
+
+                Map<String, String> paramMap = new HashMap<>(10);
+                for (String param : paramList)
+                {
+                    Matcher paramMatcher = _paramPattern.matcher(param);
+
+                    if (paramMatcher.matches())
+                    {
+                        if (paramMap.containsKey(paramMatcher.group(1)))
+                            paramErrors.add(param.trim() + ", there are multiple parameters with this name");
+                        else
+                            paramMap.put(paramMatcher.group(1), paramMatcher.group(2));
+                    }
+                    else if (!param.trim().isEmpty())
+                        paramErrors.add(param.trim());
+                }
+
+                // Stick new definition at beginning of list -- we want to replace them in reverse order
+                Definition definition = new Definition(substitutionType, webPartMatcher.start(), webPartMatcher.end(), paramMap);
+                definitions.add(0, definition);
+                wikiErrors.put(definition, paramErrors);
             }
+            while (webPartMatcher.find());
+
+            StringBuilder sb = new StringBuilder(text);
+
+            // Get the corresponding substitution handler for each type and replace template with substitution
+            for (Definition definition : definitions)
+            {
+                SubstitutionHandler handler = _substitutionHandlers.get(definition.getType());
+                FormattedHtml substitution;
+
+                if (null != handler)
+                    substitution = handler.getSubstitution(definition.getParams());
+                else
+                    substitution = new FormattedHtml(HtmlString.unsafe("<br><font class='error' color='red'>Error: unknown type, \"labkey." + PageFlowUtil.filter(definition.getType()) + "\"</font>"));
+
+                sb.replace(definition.getStart(), definition.getEnd(), substitution.getHtml().toString());
+
+                if (substitution.isVolatile())
+                    volatilePage = true;
+
+                cds.addAll(substitution.getClientDependencies());
+
+                List<String> paramErrors = wikiErrors.get(definition);
+                if (!paramErrors.isEmpty())
+                {
+                    String errorHTML = "<br>";
+                    for (String error : paramErrors)
+                        errorHTML = errorHTML.concat("<font class='error' color='red'>Error with parameter " +
+                                error + " in " + definition.getType() + "</font><br><br>");
+                    sb.insert(definition.getStart() + substitution.getHtml().toString().length(), errorHTML);
+                }
+            }
+
+            text = sb.toString();
         }
 
-        return new FormattedHtml(HtmlString.unsafe(sb.toString()), volatilePage, cds);
+        return new FormattedHtml(HtmlString.unsafe(text), volatilePage, cds);
     }
 
 

--- a/core/src/org/labkey/core/wiki/MarkdownRenderer.java
+++ b/core/src/org/labkey/core/wiki/MarkdownRenderer.java
@@ -28,7 +28,7 @@ public class MarkdownRenderer extends HtmlRenderer
 {
     public MarkdownRenderer(String hrefPrefix, String attachPrefix, Map<String, String> nameTitleMap, @Nullable Collection<? extends Attachment> attachments)
     {
-        super(hrefPrefix, attachPrefix, nameTitleMap, attachments);
+        super(false, hrefPrefix, attachPrefix, nameTitleMap, attachments);
     }
 
     @Override

--- a/core/src/org/labkey/core/wiki/WikiRenderingServiceImpl.java
+++ b/core/src/org/labkey/core/wiki/WikiRenderingServiceImpl.java
@@ -26,45 +26,32 @@ public class WikiRenderingServiceImpl implements WikiRenderingService
     public HtmlString getFormattedHtml(WikiRendererType rendererType,
                                        String source,
                                        @Nullable String sourceDescription,
+                                       boolean handleSubstitutions,
                                        String attachPrefix,
                                        Collection<? extends Attachment> attachments)
     {
         return HtmlStringBuilder.of(WIKI_PREFIX)
-            .append(getRenderer(rendererType, null, attachPrefix, null, attachments, sourceDescription).format(source).getHtml())
+            .append(getRenderer(rendererType, handleSubstitutions, null, attachPrefix, null, attachments, sourceDescription).format(source).getHtml())
             .append(WIKI_SUFFIX).getHtmlString();
     }
 
     @Override
     public HtmlString getFormattedHtml(WikiRendererType rendererType, String source, @Nullable String sourceDescription)
     {
-        return getFormattedHtml(rendererType, source, sourceDescription, null, null);
+        return getFormattedHtml(rendererType, source, sourceDescription, false, null, null);
     }
 
     @Override
-    public WikiRenderer getRenderer(WikiRendererType rendererType, String hrefPrefix,
+    public WikiRenderer getRenderer(WikiRendererType rendererType, boolean handleSubstitutions, String hrefPrefix,
                                     String attachPrefix, Map<String, String> nameTitleMap,
                                     Collection<? extends Attachment> attachments, String sourceDescription)
     {
-        WikiRenderer renderer;
-
-        switch (rendererType)
+        return switch (rendererType)
         {
-            case RADEOX:
-                renderer = new RadeoxRenderer(hrefPrefix, attachPrefix, nameTitleMap, attachments, sourceDescription);
-                break;
-            case HTML:
-                renderer = new HtmlRenderer(hrefPrefix, attachPrefix, nameTitleMap, attachments);
-                break;
-            case TEXT_WITH_LINKS:
-                renderer = new PlainTextRenderer();
-                break;
-            case MARKDOWN:
-                renderer = new MarkdownRenderer(hrefPrefix, attachPrefix, nameTitleMap, attachments);
-                break;
-            default:
-                renderer = new RadeoxRenderer(null, attachPrefix, null, attachments, sourceDescription);
-        }
-
-        return renderer;
+            case RADEOX -> new RadeoxRenderer(hrefPrefix, attachPrefix, nameTitleMap, attachments, sourceDescription);
+            case HTML -> new HtmlRenderer(handleSubstitutions, hrefPrefix, attachPrefix, nameTitleMap, attachments);
+            case TEXT_WITH_LINKS -> new PlainTextRenderer();
+            case MARKDOWN -> new MarkdownRenderer(hrefPrefix, attachPrefix, nameTitleMap, attachments);
+        };
     }
 }

--- a/wiki/src/org/labkey/wiki/RenderedWikiResource.java
+++ b/wiki/src/org/labkey/wiki/RenderedWikiResource.java
@@ -22,11 +22,6 @@ import org.labkey.api.wiki.WikiRenderingService;
 
 import java.util.Map;
 
-/**
- * User: adam
- * Date: Oct 13, 2010
- * Time: 4:38:09 PM
- */
 public class RenderedWikiResource extends WikiWebdavProvider.WikiPageResource
 {
     public RenderedWikiResource(Container c, String name, String entityId, String body, WikiRendererType rendererType, Map<String, Object> m)
@@ -51,6 +46,6 @@ public class RenderedWikiResource extends WikiWebdavProvider.WikiPageResource
     {
         WikiRenderingService service = WikiRenderingService.get();
 
-        return service.getFormattedHtml(type, body, "Wiki WebDav '" + getName() + "' in " + _c.getPath());
+        return service.getFormattedHtml(type, body, "Wiki WebDav '" + getName() + "' in " + _c.getPath(), true, null, null);
     }
 }

--- a/wiki/src/org/labkey/wiki/model/WikiVersion.java
+++ b/wiki/src/org/labkey/wiki/model/WikiVersion.java
@@ -217,7 +217,7 @@ public class WikiVersion
         if (_rendererType == null)
             _rendererType = WikiManager.DEFAULT_WIKI_RENDERER_TYPE;
 
-        return WikiRenderingService.get().getRenderer(_rendererType, hrefPrefix, attachPrefix, nameTitleMap, attachments, sourceDescription);
+        return WikiRenderingService.get().getRenderer(_rendererType, true, hrefPrefix, attachPrefix, nameTitleMap, attachments, sourceDescription);
     }
 
     // Cache the rendered wiki content by default; set to false to avoid caching


### PR DESCRIPTION
#### Rationale
We want to support webpart and dependency substitutions in HTML wikis, but not announcements or Markdown wikis. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52214

Pass a flag through `WikiRenderingService` methods to a new configuration parameter on `HtmlRenderer()`.