### PR TITLE
Consolidate to a single SMTP help message code path and fix docs link

### DIFF
--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -506,7 +506,18 @@ public abstract class ContainerFilter
         }
     }
 
+    public static ContainerFilter current(Container c, User user)
+    {
+        return Type.Current.create(c, user);
+    }
+
+    public static ContainerFilter current(ContainerUser cu)
+    {
+        return Type.Current.create(cu);
+    }
+
     // Does not validate permissions!
+    @Deprecated // Use current(Container, User) or current(ContainerUser) instead
     public static ContainerFilter current(Container c)
     {
         return new CurrentContainerFilter(c);

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2414,9 +2414,9 @@ public class SecurityManager
     {
         if (messageContentsURL != null)
         {
-            builder.append(" Alternatively, you can copy the ");
-            builder.append(new LinkBuilder("contents of the message").href(messageContentsURL).target("_blank").clearClasses());
-            builder.append(" into an email client and send it to the user manually.");
+            builder.append(" Alternatively, you can copy the ")
+                .append(new LinkBuilder("contents of the message").href(messageContentsURL).target("_blank").clearClasses())
+                .append(" into an email client and send it to the user manually.");
         }
 
         builder.unsafeAppend("</p><p>")

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -2262,6 +2262,7 @@ public class SecurityManager
 
         ActionURL messageContentsURL = null;
         User currentUser = context.getUser();
+        boolean emailFailure = false;
 
         try
         {
@@ -2317,6 +2318,9 @@ public class SecurityManager
 
             if (null != newUser)
                 UserManager.addToUserHistory(newUser, newUser.getEmail() + " was added to the system. Sending the verification email failed.");
+
+            // Error message above includes a link to the email contents; set this flag to skip rendering this link again. Issue #51936.
+            emailFailure = true;
         }
         catch (UserManagementException e)
         {
@@ -2327,20 +2331,24 @@ public class SecurityManager
         // hide showRegistrationEmail link if provider is specified for now
         if (messageContentsURL != null && provider == null)
         {
-            LinkBuilder link = new LinkBuilder("here").href(messageContentsURL).target("_blank").clearClasses();
-            message.append(" Click ").append(link).append(" to see the email.");
+            // Email failure message already includes link to the contents
+            if (!emailFailure)
+            {
+                LinkBuilder link = new LinkBuilder("here").href(messageContentsURL).target("_blank").clearClasses();
+                message.append(" Click ").append(link).append(" to see the email.");
+            }
 
             if (!context.getContainer().isRoot())
             {
                 LinkBuilder projectGroupLink = new LinkBuilder("here").href(PageFlowUtil.urlProvider(SecurityUrls.class).getPermissionsURL(context.getContainer())).clearClasses();
-                message.append(" Add the new user to a Project Group ").append(projectGroupLink).append(".");
+                message.append(" Add the new user to a Project Group ").append(projectGroupLink).append(".").append(HtmlString.BR).append(HtmlString.BR);
             }
         }
 
         return message.getHtmlString();
     }
 
-    @SuppressWarnings("unused") // Called from mGAP
+    @SuppressWarnings("unused") // Called from mGAP and mcc
     public static void sendRegistrationEmail(ViewContext context, ValidEmail email, String mailPrefix, NewUserStatus newUserStatus, @Nullable List<Pair<String, String>> extraParameters) throws Exception
     {
         sendRegistrationEmail(context, email, mailPrefix, newUserStatus, extraParameters, null, true);
@@ -2391,19 +2399,10 @@ public class SecurityManager
     {
         if (isAdmin)
         {
-            builder.append("You can attempt to resend this mail later by going to the Site Users link, clicking on the appropriate user from the list, and resetting their password.");
-
-            if (messageContentsURL != null)
-            {
-                builder.append(" Alternatively, you can copy the ");
-                builder.append(new LinkBuilder("contents of the message").href(messageContentsURL).target("_blank").clearClasses());
-                builder.append(" into an email client and send it to the user manually.");
-            }
-
-            builder.unsafeAppend("</p>");
-            builder.unsafeAppend("<p>For help on fixing your mail server settings, please consult the SMTP section of the ");
-            builder.append(new HelpTopic("labkeyxml").getSimpleLinkHtml("LabKey documentation on modifying your configuration file"));
-            builder.append(".").append(HtmlString.BR);
+            builder
+                .unsafeAppend("<p>")
+                .append("You can attempt to resend this mail later by going to the Site Users link, clicking on the appropriate user from the list, and resetting their password.");
+            appendAdminMailHelpHtml(builder, messageContentsURL);
         }
         else
         {
@@ -2411,6 +2410,21 @@ public class SecurityManager
         }
     }
 
+    public static void appendAdminMailHelpHtml(HtmlStringBuilder builder, ActionURL messageContentsURL)
+    {
+        if (messageContentsURL != null)
+        {
+            builder.append(" Alternatively, you can copy the ");
+            builder.append(new LinkBuilder("contents of the message").href(messageContentsURL).target("_blank").clearClasses());
+            builder.append(" into an email client and send it to the user manually.");
+        }
+
+        builder.unsafeAppend("</p><p>")
+            .append("Get help fixing your SMTP mail server settings ")
+            .append(new HelpTopic("SMTPsettings").getSimpleLinkHtml("here"))
+            .append(".")
+            .unsafeAppend("</p>");
+    }
 
     public static void createNewProjectGroups(Container project, User user)
     {

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -126,7 +126,6 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HelpTopic;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
-import org.labkey.api.util.Link;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
@@ -2040,16 +2039,8 @@ public class SecurityController extends SpringActionController
             HtmlStringBuilder builder = HtmlStringBuilder.of()
                 .unsafeAppend("<p>")
                 .append("You can attempt to resend this mail later by going to the Site Users link, clicking on the appropriate user from the list, and resetting their password.");
-            if (mailHref != null)
-            {
-                builder.append(" Alternatively, you can copy the ")
-                    .append(new Link.LinkBuilder("contents of the message").href(mailHref).target("_blank").clearClasses())
-                    .append(" into an email client and send it to the user manually.");
-            }
-            builder.unsafeAppend("</p>\n<p>")
-                .append("For help on fixing your mail server settings, please consult the SMTP section of the ")
-                .append(new HelpTopic("labkeyxml").getSimpleLinkHtml("LabKey Server documentation on modifying your configuration file"))
-                .unsafeAppend(".</p>");
+
+            SecurityManager.appendAdminMailHelpHtml(builder, mailHref);
 
             return builder.getHtmlString();
         }


### PR DESCRIPTION
#### Rationale
We had multiple code paths creating the same basic admin guidance around SMTP failures. And both pointed to the wrong docs page.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51936
