### PR TITLE
Issue 52247: DataRegion.renderForm updates to move _groupTables table generation to after form table generation

### DIFF
--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -2187,6 +2187,53 @@ public class DataRegion extends DisplayElement
                 renderedColumns.add(renderer.getColumnInfo().getName());
         }
 
+        //Make sure all pks are included
+        if (action == MODE_UPDATE)
+        {
+            out.write("<tr><td colspan=\"" + (span + 1) + "\" align=\"left\">");
+
+            // Note: valueMap != null, since we checked this above
+
+            if (valueMap instanceof BoundMap)
+                renderOldValues(out, valueMap);
+            else
+                renderOldValues(out, valueMap, ctx.getFieldMap());
+
+            TableViewForm viewForm = ctx.getForm();
+            List<ColumnInfo> pkCols = getTable().getPkColumns();
+            for (ColumnInfo pkCol : pkCols)
+            {
+                String pkColName = pkCol.getName();
+                if (!renderedColumns.contains(pkColName))
+                {
+                    Object pkVal = null;
+                    //UNDONE: Should we require a viewForm whenever someone
+                    //posts? I tend to think so.
+                    if (null != viewForm)
+                        pkVal = viewForm.get(pkColName);
+
+                    if (pkVal == null)
+                        pkVal = valueMap.get(pkColName);
+
+                    if (null != pkVal)
+                    {
+                        out.write("<input type='hidden' name='");
+                        if (viewForm != null)
+                            out.write(PageFlowUtil.filter(viewForm.getFormFieldName(pkCol)));
+                        else
+                            out.write(PageFlowUtil.filter(pkColName));
+                        out.write("' value=\"");
+                        out.write(PageFlowUtil.filter(pkVal.toString()));
+                        out.write("\">");
+                    }
+                    renderedColumns.add(pkColName);
+                }
+            }
+
+            out.write("</td></tr>");
+        }
+        out.write("</table>");
+
         if (!_groupTables.isEmpty())
         {
             out.write("<table class=\"labkey-group-tables\">");
@@ -2309,51 +2356,6 @@ public class DataRegion extends DisplayElement
             out.write("</table>");
         }
 
-        out.write("<tr><td colspan=\"" + (span + 1) + "\" align=\"left\">");
-
-        //Make sure all pks are included
-        if (action == MODE_UPDATE)
-        {
-            // Note: valueMap != null, since we checked this above
-
-            if (valueMap instanceof BoundMap)
-                renderOldValues(out, valueMap);
-            else
-                renderOldValues(out, valueMap, ctx.getFieldMap());
-
-            TableViewForm viewForm = ctx.getForm();
-            List<ColumnInfo> pkCols = getTable().getPkColumns();
-            for (ColumnInfo pkCol : pkCols)
-            {
-                String pkColName = pkCol.getName();
-                if (!renderedColumns.contains(pkColName))
-                {
-                    Object pkVal = null;
-                    //UNDONE: Should we require a viewForm whenever someone
-                    //posts? I tend to think so.
-                    if (null != viewForm)
-                        pkVal = viewForm.get(pkColName);
-
-                    if (pkVal == null)
-                        pkVal = valueMap.get(pkColName);
-
-                    if (null != pkVal)
-                    {
-                        out.write("<input type='hidden' name='");
-                        if (viewForm != null)
-                            out.write(viewForm.getFormFieldName(pkCol));
-                        else
-                            out.write(pkColName);
-                        out.write("' value=\"");
-                        out.write(PageFlowUtil.filter(pkVal.toString()));
-                        out.write("\">");
-                    }
-                    renderedColumns.add(pkColName);
-                }
-            }
-        }
-
-        out.write("</td></tr></table>");
         buttonBar.render(ctx, out);
         renderFormEnd(ctx, out);
     }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=52247

When the DataRegion.renderForm() is dealing with a "groupTable" case, like in the Luminex 3rd step of the upload wizard that renders the table version of the form inputs for the analyte properties, the generated HTML can include a `<table>` within a `<table>` in a way that is not properly closing the other table related HTML elements. This PR moves that groupTable HTML generation to after the single form table generation is properly closing the related elements.

#### Changes
- move _groupTables table generation to after form table generation
- encode the name prop of the hidden input for the PK column
