### PR TITLE
Issue 52191: LKSM/LKB: Sample File Import accepts invalid time integers

### DIFF
--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -159,7 +159,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
         _register(new NullSafeConverter(new _IntegerConverter()), Integer.class);
         _register(new _IntegerConverter(), Integer.TYPE);
         _register(new NullSafeConverter(new LenientSqlDateConverter()), java.sql.Date.class);
-        _register(new NullSafeConverter(new TimeConverter()), java.sql.Time.class);
+        _register(new NullSafeConverter(new LenientTimeConverter()), java.sql.Time.class);
         _register(new LenientTimestampConverter(), java.sql.Timestamp.class);
         _register(new LenientDateConverter(), java.util.Date.class);
         _register(new NullSafeConverter(new _LongConverter()), Long.class);
@@ -295,7 +295,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
         }
     }
 
-    public static class TimeConverter implements Converter
+    public static class LenientTimeConverter implements Converter
     {
         @Override
         public Object convert(Class clss, Object o)

--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -159,7 +159,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
         _register(new NullSafeConverter(new _IntegerConverter()), Integer.class);
         _register(new _IntegerConverter(), Integer.TYPE);
         _register(new NullSafeConverter(new LenientSqlDateConverter()), java.sql.Date.class);
-        _register(new NullSafeConverter(new LenientTimeConverter()), java.sql.Time.class);
+        _register(new NullSafeConverter(new TimeConverter()), java.sql.Time.class);
         _register(new LenientTimestampConverter(), java.sql.Timestamp.class);
         _register(new LenientDateConverter(), java.util.Date.class);
         _register(new NullSafeConverter(new _LongConverter()), Long.class);
@@ -295,7 +295,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
         }
     }
 
-    public static class LenientTimeConverter implements Converter
+    public static class TimeConverter implements Converter
     {
         @Override
         public Object convert(Class clss, Object o)
@@ -306,7 +306,7 @@ public class ConvertHelper implements PropertyEditorRegistrar
             if (o instanceof java.sql.Time)
                 return o;
 
-            return DateUtil.fromTimeString(o.toString(), false);
+            return DateUtil.fromTimeString(o.toString(), true);
         }
     }
 

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -1515,6 +1515,18 @@ Parse:
             }
         }
 
+        void assertIllegalFromTimeString(String s, boolean strict)
+        {
+            try
+            {
+                DateUtil.fromTimeString(s, strict);
+                fail("Not a legal time: " + s);
+            }
+            catch (ConversionException x)
+            {
+            }
+        }
+
         @Test
         public void testDateTimeUS() throws ParseException
         {
@@ -1929,6 +1941,19 @@ Parse:
 
             assertIllegalTime("1830");
             assertIllegalTime("19999 pm");
+            assertIllegalFromTimeString("19999 pm", false);
+            assertIllegalFromTimeString("19999 pm", true);
+
+            assertEquals(java.sql.Time.valueOf("3:00:00"), fromTimeString("3", true));
+            assertEquals(java.sql.Time.valueOf("3:00:00"), fromTimeString("03", true));
+            assertEquals(java.sql.Time.valueOf("6:00:00"), fromTimeString("0030", false));
+            assertIllegalFromTimeString("0030", true);
+            assertEquals(java.sql.Time.valueOf("21:00:00"), fromTimeString("0069", false));
+            assertIllegalFromTimeString("0069", true);
+            assertIllegalFromTimeString("0070", false);
+            assertIllegalFromTimeString("0070", true);
+            assertIllegalFromTimeString("1830", false);
+            assertIllegalFromTimeString("1830", true);
         }
 
         @Test

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -1946,12 +1946,12 @@ Parse:
 
             assertEquals(java.sql.Time.valueOf("3:00:00"), fromTimeString("3", true));
             assertEquals(java.sql.Time.valueOf("3:00:00"), fromTimeString("03", true));
-            assertEquals(java.sql.Time.valueOf("6:00:00"), fromTimeString("0030", false));
-            assertIllegalFromTimeString("0030", true);
-            assertEquals(java.sql.Time.valueOf("21:00:00"), fromTimeString("0069", false));
-            assertIllegalFromTimeString("0069", true);
-            assertIllegalFromTimeString("0070", false);
-            assertIllegalFromTimeString("0070", true);
+            assertEquals(java.sql.Time.valueOf("6:00:00").toString(), fromTimeString("30", false).toString());
+            assertIllegalFromTimeString("30", true);
+            assertEquals(java.sql.Time.valueOf("21:00:00").toString(), fromTimeString("69", false).toString());
+            assertIllegalFromTimeString("69", true);
+            assertIllegalFromTimeString("70", false);
+            assertIllegalFromTimeString("70", true);
             assertIllegalFromTimeString("1830", false);
             assertIllegalFromTimeString("1830", true);
         }


### PR DESCRIPTION
#### Rationale
LenientTimeConverter can yield unexpected results. For example, "0030" is parsed to "06:00", with "30" being the hours of the day, which is then converted to "6" by 30%24, which is almost never what one expects. This PR switch our Time converter from being lenient to being strict, aligning with our general approaches to be more strict about data validation. 

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Use strict mode when parsing time
