### PR TITLE
Issue 50774: Kill processes launched by pipeline jobs with JMS queue

### DIFF
--- a/pipeline/src/org/labkey/pipeline/mule/EPipelineQueueImpl.java
+++ b/pipeline/src/org/labkey/pipeline/mule/EPipelineQueueImpl.java
@@ -128,6 +128,7 @@ public class EPipelineQueueImpl extends AbstractPipelineQueue
             if (cancelRemoteExecutionEngineJob(statusFile, job)) return true;
         }
 
+        PipelineJobService.get().cancelForJob(statusFile.getJobId());
 
         return false;
     }


### PR DESCRIPTION
#### Rationale
Last year, work on issue 50774 made it so that when admins cancel a pipeline job we kill the external processes it forked. We want to do the same thing when a server is configured to use a JMS queue, which goes through a slightly different codepath.

#### Changes
- Make the same call to kill processes and queries in the JMS version of the queue manager