### PR TITLE
Issue 52394: Move indexing out of invalidate method and into more post-commit task more explicitly.

### DIFF
--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -614,16 +614,6 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
     }
 
     @Override
-    public void invalidate(Domain domain)
-    {
-        super.invalidate(domain);
-
-        ExpSampleType st = SampleTypeService.get().getSampleType(domain.getTypeURI());
-        if (st != null)
-            SampleTypeService.get().indexSampleType(st);
-    }
-
-    @Override
     public boolean matchesTemplateXML(String templateName, DomainTemplateType template, List<GWTPropertyDescriptor> properties)
     {
         return template instanceof SampleSetTemplateType;

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.exp.property;
 
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
@@ -40,6 +41,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.UnauthorizedException;
@@ -55,6 +57,7 @@ import java.util.stream.Collectors;
 
 abstract public class DomainKind<T> implements Handler<String>
 {
+    public static final Logger LOG = LogHelper.getLogger(DomainKind.class, "Generic domain kind activities.");
     abstract public String getKindName();
 
     /**
@@ -239,9 +242,15 @@ abstract public class DomainKind<T> implements Handler<String>
         String storageTableName = domain.getStorageTableName();
 
         if (null != storageTableName)
+        {
+            LOG.debug("Invalidating " + schemaName + "." + storageTableName);
             getScope().invalidateTable(schemaName, storageTableName, getSchemaType());
+        }
         else
+        {
+            LOG.debug("Invalidating " + schemaName);
             getScope().invalidateSchema(schemaName, getSchemaType());
+        }
     }
 
     /**

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -427,17 +427,6 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
     }
 
     @Override
-    public void invalidate(Domain domain)
-    {
-        LOG.debug("Invalidating data class domain " + domain.getStorageTableName());
-        super.invalidate(domain);
-
-        ExpDataClassImpl dc = getDataClass(domain);
-        if (dc != null && dc.getDomain() != null && dc.getDomain().getStorageTableName() != null)
-            ExperimentServiceImpl.get().indexDataClass(dc);
-    }
-
-    @Override
     public boolean matchesTemplateXML(String templateName, DomainTemplateType template, List<GWTPropertyDescriptor> properties)
     {
         return template instanceof DataClassTemplateType;

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
@@ -15,11 +15,9 @@
  */
 package org.labkey.experiment.api;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSequence;
@@ -295,7 +293,6 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
         }
 
         ExperimentServiceImpl.get().clearDataClassCache(getContainer());
-        ExperimentServiceImpl.get().indexDataClass(this);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
@@ -312,7 +312,7 @@ public class ExpDataClassTableImpl extends ExpTableImpl<ExpDataClassTable.Column
             Map<String, Object> ret = super._update(user, c, row, oldRow, keys);
 
             ExperimentServiceImpl.get().clearDataClassCache(c);
-
+            dc = ExperimentServiceImpl.get().getDataClass(c, rowId); // retrieve the new data class with updated domain
             ExperimentServiceImpl.get().indexDataClass(dc);
 
             return ret;

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -827,11 +827,6 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
     @Override
     public void save(User user)
     {
-        save(user, false);
-    }
-
-    public void save(User user, boolean skipCleanUpTasks /* index and cache might have been called explicitly in a postcommit task*/)
-    {
         boolean isNew = _object.getRowId() == 0;
 
         //Issue 51024: When materialLSIDprefix is set via XAR, naming collisions can happen
@@ -860,12 +855,9 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
             }
         }
 
-        if (!skipCleanUpTasks)
-        {
-            // NOTE cacheMaterialSource() of course calls transactioncache.put(), which does not alter the shared cache! (BUG?)
-            // Just call uncache(), and let normal cache loading do its thing
-            SampleTypeServiceImpl.get().clearMaterialSourceCache(getContainer());
-        }
+        // NOTE cacheMaterialSource() of course calls transactioncache.put(), which does not alter the shared cache! (BUG?)
+        // Just call uncache(), and let normal cache loading do its thing
+        SampleTypeServiceImpl.get().clearMaterialSourceCache(getContainer());
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -865,8 +865,6 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
             // NOTE cacheMaterialSource() of course calls transactioncache.put(), which does not alter the shared cache! (BUG?)
             // Just call uncache(), and let normal cache loading do its thing
             SampleTypeServiceImpl.get().clearMaterialSourceCache(getContainer());
-
-            SampleTypeServiceImpl.get().indexSampleType(this);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -7932,6 +7932,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(DataTypeForExclusion.DataClass, impl.getRowId(), c, u);
 
             tx.addCommitTask(() -> clearDataClassCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
+            tx.addCommitTask(() -> indexDataClass(getDataClass(c, bean.getName())), POSTCOMMIT);
             tx.commit();
         }
         catch (MetadataUnavailableException e)
@@ -8016,7 +8017,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (!errors.hasErrors())
             {
                 transaction.addCommitTask(() -> clearDataClassCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
-                transaction.addCommitTask(() -> ExperimentServiceImpl.get().indexDataClass(getDataClass(c, dataClass.getName())), POSTCOMMIT, POSTROLLBACK);
+                transaction.addCommitTask(() -> indexDataClass(getDataClass(c, dataClass.getName())), POSTCOMMIT);
                 transaction.commit();
             }
         }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1196,6 +1196,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     public void indexDataClass(ExpDataClassImpl dataClass)
     {
+        if (dataClass == null)
+            return;
+
         SearchService ss = SearchService.get();
         if (ss == null)
             return;
@@ -8013,6 +8016,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (!errors.hasErrors())
             {
                 transaction.addCommitTask(() -> clearDataClassCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
+                transaction.addCommitTask(() -> ExperimentServiceImpl.get().indexDataClass(getDataClass(c, dataClass.getName())), POSTCOMMIT, POSTROLLBACK);
                 transaction.commit();
             }
         }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -894,8 +894,8 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                         ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(ExperimentService.DataTypeForExclusion.DashboardSampleType, st.getRowId(), c, u);
                     transaction.addCommitTask(() -> clearMaterialSourceCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
                     transaction.addCommitTask(() -> {
-                        SampleTypeService.get().indexSampleType(SampleTypeService.get().getSampleType(domain.getTypeURI()));
-                    }, POSTCOMMIT, POSTROLLBACK);
+                        indexSampleType(SampleTypeService.get().getSampleType(domain.getTypeURI()));
+                    }, POSTCOMMIT);
 
                     return st;
                 }
@@ -1078,7 +1078,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
         try (DbScope.Transaction transaction = ensureTransaction())
         {
-            st.save(user, true);
+            st.save(user);
             String auditComment = null;
             if (hasNameChange)
             {
@@ -1103,7 +1103,6 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 boolean finalHasMetricUnitChanged = hasMetricUnitChanged;
                 transaction.addCommitTask(() -> {
                     clearMaterialSourceCache(container);
-                    SampleTypeServiceImpl.get().indexSampleType(st);
 
                     if (finalHasMetricUnitChanged)
                     {
@@ -1116,8 +1115,8 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                             throw new RuntimeSQLException(e);
                         }
                     }
-
                 }, DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
+                transaction.addCommitTask(() -> SampleTypeServiceImpl.get().indexSampleType(st), POSTCOMMIT);
                 transaction.commit();
                 refreshSampleTypeMaterializedView(st, SampleChangeType.schema);
             }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -240,6 +240,9 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     @Override
     public void indexSampleType(ExpSampleType sampleType)
     {
+        if (sampleType == null)
+            return;
+
         SearchService ss = SearchService.get();
         if (ss == null)
             return;
@@ -890,6 +893,10 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                     else
                         ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(ExperimentService.DataTypeForExclusion.DashboardSampleType, st.getRowId(), c, u);
                     transaction.addCommitTask(() -> clearMaterialSourceCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
+                    transaction.addCommitTask(() -> {
+                        SampleTypeService.get().indexSampleType(SampleTypeService.get().getSampleType(domain.getTypeURI()));
+                    }, POSTCOMMIT, POSTROLLBACK);
+
                     return st;
                 }
                 catch (ExperimentException | MetadataUnavailableException eex)


### PR DESCRIPTION
#### Rationale
[Issue 52394](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52394) Data class and sample type domain kinds were overriding the `invalidate` method in order to do an indexing of the associated data class or sample type. The invalidate method is called in a few places, including upon saving the table before having updated the domain. This can cause a bit of a race condition where the search indexer brings the old domain into the cache and then subsequent retrieval uses that old domain, even after the new domain has been saved. We really don't need the indexing to happen until after the transaction has committed, so this PR adds explicit post-commit actions to do the indexing after the caches have been cleared. 

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1196

#### Changes
- Remove override of `invalidate` for `DataClassDomainKind` and `SampleTypeDomainKind`
- Add explicit post-commit tasks for indexing updated domain classes and sample types
