### PR TITLE
Make session key use act more like API key use

### DIFF
--- a/api/src/org/labkey/api/assay/transform/DataTransformService.java
+++ b/api/src/org/labkey/api/assay/transform/DataTransformService.java
@@ -19,7 +19,6 @@ import org.labkey.api.reports.LabKeyScriptEngineManager;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.usageMetrics.SimpleMetricsService;
-import org.labkey.api.util.CSRFUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -259,7 +258,7 @@ public class DataTransformService
     {
         if (request != null)
         {
-            return CSRFUtil.SESSION_COOKIE_NAME;
+            return SecurityManager.JSESSIONID;
         }
         // issue 19748: need alternative to JSESSIONID for pipeline job transform script usage
         return SecurityManager.TRANSFORM_SESSION_ID;
@@ -310,7 +309,7 @@ public class DataTransformService
     {
         if (request != null)
         {
-            return PageFlowUtil.getCookieValue(request.getCookies(), CSRFUtil.SESSION_COOKIE_NAME, "");
+            return PageFlowUtil.getCookieValue(request.getCookies(), SecurityManager.JSESSIONID, "");
         }
         return apiKey;
     }

--- a/api/src/org/labkey/api/security/AuthFilter.java
+++ b/api/src/org/labkey/api/security/AuthFilter.java
@@ -186,7 +186,7 @@ public class AuthFilter implements Filter
 
         try
         {
-            Pair<User, HttpServletRequest> pair = SecurityManager.attemptAuthentication(req);
+            Pair<User, HttpServletRequest> pair = SecurityManager.attemptAuthentication(req, resp);
 
             if (null != pair)
             {

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -19,7 +19,9 @@ package org.labkey.api.security;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.websocket.server.HandshakeRequest;
 import org.apache.commons.codec.binary.Base64;
@@ -522,9 +524,9 @@ public class SecurityManager
         return sessionUser;
     }
 
-    public static Pair<User, HttpServletRequest> attemptAuthentication(HttpServletRequest request) throws UnsupportedEncodingException
+    public static Pair<User, HttpServletRequest> attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws UnsupportedEncodingException
     {
-        AUTH_LOG.debug("Starting authentication attempt via session, Basic auth, or API key header");
+        AUTH_LOG.debug("Starting authentication attempt via session, Basic auth, or API key header for request \"" + request.getRequestURI() + "\"");
 
         // Current best practice is to pass API keys via an "apikey" header, but they can be passed via basic auth
         // (username "apikey"), supported for backwards compatibility and clients that don't support custom headers.
@@ -549,8 +551,11 @@ public class SecurityManager
 
                 if (null != session)
                 {
-                    request = new SessionReplacingRequest(request, session);
                     AUTH_LOG.debug("   API key is a valid session key");
+                    Cookie sessionCookie = new Cookie("JSESSIONID", session.getId());
+                    sessionCookie.setPath("/");
+                    response.addCookie(sessionCookie);
+                    request = new SessionReplacingRequest(request, session);
                 }
                 else
                 {
@@ -638,7 +643,7 @@ public class SecurityManager
         }
         finally
         {
-            AUTH_LOG.debug("Finishing authentication attempt via session, Basic auth, or API key header. User: " + u);
+            AUTH_LOG.debug("Finishing authentication attempt via session, Basic auth, or API key header for request \"" + request.getRequestURI() + "\". User: " + u);
         }
     }
 

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -188,6 +188,8 @@ public class SecurityManager
     public static final String SCOPE_GROUP_ROLES = "GroupRoles";
     public static final String SCOPE_USER_GROUPS = "UserGroups";
 
+    public static final String JSESSIONID = "JSESSIONID";
+
     static
     {
         EmailTemplateService.get().registerTemplate(RegistrationEmailTemplate.class);
@@ -552,10 +554,14 @@ public class SecurityManager
                 if (null != session)
                 {
                     AUTH_LOG.debug("   API key is a valid session key");
-                    Cookie sessionCookie = new Cookie("JSESSIONID", session.getId());
-                    sessionCookie.setPath("/");
-                    response.addCookie(sessionCookie);
-                    request = new SessionReplacingRequest(request, session);
+                    String sessionId = PageFlowUtil.getCookieValue(request.getCookies(), JSESSIONID, null);
+                    if (!session.getId().equals(sessionId))
+                    {
+                        Cookie sessionCookie = new Cookie(JSESSIONID, session.getId());
+                        sessionCookie.setPath("/");
+                        response.addCookie(sessionCookie);
+                        request = new SessionReplacingRequest(request, session);
+                    }
                 }
                 else
                 {

--- a/api/src/org/labkey/api/util/CSRFUtil.java
+++ b/api/src/org/labkey/api/util/CSRFUtil.java
@@ -35,7 +35,6 @@ public class CSRFUtil
     public  static final String csrfName =    "X-LABKEY-CSRF";
     public  static final String csrfHeader =  "X-LABKEY-CSRF";
     private static final String csrfCookie =  "X-LABKEY-CSRF";
-    public static final String SESSION_COOKIE_NAME = "JSESSIONID";
 
     public static String getExpectedToken(HttpServletRequest request, @Nullable HttpServletResponse response)
     {


### PR DESCRIPTION
#### Rationale
Current behavior: session key use authenticates the current request but doesn't alter the session. This works for clients that proactively send the session key on every request, but works inconsistently on clients that require a challenge/response (e.g., Java client API). Actions that require login work fine (although every request requires two round trips), but those that don't (e.g., whoAmI, getContainers, etc.) never get the session key and therefore are always considered "guest". https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=52302

New behavior: when a valid session key is presented, set a `JESSIONID` cookie in the response with the value of the impersonated session ID. The new connection now uses that session directly, as if it's another browser tab.

#### Changes
- Also log the URI when initiating the authentication process