### PR TITLE
Issue 52254: Folder admins cannot choose a template folder

### DIFF
--- a/core/src/org/labkey/core/admin/createFolder.jsp
+++ b/core/src/org/labkey/core/admin/createFolder.jsp
@@ -622,7 +622,7 @@
         const getTemplateFolders = function(data) {
             // add the container itself to the templateFolder object if it is not the root and the user has admin perm to it
             // and if it is not a workbook or container tab folder
-            if (data.path !== "/" && LABKEY.Security.hasEffectivePermission(data.effectivePermissions, LABKEY.Security.effectivePermissions.admin)
+            if (data.path !== "/" && data.effectivePermissions && LABKEY.Security.hasEffectivePermission(data.effectivePermissions, LABKEY.Security.effectivePermissions.admin)
                     && !data.isWorkbook && !data.isContainerTab)
             {
                 templateFolders.push([data.id, data.path]);


### PR DESCRIPTION
#### Rationale
Folder admins don't have access to the root container, so `getContainers` sends neither an `effectivePermissions` array nor a `path`.

The old behavior was to call `LABKEY.Security.hasPermission()` which did a bitwise AND, so therefore tolerated an undefined value

https://github.com/LabKey/platform/pull/5718

#### Changes
- Check if we have permissions to review