### PR TITLE
Issue 52124, 52016 & 50768

### DIFF
--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -56,6 +56,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleConverter;
+import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.ReturnURLString;
@@ -1073,6 +1074,12 @@ public class ConvertHelper implements PropertyEditorRegistrar
     // Example: "Could not convert value '2.34' (Double) for Boolean field 'Medical History.Dep Diagnosed in Last 18 Months'"
     public static String getStandardConversionErrorMessage(Object value, String fieldName, Class<?> expectedClass)
     {
-        return "Could not convert value '" + value + "' (" + value.getClass().getSimpleName() + ") for " + expectedClass.getSimpleName() + " field '" + fieldName + "'";
+        String fieldType = expectedClass.getSimpleName();
+
+        // Issue 50768: Need a better error message if date value is not in the expected format.
+        if (fieldType.equalsIgnoreCase("date") || fieldType.equalsIgnoreCase("datetime"))
+            return "'" + value + "’ is not a valid " + fieldType + " for " + fieldName + " using " + LookAndFeelProperties.getInstance(ContainerManager.getRoot()).getDateParsingMode().getDisplayString() + ".";
+
+        return "Could not convert value '" + value + "' (" + value.getClass().getSimpleName() + ") for " + fieldType + " field '" + fieldName + "'" ;
     }
 }

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -132,8 +132,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
         RESERVED_NAMES.add("Status");
         RESERVED_NAMES.add("Amount");
         RESERVED_NAMES.add("RunId"); // Issue 50461
-        RESERVED_NAMES.addAll(InventoryService.InventoryStatusColumn.names());
-        RESERVED_NAMES.addAll(InventoryService.InventoryStatusColumn.labels());
+        RESERVED_NAMES.addAll(InventoryService.InventoryStatusColumn.namesAndLabels());
 
         FOREIGN_KEYS = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(
             // NOTE: We generate the LSID once on the server and insert into exp.object, exp.material, and the provisioned table at the same time.

--- a/api/src/org/labkey/api/inventory/InventoryService.java
+++ b/api/src/org/labkey/api/inventory/InventoryService.java
@@ -17,6 +17,7 @@ package org.labkey.api.inventory;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
@@ -86,9 +87,16 @@ public interface InventoryService
             return Arrays.stream(InventoryStatusColumn.values()).map(InventoryStatusColumn::name).toList();
         }
 
-        public static List<String> labels()
+        public static Set<String> namesAndLabels()
         {
-            return Arrays.stream(InventoryStatusColumn.values()).map(InventoryStatusColumn::label).toList();
+            Set<String> values = new CaseInsensitiveHashSet();
+            for (InventoryStatusColumn column : InventoryStatusColumn.values())
+            {
+                values.add(column.name());
+                values.add(column.label());
+                values.add(column.label().replaceAll("\\s", ""));
+            }
+            return values;
         }
     }
 

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -139,7 +139,6 @@ import org.labkey.experiment.lineage.ExpLineageServiceImpl;
 import org.labkey.experiment.pipeline.ExperimentPipelineProvider;
 import org.labkey.experiment.samples.DataClassFolderImporter;
 import org.labkey.experiment.samples.DataClassFolderWriter;
-import org.labkey.experiment.samples.ExperimentQueryChangeListener;
 import org.labkey.experiment.samples.SampleStatusFolderImporter;
 import org.labkey.experiment.samples.SampleTimelineAuditProvider;
 import org.labkey.experiment.samples.SampleTypeFolderImporter;
@@ -224,6 +223,7 @@ public class ExperimentModule extends SpringModule
         QueryService.get().registerMethod(ChildOfMethod.NAME, new ChildOfMethod(), JdbcType.BOOLEAN, 2, 3);
         QueryService.get().registerMethod(ParentOfMethod.NAME, new ParentOfMethod(), JdbcType.BOOLEAN, 2, 3);
         QueryService.get().addQueryListener(new ExperimentQueryChangeListener());
+        QueryService.get().addQueryListener(new PropertyQueryChangeListener());
 
         PropertyService.get().registerValidatorKind(new RegExValidator());
         PropertyService.get().registerValidatorKind(new RangeValidator());

--- a/experiment/src/org/labkey/experiment/ExperimentQueryChangeListener.java
+++ b/experiment/src/org/labkey/experiment/ExperimentQueryChangeListener.java
@@ -1,4 +1,4 @@
-package org.labkey.experiment.samples;
+package org.labkey.experiment;
 
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;

--- a/experiment/src/org/labkey/experiment/PropertyQueryChangeListener.java
+++ b/experiment/src/org/labkey/experiment/PropertyQueryChangeListener.java
@@ -1,0 +1,99 @@
+package org.labkey.experiment;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.exp.OntologyManager;
+import org.labkey.api.query.QueryChangeListener;
+import org.labkey.api.query.SchemaKey;
+import org.labkey.api.security.User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class PropertyQueryChangeListener implements QueryChangeListener
+{
+    @Override
+    public void queryCreated(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull Collection<String> queries)
+    {
+    }
+
+    private void updateLookupQuery(String newValue, SchemaKey schema, String oldQuery, Container container)
+    {
+        String fieldName = "lookupquery";
+        TableInfo pdTable = OntologyManager.getTinfoPropertyDescriptor();
+        SQLFragment updateSql = new SQLFragment("UPDATE ").append(pdTable)
+                .append(" SET ")
+                .append(fieldName)
+                .append(" = ? WHERE lookupschema = ? AND lookupquery = ? AND ")
+                .append("(lookupcontainer = ? OR (lookupcontainer IS NULL AND container = ?))")
+                .add(newValue)
+                .add(schema.toString())
+                .add(oldQuery)
+                .add(container)
+                .add(container);
+
+        new SqlExecutor(pdTable.getSchema()).execute(updateSql);
+
+    }
+
+    private void updateLookupSchema(String newValue, String oldSchema, Container container)
+    {
+        String fieldName = "lookupschema";
+        TableInfo pdTable = OntologyManager.getTinfoPropertyDescriptor();
+        SQLFragment updateSql = new SQLFragment("UPDATE ").append(pdTable)
+                .append(" SET ")
+                .append(fieldName)
+                .append(" = ? WHERE lookupschema = ? AND ")
+                .append("(lookupcontainer = ? OR (lookupcontainer IS NULL AND container = ?))")
+                .add(newValue)
+                .add(oldSchema)
+                .add(container)
+                .add(container);
+
+        new SqlExecutor(pdTable.getSchema()).execute(updateSql);
+
+    }
+
+    @Override
+    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange> changes)
+    {
+        // is there any other schema change other than assay renaming?
+        boolean isSchemaChange = schema.toString().toLowerCase().startsWith("assay.general.");
+
+        Map<String, String> queryNameChangeMap = new CaseInsensitiveHashMap<>();
+        for (QueryPropertyChange qpc : changes)
+        {
+            String oldVal = qpc.getOldValue() != null ? qpc.getOldValue().toString() : null;
+            String newVal = qpc.getNewValue() != null ? qpc.getNewValue().toString() : null;
+            if (oldVal != null && !oldVal.equals(newVal))
+                queryNameChangeMap.put(oldVal, newVal);
+        }
+
+        for (String oldValue : queryNameChangeMap.keySet())
+        {
+            String newValue = queryNameChangeMap.get(oldValue);
+            if (isSchemaChange)
+                updateLookupSchema(newValue, oldValue, container);
+            else
+                updateLookupQuery(newValue, schema, oldValue, container);
+        }
+    }
+
+    @Override
+    public void queryDeleted(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull Collection<String> queries)
+    {
+
+    }
+
+    @Override
+    public Collection<String> queryDependents(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull Collection<String> queries)
+    {
+        return List.of();
+    }
+}


### PR DESCRIPTION
#### Rationale
Issue [52124](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52124): Sample Manager: after sample type is renamed, assay design that reference this sample type no longer show up as an Import Assay option for this sample
Issue [52016](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52016): Round tripping template from sample type design doesn't catch EnteredStorage field as a reserved field.
Issue [50768](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50768): Need a better error message if date value is not in the expected format.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/684
- https://github.com/LabKey/platform/pull/6323
- https://github.com/LabKey/limsModules/pull/1167
- https://github.com/LabKey/testAutomation/pull/2280

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
