### PR TITLE
Issue 52355: Assure we always have non-blank rows for rows provided for cross-type import

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2961,7 +2961,7 @@ public class ExpDataIterators
                 ColumnInfo colInfo = getColumnInfo(i);
                 String name = colInfo.getName();
                 String lcName = name.toLowerCase();
-                if (i == _typeColIndex) // Issue 52355: assure we have some data in the row by including the type
+                if (_typeColIndex != null && _typeColIndex == i) // Issue 52355: assure we have some data in the row by including the type
                 {
                     fieldIndexes.add(i);
                     header.add(_typeColName);

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2961,7 +2961,12 @@ public class ExpDataIterators
                 ColumnInfo colInfo = getColumnInfo(i);
                 String name = colInfo.getName();
                 String lcName = name.toLowerCase();
-                if (validFields.contains(name))
+                if (i == _typeColIndex)
+                {
+                    fieldIndexes.add(i);
+                    header.add("SampleType");
+                }
+                else if (validFields.contains(name))
                 {
                     fieldIndexes.add(i);
                     header.add(_tsvWriter.quoteValue(name));

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2961,10 +2961,10 @@ public class ExpDataIterators
                 ColumnInfo colInfo = getColumnInfo(i);
                 String name = colInfo.getName();
                 String lcName = name.toLowerCase();
-                if (i == _typeColIndex)
+                if (i == _typeColIndex) // Issue 52355: assure we have some data in the row by including the type
                 {
                     fieldIndexes.add(i);
-                    header.add("SampleType");
+                    header.add(_typeColName);
                 }
                 else if (validFields.contains(name))
                 {


### PR DESCRIPTION
#### Rationale
Issue [52355](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52355): When writing out split files for cross-type import, we will include the sample type as well so we are assured that there is always data for each row in the original file. Without this, the blank rows are ignored.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1190

#### Changes
- Include SampleType in the data fields written to the split files during cross-type import
