### PR TITLE
Better support for spaces and other characters in replicate measure names

### DIFF
--- a/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateTriggerFactory.java
@@ -100,6 +100,12 @@ public class AssayPlateTriggerFactory implements TriggerFactory
             if (_replicateLsid.isEmpty() || errors.hasErrors())
                 return;
 
+            Map<String, String> aliasMap = new HashMap<>();
+            table.getColumns().forEach(col -> {
+                // include the name if different from the alias
+                if (!col.getName().equals(col.getAlias()))
+                    aliasMap.put(col.getAlias(), col.getName());
+            });
             var filter = new SimpleFilter(FieldKey.fromParts(AssayResultDomainKind.Column.ReplicateLsid.name()), _replicateLsid.keySet(), CompareType.IN);
 
             try (TableResultSet rs = new TableSelector(table, filter, null).getResultSet())
@@ -109,6 +115,12 @@ public class AssayPlateTriggerFactory implements TriggerFactory
                 while (rs.next())
                 {
                     var lsid = rs.getString(AssayResultDomainKind.Column.ReplicateLsid.name());
+                    Map<String, Object> row = rs.getRowMap();
+                    for (Map.Entry<String, String> entry : aliasMap.entrySet())
+                    {
+                        if (row.containsKey(entry.getKey()))
+                            row.put(entry.getValue(), row.get(entry.getKey()));
+                    }
                     replicates.computeIfAbsent(Lsid.parse(String.valueOf(lsid)), m -> new ArrayList<>()).add(rs.getRowMap());
                     _replicateLsid.remove(lsid);
                 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52486

The handling of assay plate replicate wells in the `update` case will issue a query to get the replicate well rows for any changed replicate `LSIDs`. The referenced issue will occur if the column alias differs from the name, in this case we want to make sure there is an entry in the row map for the measure column name since this is what is expected in the code which handles inserting or updating the replicate table.

In addition to the fix here, there is also new test code to validate this behavior.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6432
- https://github.com/LabKey/limsModules/pull/1233
