### PR TITLE
Issue 52520: Prevent guests from submitting client-side mothership reports

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10522,7 +10522,7 @@ public class AdminController extends SpringActionController
     // UNDONE: Throttle by IP to avoid DOS from buggy clients.
     @Marshal(Marshaller.Jackson)
     @SuppressWarnings("UnusedDeclaration")
-    @RequiresNoPermission
+    @RequiresLogin // Issue 52520: Prevent bots from submitting reports
     @IgnoresForbiddenProjectCheck // Skip the "forbidden project" check since it disallows root
     public static class LogClientExceptionAction extends MutatingApiAction<ExceptionForm>
     {

--- a/core/webapp/mothership.js
+++ b/core/webapp/mothership.js
@@ -268,27 +268,22 @@ LABKEY.Mothership = (function () {
         }
 
         // CONSIDER: Remove the _mothership flag and use a site-setting to suppress mothership reporting of client-side exceptions.
-        var url;
-        var o;
-        if (_mothership || (LABKEY.user && LABKEY.user.isGuest)) {
-            url = LABKEY.contextPath + '/admin/logClientException.api';
-            o = {
-                username: LABKEY.user ? LABKEY.user.email : "Unknown",
-                //site: window.location.host,
-                //version: LABKEY.versionString || "Unknown",
-                requestURL: document.URL,
-                referrerURL: document.URL,
-                exceptionMessage: msg,
-                stackTrace: stackTrace || msg,
-                file: file,
-                line: line,
-                // column: column,
-                browser: navigator && navigator.userAgent || "Unknown",
-                platform:  navigator && navigator.platform  || "Unknown"
-            };
-
+        if (_mothership) {
             try {
-                send(url, o);
+                send(LABKEY.contextPath + '/admin/logClientException.api', {
+                    username: LABKEY.user ? LABKEY.user.email : 'Unknown',
+                    //site: window.location.host,
+                    //version: LABKEY.versionString || 'Unknown',
+                    requestURL: document.URL,
+                    referrerURL: document.URL,
+                    exceptionMessage: msg,
+                    stackTrace: stackTrace || msg,
+                    file: file,
+                    line: line,
+                    // column: column,
+                    browser: navigator && navigator.userAgent || 'Unknown',
+                    platform:  navigator && navigator.platform  || 'Unknown'
+                });
                 return true;
             }
             catch (e) {
@@ -302,6 +297,11 @@ LABKEY.Mothership = (function () {
     // err is either the thrown Error object, ErrorEvent, or a string message.
     // @return {Boolean} Returns true if the error is logged to mothership, false otherwise.
     function report(err, file, line, column, errorObj) {
+        // Issue 52520: Prevent bots from submitting reports
+        if ((!LABKEY.user || LABKEY.user.isGuest)) {
+            return;
+        }
+
         //log("** report", err, errorObj);
         file = file || window.location.href;
         line = line || "None";

--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -733,7 +733,7 @@ public class MothershipController extends SpringActionController
     }
 
     @SuppressWarnings("UnusedDeclaration")
-    @RequiresPermission(ReadPermission.class)
+    @RequiresNoPermission
     public static class ClientExceptionAction extends SimpleViewAction<Object>
     {
         @Override

--- a/mothership/src/org/labkey/mothership/MothershipController.java
+++ b/mothership/src/org/labkey/mothership/MothershipController.java
@@ -733,7 +733,7 @@ public class MothershipController extends SpringActionController
     }
 
     @SuppressWarnings("UnusedDeclaration")
-    @RequiresNoPermission
+    @RequiresPermission(ReadPermission.class)
     public static class ClientExceptionAction extends SimpleViewAction<Object>
     {
         @Override


### PR DESCRIPTION
#### Rationale
This addresses [Issue 52520](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52520) by taking action to restrict guest user reporting on both the client and server.

#### Changes
- Mark AdminController.LogClientExceptionAction as `@RequiresLogin`
- Prevent guest users from submitting reports via mothership.js.
