### PR TITLE
Put study protocol designer tools under an optional flag

### DIFF
--- a/study/api-src/org/labkey/api/study/StudyUtils.java
+++ b/study/api-src/org/labkey/api/study/StudyUtils.java
@@ -27,6 +27,8 @@ public class StudyUtils
     public static final String SUBMISSION_WARNING = "Once a request is submitted, its specimen list may no longer be modified. Continue?";
     public static final String CANCELLATION_WARNING = "Canceling will permanently delete this pending request. Continue?";
 
+    public static final String STUDY_DESIGN_FEATURE_FLAG = "studyDesignFlag";
+
     //Create a fixed point number encoding the date.
     public static double sequenceNumFromDate(Date d)
     {

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -83,6 +83,7 @@ import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyInternalService;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.StudyUrls;
+import org.labkey.api.study.StudyUtils;
 import org.labkey.api.study.TimepointType;
 import org.labkey.api.study.importer.ImportHelperService;
 import org.labkey.api.study.model.CohortService;
@@ -133,7 +134,26 @@ import org.labkey.study.dataset.DatasetNotificationInfoProvider;
 import org.labkey.study.dataset.DatasetSnapshotProvider;
 import org.labkey.study.dataset.DatasetViewProvider;
 import org.labkey.study.importer.StudyImporterFactory;
-import org.labkey.study.model.*;
+import org.labkey.study.model.CohortDomainKind;
+import org.labkey.study.model.ContinuousDatasetDomainKind;
+import org.labkey.study.model.DatasetDefinition;
+import org.labkey.study.model.DateDatasetDomainKind;
+import org.labkey.study.model.GroupSecurityType;
+import org.labkey.study.model.ImportHelperServiceImpl;
+import org.labkey.study.model.Participant;
+import org.labkey.study.model.ParticipantGroupManager;
+import org.labkey.study.model.ParticipantGroupServiceImpl;
+import org.labkey.study.model.ParticipantIdImportHelper;
+import org.labkey.study.model.ProtocolDocumentType;
+import org.labkey.study.model.SequenceNumImportHelper;
+import org.labkey.study.model.StudyDomainKind;
+import org.labkey.study.model.StudyImpl;
+import org.labkey.study.model.StudyLsidHandler;
+import org.labkey.study.model.StudyManager;
+import org.labkey.study.model.TestDatasetDomainKind;
+import org.labkey.study.model.TreatmentManager;
+import org.labkey.study.model.VisitDatasetDomainKind;
+import org.labkey.study.model.VisitImpl;
 import org.labkey.study.pipeline.StudyPipeline;
 import org.labkey.study.qc.StudyQCImportExportHelper;
 import org.labkey.study.qc.StudyQCStateHandler;
@@ -404,6 +424,11 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
                 "Allow query based dataset snapshots",
                 "Allow unprovisioned, query-based dataset snapshots to be created.",
                 false);
+
+        AdminConsole.addOptionalFeatureFlag(new OptionalFeatureFlag(StudyUtils.STUDY_DESIGN_FEATURE_FLAG,
+                "Restore Study Protocol Design Tools",
+                "This option and all support for study protocol design tools and tables will be removed in LabKey Server v25.7.",
+                false, false, FeatureType.Deprecated));
 
         ReportAndDatasetChangeDigestProvider.get().addNotificationInfoProvider(new DatasetNotificationInfoProvider());
 

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -428,7 +428,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
         AdminConsole.addOptionalFeatureFlag(new OptionalFeatureFlag(StudyUtils.STUDY_DESIGN_FEATURE_FLAG,
                 "Study Protocol Design Tools",
                 "This option adds support for the study protocol and vaccine design tools.",
-                false, false, FeatureType.Optional));
+                false, false, FeatureType.Deprecated));
 
         ReportAndDatasetChangeDigestProvider.get().addNotificationInfoProvider(new DatasetNotificationInfoProvider());
 

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -426,9 +426,9 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
                 false);
 
         AdminConsole.addOptionalFeatureFlag(new OptionalFeatureFlag(StudyUtils.STUDY_DESIGN_FEATURE_FLAG,
-                "Restore Study Protocol Design Tools",
-                "This option and all support for study protocol design tools and tables will be removed in LabKey Server v25.7.",
-                false, false, FeatureType.Deprecated));
+                "Study Protocol Design Tools",
+                "This option adds support for the study protocol and vaccine design tools.",
+                false, false, FeatureType.Optional));
 
         ReportAndDatasetChangeDigestProvider.get().addNotificationInfoProvider(new DatasetNotificationInfoProvider());
 

--- a/study/src/org/labkey/study/view/manageStudy.jsp
+++ b/study/src/org/labkey/study/view/manageStudy.jsp
@@ -65,6 +65,8 @@
 <%@ page import="java.util.Collection" %>
 <%@ page import="java.util.LinkedList" %>
 <%@ page import="java.util.List" %>
+<%@ page import="org.labkey.api.study.StudyUtils" %>
+<%@ page import="org.labkey.api.settings.OptionalFeatureService" %>
 <%@ page extends="org.labkey.study.view.BaseStudyPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%!
@@ -253,6 +255,7 @@
                         <td class="lk-study-prop-desc">Manage QC states for datasets in this study</td>
                         <td><%=link("Manage Dataset QC States", ManageQCStatesAction.class) %></td>
                     </tr>
+                    <% if (OptionalFeatureService.get().isFeatureEnabled(StudyUtils.STUDY_DESIGN_FEATURE_FLAG)) { %>
                     <tr>
                         <td class="lk-study-prop-label">Study Products</td>
                         <td class="lk-study-prop-desc">This study defines <%= getStudyProducts(user, null).size() %> study products</td>
@@ -281,6 +284,7 @@
                         %>
                         <td><%= link("Manage Assay Schedule", assayScheduleURL) %></td>
                     </tr>
+                    <% } %>
                     <tr>
                         <td class="lk-study-prop-label">Demo Mode</td>
                         <td class="lk-study-prop-desc">Demo mode obscures <%=h(subjectNounSingle.toLowerCase())%> IDs on many pages</td>

--- a/study/src/org/labkey/study/view/studydesign/AssayScheduleWebpartFactory.java
+++ b/study/src/org/labkey/study/view/studydesign/AssayScheduleWebpartFactory.java
@@ -19,8 +19,8 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.TimepointType;
+import org.labkey.api.study.security.permissions.ManageStudyPermission;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.BaseWebPartFactory;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.Portal;
@@ -28,13 +28,12 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartView;
 import org.labkey.study.controllers.StudyController;
 import org.labkey.study.model.StudyManager;
-import org.labkey.api.study.security.permissions.ManageStudyPermission;
 
 /**
  * User: cnathe
  * Date: 12/16/13
  */
-public class AssayScheduleWebpartFactory extends BaseWebPartFactory
+public class AssayScheduleWebpartFactory extends StudyDesignWebpartFactory
 {
     public static String NAME = "Assay Schedule";
 
@@ -46,6 +45,9 @@ public class AssayScheduleWebpartFactory extends BaseWebPartFactory
     @Override
     public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
+        if (!canShow())
+            return null;
+
         JspView<Portal.WebPart> view = new JspView<>("/org/labkey/study/view/studydesign/assayScheduleWebpart.jsp", webPart);
         view.setTitle(NAME);
         view.setFrame(WebPartView.FrameType.PORTAL);

--- a/study/src/org/labkey/study/view/studydesign/ImmunizationScheduleWebpartFactory.java
+++ b/study/src/org/labkey/study/view/studydesign/ImmunizationScheduleWebpartFactory.java
@@ -35,7 +35,7 @@ import org.labkey.api.study.security.permissions.ManageStudyPermission;
  * User: cnathe
  * Date: 12/30/13
  */
-public class ImmunizationScheduleWebpartFactory extends BaseWebPartFactory
+public class ImmunizationScheduleWebpartFactory extends StudyDesignWebpartFactory
 {
     public static String NAME = "Immunization Schedule";
 
@@ -47,6 +47,9 @@ public class ImmunizationScheduleWebpartFactory extends BaseWebPartFactory
     @Override
     public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
+        if (!canShow())
+            return null;
+
         JspView<Portal.WebPart> view = new JspView<>("/org/labkey/study/view/studydesign/immunizationScheduleWebpart.jsp", webPart);
         view.setTitle(NAME);
         view.setFrame(WebPartView.FrameType.PORTAL);

--- a/study/src/org/labkey/study/view/studydesign/StudyDesignWebpartFactory.java
+++ b/study/src/org/labkey/study/view/studydesign/StudyDesignWebpartFactory.java
@@ -1,0 +1,25 @@
+package org.labkey.study.view.studydesign;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.settings.OptionalFeatureService;
+import org.labkey.api.study.StudyUtils;
+import org.labkey.api.view.BaseWebPartFactory;
+
+public abstract class StudyDesignWebpartFactory extends BaseWebPartFactory
+{
+    public StudyDesignWebpartFactory(String name)
+    {
+        super(name);
+    }
+
+    protected boolean canShow()
+    {
+        return OptionalFeatureService.get().isFeatureEnabled(StudyUtils.STUDY_DESIGN_FEATURE_FLAG);
+    }
+
+    @Override
+    public boolean isAvailable(Container c, String scope, String location)
+    {
+        return canShow() ? super.isAvailable(c, scope, location) : false;
+    }
+}

--- a/study/src/org/labkey/study/view/studydesign/VaccineDesignWebpartFactory.java
+++ b/study/src/org/labkey/study/view/studydesign/VaccineDesignWebpartFactory.java
@@ -26,7 +26,7 @@ import org.labkey.api.view.WebPartView;
  * User: cnathe
  * Date: 12/27/13
  */
-public class VaccineDesignWebpartFactory extends BaseWebPartFactory
+public class VaccineDesignWebpartFactory extends StudyDesignWebpartFactory
 {
     public static String NAME = "Vaccine Design";
 
@@ -38,6 +38,9 @@ public class VaccineDesignWebpartFactory extends BaseWebPartFactory
     @Override
     public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
+        if (!canShow())
+            return null;
+
         JspView<Portal.WebPart> view = new JspView<>("/org/labkey/study/view/studydesign/vaccineDesignWebpart.jsp", webPart);
         view.setTitle(NAME);
         view.setFrame(WebPartView.FrameType.PORTAL);

--- a/study/test/src/org/labkey/test/tests/study/ProgressReportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/ProgressReportTest.java
@@ -101,6 +101,7 @@ public class ProgressReportTest extends ReportTest
     @Override
     protected void doCreateSteps()
     {
+        OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
         _containerHelper.createProject(getProjectName(), null);
         _containerHelper.createSubfolder(getProjectName(), getProjectName(), getFolderName(), "Study", null);
         importStudyFromZip(STUDY_ZIP);
@@ -136,6 +137,13 @@ public class ProgressReportTest extends ReportTest
         assaySchedulePage.selectVisits(VISITS, 2);
 
         assaySchedulePage.save();
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        super.doCleanup(afterTest);
+        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
     }
 
     @Override

--- a/study/test/src/org/labkey/test/tests/study/ProgressReportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/ProgressReportTest.java
@@ -47,6 +47,7 @@ public class ProgressReportTest extends ReportTest
 {
     private static final File STUDY_ZIP = TestFileUtils.getSampleData("studies/LabkeyDemoStudy.zip");
     private static final String[] ASSAYS = {"Elispot", "Luminex", "VSVG"};
+    private Boolean _studyDesignPreviouslyEnabled;
 
     private static List<BaseManageVaccineDesignVisitPage.Visit> VISITS = Arrays.asList(
             new BaseManageVaccineDesignVisitPage.Visit("Baseline", 0.0, 0.0),
@@ -101,7 +102,7 @@ public class ProgressReportTest extends ReportTest
     @Override
     protected void doCreateSteps()
     {
-        OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
+        _studyDesignPreviouslyEnabled = OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
         _containerHelper.createProject(getProjectName(), null);
         _containerHelper.createSubfolder(getProjectName(), getProjectName(), getFolderName(), "Study", null);
         importStudyFromZip(STUDY_ZIP);
@@ -143,7 +144,8 @@ public class ProgressReportTest extends ReportTest
     protected void doCleanup(boolean afterTest)
     {
         super.doCleanup(afterTest);
-        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
+        if (_studyDesignPreviouslyEnabled != null)
+            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "studyDesignFlag", _studyDesignPreviouslyEnabled);
     }
 
     @Override

--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -314,7 +314,7 @@ public class SharedStudyTest extends BaseWebDriverTest
     @Test
     public void testCreateVisitViaAssaySchedule()
     {
-        OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
+        Boolean studyDesignPreviouslyEnabled = OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
         clickFolder(STUDY1);
         goToManageStudy();
         clickAndWait(Locator.linkWithText("manage assay schedule"));
@@ -329,7 +329,8 @@ public class SharedStudyTest extends BaseWebDriverTest
         manageVisitPage.goToEditVisit("Visit 4");
         clickButton("Delete Visit");
         clickButton("Delete");
-        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
+        if (studyDesignPreviouslyEnabled != null)
+            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "studyDesignFlag", studyDesignPreviouslyEnabled);
     }
 
     @Test

--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -39,6 +39,7 @@ import org.labkey.test.util.Crawler;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.Maps;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.StudyHelper;
 
 import java.io.File;
@@ -313,6 +314,7 @@ public class SharedStudyTest extends BaseWebDriverTest
     @Test
     public void testCreateVisitViaAssaySchedule()
     {
+        OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
         clickFolder(STUDY1);
         goToManageStudy();
         clickAndWait(Locator.linkWithText("manage assay schedule"));
@@ -327,6 +329,7 @@ public class SharedStudyTest extends BaseWebDriverTest
         manageVisitPage.goToEditVisit("Visit 4");
         clickButton("Delete Visit");
         clickButton("Delete");
+        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
     }
 
     @Test

--- a/study/test/src/org/labkey/test/tests/study/StudyDataspaceTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDataspaceTest.java
@@ -23,6 +23,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
+import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.studydesigner.ManageAssaySchedulePage;
 import org.labkey.test.components.studydesigner.ManageStudyProductsPage;
@@ -32,6 +33,7 @@ import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.StudyHelper;
 import org.openqa.selenium.WebElement;
@@ -90,6 +92,14 @@ public class StudyDataspaceTest extends StudyBaseTest
     {
         initializeFolder();
         setPipelineRoot(StudyHelper.getStudySubfolderPath());
+        OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
+    }
+
+    @Override
+    public void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        super.doCleanup(afterTest);
+        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
     }
 
     @Override

--- a/study/test/src/org/labkey/test/tests/study/StudyDataspaceTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDataspaceTest.java
@@ -55,6 +55,7 @@ public class StudyDataspaceTest extends StudyBaseTest
     protected final String SUBFOLDER_STUDY5 = "SubFolder 5";
     protected final String VISIT_TAG_QWP_TITLE = "VisitTag";
     private final PortalHelper _portalHelper = new PortalHelper(this);
+    private Boolean _studyDesignPreviouslyEnabled;
 
     @Override
     protected BrowserType bestBrowser()
@@ -92,14 +93,15 @@ public class StudyDataspaceTest extends StudyBaseTest
     {
         initializeFolder();
         setPipelineRoot(StudyHelper.getStudySubfolderPath());
-        OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
+        _studyDesignPreviouslyEnabled = OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
     }
 
     @Override
     public void doCleanup(boolean afterTest) throws TestTimeoutException
     {
         super.doCleanup(afterTest);
-        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
+        if (_studyDesignPreviouslyEnabled != null)
+            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "studyDesignFlag", _studyDesignPreviouslyEnabled);
     }
 
     @Override

--- a/study/test/src/org/labkey/test/tests/study/StudyProtocolDesignerTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyProtocolDesignerTest.java
@@ -101,13 +101,14 @@ public class StudyProtocolDesignerTest extends BaseWebDriverTest implements Post
 
 
     private PortalHelper _portalHelper;
+    private Boolean _studyDesignPreviouslyEnabled;
 
     @BeforeClass
     public static void doSetup()
     {
-        StudyProtocolDesignerTest initTest = (StudyProtocolDesignerTest)getCurrentTest();
+        StudyProtocolDesignerTest initTest = getCurrentTest();
 
-        OptionalFeatureHelper.enableOptionalFeature(initTest.createDefaultConnection(), "studyDesignFlag");
+        initTest._studyDesignPreviouslyEnabled = OptionalFeatureHelper.enableOptionalFeature(initTest.createDefaultConnection(), "studyDesignFlag");
         initTest._containerHelper.createProject(initTest.getProjectName(), null);
         initTest.importFolderFromZip(FOLDER_ARCHIVE);
 
@@ -118,7 +119,8 @@ public class StudyProtocolDesignerTest extends BaseWebDriverTest implements Post
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
-        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
+        if (_studyDesignPreviouslyEnabled != null)
+            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "studyDesignFlag", _studyDesignPreviouslyEnabled);
         super.doCleanup(afterTest);
     }
 

--- a/study/test/src/org/labkey/test/tests/study/StudyProtocolDesignerTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyProtocolDesignerTest.java
@@ -28,6 +28,7 @@ import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
+import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.studydesigner.AssayScheduleWebpart;
 import org.labkey.test.components.studydesigner.BaseManageVaccineDesignVisitPage;
@@ -39,6 +40,7 @@ import org.labkey.test.components.studydesigner.ManageTreatmentsSingleTablePage;
 import org.labkey.test.components.studydesigner.TreatmentDialog;
 import org.labkey.test.components.studydesigner.VaccineDesignWebpart;
 import org.labkey.test.util.LogMethod;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.PostgresOnlyTest;
 import org.openqa.selenium.WebElement;
@@ -105,11 +107,19 @@ public class StudyProtocolDesignerTest extends BaseWebDriverTest implements Post
     {
         StudyProtocolDesignerTest initTest = (StudyProtocolDesignerTest)getCurrentTest();
 
+        OptionalFeatureHelper.enableOptionalFeature(initTest.createDefaultConnection(), "studyDesignFlag");
         initTest._containerHelper.createProject(initTest.getProjectName(), null);
         initTest.importFolderFromZip(FOLDER_ARCHIVE);
 
         initTest._containerHelper.createSubfolder(initTest.getProjectName(), initTest.getFolderName(), "Study");
         initTest.importStudyFromZip(STUDY_ARCHIVE);
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        OptionalFeatureHelper.disableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
+        super.doCleanup(afterTest);
     }
 
     @Before


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51726

This is the first phase to put some of the study design tools behind an optional feature flag. In this initial phase we will hide the study manage links as well as web parts for these features in order to get a smaller change in place for the upcoming ESR release. In a subsequent release we plan to merge the larger change to hide the tables related to these features under the same flag.

#### Related PR
https://github.com/LabKey/testAutomation/pull/2303
