### PR TITLE
Copy property descriptor metadata to plate replicate fields

### DIFF
--- a/assay/src/org/labkey/assay/TSVProtocolSchema.java
+++ b/assay/src/org/labkey/assay/TSVProtocolSchema.java
@@ -68,6 +68,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 public class TSVProtocolSchema extends AssayProtocolSchema
 {
@@ -262,14 +263,16 @@ public class TSVProtocolSchema extends AssayProtocolSchema
             setDescription("Represents the replicate statistics for a plate based assay containing replicate well groups.");
             setName("PlateReplicateStats");
             setPublicSchemaName(_userSchema.getSchemaName());
+            FieldKey lsidFieldKey = FieldKey.fromParts("Lsid");
+            Supplier<Map<DomainProperty, Object>> defaultsSupplier = null;
 
             for (ColumnInfo col : getRealTable().getColumns())
             {
                 var columnInfo = wrapColumn(col);
                 if (col.isHidden())
-                    columnInfo .setHidden(true);
+                    columnInfo.setHidden(true);
 
-                if (col.getName().equals("Lsid"))
+                if (lsidFieldKey.equals(col.getFieldKey()))
                 {
                     columnInfo.setHidden(true);
                     columnInfo.setKeyField(true);
@@ -283,7 +286,7 @@ public class TSVProtocolSchema extends AssayProtocolSchema
                     PropertyDescriptor pd = dp.getPropertyDescriptor();
                     if (pd != null)
                     {
-                        PropertyColumn.copyAttributes(userSchema.getUser(), columnInfo, dp, getContainer(), null, containerFilter, null);
+                        defaultsSupplier = PropertyColumn.copyAttributes(userSchema.getUser(), columnInfo, dp, getContainer(), null, containerFilter, defaultsSupplier);
                         columnInfo.setFieldKey(FieldKey.fromParts(dp.getName()));
                     }
                 }

--- a/assay/src/org/labkey/assay/TSVProtocolSchema.java
+++ b/assay/src/org/labkey/assay/TSVProtocolSchema.java
@@ -34,6 +34,8 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.exp.PropertyColumn;
+import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.flag.FlagColumnRenderer;
@@ -264,10 +266,26 @@ public class TSVProtocolSchema extends AssayProtocolSchema
             for (ColumnInfo col : getRealTable().getColumns())
             {
                 var columnInfo = wrapColumn(col);
+                if (col.isHidden())
+                    columnInfo .setHidden(true);
+
                 if (col.getName().equals("Lsid"))
                 {
                     columnInfo.setHidden(true);
                     columnInfo.setKeyField(true);
+                }
+
+                // Issue 52283 : copy the property descriptor settings
+                String propertyURI = col.getPropertyURI();
+                DomainProperty dp = propertyURI != null ? domain.getPropertyByURI(propertyURI) : null;
+                if (dp != null)
+                {
+                    PropertyDescriptor pd = dp.getPropertyDescriptor();
+                    if (pd != null)
+                    {
+                        PropertyColumn.copyAttributes(userSchema.getUser(), columnInfo, dp, getContainer(), null, containerFilter, null);
+                        columnInfo.setFieldKey(FieldKey.fromParts(dp.getName()));
+                    }
                 }
                 addColumn(columnInfo);
             }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52283

For the replicate stats table we need to copy over the property descriptor metadata to get consistent column labeling behavior with it's "parent" column in the assay results table.