### PR TITLE
Issue 52268: Data Views Webpart behaves badly across time zones

### DIFF
--- a/api/src/org/labkey/api/data/views/DataViewService.java
+++ b/api/src/org/labkey/api/data/views/DataViewService.java
@@ -279,7 +279,7 @@ public class DataViewService
             {
                 // Issue 52268: Data Views Webpart behaves badly when the server is in a different time zone
                 // Serialize as a date, not a datetime
-                o.put(dp.getName(), DateUtil.formatIsoDate(d));
+                o.put(dp.getName(), DateUtil.formatDate(info.getContainer(), d));
             }
             else
             {

--- a/query/webapp/dataview/DataViewPropertiesPanel.js
+++ b/query/webapp/dataview/DataViewPropertiesPanel.js
@@ -143,7 +143,7 @@ Ext4.define('LABKEY.ext4.DataViewPropertiesPanel', {
                 name        : 'refreshDate',
                 value       : this.data.refreshDate != null  ? this.data.refreshDate : '',
                 blankText   : 'Date of last refresh',
-                format      : LABKEY.extDateInputFormat,
+                format      : LABKEY.extDefaultDateFormat,
                 editable    : true,
                 labelWidth : 120,
                 width      : 400,

--- a/query/webapp/dataview/DataViewUtil.js
+++ b/query/webapp/dataview/DataViewUtil.js
@@ -72,7 +72,7 @@ Ext4.define('LABKEY.ext4.DataViewUtil', {
                     {name : 'modified', type: 'date'},
                     {name : 'modifiedBy'},
                     {name : 'contentModified', type: 'date'},
-                    {name : 'refreshDate',  type: 'date'},
+                    {name : 'refreshDate'},
                     {name : 'name'},
                     {name : 'access', mapping: 'access.label'},
                     {name : 'accessUrl', mapping: 'access.url'},

--- a/query/webapp/dataview/DataViewsPanel.js
+++ b/query/webapp/dataview/DataViewsPanel.js
@@ -466,7 +466,8 @@ Ext4.define('LABKEY.ext4.DataViewsPanel', {
         }
         this.dateFormat = LABKEY.extDefaultDateFormat;
         this.dateRenderer = function(value) {
-            return LABKEY.Utils.encodeHtml(value);
+            var formattedVal = Ext4.util.Format.date(value, LABKEY.extDefaultDateFormat);
+            return LABKEY.Utils.encodeHtml(formattedVal);
         };
         this.editInfo = json.editInfo;
         this.sortOrder = json.sortOrder;
@@ -540,7 +541,7 @@ Ext4.define('LABKEY.ext4.DataViewsPanel', {
                 '<tr><td>Status:</td><td>{[fm.htmlEncode(values.data.status)]}</td></tr>' +
                 '</tpl>' +
                 '<tpl if="data.refreshDate != undefined">' +
-                '<tr><td valign="top">Data Cut Date:</td><td>{[this.renderDate(values.data.refreshDate)]}</td></tr>' +
+                '<tr><td valign="top">Data Cut Date:</td><td>{[m.htmlEncode(values.data.refreshDate)]}</td></tr>' +
                 '</tpl>' +
                 '<tpl if="this.isValid(data.description)">' +
                 '<tr><td valign="top">Description:</td><td>{[fm.htmlEncode(values.data.description)]}</td></tr>' +
@@ -555,9 +556,6 @@ Ext4.define('LABKEY.ext4.DataViewsPanel', {
                     },
                     renderCategory : function(cat) {
                         return Ext4.htmlEncode(Ext4.isString(cat) ? cat : cat.label);
-                    },
-                    renderDate : function(data) {
-                        return this.initialConfig.dateRenderer(data);
                     }
                 }, {dateRenderer : this.dateRenderer});
 
@@ -770,7 +768,8 @@ Ext4.define('LABKEY.ext4.DataViewsPanel', {
                  dataIndex: 'refreshDate',
                  menuDisabled : true,
                  sortable : false,
-                 renderer : this.dateRenderer,
+                 // Issue 52268: pass around date as a string to avoid timezone shifting
+                 renderer : LABKEY.Utils.encodeHtml,
                  scope    : this
              });
         }

--- a/query/webapp/dataview/DataViewsPanel.js
+++ b/query/webapp/dataview/DataViewsPanel.js
@@ -540,8 +540,8 @@ Ext4.define('LABKEY.ext4.DataViewsPanel', {
                 '<tpl if="this.isValid(data.status)">' +
                 '<tr><td>Status:</td><td>{[fm.htmlEncode(values.data.status)]}</td></tr>' +
                 '</tpl>' +
-                '<tpl if="data.refreshDate != undefined">' +
-                '<tr><td valign="top">Data Cut Date:</td><td>{[m.htmlEncode(values.data.refreshDate)]}</td></tr>' +
+                '<tpl if="data.refreshDate != undefined && data.refreshDate != \'\'">' +
+                '<tr><td valign="top">Data Cut Date:</td><td>{[fm.htmlEncode(values.data.refreshDate)]}</td></tr>' +
                 '</tpl>' +
                 '<tpl if="this.isValid(data.description)">' +
                 '<tr><td valign="top">Description:</td><td>{[fm.htmlEncode(values.data.description)]}</td></tr>' +

--- a/query/webapp/dataview/DataViewsPanel.js
+++ b/query/webapp/dataview/DataViewsPanel.js
@@ -466,8 +466,7 @@ Ext4.define('LABKEY.ext4.DataViewsPanel', {
         }
         this.dateFormat = LABKEY.extDefaultDateFormat;
         this.dateRenderer = function(value) {
-            var formattedVal = Ext4.util.Format.date(value, LABKEY.extDefaultDateFormat);
-            return LABKEY.Utils.encodeHtml(formattedVal);
+            return LABKEY.Utils.encodeHtml(value);
         };
         this.editInfo = json.editInfo;
         this.sortOrder = json.sortOrder;


### PR DESCRIPTION
#### Rationale
My previous fix actually made things worse.

#### Changes
- Switch to treating the date as a string in the client to avoid timezone parsing