### PR TITLE
Issue 51877: Allow calculated fields for list title column

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.25.0-listTitleCol51877.0",
+        "@labkey/components": "6.26.0",
         "@labkey/themes": "1.4.0"
       },
       "devDependencies": {
@@ -3059,9 +3059,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.25.0-listTitleCol51877.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.25.0-listTitleCol51877.0.tgz",
-      "integrity": "sha512-w0Y+OeqQA1QWiHxTu7P8VttMNuS96Kdojj1KSUq8uWyc8TFd9Pd6GiFo9sFSMyaplLuA4GoHC5Z6YfdaeuGuoA==",
+      "version": "6.26.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.26.0.tgz",
+      "integrity": "sha512-F7ySFIfc988WRIsYYhpWFVhk2lWJNai2W/lK2/Hhh78viMsRYv4S1BCHimixlIlZ8gyRZvm/2EZm6pwUpR6jyQ==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.38.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.25.0",
+        "@labkey/components": "6.25.0-listTitleCol51877.0",
         "@labkey/themes": "1.4.0"
       },
       "devDependencies": {
@@ -3059,9 +3059,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.25.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.25.0.tgz",
-      "integrity": "sha512-VfM6zVimmOlWcoMD64Wt2vfBwdAKQShKJ88FC9G8gqrxy8Af3jJQW4gLyS3b8uZFtabonMWd546ae9HNLOWm2g==",
+      "version": "6.25.0-listTitleCol51877.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.25.0-listTitleCol51877.0.tgz",
+      "integrity": "sha512-w0Y+OeqQA1QWiHxTu7P8VttMNuS96Kdojj1KSUq8uWyc8TFd9Pd6GiFo9sFSMyaplLuA4GoHC5Z6YfdaeuGuoA==",
       "dependencies": {
         "@hello-pangea/dnd": "17.0.0",
         "@labkey/api": "1.38.0",

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.25.0",
+    "@labkey/components": "6.25.0-listTitleCol51877.0",
     "@labkey/themes": "1.4.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -54,7 +54,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.25.0-listTitleCol51877.0",
+    "@labkey/components": "6.26.0",
     "@labkey/themes": "1.4.0"
   },
   "devDependencies": {

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -447,9 +447,18 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
         if (listDef.getTitleColumn() != null)
         {
             ColumnInfo titleColumn = getColumn(listDef.getTitleColumn());
-
             if (titleColumn != null)
                 return titleColumn.getName();
+            else
+            {
+                // Issue 51877: a list titleColumn might be a calculated field
+                List<FieldKey> calcFieldKeys = DomainUtil.getCalculatedFieldsForDefaultView(this);
+                for (FieldKey calcFieldKey : calcFieldKeys)
+                {
+                    if (listDef.getTitleColumn().equalsIgnoreCase(calcFieldKey.getName()))
+                        return calcFieldKey.getName();
+                }
+            }
         }
 
         // Title column setting is <AUTO> -- select the first string column that's not a lookup (see #9114)


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51877
We were previously filtering out the calculated fields from the options for the title column property of a list. It was still possible to set a calculated field as the title column via the XML metadata and it worked as expected, so this PR makes that possible in the list designer UI as well.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1723
- https://github.com/LabKey/platform/pull/6352

#### Changes
- ListTable.findTitleColumn to look for a list titleColumn via calculated field
- update @labkey/components package version
