### PR TITLE
Issue 52355: Assure we always have non-blank rows for dat provided for cross-type import

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -3019,7 +3019,12 @@ public class ExpDataIterators
                 ColumnInfo colInfo = getColumnInfo(i);
                 String name = colInfo.getName();
                 String lcName = name.toLowerCase();
-                if (validFields.contains(name))
+                if (_typeColIndex != null && _typeColIndex == i) // Issue 52355: assure we have some data in the row by including the type
+                {
+                    fieldIndexes.add(i);
+                    header.add(_typeColName);
+                }
+                else if (validFields.contains(name))
                 {
                     fieldIndexes.add(i);
                     header.add(_tsvWriter.quoteValue(name));


### PR DESCRIPTION
#### Rationale
Bring fix for issue [52355](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52355) into 25.2 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6357

#### Changes
- Add sample type column in files split for cross-type import
