### PR TITLE
Don't include the ETL run during folder export of experiment runs

### DIFF
--- a/api/src/org/labkey/api/di/DataIntegrationService.java
+++ b/api/src/org/labkey/api/di/DataIntegrationService.java
@@ -35,6 +35,7 @@ import java.util.function.BiFunction;
 public interface DataIntegrationService
 {
     String MODULE_NAME = "DataIntegration";
+    String ETL_PREFIX = "ETL Job: ";
 
     static DataIntegrationService get()
     {

--- a/api/src/org/labkey/api/di/DataIntegrationService.java
+++ b/api/src/org/labkey/api/di/DataIntegrationService.java
@@ -35,7 +35,6 @@ import java.util.function.BiFunction;
 public interface DataIntegrationService
 {
     String MODULE_NAME = "DataIntegration";
-    String ETL_PREFIX = "ETL Job: ";
 
     static DataIntegrationService get()
     {
@@ -56,6 +55,11 @@ public interface DataIntegrationService
     Pair<Long, String> truncateTargets(Container c, User user, String transformId);
 
     RemoteConnection getRemoteConnection(String name, Container c, @Nullable Logger log);
+
+    /**
+     * Returns the Set of transform job IDs for the container
+     */
+    Set<Integer> getTransformRunJobIds(Container c);
 
     /**
      * Execute an efficient reimport operation Create a dataIterator based on target.getQueryUpdateService()

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -101,15 +102,32 @@ public class FolderXarWriterFactory implements FolderWriterFactory
 
         private boolean hasRuns(Container c)
         {
-            return ExperimentService.get().hasExpRuns(c, this::runFilter);
+            return ExperimentService.get().hasExpRuns(c, new RunFilter(c));
         }
 
-        private boolean runFilter(ExpRun run) {
-            return !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID)
-                    && !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID)
-                    && !"recipe".equalsIgnoreCase(run.getProtocol().getImplementationName())
-                    && !"recipe".equalsIgnoreCase(run.getProtocol().getLSIDNamespacePrefix())
-                    && !(run.getName().startsWith(DataIntegrationService.ETL_PREFIX) && run.getJobId() != null);
+        private static class RunFilter implements Predicate<ExpRun>
+        {
+            private Set<Integer> _transformRuns;
+
+            public RunFilter(Container c)
+            {
+                _transformRuns = DataIntegrationService.get().getTransformRunJobIds(c);
+            }
+
+            @Override
+            public boolean test(ExpRun run)
+            {
+                return !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID)
+                        && !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID)
+                        && !"recipe".equalsIgnoreCase(run.getProtocol().getImplementationName())
+                        && !"recipe".equalsIgnoreCase(run.getProtocol().getLSIDNamespacePrefix())
+                        && !isETL(run);
+            }
+
+            private boolean isETL(ExpRun run)
+            {
+                return run.getJobId() != null && _transformRuns.contains(run.getJobId());
+            }
         }
 
         private List<ExpRun> getRuns(Container c)
@@ -118,7 +136,7 @@ public class FolderXarWriterFactory implements FolderWriterFactory
             // Also don't include recipe protocols; there's a separate folder writer and importer for the recipe module.
             // if an additional context has been furnished, filter out runs not included in this export
 
-            List<? extends ExpRun> allRuns = ExperimentServiceImpl.get().getExpRuns(c, null, null, this::runFilter);
+            List<? extends ExpRun> allRuns = ExperimentServiceImpl.get().getExpRuns(c, null, null, new RunFilter(c));
             // the smJobRuns can make reference to assay designs, so we will put all the SM Task and Protocols at the end to assure
             // the assay definitions have already been processed and can be resolved properly.
             List<ExpRun> reorderedRuns = allRuns.stream()

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -25,6 +25,7 @@ import org.labkey.api.admin.FolderWriter;
 import org.labkey.api.admin.FolderWriterFactory;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.di.DataIntegrationService;
 import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -107,7 +108,8 @@ public class FolderXarWriterFactory implements FolderWriterFactory
             return !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_DERIVATION_PROTOCOL_LSID)
                     && !run.getProtocol().getLSID().equals(ExperimentService.SAMPLE_ALIQUOT_PROTOCOL_LSID)
                     && !"recipe".equalsIgnoreCase(run.getProtocol().getImplementationName())
-                    && !"recipe".equalsIgnoreCase(run.getProtocol().getLSIDNamespacePrefix());
+                    && !"recipe".equalsIgnoreCase(run.getProtocol().getLSIDNamespacePrefix())
+                    && !(run.getName().startsWith(DataIntegrationService.ETL_PREFIX) && run.getJobId() != null);
         }
 
         private List<ExpRun> getRuns(Container c)

--- a/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
+++ b/experiment/src/org/labkey/experiment/xar/FolderXarWriterFactory.java
@@ -107,7 +107,7 @@ public class FolderXarWriterFactory implements FolderWriterFactory
 
         private static class RunFilter implements Predicate<ExpRun>
         {
-            private Set<Integer> _transformRuns;
+            private final Set<Integer> _transformRuns;
 
             public RunFilter(Container c)
             {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52142

Apparently this was causing some perf issues and these runs are useless for round-tripping.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6404
- https://github.com/LabKey/premiumModules/pull/186
