### PR TITLE
Issue 52417: StackOverflowError analyzing queries with linked core schema

### DIFF
--- a/api/src/org/labkey/api/query/QueryForeignKey.java
+++ b/api/src/org/labkey/api/query/QueryForeignKey.java
@@ -361,6 +361,20 @@ public class QueryForeignKey extends AbstractForeignKey
     }
 
     @Override
+    public SchemaKey getLookupSchemaKey()
+    {
+        if (_lookupSchemaKey != null)
+        {
+            return _lookupSchemaKey;
+        }
+        if (_schema != null)
+        {
+            return _schema.getSchemaPath();
+        }
+        return super.getLookupSchemaKey();
+    }
+
+    @Override
     protected QuerySchema getLookupSchema()
     {
         if (_schema == null && _user != null && _lookupSchemaKey != null)

--- a/api/src/org/labkey/api/query/QuerySchema.java
+++ b/api/src/org/labkey/api/query/QuerySchema.java
@@ -138,6 +138,11 @@ public interface QuerySchema extends SchemaTreeNode, ContainerUser
     @NotNull
     String getSchemaName();
 
+    default SchemaKey getSchemaPath()
+    {
+        return SchemaKey.decode(getSchemaName());
+    }
+
     /** @return short description of the content and purpose of the schema */
     @Nullable String getDescription();
 

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -98,12 +98,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
     {
         return _name;
     }
-
-    public SchemaKey getPath()
-    {
-        return _path;
-    }
-
+    
     @Override
     @Nullable
     public String getDescription()

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -374,6 +374,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         return _path.toString();
     }
 
+    @Override
     public SchemaKey getSchemaPath()
     {
         return _path;

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -1160,7 +1160,7 @@ public class QueryServiceImpl implements QueryService
 
                         for (CustomView view : qd.getSchema().getModuleCustomViews(container, qd))
                         {
-                            Path key = new Path(schema.getPath().toString(), view.getQueryDefinition().getName(), StringUtils.defaultString(view.getName(), ""));
+                            Path key = new Path(schema.getSchemaPath().toString(), view.getQueryDefinition().getName(), Objects.toString(view.getName(), ""));
                             if (!views.containsKey(key))
                                 views.put(key, view);
                         }
@@ -1172,7 +1172,7 @@ public class QueryServiceImpl implements QueryService
         // custom views in the database get highest precedence, so let them overwrite the module-defined views in the map
         for (CstmView cstmView : QueryManager.get().getAllCstmViews(container, null, null, owner, inheritable, sharedOnly))
         {
-            Path key = new Path(cstmView.getSchema(), cstmView.getQueryName(), StringUtils.defaultString(cstmView.getName(), ""));
+            Path key = new Path(cstmView.getSchema(), cstmView.getQueryName(), Objects.toString(cstmView.getName(), ""));
             // The database custom views are in priority order so check if the view has already been added
             if (!views.containsKey(key))
             {

--- a/query/webapp/query/browser/view/QueryDetails.js
+++ b/query/webapp/query/browser/view/QueryDetails.js
@@ -849,10 +849,14 @@ Ext4.define('LABKEY.query.browser.view.QueryDetails', {
                     scope : this,
                     fn : function(cmp) {
                         cmp.getEl().mask('loading dependencies');
-                        this.queriesCache.load(null, this.refreshQueryDependencies, function(error) {
+                        this.queriesCache.load(null, this.refreshQueryDependencies, LABKEY.Utils.getCallbackWrapper(function(error) {
                             this.removeQueryDependencies();
-                            this.onLoadError(error);
-                        }, this);
+                            this.getContent().add({
+                                xtype : 'box',
+                                itemId : 'lk-dependency-report',
+                                html : '<br/>Failed to load dependency information. ' + Ext4.htmlEncode(error.exception ? error.exception : ''),
+                            });
+                       }, this, true), this);
                     }
                 }
             }


### PR DESCRIPTION
#### Rationale
We can break a recursion cycle when checking linked schema FKs.

#### Changes
- Use the SchemaKey from the schema without creating the full TableInfo
- Scope the dependency error info to the dependency analysis