### PR TITLE
Remove redundant format?

### DIFF
--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -499,12 +499,6 @@ public class DateUtil
     {
         try
         {
-            return parseISODateTime(s);
-        }
-        catch (Exception ignored) {}
-
-        try
-        {
             // java.util.Date.toString produces dates in the following format.  Try to
             // convert them here.  This is necessary to pass the DRT when running in a
             // non-US timezone:

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -749,21 +749,11 @@ public class DateUtil
         {
             try
             {
-                // One final format to try - handles "2-3-01", "02-03-01", "02-03-2001", etc
-                DateParser format = getDateParser("M-d-yy");
-                return format.parse(s).getTime();
+                return parseXMLDate(s);
             }
-            catch (ParseException pe)
+            catch (IllegalArgumentException ignored)
             {
-                try
-                {
-                    return parseXMLDate(s);
-                }
-                catch (IllegalArgumentException ignored)
-                {
-                }
             }
-
             throw e;
         }
     }


### PR DESCRIPTION
#### Rationale
This pattern looks redundant (parseDateTimeEN seems to handle it).  Also it doesn't check the provided MonthDayOption.  Are there cases not covered by the Junit tests?


#### Related Pull Requests
https://github.com/LabKey/platform/commit/e089c08c23db2fb331f32daf8fc1e338a04176fb

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
