### PR TITLE
Issue 52336: Bad query generated with certain ORDER BYs

### DIFF
--- a/api/src/org/labkey/api/data/NestedRenderContext.java
+++ b/api/src/org/labkey/api/data/NestedRenderContext.java
@@ -41,7 +41,7 @@ import java.util.Map;
  */
 public class NestedRenderContext extends RenderContext
 {
-    private QueryNestingOption _nestingOption;
+    private final QueryNestingOption _nestingOption;
 
     public NestedRenderContext(QueryNestingOption nestingOption, ViewContext context)
     {
@@ -131,7 +131,7 @@ public class NestedRenderContext extends RenderContext
             // Add one to the limit so we can tell if there are more groups or not, and should therefore show pagination
             SQLFragment fullSQL = new SQLFragment(" " + groupColumn.getAlias() + " IN (SELECT " + groupColumn.getAlias() + " FROM (");
             fullSQL.append(tinfo.getSchema().getSqlDialect().limitRows(new SQLFragment("SELECT "  + groupColumn.getAlias() + " "),
-                    fromSQL, null, maxRows != Table.ALL_ROWS || offset > 0 ? sortSQL : null, groupBySQL, maxRows == Table.ALL_ROWS || maxRows == Table.NO_ROWS ? maxRows : maxRows + 1, offset));
+                    fromSQL, null, maxRows != Table.ALL_ROWS || offset > 0 ? new SQLFragment(sortSQL) : null, new SQLFragment(groupBySQL), maxRows == Table.ALL_ROWS || maxRows == Table.NO_ROWS ? maxRows : maxRows + 1, offset));
             fullSQL.append(" ) Limited )");
 
             // Apply a filter that restricts the group ids to the right "page" of data
@@ -166,7 +166,7 @@ public class NestedRenderContext extends RenderContext
         fromSQL.append(groupColumn.getAlias());
 
         // Create a TableInfo that wraps the GROUP BY query
-        VirtualTable aggTableInfo = new VirtualTable(tinfo.getSchema(), "AggTable", tinfo.getUserSchema())
+        VirtualTable<?> aggTableInfo = new VirtualTable<>(tinfo.getSchema(), "AggTable", tinfo.getUserSchema())
         {
             @NotNull
             @Override

--- a/api/src/org/labkey/api/data/Sort.java
+++ b/api/src/org/labkey/api/data/Sort.java
@@ -60,7 +60,7 @@ public class Sort
 
         public static SortDirection fromString(String s)
         {
-            if (s == null || s.length() == 0)
+            if (s == null || s.isEmpty())
                 return ASC;
 
             if (s.length() == 1)
@@ -146,9 +146,13 @@ public class Sort
             return (_dir == SortDirection.ASC ? "" : "-") + _fieldKey.toString();
         }
 
-        private String toOrderByString(SqlDialect dialect, String alias)
+        private SQLFragment toOrderByFragment(SqlDialect dialect, String alias)
         {
-            return (null != dialect ? dialect.getColumnSelectName(alias) : alias) + " " + _dir.getSqlDir();
+            SQLFragment sql = new SQLFragment();
+            sql.appendIdentifier(null != dialect ? dialect.getColumnSelectName(alias) : alias);
+            sql.append(" ");
+            sql.append(_dir.getSqlDir());
+            return sql;
         }
 
         public String getSelectName(SqlDialect dialect)
@@ -413,10 +417,9 @@ public class Sort
 
     public int indexOf(@NotNull FieldKey fieldKey)
     {
-        if (_sortList != null)
-            for (SortField sortField : _sortList)
-                if (fieldKey.equals(sortField.getFieldKey()))
-                    return _sortList.indexOf(sortField);
+        for (SortField sortField : _sortList)
+            if (fieldKey.equals(sortField.getFieldKey()))
+                return _sortList.indexOf(sortField);
 
         return -1;
     }
@@ -428,8 +431,6 @@ public class Sort
 
     public String getSortParamValue()
     {
-        if (null == _sortList)
-            return null;
 
         StringBuilder sb = new StringBuilder();
         String sep = "";
@@ -445,7 +446,7 @@ public class Sort
 
     public Set<FieldKey> getRequiredColumns(Map<FieldKey, ? extends ColumnInfo> columns)
     {
-        if (null == _sortList || _sortList.size() == 0)
+        if (_sortList.isEmpty())
             return Collections.emptySet();
 
         Set<FieldKey> requiredFieldKeys = new HashSet<>();
@@ -468,17 +469,17 @@ public class Sort
         return requiredFieldKeys;
     }
 
-    public String getOrderByClause(SqlDialect dialect)
+    public SQLFragment getOrderByClause(SqlDialect dialect)
     {
         return getOrderByClause(dialect, Collections.emptyMap());
     }
 
-    public String getOrderByClause(SqlDialect dialect, Map<FieldKey, ? extends ColumnInfo> columns)
+    public SQLFragment getOrderByClause(SqlDialect dialect, Map<FieldKey, ? extends ColumnInfo> columns)
     {
         if (_sortList.isEmpty())
-            return "";
+            return new SQLFragment();
 
-        StringBuilder sb = new StringBuilder();
+        SQLFragment sql = new SQLFragment();
 
         //NOTE: we are translating between the raw sort, and the sortFieldKeys() provided by that column
         Set<String>  distinctKeys = new CaseInsensitiveHashSet();
@@ -490,7 +491,7 @@ public class Sort
             ColumnInfo colinfo = columns.get(fieldKey);
             if (colinfo == null)
             {
-                appendColumnToSort(sf, dialect, fieldKey.getName(), distinctKeys, sb);
+                appendColumnToSort(sf, dialect, fieldKey.getName(), distinctKeys, sql);
             }
             else
             {
@@ -511,7 +512,7 @@ public class Sort
                 {
                     for (ColumnInfo sortCol : sortFields)
                     {
-                        appendColumnToSort(sf, dialect, sortCol.getAlias(), distinctKeys, sb);
+                        appendColumnToSort(sf, dialect, sortCol.getAlias(), distinctKeys, sql);
 
                         // If we have an mv indicator column, we need to sort on it secondarily
                         if (sortCol.isMvEnabled())
@@ -521,7 +522,7 @@ public class Sort
                             if (mvIndicatorColumn != null)
                             {
                                 SortField mvSortField = new SortField(mvIndicatorColumn.getFieldKey(), sf.getSortDirection());
-                                appendColumnToSort(mvSortField, dialect, mvIndicatorColumn.getAlias(), distinctKeys, sb);
+                                appendColumnToSort(mvSortField, dialect, mvIndicatorColumn.getAlias(), distinctKeys, sql);
                             }
                         }
                     }
@@ -530,30 +531,28 @@ public class Sort
         }
 
         // Determine if any ORDER BY additions were made
-        String orderBy = sb.toString();
+        if (!sql.getSQL().isEmpty())
+            return new SQLFragment("ORDER BY ").append(sql);
 
-        if (orderBy.length() > 0)
-            return "ORDER BY " + orderBy;
-
-        return "";
+        return new SQLFragment();
     }
 
-    private void appendColumnToSort(SortField sf, SqlDialect dialect, String alias, Set<String> distinctKeys, StringBuilder sb)
+    private void appendColumnToSort(SortField sf, SqlDialect dialect, String alias, Set<String> distinctKeys, SQLFragment sql)
     {
         if (distinctKeys.contains(alias))
             return;
 
-        if (distinctKeys.size() > 0)
-            sb.append(", ");
+        if (!distinctKeys.isEmpty())
+            sql.append(", ");
 
-        sb.append(sf.toOrderByString(dialect, alias));
+        sql.append(sf.toOrderByFragment(dialect, alias));
         distinctKeys.add(alias);
     }
 
     // Return an English version of the sort
     public String getSortText()
     {
-        String sql = getOrderByClause(null).replaceFirst("ORDER BY ", "");
+        String sql = getOrderByClause(null).getRawSQL().replaceFirst("ORDER BY ", "");
         return sql.replaceAll(" ,", ",").replaceAll("\"", "");
     }
 
@@ -588,7 +587,7 @@ public class Sort
         if (merge)
         {
             String existingSort = url.getParameter(key);
-            if (existingSort != null && existingSort.length() > 0)
+            if (existingSort != null && !existingSort.isEmpty())
                 value = existingSort + "," + value;
         }
 

--- a/api/src/org/labkey/api/data/dialect/LimitRowsSqlGenerator.java
+++ b/api/src/org/labkey/api/data/dialect/LimitRowsSqlGenerator.java
@@ -42,14 +42,14 @@ public class LimitRowsSqlGenerator
         }
     }
 
-    public static SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy, int maxRows, long offset, LimitRowsCustomizer customizer)
+    public static SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, SQLFragment order, SQLFragment groupBy, int maxRows, long offset, LimitRowsCustomizer customizer)
     {
         SQLFragment sql = appendFromFilterOrderAndGroupBy(select, from, filter, order, groupBy);
 
         return limitRows(sql, maxRows, offset, customizer);
     }
 
-    public static SQLFragment appendFromFilterOrderAndGroupBy(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy)
+    public static SQLFragment appendFromFilterOrderAndGroupBy(SQLFragment select, SQLFragment from, SQLFragment filter, SQLFragment order, SQLFragment groupBy)
     {
         if (select == null)
             throw new IllegalArgumentException("select");
@@ -59,7 +59,7 @@ public class LimitRowsSqlGenerator
         return appendFromFilterOrderAndGroupByNoValidation(select, from, filter, order, groupBy);
     }
 
-    public static SQLFragment appendFromFilterOrderAndGroupByNoValidation(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy)
+    public static SQLFragment appendFromFilterOrderAndGroupByNoValidation(SQLFragment select, SQLFragment from, SQLFragment filter, SQLFragment order, SQLFragment groupBy)
     {
         SQLFragment sql = new SQLFragment();
         sql.append(select);
@@ -114,3 +114,4 @@ public class LimitRowsSqlGenerator
         }
     }
 }
+

--- a/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSql91Dialect.java
@@ -338,7 +338,7 @@ public abstract class PostgreSql91Dialect extends SqlDialect
     }
 
     @Override
-    public SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy, int maxRows, long offset)
+    public SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, SQLFragment order, SQLFragment groupBy, int maxRows, long offset)
     {
         return LimitRowsSqlGenerator.limitRows(select, from, filter, order, groupBy, maxRows, offset, CUSTOMIZER);
     }

--- a/api/src/org/labkey/api/data/dialect/SimpleSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SimpleSqlDialect.java
@@ -190,7 +190,7 @@ public abstract class SimpleSqlDialect extends SqlDialect
     }
 
     @Override
-    public SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy, int maxRows, long offset)
+    public SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, SQLFragment order, SQLFragment groupBy, int maxRows, long offset)
     {
         return null;
     }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -558,7 +558,7 @@ public abstract class SqlDialect
      * @param maxRows Table.ALL_ROWS means all rows, 0 (Table.NO_ROWS) means no rows, > 0 limits result set
      * @param offset 0 based   @return the query
      */
-    public abstract SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, String order, String groupBy, int maxRows, long offset);
+    public abstract SQLFragment limitRows(SQLFragment select, SQLFragment from, SQLFragment filter, SQLFragment order, SQLFragment groupBy, int maxRows, long offset);
 
     /** Does the dialect support limitRows() with an offset? */
     public abstract boolean supportsOffset();

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -538,7 +538,7 @@ public class DataGenerator<T extends DataGenerator.Config>
         SQLFragment sql = new SQLFragment("SELECT " + columns);
         SQLFragment fromSql = new SQLFragment(" FROM ").append(tableInfo, "dc");
 
-        return dialect.limitRows(sql, fromSql, null, dialect.isSqlServer() ? "ORDER By RowId" : null, null, limit, totalCount > limit ? randomLong(0, totalCount-limit) : 0);
+        return dialect.limitRows(sql, fromSql, null, dialect.isSqlServer() ? new SQLFragment("ORDER By RowId") : null, null, limit, totalCount > limit ? randomLong(0, totalCount-limit) : 0);
     }
 
     public List<Map<String, Object>> selectExistingSamples(ExpSampleType sampleType, int limit, long totalSampleCount)

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -1822,7 +1822,7 @@ public class SecurityController extends SpringActionController
         public @NotNull User getUser(boolean throwIfNull)
         {
             if (throwIfNull && null == _user)
-                throw new IllegalStateException("User not found");
+                throw new NotFoundException("User not found");
 
             return _user;
         }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -2383,7 +2383,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return mi == null ? null : new ExpMaterialRunInputImpl(mi);
     }
 
-    private ExpProtocolInputImpl protocolInputObjectType(Map<String, Object> row)
+    private ExpProtocolInputImpl<?, ?> protocolInputObjectType(Map<String, Object> row)
     {
         String objectType = (String)row.get("ObjectType");
         if (ExpData.DEFAULT_CPAS_TYPE.equals(objectType))
@@ -2400,14 +2400,14 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             throw new IllegalStateException("objectType not supported: " + objectType);
     }
 
-    public List<? extends ExpProtocolInputImpl> getProtocolInputs(int protocolId)
+    public List<? extends ExpProtocolInputImpl<?, ?>> getProtocolInputs(int protocolId)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("protocolId"), protocolId);
         Collection<Map<String, Object>> rows = new TableSelector(getTinfoProtocolInput(), filter, new Sort("rowId")).getMapCollection();
         return rows.stream().map(this::protocolInputObjectType).toList();
     }
 
-    public ExpProtocolInputImpl getProtocolInput(int rowId)
+    public ExpProtocolInputImpl<?, ?> getProtocolInput(int rowId)
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("RowId"), rowId);
         Map<String, Object> row = new TableSelector(getTinfoProtocolInput(), filter, null).getMap();
@@ -2416,7 +2416,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     @Override
     @Nullable
-    public ExpProtocolInputImpl getProtocolInput(Lsid lsid)
+    public ExpProtocolInputImpl<?, ?> getProtocolInput(Lsid lsid)
     {
         if (!AbstractProtocolInput.NAMESPACE.equals(lsid.getNamespace()))
             return null;
@@ -2719,7 +2719,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             String parentsSelect = map.get("$PARENTS$");
             parentsSelect = StringUtils.replace(parentsSelect, "$PARENTS_INNER$", parentsInnerToken);
             // don't use parentsSelect as key, it may not consolidate correctly because of parentsInnerToken
-            parentsToken = ret.addCommonTableExpression("$PARENTS$/" + StringUtils.defaultString(options.getExpTypeValue(), "ALL") + "/" + parentsInnerSelect, "org_lk_exp_PARENTS", SQLFragment.unsafe(parentsSelect), recursive);
+            parentsToken = ret.addCommonTableExpression("$PARENTS$/" + Objects.toString(options.getExpTypeValue(), "ALL") + "/" + parentsInnerSelect, "org_lk_exp_PARENTS", SQLFragment.unsafe(parentsSelect), recursive);
         }
 
         String childrenToken = null;
@@ -2734,7 +2734,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             String childrenSelect = map.get("$CHILDREN$");
             childrenSelect = StringUtils.replace(childrenSelect, "$CHILDREN_INNER$", childrenInnerToken);
             // don't use childrenSelect as key, it may not consolidate correctly because of childrenInnerToken
-            childrenToken = ret.addCommonTableExpression("$CHILDREN$/" + StringUtils.defaultString(options.getExpTypeValue(), "ALL") + "/" + childrenInnerSelect, "org_lk_exp_CHILDREN", SQLFragment.unsafe(childrenSelect), recursive);
+            childrenToken = ret.addCommonTableExpression("$CHILDREN$/" + Objects.toString(options.getExpTypeValue(), "ALL") + "/" + childrenInnerSelect, "org_lk_exp_CHILDREN", SQLFragment.unsafe(childrenSelect), recursive);
         }
 
         return new Pair<>(parentsToken,childrenToken);
@@ -3040,7 +3040,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             edges.add(List.of(fromObjectId, toObjectId, edgeRunId));
         });
 
-        if (params.size() == 0 && edges.size() == 0)
+        if (params.isEmpty() && edges.isEmpty())
             return true;
 
         Set<List<Object>> paramSet = new HashSet<>(params);
@@ -4691,7 +4691,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                     linkedColumnNames.add(column.getName());
             }
 
-            if (linkedColumnNames.size() > 0)
+            if (!linkedColumnNames.isEmpty())
             {
                 // Obtain, for selected rows, the ids of datasets that are linked
                 Set<Integer> linkedDatasetsBySelectedRow = new HashSet<>();
@@ -4794,7 +4794,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             boolean moreBatches = true;
             while (moreBatches)
             {
-                SQLFragment sql = dialect.limitRows(new SQLFragment("SELECT *"), new SQLFragment("FROM exp.Material"), new SQLFragment("WHERE ").append(materialFilterSQL), "ORDER BY RowId", null, maxBatch, count);
+                SQLFragment sql = dialect.limitRows(new SQLFragment("SELECT *"), new SQLFragment("FROM exp.Material"), new SQLFragment("WHERE ").append(materialFilterSQL), new SQLFragment("ORDER BY RowId"), null, maxBatch, count);
                 List<Material> rawMaterials = new SqlSelector(getExpSchema(), sql).getArrayList(Material.class);
 
                 moreBatches = rawMaterials.size() == maxBatch;
@@ -5312,7 +5312,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                     .append("DELETE FROM ").append(String.valueOf(getTinfoDataAliasMap())).append(" WHERE LSID = ?").add(data.getLSID()).appendEOS()
                     .append("DELETE FROM ").append(String.valueOf(getTinfoEdge())).append(" WHERE fromObjectId = (select objectid from exp.object where objecturi = ?)").add(data.getLSID()).appendEOS()
                     .append("DELETE FROM ").append(String.valueOf(getTinfoEdge())).append(" WHERE toObjectId = (select objectid from exp.object where objecturi = ?)").add(data.getLSID()).appendEOS()
-                    .append("DELETE FROM ").append(String.valueOf(getTinfoEdge())).append(" WHERE sourceId = (select objectid from exp.object where objecturi = ?)").add(data.getLSID()).appendEOS();;
+                    .append("DELETE FROM ").append(String.valueOf(getTinfoEdge())).append(" WHERE sourceId = (select objectid from exp.object where objecturi = ?)").add(data.getLSID()).appendEOS();
                 new SqlExecutor(getExpSchema()).execute(deleteSql);
 
                 if (data.getClassId() != null)
@@ -6650,7 +6650,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         catch (BatchValidationException e)
         {
             // None of these types actually throw the exception on save
-            throw new UnexpectedException(e);
+            throw UnexpectedException.wrap(e);
         }
 
         List<ExpData> result = new ArrayList<>();
@@ -7181,9 +7181,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
             new SqlSelector(table.getSchema(), new SQLFragment("SELECT Lsid, RootMaterialRowId FROM " + table + " ")
                     .append(sqlfilter).append(" AND RootMaterialRowId <> RowId")).forEach(rs ->
-            {
-                _aliquotRootCache.put(rs.getString("Lsid"), rs.getInt("RootMaterialRowId"));
-            });
+                    _aliquotRootCache.put(rs.getString("Lsid"), rs.getInt("RootMaterialRowId")));
         }
 
         public boolean isEmpty()
@@ -7490,7 +7488,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             }
         }
 
-        private class ProtocolAppRecord
+        private static class ProtocolAppRecord
         {
             ExpProtocolApplicationImpl _protApp;
             Date _activityDate;
@@ -7526,7 +7524,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     private ExpRunImpl createRun(Map<? extends ExpMaterial, String> inputMaterials, Map<? extends ExpData, String> inputDatas,
                          Map<ExpMaterial, String> outputMaterials, Map<ExpData, String> outputDatas, ViewBackgroundInfo info) throws ExperimentException, ValidationException
     {
-        User user = info.getUser();
         PipeRoot pipeRoot = PipelineService.get().findPipelineRoot(info.getContainer());
         if (pipeRoot == null || !pipeRoot.isValid())
             throw new ValidationException("The child folder, " + info.getContainer().getPath() + ", must have a valid pipeline root.");
@@ -8110,7 +8107,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public List<ExpProtocolImpl> getAllExpProtocols()
     {
-        return getExpProtocols((SimpleFilter) null, null, null);
+        return getExpProtocols(null, null, null);
     }
 
     @Override
@@ -10166,7 +10163,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
     }
 
-    public record edge(int to, int from) {};
+    public record edge(int to, int from) {}
     public static class InnerResult
     {
         public int depth, self, fromObjectId, toObjectId;
@@ -10307,8 +10304,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             SQLFragment sql = new SQLFragment()
                     .append(d.isPostgreSQL() ? "WITH RECURSIVE" : "WITH").append(" parents AS (").append(parentsInner).append(")\n")
                     .append("SELECT * FROM parents WHERE self != fromObjectId");
-            List<InnerResult> results = new SqlSelector(getExpSchema(),sql).getArrayList(InnerResult.class);
-            return results;
+            return new SqlSelector(getExpSchema(),sql).getArrayList(InnerResult.class);
         }
 
         List<InnerResult> getChildren(int seed)
@@ -10319,8 +10315,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             SQLFragment sql = new SQLFragment()
                     .append(d.isPostgreSQL() ? "WITH RECURSIVE" : "WITH").append(" children AS (").append(childrenInner).append(")\n")
                     .append("SELECT * FROM children WHERE self != toObjectId");
-            List<InnerResult> results = new SqlSelector(getExpSchema(),sql).getArrayList(InnerResult.class);
-            return results;
+            return new SqlSelector(getExpSchema(),sql).getArrayList(InnerResult.class);
         }
 
         String path(int... id)

--- a/query/src/org/labkey/query/sql/QuerySelectView.java
+++ b/query/src/org/labkey/query/sql/QuerySelectView.java
@@ -16,7 +16,6 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.WrappedColumn;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.query.AliasManager;
 import org.labkey.api.query.FieldKey;
@@ -351,14 +350,14 @@ public class QuerySelectView extends AbstractQueryRelation
             filterFrag = filter.getSQLFragment(dialect, "x", columnMap);
         }
 
-        String orderBy = null;
+        SQLFragment orderBy = null;
 
         if (sort != null)
         {
             orderBy = sort.getOrderByClause(dialect, columnMap);
         }
 
-        if ((filterFrag == null || filterFrag.getSQL().length() == 0) && sort == null && Table.ALL_ROWS == maxRows && offset == 0 && !distinct)
+        if ((filterFrag == null || filterFrag.getSQL().isEmpty()) && sort == null && Table.ALL_ROWS == maxRows && offset == 0 && !distinct)
         {
             selectFrag.append("\n").append(fromFrag);
             return selectFrag;


### PR DESCRIPTION
#### Rationale
SQLFragment is rejecting identifiers when attempting to export a folder with a list whose PK includes certain characters

#### Changes
- Switch to specifying sorts and groups `SQLFragment` instead of `String`
- Use `SQLFragment.appendIdentifier()`
- Misc minor code cleanup