### PR TITLE
Issue 52268: Data Views Webpart behaves badly across time zones

### DIFF
--- a/api/src/org/labkey/api/data/views/DataViewService.java
+++ b/api/src/org/labkey/api/data/views/DataViewService.java
@@ -25,6 +25,7 @@ import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.reports.model.ViewCategory;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
+import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
@@ -273,6 +274,12 @@ public class DataViewService
                     o.put(dp.getName(), createUserObject(u, user));
                 else
                     o.put(dp.getName(), String.valueOf(tag.getValue()));
+            }
+            else if (DataViewProvider.EditInfo.Property.refreshDate.name().equals(dp.getName()) && tag.getValue() instanceof Date d)
+            {
+                // Issue 52268: Data Views Webpart behaves badly when the server is in a different time zone
+                // Serialize as a date, not a datetime
+                o.put(dp.getName(), DateUtil.formatIsoDate(d));
             }
             else
             {

--- a/list/src/org/labkey/list/model/ListWriter.java
+++ b/list/src/org/labkey/list/model/ListWriter.java
@@ -182,7 +182,7 @@ public class ListWriter
                             .collect(Collectors.toCollection(LinkedList::new));
 
                     // Sort the data rows by PK, #11261
-                    Sort sort = ti.getPkColumnNames().size() != 1 ? null : new Sort(ti.getPkColumnNames().get(0));
+                    Sort sort = ti.getPkColumns().size() != 1 ? null : new Sort(ti.getPkColumns().get(0).getFieldKey());
 
                     // NOTE: TSVGridWriter generates and closes Results
                     try (TSVGridWriter tsvWriter = new TSVGridWriter(()->QueryService.get().select(ti, columns, null, sort), displayColumns))


### PR DESCRIPTION
#### Rationale
There was mixed handling for the Refresh Date value - as a date, and as a datetime with timezone.

Also, fix a column name -> FieldKey error in list export

#### Changes
- Send it back as a simple date
- Pass column name as a FieldKey when generating the sort to avoid splitting on comma