### PR TITLE
Study design schema fixes for dataspace

### DIFF
--- a/study/api-src/org/labkey/api/studydesign/query/StudyDesignBaseTable.java
+++ b/study/api-src/org/labkey/api/studydesign/query/StudyDesignBaseTable.java
@@ -3,12 +3,9 @@ package org.labkey.api.studydesign.query;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MutableColumnInfo;
-import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.AliasedColumn;
-import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.column.BuiltInColumnTypes;
 import org.labkey.api.security.UserPrincipal;
@@ -54,21 +51,21 @@ public abstract class StudyDesignBaseTable extends FilteredTable<StudyDesignQuer
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        checkedPermissions.add(perm);
-        // Most tables should not be editable in Dataspace
-        if (!perm.equals(ReadPermission.class) && getContainer().isDataspace())
+        if (perm.equals(ReadPermission.class))
+            return hasPermissionOverridable(user, perm);
+        // These are editable in Dataspace, but not in a folder within a Dataspace
+        if (null == getContainer() || null == getContainer().getProject() || (getContainer().getProject().isDataspace() && !getContainer().isDataspace()))
             return false;
         return hasPermissionOverridable(user, perm);
     }
 
     protected boolean hasPermissionOverridable(UserPrincipal user, Class<? extends Permission> perm)
     {
-        return checkHasReadPermission(user, perm);
-    }
-
-    protected boolean checkHasReadPermission(UserPrincipal user, Class<? extends Permission> perm)
-    {
-        return ReadPermission.class == perm && _userSchema.getContainer().hasPermission(user, perm, getContextualRoles());
+        // Only admins are allowed to insert into these tables at the project level
+        if (getContainer().isProject())
+            return checkReadOrIsAdminPermission(user, perm);
+        else
+            return checkContainerPermission(user, perm);
     }
 
     protected boolean checkReadOrIsAdminPermission(UserPrincipal user, Class<? extends Permission> perm)

--- a/study/api-src/org/labkey/api/studydesign/query/StudyDesignQuerySchema.java
+++ b/study/api-src/org/labkey/api/studydesign/query/StudyDesignQuerySchema.java
@@ -180,14 +180,14 @@ public class StudyDesignQuerySchema extends SimpleUserSchema implements UserSche
             StudyTreatmentProductDomainKind domainKind = new StudyTreatmentProductDomainKind();
             Domain domain = ensureDomain(domainKind, StudyDesignQuerySchema.TREATMENT_PRODUCT_MAP_TABLE_NAME);
 
-            return StudyTreatmentProductTable.create(domain, this, isDataspaceProject() ? ContainerFilter.Type.Project.create(this) : cf);
+            return StudyTreatmentProductTable.create(domain, this, isDataspace() ? ContainerFilter.Type.Project.create(this) : cf);
         }
         if (TREATMENT_TABLE_NAME.equalsIgnoreCase(name))
         {
             StudyTreatmentDomainKind domainKind = new StudyTreatmentDomainKind();
             Domain domain = ensureDomain(domainKind, TREATMENT_TABLE_NAME);
 
-            return StudyTreatmentTable.create(domain, this, isDataspaceProject() ? ContainerFilter.Type.Project.create(this) : cf);
+            return StudyTreatmentTable.create(domain, this, isDataspace() ? ContainerFilter.Type.Project.create(this) : cf);
         }
         if (PERSONNEL_TABLE_NAME.equalsIgnoreCase(name))
         {
@@ -218,6 +218,15 @@ public class StudyDesignQuerySchema extends SimpleUserSchema implements UserSche
             throw new IllegalStateException("Could not find a domain for " + tableName + " in " + getContainer().getPath());
         }
         return result;
+    }
+
+    /**
+     * This only gets overridden in the DataspaceQuerySchema, we should be able to delete this and other support
+     * for dataspace in the study design schema when we confirm there are no clients who use that combination.
+     */
+    public boolean isDataspace()
+    {
+        return false;
     }
 
     public boolean isDataspaceProject()

--- a/study/api-src/org/labkey/api/studydesign/query/StudyObjectiveTable.java
+++ b/study/api-src/org/labkey/api/studydesign/query/StudyObjectiveTable.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.studydesign.query;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.DefaultQueryUpdateService;
@@ -23,6 +24,7 @@ import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.wiki.WikiRendererDisplayColumn;
 import org.labkey.api.wiki.WikiRendererType;
 import org.labkey.api.wiki.WikiService;
@@ -94,6 +96,16 @@ public class StudyObjectiveTable extends StudyDesignBaseTable
     public boolean supportsContainerFilter()
     {
         return true;
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        checkedPermissions.add(perm);
+        // Most tables should not be editable in Dataspace
+        if (!perm.equals(ReadPermission.class) && getContainer().isDataspace())
+            return false;
+        return hasPermissionOverridable(user, perm);
     }
 
     @Override

--- a/study/api-src/org/labkey/api/studydesign/query/StudyTreatmentVisitMapTable.java
+++ b/study/api-src/org/labkey/api/studydesign/query/StudyTreatmentVisitMapTable.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.studydesign.query;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.AliasedColumn;
@@ -25,6 +26,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 
 /**
  * User: cnathe
@@ -64,6 +66,16 @@ public class StudyTreatmentVisitMapTable extends StudyDesignBaseTable
     public QueryUpdateService getUpdateService()
     {
         return new DefaultQueryUpdateService(this, this.getRealTable());
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        checkedPermissions.add(perm);
+        // Most tables should not be editable in Dataspace
+        if (!perm.equals(ReadPermission.class) && getContainer().isDataspace())
+            return false;
+        return hasPermissionOverridable(user, perm);
     }
 
     @Override

--- a/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
@@ -48,6 +48,7 @@ import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
+import org.labkey.test.util.OptionalFeatureHelper;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.RReportHelper;
 import org.labkey.test.util.StudyHelper;
@@ -164,6 +165,7 @@ public class StudyPublishTest extends StudyPHIExportTest
     private final String SUB_FOLDER_NAME = "PublishedSubStudy";
     private static final String PUBLISH_FOLDER_ADMIN = "publish_admin@study.test";
     private static final String PUBLISH_SUB_FOLDER_ADMIN = "publishsub_admin@study.test";
+    private Boolean _studyDesignPreviouslyEnabled;
 
     // enum to help determine the study publish location
     public enum PublishLocation
@@ -180,6 +182,8 @@ public class StudyPublishTest extends StudyPHIExportTest
         _containerHelper.deleteProject(PUB2_NAME, afterTest, 1000000);
 
         _userHelper.deleteUsers(false, PUBLISH_FOLDER_ADMIN, PUBLISH_SUB_FOLDER_ADMIN);
+        if (_studyDesignPreviouslyEnabled != null)
+            OptionalFeatureHelper.setOptionalFeature(createDefaultConnection(), "studyDesignFlag", _studyDesignPreviouslyEnabled);
     }
 
     @Override
@@ -188,6 +192,7 @@ public class StudyPublishTest extends StudyPHIExportTest
         // fail fast if R is not configured
         RReportHelper _rReportHelper = new RReportHelper(this);
         _rReportHelper.ensureRConfig();
+        _studyDesignPreviouslyEnabled = OptionalFeatureHelper.enableOptionalFeature(createDefaultConnection(), "studyDesignFlag");
 
         importStudy();
         if (_studyHelper.isSpecimenModulePresent())


### PR DESCRIPTION
#### Rationale
Recent changes to the study design tables in the `study` schema started to cause failures in the `StudyDataspaceTest`.

Some of the refactors broke some very nuanced behavior when viewing and importing study design related data into `dataspace` projects and folders:
- Most of the tables which extend `StudyDesignBaseTable` have rules which allow `insert` into the project under certain conditions with the exception of the `objectives` and `studyTreatmentVisitMap` tables.
- While many of the study design tables are created with a `project` container filter for `dataspace` projects, the `treatment` and `treatmentProductMap` tables are usually created with the container filter passed in. This was the subtle difference between the  `isDataspace` and `isDataspaceProject` methods in the original `StudyQuerySchema` code.

Once it is determined that there are no clients who use study design with a dataspace project some of this confusing behavior can be removed.