### PR TITLE
Rename exp.FieldNames -> exp.Fields

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -642,7 +642,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     SampleStatusTable createSampleStatusTable(ExpSchema expSchema, ContainerFilter cf);
 
-    FilteredTable<ExpSchema> createFieldNamesTable(ExpSchema expSchema, ContainerFilter cf);
+    FilteredTable<ExpSchema> createFieldsTable(ExpSchema expSchema, ContainerFilter cf);
 
     FilteredTable<ExpSchema> createPhiFieldsTable(ExpSchema expSchema, ContainerFilter cf);
 

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -227,12 +227,12 @@ public class ExpSchema extends AbstractExpSchema
                 return ExperimentService.get().createSampleStatusTable(expSchema, cf);
             }
         },
-        FieldNames
+        Fields
         {
             @Override
             public TableInfo createTable(ExpSchema expSchema, String queryName, ContainerFilter cf)
             {
-                return ExperimentService.get().createFieldNamesTable(expSchema, cf);
+                return ExperimentService.get().createFieldsTable(expSchema, cf);
             }
         },
         PhiFields

--- a/experiment/src/org/labkey/experiment/api/BaseFieldsTable.java
+++ b/experiment/src/org/labkey/experiment/api/BaseFieldsTable.java
@@ -14,11 +14,11 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.security.permissions.AdminPermission;
 
-public abstract class BaseFieldNamesTable extends FilteredTable<ExpSchema>
+public abstract class BaseFieldsTable extends FilteredTable<ExpSchema>
 {
     private final String _tableName;
 
-    public BaseFieldNamesTable(String tableName, @NotNull ExpSchema userSchema, @Nullable ContainerFilter containerFilter)
+    public BaseFieldsTable(String tableName, @NotNull ExpSchema userSchema, @Nullable ContainerFilter containerFilter)
     {
         super(OntologyManager.getTinfoPropertyDescriptor(), userSchema, containerFilter);
         _tableName = tableName;

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1585,9 +1585,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public FilteredTable<ExpSchema> createFieldNamesTable(ExpSchema expSchema, ContainerFilter cf)
+    public FilteredTable<ExpSchema> createFieldsTable(ExpSchema expSchema, ContainerFilter cf)
     {
-        return new FieldNamesTable(expSchema, cf);
+        return new FieldsTable(expSchema, cf);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/FieldsTable.java
+++ b/experiment/src/org/labkey/experiment/api/FieldsTable.java
@@ -11,7 +11,7 @@ public class FieldsTable extends BaseFieldsTable
 {
     public FieldsTable(@NotNull ExpSchema userSchema, @Nullable ContainerFilter containerFilter)
     {
-        super("Fields", userSchema, containerFilter);
+        super(ExpSchema.TableType.Fields.name(), userSchema, containerFilter);
         setDescription("Shows one row for each administrator-defined field in the selected folder(s). Rows are shown in " +
             "a folder or project only if the user has administrator permissions in that folder.");
 

--- a/experiment/src/org/labkey/experiment/api/FieldsTable.java
+++ b/experiment/src/org/labkey/experiment/api/FieldsTable.java
@@ -7,11 +7,11 @@ import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.exp.query.ExpSchema;
 
-public class FieldNamesTable extends BaseFieldNamesTable
+public class FieldsTable extends BaseFieldsTable
 {
-    public FieldNamesTable(@NotNull ExpSchema userSchema, @Nullable ContainerFilter containerFilter)
+    public FieldsTable(@NotNull ExpSchema userSchema, @Nullable ContainerFilter containerFilter)
     {
-        super("FieldNames", userSchema, containerFilter);
+        super("Fields", userSchema, containerFilter);
         setDescription("Shows one row for each administrator-defined field in the selected folder(s). Rows are shown in " +
             "a folder or project only if the user has administrator permissions in that folder.");
 

--- a/experiment/src/org/labkey/experiment/api/PhiFieldsTable.java
+++ b/experiment/src/org/labkey/experiment/api/PhiFieldsTable.java
@@ -10,7 +10,7 @@ import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.exp.query.ExpSchema;
 
-public class PhiFieldsTable extends BaseFieldNamesTable
+public class PhiFieldsTable extends BaseFieldsTable
 {
     public PhiFieldsTable(@NotNull ExpSchema userSchema, @Nullable ContainerFilter containerFilter)
     {

--- a/experiment/src/org/labkey/experiment/api/PhiFieldsTable.java
+++ b/experiment/src/org/labkey/experiment/api/PhiFieldsTable.java
@@ -14,7 +14,7 @@ public class PhiFieldsTable extends BaseFieldsTable
 {
     public PhiFieldsTable(@NotNull ExpSchema userSchema, @Nullable ContainerFilter containerFilter)
     {
-        super("PHIFields", userSchema, containerFilter);
+        super(ExpSchema.TableType.PhiFields.name(), userSchema, containerFilter);
         setDescription("Shows one row for each PHI-annotated field in the selected folder(s). Rows are shown in " +
             "a folder or project only if the user has administrator permissions in that folder.");
 


### PR DESCRIPTION
#### Rationale
"Fields" is a more appropriate name and better matches the other table names in this schema. Not bothering to alias the old name since Keith doesn't think it's necessary.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6291