### PR TITLE
Require non-null user and container in UserSchemas

### DIFF
--- a/api/src/org/labkey/api/assay/AssaySchema.java
+++ b/api/src/org/labkey/api/assay/AssaySchema.java
@@ -41,12 +41,12 @@ public abstract class AssaySchema extends UserSchema
     @Nullable
     protected Container _targetStudy;
 
-    public AssaySchema(String name, User user, Container container, DbSchema dbSchema, @Nullable Container targetStudy)
+    public AssaySchema(String name, @NotNull User user, @NotNull Container container, DbSchema dbSchema, @Nullable Container targetStudy)
     {
         this(SchemaKey.fromParts(name), DESCR, user, container, dbSchema, targetStudy);
     }
 
-    protected AssaySchema(SchemaKey path, String description, User user, Container container, DbSchema dbSchema, @Nullable Container targetStudy)
+    protected AssaySchema(SchemaKey path, String description, @NotNull User user, @NotNull Container container, DbSchema dbSchema, @Nullable Container targetStudy)
     {
         super(path, description, user, container, dbSchema, null);
         _targetStudy = targetStudy;

--- a/api/src/org/labkey/api/exp/query/AbstractExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/AbstractExpSchema.java
@@ -31,7 +31,7 @@ public abstract class AbstractExpSchema extends UserSchema
 {
     protected ContainerFilter _containerFilter = null;
 
-    public AbstractExpSchema(String name, String description, User user, Container container, DbSchema dbSchema)
+    public AbstractExpSchema(String name, String description, @NotNull User user, @NotNull Container container, DbSchema dbSchema)
     {
         this(SchemaKey.fromParts(name), description, user, container, dbSchema);
     }

--- a/api/src/org/labkey/api/query/AbstractSchema.java
+++ b/api/src/org/labkey/api/query/AbstractSchema.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 abstract public class AbstractSchema implements QuerySchema
@@ -42,8 +43,8 @@ abstract public class AbstractSchema implements QuerySchema
     public AbstractSchema(DbSchema dbSchema, User user, Container container)
     {
         _dbSchema = dbSchema;
-        _user = user;
-        _container = container;
+        _user = Objects.requireNonNull(user);
+        _container = Objects.requireNonNull(container);
         MemTracker.get().put(this);
     }
 

--- a/api/src/org/labkey/api/query/AbstractSchema.java
+++ b/api/src/org/labkey/api/query/AbstractSchema.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.query;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.AbstractTableInfo;
 import org.labkey.api.data.Container;
@@ -40,7 +41,7 @@ abstract public class AbstractSchema implements QuerySchema
     protected final Container _container;
     protected boolean _hidden = false;
 
-    public AbstractSchema(DbSchema dbSchema, User user, Container container)
+    public AbstractSchema(DbSchema dbSchema, @NotNull User user, @NotNull Container container)
     {
         _dbSchema = dbSchema;
         _user = Objects.requireNonNull(user);

--- a/api/src/org/labkey/api/query/DefaultSchema.java
+++ b/api/src/org/labkey/api/query/DefaultSchema.java
@@ -207,7 +207,7 @@ final public class DefaultSchema extends AbstractSchema implements QuerySchema.C
         return schema;
     }
 
-    private DefaultSchema(User user, Container container)
+    private DefaultSchema(@NotNull User user, @NotNull Container container)
     {
         super(null, user, container);
         MemTracker.getInstance().put(this);

--- a/api/src/org/labkey/api/query/SimpleUserSchema.java
+++ b/api/src/org/labkey/api/query/SimpleUserSchema.java
@@ -78,7 +78,7 @@ public class SimpleUserSchema extends UserSchema
     private final Set<String> _available = new CaseInsensitiveTreeSet();
     protected Set<String> _visible;
 
-    public SimpleUserSchema(String name, @Nullable String description, User user, Container container, DbSchema dbschema)
+    public SimpleUserSchema(String name, @Nullable String description, @NotNull User user, @NotNull Container container, DbSchema dbschema)
     {
         super(name, description, user, container, dbschema);
         if (dbschema != null)

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -78,12 +78,12 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
 
     protected java.util.function.Predicate<TableInfo> _getTableAcceptor = (t) -> true;
 
-    public UserSchema(@NotNull String name, @Nullable String description, User user, Container container, DbSchema dbSchema)
+    public UserSchema(@NotNull String name, @Nullable String description, @NotNull User user, @NotNull Container container, DbSchema dbSchema)
     {
         this(SchemaKey.fromParts(name), description, user, container, dbSchema, null);
     }
 
-    public UserSchema(@NotNull SchemaKey path, @Nullable String description, User user, Container container, DbSchema dbSchema, Collection<UserSchemaCustomizer> schemaCustomizers)
+    public UserSchema(@NotNull SchemaKey path, @Nullable String description, @NotNull User user, @NotNull Container container, DbSchema dbSchema, Collection<UserSchemaCustomizer> schemaCustomizers)
     {
         super(dbSchema, user, container);
         _name = path.getName();

--- a/study/src/org/labkey/study/query/StudyQuerySchema.java
+++ b/study/src/org/labkey/study/query/StudyQuerySchema.java
@@ -189,7 +189,7 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
 
 
     /** use StudyQuerySchema.createSchema() */
-    protected StudyQuerySchema(@NotNull StudyImpl study, User user, @Nullable Role contextualRole)
+    protected StudyQuerySchema(@NotNull StudyImpl study, @NotNull User user, @Nullable Role contextualRole)
     {
         this(study, study.getContainer(), user, contextualRole);
 
@@ -207,7 +207,7 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
     /**
      * This c-tor is for schemas that have no study defined -- _study is null!
      */
-    private StudyQuerySchema(@Nullable StudyImpl study, Container c, User user, @Nullable Role contextualRole)
+    private StudyQuerySchema(@Nullable StudyImpl study, @NotNull Container c, @NotNull User user, @Nullable Role contextualRole)
     {
         this(SchemaKey.fromParts(SCHEMA_NAME), SCHEMA_DESCRIPTION, study, c, user, contextualRole);
     }
@@ -215,7 +215,7 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
     /**
      * This c-tor is for nested study schemas
      */
-    protected StudyQuerySchema(SchemaKey path, String description, @Nullable StudyImpl study, Container c, User user, @Nullable Role contextualRole)
+    protected StudyQuerySchema(SchemaKey path, String description, @Nullable StudyImpl study, @NotNull Container c, @NotNull User user, @Nullable Role contextualRole)
     {
         super(path, description, user, c, StudySchema.getInstance().getSchema(), null);
         _study = study;


### PR DESCRIPTION
#### Rationale
A `UserSchema` with a `null` `User` or `Container` seems less useful. Throw if either are null at construction time.

#### Related Pull Requests
- https://github.com/LabKey/commonAssays/pull/852
