### PR TITLE
explicitly start test where it expects to be

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
@@ -248,6 +248,7 @@ public class StudySimpleExportTest extends StudyBaseTest
     public void verifyDatasetFieldValidators()
     {
         log("Field Validators: export study folder to the pipeline as individual files");
+        goToProjectHome();
         exportFolderAsIndividualFiles(getFolderName(), false, false, false);
 
         log("Field Validators: import study into subfolder");


### PR DESCRIPTION
#### Rationale
This attempts to address the recent failures of [StudySimpleExportTest.verifyDatasetFieldValidators](https://teamcity.labkey.org/buildConfiguration/LabKey_253Release_Premium_CommunitySqlserver_DailyESqlserver/3411348) on 25.3 sql runs

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/2329

#### Changes
start the test at project home, instead of wherever the previous test might have finished
