### PR TITLE
Issue 51682: Improve logging for ClosedWatchServiceException

### DIFF
--- a/api/src/org/labkey/api/files/FileSystemWatcherImpl.java
+++ b/api/src/org/labkey/api/files/FileSystemWatcherImpl.java
@@ -175,15 +175,23 @@ public class FileSystemWatcherImpl implements FileSystemWatcher
 
         // ensure we catch variations such as both nfs and nfs4
         boolean pollingWatcher = null != fileStoreType && (fileStoreType.startsWith("cifs") || fileStoreType.startsWith("smbfs") || fileStoreType.startsWith("nfs"));
-        if (pollingWatcher)
+        try
         {
-            LOG.debug("Detected network file system type '" + fileStoreType + "'. Create polling file watcher service and register this directory there for directory: " + directory.toAbsolutePath());
-            watchKey = _pollingWatcher.register(directory, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
+            if (pollingWatcher)
+            {
+                LOG.debug("Detected network file system type '" + fileStoreType + "'. Create polling file watcher service and register this directory there for directory: " + directory.toAbsolutePath());
+                watchKey = _pollingWatcher.register(directory, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
+            }
+            else
+            {
+                LOG.debug("Detected local file system type '" + fileStoreType + "'. Register path with standard watcher service for directory: " + directory.toAbsolutePath());
+                watchKey = directory.register(_watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);  // Register all events (future listener might request events that current listener doesn't)
+            }
         }
-        else
+        catch (ClosedWatchServiceException e)
         {
-            LOG.debug("Detected local file system type '" + fileStoreType + "'. Register path with standard watcher service for directory: " + directory.toAbsolutePath());
-            watchKey = directory.register(_watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);  // Register all events (future listener might request events that current listener doesn't)
+            LOG.error("WatchService registration failed for {}", directory, e);
+            throw e;
         }
 
         plm.setFileStoreType(fileStoreType);


### PR DESCRIPTION
#### Rationale
It's easier to troubleshoot problems with file system watcher registration if you know which files/paths are involved.

#### Changes
- Log the path when the exception is thrown