### PR TITLE
Crawler error: Switch to a NotFoundException for bad user id

### DIFF
--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1822,7 +1822,7 @@ public class SecurityController extends SpringActionController
         public @NotNull User getUser(boolean throwIfNull)
         {
             if (throwIfNull && null == _user)
-                throw new IllegalStateException("User not found");
+                throw new NotFoundException("User not found");
 
             return _user;
         }


### PR DESCRIPTION
#### Rationale
```
ERROR ExceptionUtil            2025-02-19T07:35:06,227     http-nio-8111-exec-1 : Exception detected
java.lang.IllegalStateException: User not found
	at org.labkey.core.security.SecurityController$UserForm.getUser(SecurityController.java:1825) ~[core-24.11-SNAPSHOT.jar:?]
	at org.labkey.core.security.SecurityController$AdminResetPasswordAction.getFailView(SecurityController.java:2003) ~[core-24.11-SNAPSHOT.jar:?]
	at org.labkey.core.security.SecurityController$AdminResetPasswordAction.getFailView(SecurityController.java:1943) ~[core-24.11-SNAPSHOT.jar:?]
	at org.labkey.api.action.ConfirmAction.handleRequest(ConfirmAction.java:104) ~[api-24.11-SNAPSHOT.jar:?]
	at org.labkey.api.action.BaseViewAction.handleRequest(BaseViewAction.java:193) ~[api-24.11-SNAPSHOT.jar:?]
	at org.labkey.api.action.SpringActionController.handleRequest(SpringActionController.java:519) [api-24.11-SNAPSHOT.jar:?]
```

https://teamcity.labkey.org/viewLog.html?buildTypeId=LabKey_2411_Premium_NightlySqlserver&buildId=3387832&branch_LabKey_2411_Premium_NightlySqlserver=%3Cdefault%3E

#### Changes
- Use a `NotFoundException` to give a 404 instead of a 500