### PR TITLE
Additional test coverage for LKS client exception reporting

### DIFF
--- a/api/src/org/labkey/api/util/ExceptionUtil.java
+++ b/api/src/org/labkey/api/util/ExceptionUtil.java
@@ -16,6 +16,7 @@
 
 package org.labkey.api.util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -549,15 +550,15 @@ public class ExceptionUtil
         {
             String message = "Client exception detected";
             if (null != errorCode)
-            {
                 message += " and logged to mothership with error code " + errorCode + " ";
-            }
-            LOG.error(message + "\n" +
-                    requestURL + "\n" +
-                    referrerURL + "\n" +
-                    browser + "\n" +
-                    stackTrace.stackTrace
-            );
+
+            message += "\nrequestURL: " + requestURL;
+            if (null != referrerURL && !referrerURL.equals(requestURL))
+                message += "\nreferrerURL: " + referrerURL;
+            message += "\nbrowser: " + browser;
+            message += "\n" + stackTrace.stackTrace;
+
+            LOG.error(message);
         }
 
         return errorCode;

--- a/core/webapp/mothership.js
+++ b/core/webapp/mothership.js
@@ -276,7 +276,7 @@ LABKEY.Mothership = (function () {
                 username: LABKEY.user ? LABKEY.user.email : "Unknown",
                 //site: window.location.host,
                 //version: LABKEY.versionString || "Unknown",
-                requestURL: file,
+                requestURL: document.URL,
                 referrerURL: document.URL,
                 exceptionMessage: msg,
                 stackTrace: stackTrace || msg,

--- a/mothership/test/src/org/labkey/test/pages/mothership/ClientExceptionPage.java
+++ b/mothership/test/src/org/labkey/test/pages/mothership/ClientExceptionPage.java
@@ -1,5 +1,6 @@
 package org.labkey.test.pages.mothership;
 
+import org.labkey.remoteapi.CommandException;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
@@ -8,9 +9,12 @@ import org.labkey.test.util.mothership.MothershipHelper;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 public class ClientExceptionPage extends LabKeyPage<ClientExceptionPage.ElementCache>
 {
@@ -40,43 +44,59 @@ public class ClientExceptionPage extends LabKeyPage<ClientExceptionPage.ElementC
                 "the page did not become enabled", WAIT_FOR_JAVASCRIPT);
     }
 
-    public ClientExceptionPage clickInlineScriptError() throws Exception
+    public ClientExceptionPage clickInlineScriptError(boolean expectError) throws Exception
     {
-        waitForNewTimestamp();
+        var initialState = mothershipHelper.getOrderedStackTraces();
         elementCache().inlineScriptErrBtn.click();
+        if (expectError)
+            waitForNewTimestamp(initialState);
         return this;
     }
 
-    public ClientExceptionPage clickResourceScriptError() throws Exception
+    public ClientExceptionPage clickResourceScriptError(boolean expectError) throws Exception
     {
-        waitForNewTimestamp();
+        var initialState = mothershipHelper.getOrderedStackTraces();
         elementCache().resourceScriptErrBtn.click();
+        if (expectError)
+            waitForNewTimestamp(initialState);
         return this;
     }
 
-    public ClientExceptionPage clickNestedScriptError() throws Exception
+    public ClientExceptionPage clickNestedScriptError(boolean expectError) throws Exception
     {
-        waitForNewTimestamp();
+        var initialState = mothershipHelper.getOrderedStackTraces();
         elementCache().nestedScriptErrBtn.click();
+        if (expectError)
+            waitForNewTimestamp(initialState);
         return this;
     }
 
-    public ClientExceptionPage clickAsyncScriptError() throws Exception
+    public ClientExceptionPage clickAsyncScriptError(boolean expectError) throws Exception
     {
-        waitForNewTimestamp();
+        var initialState = mothershipHelper.getOrderedStackTraces();
         elementCache().asyncScriptErrBtn.click();
+        if (expectError)
+            waitForNewTimestamp(initialState);
         return this;
     }
 
-
-    private void waitForNewTimestamp() throws Exception
+    private void waitForNewTimestamp(List<Map<String, Object>> initialState) throws IOException, CommandException
     {
-        var stackTraces = mothershipHelper.getOrderedStackTraces();
-        if (stackTraces.isEmpty())
-            return;
-
-        var lastTimestamp = (Date)stackTraces.get(0).get("LastReport");
-        waitFor(()-> Instant.now().minus(Duration.ofSeconds(1)).isAfter(lastTimestamp.toInstant()), 2000);
+        waitFor(()-> {
+            try
+            {
+                sleep(250);
+                var latestTraces =  mothershipHelper.getOrderedStackTraces();
+                var lastTimestamp = (Date)initialState.get(0).get("LastReport");
+                if (initialState.isEmpty())
+                    return !latestTraces.isEmpty();
+                else
+                    return  !latestTraces.isEmpty() && ((Date)latestTraces.get(0).get("LastReport")).after(lastTimestamp);
+            } catch (Exception e)
+            {
+                return false;
+            }
+        }, "No new report appeared in Mothership", 2000);
     }
 
     @Override

--- a/mothership/test/src/org/labkey/test/pages/mothership/ClientExceptionPage.java
+++ b/mothership/test/src/org/labkey/test/pages/mothership/ClientExceptionPage.java
@@ -1,16 +1,13 @@
 package org.labkey.test.pages.mothership;
 
-import org.labkey.remoteapi.CommandException;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.util.mothership.MothershipHelper;
-import org.labkey.test.util.samplemanagement.BannerHelper;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;

--- a/mothership/test/src/org/labkey/test/pages/mothership/ClientExceptionPage.java
+++ b/mothership/test/src/org/labkey/test/pages/mothership/ClientExceptionPage.java
@@ -1,5 +1,6 @@
 package org.labkey.test.pages.mothership;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
@@ -46,7 +47,7 @@ public class ClientExceptionPage extends LabKeyPage<ClientExceptionPage.ElementC
 
     public ClientExceptionPage clickInlineScriptError(boolean expectError) throws Exception
     {
-        var initialState = mothershipHelper.getOrderedStackTraces();
+        var initialState = mothershipHelper.getLatestStackTrace();
         elementCache().inlineScriptErrBtn.click();
         if (expectError)
             waitForNewTimestamp(initialState);
@@ -55,7 +56,7 @@ public class ClientExceptionPage extends LabKeyPage<ClientExceptionPage.ElementC
 
     public ClientExceptionPage clickResourceScriptError(boolean expectError) throws Exception
     {
-        var initialState = mothershipHelper.getOrderedStackTraces();
+        var initialState = mothershipHelper.getLatestStackTrace();
         elementCache().resourceScriptErrBtn.click();
         if (expectError)
             waitForNewTimestamp(initialState);
@@ -64,7 +65,7 @@ public class ClientExceptionPage extends LabKeyPage<ClientExceptionPage.ElementC
 
     public ClientExceptionPage clickNestedScriptError(boolean expectError) throws Exception
     {
-        var initialState = mothershipHelper.getOrderedStackTraces();
+        var initialState = mothershipHelper.getLatestStackTrace();
         elementCache().nestedScriptErrBtn.click();
         if (expectError)
             waitForNewTimestamp(initialState);
@@ -73,30 +74,31 @@ public class ClientExceptionPage extends LabKeyPage<ClientExceptionPage.ElementC
 
     public ClientExceptionPage clickAsyncScriptError(boolean expectError) throws Exception
     {
-        var initialState = mothershipHelper.getOrderedStackTraces();
+        var initialState = mothershipHelper.getLatestStackTrace();
         elementCache().asyncScriptErrBtn.click();
         if (expectError)
             waitForNewTimestamp(initialState);
         return this;
     }
 
-    private void waitForNewTimestamp(List<Map<String, Object>> initialState) throws IOException, CommandException
+    private void waitForNewTimestamp(@Nullable Map<String, Object> initialState) throws Exception
     {
-        waitFor(()-> {
+        waitFor(() -> {
             try
             {
-                sleep(250);
-                var latestTraces =  mothershipHelper.getOrderedStackTraces();
-                var lastTimestamp = (Date)initialState.get(0).get("LastReport");
-                if (initialState.isEmpty())
-                    return !latestTraces.isEmpty();
+                sleep(500); // half a second between iterations to avoid spamming the server
+                var latestStackTrace = mothershipHelper.getLatestStackTrace();
+                if (null != initialState)
+                    return latestStackTrace != null;
                 else
-                    return  !latestTraces.isEmpty() && ((Date)latestTraces.get(0).get("LastReport")).after(lastTimestamp);
-            } catch (Exception e)
+                    return latestStackTrace != null && ((Date) latestStackTrace.get("LastReport"))
+                            .after((Date) initialState.get("LastReport"));
+            }
+            catch (Exception e)
             {
                 return false;
             }
-        }, "No new report appeared in Mothership", 2000);
+        }, "No new report appeared in Mothership", 4000);
     }
 
     @Override

--- a/mothership/test/src/org/labkey/test/pages/mothership/ClientExceptionPage.java
+++ b/mothership/test/src/org/labkey/test/pages/mothership/ClientExceptionPage.java
@@ -1,0 +1,104 @@
+package org.labkey.test.pages.mothership;
+
+import org.labkey.remoteapi.CommandException;
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.pages.LabKeyPage;
+import org.labkey.test.util.mothership.MothershipHelper;
+import org.labkey.test.util.samplemanagement.BannerHelper;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+public class ClientExceptionPage extends LabKeyPage<ClientExceptionPage.ElementCache>
+{
+    private MothershipHelper mothershipHelper;
+
+    public ClientExceptionPage(WebDriver driver)
+    {
+        super(driver);
+        mothershipHelper = new MothershipHelper(this);
+    }
+
+    public static ClientExceptionPage beginAt(WebDriverWrapper webDriverWrapper)
+    {
+        return beginAt(webDriverWrapper, webDriverWrapper.getCurrentContainerPath());
+    }
+
+    public static ClientExceptionPage beginAt(WebDriverWrapper webDriverWrapper, String containerPath)
+    {
+        webDriverWrapper.beginAt(WebTestHelper.buildURL("mothership", containerPath, "clientException"));
+        return new ClientExceptionPage(webDriverWrapper.getDriver());
+    }
+
+    @Override
+    protected void waitForPage()
+    {
+        waitFor(()-> Locator.id("inline-script").isDisplayed(getDriver()),
+                "the page did not become enabled", WAIT_FOR_JAVASCRIPT);
+    }
+
+    public ClientExceptionPage clickInlineScriptError() throws Exception
+    {
+        waitForNewTimestamp();
+        elementCache().inlineScriptErrBtn.click();
+        return this;
+    }
+
+    public ClientExceptionPage clickResourceScriptError() throws Exception
+    {
+        waitForNewTimestamp();
+        elementCache().resourceScriptErrBtn.click();
+        return this;
+    }
+
+    public ClientExceptionPage clickNestedScriptError() throws Exception
+    {
+        waitForNewTimestamp();
+        elementCache().nestedScriptErrBtn.click();
+        return this;
+    }
+
+    public ClientExceptionPage clickAsyncScriptError() throws Exception
+    {
+        waitForNewTimestamp();
+        elementCache().asyncScriptErrBtn.click();
+        return this;
+    }
+
+
+    private void waitForNewTimestamp() throws Exception
+    {
+        var stackTraces = mothershipHelper.getOrderedStackTraces();
+        if (stackTraces.isEmpty())
+            return;
+
+        var lastTimestamp = (Date)stackTraces.get(0).get("LastReport");
+        waitFor(()-> Instant.now().minus(Duration.ofSeconds(1)).isAfter(lastTimestamp.toInstant()), 2000);
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    @Override
+    protected ElementCache elementCache()
+    {
+        return (ElementCache) super.elementCache();
+    }
+
+    protected class ElementCache extends LabKeyPage<ElementCache>.ElementCache
+    {
+        final WebElement inlineScriptErrBtn = Locator.id("inline-script").findWhenNeeded(getDriver());
+        final WebElement resourceScriptErrBtn = Locator.id("resource-script").findWhenNeeded(getDriver());
+        final WebElement nestedScriptErrBtn = Locator.id("nested-script").findWhenNeeded(getDriver());
+        final WebElement asyncScriptErrBtn = Locator.id("async-script").findWhenNeeded(getDriver());
+    }
+}

--- a/mothership/test/src/org/labkey/test/pages/mothership/ClientExceptionPage.java
+++ b/mothership/test/src/org/labkey/test/pages/mothership/ClientExceptionPage.java
@@ -107,11 +107,6 @@ public class ClientExceptionPage extends LabKeyPage<ClientExceptionPage.ElementC
         return new ElementCache();
     }
 
-    @Override
-    protected ElementCache elementCache()
-    {
-        return (ElementCache) super.elementCache();
-    }
 
     protected class ElementCache extends LabKeyPage<ElementCache>.ElementCache
     {

--- a/mothership/test/src/org/labkey/test/pages/mothership/ClientExceptionPage.java
+++ b/mothership/test/src/org/labkey/test/pages/mothership/ClientExceptionPage.java
@@ -88,7 +88,7 @@ public class ClientExceptionPage extends LabKeyPage<ClientExceptionPage.ElementC
             {
                 sleep(500); // half a second between iterations to avoid spamming the server
                 var latestStackTrace = mothershipHelper.getLatestStackTrace();
-                if (null != initialState)
+                if (null == initialState)
                     return latestStackTrace != null;
                 else
                     return latestStackTrace != null && ((Date) latestStackTrace.get("LastReport"))

--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
@@ -288,20 +288,20 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
     @Test
     public void testInlineScriptClientError() throws Exception
     {
-        var initialStackTraces = _mothershipHelper.getOrderedStackTraces();
+        var initialStackTrace = _mothershipHelper.getLatestStackTrace();
 
         var exceptionPage = ClientExceptionPage.beginAt(this);
         exceptionPage.clickInlineScriptError(true);
         var url = getURL();
 
-        var testException = _mothershipHelper.getOrderedStackTraces().get(0);
+        var testException = _mothershipHelper.getLatestStackTrace();
         var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
         var rowMap = stackTraceDetailPage.getExceptionReports().getRowDataAsMap(0);
 
-        if (!initialStackTraces.isEmpty())
+        if (initialStackTrace != null)
             checker().wrapAssertion(()-> Assertions.assertThat((Date)testException.get("LastReport"))
                     .as("expect this result to occur after the most-recent previous report")
-                    .isAfter((Date)initialStackTraces.get(0).get("LastReport")));
+                    .isAfter((Date)initialStackTrace.get("LastReport")));
         checker().verifyEquals("Expect confirmation that the controller is mothership",
                 "mothership", rowMap.get("PageflowName"));
         checker().verifyEquals("Expect confirmation that the action is app",
@@ -321,21 +321,21 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
     @Test
     public void testResourceScriptClientError() throws Exception
     {
-        var initialStackTraces = _mothershipHelper.getOrderedStackTraces();
+        var initialStackTrace = _mothershipHelper.getLatestStackTrace();
 
         var exceptionPage = ClientExceptionPage.beginAt(this);
         exceptionPage.clickResourceScriptError(true);
         var url = getURL();
         checkExpectedErrors(1);
 
-        var testException = _mothershipHelper.getOrderedStackTraces().get(0);
+        var testException = _mothershipHelper.getLatestStackTrace();
         var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
         var rowMap = stackTraceDetailPage.getExceptionReports().getRowDataAsMap(0);
 
-        if (!initialStackTraces.isEmpty())
+        if (initialStackTrace != null)
             checker().wrapAssertion(()-> Assertions.assertThat((Date)testException.get("LastReport"))
                     .as("expect this result to occur after the most-recent previous report")
-                    .isAfter((Date)initialStackTraces.get(0).get("LastReport")));
+                    .isAfter((Date)initialStackTrace.get("LastReport")));
         checker().verifyEquals("Expect confirmation that the controller is mothership",
                 "mothership", rowMap.get("PageflowName"));
         checker().verifyEquals("Expect confirmation that the action is app",
@@ -355,20 +355,20 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
     @Test
     public void testNestedResourceScriptClientError() throws Exception
     {
-        var initialStackTraces = _mothershipHelper.getOrderedStackTraces();
+        var initialStackTrace = _mothershipHelper.getLatestStackTrace();
 
         var exceptionPage = ClientExceptionPage.beginAt(this);
         exceptionPage.clickNestedScriptError(true);
         var url = getURL();
 
-        var testException = _mothershipHelper.getOrderedStackTraces().get(0);
+        var testException = _mothershipHelper.getLatestStackTrace();
         var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
         var rowMap = stackTraceDetailPage.getExceptionReports().getRowDataAsMap(0);
 
-        if (!initialStackTraces.isEmpty())
+        if (initialStackTrace != null)
             checker().wrapAssertion(()-> Assertions.assertThat((Date)testException.get("LastReport"))
                     .as("expect this result to occur after the most-recent previous report")
-                    .isAfter((Date)initialStackTraces.get(0).get("LastReport")));
+                    .isAfter((Date)initialStackTrace.get("LastReport")));
         checker().verifyEquals("Expect confirmation that the controller is mothership",
                 "mothership", rowMap.get("PageflowName"));
         checker().verifyEquals("Expect confirmation that the action is app",
@@ -388,21 +388,20 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
     @Test
     public void testAsyncScriptClientError() throws Exception
     {
-        var initialStackTraces = _mothershipHelper.getOrderedStackTraces();
+        var initialStackTrace = _mothershipHelper.getLatestStackTrace();
 
         var exceptionPage = ClientExceptionPage.beginAt(this);
         exceptionPage.clickAsyncScriptError(true);
-        sleep(1000); // give it a chance to happen
         var url = getURL();
 
-        var testException = _mothershipHelper.getOrderedStackTraces().get(0);
+        var testException = _mothershipHelper.getLatestStackTrace();
         var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
         var rowMap = stackTraceDetailPage.getExceptionReports().getRowDataAsMap(0);
 
-        if (!initialStackTraces.isEmpty())
+        if (initialStackTrace != null)
             checker().wrapAssertion(()-> Assertions.assertThat((Date)testException.get("LastReport"))
                     .as("expect this result to occur after the most-recent previous report")
-                    .isAfter((Date)initialStackTraces.get(0).get("LastReport")));
+                    .isAfter((Date)initialStackTrace.get("LastReport")));
         checker().verifyEquals("Expect confirmation that the controller is mothership",
                 "mothership", rowMap.get("PageflowName"));
         checker().verifyEquals("Expect confirmation that the action is deepException",

--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
@@ -293,6 +293,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         var exceptionPage = ClientExceptionPage.beginAt(this);
         exceptionPage.clickInlineScriptError(true);
         var url = getURL();
+        checkExpectedErrors(1);
 
         var testException = _mothershipHelper.getLatestStackTrace();
         var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
@@ -315,7 +316,6 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         checker().verifyEquals("Expect instance count to be the same in the page",
                 testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
         checker().screenShotIfNewError("unexpected_record_data");
-        resetErrors();
     }
 
     @Test
@@ -349,7 +349,6 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         checker().verifyEquals("Expect instance count to be the same in the page",
                 testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
         checker().screenShotIfNewError("unexpected_record_data");
-        resetErrors();
     }
 
     @Test
@@ -360,6 +359,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         var exceptionPage = ClientExceptionPage.beginAt(this);
         exceptionPage.clickNestedScriptError(true);
         var url = getURL();
+        checkExpectedErrors(1);
 
         var testException = _mothershipHelper.getLatestStackTrace();
         var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
@@ -382,7 +382,6 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         checker().verifyEquals("Expect instance count to be the same in the page",
                 testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
         checker().screenShotIfNewError("unexpected_record_data");
-        resetErrors();
     }
 
     @Test
@@ -393,6 +392,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         var exceptionPage = ClientExceptionPage.beginAt(this);
         exceptionPage.clickAsyncScriptError(true);
         var url = getURL();
+        checkExpectedErrors(1);
 
         var testException = _mothershipHelper.getLatestStackTrace();
         var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
@@ -418,7 +418,6 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         checker().verifyEquals("Expect instance count to be the same in the page",
                 testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
         checker().screenShotIfNewError("unexpected_record_data");
-        resetErrors();
     }
 
     private String getErrorCode()

--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
@@ -16,11 +16,13 @@
 package org.labkey.test.tests.mothership;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.CommandException;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
@@ -29,6 +31,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.pages.issues.InsertPage;
+import org.labkey.test.pages.mothership.ClientExceptionPage;
 import org.labkey.test.pages.mothership.EditUpgradeMessagePage;
 import org.labkey.test.pages.mothership.ShowExceptionsPage;
 import org.labkey.test.pages.mothership.ShowExceptionsPage.ExceptionSummaryDataRegion;
@@ -43,6 +46,7 @@ import org.labkey.test.util.mothership.MothershipHelper;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -279,6 +283,142 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         ExceptionActions.illegalState.beginAt(this);
         assertNull("Shouldn't generate an error code when exception reporting is disabled", getErrorCode());
         resetErrors();
+    }
+
+    @Test
+    public void testInlineScriptClientError() throws Exception
+    {
+        var initialStackTraces = _mothershipHelper.getOrderedStackTraces();
+
+        var exceptionPage = ClientExceptionPage.beginAt(this);
+        exceptionPage.clickInlineScriptError();
+        var url = getURL();
+        checkExpectedErrors(1);
+
+        var testException = _mothershipHelper.getOrderedStackTraces().get(0);
+        var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
+        var rowMap = stackTraceDetailPage.getExceptionReports().getRowDataAsMap(0);
+
+        if (!initialStackTraces.isEmpty())
+            checker().wrapAssertion(()-> Assertions.assertThat((Date)testException.get("LastReport"))
+                    .as("expect this result to occur after the most-recent previous report")
+                    .isAfter((Date)initialStackTraces.get(0).get("LastReport")));
+        checker().verifyEquals("Expect confirmation that the controller is mothership",
+                "mothership", rowMap.get("PageflowName"));
+        checker().verifyEquals("Expect confirmation that the action is app",
+                "clientException", rowMap.get("PageflowAction"));
+        checker().verifyEquals("Unexpected exception message",
+                "TypeError: x is undefined", rowMap.get("ExceptionMessage"));
+        checker().verifyEquals("Expect confirmation that the user is correct",
+                getCurrentUser(), rowMap.get("Username"));
+        checker().verifyEquals("expext the referring URL to be the page from which we caused this",
+                url.toString(), rowMap.get("ReferrerURL"));
+        checker().verifyEquals("Expect instance count to be the same in the page",
+                testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
+        checker().screenShotIfNewError("unexpected_record_data");
+    }
+
+    @Test
+    public void testResourceScriptClientError() throws Exception
+    {
+        var initialStackTraces = _mothershipHelper.getOrderedStackTraces();
+
+        var exceptionPage = ClientExceptionPage.beginAt(this);
+        exceptionPage.clickResourceScriptError();
+        var url = getURL();
+        checkExpectedErrors(1);
+
+        var testException = _mothershipHelper.getOrderedStackTraces().get(0);
+        var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
+        var rowMap = stackTraceDetailPage.getExceptionReports().getRowDataAsMap(0);
+
+        if (!initialStackTraces.isEmpty())
+            checker().wrapAssertion(()-> Assertions.assertThat((Date)testException.get("LastReport"))
+                    .as("expect this result to occur after the most-recent previous report")
+                    .isAfter((Date)initialStackTraces.get(0).get("LastReport")));
+        checker().verifyEquals("Expect confirmation that the controller is mothership",
+                "mothership", rowMap.get("PageflowName"));
+        checker().verifyEquals("Expect confirmation that the action is app",
+                "clientException", rowMap.get("PageflowAction"));
+        checker().verifyEquals("Unexpected exception message",
+                "TypeError: x is undefined", rowMap.get("ExceptionMessage"));
+        checker().verifyEquals("Expect confirmation that the user is correct",
+                getCurrentUser(), rowMap.get("Username"));
+        checker().verifyEquals("expext the referring URL to be the page from which we caused this",
+                url.toString(), rowMap.get("ReferrerURL"));
+        checker().verifyEquals("Expect instance count to be the same in the page",
+                testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
+        checker().screenShotIfNewError("unexpected_record_data");
+    }
+
+    @Test
+    public void testNestedResourceScriptClientError() throws Exception
+    {
+        var initialStackTraces = _mothershipHelper.getOrderedStackTraces();
+
+        var exceptionPage = ClientExceptionPage.beginAt(this);
+        exceptionPage.clickNestedScriptError();
+        var url = getURL();
+        checkExpectedErrors(1);
+
+        var testException = _mothershipHelper.getOrderedStackTraces().get(0);
+        var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
+        var rowMap = stackTraceDetailPage.getExceptionReports().getRowDataAsMap(0);
+
+        if (!initialStackTraces.isEmpty())
+            checker().wrapAssertion(()-> Assertions.assertThat((Date)testException.get("LastReport"))
+                    .as("expect this result to occur after the most-recent previous report")
+                    .isAfter((Date)initialStackTraces.get(0).get("LastReport")));
+        checker().verifyEquals("Expect confirmation that the controller is mothership",
+                "mothership", rowMap.get("PageflowName"));
+        checker().verifyEquals("Expect confirmation that the action is app",
+                "clientException", rowMap.get("PageflowAction"));
+        checker().verifyEquals("Unexpected exception message",
+                "TypeError: x is undefined", rowMap.get("ExceptionMessage"));
+        checker().verifyEquals("Expect confirmation that the user is correct",
+                getCurrentUser(), rowMap.get("Username"));
+        checker().verifyEquals("expext the referring URL to be the page from which we caused this",
+                url.toString(), rowMap.get("URL"));
+        checker().verifyEquals("Expect instance count to be the same in the page",
+                testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
+        checker().screenShotIfNewError("unexpected_record_data");
+    }
+
+    @Test
+    public void testAsyncScriptClientError() throws Exception
+    {
+        var initialStackTraces = _mothershipHelper.getOrderedStackTraces();
+
+        var exceptionPage = ClientExceptionPage.beginAt(this);
+        exceptionPage.clickAsyncScriptError();
+        sleep(1000); // give it a chance to happen
+        var url = getURL();
+        checkExpectedErrors(1);
+
+        var testException = _mothershipHelper.getOrderedStackTraces().get(0);
+        var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
+        var rowMap = stackTraceDetailPage.getExceptionReports().getRowDataAsMap(0);
+
+        if (!initialStackTraces.isEmpty())
+            checker().wrapAssertion(()-> Assertions.assertThat((Date)testException.get("LastReport"))
+                    .as("expect this result to occur after the most-recent previous report")
+                    .isAfter((Date)initialStackTraces.get(0).get("LastReport")));
+        checker().verifyEquals("Expect confirmation that the controller is mothership",
+                "mothership", rowMap.get("PageflowName"));
+        checker().verifyEquals("Expect confirmation that the action is deepException",
+                "deepException", rowMap.get("PageflowAction"));
+        checker().verifyEquals("Unexpected exception message",
+                "TypeError: result.does is undefined", rowMap.get("ExceptionMessage"));
+        checker().verifyEquals("Expect confirmation that the user is correct",
+                getCurrentUser(), rowMap.get("Username"));
+        checker().verifyEquals("expect the referring URL to be the page from which we caused this",
+                url.toString(), rowMap.get("ReferrerURL"));
+        checker().wrapAssertion(()-> Assertions.assertThat(rowMap.get("URL"))
+                .as("expect url to be some line in deepException.js")
+                .contains("mothership/deepException.js?"));
+        checker().verifyEquals("Expect instance count to be the same in the page",
+                testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
+        checker().screenShotIfNewError("unexpected_record_data");
     }
 
     private String getErrorCode()

--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
@@ -291,9 +291,8 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         var initialStackTraces = _mothershipHelper.getOrderedStackTraces();
 
         var exceptionPage = ClientExceptionPage.beginAt(this);
-        exceptionPage.clickInlineScriptError();
+        exceptionPage.clickInlineScriptError(true);
         var url = getURL();
-        checkExpectedErrors(1);
 
         var testException = _mothershipHelper.getOrderedStackTraces().get(0);
         var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
@@ -316,6 +315,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         checker().verifyEquals("Expect instance count to be the same in the page",
                 testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
         checker().screenShotIfNewError("unexpected_record_data");
+        resetErrors();
     }
 
     @Test
@@ -324,7 +324,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         var initialStackTraces = _mothershipHelper.getOrderedStackTraces();
 
         var exceptionPage = ClientExceptionPage.beginAt(this);
-        exceptionPage.clickResourceScriptError();
+        exceptionPage.clickResourceScriptError(true);
         var url = getURL();
         checkExpectedErrors(1);
 
@@ -349,6 +349,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         checker().verifyEquals("Expect instance count to be the same in the page",
                 testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
         checker().screenShotIfNewError("unexpected_record_data");
+        resetErrors();
     }
 
     @Test
@@ -357,9 +358,8 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         var initialStackTraces = _mothershipHelper.getOrderedStackTraces();
 
         var exceptionPage = ClientExceptionPage.beginAt(this);
-        exceptionPage.clickNestedScriptError();
+        exceptionPage.clickNestedScriptError(true);
         var url = getURL();
-        checkExpectedErrors(1);
 
         var testException = _mothershipHelper.getOrderedStackTraces().get(0);
         var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
@@ -382,6 +382,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         checker().verifyEquals("Expect instance count to be the same in the page",
                 testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
         checker().screenShotIfNewError("unexpected_record_data");
+        resetErrors();
     }
 
     @Test
@@ -390,10 +391,9 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         var initialStackTraces = _mothershipHelper.getOrderedStackTraces();
 
         var exceptionPage = ClientExceptionPage.beginAt(this);
-        exceptionPage.clickAsyncScriptError();
+        exceptionPage.clickAsyncScriptError(true);
         sleep(1000); // give it a chance to happen
         var url = getURL();
-        checkExpectedErrors(1);
 
         var testException = _mothershipHelper.getOrderedStackTraces().get(0);
         var stackTraceDetailPage = StackTraceDetailsPage.beginAt(this, _mothershipHelper.getLatestStackTraceId());
@@ -419,6 +419,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         checker().verifyEquals("Expect instance count to be the same in the page",
                 testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
         checker().screenShotIfNewError("unexpected_record_data");
+        resetErrors();
     }
 
     private String getErrorCode()

--- a/mothership/test/src/org/labkey/test/util/mothership/MothershipHelper.java
+++ b/mothership/test/src/org/labkey/test/util/mothership/MothershipHelper.java
@@ -166,6 +166,22 @@ public class MothershipHelper extends LabKeySiteWrapper
         }
     }
 
+    public List<Map<String, Object>> getOrderedStackTraces()
+    {
+        Connection connection = createDefaultConnection();
+        SelectRowsCommand command = new SelectRowsCommand("mothership", "ExceptionStackTrace");
+        command.addSort("LastReport", Sort.Direction.DESCENDING);
+        try
+        {
+            SelectRowsResponse response = command.execute(connection, MOTHERSHIP_PROJECT);
+            return response.getRows();
+        }
+        catch (IOException|CommandException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
     public void resetStackTrace(int exceptionStackTraceId)
     {
         updateStackTrace(exceptionStackTraceId, "", "", "");

--- a/mothership/test/src/org/labkey/test/util/mothership/MothershipHelper.java
+++ b/mothership/test/src/org/labkey/test/util/mothership/MothershipHelper.java
@@ -149,6 +149,15 @@ public class MothershipHelper extends LabKeySiteWrapper
 
     public int getLatestStackTraceId()
     {
+        Map<String, Object> lastStackTrace = getLatestStackTrace();
+        if (lastStackTrace == null)
+            return 0;
+
+        return (Integer) lastStackTrace.get(ID_COLUMN);
+    }
+
+    public @Nullable Map<String, Object> getLatestStackTrace()
+    {
         Connection connection = createDefaultConnection();
         SelectRowsCommand command = new SelectRowsCommand("mothership", "ExceptionStackTrace");
         command.addSort("LastReport", Sort.Direction.DESCENDING);
@@ -156,25 +165,9 @@ public class MothershipHelper extends LabKeySiteWrapper
         try
         {
             SelectRowsResponse response = command.execute(connection, MOTHERSHIP_PROJECT);
-            if (response.getRows().isEmpty())
-                return 0;
-            return (Integer) response.getRows().get(0).get(ID_COLUMN);
-        }
-        catch (IOException|CommandException e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public List<Map<String, Object>> getOrderedStackTraces()
-    {
-        Connection connection = createDefaultConnection();
-        SelectRowsCommand command = new SelectRowsCommand("mothership", "ExceptionStackTrace");
-        command.addSort("LastReport", Sort.Direction.DESCENDING);
-        try
-        {
-            SelectRowsResponse response = command.execute(connection, MOTHERSHIP_PROJECT);
-            return response.getRows();
+             if (response.getRows().isEmpty())
+                 return null;
+             return response.getRows().get(0);
         }
         catch (IOException|CommandException e)
         {

--- a/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
@@ -248,6 +248,7 @@ public class StudySimpleExportTest extends StudyBaseTest
     public void verifyDatasetFieldValidators()
     {
         log("Field Validators: export study folder to the pipeline as individual files");
+        goToProjectHome();
         exportFolderAsIndividualFiles(getFolderName(), false, false, false);
 
         log("Field Validators: import study into subfolder");


### PR DESCRIPTION
#### Rationale
This change adds test coverage for client-side application exception reporting to mothership
Also adds a page class to wrap the new `ClientExceptionPage`

[spec with test plan](https://docs.google.com/document/d/1VSMNqr8On108Ial2Twt0T7uoy0_xg8GQML-WhA_Bz2U/edit?tab=t.0#heading=h.7u5qro28q0oc)
[Issue](https://github.com/LabKey/kanban/issues/532)

#### Related Pull Requests
tests in limsModules add coverage in the apps
https://github.com/LabKey/limsModules/pull/1219

#### Changes
Add method to `MothershipHelper`
New page class for `ClientExceptionPage`
Added test methods to `MothershipTest`
