### PR TITLE
Strip all substitution patterns before validating wikis

### DIFF
--- a/announcements/src/org/labkey/announcements/model/AnnouncementModel.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementModel.java
@@ -39,6 +39,7 @@ import org.labkey.api.util.HtmlString;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.wiki.WikiRendererType;
 import org.labkey.api.wiki.WikiRenderingService;
+import org.labkey.api.wiki.WikiRenderingService.SubstitutionMode;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -249,7 +250,7 @@ public class AnnouncementModel extends Entity implements Serializable
         if (null == attachPrefix)
             return renderingService.getFormattedHtml(_rendererType, _body, sourceDescription);
         else
-            return renderingService.getFormattedHtml(_rendererType, _body, sourceDescription, false, attachPrefix, getAttachments());
+            return renderingService.getFormattedHtml(_rendererType, _body, sourceDescription, SubstitutionMode.Ignore, attachPrefix, getAttachments());
     }
 
     public String getStatus()

--- a/api/src/org/labkey/api/wiki/WikiRendererDisplayColumn.java
+++ b/api/src/org/labkey/api/wiki/WikiRendererDisplayColumn.java
@@ -32,8 +32,6 @@ import java.util.function.Function;
 /**
  * Renders the contents of a database column in one of the supported {@link WikiRendererType} formats, as specified
  * by another column (referenced via the renderTypeColumnName constructor argument
- * User: markigra
- * Date: 10/25/11
  */
 public class WikiRendererDisplayColumn extends DataColumn
 {

--- a/api/src/org/labkey/api/wiki/WikiRenderingService.java
+++ b/api/src/org/labkey/api/wiki/WikiRenderingService.java
@@ -18,9 +18,9 @@ public interface WikiRenderingService
     // How should substitutions be handled? Substitutions are allowed in HTML wikis only.
     enum SubstitutionMode
     {
-        Ignore,
-        Remove,
-        Substitute
+        Ignore, // Don't substitute, leaving any substitution tokens as-is
+        Remove, // Substitute with blanks, ensuring that all substitution tokens are removed
+        Substitute // Substitute normally, swapping substitution tokens with their replacements
     }
 
     static @NotNull WikiRenderingService get()

--- a/api/src/org/labkey/api/wiki/WikiRenderingService.java
+++ b/api/src/org/labkey/api/wiki/WikiRenderingService.java
@@ -15,6 +15,14 @@ public interface WikiRenderingService
     HtmlString WIKI_PREFIX = HtmlString.unsafe("<div class=\"labkey-wiki\">");
     HtmlString WIKI_SUFFIX = HtmlString.unsafe("</div>");
 
+    // How should substitutions be handled? Substitutions are allowed in HTML wikis only.
+    enum SubstitutionMode
+    {
+        Ignore,
+        Remove,
+        Substitute
+    }
+
     static @NotNull WikiRenderingService get()
     {
         return Objects.requireNonNull(ServiceRegistry.get().getService(WikiRenderingService.class));
@@ -39,16 +47,16 @@ public interface WikiRenderingService
 
     /**
      * @param sourceDescription info on where the text came from for debugging purposes. For example: Announcement 6654 in /MyContainer
-     * @param handleSubstitutions allow webpart and dependency substitutions ({@code ${labkey.webPart}} and {@code ${labkey.dependency}})
+     * @param substitutionMode determines how webpart and dependency substitutions ({@code ${labkey.webPart}} and {@code ${labkey.dependency}} are handled)
      */
     HtmlString getFormattedHtml(WikiRendererType rendererType, String source, @Nullable String sourceDescription,
-                                boolean handleSubstitutions, String attachPrefix, Collection<? extends Attachment> attachments);
+                                SubstitutionMode substitutionMode, String attachPrefix, Collection<? extends Attachment> attachments);
 
     /**
      * @param sourceDescription info on where the text came from for debugging purposes. For example: Announcement 6654 in /MyContainer
-     * @param handleSubstitutions allow webpart and dependency substitutions ({@code ${labkey.webPart}} and {@code ${labkey.dependency}})
+     * @param substitutionMode determines how webpart and dependency substitutions ({@code ${labkey.webPart}} and {@code ${labkey.dependency}} are handled)
      */
-    WikiRenderer getRenderer(WikiRendererType rendererType, boolean handleSubstitutions, String hrefPrefix,
+    WikiRenderer getRenderer(WikiRendererType rendererType, SubstitutionMode substitutionMode, String hrefPrefix,
                              String attachPrefix, Map<String, String> nameTitleMap,
                              Collection<? extends Attachment> attachments,
                              String sourceDescription);

--- a/core/src/org/labkey/core/wiki/HtmlRenderer.java
+++ b/core/src/org/labkey/core/wiki/HtmlRenderer.java
@@ -278,9 +278,10 @@ public class HtmlRenderer implements WikiRenderer
             String substitutionType = substitutionMatcher.group(1);          // type
             String params = substitutionMatcher.group(2).replace(",", "");
             // Parse the parameters with the symbols in parseWith, they can be used in any order
-            // as long as they are the same symbol starts and completes a parameter value
+            // as long as the same symbol starts and completes a parameter value
             List<String> paramList = new ArrayList<>();
             paramList.add(params);
+            // Support either HTML encoded or unencoded apostrophe
             String[] parseWith = {"&#39;", "'"};
             for (String parser : parseWith)
             {

--- a/core/src/org/labkey/core/wiki/HtmlRenderer.java
+++ b/core/src/org/labkey/core/wiki/HtmlRenderer.java
@@ -250,6 +250,10 @@ public class HtmlRenderer implements WikiRenderer
         return SUBSTITUTION_PATTERN.matcher(text);
     }
 
+    // TODO: Since the Remove option is used by the Wiki validation provider, it may be more appropriate for this
+    // method to parse and verify the substitution & parameter syntax before removing them, reporting errors as
+    // appropriate. This would mean executing most of handleSubstitutions() before doing the replacement and wiring
+    // up a way to report errors to the validator (i.e., not just write errors into the rendered HTML).
     private FormattedHtml removeSubstitutions(String text)
     {
         text = getSubstitutionMatcher(text).replaceAll("");

--- a/core/src/org/labkey/core/wiki/HtmlRenderer.java
+++ b/core/src/org/labkey/core/wiki/HtmlRenderer.java
@@ -21,12 +21,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.util.HtmlString;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.JSoupUtil;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.wiki.FormattedHtml;
 import org.labkey.api.wiki.WikiRenderer;
+import org.labkey.api.wiki.WikiRenderingService.SubstitutionMode;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -47,7 +48,7 @@ import java.util.regex.Pattern;
 
 public class HtmlRenderer implements WikiRenderer
 {
-    private final boolean _allowSubstitutions;
+    private final SubstitutionMode _substitutionMode;
     private final String _hrefPrefix;
     private final String _attachPrefix;
     private final Map<String, String> _nameTitleMap;
@@ -66,9 +67,9 @@ public class HtmlRenderer implements WikiRenderer
      * HTML wiki pages allow webpart and dependency substitutions ({@code ${labkey.webPart}} and {@code ${labkey.dependency}});
      * HTML announcements and Markdown wikis (which are wrapped by this renderer) do not allow substitutions
      */
-    public HtmlRenderer(boolean handleSubstitutions, String hrefPrefix, String attachPrefix, Map<String, String> nameTitleMap, @Nullable Collection<? extends Attachment> attachments)
+    public HtmlRenderer(SubstitutionMode substitutionMode, String hrefPrefix, String attachPrefix, Map<String, String> nameTitleMap, @Nullable Collection<? extends Attachment> attachments)
     {
-        _allowSubstitutions = handleSubstitutions;
+        _substitutionMode = substitutionMode;
         _hrefPrefix = hrefPrefix;
         _attachPrefix = attachPrefix;
         _nameTitleMap = nameTitleMap == null ? new HashMap<>() : nameTitleMap;
@@ -87,7 +88,7 @@ public class HtmlRenderer implements WikiRenderer
             return new FormattedHtml(HtmlString.EMPTY_STRING);
 
         // Remove degenerate comments (e.g. "<!-->") as Tidy does not handle them properly
-        text = text.replaceAll("<!--*>|<!>", "");
+        text = text.replaceAll("<!-+>|<!>", "");
 
         FormattedHtml formattedHtml = handleLabKeySubstitutions(text);
         boolean volatilePage = formattedHtml.isVolatile();
@@ -225,117 +226,134 @@ public class HtmlRenderer implements WikiRenderer
         return new FormattedHtml(HtmlString.unsafe(innerHtml.toString()), volatilePage, wikiDependencies, Collections.emptySet(), cds);
     }
 
-
-    // ${labkey.<type>(<any_stream of characters>)}
-    // Pattern.DOTALL allows the parameter list to span multiple lines
-    private static final Pattern _substitutionPattern = Pattern.compile("\\$\\{labkey\\.(\\w+)\\((.*?)\\)}", Pattern.DOTALL);
-
-    // <any word>='<any value>', allowing whitespace before, after, and in-between
-    private static final Pattern _paramPattern = Pattern.compile("\\s*(\\w+)\\s*=\\s*'(.*)'\\s*");
-
-    private FormattedHtml handleLabKeySubstitutions(String text)
+    private FormattedHtml handleLabKeySubstitutions(final String text)
     {
         if (text == null)
             return new FormattedHtml(HtmlString.EMPTY_STRING);
 
+        // I'd rather push these calls into the enum, but the enum is defined in API and these method implementations are in core
+        return switch (_substitutionMode)
+        {
+            case Ignore -> new FormattedHtml(HtmlString.unsafe(text));
+            case Remove -> removeSubstitutions(text);
+            case Substitute -> handleSubstitutions(text);
+        };
+    }
+
+    // ${labkey.<type>(<any_stream of characters>)}
+    // Pattern.DOTALL allows the parameter list to span multiple lines
+    private static final Pattern SUBSTITUTION_PATTERN = Pattern.compile("\\$\\{labkey\\.(\\w+)\\((.*?)\\)}", Pattern.DOTALL);
+
+    // Find all substitution templates embedded in HTML wiki text that have the form ${labkey.<type>(<any_stream of characters>)}.
+    private Matcher getSubstitutionMatcher(String text)
+    {
+        return SUBSTITUTION_PATTERN.matcher(text);
+    }
+
+    private FormattedHtml removeSubstitutions(String text)
+    {
+        text = getSubstitutionMatcher(text).replaceAll("");
+        return new FormattedHtml(HtmlString.unsafe(text));
+    }
+
+    // <any word>='<any value>', allowing whitespace before, after, and in-between
+    private static final Pattern PARAM_PATTERN = Pattern.compile("\\s*(\\w+)\\s*=\\s*'(.*)'\\s*");
+
+    private FormattedHtml handleSubstitutions(String text)
+    {
         boolean volatilePage = false;
         LinkedHashSet<ClientDependency> cds = new LinkedHashSet<>();
 
-        if (_allowSubstitutions)
+        Matcher substitutionMatcher = getSubstitutionMatcher(text);
+
+        // If we find none, return immediately
+        if (!substitutionMatcher.find())
+            return new FormattedHtml(HtmlString.unsafe(text));
+
+        List<Definition> definitions = new ArrayList<>(10);
+        Map<Definition, List<String>> wikiErrors = new HashMap<>();
+        do
         {
-            // Find all substitution templates embedded in wiki text that have the form ${labkey.<type>(<any_stream of characters>)}.
-            Matcher webPartMatcher = _substitutionPattern.matcher(text);
-
-            // If we find none, return immediately
-            if (!webPartMatcher.find())
-                return new FormattedHtml(HtmlString.unsafe(text));
-
-            List<Definition> definitions = new ArrayList<>(10);
-            Map<Definition, List<String>> wikiErrors = new HashMap<>();
-            do
+            List<String> paramErrors = new ArrayList<>();
+            String substitutionType = substitutionMatcher.group(1);          // type
+            String params = substitutionMatcher.group(2).replace(",", "");
+            // Parse the parameters with the symbols in parseWith, they can be used in any order
+            // as long as they are the same symbol starts and completes a parameter value
+            List<String> paramList = new ArrayList<>();
+            paramList.add(params);
+            String[] parseWith = {"&#39;", "'"};
+            for (String parser : parseWith)
             {
-                List<String> paramErrors = new ArrayList<>();
-                String substitutionType = webPartMatcher.group(1);          // type
-                String params = webPartMatcher.group(2).replace(",", "");
-                // Parse the parameters with the symbols in parseWith, they can be used in any order
-                // as long as they are the same symbol starts and completes a parameter value
-                List<String> paramList = new ArrayList<>();
-                paramList.add(params);
-                String[] parseWith = {"&#39;", "'"};
-                for (String parser : parseWith)
+                List<String> paramListTemp = new ArrayList<>();
+                for (String paramSection : paramList)
                 {
-                    List<String> paramListTemp = new ArrayList<>();
-                    for (String paramSection : paramList)
+                    String[] paramSplit = paramSection.split(parser);
+                    for (int i = 0; i < paramSplit.length; i += 2)
                     {
-                        String[] paramSplit = paramSection.split(parser);
-                        for (int i = 0; i < paramSplit.length; i += 2)
-                        {
-                            paramListTemp.add(paramSplit[i] + (paramSplit.length > i + 1 ? "'" + paramSplit[i + 1] + "'" : ""));
-                        }
+                        paramListTemp.add(paramSplit[i] + (paramSplit.length > i + 1 ? "'" + paramSplit[i + 1] + "'" : ""));
                     }
-                    paramList = paramListTemp;
                 }
-
-                Map<String, String> paramMap = new HashMap<>(10);
-                for (String param : paramList)
-                {
-                    Matcher paramMatcher = _paramPattern.matcher(param);
-
-                    if (paramMatcher.matches())
-                    {
-                        if (paramMap.containsKey(paramMatcher.group(1)))
-                            paramErrors.add(param.trim() + ", there are multiple parameters with this name");
-                        else
-                            paramMap.put(paramMatcher.group(1), paramMatcher.group(2));
-                    }
-                    else if (!param.trim().isEmpty())
-                        paramErrors.add(param.trim());
-                }
-
-                // Stick new definition at beginning of list -- we want to replace them in reverse order
-                Definition definition = new Definition(substitutionType, webPartMatcher.start(), webPartMatcher.end(), paramMap);
-                definitions.add(0, definition);
-                wikiErrors.put(definition, paramErrors);
-            }
-            while (webPartMatcher.find());
-
-            StringBuilder sb = new StringBuilder(text);
-
-            // Get the corresponding substitution handler for each type and replace template with substitution
-            for (Definition definition : definitions)
-            {
-                SubstitutionHandler handler = _substitutionHandlers.get(definition.getType());
-                FormattedHtml substitution;
-
-                if (null != handler)
-                    substitution = handler.getSubstitution(definition.getParams());
-                else
-                    substitution = new FormattedHtml(HtmlString.unsafe("<br><font class='error' color='red'>Error: unknown type, \"labkey." + PageFlowUtil.filter(definition.getType()) + "\"</font>"));
-
-                sb.replace(definition.getStart(), definition.getEnd(), substitution.getHtml().toString());
-
-                if (substitution.isVolatile())
-                    volatilePage = true;
-
-                cds.addAll(substitution.getClientDependencies());
-
-                List<String> paramErrors = wikiErrors.get(definition);
-                if (!paramErrors.isEmpty())
-                {
-                    String errorHTML = "<br>";
-                    for (String error : paramErrors)
-                        errorHTML = errorHTML.concat("<font class='error' color='red'>Error with parameter " +
-                                error + " in " + definition.getType() + "</font><br><br>");
-                    sb.insert(definition.getStart() + substitution.getHtml().toString().length(), errorHTML);
-                }
+                paramList = paramListTemp;
             }
 
-            text = sb.toString();
+            Map<String, String> paramMap = new HashMap<>(10);
+            for (String param : paramList)
+            {
+                Matcher paramMatcher = PARAM_PATTERN.matcher(param);
+
+                if (paramMatcher.matches())
+                {
+                    if (paramMap.containsKey(paramMatcher.group(1)))
+                        paramErrors.add(param.trim() + ", there are multiple parameters with this name");
+                    else
+                        paramMap.put(paramMatcher.group(1), paramMatcher.group(2));
+                }
+                else if (!param.trim().isEmpty())
+                    paramErrors.add(param.trim());
+            }
+
+            // Stick new definition at beginning of list -- we want to replace them in reverse order
+            Definition definition = new Definition(substitutionType, substitutionMatcher.start(), substitutionMatcher.end(), paramMap);
+            definitions.add(0, definition);
+            wikiErrors.put(definition, paramErrors);
         }
+        while (substitutionMatcher.find());
+
+        StringBuilder sb = new StringBuilder(text);
+
+        // Get the corresponding substitution handler for each type and replace template with substitution
+        for (Definition definition : definitions)
+        {
+            SubstitutionHandler handler = _substitutionHandlers.get(definition.getType());
+            FormattedHtml substitution;
+
+            if (null != handler)
+                substitution = handler.getSubstitution(definition.getParams());
+            else
+                substitution = new FormattedHtml(HtmlString.unsafe("<br><font class='error' color='red'>Error: unknown type, \"labkey." + PageFlowUtil.filter(definition.getType()) + "\"</font>"));
+
+            sb.replace(definition.getStart(), definition.getEnd(), substitution.getHtml().toString());
+
+            if (substitution.isVolatile())
+                volatilePage = true;
+
+            cds.addAll(substitution.getClientDependencies());
+
+            List<String> paramErrors = wikiErrors.get(definition);
+            if (!paramErrors.isEmpty())
+            {
+                String errorHTML = "<br>";
+                for (String error : paramErrors)
+                    errorHTML = errorHTML.concat("<font class='error' color='red'>Error with parameter " +
+                            error + " in " + definition.getType() + "</font><br><br>");
+                sb.insert(definition.getStart() + substitution.getHtml().toString().length(), errorHTML);
+            }
+        }
+
+        text = sb.toString();
 
         return new FormattedHtml(HtmlString.unsafe(text), volatilePage, cds);
     }
-
 
     private static class Definition
     {

--- a/core/src/org/labkey/core/wiki/MarkdownRenderer.java
+++ b/core/src/org/labkey/core/wiki/MarkdownRenderer.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.attachments.Attachment;
 import org.labkey.api.markdown.MarkdownService;
 import org.labkey.api.wiki.FormattedHtml;
+import org.labkey.api.wiki.WikiRenderingService.SubstitutionMode;
 
 import java.util.Collection;
 import java.util.Map;
@@ -28,7 +29,7 @@ public class MarkdownRenderer extends HtmlRenderer
 {
     public MarkdownRenderer(String hrefPrefix, String attachPrefix, Map<String, String> nameTitleMap, @Nullable Collection<? extends Attachment> attachments)
     {
-        super(false, hrefPrefix, attachPrefix, nameTitleMap, attachments);
+        super(SubstitutionMode.Ignore, hrefPrefix, attachPrefix, nameTitleMap, attachments);
     }
 
     @Override

--- a/core/src/org/labkey/core/wiki/WebPartSubstitutionHandler.java
+++ b/core/src/org/labkey/core/wiki/WebPartSubstitutionHandler.java
@@ -38,11 +38,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Stack;
 
-/**
- * User: adam
- * Date: Jun 27, 2007
- * Time: 2:53:12 AM
- */
 public class WebPartSubstitutionHandler implements HtmlRenderer.SubstitutionHandler
 {
     private static final Logger LOG = LogManager.getLogger(WebPartSubstitutionHandler.class);
@@ -113,7 +108,7 @@ public class WebPartSubstitutionHandler implements HtmlRenderer.SubstitutionHand
             {
                 // Let's at least log these exceptions in dev mode
                 if (AppProps.getInstance().isDevMode())
-                    LOG.error("Error substituting " + partName, e);
+                    LOG.error("Error substituting {}", partName, e);
 
                 // Return HTML with error
                 return new FormattedHtml(HtmlString.unsafe("<br><font class='error' color='red'>Error substituting " + PageFlowUtil.filter(partName) + ": " + PageFlowUtil.filter(e.getMessage()) + "</font>"));

--- a/core/src/org/labkey/core/wiki/WikiRenderingServiceImpl.java
+++ b/core/src/org/labkey/core/wiki/WikiRenderingServiceImpl.java
@@ -26,30 +26,30 @@ public class WikiRenderingServiceImpl implements WikiRenderingService
     public HtmlString getFormattedHtml(WikiRendererType rendererType,
                                        String source,
                                        @Nullable String sourceDescription,
-                                       boolean handleSubstitutions,
+                                       SubstitutionMode substitutionMode,
                                        String attachPrefix,
                                        Collection<? extends Attachment> attachments)
     {
         return HtmlStringBuilder.of(WIKI_PREFIX)
-            .append(getRenderer(rendererType, handleSubstitutions, null, attachPrefix, null, attachments, sourceDescription).format(source).getHtml())
+            .append(getRenderer(rendererType, substitutionMode, null, attachPrefix, null, attachments, sourceDescription).format(source).getHtml())
             .append(WIKI_SUFFIX).getHtmlString();
     }
 
     @Override
     public HtmlString getFormattedHtml(WikiRendererType rendererType, String source, @Nullable String sourceDescription)
     {
-        return getFormattedHtml(rendererType, source, sourceDescription, false, null, null);
+        return getFormattedHtml(rendererType, source, sourceDescription, SubstitutionMode.Ignore, null, null);
     }
 
     @Override
-    public WikiRenderer getRenderer(WikiRendererType rendererType, boolean handleSubstitutions, String hrefPrefix,
+    public WikiRenderer getRenderer(WikiRendererType rendererType, SubstitutionMode substitutionMode, String hrefPrefix,
                                     String attachPrefix, Map<String, String> nameTitleMap,
                                     Collection<? extends Attachment> attachments, String sourceDescription)
     {
         return switch (rendererType)
         {
             case RADEOX -> new RadeoxRenderer(hrefPrefix, attachPrefix, nameTitleMap, attachments, sourceDescription);
-            case HTML -> new HtmlRenderer(handleSubstitutions, hrefPrefix, attachPrefix, nameTitleMap, attachments);
+            case HTML -> new HtmlRenderer(substitutionMode, hrefPrefix, attachPrefix, nameTitleMap, attachments);
             case TEXT_WITH_LINKS -> new PlainTextRenderer();
             case MARKDOWN -> new MarkdownRenderer(hrefPrefix, attachPrefix, nameTitleMap, attachments);
         };

--- a/wiki/src/org/labkey/wiki/RenderedWikiResource.java
+++ b/wiki/src/org/labkey/wiki/RenderedWikiResource.java
@@ -46,6 +46,6 @@ public class RenderedWikiResource extends WikiWebdavProvider.WikiPageResource
     {
         WikiRenderingService service = WikiRenderingService.get();
 
-        return service.getFormattedHtml(type, body, "Wiki WebDav '" + getName() + "' in " + _c.getPath(), true, null, null);
+        return service.getFormattedHtml(type, body, "Wiki WebDav '" + getName() + "' in " + _c.getPath(), WikiRenderingService.SubstitutionMode.Substitute, null, null);
     }
 }

--- a/wiki/src/org/labkey/wiki/WikiContentCache.java
+++ b/wiki/src/org/labkey/wiki/WikiContentCache.java
@@ -18,16 +18,11 @@ package org.labkey.wiki;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.Container;
-import org.labkey.api.util.HtmlString;
 import org.labkey.api.wiki.FormattedHtml;
+import org.labkey.api.wiki.WikiRenderingService.SubstitutionMode;
 import org.labkey.wiki.model.Wiki;
 import org.labkey.wiki.model.WikiVersion;
 
-/**
- * User: adam
- * Date: Oct 8, 2010
- * Time: 7:55:26 PM
- */
 public class WikiContentCache
 {
     private static final Cache<String, FormattedHtml> CONTENT_CACHE = CacheManager.getStringKeyCache(5000, CacheManager.DAY, "Wiki Content");
@@ -35,14 +30,14 @@ public class WikiContentCache
     public static FormattedHtml getHtml(Container c, Wiki wiki, WikiVersion version, boolean cache)
     {
         if (!cache)
-            return WikiManager.get().formatWiki(c, wiki, version);
+            return WikiManager.get().formatWiki(c, wiki, version, SubstitutionMode.Substitute);
 
         String key = c.getId() + "/" + wiki.getName() + "/" + version.getVersion();
         FormattedHtml html = CONTENT_CACHE.get(key);
 
         if (null == html)
         {
-            html = WikiManager.get().formatWiki(c, wiki, version);
+            html = WikiManager.get().formatWiki(c, wiki, version, SubstitutionMode.Substitute);
 
             if (!html.isVolatile())
                 CONTENT_CACHE.put(key, html);

--- a/wiki/src/org/labkey/wiki/WikiController.java
+++ b/wiki/src/org/labkey/wiki/WikiController.java
@@ -88,6 +88,7 @@ import org.labkey.api.view.template.PageConfig.Template;
 import org.labkey.api.wiki.FormattedHtml;
 import org.labkey.api.wiki.WikiPartFactory;
 import org.labkey.api.wiki.WikiRendererType;
+import org.labkey.api.wiki.WikiRenderingService.SubstitutionMode;
 import org.labkey.wiki.DiffMatchPatch.Diff;
 import org.labkey.wiki.model.Wiki;
 import org.labkey.wiki.model.WikiEditModel;
@@ -2718,7 +2719,7 @@ public class WikiController extends SpringActionController
             for (WikiTree tree : trees)
             {
                 Wiki wiki = WikiSelectManager.getWiki(c, tree.getRowId());
-                FormattedHtml html = mgr.formatWiki(c, wiki, wiki.getLatestVersion());
+                FormattedHtml html = mgr.formatWiki(c, wiki, wiki.getLatestVersion(), SubstitutionMode.Substitute);
 
                 Set<String> attachmentNames = wiki.getAttachments()
                     .stream()

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -69,6 +69,7 @@ import org.labkey.api.wiki.WikiChangeListener;
 import org.labkey.api.wiki.WikiPartFactory;
 import org.labkey.api.wiki.WikiRenderer;
 import org.labkey.api.wiki.WikiRendererType;
+import org.labkey.api.wiki.WikiRenderingService.SubstitutionMode;
 import org.labkey.api.wiki.WikiService;
 import org.labkey.wiki.model.Wiki;
 import org.labkey.wiki.model.WikiVersion;
@@ -94,35 +95,29 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.labkey.api.action.SpringActionController.ERROR_MSG;
 
-/**
- * User: mbellew
- * Date: Mar 10, 2005
- * Time: 1:27:36 PM
- */
 public class WikiManager implements WikiService
 {
+    public static final WikiRendererType DEFAULT_WIKI_RENDERER_TYPE = WikiRendererType.HTML;
+    public static final SearchService.SearchCategory searchCategory = new SearchService.SearchCategory("wiki", "Wiki Pages");
+
     private static final Logger LOG = LogManager.getLogger(WikiManager.class);
     private static final WikiManager _instance = new WikiManager();
+    private static final List<WikiChangeListener> listeners = new CopyOnWriteArrayList<>();
 
-    public static final WikiRendererType DEFAULT_WIKI_RENDERER_TYPE = WikiRendererType.HTML;
-
-    public static WikiManager get()
-    {
-        return _instance;
-    }
-
-    public static final SearchService.SearchCategory searchCategory = new SearchService.SearchCategory("wiki", "Wiki Pages");
+    private static List<WikiPartFactory> _wikiPartFactories;
 
     /* service/schema dependencies */
     private final CommSchema comm = CommSchema.getInstance();
     private final CoreSchema core = CoreSchema.getInstance();
 
-    private static final List<WikiChangeListener> listeners = new CopyOnWriteArrayList<>();
-    private static List<WikiPartFactory> _wikiPartFactories;
-
     private WikiManager()
     {
         LOG.debug("WikiManager instantiated");
+    }
+
+    public static WikiManager get()
+    {
+        return _instance;
     }
 
     @Override
@@ -507,7 +502,7 @@ public class WikiManager implements WikiService
         WikiCache.uncache(c);
     }
 
-    public FormattedHtml formatWiki(Container c, Wiki wiki, WikiVersion wikiversion)
+    public FormattedHtml formatWiki(Container c, Wiki wiki, WikiVersion wikiversion, SubstitutionMode substitutionMode)
     {
         String hrefPrefix = wiki.getWikiURL(WikiController.PageAction.class, "").toString();
         String attachPrefix = null;
@@ -519,7 +514,7 @@ public class WikiManager implements WikiService
         Map<String, String> nameTitleMap = WikiSelectManager.getNameAndAliasTitleMap(c);
 
         //get formatter specified for this version
-        WikiRenderer w = wikiversion.getRenderer(hrefPrefix, attachPrefix, nameTitleMap, wiki.getAttachments(), "Wiki '" + wiki.getName() + "' version " + wikiversion.getVersion() + " in " + wiki.getContainerPath());
+        WikiRenderer w = wikiversion.getRenderer(substitutionMode, hrefPrefix, attachPrefix, nameTitleMap, wiki.getAttachments(), "Wiki '" + wiki.getName() + "' version " + wikiversion.getVersion() + " in " + wiki.getContainerPath());
 
         return w.format(wikiversion.getBody());
     }

--- a/wiki/src/org/labkey/wiki/WikiValidationProviderFactory.java
+++ b/wiki/src/org/labkey/wiki/WikiValidationProviderFactory.java
@@ -10,6 +10,7 @@ import org.labkey.api.util.CspUtils;
 import org.labkey.api.util.JSoupUtil;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.wiki.FormattedHtml;
+import org.labkey.api.wiki.WikiRenderingService.SubstitutionMode;
 import org.labkey.wiki.model.Wiki;
 import org.labkey.wiki.model.WikiTree;
 import org.w3c.dom.Document;
@@ -62,7 +63,7 @@ public class WikiValidationProviderFactory implements SiteValidationProviderFact
                         String title = nameTitleMap.get(wiki.getName());
                         try
                         {
-                            FormattedHtml html = mgr.formatWiki(c, wiki, wiki.getLatestVersion());
+                            FormattedHtml html = mgr.formatWiki(c, wiki, wiki.getLatestVersion(), SubstitutionMode.Remove);
                             Collection<String> errors = new LinkedList<>();
                             Document doc = JSoupUtil.convertHtmlToDocument(html.getHtml().toString(), false, errors);
                             errors.forEach(error -> addResult(list, wiki, title, "error while converting HTML to Document, \"" + error + "\""));

--- a/wiki/src/org/labkey/wiki/model/WikiVersion.java
+++ b/wiki/src/org/labkey/wiki/model/WikiVersion.java
@@ -28,6 +28,7 @@ import org.labkey.api.wiki.FormattedHtml;
 import org.labkey.api.wiki.WikiRenderer;
 import org.labkey.api.wiki.WikiRendererType;
 import org.labkey.api.wiki.WikiRenderingService;
+import org.labkey.api.wiki.WikiRenderingService.SubstitutionMode;
 import org.labkey.wiki.WikiContentCache;
 import org.labkey.wiki.WikiManager;
 
@@ -208,7 +209,8 @@ public class WikiVersion
         _rendererType = rendererType;
     }
 
-    public WikiRenderer getRenderer(String hrefPrefix,
+    public WikiRenderer getRenderer(SubstitutionMode substitutionMode,
+                                    String hrefPrefix,
                                     String attachPrefix,
                                     Map<String, String> nameTitleMap,
                                     Collection<? extends Attachment> attachments,
@@ -217,7 +219,7 @@ public class WikiVersion
         if (_rendererType == null)
             _rendererType = WikiManager.DEFAULT_WIKI_RENDERER_TYPE;
 
-        return WikiRenderingService.get().getRenderer(_rendererType, true, hrefPrefix, attachPrefix, nameTitleMap, attachments, sourceDescription);
+        return WikiRenderingService.get().getRenderer(_rendererType, substitutionMode, hrefPrefix, attachPrefix, nameTitleMap, attachments, sourceDescription);
     }
 
     // Cache the rendered wiki content by default; set to false to avoid caching


### PR DESCRIPTION
#### Rationale
[Issue 52483: HTML substitution patterns can throw errors during wiki validation](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52483)

Introduce `SubstitutionMode` enum in place of a simple boolean to provide more flexibility in terms of substitution options. Wiki validation provider now strips out any substitution patterns prior to CSP validation.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6313