### PR TITLE
Issue 52280: Replicate stats not generated for preexisting measures

### DIFF
--- a/api/src/org/labkey/api/exp/property/Domain.java
+++ b/api/src/org/labkey/api/exp/property/Domain.java
@@ -87,11 +87,14 @@ public interface Domain extends IPropertyType
     void save(User user, boolean auditComment) throws ChangePropertyDescriptorException;
     void save(User user, @Nullable String allowAddBaseProperty) throws ChangePropertyDescriptorException;
 
+    /** Returns true if this domain has not yet been saved. */
+    boolean isNew();
+
     /**
-     * This returns a map of names -> PropertyDescriptor that is useful for import that includes all of the
+     * This returns a map of names -> PropertyDescriptor that is useful for import that includes all the
      * different names that a column may be referred to, dealing with naming collisions between aliases and property names
      * in the right way.
-     * @param includeMVIndicators whether or not to include the missing value indicator "column" names in the map
+     * @param includeMVIndicators whether to include the missing value indicator "column" names in the map
      */
     Map<String, DomainProperty> createImportMap(boolean includeMVIndicators);
 
@@ -108,7 +111,7 @@ public interface Domain extends IPropertyType
 
     /**
      * Used by storage provisioner to add indices to the provisioned table.  The indices on this Domain
-     * are in addition to those from the {@link DomainKind#getPropertyIndices()}.
+     * are in addition to those from the {@link DomainKind#getPropertyIndices(Domain)}.
      * Currently, the indices are not saved as a part of the domain definition.
      */
     void setPropertyIndices(@NotNull Set<PropertyStorageSpec.Index> indices);
@@ -116,7 +119,6 @@ public interface Domain extends IPropertyType
     @NotNull Set<PropertyStorageSpec.Index> getPropertyIndices();
 
     /**
-     *
      * @param shouldDeleteAllData Flag that all data should be deleted, initial use case is for Lists and Datasets
      *                            having all their user-editable fields replaced via Import Fields form
      */

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -964,7 +964,7 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         for (var updateField : update.getFields())
         {
             var propertyId = updateField.getPropertyId();
-            var isNew = !originalFields.containsKey(propertyId);
+            var isNew = replicateDomain.isNew() || !originalFields.containsKey(propertyId);
             var isValidType = updateField.isMeasure() && PropertyType.getFromURI(null, updateField.getRangeURI()).getJdbcType().isNumeric();
 
             if (isNew)
@@ -1001,6 +1001,18 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
                                     var updatedName = updatedNames.get(i);
                                     var dp = replicateDomain.getPropertyByName(name);
                                     dp.setName(updatedName);
+                                    domainDirty = true;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            var updatedNames = PlateReplicateStatsDomainKind.getStatsFieldNames(updateField.getName());
+                            for (String updatedName : updatedNames)
+                            {
+                                if (!existingReplicateFields.containsKey(updatedName))
+                                {
+                                    addField(replicateDomain, updatedName);
                                     domainDirty = true;
                                 }
                             }

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -110,7 +110,6 @@ public class DomainImpl implements Domain
     // But then we'd have the situation of StorageProvisioner knowing about/updating Domains, which seems fraught
     transient AliasManager _aliasManager = null;
 
-
     public DomainImpl(DomainDescriptor dd)
     {
         _dd = dd;
@@ -359,7 +358,8 @@ public class DomainImpl implements Domain
         }
     }
 
-    private boolean isNew()
+    @Override
+    public boolean isNew()
     {
         return _new;
     }
@@ -550,8 +550,8 @@ public class DomainImpl implements Domain
                 new SqlSelector(schema, sql).getArrayList(DomainDescriptor.class);
             }
 
-            List<DomainProperty> checkRequiredStatus = new ArrayList<>();
-            boolean isDomainNew = isNew();         // #32406 Need to capture because _new changes during the process
+            // Issue 32406: Need to capture because _new changes during the process
+            boolean isDomainNew = isNew();
             if (saveOnlyIfNotExists && !isDomainNew)
                 throw new IllegalStateException();
             if (!isDomainNew || saveOnlyIfNotExists)
@@ -611,7 +611,7 @@ public class DomainImpl implements Domain
             // Compile audit info for every property change
             List<PropertyChangeAuditInfo> propertyAuditInfo = new ArrayList<>();
 
-            // Delete first #8978
+            // Issue 8978: Delete first
             for (DomainPropertyImpl impl : _properties)
             {
                 if (impl._deleted || (impl.isRecreateRequired()))
@@ -634,8 +634,9 @@ public class DomainImpl implements Domain
             // Keep track of the intended final name for each updated property, and its sort order
             Map<DomainPropertyImpl, Pair<String, Integer>> finalNames = new HashMap<>();
             Map<DomainProperty, Object> defaultValueMap = new HashMap<>();
+            List<DomainProperty> checkRequiredStatus = new ArrayList<>();
 
-            // Now add and update #8978
+            // Issue 8978: Now add and update
             for (DomainPropertyImpl impl : _properties)
             {
                 if (!impl._deleted)
@@ -672,7 +673,7 @@ public class DomainImpl implements Domain
                         if (impl._pdOld != null)
                         {
                             // If this field is newly required, or it's required and we're disabling MV indicators on
-                            // it, make sure that all of the rows have values for it
+                            // it, make sure that all the rows have values for it
                             if ((!impl._pdOld.isRequired() && impl._pd.isRequired()) ||
                                     (impl._pd.isRequired() && !impl._pd.isMvEnabled() && impl._pdOld.isMvEnabled()))
                             {
@@ -689,8 +690,9 @@ public class DomainImpl implements Domain
                             if (null != impl._pdOld && !impl._pdOld.getName().equalsIgnoreCase(impl._pd.getName()))
                             {
                                 finalNames.put(impl, new Pair<>(impl.getName(), sortOrder));
-                                // Save any fields whose name changed with a temp, guaranteed unique name. This is important in case a single save
-                                // is renaming "Field1"->"Field2" and "Field2"->"Field1". See issue 17020
+                                // Issue 17020: Save any fields whose name changed with a temp, guaranteed unique name.
+                                // This is important in case a single save is renaming "Field1"->"Field2" and
+                                // "Field2"->"Field1".
                                 String tmpName = "~tmp" + new GUID().toStringNoDashes();
                                 impl.setName(tmpName);
                                 impl._pd.setStorageColumnName(tmpName);
@@ -822,8 +824,8 @@ public class DomainImpl implements Domain
 
             Runnable afterDomainCommitOrRollback = () ->
             {
-                // Even if no storage table schema changes occurred, we want to invalidate table to pick up an metadata changes
-                // Invalidate even if !propChanged, because ordering might have changed (#25296)
+                // Issue 25296: Even if no storage table schema changes occurred, we want to invalidate table to
+                // pick up any metadata changes. Invalidate even if !propChanged, because ordering might have changed.
                 OntologyManager.invalidateDomain(this);
                 if (getDomainKind() != null)
                     getDomainKind().invalidate(this);
@@ -1323,9 +1325,7 @@ public class DomainImpl implements Domain
     @Override
     public boolean equals(Object obj)
     {
-        if (!(obj instanceof DomainImpl))
-            return false;
-        return (_dd.equals(((DomainImpl) obj)._dd));
+        return obj instanceof DomainImpl impl && _dd.equals(impl._dd);
     }
 
     @Override
@@ -1365,7 +1365,7 @@ public class DomainImpl implements Domain
         Set<PropertyStorageSpec.Index> propertyIndices = new HashSet<>();
         for (GWTIndex index : indices)
         {
-            // issue 25273: verify that each index column name exists in the domain
+            // Issue 25273: verify that each index column name exists in the domain
             if (lowerReservedNames != null)
             {
                 for (String indexColName : index.getColumnNames())
@@ -1409,7 +1409,8 @@ public class DomainImpl implements Domain
             }
             for (DomainPropertyImpl dp : this.getProperties())
             {
-                if (null != dp._pd && !dp._deleted && null != dp._pd.getStorageColumnName())    // Don't claim deleted names (#23295)
+                // Issue 23295: Don't claim deleted names
+                if (null != dp._pd && !dp._deleted && null != dp._pd.getStorageColumnName())
                     _aliasManager.claimAlias(dp._pd.getStorageColumnName(), dp.getName());
             }
         }
@@ -1458,7 +1459,7 @@ public class DomainImpl implements Domain
         for (int i = 0; i < disabledFields.length(); i++)
             disabledSystemFields.add(disabledFields.optString(i));
 
-        DomainKind domainKind = getDomainKind();
+        DomainKind<?> domainKind = getDomainKind();
         if (domainKind != null)
             return domainKind.getDisabledSystemFields(disabledSystemFields);
 


### PR DESCRIPTION
#### Rationale
This addresses [Issue 52280](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52280) by distinguishing and handling when a) the replicate stat domain is new and b) the domain is not new but a measure exists that is not yet in the replicate stat domain.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1170

#### Changes
- Check for new domain
- Check for pre-existing measure not yet in the replicate stat domain
- Integration tests added in associated PR.
