### PR TITLE
Tell truncation to use UTF-8 instead of platform default

### DIFF
--- a/api/src/org/labkey/api/util/StringUtilsLabKey.java
+++ b/api/src/org/labkey/api/util/StringUtilsLabKey.java
@@ -592,7 +592,7 @@ public class StringUtilsLabKey
                     while (maxBytes > 0 && (bytes[maxBytes] & START_BYTE_MASK) != START_BYTE_MASK);
                 }
             }
-            s = new String(bytes, 0, maxBytes);
+            s = new String(bytes, 0, maxBytes, StandardCharsets.UTF_8);
         }
         return s;
     }


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_InternalSuites_OldDependenciesSqlserver/3389654

We need to specify our preferred character encoding, and not rely on the platform default

#### Changes
- UTF-8 forever