### PR TITLE
avoid  jvm crash

### DIFF
--- a/api/src/org/labkey/api/util/ContextListener.java
+++ b/api/src/org/labkey/api/util/ContextListener.java
@@ -32,11 +32,7 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.logging.LogHelper;
 import org.springframework.web.context.ContextLoaderListener;
 
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.Locale;
-import java.util.TimeZone;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -45,21 +41,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class ContextListener implements ServletContextListener
 {
-    static
-    {
-        // make sure compiler knows about DateUtil._Calendar
-        // JVM bug 17.0.7
-        Calendar c = new DateUtil._Calendar(TimeZone.getDefault(), Locale.getDefault());
-        c.get(Calendar.YEAR);       // computeFields()
-        c.set(Calendar.YEAR,2020);
-        c.getTimeInMillis();        //computeTime()
-        c = GregorianCalendar.getInstance();
-        c.get(Calendar.YEAR);       // computeFields()
-        c.set(Calendar.YEAR,2020);
-        c.getTimeInMillis();        //computeTime()
-    }
-
-
     // this is among the earliest classes loaded (except for classes loaded via annotations @ClientEndpoint @ServerEndpoint etc)
 
     // IMPORTANT see also LabKeyBootstrapClassLoader/PipelineBootstrapConfig which duplicates this code, keep them consistent

--- a/api/src/org/labkey/api/util/ContextListener.java
+++ b/api/src/org/labkey/api/util/ContextListener.java
@@ -33,6 +33,7 @@ import org.labkey.api.util.logging.LogHelper;
 import org.springframework.web.context.ContextLoaderListener;
 
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -48,7 +49,11 @@ public class ContextListener implements ServletContextListener
     {
         // make sure compiler knows about DateUtil._Calendar
         // JVM bug 17.0.7
-        var c = new DateUtil._Calendar(TimeZone.getDefault(), Locale.getDefault());
+        Calendar c = new DateUtil._Calendar(TimeZone.getDefault(), Locale.getDefault());
+        c.get(Calendar.YEAR);       // computeFields()
+        c.set(Calendar.YEAR,2020);
+        c.getTimeInMillis();        //computeTime()
+        c = GregorianCalendar.getInstance();
         c.get(Calendar.YEAR);       // computeFields()
         c.set(Calendar.YEAR,2020);
         c.getTimeInMillis();        //computeTime()

--- a/api/src/org/labkey/api/util/ContextListener.java
+++ b/api/src/org/labkey/api/util/ContextListener.java
@@ -32,7 +32,10 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.util.logging.LogHelper;
 import org.springframework.web.context.ContextLoaderListener;
 
+import java.util.Calendar;
 import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -41,6 +44,16 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class ContextListener implements ServletContextListener
 {
+    static
+    {
+        // make sure compiler knows about DateUtil._Calendar
+        // JVM bug 17.0.7
+        var c = new DateUtil._Calendar(TimeZone.getDefault(), Locale.getDefault());
+        c.set(Calendar.YEAR,2020);
+        c.getTimeInMillis();
+    }
+
+
     // this is among the earliest classes loaded (except for classes loaded via annotations @ClientEndpoint @ServerEndpoint etc)
 
     // IMPORTANT see also LabKeyBootstrapClassLoader/PipelineBootstrapConfig which duplicates this code, keep them consistent

--- a/api/src/org/labkey/api/util/ContextListener.java
+++ b/api/src/org/labkey/api/util/ContextListener.java
@@ -49,8 +49,9 @@ public class ContextListener implements ServletContextListener
         // make sure compiler knows about DateUtil._Calendar
         // JVM bug 17.0.7
         var c = new DateUtil._Calendar(TimeZone.getDefault(), Locale.getDefault());
+        c.get(Calendar.YEAR);       // computeFields()
         c.set(Calendar.YEAR,2020);
-        c.getTimeInMillis();
+        c.getTimeInMillis();        //computeTime()
     }
 
 

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -189,7 +189,8 @@ public class DateUtil
             super(tz, locale);
             setTimeInMillis(l);
         }
-//
+
+//    This seems to trigger a JVM crash in adoptium jdk 17.0.7
 //        @Override
 //        public void setTimeInMillis(long millis)
 //        {

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -173,11 +173,13 @@ public class DateUtil
         _Calendar(TimeZone tz, Locale locale)
         {
             super(tz, locale);
+            clear();
         }
 
         _Calendar(TimeZone tz, Locale locale, int year, int mon, int mday, int hour, int min, int sec, int ms)
         {
             super(tz, locale);
+            clear();
             set(year, mon, mday, hour, min, sec);
             set(Calendar.MILLISECOND, ms);
         }
@@ -2317,7 +2319,8 @@ Parse:
             l -= l % (60 * 60 * 1000);
             assertEquals(toISO(l, false).length(), "1999-12-31 23:00".length());
             Calendar c = newCalendar(l);
-            c.set(Calendar.HOUR,0);
+            c.clear(Calendar.HOUR);
+            c.set(Calendar.HOUR_OF_DAY,0);
             l = c.getTimeInMillis();
             assertEquals(toISO(l, false).length(), "1999-12-31".length());
         }

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -187,14 +187,14 @@ public class DateUtil
             super(tz, locale);
             setTimeInMillis(l);
         }
-
-        @Override
-        public void setTimeInMillis(long millis)
-        {
-            isTimeSet = true;
-            time = millis;
-            areFieldsSet = false;
-        }
+//
+//        @Override
+//        public void setTimeInMillis(long millis)
+//        {
+//            isTimeSet = true;
+//            time = millis;
+//            areFieldsSet = false;
+//        }
     }
 
     // when strict=true, disallow date overflow arithmetic

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -168,7 +168,7 @@ public class DateUtil
      * GregorianCalendar is expensive because it calls computeTime() in setTimeInMillis()
      * (which is called in the constructor)
      */
-    private static class _Calendar extends GregorianCalendar
+    public static class _Calendar extends GregorianCalendar
     {
         _Calendar(TimeZone tz, Locale locale)
         {


### PR DESCRIPTION
#### Rationale
The JVM seems to be crashing when it hits a "DEOPT" signal (e.g. the JIT has detected it wants to recompile a method).  Try to let the JVM know about our subclass early in its life-cycle.

The class in questions DateUtil._Calendar is basically unchanged since 2008.  Removing the overridden method seems to help.  The override was intended to avoid a lot of unnecessary overhead in the GregorianCalendar constructor.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
