### PR TITLE
Restore previous input role retrieval behavior

### DIFF
--- a/api/src/org/labkey/api/audit/query/DefaultAuditTypeTable.java
+++ b/api/src/org/labkey/api/audit/query/DefaultAuditTypeTable.java
@@ -62,7 +62,7 @@ public class DefaultAuditTypeTable extends FilteredTable<UserSchema>
     @Override
     protected ContainerFilter getDefaultContainerFilter()
     {
-        return  ContainerFilter.Type.Current.create(_userSchema);
+        return ContainerFilter.Type.Current.create(_userSchema);
     }
 
     public DefaultAuditTypeTable(AuditTypeProvider provider, TableInfo storage, UserSchema schema, ContainerFilter cf, List<FieldKey> defaultVisibleColumns)

--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -554,6 +554,7 @@ public abstract class ContainerFilter
         public ContainerFilterWithPermission(Container c, User user)
         {
             super(c, user);
+            assert user != null : "User is required for permissions check!";
         }
 
         @Override
@@ -579,7 +580,7 @@ public abstract class ContainerFilter
             return getSQLFragment(schema, _container, containerColumnSQL, ids, allowNulls, getIncludedChildTypes());
         }
 
-        /** return null means return all rows (1=1),  empty collection means return no rows (1=0) */
+        /** return null means return all rows (1=1), empty collection means return no rows (1=0) */
         @Nullable
         public Collection<GUID> generateIds(Container currentContainer, Class<? extends Permission> permission, Set<Role> roles)
         {

--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -506,7 +506,7 @@ public abstract class ContainerFilter
         }
     }
 
-    // short for ContainerFilter.Type.Current.create(container, null)
+    // Does not validate permissions!
     public static ContainerFilter current(Container c)
     {
         return new CurrentContainerFilter(c);
@@ -516,7 +516,6 @@ public abstract class ContainerFilter
     {
         CurrentContainerFilter(Container c)
         {
-            // CurrentContainerFilter does not validate permission
             super(c,null);
             Objects.requireNonNull(c);
         }

--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -554,7 +554,10 @@ public abstract class ContainerFilter
         public ContainerFilterWithPermission(Container c, User user)
         {
             super(c, user);
-            assert user != null : "User is required for permissions check!";
+            // TODO: InternalNoContainerFilter should extend ContainerFilter instead of ContainerFilterWithPermission,
+            // which would allow a more strict check below (c != null && user != null). Also, once verified on
+            // TeamCity, throw an exception here instead of asserting.
+            assert c == null || user != null : "User is required for permissions check if container is provided!";
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2227,7 +2227,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public Set<String> getMaterialInputRoles(Container container, ExpProtocol.ApplicationType... types)
     {
-        return getInputRoles(container, ContainerFilter.Type.Current.create(container, null), getTinfoMaterialInput(), types);
+        return getInputRoles(container, ContainerFilter.current(container), getTinfoMaterialInput(), types);
     }
 
     private Set<String> getInputRoles(Container container, ContainerFilter filter, TableInfo table, ExpProtocol.ApplicationType... types)


### PR DESCRIPTION
#### Rationale
After my `ContainerFilter.Type.Current` change (related PR), the sample derivation page failed to locate input roles. The service impl was explicitly passing a `null` user into `Current.create()` which now causes the container filter permission check to fail. Changing to `ContainerFilter.current()` restores this to a "no permission check" container filter.

Note that this was the only caller of `ContainerFilter.Type.Current.create(Container, User)` passing an explicit `null` value, although it's possible that a `null` user gets passed in to calling methods. For now, use an assert to flag any such cases.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6306