### PR TITLE
WebDav: support filename in content-disposition for attachments 

### DIFF
--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -5061,7 +5061,10 @@ public class DavController extends SpringActionController
 
         if (!StringUtils.isEmpty(contentDisposition))
         {
-            ResponseHelper.setContentDisposition(getResponse(), contentDisposition);
+            if ("attachment".equals(contentDisposition) && resource.getName() != null)
+                ResponseHelper.setContentDisposition(getResponse(), ResponseHelper.ContentDispositionType.attachment, resource.getName());
+            else
+                ResponseHelper.setContentDisposition(getResponse(), contentDisposition);
         }
 
         // Find content type

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -5061,7 +5061,9 @@ public class DavController extends SpringActionController
 
         if (!StringUtils.isEmpty(contentDisposition))
         {
-            if ("attachment".equals(contentDisposition) && resource.getName() != null)
+            // If an "attachment" content-disposition is requested and the "filename" parameter is not set, then
+            // retain the name of the resource in the content-disposition in the response header.
+            if ("attachment".equals(contentDisposition) && resource.getName() != null && getFilenameParameter() == null)
                 ResponseHelper.setContentDisposition(getResponse(), ResponseHelper.ContentDispositionType.attachment, resource.getName());
             else
                 ResponseHelper.setContentDisposition(getResponse(), contentDisposition);


### PR DESCRIPTION
#### Rationale
The server knows the name of the attachment and is able to supply this as a part of the `Content-Disposition` header for attachments.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1733
- https://github.com/LabKey/labkey-ui-premium/pull/694
- https://github.com/LabKey/platform/pull/6397
- https://github.com/LabKey/limsModules/pull/1209
- https://github.com/LabKey/testAutomation/pull/2310

#### Changes
- Supply the `filename` as a part of the `Content-Disposition` header for `attachment` resources.
- Intentionally do not conflict with the preexisting "filename" URL parameter feature.
