### PR TITLE
Migrate from Jackson deprecated methods

### DIFF
--- a/announcements/src/org/labkey/announcements/SendMessageAction.java
+++ b/announcements/src/org/labkey/announcements/SendMessageAction.java
@@ -99,11 +99,11 @@ public class SendMessageAction extends MutatingApiAction<SendMessageAction.Messa
             throw new IllegalArgumentException("You must supply a msgFrom value.");
 
         JSONArray recipients = json.optJSONArray(Props.msgRecipients.name());
-        if (recipients == null || recipients.length() < 1)
+        if (recipients == null || recipients.isEmpty())
             throw new IllegalArgumentException("No message recipients supplied.");
 
         JSONArray contents = json.optJSONArray(Props.msgContent.name());
-        if (contents == null || contents.length() < 1)
+        if (contents == null || contents.isEmpty())
             throw new IllegalArgumentException("No message contents supplied.");
 
         MailHelper.MultipartMessage msg = MailHelper.createMultipartMessage();

--- a/api/src/org/labkey/api/pipeline/FilterDeserializer.java
+++ b/api/src/org/labkey/api/pipeline/FilterDeserializer.java
@@ -28,7 +28,7 @@ public class FilterDeserializer extends StdDeserializer<Filter>
 
             while (parser.nextToken() != JsonToken.END_OBJECT)
             {
-                String fieldName = parser.getCurrentName();
+                String fieldName = parser.currentName();
                 parser.nextToken();       // get past FIELD_NAME
                 if ("_columnName".equals(fieldName))
                     columnName = parser.getValueAsString();
@@ -42,13 +42,13 @@ public class FilterDeserializer extends StdDeserializer<Filter>
 
             return new Filter(columnName, value, operator);
         }
-        else if (JsonToken.VALUE_NULL.equals(parser.getCurrentToken()))
+        else if (JsonToken.VALUE_NULL.equals(parser.currentToken()))
         {
             return null;
         }
         else
         {
-            throw new IOException("Unexpected token in serialized Filter: " + parser.getCurrentToken());
+            throw new IOException("Unexpected token in serialized Filter: " + parser.currentToken());
         }
     }
 }

--- a/api/src/org/labkey/api/pipeline/QueryKeySerialization.java
+++ b/api/src/org/labkey/api/pipeline/QueryKeySerialization.java
@@ -79,7 +79,7 @@ public class QueryKeySerialization
                 String name = null;
                 while (parser.nextToken() != JsonToken.END_OBJECT)
                 {
-                    String fieldName = parser.getCurrentName();
+                    String fieldName = parser.currentName();
                     JsonToken token1 = parser.nextToken();       // get past FIELD_NAME
                     if ("_parent".equals(fieldName))
                         parent = parser.readValueAs(SchemaKey.class);
@@ -91,13 +91,13 @@ public class QueryKeySerialization
 
                 return new SchemaKey(parent, name);
             }
-            else if (JsonToken.VALUE_NULL.equals(parser.getCurrentToken()))
+            else if (JsonToken.VALUE_NULL.equals(parser.currentToken()))
             {
                 return null;
             }
             else
             {
-                throw new IOException("Unexpected token in serialized SchemaKey: " + parser.getCurrentToken());
+                throw new IOException("Unexpected token in serialized SchemaKey: " + parser.currentToken());
             }
         }
 
@@ -124,7 +124,7 @@ public class QueryKeySerialization
                 String name = null;
                 while (parser.nextToken() != JsonToken.END_OBJECT)
                 {
-                    String fieldName = parser.getCurrentName();
+                    String fieldName = parser.currentName();
                     JsonToken token1 = parser.nextToken();       // get past FIELD_NAME
                     if ("_parent".equals(fieldName))
                         parent = parser.readValueAs(FieldKey.class);
@@ -136,13 +136,13 @@ public class QueryKeySerialization
 
                 return new FieldKey(parent, name);
             }
-            else if (JsonToken.VALUE_NULL.equals(parser.getCurrentToken()))
+            else if (JsonToken.VALUE_NULL.equals(parser.currentToken()))
             {
                 return null;
             }
             else
             {
-                throw new IOException("Unexpected token in serialized FieldKey: " + parser.getCurrentToken());
+                throw new IOException("Unexpected token in serialized FieldKey: " + parser.currentToken());
             }
         }
 

--- a/api/src/org/labkey/api/reader/JSONDataLoader.java
+++ b/api/src/org/labkey/api/reader/JSONDataLoader.java
@@ -137,7 +137,7 @@ public class JSONDataLoader extends DataLoader
                         case FIELD_NAME:
                             if (depth == 1)
                             {
-                                switch (parser.getCurrentName())
+                                switch (parser.currentName())
                                 {
                                     case "schemaName" -> {
                                         tok = parser.nextToken();
@@ -280,16 +280,16 @@ public class JSONDataLoader extends DataLoader
     {
         expectObjectStart(_parser);
 
-        while (_parser.getCurrentToken() == JsonToken.FIELD_NAME)
+        while (_parser.currentToken() == JsonToken.FIELD_NAME)
         {
-            String fieldName = _parser.getCurrentName();
+            String fieldName = _parser.currentName();
             _parser.nextToken();
 
-            if ("metaData".equals(fieldName) && _parser.getCurrentToken() == JsonToken.START_OBJECT)
+            if ("metaData".equals(fieldName) && _parser.currentToken() == JsonToken.START_OBJECT)
             {
                 parseMetadataContents();
             }
-            else if ("rows".equals(fieldName) && _parser.getCurrentToken() == JsonToken.START_ARRAY)
+            else if ("rows".equals(fieldName) && _parser.currentToken() == JsonToken.START_ARRAY)
             {
                 // stop parsing
                 break;
@@ -300,8 +300,8 @@ public class JSONDataLoader extends DataLoader
             }
         }
 
-        if (!(_parser.getCurrentToken() == JsonToken.START_ARRAY && _parser.getCurrentName().equals("rows")))
-            throw new JsonParseException(_parser, "Expected 'rows' field", _parser.getTokenLocation());
+        if (!(_parser.currentToken() == JsonToken.START_ARRAY && _parser.currentName().equals("rows")))
+            throw new JsonParseException(_parser, "Expected 'rows' field", _parser.currentTokenLocation());
     }
 
     /**
@@ -314,12 +314,12 @@ public class JSONDataLoader extends DataLoader
     {
         expectObjectStart(_parser);
 
-        while (_parser.getCurrentToken() == JsonToken.FIELD_NAME)
+        while (_parser.currentToken() == JsonToken.FIELD_NAME)
         {
-            String fieldName = _parser.getCurrentName();
+            String fieldName = _parser.currentName();
             _parser.nextToken();
 
-            if ("fields".equals(fieldName) && _parser.getCurrentToken() == JsonToken.START_ARRAY && _columns == null)
+            if ("fields".equals(fieldName) && _parser.currentToken() == JsonToken.START_ARRAY && _columns == null)
             {
                 _columns = parseFields(_parser, _mvIndicatorContainer);
             }
@@ -398,14 +398,14 @@ public class JSONDataLoader extends DataLoader
         FieldKey fieldKey = null;
         String type = null;
         Class jdbcTypeClass = null;
-        Boolean mvEnabled = Boolean.FALSE;
+        boolean mvEnabled = Boolean.FALSE;
 
-        while (parser.getCurrentToken() == JsonToken.FIELD_NAME)
+        while (parser.currentToken() == JsonToken.FIELD_NAME)
         {
-            String fieldName = parser.getCurrentName();
+            String fieldName = parser.currentName();
             parser.nextToken();
 
-            if ((fieldName.equals("fieldKey") || fieldName.equals("fieldKeyArray")) && JsonToken.START_ARRAY == parser.getCurrentToken() && fieldKey == null)
+            if ((fieldName.equals("fieldKey") || fieldName.equals("fieldKeyArray")) && JsonToken.START_ARRAY == parser.currentToken() && fieldKey == null)
             {
                 fieldKey = parser.readValueAs(FieldKey.class);
                 if (fieldKey == null)
@@ -561,7 +561,7 @@ public class JSONDataLoader extends DataLoader
      */
     protected static Map<String, Map<ColMapEntry, Object>> parseRow(JsonParser parser) throws IOException
     {
-        if (parser.getCurrentToken() != JsonToken.START_OBJECT)
+        if (parser.currentToken() != JsonToken.START_OBJECT)
             return null;
 
         expectObjectStart(parser);
@@ -1153,11 +1153,11 @@ public class JSONDataLoader extends DataLoader
             ColumnDescriptor[] cols = loader._columns;
             assertEquals(1, cols.length);
 
-            assertEquals(cols[0].name, "A");
-            assertEquals(cols[0].clazz, Integer.class);
+            assertEquals("A", cols[0].name);
+            assertEquals(Integer.class, cols[0].clazz);
 
-            assertEquals("rows", parser.getCurrentName());
-            assertEquals(JsonToken.START_ARRAY, parser.getCurrentToken());
+            assertEquals("rows", parser.currentName());
+            assertEquals(JsonToken.START_ARRAY, parser.currentToken());
         }
 
         @Test
@@ -1180,8 +1180,8 @@ public class JSONDataLoader extends DataLoader
 
             assertNull(loader._columns);
 
-            assertEquals("rows", parser.getCurrentName());
-            assertEquals(JsonToken.START_ARRAY, parser.getCurrentToken());
+            assertEquals("rows", parser.currentName());
+            assertEquals(JsonToken.START_ARRAY, parser.currentToken());
         }
 
         @Test

--- a/api/src/org/labkey/api/util/JsonUtil.java
+++ b/api/src/org/labkey/api/util/JsonUtil.java
@@ -72,28 +72,28 @@ public class JsonUtil
 
     public static JsonLocation expectObjectStart(JsonParser p) throws IOException
     {
-        if (p.getCurrentToken() != JsonToken.START_OBJECT)
-            throw new JsonParseException(p, "Expected object start '{', got '" + p.getCurrentToken() + "'", p.getTokenLocation());
+        if (p.currentToken() != JsonToken.START_OBJECT)
+            throw new JsonParseException(p, "Expected object start '{', got '" + p.currentToken() + "'", p.currentTokenLocation());
 
-        JsonLocation loc = p.getTokenLocation();
+        JsonLocation loc = p.currentTokenLocation();
         p.nextToken();
         return loc;
     }
 
     public static void expectObjectEnd(JsonParser p) throws IOException
     {
-        if (p.getCurrentToken() != JsonToken.END_OBJECT)
-            throw new JsonParseException(p, "Expected object end '}', got '" + p.getCurrentToken() + "'", p.getTokenLocation());
+        if (p.currentToken() != JsonToken.END_OBJECT)
+            throw new JsonParseException(p, "Expected object end '}', got '" + p.currentToken() + "'", p.currentTokenLocation());
 
         p.nextToken();
     }
 
     public static JsonLocation expectArrayStart(JsonParser p) throws IOException
     {
-        if (p.getCurrentToken() != JsonToken.START_ARRAY)
-            throw new JsonParseException(p, "Expected array start '[', got '" + p.getCurrentToken() + "'", p.getTokenLocation());
+        if (p.currentToken() != JsonToken.START_ARRAY)
+            throw new JsonParseException(p, "Expected array start '[', got '" + p.currentToken() + "'", p.currentTokenLocation());
 
-        JsonLocation loc = p.getTokenLocation();
+        JsonLocation loc = p.currentTokenLocation();
         p.nextToken();
         return loc;
     }
@@ -101,14 +101,14 @@ public class JsonUtil
     public static void expectArrayEnd(JsonParser p) throws IOException
     {
         if (!isArrayEnd(p))
-            throw new JsonParseException(p, "Expected array end ']', got '" + p.getCurrentToken() + "'", p.getTokenLocation());
+            throw new JsonParseException(p, "Expected array end ']', got '" + p.currentToken() + "'", p.currentTokenLocation());
 
         p.nextToken();
     }
 
     public static boolean isArrayEnd(JsonParser p)
     {
-        return p.getCurrentToken() == JsonToken.END_ARRAY;
+        return p.currentToken() == JsonToken.END_ARRAY;
     }
 
     public static void skipValue(JsonParser p) throws IOException


### PR DESCRIPTION
#### Rationale
Get rid of some yellow squiggles. Jackson has deprecated (or is about to deprecate) these methods and will remove them in 3.0. Might as well migrate our usages now. No functional change.
