### PR TITLE
Include websocket "ws:" for reactjs.hot.reload in allowed connections for dev mode

### DIFF
--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -73,7 +73,7 @@ public class ContentSecurityPolicyFilter implements Filter
     {
         // ReactJS hot reload uses localhost port 3001. If in dev mode, allow browser to access that port.
         if (AppProps.getInstance().isDevMode())
-            registerAllowedConnectionSource("reactjs.hot.reload", "localhost:3001");
+            registerAllowedConnectionSource("reactjs.hot.reload", "localhost:3001 ws:");
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
The related PR added localhost to the allowed connections in dev mode to support the client side application dev for hot module reloading. We need to also include websocket "ws:" in that connect-src.

<img width="1337" alt="Screenshot 2025-02-18 at 11 27 04 AM" src="https://github.com/user-attachments/assets/31a28e31-2640-481d-a10c-5955a222febe" />

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6295/

#### Changes
- Include websocket "ws:" for reactjs.hot.reload in allowed connections for dev mode
