### PR TITLE
Load-bearing colon

### DIFF
--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -1665,7 +1665,8 @@ public class DataRegion extends DisplayElement
                 SPAN(
                     cl("summary-stat-label"),
                     statLabel,
-                    description != null ? PageFlowUtil.popupHelp(HtmlString.of(type.getDescription()), type.getFullLabel()) : null
+                    description != null ? PageFlowUtil.popupHelp(HtmlString.of(type.getDescription()), type.getFullLabel()) : null,
+                    ":"
                 ),
                 HtmlString.NBSP,
                 value.error() ? SPAN(cl("labkey-error"), value.value()) : value.value()


### PR DESCRIPTION
#### Rationale
Related PR dropped the colon between a summary statistic's name and value. The tests are very unhappy about this change.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6416