### PR TITLE
Issue 51682: Don't add file watchers after shutting down service

### DIFF
--- a/api/src/org/labkey/api/files/FileSystemWatcherImpl.java
+++ b/api/src/org/labkey/api/files/FileSystemWatcherImpl.java
@@ -77,6 +77,7 @@ public class FileSystemWatcherImpl implements FileSystemWatcher
     private static final Logger LOG = LogHelper.getLogger(FileSystemWatcherImpl.class, "Open file system handlers and listeners");
     private static final long POLLING_PERIOD_SECONDS = 30L;
 
+    private boolean _closed = false;
     private final WatchService _watcher;
     private final ConcurrentMap<Path, PathListenerManager> _listenerMap = new ConcurrentHashMap<>(1000);
     private final PathWatchService _pollingWatcher;
@@ -167,6 +168,12 @@ public class FileSystemWatcherImpl implements FileSystemWatcher
 
     private void registerWithWatchService(Path directory, PathListenerManager plm) throws IOException
     {
+        if (_closed)
+        {
+            LOG.warn("Unable to register a file listener on {}, service is already closed", directory);
+            return;
+        }
+
         String fileStoreType = Files.getFileStore(directory).type();
         if (null != fileStoreType)
             fileStoreType = fileStoreType.toLowerCase();
@@ -322,6 +329,7 @@ public class FileSystemWatcherImpl implements FileSystemWatcher
         @Override
         protected void close()
         {
+            _closed = true;
             try
             {
                 _watcher.close();


### PR DESCRIPTION
#### Rationale
When there's a startup problem, sometimes Spring Boot shuts down the webapp while it's still in its startup sequence. This can result in confusing logging about failing to register a file watcher.

#### Changes
- Don't throw exceptions when someone tries to add a new file watcher after the service has been closed - use a `WARN` message