### PR TITLE
Try draining the indexer's queue before deleting to avoid deadlocks

### DIFF
--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 public interface SearchService extends SearchMXBean
@@ -112,6 +113,12 @@ public interface SearchService extends SearchMXBean
      * Delete the index documents for any files in a container then start a new crawler task for just that container
      */
     void reindexContainerFiles(Container c);
+
+    /**
+     * Puts work in the indexer queue at the specified priority and waits up to the timeout for it to complete
+     * @return true if the task in the queue completed before the timeout
+     */
+    boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit) throws InterruptedException;
 
     enum PRIORITY
     {

--- a/core/src/org/labkey/core/search/NoopSearchService.java
+++ b/core/src/org/labkey/core/search/NoopSearchService.java
@@ -198,6 +198,12 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
+    public boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit)
+    {
+        return true;
+    }
+
+    @Override
     public void addPathToCrawl(Path path, Date d)
     {
     }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
@@ -100,6 +100,8 @@
 <%@ page import="org.labkey.api.data.Sort" %>
 <%@ page import="org.labkey.api.exp.api.DataClassDomainKindProperties" %>
 <%@ page import="org.labkey.api.action.ApiUsageException" %>
+<%@ page import="org.labkey.api.search.SearchService" %>
+<%@ page import="java.util.concurrent.TimeUnit" %>
 
 <%@ page extends="org.labkey.api.jsp.JspTest.BVT" %>
 
@@ -118,8 +120,10 @@ public void setUp()
 }
 
 @After
-public void tearDown()
+public void tearDown() throws InterruptedException
 {
+    // Wait for the indexer to finish working on the data we just added to help avoid deadlocks
+    SearchService.get().drainQueue(SearchService.PRIORITY.crawl, 15, TimeUnit.SECONDS);
     ContainerManager.deleteAll(c, TestContext.get().getUser());
 }
 

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
@@ -90,6 +90,8 @@
 <%@ page import="org.labkey.api.reader.MapLoader" %>
 <%@ page import="org.labkey.api.action.ApiUsageException" %>
 <%@ page import="org.labkey.api.exp.api.ExpLineageService" %>
+<%@ page import="org.labkey.api.search.SearchService" %>
+<%@ page import="java.util.concurrent.TimeUnit" %>
 
 <%@ page extends="org.labkey.api.jsp.JspTest.BVT" %>
 
@@ -114,8 +116,10 @@ public void setUp()
 }
 
 @After
-public void tearDown()
+public void tearDown() throws InterruptedException
 {
+    // Wait for the indexer to finish working on the data we just added to help avoid deadlocks
+    SearchService.get().drainQueue(SearchService.PRIORITY.crawl, 15, TimeUnit.SECONDS);
     ContainerManager.deleteAll(c, TestContext.get().getUser());
 }
 

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -861,22 +861,7 @@ public class SearchController extends SpringActionController
         public void export(PriorityForm form, HttpServletResponse response, BindException errors) throws Exception
         {
             SearchService ss = SearchService.get();
-            final CountDownLatch latch = new CountDownLatch(1);
-
-            SearchService.IndexTask task = ss.createTask("WaitForIndexer", new SearchService.TaskListener()
-            {
-                @Override public void success()
-                {
-                    latch.countDown();
-                }
-                @Override public void indexError(Resource r, Throwable t) { }
-            });
-            task.addNoop(form.getPriority());
-            task.setReady();
-
-            boolean success = latch.await(5, TimeUnit.MINUTES);
-            if (ss instanceof LuceneSearchServiceImpl)
-                ((LuceneSearchServiceImpl)ss).refreshNow();
+            boolean success = ss.drainQueue(form.getPriority(), 5, TimeUnit.MINUTES);
 
             // Return an error if we time out
             if (!success)

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -34,6 +34,7 @@ import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.resource.Resource;
 import org.labkey.api.search.SearchResultTemplate;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
@@ -74,6 +75,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -600,6 +602,26 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     }
 
     @Override
+    public boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit) throws InterruptedException
+    {
+        final CountDownLatch latch = new CountDownLatch(1);
+        SearchService.IndexTask task = createTask("WaitForIndexer", new SearchService.TaskListener()
+        {
+            @Override public void success()
+            {
+                latch.countDown();
+            }
+            @Override public void indexError(Resource r, Throwable t) { }
+        });
+        task.addNoop(priority);
+        task.setReady();
+
+        boolean success = latch.await(timeout, unit);
+        refreshNow();
+        return success;
+    }
+
+    @Override
     public void notFound(URLHelper in)
     {
         try
@@ -725,7 +747,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         {
             Pair<String, String> resourceResolverKeyIdentifier = getResourceResolverKeyIdentifier(resourceIdentifier);
             if (resourceResolverKeyIdentifier == null)
-                continue;;
+                continue;
             resolverIdentifiers
                     .computeIfAbsent(resourceResolverKeyIdentifier.first, (k) -> new HashMap<>())
                     .put(resourceResolverKeyIdentifier.second, resourceIdentifier);

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -143,6 +143,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
@@ -1104,6 +1105,25 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         }
     }
 
+    @Override
+    public boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit) throws InterruptedException
+    {
+        final CountDownLatch latch = new CountDownLatch(1);
+        SearchService.IndexTask task = createTask("WaitForIndexer", new SearchService.TaskListener()
+        {
+            @Override public void success()
+            {
+                latch.countDown();
+            }
+            @Override public void indexError(Resource r, Throwable t) { }
+        });
+        task.addNoop(priority);
+        task.setReady();
+
+        boolean success = latch.await(timeout, unit);
+        refreshNow();
+        return success;
+    }
 
     /**
      * This method is used to indicate to the crawler (or any external process) which files

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -1105,26 +1105,6 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         }
     }
 
-    @Override
-    public boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit) throws InterruptedException
-    {
-        final CountDownLatch latch = new CountDownLatch(1);
-        SearchService.IndexTask task = createTask("WaitForIndexer", new SearchService.TaskListener()
-        {
-            @Override public void success()
-            {
-                latch.countDown();
-            }
-            @Override public void indexError(Resource r, Throwable t) { }
-        });
-        task.addNoop(priority);
-        task.setReady();
-
-        boolean success = latch.await(timeout, unit);
-        refreshNow();
-        return success;
-    }
-
     /**
      * This method is used to indicate to the crawler (or any external process) which files
      * this indexer will not index.


### PR DESCRIPTION
#### Rationale
We get intermittent deadlocks in tests like `ExpSampleTypeTestCase.jsp` where the post-test container delete conflicts with the indexing work initiated by the test's import.

https://teamcity.labkey.org/buildConfiguration/LabKey_2411_External_Ehr_BvtEhrSqlserver/3377344

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52257

#### Changes
- Try letting the indexer finish the queued work before deleting the container