### PR TITLE
update test to expect different action

### DIFF
--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
@@ -404,8 +404,8 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
                     .isAfter((Date)initialStackTrace.get("LastReport")));
         checker().verifyEquals("Expect confirmation that the controller is mothership",
                 "mothership", rowMap.get("PageflowName"));
-        checker().verifyEquals("Expect confirmation that the action is deepException",
-                "deepException", rowMap.get("PageflowAction"));
+        checker().verifyEquals("Expect confirmation that the action is clientException",
+                "clientException", rowMap.get("PageflowAction"));
         checker().verifyEquals("Unexpected exception message",
                 "TypeError: result.does is undefined", rowMap.get("ExceptionMessage"));
         checker().verifyEquals("Expect confirmation that the user is correct",
@@ -413,8 +413,8 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         checker().verifyEquals("expect the referring URL to be the page from which we caused this",
                 url.toString(), rowMap.get("ReferrerURL"));
         checker().wrapAssertion(()-> Assertions.assertThat(rowMap.get("URL"))
-                .as("expect url to be some line in deepException.js")
-                .contains("mothership/deepException.js?"));
+                .as("expect url to reflect a source in mothership-clientException")
+                .endsWith("_mothership/mothership-clientException.view"));
         checker().verifyEquals("Expect instance count to be the same in the page",
                 testException.get("Instances"), stackTraceDetailPage.getExceptionReports().getDataRowCount());
         checker().screenShotIfNewError("unexpected_record_data");


### PR DESCRIPTION
#### Rationale
Recently, [MothershipTest.testAsyncScriptClientError](https://teamcity.labkey.org/buildConfiguration/LabKey_253Release_Community_DailySuites_DailyDPostgres/3415953) failed on TC because the test expected to resolve the reporting action and url the way it did prior to [Nick's recent change](https://github.com/LabKey/platform/pull/6418) to correctly report those things in the apps.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/6418

#### Changes
update the test's expectations to align to new product behavior
