### PR TITLE
Issue 52467: query for fewer columns when indexing exp.data rows

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpObject.java
+++ b/api/src/org/labkey/api/exp/api/ExpObject.java
@@ -63,6 +63,10 @@ public interface ExpObject extends Identifiable, Comparable<ExpObject>
     String getComment();
     /** Stored in ontology manager */
     void setComment(User user, String comment) throws ValidationException;
+    default void setComment(User user, String comment, boolean index) throws ValidationException
+    {
+        setComment(user, comment);
+    }
     
     User getCreatedBy();
     Date getCreated();

--- a/api/src/org/labkey/api/exp/api/ExpObject.java
+++ b/api/src/org/labkey/api/exp/api/ExpObject.java
@@ -63,7 +63,9 @@ public interface ExpObject extends Identifiable, Comparable<ExpObject>
     String getComment();
     /** Stored in ontology manager */
     void setComment(User user, String comment) throws ValidationException;
+    /** @param index only a suggestion as not all implementations handle indexing - primarily used to suppress duplicate indexing with a false value */
     default void setComment(User user, String comment, boolean index) throws ValidationException
+
     {
         setComment(user, comment);
     }

--- a/api/src/org/labkey/api/exp/query/ExpDataClassDataTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpDataClassDataTable.java
@@ -16,6 +16,7 @@
 package org.labkey.api.exp.query;
 
 import org.labkey.api.data.UpdateableTableInfo;
+import org.labkey.api.query.FieldKey;
 
 /**
  * User: kevink
@@ -42,6 +43,11 @@ public interface ExpDataClassDataTable extends ExpTable<ExpDataClassDataTable.Co
         Outputs,
         DataFileUrl,
         Properties,
-        QueryableInputs,
+        QueryableInputs;
+
+        public FieldKey fieldKey()
+        {
+            return FieldKey.fromParts(name());
+        }
     }
 }

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -801,7 +801,7 @@ public class ExpDataIterators
                             if (sample == null)
                                 sample = ExperimentService.get().getExpMaterial(lsid);
                             if (sample != null)
-                                sample.setComment(_user, flag);
+                                sample.setComment(_user, flag, false);
                         }
                         else
                         {
@@ -815,7 +815,7 @@ public class ExpDataIterators
                             if (data == null)
                                 data = ExperimentService.get().getExpData(lsid);
                             if (data != null)
-                                data.setComment(_user, flag);
+                                data.setComment(_user, flag, false);
                         }
                     }
                     catch (ValidationException e)

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -58,6 +58,7 @@ import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryRowReference;
 import org.labkey.api.query.QueryService;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchResultTemplate;
 import org.labkey.api.search.SearchScope;
 import org.labkey.api.search.SearchService;
@@ -174,6 +175,21 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
     public ExpDataImpl(Data data)
     {
         super(data);
+    }
+
+    @Override
+    public void setComment(User user, String comment) throws ValidationException
+    {
+        setComment(user, comment, true);
+    }
+
+    @Override
+    public void setComment(User user, String comment, boolean index) throws ValidationException
+    {
+        super.setComment(user, comment);
+
+        if (index)
+            index(null, null);
     }
 
     @Override
@@ -499,16 +515,15 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
 
         // collect the set of columns to index
         Set<ColumnInfo> columns = table.getExtendedColumns(true).values().stream().filter(col -> {
-            final String name = col.getName();
-
             // skip the base-columns - they will be added to the index separately and/or we don't want to index them (Issue 52467)
-            if (skipColumns.contains(name))
+            if (skipColumns.contains(col.getName()))
                 return false;
 
             // skip non-text columns or columns that aren't lookups
             if (!(col.getJdbcType().isText() || col.getFk() != null))
                 return false;
 
+            // Issue 52467: Skip indexing both the raw columns like LSID and the wrapped versions of those columns that are lookups to other data
             if ("lsidtype".equalsIgnoreCase(col.getSqlTypeName()) || "entityid".equalsIgnoreCase(col.getSqlTypeName()))
                 return false;
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -57,7 +58,6 @@ import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryRowReference;
 import org.labkey.api.query.QueryService;
-import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchResultTemplate;
 import org.labkey.api.search.SearchScope;
 import org.labkey.api.search.SearchService;
@@ -174,13 +174,6 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
     public ExpDataImpl(Data data)
     {
         super(data);
-    }
-
-    @Override
-    public void setComment(User user, String comment) throws ValidationException
-    {
-        super.setComment(user, comment);
-        index(null, null);
     }
 
     @Override
@@ -498,31 +491,34 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         JSONObject jsonData
     )
     {
+        CaseInsensitiveHashSet skipColumns = new CaseInsensitiveHashSet();
+        for (ExpDataClassDataTable.Column column : ExpDataClassDataTable.Column.values())
+            skipColumns.add(column.name());
+        skipColumns.add("Ancestors");
+        skipColumns.add("Container");
+
         // collect the set of columns to index
         Set<ColumnInfo> columns = table.getExtendedColumns(true).values().stream().filter(col -> {
-            // skip the base-columns - they will be added to the index separately
             final String name = col.getName();
-            try
-            {
-                ExpDataClassDataTable.Column x = ExpDataClassDataTable.Column.valueOf(name);
+
+            // skip the base-columns - they will be added to the index separately and/or we don't want to index them (Issue 52467)
+            if (skipColumns.contains(name))
                 return false;
-            }
-            catch (IllegalArgumentException ex)
-            {
-                // ok
-            }
 
             // skip non-text columns or columns that aren't lookups
             if (!(col.getJdbcType().isText() || col.getFk() != null))
                 return false;
 
-            if (name.equalsIgnoreCase("container") || name.equalsIgnoreCase("folder"))
+            if ("lsidtype".equalsIgnoreCase(col.getSqlTypeName()) || "entityid".equalsIgnoreCase(col.getSqlTypeName()))
                 return false;
 
             return true;
         }).collect(Collectors.toCollection(LinkedHashSet::new));
 
-        TableSelector ts = new TableSelector(table, columns, new SimpleFilter(FieldKey.fromParts("rowId"), getRowId()), null);
+        if (columns.isEmpty())
+            return;
+
+        TableSelector ts = new TableSelector(table, columns, new SimpleFilter(ExpDataClassDataTable.Column.RowId.fieldKey(), getRowId()), null);
         ts.setForDisplay(true);
         try (Results r = ts.getResults())
         {
@@ -555,7 +551,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
                     if (searchProperty != null)
                     {
                         // Fow now only add indexed field values to search jsonData
-                        if (values.size() > 0)
+                        if (!values.isEmpty())
                         {
                             if (values.size() == 1)
                                 jsonData.put(fieldKey.toString(), values.get(0));

--- a/experiment/src/org/labkey/experiment/api/ExpObjectImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpObjectImpl.java
@@ -28,7 +28,6 @@ import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.property.ExperimentProperty;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
-import org.labkey.api.settings.AppProps;
 
 import java.io.Serializable;
 import java.util.Map;

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -5179,9 +5179,6 @@ public class ExperimentController extends SpringActionController
             }
 
             obj.setComment(getUser(), form.getComment());
-            if (obj instanceof ExpDataImpl expData)
-                expData.index(null, null);
-
             return true;
         }
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -5179,6 +5179,9 @@ public class ExperimentController extends SpringActionController
             }
 
             obj.setComment(getUser(), form.getComment());
+            if (obj instanceof ExpDataImpl expData)
+                expData.index(null, null);
+
             return true;
         }
 


### PR DESCRIPTION
#### Rationale
We are querying for a large number of columns and in particular complex columns (MVFKs, ancestors, etc.) when indexing individual exp.data rows. Subsequently, we're dropping many of these columns results and not actually including them in the index and/or we don't need to be. See [Issue 52467](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52467).

#### Changes
- Skip `lsidtype` and `entityid` type columns in the query as their results are already ignored.
- Change how we skip columns to avoid try/catch.
- remove redundant indexing when comments are set on exp.data. Move to controller action.
