### PR TITLE
Update expected result count for "Sample" search

### DIFF
--- a/study/test/src/org/labkey/test/tests/search/SearchTest.java
+++ b/study/test/src/org/labkey/test/tests/search/SearchTest.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.tests.search;
 
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -245,7 +246,15 @@ public abstract class SearchTest extends StudyBaseTest
 
         waitAndClick(Locator.radioButtonByNameAndValue("scope", "Project"));
         _searchHelper.searchFor(searchTerm);
-        waitForElement(Locator.tagWithText("div", "Found 6 results"));
+        List<String> results = getTexts(Locator.css(".labkey-search-result h4").findElements(getDriver()));
+        Assertions.assertThat(results).as("'Project' scoped search results").containsExactlyInAnyOrder(
+            "\"sample.txt\" attached to page \"Roquefort\"",
+            "pdf_sample.pdf",
+            "docx_sample.docx",
+            "InlineFile.html",
+            "verifyAssay"
+        );
+        waitForElement(Locator.tagWithText("div", "Found 5 results"));
 
         waitAndClick(Locator.radioButtonByNameAndValue("scope", "Folder"));
         _searchHelper.searchFor(searchTerm);
@@ -253,7 +262,7 @@ public abstract class SearchTest extends StudyBaseTest
 
         waitAndClick(Locator.radioButtonByNameAndValue("scope", "FolderAndSubfolders"));
         _searchHelper.searchFor(searchTerm);
-        waitForElement(Locator.tagWithText("div", "Found 6 results"));
+        waitForElement(Locator.tagWithText("div", "Found 5 results"));
 
         //Now create subfolders:
         goToProjectHome();


### PR DESCRIPTION
#### Rationale
Previously, a search for "Sample" would include the specimen sample type ("Sample Type - Study Specimens") in its results. After a recent change (I suspect #6381), that is no longer the case.
I investigated the previous behavior (on 24.11) and found that we were indexing the sample type but none of the individual samples. Since we don't index the samples, it makes sense to not index the sample type either. Let me know if you disagree and I will open an issue.

#### Related Pull Requests
- #6381 

#### Changes
- Update expected result count for "Sample" search
