### PR TITLE
Issue 52247: DataRegion.renderForm to encode primary key hidden input name property for update row case

### DIFF
--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -2350,9 +2350,9 @@ public class DataRegion extends DisplayElement
                     {
                         out.write("<input type='hidden' name='");
                         if (viewForm != null)
-                            out.write(viewForm.getFormFieldName(pkCol));
+                            out.write(PageFlowUtil.filter(viewForm.getFormFieldName(pkCol)));
                         else
-                            out.write(pkColName);
+                            out.write(PageFlowUtil.filter(pkColName));
                         out.write("' value=\"");
                         out.write(PageFlowUtil.filter(pkVal.toString()));
                         out.write("\">");


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=52247
Backport change from develop. DataRegion.renderForm needs to encode the primary key hidden input name property for the update form input case.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6318

#### Changes
- encode the name prop of the hidden input for the PK column
