### PR TITLE
Issue 52501: Cross-folder context for list column validators

### DIFF
--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -296,7 +296,7 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
             dps.put(dp.getPropertyURI(), dp);
         }
 
-        ValidatorContext validatorCache = new ValidatorContext(_list.getContainer(), user);
+        ValidatorContext validatorCache = new ValidatorContext(container, user);
 
         ListItm itm = new ListItm();
         itm.setEntityId((String) oldRow.get(ID));


### PR DESCRIPTION
#### Rationale
This addresses [Issue 52501](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52501) by setting the container context on the `ValidatorContext` constructed during update of list rows to match the supplied container.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2344

#### Changes
- Set container context to the supplied container for list row updates
