### PR TITLE
Complete migration from srcURL and returnURL to returnUrl

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementsController.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementsController.java
@@ -303,11 +303,11 @@ public class AnnouncementsController extends SpringActionController
         }
     }
 
-    public static ActionURL getAdminEmailURL(Container c, @Nullable URLHelper returnURL)
+    public static ActionURL getAdminEmailURL(Container c, @Nullable URLHelper returnUrl)
     {
         ActionURL url = urlProvider(AdminUrls.class).getNotificationsURL(c);
-        if (returnURL != null)
-            url.addReturnURL(returnURL);
+        if (returnUrl != null)
+            url.addReturnUrl(returnUrl);
 
         return url;
     }
@@ -381,7 +381,7 @@ public class AnnouncementsController extends SpringActionController
         @Override
         public @NotNull URLHelper getSuccessURL(AnnouncementDeleteForm form)
         {
-            return form.getReturnURLHelper(new ActionURL(BeginAction.class, getContainer()));
+            return form.getReturnUrlHelper(new ActionURL(BeginAction.class, getContainer()));
         }
 
         @Override
@@ -461,7 +461,7 @@ public class AnnouncementsController extends SpringActionController
     {
         ActionURL url = new ActionURL(DeleteResponseAction.class, c);
         url.addParameter("entityId", entityId);
-        url.addReturnURL(returnUrl);
+        url.addReturnUrl(returnUrl);
 
         return url;
     }
@@ -693,7 +693,7 @@ public class AnnouncementsController extends SpringActionController
     {
         ActionURL url = new ActionURL(CustomizeAction.class, c);
         if (returnUrl != null)
-            url.addReturnURL(returnUrl);
+            url.addReturnUrl(returnUrl);
 
         return url;
     }
@@ -705,7 +705,7 @@ public class AnnouncementsController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(Settings form)
         {
-            return form.getReturnURLHelper();
+            return form.getReturnUrlHelper();
         }
 
         @Override
@@ -714,7 +714,7 @@ public class AnnouncementsController extends SpringActionController
             CustomizeBean bean = new CustomizeBean();
 
             bean.settings = getSettings();   // TODO: Just use form?
-            bean.returnURL = form.getReturnURLHelper();
+            bean.returnUrl = form.getReturnUrlHelper();
             bean.assignedToSelect = getAssignedToSelect(getContainer(), bean.settings.getDefaultAssignedTo(), "defaultAssignedTo", getUser());
 
             if (hasEditorPerm(Group.groupGuests))
@@ -751,7 +751,7 @@ public class AnnouncementsController extends SpringActionController
     public static class CustomizeBean
     {
         public Settings settings;
-        public URLHelper returnURL;    // TODO: Settings has a returnUrl
+        public URLHelper returnUrl;    // TODO: Settings has a returnUrl
         public String securityWarning;
         public SelectBuilder assignedToSelect;
     }
@@ -821,10 +821,10 @@ public class AnnouncementsController extends SpringActionController
                 return false;
             }
 
-            URLHelper returnURL = form.getReturnURLHelper();
+            URLHelper returnUrl = form.getReturnUrlHelper();
 
             // Null in insert/update message case, since we want to redirect to thread view anchoring to new post
-            if (null == returnURL)
+            if (null == returnUrl)
             {
                 AnnouncementModel thread = insert;
                 if (null != insert.getParent())
@@ -832,24 +832,24 @@ public class AnnouncementsController extends SpringActionController
 
                 if (form.isFromDiscussion() && null != thread.getDiscussionSrcIdentifier())
                 {
-                    returnURL = DiscussionServiceImpl.fromSaved(thread.getDiscussionSrcURL());
-                    returnURL.addParameter("discussion.id", "" + thread.getRowId());
-                    returnURL.addParameter("_anchor", "discussionArea");               // TODO: insert.getRowId() instead? -- target just inserted response
+                    returnUrl = DiscussionServiceImpl.fromSaved(thread.getDiscussionSrcURL());
+                    returnUrl.addParameter("discussion.id", "" + thread.getRowId());
+                    returnUrl.addParameter("_anchor", "discussionArea");               // TODO: insert.getRowId() instead? -- target just inserted response
                 }
                 else
                 {
                     String threadId = thread.getEntityId();
-                    returnURL = getThreadURL(c, threadId, insert.getRowId());
+                    returnUrl = getThreadURL(c, threadId, insert.getRowId());
                 }
             }
 
-            _attachmentErrorView = AttachmentService.get().getErrorView(files, errors, returnURL);
+            _attachmentErrorView = AttachmentService.get().getErrorView(files, errors, returnUrl);
 
             boolean success = (null == _attachmentErrorView);
 
             // Can't use getSuccessURL since this is a URLHelper, not an ActionURL
             if (success)
-                throw new RedirectException(returnURL);
+                throw new RedirectException(returnUrl);
 
             return false;
         }
@@ -895,7 +895,7 @@ public class AnnouncementsController extends SpringActionController
                 throw new UnauthorizedException();
             }
 
-            InsertMessageView insertView = new InsertMessageView(form, "New " + settings.getConversationName(), errors, reshow, form.getReturnURLHelper(), false, true);
+            InsertMessageView insertView = new InsertMessageView(form, "New " + settings.getConversationName(), errors, reshow, form.getReturnUrlHelper(), false, true);
             insertView.setShowTitle(false);
 
             getPageConfig().setFocusId("title");
@@ -956,7 +956,7 @@ public class AnnouncementsController extends SpringActionController
             ThreadView threadView = new ThreadView(c, getActionURL(), parent, perm);
             threadView.setFrame(WebPartView.FrameType.DIV);
 
-            HttpView respondView = new RespondView(c, parent, form, form.getReturnURLHelper(), errors, reshow, false);
+            HttpView respondView = new RespondView(c, parent, form, form.getReturnUrlHelper(), errors, reshow, false);
 
             getPageConfig().setFocusId("body");
             _parent = parent;
@@ -1067,11 +1067,11 @@ public class AnnouncementsController extends SpringActionController
     }
 
 
-    private static ActionURL getInsertURL(Container c, @Nullable ActionURL returnURL)
+    private static ActionURL getInsertURL(Container c, @Nullable ActionURL returnUrl)
     {
         ActionURL url = new ActionURL(InsertAction.class, c);
-        if (returnURL != null)
-            url.addReturnURL(returnURL);
+        if (returnUrl != null)
+            url.addReturnUrl(returnUrl);
 
         return url;
     }
@@ -1200,7 +1200,7 @@ public class AnnouncementsController extends SpringActionController
     {
         ActionURL url = new ActionURL(UpdateAction.class, c);
         url.addParameter("entityId", threadId);
-        url.addReturnURL(returnUrl);
+        url.addReturnUrl(returnUrl);
         return url;
     }
 
@@ -1288,7 +1288,7 @@ public class AnnouncementsController extends SpringActionController
 
             // Needs to support non-ActionURL (e.g., an HTML page using the client API with embedded discussion webpart)
             // so we can't use getSuccessURL()
-            URLHelper urlHelper = form.getReturnURLHelper();
+            URLHelper urlHelper = form.getReturnUrlHelper();
             if (null != urlHelper)
                 throw new RedirectException(urlHelper);
             else
@@ -1496,7 +1496,7 @@ public class AnnouncementsController extends SpringActionController
         ActionURL result = new ActionURL(EmailPreferencesAction.class, c);
         result.addParameter("srcIdentifier", srcIdentifier);
         if (returnUrl != null)
-            result.addReturnURL(returnUrl);
+            result.addReturnUrl(returnUrl);
 
         return result;
     }
@@ -2022,13 +2022,13 @@ public class AnnouncementsController extends SpringActionController
         {
             // This is set to the outer page URL in the case of rendering a dynamic webpart; use it instead of
             // the getWebPart URL.
-            String returnURL = (String)ctx.get(ActionURL.Param.returnUrl.name());
+            String returnUrl = (String)ctx.get(ActionURL.Param.returnUrl.name());
 
-            if (null != returnURL)
+            if (null != returnUrl)
             {
                 try
                 {
-                    return new ActionURL(returnURL);
+                    return new ActionURL(returnUrl);
                 }
                 catch (IllegalArgumentException x)
                 {
@@ -2371,7 +2371,7 @@ public class AnnouncementsController extends SpringActionController
             bean.message = null;
             bean.perm = perm;
             bean.isResponse = isResponse;
-            bean.messagesURL = getBeginURL(c);  // TODO: Used as returnURL after delete thread... should be messages or list, as appropriate
+            bean.messagesURL = getBeginURL(c);  // TODO: Used as returnUrl after delete thread... should be messages or list, as appropriate
             bean.listURL = getListURL(c);
             bean.printURL = null == currentURL ? null : currentURL.clone().replaceParameter(ActionURL.Param._print.name(), "1");
             bean.print = print;
@@ -2399,7 +2399,7 @@ public class AnnouncementsController extends SpringActionController
                         // Build up a link to unsubscribe from the thread
                         ActionURL url = new ActionURL(SubscribeThreadAction.class, c);
                         url.addParameter("threadId", ann.getParent() == null ? ann.getEntityId() : ann.getParent());
-                        url.addReturnURL(getViewContext().getActionURL());
+                        url.addReturnUrl(getViewContext().getActionURL());
                         url.addParameter("unsubscribe", true);
                         buttons.addChild("unsubscribe", url).usePost();
                     }
@@ -2438,7 +2438,7 @@ public class AnnouncementsController extends SpringActionController
                             subscribeTree.addChild("forum", getEmailPreferencesURL(c, getViewContext().getActionURL(), ann.lookupSrcIdentifier()));
                             ActionURL subscribeThreadURL = new ActionURL(SubscribeThreadAction.class, c);
                             subscribeThreadURL.addParameter("threadId", ann.getParent() == null ? ann.getEntityId() : ann.getParent());
-                            subscribeThreadURL.addReturnURL(getViewContext().getActionURL());
+                            subscribeThreadURL.addReturnUrl(getViewContext().getActionURL());
                             subscribeTree.addChild("thread", subscribeThreadURL).usePost();
                             buttons.addChild(subscribeTree);
                         }
@@ -2582,7 +2582,7 @@ public class AnnouncementsController extends SpringActionController
             public SelectBuilder statusSelect;
             public SelectBuilder renderAsSelect;
             public String memberList;
-            public URLHelper returnURL;
+            public URLHelper returnUrl;
 
             private UpdateBean(AnnouncementForm form, AnnouncementModel ann)
             {
@@ -2595,7 +2595,7 @@ public class AnnouncementsController extends SpringActionController
                 statusSelect = getStatusSelect(ann.getStatus());
                 assignedToSelect = getAssignedToSelect(c, ann.getAssignedTo(), "assignedTo", getViewContext().getUser());
                 renderAsSelect = getRenderAsSelect(WikiRendererType.valueOf(ann.getRendererType()));
-                returnURL = form.getReturnURLHelper();
+                returnUrl = form.getReturnUrlHelper();
             }
         }
     }

--- a/announcements/src/org/labkey/announcements/announcementThread.jsp
+++ b/announcements/src/org/labkey/announcements/announcementThread.jsp
@@ -270,7 +270,7 @@ if (!bean.isResponse && !bean.print)
         else
         {
             ActionURL respond = announcementURL(c, RespondAction.class, "parentId", announcementModel.getEntityId());
-            respond.addReturnURL(bean.currentURL);
+            respond.addReturnUrl(bean.currentURL);
             %>
         <%= button("Respond").href(respond) %>&nbsp;<%
         }
@@ -282,11 +282,11 @@ if (!bean.isResponse && !bean.print)
         if (bean.embedded)
         {
             URLHelper redirect = bean.currentURL.clone().deleteScopeParameters("discussion");
-            deleteThread.addReturnURL(redirect);
+            deleteThread.addReturnUrl(redirect);
         }
         else
         {
-            deleteThread.addReturnURL(bean.messagesURL);
+            deleteThread.addReturnUrl(bean.messagesURL);
         }
         %>
         <%= button("Delete " + settings.getConversationName()).href(deleteThread) %>&nbsp;<%

--- a/announcements/src/org/labkey/announcements/customize.jsp
+++ b/announcements/src/org/labkey/announcements/customize.jsp
@@ -33,7 +33,7 @@
     DiscussionService.Settings settings = bean.settings;
 
 %><labkey:form action="<%=urlFor(CustomizeAction.class)%>" method="post">
-<%=generateReturnUrlFormField(bean.returnURL)%>
+<%=generateReturnUrlFormField(bean.returnUrl)%>
 <table class="lk-fields-table">
     <tr>
         <td class="labkey-form-label">Board name</td>
@@ -168,8 +168,8 @@
         <td colspan=2>
             <br/>
             <%= button("Save").submit(true) %>
-            <% if (null != bean.returnURL) { %>
-                <%= button("Cancel").href(bean.returnURL) %>
+            <% if (null != bean.returnUrl) { %>
+                <%= button("Cancel").href(bean.returnUrl) %>
             <% } %>
         </td>
     </tr>

--- a/announcements/src/org/labkey/announcements/update.jsp
+++ b/announcements/src/org/labkey/announcements/update.jsp
@@ -59,7 +59,7 @@
 <labkey:form method="post" action='<%=baseUrl.setAction(AnnouncementsController.UpdateAction.class)%>' enctype="multipart/form-data" onsubmit="return onSubmit(this);">
 <labkey:input type="hidden" name="rowId" value="<%=ann.getRowId()%>"/>
 <labkey:input type="hidden" name="entityId" value="<%=ann.getEntityId()%>"/>
-<%=generateReturnUrlFormField(bean.returnURL)%>
+<%=generateReturnUrlFormField(bean.returnUrl)%>
 <table><%
 
 if (settings.isTitleEditable())

--- a/api/src/org/labkey/api/action/ReturnUrlForm.java
+++ b/api/src/org/labkey/api/action/ReturnUrlForm.java
@@ -21,13 +21,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.ReturnURLString;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.HttpView;
 
 /**
  * Simple form bean that includes a returnUrl property, typically used to send the user back to the page where they initiated the action.
@@ -89,7 +87,7 @@ public class ReturnUrlForm
     }
 
     @Nullable
-    public URLHelper getReturnURLHelper()
+    public URLHelper getReturnUrlHelper()
     {
         return _returnUrl != null ? _returnUrl.getURLHelper() : null;
     }
@@ -111,9 +109,9 @@ public class ReturnUrlForm
     /**
      * Get the first non-null URL from <code>returnUrl</code> or the <code>defaultURL</code> parameter.
      */
-    public URLHelper getReturnURLHelper(URLHelper defaultURL)
+    public URLHelper getReturnUrlHelper(URLHelper defaultURL)
     {
-        return firstOf(getReturnURLHelper(), defaultURL);
+        return firstOf(getReturnUrlHelper(), defaultURL);
     }
 
     /**
@@ -192,27 +190,24 @@ public class ReturnUrlForm
                 defaultURL);
     }
 
-    // when we convert code to use ReturnUrlForm we may leave behind bookmarks using "returnURL"
     @Deprecated
     public ReturnURLString getReturnURL()
     {
-        throwBadParam();
         return _returnUrl;
     }
 
     @Deprecated
     public void setReturnURL(ReturnURLString returnUrl)
     {
-        throwBadParam();
         setReturnUrl(returnUrl);
     }
 
     /** Applies the return URL from this form (if any) to the given URL */
     public void propagateReturnURL(ActionURL urlNeedingParameter)
     {
-        if (getReturnURLHelper() != null)
+        if (getReturnUrlHelper() != null)
         {
-            urlNeedingParameter.addReturnURL(getReturnURLHelper());
+            urlNeedingParameter.addReturnUrl(getReturnUrlHelper());
         }
     }
 
@@ -225,30 +220,4 @@ public class ReturnUrlForm
 
         return null;
     }
-
-    /**
-     * Report a bad returnUrl usage.
-     * Some views don't show Spring binding errors from the thrown exception so
-     * log an ERROR message to the console and let the test framework report it.
-     */
-    public static void throwBadParam()
-    {
-        throwBadParam("returnURL");
-    }
-
-    /**
-     * Report a bad returnUrl usage.
-     * Some views don't show Spring binding errors from the thrown exception so
-     * log an ERROR message to the console and let the test framework report it.
-     */
-    public static void throwBadParam(String badParamName)
-    {
-        StringBuilder msg = new StringBuilder("Use 'returnUrl' instead of '").append(badParamName).append("'");
-        if (HttpView.hasCurrentView())
-            msg.append(" from URL: ").append(HttpView.currentContext().getRequest().getRequestURI());
-        LOG.error(msg.toString());
-        if (AppProps.getInstance().isDevMode())
-            throw new UnsupportedOperationException(msg.toString());
-    }
-
 }

--- a/api/src/org/labkey/api/action/ReturnUrlForm.java
+++ b/api/src/org/labkey/api/action/ReturnUrlForm.java
@@ -190,18 +190,6 @@ public class ReturnUrlForm
                 defaultURL);
     }
 
-    @Deprecated
-    public ReturnURLString getReturnURL()
-    {
-        return _returnUrl;
-    }
-
-    @Deprecated
-    public void setReturnURL(ReturnURLString returnUrl)
-    {
-        setReturnUrl(returnUrl);
-    }
-
     /** Applies the return URL from this form (if any) to the given URL */
     public void propagateReturnURL(ActionURL urlNeedingParameter)
     {

--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -630,7 +630,7 @@ public abstract class SpringActionController implements Controller, HasViewConte
                 if (user.isSearchUser())
                     return null;
 
-                URLHelper returnURL = null;
+                URLHelper returnUrl = null;
                 try
                 {
                     StringBuilder url = new StringBuilder(request.getRequestURL().toString());
@@ -639,7 +639,7 @@ public abstract class SpringActionController implements Controller, HasViewConte
                         url.append("?");
                         url.append(request.getQueryString());
                     }
-                    returnURL = new URLHelper(url.toString());
+                    returnUrl = new URLHelper(url.toString());
                 }
                 catch (URISyntaxException e)
                 {
@@ -656,11 +656,11 @@ public abstract class SpringActionController implements Controller, HasViewConte
                         uae.setType(UnauthorizedException.Type.sendBasicAuth);
                         throw uae;
                     }
-                    return urlProvider(AdminUrls.class).getMaintenanceURL(returnURL);
+                    return urlProvider(AdminUrls.class).getMaintenanceURL(returnUrl);
                 }
                 else if (upgradeRequired || !startupComplete)
                 {
-                    return urlProvider(AdminUrls.class).getModuleStatusURL(returnURL);
+                    return urlProvider(AdminUrls.class).getModuleStatusURL(returnUrl);
                 }
             }
         }

--- a/api/src/org/labkey/api/admin/AdminUrls.java
+++ b/api/src/org/labkey/api/admin/AdminUrls.java
@@ -30,10 +30,10 @@ public interface AdminUrls extends UrlProvider
 {
     ActionURL getModuleErrorsURL();
     ActionURL getAdminConsoleURL();
-    ActionURL getModuleStatusURL(URLHelper returnURL);
+    ActionURL getModuleStatusURL(URLHelper returnUrl);
     ActionURL getCustomizeSiteURL();
     ActionURL getCustomizeSiteURL(boolean upgradeInProgress);
-    ActionURL getMaintenanceURL(URLHelper returnURL);
+    ActionURL getMaintenanceURL(URLHelper returnUrl);
     ActionURL getModulesDetailsURL();
     ActionURL getDeleteModuleURL(String moduleName);
 
@@ -57,10 +57,10 @@ public interface AdminUrls extends UrlProvider
     ActionURL getProjectSettingsFileURL(Container c);
     ActionURL getFolderSettingsURL(Container c);
 
-    ActionURL getCreateProjectURL(@Nullable ActionURL returnURL);
-    ActionURL getCreateFolderURL(Container c, @Nullable ActionURL returnURL);
+    ActionURL getCreateProjectURL(@Nullable ActionURL returnUrl);
+    ActionURL getCreateFolderURL(Container c, @Nullable ActionURL returnUrl);
     ActionURL getMemTrackerURL();
-    ActionURL getCustomizeEmailURL(Container c, Class<? extends EmailTemplate> selectedTemplate, URLHelper returnURL);
+    ActionURL getCustomizeEmailURL(Container c, Class<? extends EmailTemplate> selectedTemplate, URLHelper returnUrl);
     ActionURL getFilesSiteSettingsURL(boolean upgrade);
     ActionURL getSessionLoggingURL();
     ActionURL getTrackedAllocationsViewerURL();

--- a/api/src/org/labkey/api/assay/AssayUrls.java
+++ b/api/src/org/labkey/api/assay/AssayUrls.java
@@ -35,7 +35,7 @@ public interface AssayUrls extends UrlProvider
     ActionURL getProtocolURL(Container container, ExpProtocol protocol, Class<? extends Controller> action);
 
     @Nullable
-    ActionURL getDesignerURL(Container container, String providerName, @Nullable ActionURL returnURL);
+    ActionURL getDesignerURL(Container container, String providerName, @Nullable ActionURL returnUrl);
 
     /**
      * Returns the URL for the assay designer

--- a/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
+++ b/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
@@ -416,9 +416,9 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         {
             view.getDataRegion().addHiddenFormField("reRunId", form.getReRunId().toString());
         }
-        if (form.getReturnURLHelper() != null)
+        if (form.getReturnUrlHelper() != null)
         {
-            view.getDataRegion().addHiddenFormField(ActionURL.Param.returnUrl, form.getReturnURLHelper());
+            view.getDataRegion().addHiddenFormField(ActionURL.Param.returnUrl, form.getReturnUrlHelper());
         }
 
         if (null != StudyPublishService.get())
@@ -492,8 +492,8 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         bbar.setStyle(ButtonBar.Style.separateButtons);
         addNextButton(bbar);
         addResetButton(runForm, insertView, bbar);
-        ActionURL returnURL = runForm.getReturnActionURL();
-        addCancelButton(bbar, returnURL);
+        ActionURL returnUrl = runForm.getReturnActionURL();
+        addCancelButton(bbar, returnUrl);
         insertView.getDataRegion().setButtonBar(bbar, DataRegion.MODE_INSERT);
 
         JspView<AssayRunUploadForm<?>> assayPropsView = new JspView<>("/org/labkey/assay/view/newUploadAssayProperties.jsp", runForm);
@@ -536,12 +536,12 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         bbar.add(cancelButton);
     }
 
-    protected void addCancelButton(ButtonBar bbar, String returnURL)
+    protected void addCancelButton(ButtonBar bbar, String returnUrl)
     {
         ActionURL link;
-        if (returnURL != null && !returnURL.equals(""))
+        if (returnUrl != null && !returnUrl.isEmpty())
         {
-            link = new ActionURL(returnURL);
+            link = new ActionURL(returnUrl);
         }
         else
         {
@@ -551,12 +551,12 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         bbar.add(cancelButton);
     }
 
-    protected void addCancelButton(ButtonBar bbar, ActionURL returnURL)
+    protected void addCancelButton(ButtonBar bbar, ActionURL returnUrl)
     {
         ActionURL link;
-        if (returnURL != null)
+        if (returnUrl != null)
         {
-            link = returnURL;
+            link = returnUrl;
         }
         else
         {
@@ -652,8 +652,8 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         ButtonBar bbar = new ButtonBar();
         bbar.setStyle(ButtonBar.Style.separateButtons);
         addRunActionButtons(newRunForm, insertView, bbar);
-        ActionURL returnURL = newRunForm.getReturnActionURL();
-        addCancelButton(bbar, returnURL);
+        ActionURL returnUrl = newRunForm.getReturnActionURL();
+        addCancelButton(bbar, returnUrl);
 
         insertView.getDataRegion().setButtonBar(bbar, DataRegion.MODE_INSERT);
         insertView.setTitle("Run Properties");

--- a/api/src/org/labkey/api/assay/actions/newUploadWarnings.jsp
+++ b/api/src/org/labkey/api/assay/actions/newUploadWarnings.jsp
@@ -34,10 +34,10 @@
     }
 %>
 <%
-    JspView<AssayRunUploadForm> me = (JspView<AssayRunUploadForm>) HttpView.currentView();
+    JspView<AssayRunUploadForm<?>> me = HttpView.currentView();
     AssayRunUploadForm<? extends AssayProvider> bean = me.getModelBean();
 
-    ActionURL returnURL = urlFor(AssayRunsAction.class).addParameter("rowId", bean.getProtocol().getRowId())
+    ActionURL returnUrl = urlFor(AssayRunsAction.class).addParameter("rowId", bean.getProtocol().getRowId())
             .addParameter("uploadAttemptID", bean.getUploadAttemptID());
 
     if (bean.getTransformResult().getWarnings() != null)
@@ -64,7 +64,7 @@
 %>
         <br/>
         <%= button("Proceed").onClick("submitForm(getRegionForm()); return false;") %>
-        <%= button("Cancel").href(returnURL).style("margin: 0 0 0 10px;") %>
+        <%= button("Cancel").href(returnUrl).style("margin: 0 0 0 10px;") %>
 <%
     }
 %>

--- a/api/src/org/labkey/api/assay/query/BatchListQueryView.java
+++ b/api/src/org/labkey/api/assay/query/BatchListQueryView.java
@@ -56,7 +56,7 @@ public class BatchListQueryView extends QueryView
     {
         super.populateButtonBar(view, bar);
 
-        ActionURL deleteURL = PageFlowUtil.urlProvider(ExperimentUrls.class).getDeleteExperimentsURL(getContainer(), getReturnURL());
+        ActionURL deleteURL = PageFlowUtil.urlProvider(ExperimentUrls.class).getDeleteExperimentsURL(getContainer(), getReturnUrl());
         ActionButton deleteButton = new ActionButton(deleteURL, "Delete");
         deleteButton.setIconCls("trash");
         deleteButton.setURL(deleteURL);

--- a/api/src/org/labkey/api/assay/query/ResultsQueryView.java
+++ b/api/src/org/labkey/api/assay/query/ResultsQueryView.java
@@ -108,18 +108,18 @@ public class ResultsQueryView extends AssayBaseQueryView
         // Add a default sort to the end of any sorts that have already been specified (by a custom view, for example)
         sort.appendSortColumn(AssayService.get().getProvider(_protocol).getTableMetadata(_protocol).getResultRowIdFieldKey(), Sort.SortDirection.ASC, false);
         view.getDataRegion().addHiddenFormField("rowId", "" + _protocol.getRowId());
-        String returnURL = getViewContext().getRequest().getParameter(ActionURL.Param.returnUrl.name());
+        String returnUrl = getViewContext().getRequest().getParameter(ActionURL.Param.returnUrl.name());
 
-        if (returnURL == null)
+        if (returnUrl == null)
         {
-            // 27693: Respect returnURL from async webpart requests
-            if (getSettings().getReturnURLHelper() != null)
-                returnURL = getSettings().getReturnURLHelper().toString();
+            // 27693: Respect returnUrl from async webpart requests
+            if (getSettings().getReturnUrlHelper() != null)
+                returnUrl = getSettings().getReturnUrlHelper().toString();
             else
-                returnURL = getViewContext().getActionURL().toString();
+                returnUrl = getViewContext().getActionURL().toString();
         }
 
-        view.getDataRegion().addHiddenFormField(ActionURL.Param.returnUrl, returnURL);
+        view.getDataRegion().addHiddenFormField(ActionURL.Param.returnUrl, returnUrl);
 
         String redirectUrl = getViewContext().getRequest().getParameter(ActionURL.Param.redirectUrl.name());
         if (redirectUrl != null)

--- a/api/src/org/labkey/api/assay/query/RunListQueryView.java
+++ b/api/src/org/labkey/api/assay/query/RunListQueryView.java
@@ -143,7 +143,7 @@ public class RunListQueryView extends ExperimentRunListView
             if (getContainer().hasPermission(getUser(), QCAnalystPermission.class))
             {
                 ActionURL updateAction = PageFlowUtil.urlProvider(AssayUrls.class).getUpdateQCStateURL(getContainer(), schema.getProtocol())
-                        .addReturnURL(getViewContext().getActionURL());
+                        .addReturnUrl(getViewContext().getActionURL());
                 NavTree updateItem = button.addMenuItem("Update state of selected rows", "if (verifySelected(" + DataRegion.getJavaScriptObjectReference(getDataRegionName()) + ".form, \"" +
                         updateAction.getLocalURIString() + "\", \"post\", \"rows\")) " + DataRegion.getJavaScriptObjectReference(getDataRegionName()) + ".form.submit()");
                 updateItem.setId("QCState:updateSelected");
@@ -154,7 +154,7 @@ public class RunListQueryView extends ExperimentRunListView
             if (protocolContainer.hasPermission(getUser(), AdminPermission.class))
             {
                 button.addMenuItem("Manage states", PageFlowUtil.urlProvider(CoreUrls.class).getManageQCStatesURL(protocolContainer)
-                        .addReturnURL(getViewContext().getActionURL()));
+                        .addReturnUrl(getViewContext().getActionURL()));
                 addButton = true;
             }
 

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -31,7 +31,6 @@ import org.json.JSONObject;
 import org.labkey.api.action.BaseViewAction;
 import org.labkey.api.action.HasBindParameters;
 import org.labkey.api.action.NullSafeBindException;
-import org.labkey.api.action.ReturnUrlForm;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.query.SchemaKey;
@@ -358,8 +357,8 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
             if (null == pkVal)
             {
                 Object oldValues = getOldValues();
-                if (oldValues instanceof Map)
-                    pkVal = ((Map) oldValues).get(pkName);
+                if (oldValues instanceof Map m)
+                    pkVal = m.get(pkName);
                 else
                     try
                     {
@@ -616,7 +615,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
     public void setTypedValues(Map<String, Object> values, boolean merge)
     {
         assert null != _dynaClass;
-        assert null != (values = Collections.unmodifiableMap(values));
+        values = Collections.unmodifiableMap(values);
 
         //We assume this means data is loaded.
         _isDataLoaded = true;
@@ -784,7 +783,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         if (_isBulkUpdate)
         {
             Set<String> selected = DataRegionSelection.getSelected(context, null, false);
-            _selectedRows = selected.toArray(new String[selected.size()]);
+            _selectedRows = selected.toArray(new String[0]);
         }
         else
         {
@@ -827,12 +826,6 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
 
         // handle binding of base class ReturnURLForm
         PropertyValue pvReturn = params.getPropertyValue(ActionURL.Param.returnUrl.toString());
-        if (null == pvReturn)
-        {
-            pvReturn = params.getPropertyValue("returnURL");
-            if (pvReturn != null)
-                ReturnUrlForm.throwBadParam();
-        }
         if (null != pvReturn)
         {
             try

--- a/api/src/org/labkey/api/defaults/SetDefaultValuesAction.java
+++ b/api/src/org/labkey/api/defaults/SetDefaultValuesAction.java
@@ -169,13 +169,13 @@ public class SetDefaultValuesAction<FormType extends DomainIdForm> extends Defau
     @Override
     public HttpView getView(FormType domainIdForm, boolean reshow, BindException errors) throws Exception
     {
-        _returnUrl = domainIdForm.getReturnURLHelper(PageFlowUtil.urlProvider(ProjectUrls.class).getStartURL(getContainer()));
+        _returnUrl = domainIdForm.getReturnUrlHelper(PageFlowUtil.urlProvider(ProjectUrls.class).getStartURL(getContainer()));
         Domain domain = getDomain(domainIdForm);
         List<? extends DomainProperty> properties = domain.getProperties();
         if (properties.isEmpty())
         {
             return HtmlView.unsafe("No fields are defined for this table.<br><br>" +
-                    PageFlowUtil.button("Cancel").href(domainIdForm.getReturnURLHelper()));
+                    PageFlowUtil.button("Cancel").href(domainIdForm.getReturnUrlHelper()));
         }
 
 
@@ -294,9 +294,9 @@ public class SetDefaultValuesAction<FormType extends DomainIdForm> extends Defau
     {
         // Overrides to this method should call super, and then add any additional url parameters the entity type may need.
         ActionURL url = new ActionURL(this.getClass(), container);
-        URLHelper returnUrl = domainIdForm.getReturnURLHelper();
+        URLHelper returnUrl = domainIdForm.getReturnUrlHelper();
         if (returnUrl != null)
-            url.addReturnURL(returnUrl);
+            url.addReturnUrl(returnUrl);
         url.addParameter("domainId", domainIdForm.getDomainId());
         return url;
     }

--- a/api/src/org/labkey/api/exp/ExperimentRunListView.java
+++ b/api/src/org/labkey/api/exp/ExperimentRunListView.java
@@ -156,7 +156,7 @@ public class ExperimentRunListView extends QueryView
         if (_showRemoveFromExperimentButton)
         {
             getExperiment();
-            ActionURL removeRunUrl = PageFlowUtil.urlProvider(ExperimentUrls.class).getRemoveSelectedExpRunsURL(getContainer(), getReturnURL(), getExperiment());
+            ActionURL removeRunUrl = PageFlowUtil.urlProvider(ExperimentUrls.class).getRemoveSelectedExpRunsURL(getContainer(), getReturnUrl(), getExperiment());
             ActionButton removeRunAction = new ActionButton(removeRunUrl,"Remove");
             removeRunAction.setActionType(ActionButton.Action.POST);
             removeRunAction.setRequiresSelection(true);
@@ -167,7 +167,7 @@ public class ExperimentRunListView extends QueryView
 
         if (showDeleteButton())
         {
-            ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getDeleteSelectedExpRunsURL(context.getContainer(), getReturnURL());
+            ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getDeleteSelectedExpRunsURL(context.getContainer(), getReturnUrl());
             ActionButton deleteButton = new ActionButton(url, "Delete");
             deleteButton.setIconCls("trash");
             deleteButton.setActionType(ActionButton.Action.POST);
@@ -181,7 +181,7 @@ public class ExperimentRunListView extends QueryView
             MenuButton addToExperimentButton = new MenuButton("Add to run group");
             addToExperimentButton.setRequiresSelection(true);
 
-            ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getCreateRunGroupURL(getContainer(), getReturnURL(), true).addParameter("noPost", "true");
+            ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getCreateRunGroupURL(getContainer(), getReturnUrl(), true).addParameter("noPost", "true");
             String javascript = view.getDataRegion().getJavascriptFormReference() + ".method = \"POST\";\n " +
                     view.getDataRegion().getJavascriptFormReference() + ".action = " + PageFlowUtil.jsString(url) + ";\n " +
                     view.getDataRegion().getJavascriptFormReference() + ".submit();";

--- a/api/src/org/labkey/api/exp/api/ExperimentUrls.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentUrls.java
@@ -46,15 +46,15 @@ public interface ExperimentUrls extends UrlProvider
     default ActionURL getRunTextURL(Container c, int rowId) { return null; }
     default ActionURL getRunTextURL(ExpRun run) { return null; }
 
-    default ActionURL getDeleteProtocolURL(@NotNull ExpProtocol protocol, URLHelper returnURL) { return null; }
+    default ActionURL getDeleteProtocolURL(@NotNull ExpProtocol protocol, URLHelper returnUrl) { return null; }
 
-    default ActionURL getDeleteExperimentsURL(Container container, URLHelper returnURL) { return null; }
+    default ActionURL getDeleteExperimentsURL(Container container, URLHelper returnUrl) { return null; }
 
-    default ActionURL getDeleteDatasURL(Container container, URLHelper returnURL) { return null; }
+    default ActionURL getDeleteDatasURL(Container container, URLHelper returnUrl) { return null; }
 
     default ActionURL getExperimentDetailsURL(Container c, ExpExperiment expExperiment) { return null; }
 
-    default ActionURL getRemoveSelectedExpRunsURL(Container container, URLHelper returnURL, ExpExperiment expExperiment) { return null; }
+    default ActionURL getRemoveSelectedExpRunsURL(Container container, URLHelper returnUrl, ExpExperiment expExperiment) { return null; }
 
     default ActionURL getExportProtocolURL(Container container, ExpProtocol protocol) { return null; }
 
@@ -64,9 +64,9 @@ public interface ExperimentUrls extends UrlProvider
 
     default ActionURL getMoveRunsLocationURL(Container container) { return null; }
 
-    default ActionURL getDeleteSelectedExpRunsURL(Container container, URLHelper returnURL) { return null; }
+    default ActionURL getDeleteSelectedExpRunsURL(Container container, URLHelper returnUrl) { return null; }
 
-    default ActionURL getCreateRunGroupURL(Container container, URLHelper returnURL, boolean addSelectedRuns) { return null; }
+    default ActionURL getCreateRunGroupURL(Container container, URLHelper returnUrl, boolean addSelectedRuns) { return null; }
 
     default ActionURL getShowRunsURL(Container c, ExperimentRunType type) { return null; }
 

--- a/api/src/org/labkey/api/jsp/JspBase.java
+++ b/api/src/org/labkey/api/jsp/JspBase.java
@@ -503,9 +503,9 @@ public abstract class JspBase extends JspContext implements HasViewContext
         return PageFlowUtil.makeHtmlId(s);
     }
 
-    public HtmlString generateReturnUrlFormField(URLHelper returnURL)
+    public HtmlString generateReturnUrlFormField(URLHelper returnUrl)
     {
-        return ReturnUrlForm.generateHiddenFormField(returnURL);
+        return ReturnUrlForm.generateHiddenFormField(returnUrl);
     }
 
     public HtmlString generateReturnUrlFormField(ReturnUrlForm form)

--- a/api/src/org/labkey/api/portal/ProjectUrls.java
+++ b/api/src/org/labkey/api/portal/ProjectUrls.java
@@ -31,13 +31,13 @@ public interface ProjectUrls extends UrlProvider
     ActionURL getHomeURL();
     ActionURL getCustomizeWebPartURL(Container c);
     ActionURL getAddWebPartURL(Container c);
-    ActionURL getCustomizeWebPartURL(Container c, Portal.WebPart webPart, ActionURL returnURL);
-    ActionURL getMoveWebPartURL(Container c, Portal.WebPart webPart, int direction, ActionURL returnURL);
-    ActionURL getDeleteWebPartURL(Container c, Portal.WebPart webPart, ActionURL returnURL);
-    ActionURL getDeleteWebPartURL(Container c, String pageId, int index, ActionURL returnURL);
-    ActionURL getHidePortalPageURL(Container c, String pageId, ActionURL returnURL);
-    ActionURL getDeletePortalPageURL(Container c, String pageId, ActionURL returnURL);
+    ActionURL getCustomizeWebPartURL(Container c, Portal.WebPart webPart, ActionURL returnUrl);
+    ActionURL getMoveWebPartURL(Container c, Portal.WebPart webPart, int direction, ActionURL returnUrl);
+    ActionURL getDeleteWebPartURL(Container c, Portal.WebPart webPart, ActionURL returnUrl);
+    ActionURL getDeleteWebPartURL(Container c, String pageId, int index, ActionURL returnUrl);
+    ActionURL getHidePortalPageURL(Container c, String pageId, ActionURL returnUrl);
+    ActionURL getDeletePortalPageURL(Container c, String pageId, ActionURL returnUrl);
     ActionURL getExpandCollapseURL(Container c, String path, String treeId);
     ActionURL getFileBrowserURL(Container c, String path);
-    ActionURL getTogglePageAdminModeURL(Container c, ActionURL returnURL);
+    ActionURL getTogglePageAdminModeURL(Container c, ActionURL returnUrl);
 }

--- a/api/src/org/labkey/api/query/QueryParam.java
+++ b/api/src/org/labkey/api/query/QueryParam.java
@@ -37,9 +37,6 @@ public enum QueryParam implements SafeToRenderEnum
 
     allowHeaderLock,
     dataRegionName,
-    /** Use {@link ActionURL.Param#returnUrl} and {@link ActionURL#addReturnURL(URLHelper)} instead. */
-    @Deprecated
-    srcURL,
     containerFilterName,
     selectionKey
 }

--- a/api/src/org/labkey/api/query/QuerySettings.java
+++ b/api/src/org/labkey/api/query/QuerySettings.java
@@ -21,7 +21,6 @@ import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.action.ReturnUrlForm;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Aggregate;
 import org.labkey.api.data.AnalyticsProviderItem;
@@ -87,7 +86,7 @@ public class QuerySettings
     private ShowRows _showRows = ShowRows.PAGINATED;
 
     PropertyValues _filterSort = null;
-    private ReturnURLString _returnURL = null;
+    private ReturnURLString _returnUrl = null;
 
     private String _containerFilterName;
     private List<AnalyticsProviderItem> _analyticsProviders = new ArrayList<>();
@@ -305,24 +304,12 @@ public class QuerySettings
             setContainerFilterName(containerFilterNameParam);
         }
 
-        String returnURL = _getParameter(ActionURL.Param.returnUrl.name());
-        if (returnURL == null)
-        {
-            returnURL = _getParameter("returnURL");
-            if (returnURL != null)
-                ReturnUrlForm.throwBadParam();
-        }
-        if (returnURL == null)
-        {
-            returnURL = _getParameter(QueryParam.srcURL.toString());
-            if (returnURL != null)
-                ReturnUrlForm.throwBadParam("srcURL");
-        }
-        if (returnURL != null)
+        String returnUrl = _getParameter(ActionURL.Param.returnUrl.name());
+        if (returnUrl != null)
         {
             try
             {
-                URLHelper url = new URLHelper(returnURL);
+                URLHelper url = new URLHelper(returnUrl);
                 url.setReadOnly();
                 setReturnUrl(new ReturnURLString(url));
             }
@@ -499,26 +486,26 @@ public class QuerySettings
      */
     public ReturnURLString getReturnUrl()
     {
-        return _returnURL;
+        return _returnUrl;
     }
 
-    public void setReturnUrl(ReturnURLString returnURL)
+    public void setReturnUrl(ReturnURLString returnUrl)
     {
-        _returnURL = returnURL;
+        _returnUrl = returnUrl;
     }
 
     /**
      * Returns the "returnUrl" parameter or null if none.
      * The url may not necessarily be an ActionURL, e.g. if served from a FileContent html page.
      */
-    public URLHelper getReturnURLHelper()
+    public URLHelper getReturnUrlHelper()
     {
-        return _returnURL == null ? null : _returnURL.getURLHelper();
+        return _returnUrl == null ? null : _returnUrl.getURLHelper();
     }
 
-    public URLHelper getReturnURLHelper(URLHelper defaultURL)
+    public URLHelper getReturnUrlHelper(URLHelper defaultURL)
     {
-        URLHelper url = getReturnURLHelper();
+        URLHelper url = getReturnUrlHelper();
         if (url == null)
             url = defaultURL;
         return url;
@@ -556,8 +543,7 @@ public class QuerySettings
         String queryName = getQueryName();
         if (queryName == null)
             return null;
-        TableInfo table = schema.getTableCFF(queryName, ContainerFilter.getType(getContainerFilterName()));
-        return table;
+        return schema.getTableCFF(queryName, ContainerFilter.getType(getContainerFilterName()));
     }
 
     public final QueryDefinition getQueryDef(UserSchema schema)
@@ -726,7 +712,7 @@ public class QuerySettings
 
     public void addSortFilters(Map<String, Object> filters)
     {
-        if (filters != null && filters.size() > 0)
+        if (filters != null && !filters.isEmpty())
         {
             // UNDONE: there should be an easier way to convert into a Filter than having to serialize them onto an ActionUrl and back out.
             // Issue 17411: Support multiple filters and aggregates on the same column.
@@ -854,7 +840,7 @@ public class QuerySettings
 
     // Always throws BadRequestException with our standard message. Use this for convenience and consistency. Also
     // helps address Issue 45567.
-    public static void throwParameterParseException(Enum parameterEnum)
+    public static void throwParameterParseException(Enum<?> parameterEnum)
     {
         throw new BadRequestException(String.format(parseError, parameterEnum.name()));
     }

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -307,9 +307,9 @@ public class QueryView extends WebPartView<Object> implements ContainerUser
     /**
      * Returns an ActionURL for the "returnUrl" parameter or the current ActionURL if none.
      */
-    public URLHelper getReturnURL()
+    public URLHelper getReturnUrl()
     {
-        return getSettings().getReturnURLHelper(ViewServlet.getRequestURL());
+        return getSettings().getReturnUrlHelper(ViewServlet.getRequestURL());
     }
 
     protected boolean verboseErrors()
@@ -491,7 +491,7 @@ public class QueryView extends WebPartView<Object> implements ContainerUser
         if (expr == null)
             return null;
 
-        // Don't append the returnURL parameter in API responses
+        // Don't append the returnUrl parameter in API responses
         if (!isApiResponseView())
         {
             switch (action)
@@ -504,10 +504,10 @@ public class QueryView extends WebPartView<Object> implements ContainerUser
                 case deleteQueryRows:
                 {
                     // ICK
-                    URLHelper returnURL = getReturnURL();
-                    if (returnURL != null)
+                    URLHelper returnUrl = getReturnUrl();
+                    if (returnUrl != null)
                     {
-                        String encodedReturnURL = PageFlowUtil.encode(returnURL.getLocalURIString());
+                        String encodedReturnURL = PageFlowUtil.encode(returnUrl.getLocalURIString());
                         expr = ((StringExpressionFactory.AbstractStringExpression) expr).addParameter(ActionURL.Param.returnUrl.name(), encodedReturnURL);
                     }
                 }
@@ -596,7 +596,7 @@ public class QueryView extends WebPartView<Object> implements ContainerUser
             case importData:
             case updateQueryRows:
             case deleteQueryRows:
-                ret.addReturnURL(getReturnURL());
+                ret.addReturnUrl(getReturnUrl());
                 break;
             case editSnapshot:
                 ret.addParameter("snapshotName", getSettings().getQueryName());
@@ -677,7 +677,7 @@ public class QueryView extends WebPartView<Object> implements ContainerUser
                 bean.setViewName(getSettings().getViewName());
                 bean.setDataRegionName(getDataRegionName());
 
-                bean.setRedirectUrl(getReturnURL().getLocalURIString());
+                bean.setRedirectUrl(getReturnUrl().getLocalURIString());
                 return ReportUtil.getScriptReportDesignerURL(_viewContext, bean);
         }
         return ret;
@@ -713,7 +713,7 @@ public class QueryView extends WebPartView<Object> implements ContainerUser
 
     protected URLHelper urlRefreshQuery()
     {
-        URLHelper ret = getSettings().getReturnURLHelper(getSettings().getSortFilterURL());
+        URLHelper ret = getSettings().getReturnUrlHelper(getSettings().getSortFilterURL());
         ret = ret.clone();
         ret.deleteParameter(param(QueryParam.queryName));
         ret.deleteParameter(param(QueryParam.viewName));
@@ -738,7 +738,7 @@ public class QueryView extends WebPartView<Object> implements ContainerUser
 
     protected URLHelper urlChangeView()
     {
-        URLHelper ret = getSettings().getReturnURLHelper();
+        URLHelper ret = getSettings().getReturnUrlHelper();
         if (null == ret)
         {
             ret = getSettings().getSortFilterURL();
@@ -1662,7 +1662,7 @@ public class QueryView extends WebPartView<Object> implements ContainerUser
     {
         if (_customView != null && _customView.hasFilterOrSort())
         {
-            URLHelper url = getSettings().getReturnURLHelper(getSettings().getSortFilterURL());
+            URLHelper url = getSettings().getReturnUrlHelper(getSettings().getSortFilterURL());
             url = url.clone();
             NavTree item;
             String label = "Apply Grid Filter";
@@ -1698,7 +1698,7 @@ public class QueryView extends WebPartView<Object> implements ContainerUser
 
             for (ContainerFilter.Type filterType : getAllowableContainerFilterTypes())
             {
-                URLHelper url = getSettings().getReturnURLHelper(getSettings().getSortFilterURL());
+                URLHelper url = getSettings().getReturnUrlHelper(getSettings().getSortFilterURL());
                 url = url.clone();
                 String propName = getDataRegionName() + DataRegion.CONTAINER_FILTER_NAME;
                 url.replaceParameter(propName, filterType.name());

--- a/api/src/org/labkey/api/query/UserSchemaAction.java
+++ b/api/src/org/labkey/api/query/UserSchemaAction.java
@@ -145,18 +145,18 @@ public abstract class UserSchemaAction extends FormViewAction<QueryUpdateForm>
         return resolveReturnUrl(form == null ? getActionURLParam(ActionURL.Param.cancelUrl) : null, form);
     }
 
-    private ActionURL resolveReturnUrl(@Nullable ActionURL returnURL, QueryUpdateForm form)
+    private ActionURL resolveReturnUrl(@Nullable ActionURL returnUrl, QueryUpdateForm form)
     {
-        if (null == returnURL)
-            returnURL = getActionURLParam(ActionURL.Param.returnUrl);
-        if (null == returnURL)
+        if (null == returnUrl)
+            returnUrl = getActionURLParam(ActionURL.Param.returnUrl);
+        if (null == returnUrl)
         {
             if (_schema != null && _table != null)
-                returnURL = _schema.urlFor(QueryAction.executeQuery, _form.getQueryDef());
+                returnUrl = _schema.urlFor(QueryAction.executeQuery, _form.getQueryDef());
             else
-                returnURL = QueryService.get().urlDefault(form.getContainer(), QueryAction.executeQuery, null, null);
+                returnUrl = QueryService.get().urlDefault(form.getContainer(), QueryAction.executeQuery, null, null);
         }
-        return returnURL;
+        return returnUrl;
     }
 
     public ActionURL getCancelURL(QueryUpdateForm form)

--- a/api/src/org/labkey/api/reports/Report.java
+++ b/api/src/org/labkey/api/reports/Report.java
@@ -126,7 +126,7 @@ public interface Report extends AttachmentParent, ThumbnailProvider
     String getRunReportTarget();
 
     @Nullable ActionURL getEditReportURL(ViewContext context);
-    @Nullable ActionURL getEditReportURL(ViewContext context, ActionURL returnURL);
+    @Nullable ActionURL getEditReportURL(ViewContext context, ActionURL returnUrl);
 
     /**
      * Allows source grid data to be downloaded for query based reports. This would be most

--- a/api/src/org/labkey/api/reports/report/AbstractReport.java
+++ b/api/src/org/labkey/api/reports/report/AbstractReport.java
@@ -198,10 +198,10 @@ public abstract class AbstractReport implements Report, Cloneable // TODO: Remov
     // Callers should pass in the "after save" redirect location; report might not be able to figure this out
     // (e.g., when manage views call this method, context.getActionURL() is a JSON API action)
     @Override
-    public @Nullable ActionURL getEditReportURL(ViewContext context, ActionURL returnURL)
+    public @Nullable ActionURL getEditReportURL(ViewContext context, ActionURL returnUrl)
     {
         ActionURL url = getEditReportURL(context);
-        return null != url ? url.addReturnURL(returnURL) : null;
+        return null != url ? url.addReturnUrl(returnUrl) : null;
     }
 
     @Override

--- a/api/src/org/labkey/api/reports/report/ReportUrls.java
+++ b/api/src/org/labkey/api/reports/report/ReportUrls.java
@@ -44,8 +44,8 @@ public interface ReportUrls extends UrlProvider
     // Thumbnail or icon, depending on ImageType
     ActionURL urlImage(Container c, Report r, ThumbnailService.ImageType type, @Nullable Integer revision);
     ActionURL urlReportInfo(Container c);
-    ActionURL urlAttachmentReport(Container c, ActionURL returnURL);
-    ActionURL urlLinkReport(Container c, ActionURL returnURL);
+    ActionURL urlAttachmentReport(Container c, ActionURL returnUrl);
+    ActionURL urlLinkReport(Container c, ActionURL returnUrl);
     ActionURL urlReportDetails(Container c, Report r);
     ActionURL urlQueryReport(Container c, Report r);
     ActionURL urlManageNotifications(Container c);

--- a/api/src/org/labkey/api/reports/report/view/RunReportView.java
+++ b/api/src/org/labkey/api/reports/report/view/RunReportView.java
@@ -131,12 +131,12 @@ public abstract class RunReportView extends TabStripView
     protected URLHelper getBaseUrl()
     {
         ActionURL url = getViewContext().getActionURL();
-        String returnURL = url.getParameter(ActionURL.Param.returnUrl);
+        String returnUrl = url.getParameter(ActionURL.Param.returnUrl);
 
         try
         {
-            if (!StringUtils.isBlank(returnURL))
-                return new URLHelper(returnURL);
+            if (!StringUtils.isBlank(returnUrl))
+                return new URLHelper(returnUrl);
             else
                 return new URLHelper(url.toString());
         }

--- a/api/src/org/labkey/api/security/AuthenticationConfiguration.java
+++ b/api/src/org/labkey/api/security/AuthenticationConfiguration.java
@@ -85,7 +85,7 @@ public interface AuthenticationConfiguration<AP extends AuthenticationProvider> 
 
     interface PrimaryAuthenticationConfiguration<AP extends PrimaryAuthenticationProvider<?>> extends AuthenticationConfiguration<AP>
     {
-        default @Nullable URLHelper logout(HttpServletRequest request, @Nullable URLHelper returnURL)
+        default @Nullable URLHelper logout(HttpServletRequest request, @Nullable URLHelper returnUrl)
         {
             return null;
         }

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -663,7 +663,7 @@ public class AuthenticationManager
         Success
         {
             @Override
-            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnURL, DisplayLocation location)
+            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnUrl, DisplayLocation location)
             {
                 throw new IllegalStateException("Shouldn't be adding an error message in success case");
             }
@@ -671,13 +671,13 @@ public class AuthenticationManager
         BadCredentials
         {
             @Override
-            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnURL, DisplayLocation location)
+            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnUrl, DisplayLocation location)
             {
                 String errorMessage = "The email address and password you entered did not match any accounts on file." + (DisplayLocation.WebUI == location ? "\nNote: Passwords are case sensitive; make sure your Caps Lock is off." : "");
                 errors.addError(new LabKeyError(errorMessage));
 
                 // Provide additional guidance on failed login, pointing user toward the SSO configuration(s) claiming their email domain
-                if (null != fullEmailAddress && null != returnURL && DisplayLocation.WebUI == location)
+                if (null != fullEmailAddress && null != returnUrl && DisplayLocation.WebUI == location)
                 {
                     String domain = fullEmailAddress.split("@")[1]; // Callers must ensure that fullEmailAddress includes @
                     Collection<SSOAuthenticationConfiguration> ssoConfigs = AuthenticationConfigurationCache.getActiveConfigurationsForDomain(domain).stream()
@@ -692,7 +692,7 @@ public class AuthenticationManager
                             .collect(Collectors.joining(" or ")) + ": ";
 
                         HtmlString logos = ssoConfigs.stream()
-                            .map(ac -> ac.getLinkFactory().getLink(returnURL, AuthLogoType.LOGIN_PAGE))
+                            .map(ac -> ac.getLinkFactory().getLink(returnUrl, AuthLogoType.LOGIN_PAGE))
                             .filter(Objects::nonNull) // Only those with a login page logo
                             .collect(LabKeyCollectors.joining(HtmlString.unsafe("&nbsp;&nbsp;")));
 
@@ -707,7 +707,7 @@ public class AuthenticationManager
         InactiveUser
         {
             @Override
-            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnURL, DisplayLocation location)
+            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnUrl, DisplayLocation location)
             {
                 errors.addError(new ContactAnAdministratorError("Your account has been deactivated.", "to request reactivation of this account."));
             }
@@ -715,7 +715,7 @@ public class AuthenticationManager
         LoginDisabled
         {
             @Override
-            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnURL, DisplayLocation location)
+            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnUrl, DisplayLocation location)
             {
                 String errorMessage = result.getMessage() == null ? "Due to the number of recent failed login attempts, authentication has been temporarily paused.\nTry again in one minute." : result.getMessage();
                 errors.reject(ERROR_MSG, errorMessage);
@@ -724,7 +724,7 @@ public class AuthenticationManager
         LoginPaused
         {
             @Override
-            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnURL, DisplayLocation location)
+            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnUrl, DisplayLocation location)
             {
                 errors.reject(ERROR_MSG, "Due to the number of recent failed login attempts, authentication has been temporarily paused.\nTry again in one minute.");
             }
@@ -732,7 +732,7 @@ public class AuthenticationManager
         UserCreationError
         {
             @Override
-            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnURL, DisplayLocation location)
+            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnUrl, DisplayLocation location)
             {
                 errors.addError(new ContactAnAdministratorError("The server could not create your account.", "for assistance."));
             }
@@ -740,7 +740,7 @@ public class AuthenticationManager
         UserCreationNotAllowed
         {
             @Override
-            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnURL, DisplayLocation location)
+            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnUrl, DisplayLocation location)
             {
                 errors.addError(new ContactAnAdministratorError("This server is not configured to create new accounts automatically.", "to request a new account."));
             }
@@ -754,7 +754,7 @@ public class AuthenticationManager
             }
 
             @Override
-            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnURL, DisplayLocation location)
+            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnUrl, DisplayLocation location)
             {
                 errors.reject(ERROR_MSG, "Your password has expired; please choose a new password.");
             }
@@ -768,20 +768,20 @@ public class AuthenticationManager
             }
 
             @Override
-            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnURL, DisplayLocation location)
+            public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnUrl, DisplayLocation location)
             {
                 errors.reject(ERROR_MSG, "Your password does not meet the complexity requirements; please choose a new password.");
             }
         };
 
         // Add an appropriate error message to display to the user in the web UI
-        public final void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnURL)
+        public final void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnUrl)
         {
-            addUserErrorMessage(errors, result, fullEmailAddress, returnURL, DisplayLocation.WebUI);
+            addUserErrorMessage(errors, result, fullEmailAddress, returnUrl, DisplayLocation.WebUI);
         }
 
         // Add an appropriate error message to show the user in the specified DisplayLocation
-        public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnURL, DisplayLocation location)
+        public void addUserErrorMessage(BindException errors, PrimaryAuthenticationResult result, @Nullable String fullEmailAddress, @Nullable URLHelper returnUrl, DisplayLocation location)
         {
         }
 
@@ -919,7 +919,7 @@ public class AuthenticationManager
     }
 
 
-    public static @NotNull PrimaryAuthenticationResult authenticate(HttpServletRequest request, String id, String password, URLHelper returnURL, boolean logFailures) throws InvalidEmailException
+    public static @NotNull PrimaryAuthenticationResult authenticate(HttpServletRequest request, String id, String password, URLHelper returnUrl, boolean logFailures) throws InvalidEmailException
     {
         PrimaryAuthenticationResult result = null;
         try
@@ -927,7 +927,7 @@ public class AuthenticationManager
             result = _beforeAuthenticate(request, id, password);
             if (null != result)
                 return result;
-            result = _authenticate(request, id, password, returnURL, logFailures);
+            result = _authenticate(request, id, password, returnUrl, logFailures);
             return result;
         }
         finally
@@ -937,7 +937,7 @@ public class AuthenticationManager
     }
 
 
-    private static @NotNull PrimaryAuthenticationResult _authenticate(HttpServletRequest request, final String id, String password, URLHelper returnURL, boolean logFailures) throws InvalidEmailException
+    private static @NotNull PrimaryAuthenticationResult _authenticate(HttpServletRequest request, final String id, String password, URLHelper returnUrl, boolean logFailures) throws InvalidEmailException
     {
         if (areNotBlank(id, password))
         {
@@ -950,7 +950,7 @@ public class AuthenticationManager
                 try
                 {
                     LoginFormAuthenticationProvider provider = configuration.getAuthenticationProvider();
-                    authResponse = provider.authenticate(configuration, id, password, returnURL);
+                    authResponse = provider.authenticate(configuration, id, password, returnUrl);
                 }
                 catch (RedirectException e)
                 {
@@ -1256,7 +1256,7 @@ public class AuthenticationManager
         throw new UnauthorizedException(message != null ? message : primaryResult.getStatusErrorMessage(DisplayLocation.API));
     }
 
-    public static URLHelper logout(@NotNull User user, @NotNull HttpServletRequest request, URLHelper returnURL)
+    public static URLHelper logout(@NotNull User user, @NotNull HttpServletRequest request, URLHelper returnUrl)
     {
         URLHelper ret = null;
         HttpSession session = request.getSession(false);
@@ -1269,7 +1269,7 @@ public class AuthenticationManager
 
             if (null != configuration)
             {
-                ret = configuration.logout(request, returnURL);
+                ret = configuration.logout(request, returnUrl);
             }
         }
 
@@ -1567,23 +1567,23 @@ public class AuthenticationManager
         if (null == properties)
             properties = new LoginReturnProperties();
 
-        URLHelper returnURL;
+        URLHelper returnUrl;
 
         if (null != properties.getReturnUrl())
         {
-            returnURL = properties.getReturnUrl();
+            returnUrl = properties.getReturnUrl();
         }
         else
         {
-            // We don't have a returnURL. Try not to redirect to a folder where the user doesn't have permissions, #12947
+            // We don't have a returnUrl. Try not to redirect to a folder where the user doesn't have permissions, #12947
             Container c = (null == current || current.isRoot() ? ContainerManager.getHomeContainer() : current);
-            returnURL = !c.hasPermission(user, ReadPermission.class) ? getWelcomeURL() : c.getStartURL(user);
+            returnUrl = !c.hasPermission(user, ReadPermission.class) ? getWelcomeURL() : c.getStartURL(user);
         }
 
         // if not explicitly skipping profile page and some required field is blank, then go to update profile page
         if (!properties.isSkipProfile() && PageFlowUtil.urlProvider(UserUrls.class).requiresProfileUpdate(user))
         {
-            returnURL = PageFlowUtil.urlProvider(UserUrls.class).getUserUpdateURL(current, returnURL, user.getUserId());
+            returnUrl = PageFlowUtil.urlProvider(UserUrls.class).getUserUpdateURL(current, returnUrl, user.getUserId());
         }
 
         // if this is the users first login, reset the user cache
@@ -1594,10 +1594,10 @@ public class AuthenticationManager
 
         if (null != properties.getUrlhash())
         {
-            returnURL.setFragment(properties.getUrlhash().replace("#", ""));
+            returnUrl.setFragment(properties.getUrlhash().replace("#", ""));
         }
 
-        return returnURL;
+        return returnUrl;
     }
 
     public static void registerMetricsProvider()
@@ -1632,17 +1632,17 @@ public class AuthenticationManager
             _configuration = configuration;
         }
 
-        private @Nullable HtmlString getLink(URLHelper returnURL, AuthLogoType prefix)
+        private @Nullable HtmlString getLink(URLHelper returnUrl, AuthLogoType prefix)
         {
             HtmlString img = getImg(prefix);
 
-            return null != img ? new LinkBuilder(img).href(getURL(returnURL, false)).clearClasses().getHtmlString() : null;
+            return null != img ? new LinkBuilder(img).href(getURL(returnUrl, false)).clearClasses().getHtmlString() : null;
         }
 
         @SuppressWarnings("ConstantConditions")
-        public ActionURL getURL(URLHelper returnURL, boolean skipProfile)
+        public ActionURL getURL(URLHelper returnUrl, boolean skipProfile)
         {
-            return PageFlowUtil.urlProvider(LoginUrls.class).getSSORedirectURL(_configuration, returnURL, skipProfile);
+            return PageFlowUtil.urlProvider(LoginUrls.class).getSSORedirectURL(_configuration, returnUrl, skipProfile);
         }
 
         public HtmlString getImg(AuthLogoType logoType)

--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -192,7 +192,7 @@ public interface AuthenticationProvider
     interface LoginFormAuthenticationProvider<AC extends LoginFormAuthenticationConfiguration<?>> extends PrimaryAuthenticationProvider<AC>
     {
         // id and password will not be blank (not null, not empty, not whitespace only)
-        @NotNull AuthenticationResponse authenticate(AC configuration, @NotNull String id, @NotNull String password, URLHelper returnURL) throws InvalidEmailException;
+        @NotNull AuthenticationResponse authenticate(AC configuration, @NotNull String id, @NotNull String password, URLHelper returnUrl) throws InvalidEmailException;
     }
 
     interface SSOAuthenticationProvider<SSO extends SSOAuthenticationConfiguration<? extends SSOAuthenticationProvider<SSO>>> extends PrimaryAuthenticationProvider<SSO>

--- a/api/src/org/labkey/api/security/LoginUrls.java
+++ b/api/src/org/labkey/api/security/LoginUrls.java
@@ -29,14 +29,14 @@ public interface LoginUrls extends UrlProvider
 {
     ActionURL getConfigureURL();
     ActionURL getVerificationURL(Container c, User user, String verification, @Nullable List<Pair<String, String>> extraParameters);
-    ActionURL getChangePasswordURL(Container c, User user, URLHelper returnURL, @Nullable String message);
+    ActionURL getChangePasswordURL(Container c, User user, URLHelper returnUrl, @Nullable String message);
     ActionURL getInitialUserURL();
     ActionURL getLoginURL();
-    ActionURL getLoginURL(URLHelper returnURL);
-    ActionURL getLoginURL(Container c, @Nullable URLHelper returnURL);
+    ActionURL getLoginURL(URLHelper returnUrl);
+    ActionURL getLoginURL(Container c, @Nullable URLHelper returnUrl);
     ActionURL getLogoutURL(Container c);
-    ActionURL getLogoutURL(Container c, URLHelper returnURL);
-    ActionURL getStopImpersonatingURL(Container c, @Nullable URLHelper returnURL);
-    ActionURL getAgreeToTermsURL(Container c, URLHelper returnURL);
-    ActionURL getSSORedirectURL(SSOAuthenticationConfiguration<?> configuration, URLHelper returnURL, boolean skipProfile);
+    ActionURL getLogoutURL(Container c, URLHelper returnUrl);
+    ActionURL getStopImpersonatingURL(Container c, @Nullable URLHelper returnUrl);
+    ActionURL getAgreeToTermsURL(Container c, URLHelper returnUrl);
+    ActionURL getSSORedirectURL(SSOAuthenticationConfiguration<?> configuration, URLHelper returnUrl, boolean skipProfile);
 }

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -812,14 +812,14 @@ public class SecurityManager
         return newSession;
     }
 
-    public static URLHelper logoutUser(HttpServletRequest request, User user, @Nullable URLHelper returnURL)
+    public static URLHelper logoutUser(HttpServletRequest request, User user, @Nullable URLHelper returnUrl)
     {
-        URLHelper ret = AuthenticationManager.logout(user, request, returnURL);   // Let AuthenticationProvider clean up auth-specific cookies, etc.
+        URLHelper ret = AuthenticationManager.logout(user, request, returnUrl);   // Let AuthenticationProvider clean up auth-specific cookies, etc.
         SessionHelper.clearSession(request, true);
         return ret;
     }
 
-    public static void impersonateUser(ViewContext viewContext, User impersonatedUser, ActionURL returnURL)
+    public static void impersonateUser(ViewContext viewContext, User impersonatedUser, ActionURL returnUrl)
     {
         @Nullable Container project = viewContext.getContainer().getProject();
         User user = viewContext.getUser();
@@ -827,16 +827,16 @@ public class SecurityManager
         if (user.hasRootAdminPermission())
             project = null;
 
-        impersonate(viewContext, new UserImpersonationContextFactory(project, user, impersonatedUser, returnURL));
+        impersonate(viewContext, new UserImpersonationContextFactory(project, user, impersonatedUser, returnUrl));
     }
 
-    public static void impersonateGroup(ViewContext viewContext, Group group, ActionURL returnURL)
+    public static void impersonateGroup(ViewContext viewContext, Group group, ActionURL returnUrl)
     {
         @Nullable Container project = viewContext.getContainer().getProject();
-        impersonate(viewContext, new GroupImpersonationContextFactory(project, viewContext.getUser(), group, returnURL));
+        impersonate(viewContext, new GroupImpersonationContextFactory(project, viewContext.getUser(), group, returnUrl));
     }
 
-    public static void impersonateRoles(ViewContext viewContext, Collection<Role> newImpersonationRoles, Set<Role> currentImpersonationRoles, ActionURL returnURL)
+    public static void impersonateRoles(ViewContext viewContext, Collection<Role> newImpersonationRoles, Set<Role> currentImpersonationRoles, ActionURL returnUrl)
     {
         @Nullable Container project = viewContext.getContainer().getProject();
         User user = viewContext.getUser();
@@ -844,7 +844,7 @@ public class SecurityManager
         if (user.hasRootPermission(CanImpersonateSiteRolesPermission.class))
             project = null;
 
-        impersonate(viewContext, new RoleImpersonationContextFactory(project, user, newImpersonationRoles, currentImpersonationRoles, returnURL));
+        impersonate(viewContext, new RoleImpersonationContextFactory(project, user, newImpersonationRoles, currentImpersonationRoles, returnUrl));
     }
 
     private static void impersonate(ViewContext viewContext, ImpersonationContextFactory factory)

--- a/api/src/org/labkey/api/security/SecurityUrls.java
+++ b/api/src/org/labkey/api/security/SecurityUrls.java
@@ -24,19 +24,19 @@ import org.labkey.api.view.ActionURL;
 public interface SecurityUrls extends UrlProvider
 {
     ActionURL getBeginURL(Container container);
-    ActionURL getManageGroupURL(Container container, String groupName, URLHelper returnURL);
+    ActionURL getManageGroupURL(Container container, String groupName, URLHelper returnUrl);
     ActionURL getManageGroupURL(Container container, String groupName);
-    ActionURL getGroupPermissionURL(Container container, int id, URLHelper returnURL);
+    ActionURL getGroupPermissionURL(Container container, int id, URLHelper returnUrl);
     ActionURL getGroupPermissionURL(Container container, int id);
     ActionURL getPermissionsURL(Container container);
-    ActionURL getPermissionsURL(Container container, URLHelper returnURL);
-    ActionURL getSiteGroupsURL(Container container, URLHelper returnURL);
+    ActionURL getPermissionsURL(Container container, URLHelper returnUrl);
+    ActionURL getSiteGroupsURL(Container container, URLHelper returnUrl);
     ActionURL getContainerURL(Container container);
     ActionURL getShowRegistrationEmailURL(Container container, User user, String mailPrefix);
     ActionURL getAddUsersURL(Container container);
     ActionURL getFolderAccessURL(Container container);
-    ActionURL getExternalToolsViewURL(User user, Container c, @NotNull ActionURL returnURL);
+    ActionURL getExternalToolsViewURL(User user, Container c, @NotNull ActionURL returnUrl);
     ActionURL getCompleteUserURL(Container container);
     ActionURL getCompleteUserReadURL(Container container);
-    ActionURL getClonePermissionsURL(User targetUser, @NotNull ActionURL returnURL);
+    ActionURL getClonePermissionsURL(User targetUser, @NotNull ActionURL returnUrl);
 }

--- a/api/src/org/labkey/api/security/UserUrls.java
+++ b/api/src/org/labkey/api/security/UserUrls.java
@@ -31,9 +31,9 @@ public interface UserUrls extends UrlProvider
     ActionURL getSiteUsersURL();
     ActionURL getProjectUsersURL(Container container);
     ActionURL getUserAccessURL(Container container, int userId);
-    ActionURL getUserDetailsURL(Container container, int userId, @Nullable URLHelper returnURL);
-    ActionURL getUserDetailsURL(Container c, @Nullable URLHelper returnURL);
-    ActionURL getUserUpdateURL(Container c, URLHelper returnURL, int userId);
+    ActionURL getUserDetailsURL(Container container, int userId, @Nullable URLHelper returnUrl);
+    ActionURL getUserDetailsURL(Container c, @Nullable URLHelper returnUrl);
+    ActionURL getUserUpdateURL(Container c, URLHelper returnUrl, int userId);
     ActionURL getUserAttachmentDownloadURL(User user, String name);
 
     /**

--- a/api/src/org/labkey/api/security/impersonation/AbstractImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/AbstractImpersonationContext.java
@@ -33,14 +33,14 @@ public abstract class AbstractImpersonationContext implements ImpersonationConte
     private final User _adminUser;
     private final @Nullable Container _project;
     @JsonIgnore // Can't be handled by remote pipelines
-    private final ActionURL _returnURL;
+    private final ActionURL _returnUrl;
     private final ImpersonationContextFactory _factory;
 
-    protected AbstractImpersonationContext(User adminUser, @Nullable Container project, ActionURL returnURL, ImpersonationContextFactory factory)
+    protected AbstractImpersonationContext(User adminUser, @Nullable Container project, ActionURL returnUrl, ImpersonationContextFactory factory)
     {
         _adminUser = adminUser;
         _project = project;
-        _returnURL = returnURL;
+        _returnUrl = returnUrl;
         _factory = factory;
     }
 
@@ -63,15 +63,15 @@ public abstract class AbstractImpersonationContext implements ImpersonationConte
     }
 
     @Override
-    public final ActionURL getReturnURL()
+    public final ActionURL getReturnUrl()
     {
-        return _returnURL;
+        return _returnUrl;
     }
 
     @Override
     public void addMenu(NavTree menu, Container c, User user, ActionURL currentURL)
     {
-        ActionURL url = PageFlowUtil.urlProvider(LoginUrls.class).getStopImpersonatingURL(c, user.getImpersonationContext().getReturnURL());
+        ActionURL url = PageFlowUtil.urlProvider(LoginUrls.class).getStopImpersonatingURL(c, user.getImpersonationContext().getReturnUrl());
         NavTree stop = new NavTree("Stop Impersonating", url).usePost();
         menu.addChild(stop);
     }

--- a/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/GroupImpersonationContextFactory.java
@@ -51,7 +51,7 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
     private final @Nullable GUID _projectId;
     private final int _groupId;
     @JsonIgnore // Can't be handled by remote pipelines
-    private final ActionURL _returnURL;
+    private final ActionURL _returnUrl;
     private final int _adminUserId;
 
     @JsonCreator
@@ -64,15 +64,15 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
         _projectId = projectId;
         _groupId = groupId;
         _adminUserId = adminUserId;
-        _returnURL = null;
+        _returnUrl = null;
     }
 
-    public GroupImpersonationContextFactory(@Nullable Container project, User adminUser, Group group, ActionURL returnURL)
+    public GroupImpersonationContextFactory(@Nullable Container project, User adminUser, Group group, ActionURL returnUrl)
     {
         _projectId = null != project ? project.getEntityId() : null;
         _adminUserId = adminUser.getUserId();
         _groupId = group.getUserId();
-        _returnURL = returnURL;
+        _returnUrl = returnUrl;
     }
 
     @Override
@@ -81,7 +81,7 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
         Container project = (null != _projectId ? ContainerManager.getForId(_projectId) : null);
         Group group = SecurityManager.getGroup(_groupId);
 
-        return new GroupImpersonationContext(project, getAdminUser(), group, _returnURL, this);
+        return new GroupImpersonationContext(project, getAdminUser(), group, _returnUrl, this);
     }
 
     @Override
@@ -184,20 +184,20 @@ public class GroupImpersonationContextFactory extends AbstractImpersonationConte
                 @JsonProperty("_adminUser") User adminUser,
                 @JsonProperty("_group") Group group,
                 @JsonProperty("_groups") PrincipalArray groups,
-                @JsonProperty("_returnURL") ActionURL returnURL,
+                @JsonProperty("_returnUrl") ActionURL returnUrl,
                 @JsonProperty("_factory") ImpersonationContextFactory factory)
 
         {
-            super(adminUser, project, returnURL, factory);
+            super(adminUser, project, returnUrl, factory);
             _group = group;
             _groups = groups;
         }
 
-        private GroupImpersonationContext(@Nullable Container project, User user, Group group, ActionURL returnURL, ImpersonationContextFactory factory)
+        private GroupImpersonationContext(@Nullable Container project, User user, Group group, ActionURL returnUrl, ImpersonationContextFactory factory)
         {
             // project is used to verify authorization, but isn't needed while impersonating... the group itself will
             // limit the admin user appropriately
-            super(user, null, returnURL, factory);
+            super(user, null, returnUrl, factory);
 
             if (!canImpersonateGroup(project, user, group))
                 throw new UnauthorizedImpersonationException("You are not allowed to impersonate this group", getFactory());

--- a/api/src/org/labkey/api/security/impersonation/ImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/ImpersonationContext.java
@@ -49,7 +49,7 @@ public interface ImpersonationContext extends Serializable
     User getAdminUser();
     String getCacheKey();  // Caching permission-related state is very tricky with impersonation; context provides a cache key suffix that captures the current impersonation state
     /** @return the URL to which the user should be returned when impersonation is over */
-    ActionURL getReturnURL();
+    ActionURL getReturnUrl();
     PrincipalArray getGroups(User user);
 
     /**

--- a/api/src/org/labkey/api/security/impersonation/NotImpersonatingContext.java
+++ b/api/src/org/labkey/api/security/impersonation/NotImpersonatingContext.java
@@ -69,7 +69,7 @@ public class NotImpersonatingContext implements ImpersonationContext
     }
 
     @Override
-    public ActionURL getReturnURL()
+    public ActionURL getReturnUrl()
     {
         return null;
     }

--- a/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/RoleImpersonationContextFactory.java
@@ -56,7 +56,7 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
     private final RoleSet _roles;
     private final RoleSet _previousRoles;
     @JsonIgnore // Can't be handled by remote pipelines
-    private final ActionURL _returnURL;
+    private final ActionURL _returnUrl;
     private final String _cacheKey;
 
     @JsonCreator
@@ -72,15 +72,15 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
         _adminUserId = adminUserId;
         _roles = roles;
         _previousRoles = previousRoles;
-        _returnURL = null;
+        _returnUrl = null;
         _cacheKey = cacheKey;
     }
     
-    public RoleImpersonationContextFactory(@Nullable Container project, User adminUser, Collection<Role> newImpersonationRoles, Set<Role> currentImpersonationRoles, ActionURL returnURL)
+    public RoleImpersonationContextFactory(@Nullable Container project, User adminUser, Collection<Role> newImpersonationRoles, Set<Role> currentImpersonationRoles, ActionURL returnUrl)
     {
         _projectId = null != project ? project.getEntityId() : null;
         _adminUserId = adminUser.getUserId();
-        _returnURL = returnURL;
+        _returnUrl = returnUrl;
 
         // Compute the navtree cache key based on role names + project: NavTree will be different for each role set + project combination
         StringBuilder cacheKey = new StringBuilder("/impersonationRole=");
@@ -106,7 +106,7 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
     {
         Container project = (null != _projectId ? ContainerManager.getForId(_projectId) : null);
 
-        return new RoleImpersonationContext(project, getAdminUser(), _roles, _returnURL, this, _cacheKey);
+        return new RoleImpersonationContext(project, getAdminUser(), _roles, _returnUrl, this, _cacheKey);
     }
 
     @Override
@@ -214,11 +214,11 @@ public class RoleImpersonationContextFactory extends AbstractImpersonationContex
                 @Nullable Container project,
                 User adminUser,
                 RoleSet roles,
-                ActionURL returnURL,
+                ActionURL returnUrl,
                 ImpersonationContextFactory factory,
                 String cacheKey)
         {
-            super(adminUser, project, returnURL, factory);
+            super(adminUser, project, returnUrl, factory);
             _roles = roles;
             _cacheKey = cacheKey;
             verifyPermissions(project, adminUser, _roles.getRoles());

--- a/api/src/org/labkey/api/security/impersonation/UserImpersonationContextFactory.java
+++ b/api/src/org/labkey/api/security/impersonation/UserImpersonationContextFactory.java
@@ -51,7 +51,7 @@ public class UserImpersonationContextFactory extends AbstractImpersonationContex
     private final int _adminUserId;
     private final int _impersonatedUserId;
     @JsonIgnore // Can't be handled by remote pipelines
-    private final ActionURL _returnURL;
+    private final ActionURL _returnUrl;
 
     @JsonCreator
     protected UserImpersonationContextFactory(
@@ -63,15 +63,15 @@ public class UserImpersonationContextFactory extends AbstractImpersonationContex
         _projectId = projectId;
         _adminUserId = adminUserId;
         _impersonatedUserId = impersonatedUserId;
-        _returnURL = null;
+        _returnUrl = null;
     }
 
-    public UserImpersonationContextFactory(@Nullable Container project, User adminUser, User impersonatedUser, ActionURL returnURL)
+    public UserImpersonationContextFactory(@Nullable Container project, User adminUser, User impersonatedUser, ActionURL returnUrl)
     {
         _projectId = null != project ? project.getEntityId() : null;
         _adminUserId = adminUser.getUserId();
         _impersonatedUserId = impersonatedUser.getUserId();
-        _returnURL = returnURL;
+        _returnUrl = returnUrl;
     }
 
     @Override
@@ -85,7 +85,7 @@ public class UserImpersonationContextFactory extends AbstractImpersonationContex
     {
         Container project = (null != _projectId ? ContainerManager.getForId(_projectId) : null);
 
-        return new UserImpersonationContext(project, getAdminUser(), UserManager.getUser(_impersonatedUserId), _returnURL, this);
+        return new UserImpersonationContext(project, getAdminUser(), UserManager.getUser(_impersonatedUserId), _returnUrl, this);
     }
 
     @Override
@@ -178,9 +178,9 @@ public class UserImpersonationContextFactory extends AbstractImpersonationContex
             super(adminUser, project, null, factory);
         }
 
-        private UserImpersonationContext(@Nullable Container project, User adminUser, User impersonatedUser, ActionURL returnURL, ImpersonationContextFactory factory)
+        private UserImpersonationContext(@Nullable Container project, User adminUser, User impersonatedUser, ActionURL returnUrl, ImpersonationContextFactory factory)
         {
-            super(adminUser, project, returnURL, factory);
+            super(adminUser, project, returnUrl, factory);
             verifyPermissions(project, impersonatedUser, adminUser);
         }
 

--- a/api/src/org/labkey/api/security/impersonation/WrappedImpersonationContext.java
+++ b/api/src/org/labkey/api/security/impersonation/WrappedImpersonationContext.java
@@ -74,9 +74,9 @@ public class WrappedImpersonationContext implements ImpersonationContext
     }
 
     @Override
-    public ActionURL getReturnURL()
+    public ActionURL getReturnUrl()
     {
-        return _delegate.getReturnURL();
+        return _delegate.getReturnUrl();
     }
 
     @Override

--- a/api/src/org/labkey/api/study/publish/AbstractPublishConfirmAction.java
+++ b/api/src/org/labkey/api/study/publish/AbstractPublishConfirmAction.java
@@ -127,7 +127,7 @@ public abstract class AbstractPublishConfirmAction<FORM extends PublishConfirmFo
         if (_allObjects == null) // On first post, this is empty, so use the current selection
             _allObjects = new ArrayList<>(_selectedObjects);
 
-        if (form.getReturnURLHelper() == null)
+        if (form.getReturnUrlHelper() == null)
             errors.reject(SpringActionController.ERROR_MSG, "No return URL configured for this form");
     }
 
@@ -209,12 +209,12 @@ public abstract class AbstractPublishConfirmAction<FORM extends PublishConfirmFo
         Map<String, Object> fields = new HashMap<>();
 
         fields.put("rowId", form.getRowId());
-        String returnURL = getViewContext().getRequest().getParameter(ActionURL.Param.returnUrl.name());
-        if (returnURL == null)
+        String returnUrl = getViewContext().getRequest().getParameter(ActionURL.Param.returnUrl.name());
+        if (returnUrl == null)
         {
-            returnURL = getViewContext().getActionURL().toString();
+            returnUrl = getViewContext().getActionURL().toString();
         }
-        fields.put(ActionURL.Param.returnUrl.name(), returnURL);
+        fields.put(ActionURL.Param.returnUrl.name(), returnUrl);
 
         return fields;
     }
@@ -254,11 +254,11 @@ public abstract class AbstractPublishConfirmAction<FORM extends PublishConfirmFo
                 getHiddenPublishResultsCaptions(form));
 
         List<ActionButton> buttons = new ArrayList<>();
-        URLHelper returnURL = form.getReturnURLHelper();
-        if (null == returnURL)
+        URLHelper returnUrl = form.getReturnUrlHelper();
+        if (null == returnUrl)
         {
             // consider deleting in the future unless we can find legitimate cases where the return URL is not provided in the form bean
-//            returnURL = PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), _protocol).addParameter("clearDataRegionSelectionKey", publishConfirmForm.getDataRegionSelectionKey());
+//            returnUrl = PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), _protocol).addParameter("clearDataRegionSelectionKey", publishConfirmForm.getDataRegionSelectionKey());
         }
 
         ActionURL publishURL = getPublishHandlerURL(form);
@@ -300,7 +300,7 @@ public abstract class AbstractPublishConfirmAction<FORM extends PublishConfirmFo
             buttons.add(fromSpecimenButton);
         }
 
-        ActionButton cancelButton = new ActionButton("Cancel", returnURL);
+        ActionButton cancelButton = new ActionButton("Cancel", returnUrl);
         cancelButton.setScript("LABKEY.setSubmit(true);", true);
         buttons.add(cancelButton);
 

--- a/api/src/org/labkey/api/study/publish/PublishBean.java
+++ b/api/src/org/labkey/api/study/publish/PublishBean.java
@@ -13,7 +13,7 @@ public class PublishBean
     private final boolean _nullStudies;
     private final boolean _insufficientPermissions;
     private final String _dataRegionSelectionKey;
-    private final ActionURL _returnURL;
+    private final ActionURL _returnUrl;
     private final ActionURL _successURL;
     private final String _containerFilterName;
     private final List<Integer> _batchIds;
@@ -22,7 +22,7 @@ public class PublishBean
 
     public PublishBean(ActionURL successURL,
                        List<Integer> ids, String dataRegionSelectionKey,
-                       Set<Container> studies, boolean nullStudies, boolean insufficientPermissions, ActionURL returnURL,
+                       Set<Container> studies, boolean nullStudies, boolean insufficientPermissions, ActionURL returnUrl,
                        String containerFilterName, List<Integer> batchIds, String batchNoun, boolean autoLinkEnabled)
     {
         _successURL = successURL;
@@ -31,7 +31,7 @@ public class PublishBean
         _nullStudies = nullStudies;
         _ids = ids;
         _dataRegionSelectionKey = dataRegionSelectionKey;
-        _returnURL = returnURL;
+        _returnUrl = returnUrl;
         _containerFilterName = containerFilterName;
         _batchIds = batchIds;
         _batchNoun = batchNoun;
@@ -43,9 +43,9 @@ public class PublishBean
         return _successURL;
     }
 
-    public ActionURL getReturnURL()
+    public ActionURL getReturnUrl()
     {
-        return _returnURL;
+        return _returnUrl;
     }
 
     public List<Integer> getIds()

--- a/api/src/org/labkey/api/study/publish/publishChooseStudy.jsp
+++ b/api/src/org/labkey/api/study/publish/publishChooseStudy.jsp
@@ -268,7 +268,7 @@
     %>
 
     <labkey:button text="Next" onclick="handleNext();" id="next-btn" submit="false" enabled="<%=!exceedsMaxRows || !bean.getBatchIds().isEmpty()%>"/>
-    <labkey:button text="Cancel" href="<%=bean.getReturnURL()%>"/>
+    <labkey:button text="Cancel" href="<%=bean.getReturnUrl()%>"/>
 
     <%
         for (Pair<String, String> parameter : parameters)
@@ -292,7 +292,7 @@
     <%
         }
     %>
-    <input type="hidden" name="<%=ActionURL.Param.returnUrl%>" value="<%= h(bean.getReturnURL()) %>">
+    <input type="hidden" name="<%=ActionURL.Param.returnUrl%>" value="<%= h(bean.getReturnUrl()) %>">
     <input type="hidden" name="containerFilterName" value="<%= h(bean.getContainerFilterName()) %>">
     <input type="hidden" name="<%= h(DataRegionSelection.DATA_REGION_SELECTION_KEY) %>" value="<%=h(bean.getDataRegionSelectionKey())%>">
 </labkey:form>

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -2339,15 +2339,15 @@ public class PageFlowUtil
     }
 
     @Nullable
-    public static Project getTermsOfUseProject(Container container, String returnURL)
+    public static Project getTermsOfUseProject(Container container, String returnUrl)
     {
         Container termsContainer = null;
 
-        if (null != returnURL)
+        if (null != returnUrl)
         {
             try
             {
-                URLHelper urlHelper = new URLHelper(returnURL);
+                URLHelper urlHelper = new URLHelper(returnUrl);
                 Container redirectContainer = ContainerManager.getForURL(new ActionURL(urlHelper.getLocalURIString()));
                 if (null != redirectContainer)
                     termsContainer = redirectContainer.getProject();

--- a/api/src/org/labkey/api/util/ReturnURLString.java
+++ b/api/src/org/labkey/api/util/ReturnURLString.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  */
 public class ReturnURLString
 {
-    private static final Logger LOG = LogHelper.getLogger(ReturnURLString.class, "Validates that returnURL parameters are safe");
+    private static final Logger LOG = LogHelper.getLogger(ReturnURLString.class, "Validates that returnUrl parameters are safe");
 
     private final @Nullable URLHelper _url;
 

--- a/api/src/org/labkey/api/util/URLHelper.java
+++ b/api/src/org/labkey/api/util/URLHelper.java
@@ -454,7 +454,7 @@ public class URLHelper implements Cloneable, Serializable, JSONString
     }
 
 
-    public URLHelper addParameter(Enum key, boolean value)
+    public URLHelper addParameter(Enum<?> key, boolean value)
     {
         return addParameter(key.name(), value);
     }
@@ -468,8 +468,6 @@ public class URLHelper implements Cloneable, Serializable, JSONString
     public URLHelper addParameter(String key, String value)
     {
         if (_readOnly) throw new java.lang.IllegalStateException();
-        if (key.equals("returnURL"))
-            ReturnUrlForm.throwBadParam();
         if (null == _parameters) _parameters = new ArrayList<>();
         _parameters.add(new Pair<>(key, value));
         return this;
@@ -878,9 +876,7 @@ public class URLHelper implements Cloneable, Serializable, JSONString
         if (null == getScheme() || null == getHost())
             return false;
         String scheme = getScheme().toLowerCase();
-        if ("https".equals(scheme) || "http".equals(scheme))
-            return true;
-        return false;
+        return "https".equals(scheme) || "http".equals(scheme);
     }
 
     public static boolean isHttpURL(String url)
@@ -925,7 +921,7 @@ public class URLHelper implements Cloneable, Serializable, JSONString
     {
         String host = StringUtils.trimToNull(this.getHost());
 
-        // We have a returnURL that includes a server host name
+        // We have a returnUrl that includes a server host name
         if (host != null)
         {
             // Check if it matches the current server's preferred host name, per the base server URL setting
@@ -945,7 +941,7 @@ public class URLHelper implements Cloneable, Serializable, JSONString
 
                 if (!isConfigured)
                 {
-                    String logMessageDetails = "returnURL value: " + this;
+                    String logMessageDetails = "returnUrl value: " + this;
                     HttpServletRequest request = HttpView.currentRequest();
                     if (request != null)
                     {
@@ -962,7 +958,7 @@ public class URLHelper implements Cloneable, Serializable, JSONString
                 }
                 else
                 {
-                    LOG.debug("Detected configured external host returnURL: " + this);
+                    LOG.debug("Detected configured external host returnUrl: " + this);
                 }
             }
         }

--- a/api/src/org/labkey/api/view/ActionURL.java
+++ b/api/src/org/labkey/api/view/ActionURL.java
@@ -242,13 +242,13 @@ public class ActionURL extends URLHelper implements Cloneable
     }
 
 
-    public String getParameter(Enum key)
+    public String getParameter(Enum<?> key)
     {
         return getParameter(key.toString());
     }
 
     @Override
-    public ActionURL addParameter(Enum key, boolean value)
+    public ActionURL addParameter(Enum<?> key, boolean value)
     {
         return (ActionURL)super.addParameter(key, value);
     }
@@ -265,12 +265,12 @@ public class ActionURL extends URLHelper implements Cloneable
         return (ActionURL) super.addParameter(key, value);
     }
 
-    public ActionURL addParameter(Enum key, int value)
+    public ActionURL addParameter(Enum<?> key, int value)
     {
         return addParameter(key.name(), value);
     }
 
-    public ActionURL addParameter(Enum key, long value)
+    public ActionURL addParameter(Enum<?> key, long value)
     {
         return addParameter(key.name(), value);
     }
@@ -285,7 +285,7 @@ public class ActionURL extends URLHelper implements Cloneable
         return (ActionURL) super.addParameter(key, String.valueOf(value));
     }
 
-    public ActionURL addParameter(Enum e, String value)
+    public ActionURL addParameter(Enum<?> e, String value)
     {
         return addParameter(e.name(), value);
     }
@@ -366,7 +366,7 @@ public class ActionURL extends URLHelper implements Cloneable
     }
 
     // Add url as a parameter using standard parameter name
-    public ActionURL addReturnURL(@NotNull URLHelper url)
+    public ActionURL addReturnUrl(@NotNull URLHelper url)
     {
         return replaceParameter(Param.returnUrl, url.getLocalURIString());
     }
@@ -384,15 +384,15 @@ public class ActionURL extends URLHelper implements Cloneable
     }
 
     @Nullable
-    public URLHelper getReturnURL()
+    public URLHelper getReturnUrl()
     {
-        String returnURLStr = getParameter(ActionURL.Param.returnUrl);
-        if (null == returnURLStr)
+        String returnUrlStr = getParameter(ActionURL.Param.returnUrl);
+        if (null == returnUrlStr)
             return null;
 
         try
         {
-            return new URLHelper(returnURLStr);
+            return new URLHelper(returnUrlStr);
         }
         catch (IllegalArgumentException | URISyntaxException e)
         {

--- a/api/src/org/labkey/api/view/Portal.java
+++ b/api/src/org/labkey/api/view/Portal.java
@@ -380,8 +380,8 @@ public class Portal implements ModuleChangeListener
             ActionURL ret = urlProvider().getCustomizeWebPartURL(container);
             ret.addParameter("pageId", getPageId());
             ret.addParameter("index", Integer.toString(getIndex()));
-            if (null != current.getReturnURL())
-                ret.addReturnURL(current.getReturnURL());
+            if (null != current.getReturnUrl())
+                ret.addReturnUrl(current.getReturnUrl());
             return ret;
         }
 

--- a/api/src/org/labkey/api/view/menu/SiteAdminMenu.java
+++ b/api/src/org/labkey/api/view/menu/SiteAdminMenu.java
@@ -56,19 +56,19 @@ public class SiteAdminMenu extends NavTreeMenu
         if (user.hasRootPermission(TroubleshooterPermission.class))
             items.add(getAdminConsole(context));
 
-        URLHelper returnURL = context.getActionURL().getReturnURL() == null ? context.getActionURL() : context.getActionURL().getReturnURL();
+        URLHelper returnUrl = context.getActionURL().getReturnUrl() == null ? context.getActionURL() : context.getActionURL().getReturnUrl();
 
         if (user.hasSiteAdminPermission())
         {
-            items.add(new NavTree("Site Admins", securityUrls.getManageGroupURL(root, "Administrators", returnURL)));
-            items.add(new NavTree("Site Developers", securityUrls.getManageGroupURL(root, "Developers", returnURL)));
+            items.add(new NavTree("Site Admins", securityUrls.getManageGroupURL(root, "Administrators", returnUrl)));
+            items.add(new NavTree("Site Developers", securityUrls.getManageGroupURL(root, "Developers", returnUrl)));
         }
 
         if (user.hasRootPermission(UserManagementPermission.class))
         {
-            items.add(new NavTree("Site Users", PageFlowUtil.urlProvider(UserUrls.class).getSiteUsersURL().addReturnURL(returnURL)));
-            items.add(new NavTree("Site Groups", securityUrls.getSiteGroupsURL(root, returnURL)));
-            items.add(new NavTree("Site Permissions", securityUrls.getPermissionsURL(root, returnURL)));
+            items.add(new NavTree("Site Users", PageFlowUtil.urlProvider(UserUrls.class).getSiteUsersURL().addReturnUrl(returnUrl)));
+            items.add(new NavTree("Site Groups", securityUrls.getSiteGroupsURL(root, returnUrl)));
+            items.add(new NavTree("Site Permissions", securityUrls.getPermissionsURL(root, returnUrl)));
         }
 
         if (user.hasRootAdminPermission())
@@ -92,10 +92,10 @@ public class SiteAdminMenu extends NavTreeMenu
         ActionURL consoleUrl = adminUrls.getAdminConsoleURL();
         if (null != context && null != context.getActionURL())
         {
-            if (null == context.getActionURL().getReturnURL())
-                consoleUrl.addReturnURL(context.getActionURL());
+            if (null == context.getActionURL().getReturnUrl())
+                consoleUrl.addReturnUrl(context.getActionURL());
             else
-                consoleUrl.addReturnURL(context.getActionURL().getReturnURL());
+                consoleUrl.addReturnUrl(context.getActionURL().getReturnUrl());
         }
 
         return new NavTree("Admin Console", consoleUrl);

--- a/api/webapp/clientapi/dom/WebPart.js
+++ b/api/webapp/clientapi/dom/WebPart.js
@@ -211,10 +211,6 @@
                     _partConfig["webpart.title"] = _title;
                 if (_titleHref)
                     _partConfig["webpart.titleHref"] = _titleHref;
-                // Prefer using 'returnUrl' instead of 'returnURL'
-                if (_partConfig.returnURL) {
-                    throw new Error("Use 'returnUrl' instead of 'returnURL'");
-                }
 
                 if (!_errorCallback)
                     _errorCallback = handleLoadError;

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -548,9 +548,9 @@ public class AssayController extends SpringActionController
                 {
                     //if user doesn't have read permission to the target container, set the return URL to be
                     //the current container
-                    ActionURL returnURL = (c.hasPermission(user, ReadPermission.class)) ? projectUrls.getStartURL(c) : projectUrls.getStartURL(currentContainer);
+                    ActionURL returnUrl = (c.hasPermission(user, ReadPermission.class)) ? projectUrls.getStartURL(c) : projectUrls.getStartURL(currentContainer);
 
-                    ActionURL copyURL = urlProvider(AssayUrls.class).getDesignerURL(c, _protocol, true, returnURL);
+                    ActionURL copyURL = urlProvider(AssayUrls.class).getDesignerURL(c, _protocol, true, returnUrl);
                     html.append("<a href=\"");
                     html.append(copyURL.getEncodedLocalURIString());
                     html.append("\">");
@@ -979,24 +979,24 @@ public class AssayController extends SpringActionController
         }
 
         @Override
-        public @Nullable ActionURL getDesignerURL(Container container, ExpProtocol protocol, boolean copy, @Nullable ActionURL returnURL)
+        public @Nullable ActionURL getDesignerURL(Container container, ExpProtocol protocol, boolean copy, @Nullable ActionURL returnUrl)
         {
             AssayProvider provider = AssayService.get().getProvider(protocol);
-            return getDesignerURL(container, provider, protocol, copy, returnURL);
+            return getDesignerURL(container, provider, protocol, copy, returnUrl);
         }
 
         @Override
-        public @Nullable ActionURL getDesignerURL(Container container, String providerName, ActionURL returnURL)
+        public @Nullable ActionURL getDesignerURL(Container container, String providerName, ActionURL returnUrl)
         {
             AssayProvider provider = AssayService.get().getProvider(providerName);
             if (provider == null)
             {
                 return null;
             }
-            return getDesignerURL(container, provider, null, false, returnURL);
+            return getDesignerURL(container, provider, null, false, returnUrl);
         }
 
-        private ActionURL getDesignerURL(Container container, @NotNull AssayProvider provider, @Nullable ExpProtocol protocol, boolean copy, ActionURL returnURL)
+        private ActionURL getDesignerURL(Container container, @NotNull AssayProvider provider, @Nullable ExpProtocol protocol, boolean copy, ActionURL returnUrl)
         {
             Class<? extends Controller> designerAction = provider.getDesignerAction();
             if (designerAction == null)
@@ -1006,8 +1006,8 @@ public class AssayController extends SpringActionController
             if (copy)
                 url.addParameter("copy", "true");
             url.addParameter("providerName", provider.getName());
-            if (returnURL != null)
-                url.addReturnURL(returnURL);
+            if (returnUrl != null)
+                url.addReturnUrl(returnUrl);
 
             return url;
         }
@@ -1265,7 +1265,7 @@ public class AssayController extends SpringActionController
             ActionURL url = new ActionURL(SetDefaultValuesAssayAction.class, container);
             url.addParameter("providerName", providerName);
             url.addParameter("domainId", domain.getTypeId());
-            url.addReturnURL(returnUrl);
+            url.addReturnUrl(returnUrl);
 
             return url;
         }

--- a/assay/src/org/labkey/assay/AssayListPortalView.java
+++ b/assay/src/org/labkey/assay/AssayListPortalView.java
@@ -46,7 +46,7 @@ public class AssayListPortalView extends AssayListQueryView
         if (getContainer().hasPermission(getUser(), DesignAssayPermission.class))
         {
             ActionURL insertURL = PageFlowUtil.urlProvider(AssayUrls.class).getChooseAssayTypeURL(view.getViewContext().getContainer());
-            insertURL.addReturnURL(getViewContext().getActionURL());
+            insertURL.addReturnUrl(getViewContext().getActionURL());
             bar.add(new ActionButton("New Assay Design", insertURL));
         }
         bar.add(new ActionButton("Manage Assays", PageFlowUtil.urlProvider(AssayUrls.class).getBeginURL(getContainer())));

--- a/assay/src/org/labkey/assay/AssayListQueryView.java
+++ b/assay/src/org/labkey/assay/AssayListQueryView.java
@@ -57,7 +57,7 @@ public class AssayListQueryView extends QueryView
         if (getContainer().hasPermission(getUser(), DesignAssayPermission.class))
         {
             ActionURL insertURL = PageFlowUtil.urlProvider(AssayUrls.class).getChooseAssayTypeURL(view.getViewContext().getContainer());
-            insertURL.addReturnURL(getViewContext().getActionURL());
+            insertURL.addReturnUrl(getViewContext().getActionURL());
             ActionButton insert = new ActionButton("New Assay Design", insertURL);
             insert.setActionType(ActionButton.Action.LINK);
             insert.setDisplayPermission(DesignAssayPermission.class);
@@ -87,7 +87,7 @@ public class AssayListQueryView extends QueryView
         if (getContainer().hasPermission(getUser(), DesignAssayPermission.class))
         {
             ActionURL plateURL = PageFlowUtil.urlProvider(PlateUrls.class).getPlateListURL(getContainer());
-            plateURL.addReturnURL(getViewContext().getActionURL());
+            plateURL.addReturnUrl(getViewContext().getActionURL());
             ActionButton insert = new ActionButton("Configure Plates", plateURL);
             insert.setActionType(ActionButton.Action.LINK);
             insert.setDisplayPermission(DesignAssayPermission.class);

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -449,7 +449,7 @@ public class AssayManager implements AssayService
             if (context.getContainer().hasPermission(context.getUser(), DesignAssayPermission.class))
             {
                 ActionURL insertURL = PageFlowUtil.urlProvider(AssayUrls.class).getChooseAssayTypeURL(context.getContainer());
-                insertURL.addReturnURL(context.getActionURL());
+                insertURL.addReturnUrl(context.getActionURL());
                 menu.addChild("New Assay Design", insertURL);
             }
             menu.addChild("Manage Assays", PageFlowUtil.urlProvider(AssayUrls.class).getBeginURL(context.getContainer()));

--- a/core/src/client/ListDesigner/ListDesigner.tsx
+++ b/core/src/client/ListDesigner/ListDesigner.tsx
@@ -112,7 +112,7 @@ export class ListDesigner extends React.Component<Props, State> {
         const returnUrl = ActionURL.getReturnUrl();
         if (!returnUrl || !model) return returnUrl;
 
-        // Issue 47356: Rewrite returnURL in the event of a list name change
+        // Issue 47356: Rewrite returnUrl in the event of a list name change
         const { action, containerPath, controller } = ActionURL.getPathFromLocation(returnUrl);
         if (controller?.toLowerCase() === 'list' && action?.toLowerCase() === 'grid') {
             const parameters = ActionURL.getParameters(returnUrl);

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -587,7 +587,7 @@ public class AdminController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            URLHelper returnUrl = getViewContext().getActionURL().getReturnURL();
+            URLHelper returnUrl = getViewContext().getActionURL().getReturnUrl();
             if (null != returnUrl)
                 root.addChild("Return to Project", returnUrl);
             root.addChild("Admin Console");
@@ -626,9 +626,9 @@ public class AdminController extends SpringActionController
         }
 
         @Override
-        public ActionURL getModuleStatusURL(URLHelper returnURL)
+        public ActionURL getModuleStatusURL(URLHelper returnUrl)
         {
-            return AdminController.getModuleStatusURL(returnURL);
+            return AdminController.getModuleStatusURL(returnUrl);
         }
 
         @Override
@@ -672,21 +672,21 @@ public class AdminController extends SpringActionController
         }
 
         @Override
-        public ActionURL getCustomizeEmailURL(@NotNull Container c, @Nullable Class<? extends EmailTemplate> selectedTemplate, @Nullable URLHelper returnURL)
+        public ActionURL getCustomizeEmailURL(@NotNull Container c, @Nullable Class<? extends EmailTemplate> selectedTemplate, @Nullable URLHelper returnUrl)
         {
-            return getCustomizeEmailURL(c, selectedTemplate == null ? null : selectedTemplate.getName(), returnURL);
+            return getCustomizeEmailURL(c, selectedTemplate == null ? null : selectedTemplate.getName(), returnUrl);
         }
 
-        public ActionURL getCustomizeEmailURL(@NotNull Container c, @Nullable String selectedTemplate, @Nullable URLHelper returnURL)
+        public ActionURL getCustomizeEmailURL(@NotNull Container c, @Nullable String selectedTemplate, @Nullable URLHelper returnUrl)
         {
             ActionURL url = new ActionURL(CustomizeEmailAction.class, c);
             if (selectedTemplate != null)
             {
                 url.addParameter("templateClass", selectedTemplate);
             }
-            if (returnURL != null)
+            if (returnUrl != null)
             {
-                url.addReturnURL(returnURL);
+                url.addReturnUrl(returnUrl);
             }
             return url;
         }
@@ -697,11 +697,11 @@ public class AdminController extends SpringActionController
         }
 
         @Override
-        public ActionURL getMaintenanceURL(URLHelper returnURL)
+        public ActionURL getMaintenanceURL(URLHelper returnUrl)
         {
             ActionURL url = new ActionURL(MaintenanceAction.class, ContainerManager.getRoot());
-            if (returnURL != null)
-                url.addReturnURL(returnURL);
+            if (returnUrl != null)
+                url.addReturnUrl(returnUrl);
             return url;
         }
 
@@ -742,18 +742,18 @@ public class AdminController extends SpringActionController
         }
 
         @Override
-        public ActionURL getCreateProjectURL(@Nullable ActionURL returnURL)
+        public ActionURL getCreateProjectURL(@Nullable ActionURL returnUrl)
         {
-            return getCreateFolderURL(ContainerManager.getRoot(), returnURL);
+            return getCreateFolderURL(ContainerManager.getRoot(), returnUrl);
         }
 
         @Override
-        public ActionURL getCreateFolderURL(Container c, @Nullable ActionURL returnURL)
+        public ActionURL getCreateFolderURL(Container c, @Nullable ActionURL returnUrl)
         {
             ActionURL result = new ActionURL(CreateFolderAction.class, c);
-            if (returnURL != null)
+            if (returnUrl != null)
             {
-                result.addReturnURL(returnURL);
+                result.addReturnUrl(returnUrl);
             }
             return result;
         }
@@ -887,7 +887,7 @@ public class AdminController extends SpringActionController
      * During upgrade, startup, or maintenance mode, the user will be redirected to
      * MaintenanceAction and only admin users will be allowed to log into the server.
      * The maintenance.jsp page checks startup is complete or adminOnly mode is turned off
-     * and will redirect to the returnURL or the loginURL.
+     * and will redirect to the returnUrl or the loginURL.
      * See Issue 18758 for more information.
      */
     @RequiresNoPermission
@@ -933,9 +933,9 @@ public class AdminController extends SpringActionController
             ActionURL loginURL = null;
             if (getUser().isGuest())
             {
-                URLHelper returnURL = form.getReturnURLHelper();
-                if (returnURL != null)
-                    loginURL = urlProvider(LoginUrls.class).getLoginURL(ContainerManager.getRoot(), returnURL);
+                URLHelper returnUrl = form.getReturnUrlHelper();
+                if (returnUrl != null)
+                    loginURL = urlProvider(LoginUrls.class).getLoginURL(ContainerManager.getRoot(), returnUrl);
                 else
                     loginURL = urlProvider(LoginUrls.class).getLoginURL();
             }
@@ -4303,11 +4303,11 @@ public class AdminController extends SpringActionController
         }
     }
 
-    public static ActionURL getModuleStatusURL(URLHelper returnURL)
+    public static ActionURL getModuleStatusURL(URLHelper returnUrl)
     {
         ActionURL url = new ActionURL(ModuleStatusAction.class, ContainerManager.getRoot());
-        if (returnURL != null)
-            url.addReturnURL(returnURL);
+        if (returnUrl != null)
+            url.addReturnUrl(returnUrl);
         return url;
     }
 
@@ -6121,7 +6121,7 @@ public class AdminController extends SpringActionController
         {
             ActionURL url = new ActionURL(FileRootsStandAloneAction.class, getContainer())
                     .addParameter("folderSetup", true)
-                    .addReturnURL(getViewContext().getActionURL().getReturnURL());
+                    .addReturnUrl(getViewContext().getActionURL().getReturnUrl());
 
             if (form.isFileRootChanged())
                 url.addParameter("rootSet", form.getMigrateFilesOption());
@@ -6169,9 +6169,9 @@ public class AdminController extends SpringActionController
         {
             ActionURL url = getContainer().getStartURL(getUser());
 
-            if (getViewContext().getActionURL().getReturnURL() != null)
+            if (getViewContext().getActionURL().getReturnUrl() != null)
             {
-                url.addReturnURL(getViewContext().getActionURL().getReturnURL());
+                url.addReturnUrl(getViewContext().getActionURL().getReturnUrl());
             }
 
             return url;
@@ -7162,7 +7162,7 @@ public class AdminController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(CustomEmailForm form)
         {
-            return new AdminUrlsImpl().getCustomizeEmailURL(getContainer(), form.getTemplateClass(), form.getReturnURLHelper());
+            return new AdminUrlsImpl().getCustomizeEmailURL(getContainer(), form.getTemplateClass(), form.getReturnUrlHelper());
         }
     }
 
@@ -7540,7 +7540,7 @@ public class AdminController extends SpringActionController
     @RequiresPermission(AdminPermission.class)
     public class RenameFolderAction extends FormViewAction<ManageFoldersForm>
     {
-        private ActionURL _returnURL;
+        private ActionURL _returnUrl;
 
         @Override
         public void validateCommand(ManageFoldersForm target, Errors errors)
@@ -7560,7 +7560,7 @@ public class AdminController extends SpringActionController
             {
                 String title = form.isTitleSameAsName() ? null : StringUtils.trimToNull(form.getTitle());
                 Container c = ContainerManager.rename(getContainer(), getUser(), form.getName(), title, form.isAddAlias());
-                _returnURL = new AdminUrlsImpl().getManageFoldersURL(c);
+                _returnUrl = new AdminUrlsImpl().getManageFoldersURL(c);
                 return true;
             }
             catch (Exception e)
@@ -7574,7 +7574,7 @@ public class AdminController extends SpringActionController
         @Override
         public ActionURL getSuccessURL(ManageFoldersForm form)
         {
-            return _returnURL;
+            return _returnUrl;
         }
 
         @Override

--- a/core/src/org/labkey/core/admin/createFolder.jsp
+++ b/core/src/org/labkey/core/admin/createFolder.jsp
@@ -316,7 +316,7 @@
                     text: 'Cancel',
                     cls: 'labkey-button',
                     handler: function() {
-                        window.location = <%= q(form.getReturnURLHelper(new ActionURL(ProjectController.StartAction.class, ContainerManager.getHomeContainer()))) %>;
+                        window.location = <%= q(form.getReturnUrlHelper(new ActionURL(ProjectController.StartAction.class, ContainerManager.getHomeContainer()))) %>;
                     }
                 },{
                     text: 'Next',

--- a/core/src/org/labkey/core/admin/customizeEmail.jsp
+++ b/core/src/org/labkey/core/admin/customizeEmail.jsp
@@ -98,7 +98,7 @@
         <tr>
             <td></td><td>
             <%= button("Save").submit(true) %>
-            <%= button("Cancel").href(bean.getReturnURLHelper(urlProvider(AdminUrls.class).getAdminConsoleURL())) %>
+            <%= button("Cancel").href(bean.getReturnUrlHelper(urlProvider(AdminUrls.class).getAdminConsoleURL())) %>
             <%= button("Reset to Default Template").submit(true).onClick("this.form.action=" + q(urlFor(DeleteCustomEmailAction.class)) + ";").id("siteResetButton").style("display: none;")%>
             <%= button("Delete " + getContainer().getContainerNoun() + "-Level Template").submit(true).onClick("this.form.action=" + q(urlFor(DeleteCustomEmailAction.class)) + ";").id("folderResetButton").style("display: none;")%>
         </tr>

--- a/core/src/org/labkey/core/admin/view/filesProjectSettings.jsp
+++ b/core/src/org/labkey/core/admin/view/filesProjectSettings.jsp
@@ -79,8 +79,8 @@
     String folderSetup = getActionURL().getParameter("folderSetup");
     boolean isFolderSetup = "true".equalsIgnoreCase(folderSetup);
     String cancelButtonText = isFolderSetup ? "Next" : "Cancel";
-    URLHelper cancelButtonUrl = isFolderSetup && getActionURL().getReturnURL() != null
-            ? getActionURL().getReturnURL()
+    URLHelper cancelButtonUrl = isFolderSetup && getActionURL().getReturnUrl() != null
+            ? getActionURL().getReturnUrl()
             : c.getStartURL(getUser());
     ActionURL redirectToPipeline = urlProvider(PipelineUrls.class).urlBegin(c);
     boolean isCurrentFileRootCloud = FileRootProp.cloudRoot.name().equals(bean.getFileRootOption());

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -303,7 +303,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
     }
 
     @Override
-    public HttpView getErrorView(List<AttachmentFile> files, BindException errors, URLHelper returnURL)
+    public HttpView getErrorView(List<AttachmentFile> files, BindException errors, URLHelper returnUrl)
     {
         boolean hasErrors = null != errors && errors.hasErrors();
         HtmlString errorHtml = getErrorHtml(files);      // TODO: Get rid of getErrorHtml() -- use errors collection
@@ -313,7 +313,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
 
         try
         {
-            return new ErrorView(errorHtml, errors, returnURL);
+            return new ErrorView(errorHtml, errors, returnUrl);
         }
         catch (Exception e)
         {
@@ -343,13 +343,13 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
     public static class ErrorView extends JspView<Object>
     {
         public HtmlString errorHtml;
-        public URLHelper returnURL;
+        public URLHelper returnUrl;
 
-        private ErrorView(HtmlString errorHtml, BindException errors, URLHelper returnURL)
+        private ErrorView(HtmlString errorHtml, BindException errors, URLHelper returnUrl)
         {
             super("/org/labkey/core/attachment/showErrors.jsp", new Object(), errors);
             this.errorHtml = errorHtml;
-            this.returnURL = returnURL;
+            this.returnUrl = returnUrl;
         }
     }
 

--- a/core/src/org/labkey/core/attachment/showErrors.jsp
+++ b/core/src/org/labkey/core/attachment/showErrors.jsp
@@ -20,8 +20,8 @@
 <%@ page import="org.labkey.core.attachment.AttachmentServiceImpl" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    AttachmentServiceImpl.ErrorView me = (AttachmentServiceImpl.ErrorView) HttpView.currentView();
+    AttachmentServiceImpl.ErrorView me = HttpView.currentView();
 %>
 <%=formatMissedErrors("form")%>
 <%=null != me.errorHtml ? me.errorHtml : HtmlString.EMPTY_STRING%>
-<br><br><%= button("Continue").href(me.returnURL) %>
+<br><br><%= button("Continue").href(me.returnUrl) %>

--- a/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
+++ b/core/src/org/labkey/core/login/DbLoginAuthenticationProvider.java
@@ -109,7 +109,7 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
 
     @Override
     // id and password will not be blank (not null, not empty, not whitespace only)
-    public @NotNull AuthenticationResponse authenticate(DbLoginConfiguration configuration, @NotNull String id, @NotNull String password, URLHelper returnURL) throws InvalidEmailException
+    public @NotNull AuthenticationResponse authenticate(DbLoginConfiguration configuration, @NotNull String id, @NotNull String password, URLHelper returnUrl) throws InvalidEmailException
     {
         // Check for API key first
         if (API_KEY.equals(id))
@@ -170,7 +170,7 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
 
                 if (!rule.isValidForLogin(password, user, messages))
                 {
-                    return getChangePasswordResponse(configuration, user, returnURL, FailureReason.complexity);
+                    return getChangePasswordResponse(configuration, user, returnUrl, FailureReason.complexity);
                 }
                 else
                 {
@@ -179,7 +179,7 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
 
                     if (expiration.hasExpired(() -> LoginManager.getLastChanged(user2)))
                     {
-                        return getChangePasswordResponse(configuration, user, returnURL, FailureReason.expired);
+                        return getChangePasswordResponse(configuration, user, returnUrl, FailureReason.expired);
                     }
                 }
             }
@@ -225,7 +225,7 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
     }
 
     // If this appears to be a browser request then return an AuthenticationResponse that will result in redirect to the change password page.
-    private AuthenticationResponse getChangePasswordResponse(DbLoginConfiguration configuration, User user, URLHelper returnURL, FailureReason failureReason)
+    private AuthenticationResponse getChangePasswordResponse(DbLoginConfiguration configuration, User user, URLHelper returnUrl, FailureReason failureReason)
     {
         ActionURL redirectURL = null;
 
@@ -242,11 +242,11 @@ public class DbLoginAuthenticationProvider implements LoginFormAuthenticationPro
                     // We have a container, so redirect to password change page
 
                     // Fall back plan is the home page
-                    if (null == returnURL)
-                        returnURL = AppProps.getInstance().getHomePageActionURL();
+                    if (null == returnUrl)
+                        returnUrl = AppProps.getInstance().getHomePageActionURL();
 
                     LoginUrls urls = PageFlowUtil.urlProvider(LoginUrls.class);
-                    redirectURL = urls.getChangePasswordURL(c, user, returnURL, "Your " + failureReason.getMessage() + "; please choose a new password.");
+                    redirectURL = urls.getChangePasswordURL(c, user, returnUrl, "Your " + failureReason.getMessage() + "; please choose a new password.");
                 }
             }
         }

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -190,7 +190,7 @@ public class LoginController extends SpringActionController
         }
 
         @Override
-        public ActionURL getChangePasswordURL(Container c, User user, URLHelper returnURL, @Nullable String message)
+        public ActionURL getChangePasswordURL(Container c, User user, URLHelper returnUrl, @Nullable String message)
         {
             ActionURL url = new ActionURL(ChangePasswordAction.class, LookAndFeelProperties.getSettingsContainer(c));
             url.addParameter("userId", user.getUserId());
@@ -198,7 +198,7 @@ public class LoginController extends SpringActionController
             if (null != message)
                 url.addParameter("message", message);
 
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
 
             return url;
         }
@@ -210,28 +210,28 @@ public class LoginController extends SpringActionController
         }
 
         @Override
-        public ActionURL getLoginURL(URLHelper returnURL)
+        public ActionURL getLoginURL(URLHelper returnUrl)
         {
-            // Use root as placeholder; extra path of returnURL determines the real login URL path
+            // Use root as placeholder; extra path of returnUrl determines the real login URL path
             ActionURL url = new ActionURL(LoginAction.class, ContainerManager.getRoot());
 
-            if (null == returnURL)
-                returnURL = AppProps.getInstance().getHomePageActionURL();
+            if (null == returnUrl)
+                returnUrl = AppProps.getInstance().getHomePageActionURL();
 
-            if (returnURL instanceof ActionURL)
-                url.setExtraPath(((ActionURL) returnURL).getExtraPath());
+            if (returnUrl instanceof ActionURL)
+                url.setExtraPath(((ActionURL) returnUrl).getExtraPath());
 
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
             return url;
         }
 
         @Override
-        public ActionURL getLoginURL(Container c, @Nullable URLHelper returnURL)
+        public ActionURL getLoginURL(Container c, @Nullable URLHelper returnUrl)
         {
             ActionURL url = new ActionURL(LoginAction.class, c);
 
-            if (null != returnURL)
-                url.addReturnURL(returnURL);
+            if (null != returnUrl)
+                url.addReturnUrl(returnUrl);
 
             return url;
         }
@@ -243,34 +243,34 @@ public class LoginController extends SpringActionController
         }
 
         @Override
-        public ActionURL getLogoutURL(Container c, URLHelper returnURL)
+        public ActionURL getLogoutURL(Container c, URLHelper returnUrl)
         {
             ActionURL url = getLogoutURL(c);
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
             return url;
         }
 
         @Override
-        public ActionURL getStopImpersonatingURL(Container c, @Nullable URLHelper returnURL)
+        public ActionURL getStopImpersonatingURL(Container c, @Nullable URLHelper returnUrl)
         {
             ActionURL url = new ActionURL(StopImpersonatingAction.class, c);
 
-            if (null != returnURL)
-                url.addReturnURL(returnURL);
+            if (null != returnUrl)
+                url.addReturnUrl(returnUrl);
 
             return url;
         }
 
         @Override
-        public ActionURL getAgreeToTermsURL(Container c, URLHelper returnURL)
+        public ActionURL getAgreeToTermsURL(Container c, URLHelper returnUrl)
         {
             ActionURL url = new ActionURL(AgreeToTermsAction.class, c);
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
             return url;
         }
 
         @Override
-        public ActionURL getSSORedirectURL(SSOAuthenticationConfiguration<?> configuration, URLHelper returnURL, boolean skipProfile)
+        public ActionURL getSSORedirectURL(SSOAuthenticationConfiguration<?> configuration, URLHelper returnUrl, boolean skipProfile)
         {
             ActionURL url = new ActionURL(SsoRedirectAction.class, ContainerManager.getRoot());
             url.addParameter("configuration", configuration.getRowId());
@@ -278,12 +278,12 @@ public class LoginController extends SpringActionController
             {
                 url.addParameter("skipProfile", 1);
             }
-            if (null != returnURL)
+            if (null != returnUrl)
             {
-                String fragment = returnURL.getFragment();
-                if (!returnURL.isReadOnly())
-                    returnURL.setFragment(null);
-                url.addReturnURL(returnURL);
+                String fragment = returnUrl.getFragment();
+                if (!returnUrl.isReadOnly())
+                    returnUrl.setFragment(null);
+                url.addReturnUrl(returnUrl);
                 if (!StringUtils.isBlank(fragment))
                     url.replaceParameter("urlhash", "#" + fragment);
             }
@@ -315,7 +315,7 @@ public class LoginController extends SpringActionController
             try
             {
                 // Attempt authentication with all active form providers
-                PrimaryAuthenticationResult result = AuthenticationManager.authenticate(request, form.getEmail(), form.getPassword(), form.getReturnURLHelper(), true);
+                PrimaryAuthenticationResult result = AuthenticationManager.authenticate(request, form.getEmail(), form.getPassword(), form.getReturnUrlHelper(), true);
                 AuthenticationStatus status = result.getStatus();
 
                 if (Success == status)
@@ -335,7 +335,7 @@ public class LoginController extends SpringActionController
                     else
                     {
                         // Pass in normalized email address, but only if user provided a full email address
-                        status.addUserErrorMessage(errors, result, form.getEmail().contains("@") ? email.getEmailAddress() : null, form.getReturnURLHelper());
+                        status.addUserErrorMessage(errors, result, form.getEmail().contains("@") ? email.getEmailAddress() : null, form.getReturnUrlHelper());
                     }
                 }
             }
@@ -563,11 +563,11 @@ public class LoginController extends SpringActionController
     {
         if (!getUser().isGuest())
         {
-            URLHelper returnURL = form.getReturnURLHelper();
+            URLHelper returnUrl = form.getReturnUrlHelper();
 
-            // Create LoginReturnProperties if we have a returnURL or skipProfile param
-            LoginReturnProperties properties = null != returnURL || form.getSkipProfile()
-                    ? new LoginReturnProperties(returnURL, form.getUrlhash(), form.getSkipProfile()) : null;
+            // Create LoginReturnProperties if we have a returnUrl or skipProfile param
+            LoginReturnProperties properties = null != returnUrl || form.getSkipProfile()
+                    ? new LoginReturnProperties(returnUrl, form.getUrlhash(), form.getSkipProfile()) : null;
 
             return HttpView.redirect(AuthenticationManager.getAfterLoginURL(getContainer(), properties, getUser()), true);
         }
@@ -619,12 +619,12 @@ public class LoginController extends SpringActionController
         {
             HttpServletRequest request = getViewContext().getRequest();
 
-            // Store passed in returnURL and skipProfile param at the start of the login so we can redirect to it after
+            // Store passed in returnUrl and skipProfile param at the start of the login so we can redirect to it after
             // any password resets, secondary logins, profile updates, etc. have finished
-            URLHelper returnURL = form.getReturnURLHelper();
-            if (null != returnURL || form.getSkipProfile())
+            URLHelper returnUrl = form.getReturnUrlHelper();
+            if (null != returnUrl || form.getSkipProfile())
             {
-                LoginReturnProperties properties = new LoginReturnProperties(returnURL, form.getUrlhash(), form.getSkipProfile());
+                LoginReturnProperties properties = new LoginReturnProperties(returnUrl, form.getUrlhash(), form.getSkipProfile());
                 AuthenticationManager.setLoginReturnProperties(request, properties);
             }
 
@@ -756,7 +756,7 @@ public class LoginController extends SpringActionController
 
             if (isOldPasswordMatch(_user, oldPassword, errors))
             {
-                AuthenticationResult result = attemptSetPassword(_user, form.getReturnURLHelper(), "Changed password.", false, errors);
+                AuthenticationResult result = attemptSetPassword(_user, form.getReturnUrlHelper(), "Changed password.", false, errors);
                 if (result != null)
                     response.put(ActionURL.Param.returnUrl.name(), result.getRedirectURL());
             }
@@ -784,7 +784,7 @@ public class LoginController extends SpringActionController
                 User user = attemptVerification(form, errors);
                 if (user != null)
                 {
-                    AuthenticationResult result = attemptSetPassword(user, form.getReturnURLHelper(), "Verified and chose a password.", true, errors);
+                    AuthenticationResult result = attemptSetPassword(user, form.getReturnUrlHelper(), "Verified and chose a password.", true, errors);
                     if (result != null)
                         response.put(ActionURL.Param.returnUrl.name(), result.getRedirectURL());
                 }
@@ -988,12 +988,12 @@ public class LoginController extends SpringActionController
         public Object execute(LoginForm form, BindException errors)
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
-            URLHelper returnURL = form.getReturnURLHelper();
-            if (null != returnURL && null != form.getUrlhash())
+            URLHelper returnUrl = form.getReturnUrlHelper();
+            if (null != returnUrl && null != form.getUrlhash())
             {
-                returnURL.setFragment(form.getUrlhash().replace("#", ""));
+                returnUrl.setFragment(form.getUrlhash().replace("#", ""));
             }
-            HtmlString otherLoginMechanisms = AuthenticationManager.getLoginPageLogoHtml(returnURL);
+            HtmlString otherLoginMechanisms = AuthenticationManager.getLoginPageLogoHtml(returnUrl);
             response.put("otherLoginMechanismsContent", null != otherLoginMechanisms ? otherLoginMechanisms.toString() : null);
             return response;
         }
@@ -1074,7 +1074,7 @@ public class LoginController extends SpringActionController
             // see if any of the SSO auth providers are set to autoRedirect from the login action
             SSOAuthenticationConfiguration<?> ssoAuthenticationConfiguration = AuthenticationManager.getAutoRedirectSSOAuthConfiguration();
             if (ssoAuthenticationConfiguration != null)
-                return HttpView.redirect(ssoAuthenticationConfiguration.getLinkFactory().getURL(form.getReturnURLHelper(), form.getSkipProfile()));
+                return HttpView.redirect(ssoAuthenticationConfiguration.getLinkFactory().getURL(form.getReturnUrlHelper(), form.getSkipProfile()));
         }
 
         page.setTemplate(PageConfig.Template.Dialog);
@@ -1221,7 +1221,7 @@ public class LoginController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(AgreeToTermsForm form)
         {
-            return form.getReturnURLHelper();
+            return form.getReturnUrlHelper();
         }
 
         @Override
@@ -1396,7 +1396,7 @@ public class LoginController extends SpringActionController
         @Override
         public boolean handlePost(ReturnUrlForm form, BindException errors) throws Exception
         {
-            _redirectURL = SecurityManager.logoutUser(getViewContext().getRequest(), getUser(), form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL()));
+            _redirectURL = SecurityManager.logoutUser(getViewContext().getRequest(), getUser(), form.getReturnUrlHelper(AppProps.getInstance().getHomePageActionURL()));
             return true;
         }
 
@@ -1415,7 +1415,7 @@ public class LoginController extends SpringActionController
                     throw new RuntimeException(e);
                 }
             }
-            return form.getReturnURLHelper(AuthenticationManager.getWelcomeURL());
+            return form.getReturnUrlHelper(AuthenticationManager.getWelcomeURL());
         }
     }
 
@@ -1443,7 +1443,7 @@ public class LoginController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(ReturnUrlForm form)
         {
-            return form.getReturnURLHelper(AuthenticationManager.getWelcomeURL());
+            return form.getReturnUrlHelper(AuthenticationManager.getWelcomeURL());
         }
     }
 
@@ -1480,7 +1480,7 @@ public class LoginController extends SpringActionController
         @Override
         public Object execute(ReturnUrlForm form, BindException errors)
         {
-            URLHelper redirectURL = SecurityManager.logoutUser(getViewContext().getRequest(), getUser(), form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL()));
+            URLHelper redirectURL = SecurityManager.logoutUser(getViewContext().getRequest(), getUser(), form.getReturnUrlHelper(AppProps.getInstance().getHomePageActionURL()));
             ApiSimpleResponse response = new ApiSimpleResponse("success", true);
             if (null != redirectURL)
                 response.put("redirectUrl", redirectURL.getURIString());
@@ -1527,11 +1527,11 @@ public class LoginController extends SpringActionController
             if (!getUser().isGuest())
                 return HttpView.redirect(form.getReturnActionURL(AppProps.getInstance().getHomePageActionURL()));
 
-            // If we have a returnURL or skipProfile param then create and stash LoginReturnProperties
-            URLHelper returnURL = form.getReturnURLHelper();
-            if (null != returnURL || form.getSkipProfile())
+            // If we have a returnUrl or skipProfile param then create and stash LoginReturnProperties
+            URLHelper returnUrl = form.getReturnUrlHelper();
+            if (null != returnUrl || form.getSkipProfile())
             {
-                LoginReturnProperties properties = new LoginReturnProperties(returnURL, form.getUrlhash(), form.getSkipProfile());
+                LoginReturnProperties properties = new LoginReturnProperties(returnUrl, form.getUrlhash(), form.getSkipProfile());
                 AuthenticationManager.setLoginReturnProperties(getViewContext().getRequest(), properties);
             }
 
@@ -1612,11 +1612,11 @@ public class LoginController extends SpringActionController
             page.setIncludeLoginLink(false);
             page.setIncludeSearch(false);
 
-            // If we have a returnURL or skipProfile param then create and stash LoginReturnProperties
-            URLHelper returnURL = form.getReturnURLHelper();
-            if (null != returnURL || form.getSkipProfile())
+            // If we have a returnUrl or skipProfile param then create and stash LoginReturnProperties
+            URLHelper returnUrl = form.getReturnUrlHelper();
+            if (null != returnUrl || form.getSkipProfile())
             {
-                LoginReturnProperties properties = new LoginReturnProperties(returnURL, form.getUrlhash(), form.getSkipProfile());
+                LoginReturnProperties properties = new LoginReturnProperties(returnUrl, form.getUrlhash(), form.getSkipProfile());
                 AuthenticationManager.setLoginReturnProperties(getViewContext().getRequest(), properties);
             }
 
@@ -1633,7 +1633,7 @@ public class LoginController extends SpringActionController
         @Override
         public boolean handlePost(SetPasswordForm form, BindException errors) throws Exception
         {
-            AuthenticationResult result = attemptSetPassword(_user, form.getReturnURLHelper(), getAuditMessage(), clearVerification(), errors);
+            AuthenticationResult result = attemptSetPassword(_user, form.getReturnUrlHelper(), getAuditMessage(), clearVerification(), errors);
 
             if (errors.hasErrors())
                 return false;

--- a/core/src/org/labkey/core/login/setPassword.jsp
+++ b/core/src/org/labkey/core/login/setPassword.jsp
@@ -133,20 +133,20 @@
             <labkey:input type="hidden" name="skipProfile" value="1"/>
         <% }
 
-        if (null != bean.form.getReturnURLHelper()) { %>
+        if (null != bean.form.getReturnUrlHelper()) { %>
             <%=generateReturnUrlFormField(bean.form)%>
         <% } %>
         </div>
 
         <div class="auth-item">
             <%= button(bean.buttonText).submit(true).name("set") %>
-            <%=unsafe(bean.cancellable ? button("Cancel").href(bean.form.getReturnURLHelper() != null ? bean.form.getReturnURLHelper() : new ActionURL(HomeAction.class, getContainer())).toString() : "")%>
+            <%=unsafe(bean.cancellable ? button("Cancel").href(bean.form.getReturnUrlHelper() != null ? bean.form.getReturnUrlHelper() : new ActionURL(HomeAction.class, getContainer())).toString() : "")%>
         </div>
     <% }
        else
        {
             Container c = getContainer().isRoot() ? ContainerManager.getHomeContainer() : getContainer();
-            URLHelper homeURL = bean.form.getReturnURLHelper() != null ? bean.form.getReturnURLHelper() : new ActionURL(StartAction.class, c);
+            URLHelper homeURL = bean.form.getReturnUrlHelper() != null ? bean.form.getReturnUrlHelper() : new ActionURL(StartAction.class, c);
     %>
             <div class="auth-item">
                 <%= unsafe(button("Home").href(homeURL).toString()) %>

--- a/core/src/org/labkey/core/login/termsOfUse.jsp
+++ b/core/src/org/labkey/core/login/termsOfUse.jsp
@@ -34,15 +34,15 @@
     }
 %>
 <%
-    HttpView<AgreeToTermsBean> me = (HttpView<AgreeToTermsBean>) HttpView.currentView();
+    HttpView<AgreeToTermsBean> me = HttpView.currentView();
     AgreeToTermsBean bean = me.getModelBean();
 
-    URLHelper returnURL = bean.form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL());
+    URLHelper returnUrl = bean.form.getReturnUrlHelper(AppProps.getInstance().getHomePageActionURL());
     HtmlString termsHtml = bean.termsOfUseHTML;
 
     // Redirect immediately if terms are blank or null
     if (HtmlString.isBlank(termsHtml))
-        throw new RedirectException(returnURL);
+        throw new RedirectException(returnUrl);
 
     ActionURL formURL = urlFor(AgreeToTermsAction.class);
 %>
@@ -68,7 +68,7 @@
             </div>
         </div>
 
-        <%=generateReturnUrlFormField(returnURL)%>
+        <%=generateReturnUrlFormField(returnUrl)%>
 
         <input type="hidden" id="urlhash" name="urlhash">
     </form>

--- a/core/src/org/labkey/core/portal/ProjectController.java
+++ b/core/src/org/labkey/core/portal/ProjectController.java
@@ -162,57 +162,57 @@ public class ProjectController extends SpringActionController
         }
 
         @Override
-        public ActionURL getCustomizeWebPartURL(Container c, Portal.WebPart webPart, ActionURL returnURL)
+        public ActionURL getCustomizeWebPartURL(Container c, Portal.WebPart webPart, ActionURL returnUrl)
         {
             ActionURL url = getCustomizeWebPartURL(c);
             url.addParameter("webPartId", String.valueOf(webPart.getRowId()));
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
             return url;
         }
 
         @Override
-        public ActionURL getMoveWebPartURL(Container c, Portal.WebPart webPart, int direction, ActionURL returnURL)
+        public ActionURL getMoveWebPartURL(Container c, Portal.WebPart webPart, int direction, ActionURL returnUrl)
         {
             ActionURL url = new ActionURL(MoveWebPartAction.class, c);
             url.addParameter("pageId", webPart.getPageId());
             url.addParameter("index", String.valueOf(webPart.getIndex()));
             url.addParameter("direction", String.valueOf(direction));
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
             return url;
         }
 
         @Override
-        public ActionURL getDeleteWebPartURL(Container c, String pageId, int index, ActionURL returnURL)
+        public ActionURL getDeleteWebPartURL(Container c, String pageId, int index, ActionURL returnUrl)
         {
             ActionURL url = new ActionURL(DeleteWebPartAction.class, c);
             url.addParameter("pageId", pageId);
             url.addParameter("index", index);
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
             return url;
         }
 
         @Override
-        public ActionURL getHidePortalPageURL(Container c, String pageId, ActionURL returnURL)
+        public ActionURL getHidePortalPageURL(Container c, String pageId, ActionURL returnUrl)
         {
             ActionURL url = new ActionURL(HidePortalPageAction.class, c);
             url.addParameter("pageId", pageId);
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
             return url;
         }
 
         @Override
-        public ActionURL getDeletePortalPageURL(Container c, String pageId, ActionURL returnURL)
+        public ActionURL getDeletePortalPageURL(Container c, String pageId, ActionURL returnUrl)
         {
             ActionURL url = new ActionURL(DeletePortalPageAction.class, c);
             url.addParameter("pageId", pageId);
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
             return url;
         }
 
         @Override
-        public ActionURL getDeleteWebPartURL(Container c, Portal.WebPart webPart, ActionURL returnURL)
+        public ActionURL getDeleteWebPartURL(Container c, Portal.WebPart webPart, ActionURL returnUrl)
         {
-            return getDeleteWebPartURL(c, webPart.getPageId(), webPart.getIndex(), returnURL);
+            return getDeleteWebPartURL(c, webPart.getPageId(), webPart.getIndex(), returnUrl);
         }
 
         @Override
@@ -235,10 +235,10 @@ public class ProjectController extends SpringActionController
         }
 
         @Override
-        public ActionURL getTogglePageAdminModeURL(Container c, ActionURL returnURL)
+        public ActionURL getTogglePageAdminModeURL(Container c, ActionURL returnUrl)
         {
             ActionURL url = new ActionURL(TogglePageAdminModeAction.class, c);
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
             return url;
         }
     }
@@ -546,7 +546,7 @@ public class ProjectController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(CustomizePortletForm form)
         {
-            return form.getReturnURLHelper(beginURL());
+            return form.getReturnUrlHelper(beginURL());
         }
     }
 
@@ -574,7 +574,7 @@ public class ProjectController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(CustomizePortletForm form)
         {
-            URLHelper successURL = form.getReturnURLHelper(beginURL());
+            URLHelper successURL = form.getReturnUrlHelper(beginURL());
             if (null != successURL)
             {
                 //Don't return to the deleted page
@@ -606,7 +606,7 @@ public class ProjectController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(MovePortletForm movePortletForm)
         {
-            return movePortletForm.getReturnURLHelper(beginURL());
+            return movePortletForm.getReturnUrlHelper(beginURL());
         }
     }
 
@@ -650,10 +650,10 @@ public class ProjectController extends SpringActionController
                 return new ActionURL(CustomizeWebPartAction.class, getContainer())
                         .addParameter("pageId", form.getPageId())
                         .addParameter("index", "" + _newPart.getIndex())
-                        .addReturnURL(form.getReturnActionURL());
+                        .addReturnUrl(form.getReturnActionURL());
             }
             else
-                return form.getReturnURLHelper();
+                return form.getReturnUrlHelper();
         }
 
         @Override
@@ -929,7 +929,7 @@ public class ProjectController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(CustomizePortletForm customizePortletForm)
         {
-            return customizePortletForm.getReturnURLHelper(beginURL());
+            return customizePortletForm.getReturnUrlHelper(beginURL());
         }
 
         @Override
@@ -1873,7 +1873,7 @@ public class ProjectController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(ReturnUrlForm form)
         {
-            return form.getReturnURLHelper(beginURL());
+            return form.getReturnUrlHelper(beginURL());
         }
     }
 }

--- a/core/src/org/labkey/core/project/folderNav.jsp
+++ b/core/src/org/labkey/core/project/folderNav.jsp
@@ -63,10 +63,10 @@
     ActionURL startURL = c.getStartURL(getUser()); // 30975: Return to startURL due to async view context
 
     ActionURL createProjectURL = urlProvider(AdminUrls.class).getCreateProjectURL(null);
-    createProjectURL.addReturnURL(startURL);
+    createProjectURL.addReturnUrl(startURL);
 
     ActionURL createFolderURL = urlProvider(AdminUrls.class).getCreateFolderURL(c, null);
-    createFolderURL.addReturnURL(startURL);
+    createFolderURL.addReturnUrl(startURL);
 
     ActionURL folderManagementURL = urlProvider(AdminUrls.class).getManageFoldersURL(c);
     if (size > 1) { // Only show the nav trail if subfolders exist

--- a/core/src/org/labkey/core/security/SecurityController.java
+++ b/core/src/org/labkey/core/security/SecurityController.java
@@ -212,7 +212,7 @@ public class SecurityController extends SpringActionController
         {
             ActionURL url = new ActionURL(GroupAction.class, container);
             if (returnUrl != null)
-                url = url.addReturnURL(returnUrl);
+                url = url.addReturnUrl(returnUrl);
             return url.addParameter("group", groupName);
         }
 
@@ -223,12 +223,12 @@ public class SecurityController extends SpringActionController
         }
 
         @Override
-        public ActionURL getGroupPermissionURL(Container container, int id, @Nullable URLHelper returnURL)
+        public ActionURL getGroupPermissionURL(Container container, int id, @Nullable URLHelper returnUrl)
         {
             ActionURL url = new ActionURL(GroupPermissionAction.class, container);
             url.addParameter("id", id);
-            if (returnURL != null)
-                url.addReturnURL(returnURL);
+            if (returnUrl != null)
+                url.addReturnUrl(returnUrl);
             return url;
         }
 
@@ -245,21 +245,21 @@ public class SecurityController extends SpringActionController
         }
 
         @Override
-        public ActionURL getPermissionsURL(Container container, @Nullable URLHelper returnURL)
+        public ActionURL getPermissionsURL(Container container, @Nullable URLHelper returnUrl)
         {
             ActionURL url = new ActionURL(PermissionsAction.class, container);
-            if (returnURL != null)
-               url.addReturnURL(returnURL);
+            if (returnUrl != null)
+               url.addReturnUrl(returnUrl);
             return url;
         }
 
         @Override
-        public ActionURL getSiteGroupsURL(Container container, @Nullable URLHelper returnURL)
+        public ActionURL getSiteGroupsURL(Container container, @Nullable URLHelper returnUrl)
         {
             ActionURL url = new ActionURL(PermissionsAction.class, container);
             url.addParameter("t", "sitegroups");
-            if (returnURL != null)
-                url.addReturnURL(returnURL);
+            if (returnUrl != null)
+                url.addReturnUrl(returnUrl);
             return url;
         }
 
@@ -312,7 +312,7 @@ public class SecurityController extends SpringActionController
 
         @Override
         @Nullable
-        public ActionURL getExternalToolsViewURL(User user, Container c, @NotNull ActionURL returnURL)
+        public ActionURL getExternalToolsViewURL(User user, Container c, @NotNull ActionURL returnUrl)
         {
             long viewCount = ExternalToolsViewService.get().getExternalAccessViewProviders().stream()
                 .filter(externalToolsViewProvider -> !externalToolsViewProvider.getViews(user).isEmpty())
@@ -320,7 +320,7 @@ public class SecurityController extends SpringActionController
             if (viewCount > 0)
             {
                 ActionURL url = new ActionURL(ExternalToolsViewAction.class, c);
-                url.addReturnURL(returnURL);
+                url.addReturnUrl(returnUrl);
                 return url;
             }
             return null;
@@ -331,7 +331,7 @@ public class SecurityController extends SpringActionController
         {
             return new ActionURL(ClonePermissionsAction.class, ContainerManager.getRoot())
                 .addParameter("targetUser", targetUser.getUserId())
-                .addReturnURL(returnUrl);
+                .addReturnUrl(returnUrl);
         }
     }
 
@@ -1511,11 +1511,11 @@ public class SecurityController extends SpringActionController
             if (form.isSkipProfile())
                 extraParams.add(new Pair<>("skipProfile", "1"));
 
-            URLHelper returnURL = null;
+            URLHelper returnUrl = null;
             if (null != form.getReturnUrl())
             {
                 extraParams.add(new Pair<>(ActionURL.Param.returnUrl.name(), form.getReturnUrl()));
-                returnURL = form.getReturnURLHelper();
+                returnUrl = form.getReturnUrlHelper();
             }
 
             for (ValidEmail email : emails)
@@ -1531,7 +1531,7 @@ public class SecurityController extends SpringActionController
                 {
                     if (HtmlString.isBlank(result))
                     {
-                        ActionURL url = urlProvider(UserUrls.class).getUserDetailsURL(getContainer(), newUser.getUserId(), returnURL);
+                        ActionURL url = urlProvider(UserUrls.class).getUserDetailsURL(getContainer(), newUser.getUserId(), returnUrl);
                         result = HtmlString.unsafe(PageFlowUtil.filter(email) + " was already a registered system user. Click <a href=\"" + url.getEncodedLocalURIString() + "\">here</a> to see this user's profile and history.");
                     }
                     else if (userToClone != null)
@@ -1932,7 +1932,7 @@ public class SecurityController extends SpringActionController
         @Override
         public @NotNull URLHelper getSuccessURL(UserForm form)
         {
-            return form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL());
+            return form.getReturnUrlHelper(AppProps.getInstance().getHomePageActionURL());
         }
     }
 
@@ -1985,7 +1985,7 @@ public class SecurityController extends SpringActionController
                 PageFlowUtil.filter(affectedUser.getEmail()),
                 _loginExists ? "reset" : "created",
                 PageFlowUtil.filter(actionURL.getLocalURIString()),
-                PageFlowUtil.button("Done").href(form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL()))
+                PageFlowUtil.button("Done").href(form.getReturnUrlHelper(AppProps.getInstance().getHomePageActionURL()))
             );
 
             getPageConfig().setTemplate(PageConfig.Template.Dialog);
@@ -2010,7 +2010,7 @@ public class SecurityController extends SpringActionController
             builder.unsafeAppend("<p>")
                 .append(getErrorMessage(errors))
                 .unsafeAppend("</p>")
-                .append(PageFlowUtil.button("Done").href(form.getReturnURLHelper(AppProps.getInstance().getHomePageActionURL())));
+                .append(PageFlowUtil.button("Done").href(form.getReturnUrlHelper(AppProps.getInstance().getHomePageActionURL())));
 
             getPageConfig().setTemplate(PageConfig.Template.Dialog);
             setTitle("Password Reset Failed");

--- a/core/src/org/labkey/core/security/addUsers.jsp
+++ b/core/src/org/labkey/core/security/addUsers.jsp
@@ -125,12 +125,12 @@
     }
 %>
                 <%=submit%>
-                <% if (form.getReturnURLHelper() == null) { %>
+                <% if (form.getReturnUrlHelper() == null) { %>
                 <%= button("Done").href(urlFor(ShowUsersAction.class)) %>
                 <% }
                    else {
                 %>
-                <%= button("Done").href(form.getReturnURLHelper()) %>
+                <%= button("Done").href(form.getReturnUrlHelper()) %>
                 <% } %>
                 <%=generateReturnUrlFormField(form)%>
             </td>

--- a/core/src/org/labkey/core/security/clonePermissions.jsp
+++ b/core/src/org/labkey/core/security/clonePermissions.jsp
@@ -78,7 +78,7 @@
                 <input type="hidden" name="targetUser" value="<%=target.getUserId()%>">
                 <%=ReturnUrlForm.generateHiddenFormField(form.getReturnActionURL())%>
                 <%=button("Clone Permissions").submit(true)%>
-                <%=button("Cancel").href(form.getReturnURLHelper())%>
+                <%=button("Cancel").href(form.getReturnUrlHelper())%>
             </td>
         </tr>
         <%

--- a/core/src/org/labkey/core/security/externalToolsBase.jsp
+++ b/core/src/org/labkey/core/security/externalToolsBase.jsp
@@ -24,7 +24,7 @@
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
     ReturnUrlForm form = ((JspView<ReturnUrlForm>) HttpView.currentView()).getModelBean();
-    ActionURL alternativeURL = urlProvider(ProjectUrls.class).getBeginURL(getContainer());
-    ActionURL returnURL = form.getReturnActionURL(alternativeURL);
+    ActionURL alternativeUrl = urlProvider(ProjectUrls.class).getBeginURL(getContainer());
+    ActionURL returnUrl = form.getReturnActionURL(alternativeUrl);
 %>
-<%= button("Done").href(returnURL) %>
+<%= button("Done").href(returnUrl) %>

--- a/core/src/org/labkey/core/security/group.jsp
+++ b/core/src/org/labkey/core/security/group.jsp
@@ -58,7 +58,7 @@
 
     ActionURL completionUrl = urlFor(CompleteMemberAction.class);
     completionUrl.addParameter("groupId", bean.group.getUserId());
-    URLHelper returnURL = getActionURL().clone().deleteParameter(ActionURL.Param.returnUrl);
+    URLHelper returnUrl = getActionURL().clone().deleteParameter(ActionURL.Param.returnUrl);
 %>
 <style type="text/css">
     .lowlight {
@@ -262,11 +262,11 @@ else
             <td>
                 <% if (!isGroup)
                    {
-                    %><%= link("permissions", urlProvider(UserUrls.class).getUserAccessURL(c, userId).addReturnURL(returnURL)) %><%
+                    %><%= link("permissions", urlProvider(UserUrls.class).getUserAccessURL(c, userId).addReturnUrl(returnUrl)) %><%
                    }
                    else
                    {
-                    %><%= link("permissions", urlProvider(SecurityUrls.class).getGroupPermissionURL(c, userId).addReturnURL(returnURL)) %><%
+                    %><%= link("permissions", urlProvider(SecurityUrls.class).getGroupPermissionURL(c, userId).addReturnUrl(returnUrl)) %><%
                    }
                 %>
             </td>

--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -226,36 +226,36 @@ public class UserController extends SpringActionController
         }
 
         @Override
-        public ActionURL getUserDetailsURL(Container c, int userId, @Nullable URLHelper returnURL)
+        public ActionURL getUserDetailsURL(Container c, int userId, @Nullable URLHelper returnUrl)
         {
             ActionURL url = new ActionURL(DetailsAction.class, c);
             url.addParameter("userId", userId);
 
-            if (null != returnURL)
-                url.addReturnURL(returnURL);
+            if (null != returnUrl)
+                url.addReturnUrl(returnUrl);
 
             return url;
         }
 
         @Override
-        public ActionURL getUserDetailsURL(Container c, @Nullable URLHelper returnURL)
+        public ActionURL getUserDetailsURL(Container c, @Nullable URLHelper returnUrl)
         {
             ActionURL url = new ActionURL(DetailsAction.class, c);
 
-            if (null != returnURL)
-                url.addReturnURL(returnURL);
+            if (null != returnUrl)
+                url.addReturnUrl(returnUrl);
 
             return url;
         }
 
         @Override
-        public ActionURL getUserUpdateURL(Container c, URLHelper returnURL, int userId)
+        public ActionURL getUserUpdateURL(Container c, URLHelper returnUrl, int userId)
         {
             ActionURL url = new ActionURL(ShowUpdateAction.class, c);
             url.addParameter("userId", userId);
             url.addParameter(QueryParam.schemaName.toString(), CoreQuerySchema.NAME);
             url.addParameter(QueryView.DATAREGIONNAME_DEFAULT + "." + QueryParam.queryName, CoreQuerySchema.USERS_TABLE_NAME);
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
 
             return url;
         }
@@ -302,7 +302,7 @@ public class UserController extends SpringActionController
         editURL.addParameter(QueryParam.schemaName.toString(), "core");
         editURL.addParameter(QueryView.DATAREGIONNAME_DEFAULT + "." + QueryParam.queryName, CoreQuerySchema.SITE_USERS_TABLE_NAME);
         editURL.addParameter("userId", NumberUtils.toInt(currentURL.getParameter("userId")));
-        editURL.addReturnURL(currentURL);
+        editURL.addReturnUrl(currentURL);
 
         if (isOwnRecord || (getUser().hasRootPermission(UpdateUserPermission.class) && canManageDetailsUser))
         {
@@ -401,9 +401,9 @@ public class UserController extends SpringActionController
             if (domain != null)
             {
                 ActionURL url = domain.getDomainKind().urlEditDefinition(domain, getViewContext());
-                ActionURL returnURL = getViewContext().getActionURL();
-                if (returnURL != null)
-                    url.addReturnURL(returnURL);
+                ActionURL returnUrl = getViewContext().getActionURL();
+                if (returnUrl != null)
+                    url.addReturnUrl(returnUrl);
 
                 if (canUpdateUser)
                 {
@@ -952,7 +952,7 @@ public class UserController extends SpringActionController
             if (domain != null)
             {
                 successUrl = domain.getDomainKind().urlEditDefinition(domain, getViewContext());
-                successUrl.addReturnURL(getViewContext().getActionURL());
+                successUrl.addReturnUrl(getViewContext().getActionURL());
             }
 
             return successUrl;
@@ -1647,7 +1647,7 @@ public class UserController extends SpringActionController
                     // an alternate login, e.g., in case LDAP server goes down or configuration changes.
                     ActionURL resetURL = new ActionURL(AdminResetPasswordAction.class, c);
                     resetURL.addParameter("userId", detailsUser.getUserId());
-                    resetURL.addReturnURL(currentUrl);
+                    resetURL.addReturnUrl(currentUrl);
                     ActionButton reset = new ActionButton(resetURL, loginExists ? "Reset Password" : "Create Password");
                     reset.setActionType(ActionButton.Action.LINK);
                     bb.add(reset);
@@ -1656,7 +1656,7 @@ public class UserController extends SpringActionController
                     {
                         ActionURL deleteURL = new ActionURL(AdminDeletePasswordAction.class, c);
                         deleteURL.addParameter("userId", detailsUser.getUserId());
-                        deleteURL.addReturnURL(currentUrl);
+                        deleteURL.addReturnUrl(currentUrl);
                         ActionButton delete = new ActionButton(deleteURL, "Delete Password");
                         delete.setActionType(ActionButton.Action.LINK);
                         bb.add(delete);
@@ -1685,7 +1685,7 @@ public class UserController extends SpringActionController
                     {
                         ActionURL deactivateUrl = new ActionURL(detailsUser.isActive() ? DeactivateUsersAction.class : ActivateUsersAction.class, c);
                         deactivateUrl.addParameter("userId", _detailsUserId);
-                        deactivateUrl.addReturnURL(currentUrl);
+                        deactivateUrl.addReturnUrl(currentUrl);
                         bb.add(new ActionButton(detailsUser.isActive() ? "Deactivate" : "Reactivate", deactivateUrl));
                     }
 
@@ -1710,7 +1710,7 @@ public class UserController extends SpringActionController
             if (isProjectAdminOrBetter)
             {
                 ActionURL viewPermissionsURL = new UserUrlsImpl().getUserAccessURL(c, _detailsUserId);
-                viewPermissionsURL.addReturnURL(currentUrl);
+                viewPermissionsURL.addReturnUrl(currentUrl);
                 ActionButton viewPermissions = new ActionButton(viewPermissionsURL, "View Permissions");
                 viewPermissions.setActionType(ActionButton.Action.LINK);
                 bb.add(viewPermissions);
@@ -1742,7 +1742,7 @@ public class UserController extends SpringActionController
 
                 if (null != form.getReturnUrl())
                 {
-                    doneButton = new ActionButton("Done", form.getReturnURLHelper());
+                    doneButton = new ActionButton("Done", form.getReturnUrlHelper());
                     rgn.addHiddenFormField(ActionURL.Param.returnUrl, form.getReturnUrl());
                 }
                 else
@@ -1793,7 +1793,7 @@ public class UserController extends SpringActionController
         {
             ActionURL changeEmailURL = getChangeEmailURL(c, user);
             changeEmailURL.addParameter("isChangeEmailRequest", true);
-            changeEmailURL.addReturnURL(getViewContext().getActionURL());
+            changeEmailURL.addReturnUrl(getViewContext().getActionURL());
             ActionButton changeEmail = new ActionButton(changeEmailURL, "Change Email");
             changeEmail.setActionType(ActionButton.Action.LINK);
             return changeEmail;
@@ -2024,7 +2024,7 @@ public class UserController extends SpringActionController
                     }
 
                     String userEmail = userToChange.getEmail();
-                    boolean isAuthenticated = authenticate(userEmail, form.getPassword(), getViewContext().getActionURL().getReturnURL(), errors);
+                    boolean isAuthenticated = authenticate(userEmail, form.getPassword(), getViewContext().getActionURL().getReturnUrl(), errors);
                     if (isAuthenticated)
                     {
                         String verificationToken = LoginManager.createTempPassword();
@@ -2095,12 +2095,12 @@ public class UserController extends SpringActionController
                 }
                 else  // actually making self-service email change, so redirect to user details page
                 {
-                    return new UserUrlsImpl().getUserDetailsURL(getContainer(), currentUser.getUserId(), form.getReturnURLHelper());
+                    return new UserUrlsImpl().getUserDetailsURL(getContainer(), currentUser.getUserId(), form.getReturnUrlHelper());
                 }
             }
             else  // admin email change, so redirect to user details page
             {
-                return new UserUrlsImpl().getUserDetailsURL(getContainer(), form.getUserId(), form.getReturnURLHelper());
+                return new UserUrlsImpl().getUserDetailsURL(getContainer(), form.getUserId(), form.getReturnUrlHelper());
             }
         }
 
@@ -2967,11 +2967,11 @@ public class UserController extends SpringActionController
             if (null == group)
                 return "Group doesn't exist";
 
-            ActionURL returnURL = form.getReturnActionURL(AppProps.getInstance().getHomePageActionURL());
+            ActionURL returnUrl = form.getReturnActionURL(AppProps.getInstance().getHomePageActionURL());
 
             try
             {
-                SecurityManager.impersonateGroup(getViewContext(), group, returnURL);
+                SecurityManager.impersonateGroup(getViewContext(), group, returnUrl);
             }
             catch (UnauthorizedImpersonationException uie)
             {
@@ -3072,8 +3072,8 @@ public class UserController extends SpringActionController
                 newImpersonationRoles.add(role);
             }
 
-            ActionURL returnURL = context.isImpersonating() ? context.getReturnURL() : form.getReturnActionURL(AppProps.getInstance().getHomePageActionURL());
-            SecurityManager.impersonateRoles(getViewContext(), newImpersonationRoles, currentImpersonationRoles, returnURL);
+            ActionURL returnUrl = context.isImpersonating() ? context.getReturnUrl() : form.getReturnActionURL(AppProps.getInstance().getHomePageActionURL());
+            SecurityManager.impersonateRoles(getViewContext(), newImpersonationRoles, currentImpersonationRoles, returnUrl);
 
             return null;
         }

--- a/core/src/org/labkey/core/user/securityAccess.jsp
+++ b/core/src/org/labkey/core/user/securityAccess.jsp
@@ -60,7 +60,7 @@
 
     DataRegion accessRegion = new DataRegion();
     accessRegion.setName("access");
-    URLHelper returnURL = getActionURL().clone().deleteParameter(ActionURL.Param.returnUrl);
+    URLHelper returnUrl = getActionURL().clone().deleteParameter(ActionURL.Param.returnUrl);
 
     int cellPadding = 3;
 %>
@@ -108,7 +108,7 @@
 <%
         if (!bean.showUserCol())
         {
-            ActionURL containerPermissionsLink = urlProvider(SecurityUrls.class).getPermissionsURL(row.getContainer(), returnURL);
+            ActionURL containerPermissionsLink = urlProvider(SecurityUrls.class).getPermissionsURL(row.getContainer(), returnUrl);
             ActionURL folderAccessLink = urlProvider(SecurityUrls.class).getFolderAccessURL(row.getContainer());
 %>
             <td><%= link("permissions", containerPermissionsLink) %></td>
@@ -119,7 +119,7 @@
         }
         else
         {
-            %><td><%= link("details", urlProvider(UserUrls.class).getUserDetailsURL(c, row.getUser().getUserId(), returnURL)) %></td>
+            %><td><%= link("details", urlProvider(UserUrls.class).getUserDetailsURL(c, row.getUser().getUserId(), returnUrl)) %></td>
             <td style='padding-left:"<%=cellPadding%>px;'><%
             if (isUser)
             {

--- a/core/src/org/labkey/core/view/template/bootstrap/header.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/header.jsp
@@ -259,7 +259,7 @@
 
     if (user != null && user.isImpersonated())
     {
-        ActionURL stopUrl = urlProvider(LoginUrls.class).getStopImpersonatingURL(c, user.getImpersonationContext().getReturnURL());
+        ActionURL stopUrl = urlProvider(LoginUrls.class).getStopImpersonatingURL(c, user.getImpersonationContext().getReturnUrl());
 %>
             <li>
                 <%=link("Stop impersonating").href(stopUrl).clearClasses().addClass("btn btn-primary").usePost()%>

--- a/core/webapp/extWidgets/DetailsPanel.js
+++ b/core/webapp/extWidgets/DetailsPanel.js
@@ -98,8 +98,7 @@ Ext4.define('LABKEY.ext.DetailsPanel', {
         if(bbar)
             bbar.removeAll();
 
-        // Prefer using 'returnUrl' instead of 'returnURL' or 'srcURL'
-        var url = LABKEY.ActionURL.getReturnUrl() || LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.getParameter('returnURL');
+        var url = LABKEY.ActionURL.getReturnUrl();
 
         if (url && this.showBackBtn !== false){
             bbar.add({

--- a/core/webapp/extWidgets/ExcelUploadPanel.js
+++ b/core/webapp/extWidgets/ExcelUploadPanel.js
@@ -435,7 +435,7 @@ Ext4.define('LABKEY.ext4.ExcelUploadPanel', {
     },
 
     goToReturnUrl: function() {
-        var returnUrl = LABKEY.ActionURL.getReturnUrl() || LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.getParameter('returnURL');
+        var returnUrl = LABKEY.ActionURL.getReturnUrl();
 
         if (!returnUrl) {
             // default to using the project-begin action

--- a/core/webapp/extWidgets/Ext4FormPanel.js
+++ b/core/webapp/extWidgets/Ext4FormPanel.js
@@ -433,7 +433,7 @@ LABKEY.ext4.FORMBUTTONS = {
         return Ext4.Object.merge({
             text: 'Submit',
             formBind: true,
-            successURL: LABKEY.ActionURL.getReturnUrl() || LABKEY.ActionURL.getParameter('srcURL'),
+            successURL: LABKEY.ActionURL.getReturnUrl(),
             handler: function(btn){
                 var panel = btn.up('form');
                 panel.doSubmit(btn);
@@ -475,9 +475,9 @@ LABKEY.ext4.FORMBUTTONS = {
     CANCEL: function(config){
         return Ext4.Object.merge({
             text: 'Cancel',
-            returnURL: LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.getParameter('returnUrl'),
+            returnUrl: LABKEY.ActionURL.getParameter('returnUrl'),
             handler: function(btn, key){
-                window.location = btn.returnURL || LABKEY.ActionURL.buildURL('project', 'begin');
+                window.location = btn.returnUrl || LABKEY.ActionURL.buildURL('project', 'begin');
             }
         }, config)
     }

--- a/core/webapp/extWidgets/Ext4GridPanel.js
+++ b/core/webapp/extWidgets/Ext4GridPanel.js
@@ -392,7 +392,7 @@ LABKEY.ext4.GRIDBUTTONS = {
         return Ext4.Object.merge({
             text: 'Cancel',
             handler: function(btn, key){
-                window.location = btn.returnURL || LABKEY.ActionURL.getReturnUrl() || LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.buildURL('project', 'begin')
+                window.location = btn.returnUrl || LABKEY.ActionURL.getReturnUrl() || LABKEY.ActionURL.buildURL('project', 'begin')
             }
         }, config)
     }

--- a/core/webapp/extWidgets/ImportPanel.js
+++ b/core/webapp/extWidgets/ImportPanel.js
@@ -69,7 +69,7 @@ Ext4.define('LABKEY.ext.ImportPanel', {
     },
 
     goToReturnUrl: function() {
-        var returnUrl = LABKEY.ActionURL.getReturnUrl() || LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.getParameter('returnURL');
+        var returnUrl = LABKEY.ActionURL.getReturnUrl();
 
         if (!returnUrl) {
             // default to using the project-begin action

--- a/experiment/src/org/labkey/experiment/DataClassWebPart.java
+++ b/experiment/src/org/labkey/experiment/DataClassWebPart.java
@@ -119,7 +119,7 @@ public class DataClassWebPart extends QueryView
         super.populateButtonBar(view, bar);
 
         ActionURL deleteURL = new ActionURL(ExperimentController.DeleteDataClassAction.class, getContainer());
-        deleteURL.addReturnURL(getViewContext().getActionURL());
+        deleteURL.addReturnUrl(getViewContext().getActionURL());
 
         ActionButton deleteButton = new ActionButton(ExperimentController.DeleteDataClassAction.class, "Delete", ActionButton.Action.GET);
         deleteButton.setDisplayPermission(DesignDataClassPermission.class);
@@ -130,7 +130,7 @@ public class DataClassWebPart extends QueryView
         bar.add(deleteButton);
 
         ActionURL urlInsert = new ActionURL(ExperimentController.EditDataClassAction.class, getContainer());
-        urlInsert.addReturnURL(getViewContext().getActionURL());
+        urlInsert.addReturnUrl(getViewContext().getActionURL());
         Set<String> templates = DomainTemplateGroup.getTemplatesForDomainKind(getContainer(), DataClassDomainKind.NAME);
         if (templates.size() > 0)
         {
@@ -141,7 +141,7 @@ public class DataClassWebPart extends QueryView
             insertItem.setId("NewDataClass:fromDesigner");
 
             ActionURL urlTemplate = new ActionURL(ExperimentController.CreateDataClassFromTemplateAction.class, getContainer());
-            urlTemplate.addReturnURL(getViewContext().getActionURL());
+            urlTemplate.addReturnUrl(getViewContext().getActionURL());
             NavTree templateItem = createMenuButton.addMenuItem("Create from Template", urlTemplate);
             templateItem.setId("NewDataClass:fromTemplate");
 

--- a/experiment/src/org/labkey/experiment/RunGroupWebPart.java
+++ b/experiment/src/org/labkey/experiment/RunGroupWebPart.java
@@ -131,7 +131,7 @@ public class RunGroupWebPart extends QueryView
                 bb.add(addXarFile);
             }
 
-            ActionButton createExperiment = new ActionButton(ExperimentController.ExperimentUrlsImpl.get().getCreateRunGroupURL(getViewContext().getContainer(), getReturnURL(), false), "Create Run Group");
+            ActionButton createExperiment = new ActionButton(ExperimentController.ExperimentUrlsImpl.get().getCreateRunGroupURL(getViewContext().getContainer(), getReturnUrl(), false), "Create Run Group");
             createExperiment.setActionType(ActionButton.Action.LINK);
             createExperiment.setDisplayPermission(InsertPermission.class);
             bb.add(createExperiment);

--- a/experiment/src/org/labkey/experiment/SampleTypeWebPart.java
+++ b/experiment/src/org/labkey/experiment/SampleTypeWebPart.java
@@ -19,7 +19,6 @@ import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DataRegion;
-import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.qc.SampleStatusService;
 import org.labkey.api.query.FieldKey;
@@ -28,9 +27,7 @@ import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.DesignSampleTypePermission;
-import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.study.StudyUrls;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
@@ -95,7 +92,7 @@ public class SampleTypeWebPart extends QueryView
         super.populateButtonBar(view, bar);
 
         ActionURL deleteURL = new ActionURL(ExperimentController.DeleteSampleTypesAction.class, getContainer());
-        deleteURL.addReturnURL(getViewContext().getActionURL());
+        deleteURL.addReturnUrl(getViewContext().getActionURL());
 
         ActionButton deleteButton = new ActionButton(ExperimentController.DeleteSampleTypesAction.class, "Delete", ActionButton.Action.GET);
         deleteButton.setDisplayPermission(DesignSampleTypePermission.class);
@@ -106,7 +103,7 @@ public class SampleTypeWebPart extends QueryView
         bar.add(deleteButton);
 
         ActionURL urlInsert = new ActionURL(ExperimentController.EditSampleTypeAction.class, getContainer());
-        urlInsert.addReturnURL(getViewContext().getActionURL());
+        urlInsert.addReturnUrl(getViewContext().getActionURL());
         ActionButton createNewButton = new ActionButton(urlInsert, "New Sample Type", ActionButton.Action.LINK);
         createNewButton.setDisplayPermission(DesignSampleTypePermission.class);
         createNewButton.setURL(urlInsert);

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -723,7 +723,7 @@ public class ExperimentController extends SpringActionController
                 {
                     ActionURL updateURL = new ActionURL(EditSampleTypeAction.class, _sampleType.getContainer());
                     updateURL.addParameter("RowId", _sampleType.getRowId());
-                    updateURL.addReturnURL(getViewContext().getActionURL());
+                    updateURL.addReturnUrl(getViewContext().getActionURL());
 
                     if (!getContainer().equals(_sampleType.getContainer()))
                     {
@@ -743,7 +743,7 @@ public class ExperimentController extends SpringActionController
 
                     ActionURL deleteURL = new ActionURL(DeleteSampleTypesAction.class, _sampleType.getContainer());
                     deleteURL.addParameter("singleObjectRowId", _sampleType.getRowId());
-                    deleteURL.addReturnURL(ExperimentUrlsImpl.get().getShowSampleTypeListURL(getContainer()));
+                    deleteURL.addReturnUrl(ExperimentUrlsImpl.get().getShowSampleTypeListURL(getContainer()));
                     ActionButton deleteButton = new ActionButton(deleteURL, "Delete Type", ActionButton.Action.LINK);
                     deleteButton.setDisplayPermission(DesignSampleTypePermission.class);
                     detailsView.getDataRegion().getButtonBar(DataRegion.MODE_DETAILS).add(deleteButton);
@@ -753,7 +753,7 @@ public class ExperimentController extends SpringActionController
                     ActionURL editURL = domainKind.urlEditDefinition(_sampleType.getDomain(), new ViewBackgroundInfo(_sampleType.getContainer(), getUser(), getViewContext().getActionURL()));
                     if (editURL != null)
                     {
-                        editURL.addReturnURL(getViewContext().getActionURL());
+                        editURL.addReturnUrl(getViewContext().getActionURL());
                         ActionButton editTypeButton = new ActionButton(editURL, "Edit Fields");
                         editTypeButton.setDisplayPermission(UpdatePermission.class);
                         detailsView.getDataRegion().getButtonBar(DataRegion.MODE_DETAILS).add(editTypeButton);
@@ -770,7 +770,7 @@ public class ExperimentController extends SpringActionController
                     if (importURL != null)
                     {
                         importURL = importURL.clone();
-                        importURL.addReturnURL(getViewContext().getActionURL());
+                        importURL.addReturnUrl(getViewContext().getActionURL());
                         ActionButton uploadButton = new ActionButton(importURL, "Import More Samples", ActionButton.Action.LINK);
                         uploadButton.setDisplayPermission(UpdatePermission.class);
                         detailsView.getDataRegion().getButtonBar(DataRegion.MODE_DETAILS).add(uploadButton);
@@ -1079,7 +1079,7 @@ public class ExperimentController extends SpringActionController
             {
                 ActionURL updateURL = new ActionURL(EditDataClassAction.class, _dataClass.getContainer());
                 updateURL.addParameter("rowId", _dataClass.getRowId());
-                updateURL.addReturnURL(urlProvider(ExperimentUrls.class).getShowDataClassURL(_dataClass.getContainer(), _dataClass.getRowId()));
+                updateURL.addReturnUrl(urlProvider(ExperimentUrls.class).getShowDataClassURL(_dataClass.getContainer(), _dataClass.getRowId()));
 
                 if (inDefinitionContainer)
                 {
@@ -1099,7 +1099,7 @@ public class ExperimentController extends SpringActionController
 
                 ActionURL deleteURL = new ActionURL(DeleteDataClassAction.class, _dataClass.getContainer());
                 deleteURL.addParameter("singleObjectRowId", _dataClass.getRowId());
-                deleteURL.addReturnURL(ExperimentUrlsImpl.get().getDataClassListURL(getContainer()));
+                deleteURL.addReturnUrl(ExperimentUrlsImpl.get().getDataClassListURL(getContainer()));
                 ActionButton deleteButton = new ActionButton(deleteURL, "Delete Data Class", ActionButton.Action.LINK);
 
                 if (inDefinitionContainer)
@@ -6701,19 +6701,19 @@ public class ExperimentController extends SpringActionController
         }
 
         @Override
-        public ActionURL getDeleteExperimentsURL(Container container, URLHelper returnURL)
+        public ActionURL getDeleteExperimentsURL(Container container, URLHelper returnUrl)
         {
-            return new ActionURL(DeleteSelectedExperimentsAction.class, container).addReturnURL(returnURL);
+            return new ActionURL(DeleteSelectedExperimentsAction.class, container).addReturnUrl(returnUrl);
         }
 
         @Override
-        public ActionURL getDeleteProtocolURL(@NotNull ExpProtocol protocol, URLHelper returnURL)
+        public ActionURL getDeleteProtocolURL(@NotNull ExpProtocol protocol, URLHelper returnUrl)
         {
             ActionURL result = new ActionURL(DeleteProtocolByRowIdsAction.class, protocol.getContainer());
             result.addParameter("singleObjectRowId", protocol.getRowId());
-            if (returnURL != null)
+            if (returnUrl != null)
             {
-                result.addReturnURL(returnURL);
+                result.addReturnUrl(returnUrl);
             }
             return result;
         }
@@ -6787,26 +6787,26 @@ public class ExperimentController extends SpringActionController
         }
 
         @Override
-        public ActionURL getDeleteDatasURL(Container c, URLHelper returnURL)
+        public ActionURL getDeleteDatasURL(Container c, URLHelper returnUrl)
         {
             ActionURL url = new ActionURL(DeleteSelectedDataAction.class, c);
-            if (returnURL != null)
-                url.addReturnURL(returnURL);
+            if (returnUrl != null)
+                url.addReturnUrl(returnUrl);
             return url;
         }
 
-        public ActionURL getDeleteSelectedExperimentsURL(Container c, URLHelper returnURL)
+        public ActionURL getDeleteSelectedExperimentsURL(Container c, URLHelper returnUrl)
         {
             ActionURL result = new ActionURL(DeleteSelectedExperimentsAction.class, c);
-            if (returnURL != null)
-                result.addReturnURL(returnURL);
+            if (returnUrl != null)
+                result.addReturnUrl(returnUrl);
             return result;
         }
 
         @Override
-        public ActionURL getDeleteSelectedExpRunsURL(Container container, URLHelper returnURL)
+        public ActionURL getDeleteSelectedExpRunsURL(Container container, URLHelper returnUrl)
         {
-            return new ActionURL(DeleteSelectedExpRunsAction.class, container).addReturnURL(returnURL);
+            return new ActionURL(DeleteSelectedExpRunsAction.class, container).addReturnUrl(returnUrl);
         }
 
         public ActionURL getShowUpdateURL(ExpExperiment experiment)
@@ -6815,18 +6815,18 @@ public class ExperimentController extends SpringActionController
         }
 
         @Override
-        public ActionURL getRemoveSelectedExpRunsURL(Container container, URLHelper returnURL, ExpExperiment exp)
+        public ActionURL getRemoveSelectedExpRunsURL(Container container, URLHelper returnUrl, ExpExperiment exp)
         {
-            return new ActionURL(RemoveSelectedExpRunsAction.class, container).addReturnURL(returnURL).addParameter("expRowId", exp.getRowId());
+            return new ActionURL(RemoveSelectedExpRunsAction.class, container).addReturnUrl(returnUrl).addParameter("expRowId", exp.getRowId());
         }
 
         @Override
-        public ActionURL getCreateRunGroupURL(Container container, URLHelper returnURL, boolean addSelectedRuns)
+        public ActionURL getCreateRunGroupURL(Container container, URLHelper returnUrl, boolean addSelectedRuns)
         {
             ActionURL result = new ActionURL(CreateRunGroupAction.class, container);
-            if (returnURL != null)
+            if (returnUrl != null)
             {
-                result.addReturnURL(returnURL);
+                result.addReturnUrl(returnUrl);
             }
             if (addSelectedRuns)
             {

--- a/experiment/src/org/labkey/experiment/controllers/exp/SampleTypeContentsView.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/SampleTypeContentsView.java
@@ -67,18 +67,18 @@ public class SampleTypeContentsView extends QueryView
     public DataView createDataView()
     {
         DataView view = super.createDataView();
-        String returnURL = getViewContext().getRequest().getParameter(ActionURL.Param.returnUrl.name());
+        String returnUrl = getViewContext().getRequest().getParameter(ActionURL.Param.returnUrl.name());
 
-        if (returnURL == null)
+        if (returnUrl == null)
         {
-            // 27693: Respect returnURL from async webpart requests
-            if (getSettings().getReturnURLHelper() != null)
-                returnURL = getSettings().getReturnURLHelper().toString();
+            // 27693: Respect returnUrl from async webpart requests
+            if (getSettings().getReturnUrlHelper() != null)
+                returnUrl = getSettings().getReturnUrlHelper().toString();
             else
-                returnURL = getViewContext().getActionURL().toString();
+                returnUrl = getViewContext().getActionURL().toString();
         }
 
-        view.getDataRegion().addHiddenFormField(ActionURL.Param.returnUrl, returnURL);
+        view.getDataRegion().addHiddenFormField(ActionURL.Param.returnUrl, returnUrl);
         view.getDataRegion().addHiddenFormField("rowId", String.valueOf(_source.getRowId()));
 
         return view;

--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -211,9 +211,9 @@ public class PropertyController extends SpringActionController
                 // re-fetch the domain so that we can redirect using the saved domainId
                 _domain = PropertyService.get().getDomain(getContainer(), domainURI);
                 ActionURL redirectURL = urlProvider(ExperimentUrls.class).getDomainEditorURL(getContainer(), _domain);
-                URLHelper returnURL = getViewContext().getActionURL().getReturnURL();
-                if (returnURL != null)
-                    redirectURL.addReturnURL(returnURL);
+                URLHelper returnUrl = getViewContext().getActionURL().getReturnUrl();
+                if (returnUrl != null)
+                    redirectURL.addReturnUrl(returnUrl);
                 throw new RedirectException(redirectURL);
             }
             else

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -625,7 +625,7 @@ public class IssuesController extends SpringActionController
             page.setCustomColumnConfiguration(customColumnConfig);
             page.setBody(form.getComment() == null ? form.getBody() : form.getComment());
             page.setCallbackURL(form.getCallbackURL());
-            page.setReturnURL(form.getReturnActionURL());
+            page.setReturnUrl(form.getReturnActionURL());
             page.setVisibleFields(getVisibleFields(page.getAction(), customColumnConfig));
             page.setReadOnlyFields(getReadOnlyFields(page.getAction()));
             page.setRequiredFields(IssueManager.getRequiredIssueFields(getContainer()));
@@ -1310,7 +1310,7 @@ public class IssuesController extends SpringActionController
             page.setPrevIssue(prevIssue);
             page.setCustomColumnConfiguration(getColumnConfiguration());
             page.setBody(form.getComment());
-            page.setReturnURL(form.getReturnActionURL());
+            page.setReturnUrl(form.getReturnActionURL());
             page.setVisibleFields(getVisibleFields(page.getAction(), getColumnConfiguration()));
             page.setReadOnlyFields(getReadOnlyFields(page.getAction()));
             page.setRequiredFields(IssueManager.getRequiredIssueFields(getContainer()));

--- a/issues/src/org/labkey/issue/model/IssuePage.java
+++ b/issues/src/org/labkey/issue/model/IssuePage.java
@@ -98,7 +98,7 @@ public class IssuePage implements DataRegionSelection.DataSelectionKeyForm
     private Set<String> _visible = Collections.emptySet();
     private Set<String> _readOnly = Collections.emptySet();
     private String _callbackURL;
-    private ActionURL _returnURL;
+    private ActionURL _returnUrl;
     private BindException _errors;
     private Issue.action _action;
     private String _body;
@@ -209,14 +209,14 @@ public class IssuePage implements DataRegionSelection.DataSelectionKeyForm
         _callbackURL = callbackURL;
     }
 
-    public ActionURL getReturnURL()
+    public ActionURL getReturnUrl()
     {
-        return _returnURL;
+        return _returnUrl;
     }
 
-    public void setReturnURL(ActionURL returnURL)
+    public void setReturnUrl(ActionURL returnUrl)
     {
-        _returnURL = returnURL;
+        _returnUrl = returnUrl;
     }
 
     public BindException getErrors()

--- a/issues/src/org/labkey/issue/view/updateView.jsp
+++ b/issues/src/org/labkey/issue/view/updateView.jsp
@@ -109,9 +109,9 @@
     ActionURL completionUrl = urlProvider(SecurityUrls.class).getCompleteUserReadURL(c);
     ActionURL cancelURL;
 
-    if (bean.getReturnURL() != null)
+    if (bean.getReturnUrl() != null)
     {
-        cancelURL = bean.getReturnURL();
+        cancelURL = bean.getReturnUrl();
     }
     else if (issue.getIssueId() > 0)
     {
@@ -439,9 +439,9 @@
         <input type="hidden" name="callbackURL" value="<%=h(bean.getCallbackURL())%>"/><%
     }
 
-    if (bean.getReturnURL() != null)
+    if (bean.getReturnUrl() != null)
     {%>
-        <%= generateReturnUrlFormField(bean.getReturnURL()) %> <%
+        <%= generateReturnUrlFormField(bean.getReturnUrl()) %> <%
     }%>
     <input type="hidden" name="action" value="<%=h(bean.getAction().name())%>">
     <input type="hidden" name="dirty" value="false">

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -55,6 +55,7 @@ import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.defaults.ClearDefaultValuesAction;
+import org.labkey.api.defaults.DomainIdForm;
 import org.labkey.api.defaults.SetDefaultValuesAction;
 import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListItem;
@@ -73,7 +74,6 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryAction;
 import org.labkey.api.query.QueryForm;
-import org.labkey.api.query.QueryParam;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryUpdateForm;
@@ -213,7 +213,7 @@ public class ListController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction<QueryForm>
+    public static class BeginAction extends SimpleViewAction<QueryForm>
     {
         @Override
         public ModelAndView getView(QueryForm queryForm, BindException errors)
@@ -409,7 +409,7 @@ public class ListController extends SpringActionController
         @Override @NotNull
         public URLHelper getSuccessURL(ListDeletionForm form)
         {
-            return form.getReturnURLHelper(getBeginURL(getContainer()));
+            return form.getReturnUrlHelper(getBeginURL(getContainer()));
         }
     }
 
@@ -542,10 +542,6 @@ public class ListController extends SpringActionController
                 {
                     url.addParameter(ActionURL.Param.returnUrl, (String) value.getValue());
                 }
-                else if (value.getName().equalsIgnoreCase(ActionURL.Param.returnUrl.toString()))
-                {
-                    ReturnUrlForm.throwBadParam();
-                }
                 else
                     inputs.add(Pair.of(value.getName(), value.getValue().toString()));
             }
@@ -600,7 +596,7 @@ public class ListController extends SpringActionController
 
             if (form.isShowHistory())
             {
-                WebPartView linkView = new HtmlView(PageFlowUtil.link("hide item history").href(getViewContext().cloneActionURL().deleteParameter("showHistory")).build());
+                WebPartView<?> linkView = new HtmlView(PageFlowUtil.link("hide item history").href(getViewContext().cloneActionURL().deleteParameter("showHistory")).build());
                 linkView.setFrame(WebPartView.FrameType.NONE);
                 view.addView(linkView);
 
@@ -820,7 +816,7 @@ public class ListController extends SpringActionController
         }
     }
 
-    private String getUrlParam(Enum param)
+    private String getUrlParam(Enum<?> param)
     {
         String s = getViewContext().getActionURL().getParameter(param);
         ReturnUrlForm form = new ReturnUrlForm();
@@ -829,7 +825,7 @@ public class ListController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class ListItemDetailsAction extends SimpleViewAction
+    public class ListItemDetailsAction extends SimpleViewAction<Object>
     {
         private ListDefinition _list;
 
@@ -865,8 +861,6 @@ public class ListController extends SpringActionController
                 String srcUrl = getUrlParam(ActionURL.Param.redirectUrl);
                 if (srcUrl == null)
                     srcUrl = getUrlParam(ActionURL.Param.returnUrl);
-                if (srcUrl == null)
-                    srcUrl = getUrlParam(QueryParam.srcURL);
                 if (srcUrl == null)
                     srcUrl = _list.urlFor(ListController.HistoryAction.class, getContainer()).getLocalURIString();
                 AuditChangesView view = new AuditChangesView(comment, oldData, newData);
@@ -914,7 +908,7 @@ public class ListController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class DownloadAction extends BaseDownloadAction<ListAttachmentForm>
+    public static class DownloadAction extends BaseDownloadAction<ListAttachmentForm>
     {
         @Override
         public void validate(ListAttachmentForm form, BindException errors)
@@ -944,7 +938,7 @@ public class ListController extends SpringActionController
 
 
     @RequiresPermission(DesignListPermission.class)
-    public class ExportListArchiveAction extends ExportAction<ListDefinitionForm>
+    public static class ExportListArchiveAction extends ExportAction<ListDefinitionForm>
     {
         @Override
         public void export(ListDefinitionForm form, HttpServletResponse response, BindException errors) throws Exception
@@ -1067,7 +1061,7 @@ public class ListController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BrowseListsAction extends ReadOnlyApiAction<Object>
+    public static class BrowseListsAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object form, BindException errors)
@@ -1094,7 +1088,7 @@ public class ListController extends SpringActionController
     }
 
     @RequiresPermission(DesignListPermission.class)
-    public static class SetDefaultValuesListAction extends SetDefaultValuesAction
+    public static class SetDefaultValuesListAction extends SetDefaultValuesAction<DomainIdForm>
     {
     }
 

--- a/list/src/org/labkey/list/model/ListDefinitionImpl.java
+++ b/list/src/org/labkey/list/model/ListDefinitionImpl.java
@@ -734,7 +734,7 @@ public class ListDefinitionImpl implements ListDefinition
         if (returnAndCancelUrl != null)
         {
             url.addCancelURL(returnAndCancelUrl);
-            url.addReturnURL(returnAndCancelUrl);
+            url.addReturnUrl(returnAndCancelUrl);
         }
 
         return url;

--- a/list/src/org/labkey/list/model/ListManagerSchema.java
+++ b/list/src/org/labkey/list/model/ListManagerSchema.java
@@ -155,7 +155,7 @@ public class ListManagerSchema extends UserSchema
                 private Button createImportListArchiveButton()
                 {
                     ActionURL urlImport = new ActionURL(ListController.ImportListArchiveAction.class, getContainer());
-                    urlImport.addReturnURL(getReturnURL());
+                    urlImport.addReturnUrl(getReturnUrl());
                     Button btnImport = new Button.ButtonBuilder("Import List Archive")
                             .href(urlImport)
                             .build();
@@ -167,7 +167,7 @@ public class ListManagerSchema extends UserSchema
                 public ActionButton createDeleteButton()
                 {
                     ActionURL urlDelete = new ActionURL(ListController.DeleteListDefinitionAction.class, getContainer());
-                    urlDelete.addReturnURL(getReturnURL());
+                    urlDelete.addReturnUrl(getReturnUrl());
                     ActionButton btnDelete = new ActionButton(urlDelete, "Delete");
                     btnDelete.setIconCls("trash");
                     btnDelete.setActionType(ActionButton.Action.GET);

--- a/list/src/org/labkey/list/view/ListDefinitionForm.java
+++ b/list/src/org/labkey/list/view/ListDefinitionForm.java
@@ -58,12 +58,6 @@ public class ListDefinitionForm extends ViewForm
         return _listDef;
     }
 
-    // alias to support both returnUrl and srcURL parameters
-    public void setSrcURL(String srcUrl)
-    {
-        ReturnUrlForm.throwBadParam();
-    }
-
     public boolean isShowHistory()
     {
         return _showHistory;

--- a/list/src/org/labkey/list/view/ListQueryView.java
+++ b/list/src/org/labkey/list/view/ListQueryView.java
@@ -73,8 +73,8 @@ public class ListQueryView extends QueryView
         if (getViewContext().hasPermission(DesignListPermission.class))
         {
             ActionURL designURL = getList().urlShowDefinition();
-            URLHelper returnURL = getSettings() != null ? getSettings().getReturnURLHelper() : null;
-            designURL.addReturnURL(returnURL != null ? returnURL : getViewContext().getActionURL());
+            URLHelper returnUrl = getSettings() != null ? getSettings().getReturnUrlHelper() : null;
+            designURL.addReturnUrl(returnUrl != null ? returnUrl : getViewContext().getActionURL());
             ActionButton btnUpload = new ActionButton("Design", designURL);
             bar.add(btnUpload);
         }

--- a/pipeline/src/org/labkey/pipeline/PipelineController.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineController.java
@@ -165,16 +165,16 @@ public class PipelineController extends SpringActionController
         return urlSetup(c, null);
     }
 
-    public static ActionURL urlSetup(Container c, ActionURL returnURL)
+    public static ActionURL urlSetup(Container c, ActionURL returnUrl)
     {
-        return urlSetup(c, returnURL, false, false);
+        return urlSetup(c, returnUrl, false, false);
     }
 
-    public static ActionURL urlSetup(Container c, ActionURL returnURL, boolean rootSet, boolean overrideRoot)
+    public static ActionURL urlSetup(Container c, ActionURL returnUrl, boolean rootSet, boolean overrideRoot)
     {
         ActionURL url = new ActionURL(SetupAction.class, c);
-        if (returnURL != null)
-            url.addReturnURL(returnURL);
+        if (returnUrl != null)
+            url.addReturnUrl(returnUrl);
         if (rootSet)
             url.addParameter(Params.rootset, "1");
         if (overrideRoot)
@@ -1505,7 +1505,7 @@ public class PipelineController extends SpringActionController
             {
                 _title = "Update Pipeline Trigger";
                 Integer rowId = form.getRowId();
-                String returnURL = form.getReturnUrl();
+                String returnUrl = form.getReturnUrl();
                 SimpleFilter filter = SimpleFilter.createContainerFilter(getContainer());
                 filter.addCondition(FieldKey.fromParts("RowId"), form.getRowId());
                 PipelineTriggerForm savedForm = new TableSelector(PipelineSchema.getInstance().getTableInfoTriggerConfigurations(), filter, null).getObject(PipelineTriggerForm.class);
@@ -1514,7 +1514,7 @@ public class PipelineController extends SpringActionController
                 {
                     form = savedForm;
                     form.setRowId(rowId);
-                    form.setReturnUrl(returnURL);
+                    form.setReturnUrl(returnUrl);
                 }
                 else
                 {
@@ -1658,7 +1658,7 @@ public class PipelineController extends SpringActionController
             ActionURL url = new ActionURL(BrowseAction.class, container);
 
             if (null != returnUrl)
-                url.addReturnURL(returnUrl);
+                url.addReturnUrl(returnUrl);
 
             if (path != null)
                 url.addParameter(Params.path, path);
@@ -1730,7 +1730,7 @@ public class PipelineController extends SpringActionController
                 url.addParameter("pipelineTask", pipelineId);
 
             if (returnUrl != null)
-                url.addReturnURL(returnUrl);
+                url.addReturnUrl(returnUrl);
 
             return url;
         }

--- a/pipeline/src/org/labkey/pipeline/analysis/ProtocolManagementWebPart.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/ProtocolManagementWebPart.java
@@ -90,7 +90,7 @@ public class ProtocolManagementWebPart extends GridView
         for (AnalysisController.ProtocolTask action : AnalysisController.ProtocolTask.values())
         {
             ActionURL url = new ActionURL(AnalysisController.ProtocolManagementAction.class, getViewContext().getContainer());
-            url.addParameter("action", action.toString()).addReturnURL(getContextURLHelper());
+            url.addParameter("action", action.toString()).addReturnUrl(getContextURLHelper());
             ActionButton button = new ActionButton(url, action.toString());
             String confirmMessage = "Are you sure you want to " + action.toString() + " the selected ";
             button.setRequiresSelection(true, confirmMessage + "protocol?", confirmMessage + "protocols?");
@@ -112,7 +112,7 @@ public class ProtocolManagementWebPart extends GridView
             params.put("name", "name");
             params.put("archived", "archived");
             ActionURL actionURL = new ActionURL(AnalysisController.ProtocolDetailsAction.class, getViewContext().getContainer());
-            DetailsURL url = new DetailsURL(actionURL.addReturnURL(getContextURLHelper()), params);
+            DetailsURL url = new DetailsURL(actionURL.addReturnUrl(getContextURLHelper()), params);
             ((BaseColumnInfo)colInfos.get(1)).setURL(url);
             setResults(new ResultsImpl(rs, colInfos));
             getDataRegion().setColumns(colInfos);

--- a/pipeline/src/org/labkey/pipeline/analysis/protocolDetail.jsp
+++ b/pipeline/src/org/labkey/pipeline/analysis/protocolDetail.jsp
@@ -77,7 +77,7 @@
             ActionURL urlBase = urlFor(AnalysisController.ProtocolManagementAction.class);
             urlBase.addParameter("taskId", form.getTaskId());
             urlBase.addParameter("name", form.getName());
-            urlBase.addReturnURL(returnUrl);
+            urlBase.addReturnUrl(returnUrl);
         %>
         <textarea id="xmlParameters"></textarea>
         <br/>

--- a/pipeline/src/org/labkey/pipeline/status/PipelineQueryView.java
+++ b/pipeline/src/org/labkey/pipeline/status/PipelineQueryView.java
@@ -24,13 +24,11 @@ import org.labkey.api.data.Filter;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.pipeline.PipelineJob;
-import org.labkey.api.pipeline.PipelineProvider;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.PipelineUrls;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
-import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
@@ -51,16 +49,16 @@ public class PipelineQueryView extends QueryView
     private final ViewContext _context;
     private final Class<? extends ReadOnlyApiAction> _apiAction;
     private final PipelineService.PipelineButtonOption _buttonOption;
-    private final ActionURL _returnURL;
+    private final ActionURL _returnUrl;
 
-    public PipelineQueryView(ViewContext context, BindException errors, Class<? extends ReadOnlyApiAction> apiAction, PipelineService.PipelineButtonOption buttonOption, ActionURL returnURL)
+    public PipelineQueryView(ViewContext context, BindException errors, Class<? extends ReadOnlyApiAction> apiAction, PipelineService.PipelineButtonOption buttonOption, ActionURL returnUrl)
     {
         super(new PipelineQuerySchema(context.getUser(), context.getContainer()), null, errors);
         _buttonOption = buttonOption;
         setSettings(createSettings(context));
         _context = context;
         _apiAction = apiAction;
-        _returnURL = returnURL;
+        _returnUrl = returnUrl;
 
         setShadeAlternatingRows(true);
         setShowBorders(true);
@@ -80,7 +78,7 @@ public class PipelineQueryView extends QueryView
     @Override
     protected DataRegion createDataRegion()
     {
-        StatusDataRegion rgn = new StatusDataRegion(_apiAction, _returnURL);
+        StatusDataRegion rgn = new StatusDataRegion(_apiAction, _returnUrl);
         configureDataRegion(rgn);
         return rgn;
     }
@@ -134,7 +132,7 @@ public class PipelineQueryView extends QueryView
             if (showDeleteButton())
             {
                 ActionURL deleteURL = new ActionURL(StatusController.DeleteStatusAction.class, getContainer());
-                deleteURL.addReturnURL(_returnURL);
+                deleteURL.addReturnUrl(_returnUrl);
                 ActionButton deleteStatus = new ActionButton(deleteURL, "Delete");
                 deleteStatus.setIconCls("trash");
                 deleteStatus.setRequiresSelection(true);
@@ -158,7 +156,7 @@ public class PipelineQueryView extends QueryView
         if (_buttonOption == PipelineService.PipelineButtonOption.Standard)
         {
             ActionURL retryURL = new ActionURL(StatusController.RetryStatusAction.class, getContainer());
-            retryURL.addReturnURL(_returnURL);
+            retryURL.addReturnUrl(_returnUrl);
 
             ActionButton retryStatus = new ActionButton(retryURL, "Retry");
             retryStatus.setRequiresSelection(true);
@@ -167,7 +165,7 @@ public class PipelineQueryView extends QueryView
             bar.add(retryStatus);
 
             ActionURL cancelURL = new ActionURL(StatusController.CancelStatusAction.class, getContainer());
-            cancelURL.addReturnURL(_returnURL);
+            cancelURL.addReturnUrl(_returnUrl);
             ActionButton cancelButton = new ActionButton(cancelURL, "Cancel");
             cancelButton.setRequiresSelection(true);
             cancelButton.setActionType(ActionButton.Action.POST);
@@ -175,7 +173,7 @@ public class PipelineQueryView extends QueryView
             bar.add(cancelButton);
 
             ActionURL completeURL = new ActionURL(StatusController.CompleteStatusAction.class, getContainer());
-            completeURL.addReturnURL(_returnURL);
+            completeURL.addReturnUrl(_returnUrl);
             ActionButton completeStatus = new ActionButton(completeURL, "Complete");
             completeStatus.setRequiresSelection(true);
             completeStatus.setActionType(ActionButton.Action.POST);

--- a/pipeline/src/org/labkey/pipeline/status/StatusController.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusController.java
@@ -793,7 +793,7 @@ public class StatusController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(ConfirmDeleteStatusForm form)
         {
-            URLHelper ret = form.getReturnURLHelper();
+            URLHelper ret = form.getReturnUrlHelper();
             if (null == ret)
                 ret = urlShowList(getContainer(), true, null);
             return ret;
@@ -958,7 +958,7 @@ public class StatusController extends SpringActionController
         ActionURL url = new ActionURL(PipelineController.CancelJobAction.class, c);
         url.addParameter("rowId", rowId);
         if (returnUrl != null)
-            url.addReturnURL(returnUrl);
+            url.addReturnUrl(returnUrl);
         return url;
     }
 

--- a/pipeline/src/org/labkey/pipeline/status/StatusDataRegion.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusDataRegion.java
@@ -41,15 +41,15 @@ import java.sql.SQLException;
 public class StatusDataRegion extends DataRegion
 {
     private Class<? extends ReadOnlyApiAction> _apiAction;
-    private ActionURL _returnURL;
+    private ActionURL _returnUrl;
 
-    public StatusDataRegion(Class<? extends ReadOnlyApiAction> apiAction, ActionURL returnURL)
+    public StatusDataRegion(Class<? extends ReadOnlyApiAction> apiAction, ActionURL returnUrl)
     {
         setShowPagination(false);
         setAllowHeaderLock(false); // 13731: disabling header locking due to async rendering issues
         _apiAction = apiAction;
-        _returnURL = returnURL.clone();
-        _returnURL.deleteParameter(ActionURL.Param.returnUrl);
+        _returnUrl = returnUrl.clone();
+        _returnUrl.deleteParameter(ActionURL.Param.returnUrl);
     }
 
     private void renderTab(Writer out, String text, ActionURL url, boolean selected) throws IOException
@@ -84,7 +84,7 @@ public class StatusDataRegion extends DataRegion
                 "LABKEY.requiresExt4Sandbox(function() {\n" +
                     "LABKEY.requiresScript('pipeline/StatusUpdate.js', function(){\n" +
                         "if (!LABKEY.pipeline.statusUpdateInstance)\n" +
-                            "LABKEY.pipeline.statusUpdateInstance = new LABKEY.pipeline.StatusUpdate(" + PageFlowUtil.jsString(controller) + "," + PageFlowUtil.jsString(action) + "," + PageFlowUtil.jsString(_returnURL.toString()) + ");\n" +
+                            "LABKEY.pipeline.statusUpdateInstance = new LABKEY.pipeline.StatusUpdate(" + PageFlowUtil.jsString(controller) + "," + PageFlowUtil.jsString(action) + "," + PageFlowUtil.jsString(_returnUrl.toString()) + ");\n" +
                         "LABKEY.pipeline.statusUpdateInstance.start();\n" +
                     "});\n" +
                 "});\n");

--- a/pipeline/webapp/pipeline/StatusUpdate.js
+++ b/pipeline/webapp/pipeline/StatusUpdate.js
@@ -25,10 +25,10 @@ Ext4.ns('LABKEY.pipeline');
   * @constructor
   * @param {String} controller The controller in which the region should update itself.
   * @param {String} action The action in the specified controller in which the region should update itself.
-  * @param {String} returnURL The URL to which operations (cancel, delete, etc requests) should return after they've been processed.
+  * @param {String} returnUrl The URL to which operations (cancel, delete, etc requests) should return after they've been processed.
   */
 
-LABKEY.pipeline.StatusUpdate = function(controller, action, returnURL)
+LABKEY.pipeline.StatusUpdate = function(controller, action, returnUrl)
 {
     //private data
     var _controller = controller;
@@ -78,7 +78,7 @@ LABKEY.pipeline.StatusUpdate = function(controller, action, returnURL)
 
         // Get the current parameters, then replace (or add) a returnUrl value, see issue 41283
         var params = LABKEY.ActionURL.getParameters();
-        params.returnUrl = returnURL;
+        params.returnUrl = returnUrl;
 
         var url = LABKEY.ActionURL.buildURL(_controller, _action, null, params);
 

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3190,9 +3190,7 @@ public class QueryServiceImpl implements QueryService
         url.deleteParameter(ActionURL.Param.cancelUrl);
         url.deleteParameter(ActionURL.Param.redirectUrl);
         url.deleteParameter(ActionURL.Param.returnUrl);
-        url.deleteParameter("returnURL");
         url.deleteParameter(ActionURL.Param.successUrl);
-        url.deleteParameter("srcURL");
         url.deleteParameter(CSRFUtil.csrfName);
         DetailsURL detailsURL = new DetailsURL(url);
         event.setDetailsUrl(detailsURL.toString());

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -426,7 +426,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
                         ActionURL editUrl = kind.urlEditDefinition(domain, getViewContext());
                         ActionURL showDataUrl = domain.urlShowData(getViewContext());
                         if (editUrl != null && showDataUrl != null)
-                            editUrl.addReturnURL(showDataUrl); // send user to executeQuery action after save
+                            editUrl.addReturnUrl(showDataUrl); // send user to executeQuery action after save
                         resp.put("editDefinitionUrl", editUrl);
                     }
                 }

--- a/query/src/org/labkey/query/controllers/OlapController.java
+++ b/query/src/org/labkey/query/controllers/OlapController.java
@@ -411,7 +411,7 @@ public class OlapController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(CustomOlapDescriptorForm form)
         {
-            return form.getReturnURLHelper() != null ? form.getReturnActionURL() : new ActionURL(TestBrowserAction.class, getContainer());
+            return form.getReturnUrlHelper() != null ? form.getReturnActionURL() : new ActionURL(TestBrowserAction.class, getContainer());
         }
 
     }
@@ -515,8 +515,8 @@ public class OlapController extends SpringActionController
         @Override
         public URLHelper getSuccessURL(CustomOlapDescriptorForm form)
         {
-            return form.getReturnURLHelper() != null ?
-                    form.getReturnURLHelper() :
+            return form.getReturnUrlHelper() != null ?
+                    form.getReturnUrlHelper() :
                     new ActionURL(TestBrowserAction.class, getContainer());
         }
     }

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2392,7 +2392,7 @@ public class QueryController extends SpringActionController
                                                  boolean share, boolean inherit,
                                                  boolean session, boolean saveFilter,
                                                  boolean hidden, JSONObject jsonView,
-                                                 ActionURL srcURL,
+                                                 ActionURL returnUrl,
                                                  BindException errors)
     {
         User owner = getUser();
@@ -2480,7 +2480,7 @@ public class QueryController extends SpringActionController
                     try
                     {
                         view.delete(getUser(), getViewContext().getRequest());
-                        Map<String, Object> ret = saveCustomView(container, queryDef, regionName, viewName, replaceExisting, share, inherit, session, saveFilter, hidden, jsonView, srcURL, errors);
+                        Map<String, Object> ret = saveCustomView(container, queryDef, regionName, viewName, replaceExisting, share, inherit, session, saveFilter, hidden, jsonView, returnUrl, errors);
                         success = !errors.hasErrors() && ret != null;
                         return success ? ret : null;
                     }
@@ -2526,35 +2526,34 @@ public class QueryController extends SpringActionController
             }
         }
 
-        ActionURL returnURL = srcURL;
-        if (null == returnURL)
+        if (null == returnUrl)
         {
-            returnURL = getViewContext().cloneActionURL().setAction(ExecuteQueryAction.class);
+            returnUrl = getViewContext().cloneActionURL().setAction(ExecuteQueryAction.class);
         }
         else
         {
-            returnURL = returnURL.clone();
+            returnUrl = returnUrl.clone();
             if (name == null || !canEdit)
             {
-                returnURL.deleteParameter(regionName + "." + QueryParam.viewName);
+                returnUrl.deleteParameter(regionName + "." + QueryParam.viewName);
             }
             else if (!isHidden)
             {
-                returnURL.replaceParameter(regionName + "." + QueryParam.viewName, name);
+                returnUrl.replaceParameter(regionName + "." + QueryParam.viewName, name);
             }
-            returnURL.deleteParameter(regionName + "." + QueryParam.ignoreFilter.toString());
+            returnUrl.deleteParameter(regionName + "." + QueryParam.ignoreFilter.toString());
             if (saveFilter)
             {
-                for (String key : returnURL.getKeysByPrefix(regionName + "."))
+                for (String key : returnUrl.getKeysByPrefix(regionName + "."))
                 {
                     if (isFilterOrSort(regionName, key))
-                        returnURL.deleteFilterParameters(key);
+                        returnUrl.deleteFilterParameters(key);
                 }
             }
         }
 
         Map<String, Object> ret = new HashMap<>();
-        ret.put("redirect", returnURL);
+        ret.put("redirect", returnUrl);
         if (view != null)
             ret.put("view", CustomViewUtil.toMap(view, getUser(), true));
         return ret;

--- a/query/src/org/labkey/query/reports/ReportViewProvider.java
+++ b/query/src/org/labkey/query/reports/ReportViewProvider.java
@@ -229,9 +229,9 @@ public class ReportViewProvider implements DataViewProvider
 
                         if (reportPermUrl != null)
                         {
-                            URLHelper returnUrl = context.getActionURL().getReturnURL();
+                            URLHelper returnUrl = context.getActionURL().getReturnUrl();
                             if (returnUrl != null)
-                                reportPermUrl.addReturnURL(returnUrl);
+                                reportPermUrl.addReturnUrl(returnUrl);
                         }
                     }
                 }

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -317,15 +317,15 @@ public class ReportsController extends SpringActionController
         }
 
         @Override
-        public ActionURL urlAttachmentReport(Container c, ActionURL returnURL)
+        public ActionURL urlAttachmentReport(Container c, ActionURL returnUrl)
         {
-            return getCreateAttachmentReportURL(c, returnURL);
+            return getCreateAttachmentReportURL(c, returnUrl);
         }
 
         @Override
-        public ActionURL urlLinkReport(Container c, ActionURL returnURL)
+        public ActionURL urlLinkReport(Container c, ActionURL returnUrl)
         {
-            return getCreateLinkReportURL(c, returnURL);
+            return getCreateLinkReportURL(c, returnUrl);
         }
 
         @Override
@@ -1627,24 +1627,24 @@ public class ReportsController extends SpringActionController
         public static String getHelpTopic() { return "thumbnails"; }
     }
 
-    public static ActionURL getCreateAttachmentReportURL(Container c, ActionURL returnURL)
+    public static ActionURL getCreateAttachmentReportURL(Container c, ActionURL returnUrl)
     {
         ActionURL url = new ActionURL(CreateAttachmentReportAction.class, c);
-        url.addReturnURL(returnURL);
+        url.addReturnUrl(returnUrl);
         return url;
     }
 
-    public static ActionURL getCreateLinkReportURL(Container c, ActionURL returnURL)
+    public static ActionURL getCreateLinkReportURL(Container c, ActionURL returnUrl)
     {
         ActionURL url = new ActionURL(CreateLinkReportAction.class, c);
-        url.addReturnURL(returnURL);
+        url.addReturnUrl(returnUrl);
         return url;
     }
 
-    public static ActionURL getCreateQueryReportURL(Container c, ActionURL returnURL)
+    public static ActionURL getCreateQueryReportURL(Container c, ActionURL returnUrl)
     {
         ActionURL url = new ActionURL(CreateQueryReportAction.class, c);
-        url.addReturnURL(returnURL);
+        url.addReturnUrl(returnUrl);
         return url;
     }
 

--- a/query/src/org/labkey/query/reports/view/ReportUIProvider.java
+++ b/query/src/org/labkey/query/reports/view/ReportUIProvider.java
@@ -142,7 +142,7 @@ public class ReportUIProvider extends DefaultReportUIProvider
     public List<ReportService.DesignerInfo> getDesignerInfo(ViewContext context, QuerySettings settings)
     {
         List<ReportService.DesignerInfo> designers = new ArrayList<>();
-        URLHelper returnUrl = settings.getReturnURLHelper(context.getActionURL());
+        URLHelper returnUrl = settings.getReturnUrlHelper(context.getActionURL());
 
         if (ReportUtil.canCreateScript(context, "r") && RReport.isEnabled())
         {

--- a/query/src/org/labkey/query/reports/view/manageNotifications.jsp
+++ b/query/src/org/labkey/query/reports/view/manageNotifications.jsp
@@ -29,17 +29,17 @@
     }
 %>
 <%
-    JspView<NotificationsForm> me = (JspView<NotificationsForm>) HttpView.currentView();
+    JspView<NotificationsForm> me = HttpView.currentView();
     NotificationsForm form = me.getModelBean();
-    String returnURLString = form.getReturnUrl();
+    String returnUrlString = form.getReturnUrl();
 %>
 
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
     Ext4.onReady(function()
     {
         var returnUrl = LABKEY.ActionURL.buildURL('project', 'begin', null, {'pageId' : 'study.DATA_ANALYSIS'});
-        <% if (null != returnURLString) {%>
-            returnUrl = <%=q(returnURLString)%>;
+        <% if (null != returnUrlString) {%>
+            returnUrl = <%=q(returnUrlString)%>;
         <%}%>
 
         Ext4.create('LABKEY.ext4.ReportNotificationPanel', {

--- a/query/src/org/labkey/query/view/cube.jsp
+++ b/query/src/org/labkey/query/view/cube.jsp
@@ -41,7 +41,7 @@
         dependencies.add("Ext4");
     }
 %>
-<%=link("create new", new ActionURL(OlapController.CreateDefinitionAction.class, getContainer()).addReturnUrl(getActionURL().clone()))%>
+<%=link("create new", new ActionURL(OlapController.CreateDefinitionAction.class, getContainer()).addReturnUrl(getActionURL()))%>
 <%
     Collection<OlapSchemaDescriptor> list = ServerManager.getDescriptors(getContainer());
     for (OlapSchemaDescriptor sd : list)

--- a/query/src/org/labkey/query/view/cube.jsp
+++ b/query/src/org/labkey/query/view/cube.jsp
@@ -41,7 +41,7 @@
         dependencies.add("Ext4");
     }
 %>
-<%=link("create new", new ActionURL(OlapController.CreateDefinitionAction.class, getContainer()).addReturnURL(getActionURL().clone()))%>
+<%=link("create new", new ActionURL(OlapController.CreateDefinitionAction.class, getContainer()).addReturnUrl(getActionURL().clone()))%>
 <%
     Collection<OlapSchemaDescriptor> list = ServerManager.getDescriptors(getContainer());
     for (OlapSchemaDescriptor sd : list)

--- a/query/src/org/labkey/query/view/manageApps.jsp
+++ b/query/src/org/labkey/query/view/manageApps.jsp
@@ -234,7 +234,7 @@
 </br>
 <h3>OLAP Cube definitions in this folder:</h3>
 <p>
-<%=link("create new", new ActionURL(OlapController.CreateDefinitionAction.class, getContainer()).addReturnUrl(getActionURL().clone())).id("create-cube-definition")%>
+<%=link("create new", new ActionURL(OlapController.CreateDefinitionAction.class, getContainer()).addReturnUrl(getActionURL())).id("create-cube-definition")%>
 </p>
 <%
     Collection<OlapSchemaDescriptor> list = ServerManager.getDescriptors(getContainer());
@@ -244,8 +244,8 @@
         %><tr data-name="<%=h(sd.getName())%>">
             <td style="font-weight: bold;"><%=h(sd.getName())%></td>
             <% if (sd.isEditable()) { %>
-                <td><%=link("edit", ((CustomOlapSchemaDescriptor) sd).urlEdit().addReturnUrl(getActionURL().clone()))%></td>
-                <td><%=link("delete", ((CustomOlapSchemaDescriptor)sd).urlDelete().addReturnUrl(getActionURL().clone()))%></td>
+                <td><%=link("edit", ((CustomOlapSchemaDescriptor) sd).urlEdit().addReturnUrl(getActionURL()))%></td>
+                <td><%=link("delete", ((CustomOlapSchemaDescriptor)sd).urlDelete().addReturnUrl(getActionURL()))%></td>
             <% } %>
         </tr><%
 

--- a/query/src/org/labkey/query/view/manageApps.jsp
+++ b/query/src/org/labkey/query/view/manageApps.jsp
@@ -234,7 +234,7 @@
 </br>
 <h3>OLAP Cube definitions in this folder:</h3>
 <p>
-<%=link("create new", new ActionURL(OlapController.CreateDefinitionAction.class, getContainer()).addReturnURL(getActionURL().clone())).id("create-cube-definition")%>
+<%=link("create new", new ActionURL(OlapController.CreateDefinitionAction.class, getContainer()).addReturnUrl(getActionURL().clone())).id("create-cube-definition")%>
 </p>
 <%
     Collection<OlapSchemaDescriptor> list = ServerManager.getDescriptors(getContainer());
@@ -244,8 +244,8 @@
         %><tr data-name="<%=h(sd.getName())%>">
             <td style="font-weight: bold;"><%=h(sd.getName())%></td>
             <% if (sd.isEditable()) { %>
-                <td><%=link("edit", ((CustomOlapSchemaDescriptor) sd).urlEdit().addReturnURL(getActionURL().clone()))%></td>
-                <td><%=link("delete", ((CustomOlapSchemaDescriptor)sd).urlDelete().addReturnURL(getActionURL().clone()))%></td>
+                <td><%=link("edit", ((CustomOlapSchemaDescriptor) sd).urlEdit().addReturnUrl(getActionURL().clone()))%></td>
+                <td><%=link("delete", ((CustomOlapSchemaDescriptor)sd).urlDelete().addReturnUrl(getActionURL().clone()))%></td>
             <% } %>
         </tr><%
 

--- a/specimen/src/org/labkey/specimen/actions/ShowGroupMembersAction.java
+++ b/specimen/src/org/labkey/specimen/actions/ShowGroupMembersAction.java
@@ -60,7 +60,7 @@ public class ShowGroupMembersAction extends FormViewAction<ShowGroupMembersActio
         if (locationId != null)
             url.addParameter("locationId", locationId);
         if (returnUrl != null)
-            url.addReturnURL(returnUrl);
+            url.addReturnUrl(returnUrl);
 
         return url;
     }

--- a/specimen/src/org/labkey/specimen/actions/SpecimenController.java
+++ b/specimen/src/org/labkey/specimen/actions/SpecimenController.java
@@ -425,7 +425,7 @@ public class SpecimenController extends SpringActionController
                 if (getViewContext().getContainer().hasPermission(getViewContext().getUser(), RequestSpecimensPermission.class))
                 {
                     final String jsRegionObject = DataRegion.getJavaScriptObjectReference(gridView.getSettings().getDataRegionName());
-                    String createRequestURL = urlFor(ShowCreateSpecimenRequestAction.class).addReturnURL(getViewContext().getActionURL()).toString();
+                    String createRequestURL = urlFor(ShowCreateSpecimenRequestAction.class).addReturnUrl(getViewContext().getActionURL()).toString();
 
                     requestMenuButton.addMenuItem("Create New Request",
                             "if (verifySelected(" + jsRegionObject + ".form, '" + createRequestURL +
@@ -2585,7 +2585,7 @@ public class SpecimenController extends SpringActionController
         ActionURL url = new ActionURL(ManageRequestAction.class, c);
         url.addParameter(IdForm.PARAMS.id, Integer.toString(requestID));
         if (returnUrl != null)
-            url.addReturnURL(returnUrl);
+            url.addReturnUrl(returnUrl);
         return url;
     }
 
@@ -4127,7 +4127,7 @@ public class SpecimenController extends SpringActionController
                             addParameter(ParticipantCommentForm.params.participantId, vial.getPtid()).
                             addParameter(ParticipantCommentForm.params.visitId, String.valueOf(vial.getVisitValue())).
                             addParameter(ParticipantCommentForm.params.comment, commentsForm.getComments()).
-                            addReturnURL(new URLHelper(commentsForm.getReferrer()));
+                                addReturnUrl(new URLHelper(commentsForm.getReferrer()));
                     }
                 }
                 else
@@ -4135,7 +4135,7 @@ public class SpecimenController extends SpringActionController
                     _successUrl = new ActionURL(CopyParticipantCommentAction.class, container).
                         addParameter(ParticipantCommentForm.params.participantId, commentsForm.getCopyParticipantId()).
                         addParameter(ParticipantCommentForm.params.comment, commentsForm.getComments()).
-                        addReturnURL(new URLHelper(commentsForm.getReferrer()));
+                            addReturnUrl(new URLHelper(commentsForm.getReferrer()));
                 }
 
                 // delete existing vial comments if move is specified
@@ -5629,7 +5629,7 @@ public class SpecimenController extends SpringActionController
 
                 url.addParameter(ParticipantCommentForm.params.datasetId, ds.getDatasetId()).
                         addParameter(ParticipantCommentForm.params.comment, form.getComment()).
-                        addReturnURL(form.getReturnActionURL()).
+                        addReturnUrl(form.getReturnActionURL()).
                         addParameter(ParticipantCommentForm.params.visitId, form.getVisitId());
 
                 for (int rowId : form.getVialCommentsToClear())

--- a/specimen/src/org/labkey/specimen/query/SpecimenQueryView.java
+++ b/specimen/src/org/labkey/specimen/query/SpecimenQueryView.java
@@ -213,7 +213,7 @@ public class SpecimenQueryView extends BaseSpecimenQueryView
     protected static ActionURL getHistoryLinkURL(ViewContext ctx, String containerId)
     {
         Container container = null != containerId ? ContainerManager.getForId(containerId) : ctx.getContainer();
-        return new ActionURL(SpecimenController.SpecimenEventsAction.class, container).addReturnURL(ctx.getActionURL());
+        return new ActionURL(SpecimenController.SpecimenEventsAction.class, container).addReturnUrl(ctx.getActionURL());
     }
 
     private class SpecimenRestrictedDataRegion extends SpecimenDataRegion

--- a/specimen/src/org/labkey/specimen/view/chooseImporter.jsp
+++ b/specimen/src/org/labkey/specimen/view/chooseImporter.jsp
@@ -27,7 +27,7 @@
     Collection<SpecimenTransform> specimenTransforms = SpecimenService.get().getSpecimenTransforms(c);
     specimenTransforms.removeIf(transform -> null == transform.getManageAction(c, user));
 
-    URLHelper cancelLink = getActionURL().getReturnURL();
+    URLHelper cancelLink = getActionURL().getReturnUrl();
     if (cancelLink == null)
         cancelLink = urlProvider(StudyUrls.class).getManageStudyURL(getContainer());
     int numberOfTransforms = specimenTransforms.size();

--- a/specimen/src/org/labkey/specimen/view/manageSpecimens.jsp
+++ b/specimen/src/org/labkey/specimen/view/manageSpecimens.jsp
@@ -71,19 +71,19 @@
             if (domainEvent != null)
             {
                 specimenEventUrl = domainEvent.getDomainKind().urlEditDefinition(domainEvent, getViewContext())
-                    .addReturnURL(getViewContext().getActionURL());
+                    .addReturnUrl(getViewContext().getActionURL());
             }
 
             if (domainVial != null)
             {
                 vialUrl = domainVial.getDomainKind().urlEditDefinition(domainVial, getViewContext())
-                    .addReturnURL(getViewContext().getActionURL());
+                    .addReturnUrl(getViewContext().getActionURL());
             }
 
             if (domainSpecimen != null)
             {
                 specimenUrl = domainSpecimen.getDomainKind().urlEditDefinition(domainSpecimen, getViewContext())
-                    .addReturnURL(getViewContext().getActionURL());
+                    .addReturnUrl(getViewContext().getActionURL());
             }
 
 %>

--- a/specimen/src/org/labkey/specimen/view/specimenHeader.jsp
+++ b/specimen/src/org/labkey/specimen/view/specimenHeader.jsp
@@ -42,7 +42,7 @@
     SpecimenHeaderBean bean = me.getModelBean();
     ActionURL createRequestURL = new ActionURL(ShowSearchAction.class, getContainer());
     createRequestURL.addParameter("fromGroupedView", !bean.isShowingVials());
-    createRequestURL.addReturnURL(getActionURL());
+    createRequestURL.addReturnUrl(getActionURL());
     String subjectNounSingle = StudyService.get().getSubjectNounSingular(getContainer());
     String subjectNounPlural = StudyService.get().getSubjectNounPlural(getContainer());
 %>

--- a/study/src/org/labkey/study/controllers/ParticipantGroupController.java
+++ b/study/src/org/labkey/study/controllers/ParticipantGroupController.java
@@ -366,7 +366,7 @@ public class ParticipantGroupController extends BaseStudyController
      */
     public static class DeleteParticipantCategories extends FormHandlerAction<QueryForm>
     {
-        private ActionURL _returnURL;
+        private ActionURL _returnUrl;
 
         @Override
         public void validateCommand(QueryForm target, Errors errors)
@@ -376,7 +376,7 @@ public class ParticipantGroupController extends BaseStudyController
         @Override
         public boolean handlePost(QueryForm form, BindException errors) throws Exception
         {
-            _returnURL = form.getReturnActionURL();
+            _returnUrl = form.getReturnActionURL();
 
             DbScope scope = StudySchema.getInstance().getSchema().getScope();
 
@@ -398,7 +398,7 @@ public class ParticipantGroupController extends BaseStudyController
         @Override
         public URLHelper getSuccessURL(QueryForm form)
         {
-            return _returnURL;
+            return _returnUrl;
         }
     }
 
@@ -1286,7 +1286,7 @@ public class ParticipantGroupController extends BaseStudyController
      */
     public static class DeleteParticipantGroups extends FormHandlerAction<QueryForm>
     {
-        private ActionURL _returnURL;
+        private ActionURL _returnUrl;
 
         @Override
         public void validateCommand(QueryForm target, Errors errors)
@@ -1296,7 +1296,7 @@ public class ParticipantGroupController extends BaseStudyController
         @Override
         public boolean handlePost(QueryForm form, BindException errors) throws Exception
         {
-            _returnURL = form.getReturnActionURL();
+            _returnUrl = form.getReturnActionURL();
 
             DbScope scope = StudySchema.getInstance().getSchema().getScope();
 
@@ -1319,7 +1319,7 @@ public class ParticipantGroupController extends BaseStudyController
         @Override
         public URLHelper getSuccessURL(QueryForm form)
         {
-            return _returnURL;
+            return _returnUrl;
         }
     }
 

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -1998,7 +1998,7 @@ public class StudyController extends BaseStudyController
         @Override
         public URLHelper getSuccessURL(LocationForm form)
         {
-            return form.getReturnURLHelper();
+            return form.getReturnUrlHelper();
         }
 
         private Collection<Container> getContainers(LocationForm form)
@@ -3253,7 +3253,7 @@ public class StudyController extends BaseStudyController
                 base.addParameter(param.getKey(), param.getValue());
             }
         }
-        base.addReturnURL(url); // Set current URL so participant page can navigate back (nav trail)
+        base.addReturnUrl(url); // Set current URL so participant page can navigate back (nav trail)
 
         for (DisplayColumn col : columns)
         {
@@ -5195,7 +5195,7 @@ public class StudyController extends BaseStudyController
 
                         _successURL = new ActionURL(StudyController.EditTypeAction.class, getContainer())
                                 .addParameter("datasetId", def.getDatasetId())
-                                .addReturnURL(returnUrl);
+                                .addReturnUrl(returnUrl);
                     }
                 }
                 else if (StudySnapshotForm.CREATE_SNAPSHOT.equals(form.getAction()))
@@ -5999,7 +5999,7 @@ public class StudyController extends BaseStudyController
             if (_showCustomizeLink && c.hasPermissions(getViewContext().getUser(), permissions))
             {
                 ActionURL customizeURL = new ActionURL(CustomizeParticipantViewAction.class, c);
-                customizeURL.addReturnURL(getViewContext().getActionURL());
+                customizeURL.addReturnUrl(getViewContext().getActionURL());
                 customizeURL.addParameter("participantId", _currentParticipantId);
                 out.print("</td><td>");
                 PageFlowUtil.link("Customize View").href(customizeURL).appendTo(out);

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -3575,7 +3575,7 @@ public class StudyController extends BaseStudyController
 
     public static ActionURL getManageQCStatesURL(Container c, @NotNull ActionURL returnUrl)
     {
-        return new ActionURL(ManageQCStatesAction.class, c).addReturnURL(returnUrl);
+        return new ActionURL(ManageQCStatesAction.class, c).addReturnUrl(returnUrl);
     }
 
     @RequiresPermission(AdminPermission.class)

--- a/study/src/org/labkey/study/designer/view/studySummary.jsp
+++ b/study/src/org/labkey/study/designer/view/studySummary.jsp
@@ -47,7 +47,7 @@
     String grant = study.getGrant();
     List<Attachment> protocolDocs = study.getProtocolDocuments();
     ActionURL editMetadataURL = new ActionURL(StudyController.ManageStudyPropertiesAction.class, c);
-    editMetadataURL.addReturnURL(getActionURL());
+    editMetadataURL.addReturnUrl(getActionURL());
 %>
     <script type="text/javascript" nonce="<%=getScriptNonce()%>">
         LABKEY.requiresCss("editInPlaceElement.css");

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -602,7 +602,7 @@ public class DatasetQueryView extends StudyQueryView
                 button.addSeparator();
             }
             ActionURL updateAction = new ActionURL(StudyController.UpdateQCStateAction.class, getContainer());
-            updateAction.addReturnURL(getViewContext().getActionURL());
+            updateAction.addReturnUrl(getViewContext().getActionURL());
             NavTree updateItem = button.addMenuItem("Update state of selected rows", "if (verifySelected(" + DataRegion.getJavaScriptObjectReference(getDataRegionName()) + ".form, \"" +
                     updateAction.getLocalURIString() + "\", \"post\", \"rows\")) " + DataRegion.getJavaScriptObjectReference(getDataRegionName()) + ".form.submit()");
             updateItem.setId("QCState:updateSelected");

--- a/study/src/org/labkey/study/query/LocationQueryView.java
+++ b/study/src/org/labkey/study/query/LocationQueryView.java
@@ -64,7 +64,7 @@ public class LocationQueryView extends QueryView
             bar.add(createInsertButton());
             bar.add(createDeleteButton());
             ActionURL deleteUnusedURL = new ActionURL(StudyController.DeleteAllUnusedLocationsAction.class, getSchema().getContainer());
-            deleteUnusedURL.addReturnURL(getReturnURL());
+            deleteUnusedURL.addReturnUrl(getReturnUrl());
             ContainerFilter cFilter = getContainerFilter();
             if (null != cFilter)
             {
@@ -76,7 +76,7 @@ public class LocationQueryView extends QueryView
             ActionButton deleteAllUnused = new ActionButton(deleteUnusedURL, "Delete All Unused");
             deleteAllUnused.setActionType(ActionButton.Action.LINK);
             deleteAllUnused.setRequiresSelection(false, "Are you sure you want to delete the selected location?", "Are you sure you want to delete the selected locations?");
-            deleteUnusedURL.addReturnURL(getViewContext().getActionURL());
+            deleteUnusedURL.addReturnUrl(getViewContext().getActionURL());
             bar.add(deleteAllUnused);
         }
 

--- a/study/src/org/labkey/study/reports/StudyReportUIProvider.java
+++ b/study/src/org/labkey/study/reports/StudyReportUIProvider.java
@@ -139,7 +139,7 @@ public class StudyReportUIProvider extends DefaultReportUIProvider
         crossTabURL.replaceParameter(QueryParam.viewName, settings.getViewName());
         crossTabURL.replaceParameter(QueryParam.dataRegionName, settings.getDataRegionName());
 
-        URLHelper returnUrl = settings.getReturnURLHelper(context.getActionURL());
+        URLHelper returnUrl = settings.getReturnUrlHelper(context.getActionURL());
         crossTabURL.addParameter(ActionURL.Param.redirectUrl, returnUrl.getLocalURIString());
 
         if (StudySchema.getInstance().getSchemaName().equals(settings.getSchemaName()))

--- a/study/src/org/labkey/study/view/StudySummaryWebPartFactory.java
+++ b/study/src/org/labkey/study/view/StudySummaryWebPartFactory.java
@@ -147,7 +147,7 @@ public class StudySummaryWebPartFactory extends BaseWebPartFactory
         if(portalCtx.getContainer().hasPermission(portalCtx.getUser(), AdminPermission.class))
         {
             ActionURL editMetaDataURL = new ActionURL(StudyController.ManageStudyPropertiesAction.class, portalCtx.getContainer());
-            editMetaDataURL.addReturnURL(portalCtx.getActionURL());
+            editMetaDataURL.addReturnUrl(portalCtx.getActionURL());
             NavTree edit = new NavTree("Edit", editMetaDataURL.toString(), null, "fa fa-pencil");
             v.addCustomMenu(edit);
         }

--- a/study/src/org/labkey/study/view/bulkVisitDelete.jsp
+++ b/study/src/org/labkey/study/view/bulkVisitDelete.jsp
@@ -56,7 +56,7 @@
     boolean isDateBased = study != null && study.getTimepointType() == TimepointType.DATE;
     String noun = isDateBased ? "Timepoint" : "Visit";
 
-    ActionURL returnURL = form.getReturnActionURL(urlFor(ManageVisitsAction.class));
+    ActionURL returnUrl = form.getReturnActionURL(urlFor(ManageVisitsAction.class));
 
     Map<VisitMapKey, VisitManager.VisitStatistics> visitSummaryMap = visitManager.getVisitSummary(getUser(), null, null, Collections.singleton(VisitManager.VisitStatistic.RowCount), true);
     Map<Integer, Integer> visitRowCountMap = new HashMap<>();
@@ -120,7 +120,7 @@
         "return true;" +
     "} " +
     "else return false;")%>
-<%= button("Cancel").href(returnURL) %>
+<%= button("Cancel").href(returnUrl) %>
 </labkey:form>
 
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">

--- a/study/src/org/labkey/study/view/createCrosstabReport.jsp
+++ b/study/src/org/labkey/study/view/createCrosstabReport.jsp
@@ -30,15 +30,15 @@
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    JspView<CreateCrosstabBean> me = (JspView<CreateCrosstabBean>) HttpView.currentView();
+    JspView<CreateCrosstabBean> me = HttpView.currentView();
     CreateCrosstabBean bean = me.getModelBean();
 
-    ActionURL returnURL = urlProvider(ReportUrls.class).urlManageViews(getContainer());
+    ActionURL returnUrl = urlProvider(ReportUrls.class).urlManageViews(getContainer());
 %>
 <labkey:form action="<%=urlFor(ParticipantCrosstabAction.class)%>" method="GET">
 <input type="hidden" name="<%=QueryParam.schemaName%>" value="<%=h(StudySchema.getInstance().getSchemaName())%>">
 <input type="hidden" name="<%=ReportDescriptor.Prop.reportType%>" value="<%=h(StudyCrosstabReport.TYPE)%>">
-<input type="hidden" name="redirectUrl" value="<%=h(returnURL)%>">
+<input type="hidden" name="redirectUrl" value="<%=h(returnUrl)%>">
 <table>
     <tr>
         <td>Dataset</td>
@@ -75,7 +75,7 @@
         <td></td>
         <td>
             <%= button("Next").submit(true) %>
-            <%= button("Cancel").href(returnURL) %>
+            <%= button("Cancel").href(returnUrl) %>
         </td>
     </tr>
 </table>

--- a/study/src/org/labkey/study/view/createVisit.jsp
+++ b/study/src/org/labkey/study/view/createVisit.jsp
@@ -30,16 +30,16 @@
 <%@ page extends="org.labkey.study.view.BaseStudyPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
-    JspView<VisitForm> me = (JspView<VisitForm>)HttpView.currentView();
+    JspView<VisitForm> me = HttpView.currentView();
     VisitForm form = me.getModelBean();
     VisitImpl v = form.getBean();
 
     StudyImpl study = StudyManager.getInstance().getStudy(getContainer());
     boolean isDateBased = study != null && study.getTimepointType() == TimepointType.DATE;
 
-    ActionURL returnURL = form.getReturnActionURL();
-    if (null == returnURL)
-        returnURL = urlFor(ManageVisitsAction.class);
+    ActionURL returnUrl = form.getReturnActionURL();
+    if (null == returnUrl)
+        returnUrl = urlFor(ManageVisitsAction.class);
 %>
 <labkey:errors/>
 <p style="width: 750px;">
@@ -130,6 +130,6 @@ is uploaded along with the data. This form allows you to define a range of seque
         </tr>
     </table>
     <br/>
-    <%=generateReturnUrlFormField(returnURL)%>
-    <%= button("Save").submit(true) %>&nbsp;<%= button("Cancel").href(returnURL) %>
+    <%=generateReturnUrlFormField(returnUrl)%>
+    <%= button("Save").submit(true) %>&nbsp;<%= button("Cancel").href(returnUrl) %>
 </labkey:form>

--- a/study/src/org/labkey/study/view/editSnapshot.jsp
+++ b/study/src/org/labkey/study/view/editSnapshot.jsp
@@ -62,7 +62,7 @@
     <%= button("Update Snapshot").submit(true).onClick("this.form.action='';return confirm('Updating will replace all existing data with a new set of data. Continue?');")%>
     <% if (def != null && dsDef != null) {
         ActionURL deleteSnapshotURL = new ActionURL(StudyController.DeleteDatasetAction.class, getContainer()).addParameter("id", dsDef.getDatasetId());
-        ActionURL editDatasetURL = new ActionURL(StudyController.EditTypeAction.class, getContainer()).addParameter("datasetId", dsDef.getDatasetId()).addReturnURL(getActionURL());
+        ActionURL editDatasetURL = new ActionURL(StudyController.EditTypeAction.class, getContainer()).addParameter("datasetId", dsDef.getDatasetId()).addReturnUrl(getActionURL());
     %>
         <%= button("Delete Snapshot")
                 .href(deleteSnapshotURL)

--- a/study/src/org/labkey/study/view/manageStudy.jsp
+++ b/study/src/org/labkey/study/view/manageStudy.jsp
@@ -176,7 +176,7 @@
                             if (p.hasPermission(user, AdminPermission.class))
                             {
                                 ActionURL editDefinition = new ActionURL(EditStudyDefinitionAction.class, p)
-                                    .addReturnURL(getActionURL());
+                                    .addReturnUrl(getActionURL());
                                 %><%=link("Define Custom Study Properties", editDefinition).usePost()%><%
 
                             }
@@ -263,7 +263,7 @@
                         <td class="lk-study-prop-desc">This study defines <%= getStudyProducts(user, null).size() %> study products</td>
                         <%
                             ActionURL manageStudyProductsURL = urlFor(ManageStudyProductsAction.class)
-                                .addReturnURL(getActionURL());
+                                .addReturnUrl(getActionURL());
                         %>
                         <td><%= link("Manage Study Products", manageStudyProductsURL) %></td>
                     </tr>
@@ -272,7 +272,7 @@
                         <td class="lk-study-prop-desc">This study defines <%= getStudyTreatments(user).size() %> treatments</td>
                         <%
                             ActionURL manageTreatmentsURL = urlProvider(StudyUrls.class).getManageTreatmentsURL(getContainer(), false)
-                                .addReturnURL(getActionURL());
+                                .addReturnUrl(getActionURL());
                         %>
                         <td><%= link("Manage Treatments", manageTreatmentsURL) %></td>
                     </tr>
@@ -282,7 +282,7 @@
                         <%
                             boolean hasRhoModule = getContainer().getActiveModules().contains(ModuleLoader.getInstance().getModule("rho"));
                             ActionURL assayScheduleURL = urlProvider(StudyUrls.class).getManageAssayScheduleURL(getContainer(), hasRhoModule)
-                                .addReturnURL(getActionURL());
+                                .addReturnUrl(getActionURL());
                         %>
                         <td><%= link("Manage Assay Schedule", assayScheduleURL) %></td>
                     </tr>

--- a/study/src/org/labkey/study/view/manageStudyPropertiesExt.jsp
+++ b/study/src/org/labkey/study/view/manageStudyPropertiesExt.jsp
@@ -35,7 +35,7 @@
     boolean canEdit = getContainer().hasPermission(getUser(), AdminPermission.class);
     boolean emptyStudy = getStudy().isEmptyStudy();
     TimepointType timepointType = getStudy().getTimepointType();
-    URLHelper cancelLink = getActionURL().getReturnURL();
+    URLHelper cancelLink = getActionURL().getReturnUrl();
     if (cancelLink == null)
         cancelLink = new ActionURL(StudyController.ManageStudyAction.class, getContainer());
 %>

--- a/study/src/org/labkey/study/view/studySummary.jsp
+++ b/study/src/org/labkey/study/view/studySummary.jsp
@@ -75,7 +75,7 @@
     String grant = bean.getGrant();
     List<Attachment> protocolDocs = bean.getProtocolDocuments();
     ActionURL editMetadataURL = new ActionURL(StudyController.ManageStudyPropertiesAction.class, c);
-    editMetadataURL.addReturnURL(bean.getCurrentURL());
+    editMetadataURL.addReturnUrl(bean.getCurrentURL());
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
     LABKEY.requiresCss("editInPlaceElement.css");

--- a/study/src/org/labkey/study/view/studydesign/assayScheduleWebpart.jsp
+++ b/study/src/org/labkey/study/view/studydesign/assayScheduleWebpart.jsp
@@ -57,7 +57,7 @@
             ActionURL editUrl = new ActionURL(StudyDesignController.ManageAssayScheduleAction.class, getContainer());
             if (useAlternateLookupFields)
                 editUrl.addParameter("useAlternateLookupFields", true);
-            editUrl.addReturnURL(getActionURL());
+            editUrl.addReturnUrl(getActionURL());
 %>
             <%=link("Manage Assay Schedule", editUrl)%><br/>
 <%

--- a/study/src/org/labkey/study/view/studydesign/immunizationScheduleWebpart.jsp
+++ b/study/src/org/labkey/study/view/studydesign/immunizationScheduleWebpart.jsp
@@ -75,7 +75,7 @@
         if (canEdit)
         {
             ActionURL editUrl = urlProvider(StudyUrls.class).getManageTreatmentsURL(c, c.hasActiveModuleByName("viscstudies"));
-            editUrl.addReturnURL(getActionURL());
+            editUrl.addReturnUrl(getActionURL());
 %>
             <%=link("Manage Treatments", editUrl)%><br/>
 <%

--- a/study/src/org/labkey/study/view/studydesign/manageAssaySchedule.jsp
+++ b/study/src/org/labkey/study/view/studydesign/manageAssaySchedule.jsp
@@ -62,7 +62,7 @@
             disableEdit : <%=disableEdit%>,
             visitNoun : <%=q(visitNoun)%>,
             useAlternateLookupFields : <%=form.isUseAlternateLookupFields()%>,
-            returnURL : <%=q(returnUrl)%>
+            returnUrl : <%=q(returnUrl)%>
         });
     });
 </script>

--- a/study/src/org/labkey/study/view/studydesign/manageStudyProducts.jsp
+++ b/study/src/org/labkey/study/view/studydesign/manageStudyProducts.jsp
@@ -53,7 +53,7 @@
         Ext4.create('LABKEY.VaccineDesign.StudyProductsPanel', {
             renderTo : 'study-products-panel',
             disableEdit : <%=isDataspaceProject%>,
-            returnURL : <%=q(returnUrl)%>
+            returnUrl : <%=q(returnUrl)%>
         });
     });
 </script>
@@ -62,7 +62,7 @@
 if (isDataspaceProject)
 {
     ActionURL projectManageProductsURL = new ActionURL(StudyDesignController.ManageStudyProductsAction.class, getContainer().getProject());
-    projectManageProductsURL.addReturnURL(getActionURL());
+    projectManageProductsURL.addReturnUrl(getActionURL());
 %>
 Vaccine design information is defined at the project level for Dataspace projects. The grids below are read-only.
 <div style="width: 850px;">
@@ -86,7 +86,7 @@ Enter vaccine design information in the grids below.
             Use the manage treatments page to describe the schedule of treatments and combinations of study products administered at each timepoint.
             <%
                 ActionURL manageTreatmentsURL = urlProvider(StudyUrls.class).getManageTreatmentsURL(c, c.hasActiveModuleByName("viscstudies"));
-                manageTreatmentsURL.addReturnURL(getActionURL());
+                manageTreatmentsURL.addReturnUrl(getActionURL());
             %>
             <%=link("Manage Treatments", manageTreatmentsURL)%>
         </li>

--- a/study/src/org/labkey/study/view/studydesign/manageTreatments.jsp
+++ b/study/src/org/labkey/study/view/studydesign/manageTreatments.jsp
@@ -84,7 +84,7 @@
                         disableEdit : <%=isDataspaceProject%>,
                         subjectNoun : <%=q(subjectNoun)%>,
                         visitNoun : <%=q(visitNoun)%>,
-                        returnURL : <%=q(returnUrl)%>,
+                        returnUrl : <%=q(returnUrl)%>,
                         productRoles: productRoles
                     });
                 }
@@ -128,7 +128,7 @@ Enter treatment information in the grids below.
             Use the manage study products page to change or update the set of available values.
             <%
                 ActionURL manageStudyProductsURL = new ActionURL(StudyDesignController.ManageStudyProductsAction.class, getContainer());
-                manageStudyProductsURL.addReturnURL(getActionURL());
+                manageStudyProductsURL.addReturnUrl(getActionURL());
             %>
             <%=link("Manage Study Products", manageStudyProductsURL)%>
         </li>
@@ -152,7 +152,7 @@ Enter treatment information in the grids below.
         {
 %>
             <li>Use the change visit order page to adjust the display order of visits in the treatment schedule table.
-            <%= link("Change Visit Order", new ActionURL(StudyController.VisitOrderAction.class, c).addReturnURL(getActionURL())) %>
+            <%= link("Change Visit Order", new ActionURL(StudyController.VisitOrderAction.class, c).addReturnUrl(getActionURL())) %>
             </li>
 <%
         }

--- a/study/src/org/labkey/study/view/studydesign/vaccineDesignWebpart.jsp
+++ b/study/src/org/labkey/study/view/studydesign/vaccineDesignWebpart.jsp
@@ -43,7 +43,7 @@
         if (container.hasPermission(user, UpdatePermission.class))
         {
             ActionURL editUrl = new ActionURL(StudyDesignController.ManageStudyProductsAction.class, getContainer());
-            editUrl.addReturnURL(getActionURL());
+            editUrl.addReturnUrl(getActionURL());
 %>
             <%=link("Manage Study Products", editUrl)%><br/>
 <%

--- a/study/src/org/labkey/study/view/visitOrder.jsp
+++ b/study/src/org/labkey/study/view/visitOrder.jsp
@@ -28,11 +28,11 @@
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.study.view.BaseStudyPage" %>
 <%
-    JspView<VisitReorderForm> me = (JspView<VisitReorderForm>) HttpView.currentView();
+    JspView<VisitReorderForm> me = HttpView.currentView();
 
-    ActionURL returnURL = (me.getModelBean()).getReturnActionURL();
-    if (null == returnURL)
-        returnURL = urlFor(ManageVisitsAction.class);
+    ActionURL returnUrl = (me.getModelBean()).getReturnActionURL();
+    if (null == returnUrl)
+        returnUrl = urlFor(ManageVisitsAction.class);
 %>
 <style>
     .button-reordering {
@@ -191,7 +191,7 @@ function orderModule(listName, hiddenElName, down)
                 %>
                 </select>
                 <input type="hidden" name="chronologicalOrder" value="<%= h(orderedList) %>">
-                <%=generateReturnUrlFormField(returnURL)%>
+                <%=generateReturnUrlFormField(returnUrl)%>
             </td>
             <td align="center" valign="center" style="padding-left: 10px;">
                 <%= button("Move Up").addClass("button-reordering").onClick("return orderModule('chronologicalOrderItems', 'chronologicalOrder', 0)") %><br>
@@ -201,5 +201,5 @@ function orderModule(listName, hiddenElName, down)
     </table>
     <br/>
     <%= button("Save").submit(true) %>
-    <%= button("Cancel").href(returnURL) %>
+    <%= button("Cancel").href(returnUrl) %>
 </labkey:form>

--- a/study/webapp/study/vaccineDesign/AssaySchedule.js
+++ b/study/webapp/study/vaccineDesign/AssaySchedule.js
@@ -16,7 +16,7 @@ Ext4.define('LABKEY.VaccineDesign.AssaySchedulePanel', {
 
     dirty : false,
 
-    returnURL : null,
+    returnUrl : null,
 
     initComponent : function()
     {
@@ -213,7 +213,7 @@ Ext4.define('LABKEY.VaccineDesign.AssaySchedulePanel', {
     goToReturnURL : function()
     {
         this.setDirty(false);
-        window.location = this.returnURL;
+        window.location = this.returnUrl;
     },
 
     onFailure : function(text)

--- a/study/webapp/study/vaccineDesign/StudyProducts.js
+++ b/study/webapp/study/vaccineDesign/StudyProducts.js
@@ -16,7 +16,7 @@ Ext4.define('LABKEY.VaccineDesign.StudyProductsPanel', {
 
     dirty : false,
 
-    returnURL : null,
+    returnUrl : null,
 
     initComponent : function()
     {
@@ -198,7 +198,7 @@ Ext4.define('LABKEY.VaccineDesign.StudyProductsPanel', {
     goToReturnURL : function()
     {
         this.setDirty(false);
-        window.location = this.returnURL;
+        window.location = this.returnUrl;
     },
 
     onFailure : function(text)

--- a/study/webapp/study/vaccineDesign/TreatmentScheduleBase.js
+++ b/study/webapp/study/vaccineDesign/TreatmentScheduleBase.js
@@ -14,7 +14,7 @@ Ext4.define('LABKEY.VaccineDesign.TreatmentSchedulePanelBase', {
 
     dirty : false,
 
-    returnURL : null,
+    returnUrl : null,
 
     getButtonBar : function()
     {
@@ -135,7 +135,7 @@ Ext4.define('LABKEY.VaccineDesign.TreatmentSchedulePanelBase', {
     goToReturnURL : function()
     {
         this.setDirty(false);
-        window.location = this.returnURL;
+        window.location = this.returnUrl;
     },
 
     onFailure : function(text)

--- a/survey/src/org/labkey/survey/SurveyController.java
+++ b/survey/src/org/labkey/survey/SurveyController.java
@@ -906,7 +906,7 @@ public class SurveyController extends SpringActionController implements SurveyUr
     @RequiresPermission(DeletePermission.class)
     public class DeleteSurveysAction extends FormHandlerAction<QueryForm>
     {
-        private ActionURL _returnURL;
+        private ActionURL _returnUrl;
 
         @Override
         public void validateCommand(QueryForm target, Errors errors)
@@ -916,7 +916,7 @@ public class SurveyController extends SpringActionController implements SurveyUr
         @Override
         public boolean handlePost(QueryForm form, BindException errors)
         {
-            _returnURL = form.getReturnActionURL();
+            _returnUrl = form.getReturnActionURL();
 
             DbScope scope = SurveySchema.getInstance().getSchema().getScope();
 
@@ -936,14 +936,14 @@ public class SurveyController extends SpringActionController implements SurveyUr
         @Override
         public URLHelper getSuccessURL(QueryForm form)
         {
-            return _returnURL;
+            return _returnUrl;
         }
     }
 
     @RequiresPermission(DeletePermission.class)
     public class DeleteSurveyDesignsAction extends FormHandlerAction<QueryForm>
     {
-        private ActionURL _returnURL;
+        private ActionURL _returnUrl;
 
         @Override
         public void validateCommand(QueryForm target, Errors errors)
@@ -953,7 +953,7 @@ public class SurveyController extends SpringActionController implements SurveyUr
         @Override
         public boolean handlePost(QueryForm form, BindException errors)
         {
-            _returnURL = form.getReturnActionURL();
+            _returnUrl = form.getReturnActionURL();
 
             DbScope scope = SurveySchema.getInstance().getSchema().getScope();
 
@@ -973,7 +973,7 @@ public class SurveyController extends SpringActionController implements SurveyUr
         @Override
         public URLHelper getSuccessURL(QueryForm form)
         {
-            return _returnURL;
+            return _returnUrl;
         }
     }
 

--- a/survey/src/org/labkey/survey/query/SurveyDesignQueryView.java
+++ b/survey/src/org/labkey/survey/query/SurveyDesignQueryView.java
@@ -55,7 +55,7 @@ public class SurveyDesignQueryView extends QueryView
         if (getContainer().hasPermission(getUser(), InsertPermission.class))
         {
             ActionURL insertURL = new ActionURL(SurveyController.SurveyDesignAction.class, getContainer());
-            insertURL.addReturnURL(getReturnURL());
+            insertURL.addReturnUrl(getReturnUrl());
 
             ActionButton insert = new ActionButton(insertURL, "Create Survey Design");
             insert.setActionType(ActionButton.Action.LINK);
@@ -68,7 +68,7 @@ public class SurveyDesignQueryView extends QueryView
     public ActionButton createDeleteButton()
     {
         ActionURL url = new ActionURL(SurveyController.DeleteSurveyDesignsAction.class, getContainer());
-        url.addReturnURL(getReturnURL());
+        url.addReturnUrl(getReturnUrl());
 
         ActionButton btnDelete = new ActionButton(url, "Delete");
         btnDelete.setActionType(ActionButton.Action.POST);

--- a/survey/src/org/labkey/survey/query/SurveyQueryView.java
+++ b/survey/src/org/labkey/survey/query/SurveyQueryView.java
@@ -63,7 +63,7 @@ public class SurveyQueryView extends QueryView
         {
             ActionURL insertURL = new ActionURL(SurveyController.UpdateSurveyAction.class, getContainer());
             insertURL.addParameter("surveyDesignId", _surveyDesignId);
-            insertURL.addReturnURL(getReturnURL());
+            insertURL.addReturnUrl(getReturnUrl());
 
             ActionButton insert = new ActionButton(insertURL, "Create Survey");
             insert.setActionType(ActionButton.Action.LINK);

--- a/survey/src/org/labkey/survey/view/surveyWizard.jsp
+++ b/survey/src/org/labkey/survey/view/surveyWizard.jsp
@@ -42,7 +42,7 @@
     String responsesPk = null;
     String surveyLabel = null;
     boolean submitted = false;
-    String returnURL = null;
+    String returnUrl = null;
     if (bean != null)
     {
         if (bean.getRowId() != null)
@@ -52,7 +52,7 @@
         responsesPk = bean.getResponsesPk();
         surveyLabel = bean.getLabel();
         submitted = bean.isSubmitted();
-        returnURL = bean.getReturnActionURL() != null ? bean.getReturnActionURL().getLocalURIString() : null;
+        returnUrl = bean.getReturnActionURL() != null ? bean.getReturnActionURL().getLocalURIString() : null;
     }
 
     Survey survey = SurveyManager.get().getSurvey(getContainer(), getUser(), rowId);
@@ -95,7 +95,7 @@
             renderTo        : <%=q(formRenderId)%>,
             headerRenderTo  : <%=q(headerRenderId)%>,
             footerRenderTo  : <%=q(footerRenderId)%>,
-            returnUrl       : <%=q(returnURL)%>,
+            returnUrl       : <%=q(returnUrl)%>,
             autosaveInterval: 60000
         });
 

--- a/wiki/src/org/labkey/wiki/model/BaseWikiView.java
+++ b/wiki/src/org/labkey/wiki/model/BaseWikiView.java
@@ -184,7 +184,7 @@ public abstract class BaseWikiView extends JspView<Object>
                 // the customize URL should always be for the current container (not the wiki webpart's container)
                 customizeURL = PageFlowUtil.urlProvider(ProjectUrls.class).getCustomizeWebPartURL(getViewContext().getContainer());
                 customizeURL.addParameter("webPartId", _webPartId);
-                customizeURL.addReturnURL(getViewContext().getActionURL());
+                customizeURL.addReturnUrl(getViewContext().getActionURL());
             }
 
             if (perms.allowRead(wiki))


### PR DESCRIPTION
#### Rationale
In 2021 we made a major push to use `returnUrl` consistently instead of `srcURL` or `returnURL`. We can finish the job.

Issue 7580: inconsistent use of returnUrl parameter

#### Changes
- Change everything to `returnUrl` and get rid of code checking for old versions of the parameters