### PR TITLE
Changes to the site settings for Allowed File Extensions doesn't set User

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10949,7 +10949,7 @@ public class AdminController extends SpringActionController
                     if (null != urlToDelete && urlToDelete.trim().equalsIgnoreCase(externalHost.trim()))
                     {
                         hosts.remove(externalHost);
-                        hostType.setHosts(hosts);
+                        hostType.setHosts(hosts, getUser());
                         break;
                     }
                 }
@@ -10961,7 +10961,7 @@ public class AdminController extends SpringActionController
                 if (errors.hasErrors())
                     return false;
 
-                hostType.setHosts(validatedHosts.stream().toList());
+                hostType.setHosts(validatedHosts.stream().toList(), getUser());
             }
             //save new external host
             else if (form.isSaveNew())
@@ -10970,7 +10970,7 @@ public class AdminController extends SpringActionController
                 if (errors.hasErrors())
                     return false;
 
-                hostType.setHosts(hostSet);
+                hostType.setHosts(hostSet, getUser());
             }
 
             return true;

--- a/core/src/org/labkey/core/admin/ExternalServerType.java
+++ b/core/src/org/labkey/core/admin/ExternalServerType.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.labkey.api.action.LabKeyError;
 import org.labkey.api.data.Container;
+import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.WriteableAppProps;
 import org.labkey.api.util.HtmlString;
@@ -43,11 +44,11 @@ public enum ExternalServerType
         }
 
         @Override
-        public void setHosts(Collection<String> hosts)
+        public void setHosts(Collection<String> hosts, User user)
         {
             WriteableAppProps props = AppProps.getWriteableInstance();
             props.setExternalSourceHosts(hosts);
-            props.save(null);
+            props.save(user);
 
             // Refresh the CSP with new values.
             ContentSecurityPolicyFilter.unregisterAllowedConnectionSource(EXTERNAL_SOURCE_HOSTS_KEY);
@@ -94,11 +95,11 @@ public enum ExternalServerType
         }
 
         @Override
-        public void setHosts(Collection<String> hosts)
+        public void setHosts(Collection<String> hosts, User user)
         {
             WriteableAppProps props = AppProps.getWriteableInstance();
             props.setExternalRedirectHosts(hosts);
-            props.save(null);
+            props.save(user);
         }
 
         @Override
@@ -136,11 +137,11 @@ public enum ExternalServerType
         }
 
         @Override
-        public void setHosts(Collection<String> allowedExtensions)
+        public void setHosts(Collection<String> allowedExtensions, User user)
         {
             WriteableAppProps props = AppProps.getWriteableInstance();
             props.setAllowedFileExtensions(allowedExtensions);
-            props.save(null);
+            props.save(user);
         }
 
         @Override
@@ -174,7 +175,7 @@ public enum ExternalServerType
 
     public abstract HtmlString getDescription();
     public abstract List<String> getHosts();
-    public abstract void setHosts(Collection<String> redirectHosts);
+    public abstract void setHosts(Collection<String> redirectHosts, User user);
     public abstract HtmlString getTitle();
     public abstract HtmlString getLabel();
 


### PR DESCRIPTION
#### Rationale
[Issue 52139: User who makes changes to the 'Allowed File Extensions' setting is not correctly captured in the audit log](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52139)

#### Changes
- Pass user through to save method