### PR TITLE
Ensure maintenance task and optional feature flag startup property names are valid

### DIFF
--- a/api/src/org/labkey/api/settings/AdminConsole.java
+++ b/api/src/org/labkey/api/settings/AdminConsole.java
@@ -15,12 +15,16 @@
  */
 package org.labkey.api.settings;
 
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.settings.OptionalFeatureService.FeatureType;
+import org.labkey.api.util.StringUtilsLabKey;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 
 import java.util.Collection;
@@ -59,6 +63,7 @@ public class AdminConsole
         }
     }
 
+    private static final Logger LOG = LogHelper.getLogger(AdminConsole.class, "Warnings about optional feature flag names");
     private static final Map<SettingsLinkType, Collection<AdminLink>> _links = new HashMap<>();
     private static final Set<OptionalFeatureFlag> _optionalFlags = new ConcurrentSkipListSet<>();
 
@@ -138,6 +143,10 @@ public class AdminConsole
         }
     }
 
+    /**
+     * @param flag must be unique. Can be used as a startup property to enable/disable the task, but only if it follows
+     *             the Java identifier rules (e.g., alphanumeric plus _, start with a letter, no spaces).
+     */
     public static void addExperimentalFeatureFlag(String flag, String title, String description, boolean requiresRestart)
     {
         addOptionalFeatureFlag(new OptionalFeatureFlag(flag, title, description, requiresRestart, false, FeatureType.Experimental));
@@ -171,6 +180,10 @@ public class AdminConsole
         private final boolean _hidden;
         private final FeatureType _type;
 
+        /**
+         * @param flag must be unique. Can be used as a startup property to enable/disable the task, but only if it follows
+         *             the Java identifier rules (e.g., alphanumeric plus _, start with a letter, no spaces).
+         */
         public OptionalFeatureFlag(String flag, String title, String description, boolean requiresRestart, boolean hidden, FeatureType type)
         {
             _flag = flag;
@@ -225,11 +238,20 @@ public class AdminConsole
 
         // StartupProperty implementation
 
-        @NotNull
+        /**
+         *  Returns {@code null} if {@code getFlag()} does not conform to the property name rules.
+         */
+        @Nullable
         @Override
         public String getPropertyName()
         {
-            return getFlag();
+            String name = getFlag();
+            if (!StringUtilsLabKey.isValidJavaIdentifier(name))
+            {
+                LOG.debug("Feature flag name doesn't conform to the property name rules so it won't be available as a startup property: {}", name);
+                name = null;
+            }
+            return name;
         }
     }
 }

--- a/api/src/org/labkey/api/settings/OptionalFeatureStartupListener.java
+++ b/api/src/org/labkey/api/settings/OptionalFeatureStartupListener.java
@@ -32,7 +32,9 @@ public class OptionalFeatureStartupListener implements StartupListener
             super(
                 SCOPE_OPTIONAL_FEATURE,
                 OptionalFeatureFlag.class.getName(),
-                AdminConsole.getOptionalFeatureFlags().stream().sorted(Comparator.comparing(OptionalFeatureFlag::getPropertyName, String.CASE_INSENSITIVE_ORDER))
+                AdminConsole.getOptionalFeatureFlags().stream()
+                    .filter(flag -> flag.getPropertyName() != null)
+                    .sorted(Comparator.comparing(OptionalFeatureFlag::getPropertyName, String.CASE_INSENSITIVE_ORDER))
             );
         }
 

--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -947,7 +947,7 @@ public class StringUtilsLabKey
             assertTrue(isValidJavaIdentifier("abc"));
             assertTrue(isValidJavaIdentifier("Abc123"));
             assertTrue(isValidJavaIdentifier("This_and_that"));
-            assertTrue(isValidJavaIdentifier("This$andthat"));
+            assertTrue(isValidJavaIdentifier("This$and$that"));
             assertTrue(isValidJavaIdentifier("This_"));
             assertTrue(isValidJavaIdentifier("This$"));
             assertTrue(isValidJavaIdentifier("_ABC"));

--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -546,6 +546,25 @@ public class StringUtilsLabKey
         return fullTrimToEmpty(replaceSeparators(stringVal));
     }
 
+    /**
+     * Tests whether the provided string could be used as a Java identifier or part of a name in a property file. Does
+     * not check for Java keywords.
+     */
+    public static boolean isValidJavaIdentifier(@Nullable String test)
+    {
+        boolean valid = !StringUtils.isBlank(test);
+        if (valid)
+        {
+            valid = Character.isJavaIdentifierStart(test.charAt(0));
+            int i = 1;
+            while (valid && i < test.length())
+            {
+                valid = Character.isJavaIdentifierPart(test.charAt(i++));
+            }
+        }
+        return valid;
+    }
+
     public static class TestCase extends Assert
     {
         @Test
@@ -908,6 +927,31 @@ public class StringUtilsLabKey
         {
             List<String> strings = Arrays.asList(elements);
             assertEquals(expected, joinWithConjunction(strings, "and"));
+        }
+
+        @Test
+        public void testIsValidIdentifier()
+        {
+            assertFalse(isValidJavaIdentifier(null));
+            assertFalse(isValidJavaIdentifier(""));
+            assertFalse(isValidJavaIdentifier(" "));
+            assertFalse(isValidJavaIdentifier("   "));
+            assertFalse(isValidJavaIdentifier("1"));
+            assertFalse(isValidJavaIdentifier("123"));
+            assertFalse(isValidJavaIdentifier("I have spaces"));
+            assertFalse(isValidJavaIdentifier("!niceTry"));
+
+            assertTrue(isValidJavaIdentifier("A"));
+            assertTrue(isValidJavaIdentifier("$"));
+            assertTrue(isValidJavaIdentifier("ABC"));
+            assertTrue(isValidJavaIdentifier("abc"));
+            assertTrue(isValidJavaIdentifier("Abc123"));
+            assertTrue(isValidJavaIdentifier("This_and_that"));
+            assertTrue(isValidJavaIdentifier("This$andthat"));
+            assertTrue(isValidJavaIdentifier("This_"));
+            assertTrue(isValidJavaIdentifier("This$"));
+            assertTrue(isValidJavaIdentifier("_ABC"));
+            assertTrue(isValidJavaIdentifier("$ABC"));
         }
     }
 }

--- a/api/src/org/labkey/api/util/SystemMaintenance.java
+++ b/api/src/org/labkey/api/util/SystemMaintenance.java
@@ -303,7 +303,6 @@ public class SystemMaintenance
         /**
          * Specify if the task is meant to be configurable / recurring and therefore shown in the group of maintenance
          * tasks that can be enabled / disabled as part of the daily/nightly schedule.
-         *
          * Note: If your task is associated with a Java upgrade code method then you probably don't need to override
          * this or have a maintenance task at all. Administrators can now invoke any Java upgrade code methods from
          * the link on the SQL Scripts page.
@@ -314,8 +313,8 @@ public class SystemMaintenance
         }
 
         /**
-         * For StartupProperty implementation. Will return null if the maintenance task's getName() does not conform
-         * to property name rules.
+         * For StartupProperty implementation. Returns {@code null} if {@code getName()} does not conform to property
+         * name rules.
          */
         @Override
         @Nullable

--- a/api/src/org/labkey/api/util/SystemMaintenance.java
+++ b/api/src/org/labkey/api/util/SystemMaintenance.java
@@ -46,7 +46,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 /**
- * Manages scheduling and queuing system maintenance tasks.
+ * Manages scheduling and queuing of system maintenance tasks.
  */
 public class SystemMaintenance
 {
@@ -314,13 +314,15 @@ public class SystemMaintenance
         }
 
         /**
-         * For StartupProperty implementation
+         * For StartupProperty implementation. Will return null if the maintenance task's getName() does not conform
+         * to property name rules.
          */
         @Override
-        @NotNull
+        @Nullable
         default String getPropertyName()
         {
-            return getName();
+            String name = getName();
+            return StringUtilsLabKey.isValidJavaIdentifier(name) ? name : null;
         }
     }
 }

--- a/api/src/org/labkey/api/util/SystemMaintenance.java
+++ b/api/src/org/labkey/api/util/SystemMaintenance.java
@@ -23,7 +23,9 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.PropertyManager;
 import org.labkey.api.data.PropertyManager.WritablePropertyMap;
 import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.settings.StartupProperty;
+import org.labkey.api.util.logging.LogHelper;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
@@ -50,6 +52,7 @@ import java.util.stream.Collectors;
  */
 public class SystemMaintenance
 {
+    private static final Logger LOG = LogHelper.getLogger(AdminConsole.class, "Warnings about maintenance task names");
     private static final Object TIMER_LOCK = new Object();
     private static final List<MaintenanceTask> TASKS = new CopyOnWriteArrayList<>();
     private static final TriggerKey TRIGGER_KEY = new TriggerKey(SystemMaintenance.class.getCanonicalName());
@@ -313,15 +316,20 @@ public class SystemMaintenance
         }
 
         /**
-         * For StartupProperty implementation. Returns {@code null} if {@code getName()} does not conform to property
-         * name rules.
+         * For StartupProperty implementation. Returns {@code null} if {@code getName()} does not conform to the
+         * property name rules.
          */
         @Override
         @Nullable
         default String getPropertyName()
         {
             String name = getName();
-            return StringUtilsLabKey.isValidJavaIdentifier(name) ? name : null;
+            if (!StringUtilsLabKey.isValidJavaIdentifier(name))
+            {
+                LOG.debug("Maintenance task name doesn't conform to the property name rules so it won't be available as a startup property: {}", name);
+                name = null;
+            }
+            return name;
         }
     }
 }

--- a/api/src/org/labkey/api/util/SystemMaintenanceStartupListener.java
+++ b/api/src/org/labkey/api/util/SystemMaintenanceStartupListener.java
@@ -37,6 +37,7 @@ public class SystemMaintenanceStartupListener implements StartupListener
                 MaintenanceTask.class.getName(),
                 SystemMaintenance.getTasks().stream()
                     .filter(MaintenanceTask::canDisable)
+                    .filter(task -> task.getPropertyName() != null)
                     .sorted(Comparator.comparing(MaintenanceTask::getPropertyName, String.CASE_INSENSITIVE_ORDER))
             );
         }

--- a/experiment/src/org/labkey/experiment/api/FieldNamesTable.java
+++ b/experiment/src/org/labkey/experiment/api/FieldNamesTable.java
@@ -22,6 +22,7 @@ public class FieldNamesTable extends BaseFieldNamesTable
     @Override
     protected void addColumnSQL(SQLFragment sql)
     {
+        // Note that within a range expression, LIKE wildcards (such as underscore) don't need to be escaped
         addBooleanPatternColumn(sql, "pd.Name NOT", "%[^A-Za-z0-9_]%", "AlphaNumeric");
         addBooleanPatternColumn(sql, "pd.Name", "%[/ \"&\\\\$}~,.]%", "SpecialCharacters");
     }


### PR DESCRIPTION
#### Rationale
Maintenance task names and optional feature flags are registered as startup property names, but they might be unusable since there's no guarantee that these names follow the property name rules. This filters out the tasks and flags whose names don't conform so they don't appear on the docs page, etc.

https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=52225

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6192

#### Changes
- Introduce `StringUtilsLabKey.isValidJavaIdentifier()`
- Register a startup property for maintenance tasks and optional features only if the name is a valid Java identifier