### PR TITLE
Issue 52304: Sample Manager: Edit Lineage in grid not saving updates if names contains comma

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -1103,6 +1103,12 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                 .collect(Collectors.toSet()))
                 .containsAll(includedColumns);
         TableInfo selectTable = isAllFromMaterialTable ? ExperimentService.get().getTinfoMaterial() : getQueryTable();
+        if (isAllFromMaterialTable)
+        {
+            // ExperimentService.get().getTinfoMaterial() uses Container column, not Folder
+            includedColumns.remove(ExpMaterialTable.Column.Folder.name());
+            includedColumns.add("container");
+        }
 
         boolean hasParentInput = false;
         if (_sampleType != null)


### PR DESCRIPTION
#### Rationale
When editing lineage data in grid, there is an info log on the server log that "folder" column is not found for "exp.material" table. exp.material table has Container column and not Folder column.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1722
- https://github.com/LabKey/labkey-ui-premium/pull/688
- https://github.com/LabKey/platform/pull/6351
- https://github.com/LabKey/limsModules/pull/1184

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
