### PR TITLE
Fb file constructor mitigation

### DIFF
--- a/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
@@ -29,11 +29,11 @@ import org.labkey.api.query.QueryService.NamedParameterNotProvided;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reports.ExternalScriptEngine;
-import org.labkey.api.reports.report.r.RConnectionHolder;
 import org.labkey.api.reports.Report;
-import org.labkey.api.reports.report.r.RserveScriptEngine;
 import org.labkey.api.reports.report.r.ParamReplacement;
 import org.labkey.api.reports.report.r.ParamReplacementSvc;
+import org.labkey.api.reports.report.r.RConnectionHolder;
+import org.labkey.api.reports.report.r.RserveScriptEngine;
 import org.labkey.api.reports.report.r.view.ConsoleOutput;
 import org.labkey.api.reports.report.view.ReportUtil;
 import org.labkey.api.reports.report.view.RunReportView;
@@ -53,6 +53,8 @@ import org.labkey.api.view.VBox;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.api.writer.PrintWriters;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
@@ -281,16 +283,17 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
     {
         if (null != output)
         {
-            File console = new File(getReportDir(context.getContainer().getId()), CONSOLE_OUTPUT);
+            FileLike console = getReportDirFileLike(context.getContainer().getId()).resolveChild(CONSOLE_OUTPUT);
+            File consoleFile = FileSystemLike.toFile(console);
 
-            try (PrintWriter pw = PrintWriters.getPrintWriter(console))
+            try (PrintWriter pw = PrintWriters.getPrintWriter(consoleFile))
             {
                 pw.write(output.toString());
             }
 
             ParamReplacement param = ParamReplacementSvc.get().getHandlerInstance(ConsoleOutput.ID);
             param.setName("console");
-            param.addFile(console);
+            param.addFile(consoleFile);
             outputSubst.add(param);
         }
     }
@@ -300,7 +303,8 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
      */
     protected void saveAdditionalFileOutput(List<ParamReplacement> outputSubst, @NotNull ContainerUser context)
     {
-        File reportDir = getReportDir(context.getContainer().getId());
+        FileLike reportDirFileLike = getReportDirFileLike(context.getContainer().getId());
+        File reportDir = FileSystemLike.toFile(reportDirFileLike);
         if (reportDir != null && reportDir.exists())
         {
             Set<String> boundFiles = new CaseInsensitiveHashSet();
@@ -342,7 +346,7 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
         try (TransformSession session = SecurityManager.createTransformSession(context))
         {
             Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
-            bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, getReportDir(context.getContainer().getId()).getAbsolutePath());
+            bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, getReportDirFileLike(context.getContainer().getId()).getPath());
 
             Map<String, String> paramMap = new HashMap<>();
             DataTransformService.get().addStandardParameters(null, context.getContainer(), null, session.getApiKey(), paramMap);

--- a/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ExternalScriptEngineReport.java
@@ -346,7 +346,7 @@ public class ExternalScriptEngineReport extends ScriptEngineReport implements At
         try (TransformSession session = SecurityManager.createTransformSession(context))
         {
             Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
-            bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, getReportDirFileLike(context.getContainer().getId()).getPath());
+            bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, getReportDirFileLike(context.getContainer().getId()).toNioPathForWrite().toString());
 
             Map<String, String> paramMap = new HashMap<>();
             DataTransformService.get().addStandardParameters(null, context.getContainer(), null, session.getApiKey(), paramMap);

--- a/api/src/org/labkey/api/reports/report/InternalScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/InternalScriptEngineReport.java
@@ -118,7 +118,7 @@ public class InternalScriptEngineReport extends ScriptEngineReport
                 bindings.put("viewContext", context);
                 bindings.put("consoleOut", consolePw);
 
-                bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, getReportDirFileLike(context.getContainer().getId()).getPath());
+                bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, getReportDirFileLike(context.getContainer().getId()).toNioPathForWrite().toString());
 
                 SimpleMetricsService.get().increment(ModuleLoader.getInstance().getModule(ApiModule.class).getName(), METRIC_FEATURE_AREA, "Internal-" + engine.getFactory().getEngineName());
 

--- a/api/src/org/labkey/api/reports/report/InternalScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/InternalScriptEngineReport.java
@@ -29,6 +29,8 @@ import org.labkey.api.view.VBox;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.api.writer.PrintWriters;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
@@ -116,7 +118,7 @@ public class InternalScriptEngineReport extends ScriptEngineReport
                 bindings.put("viewContext", context);
                 bindings.put("consoleOut", consolePw);
 
-                bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, getReportDir(context.getContainer().getId()).getAbsolutePath());
+                bindings.put(ExternalScriptEngine.WORKING_DIRECTORY, getReportDirFileLike(context.getContainer().getId()).getPath());
 
                 SimpleMetricsService.get().increment(ModuleLoader.getInstance().getModule(ApiModule.class).getName(), METRIC_FEATURE_AREA, "Internal-" + engine.getFactory().getEngineName());
 
@@ -127,9 +129,8 @@ public class InternalScriptEngineReport extends ScriptEngineReport
                 // render the output into the console
                 if (output != null || consoleString != null)
                 {
-                    File console = new File(getReportDir(context.getContainer().getId()), CONSOLE_OUTPUT);
-
-                    try (PrintWriter pw = PrintWriters.getPrintWriter(console))
+                    FileLike console = getReportDirFileLike(context.getContainer().getId()).resolveChild(CONSOLE_OUTPUT);
+                    try (PrintWriter pw = PrintWriters.getPrintWriter(console.toNioPathForRead()))
                     {
                         if (output != null)
                             pw.write(output.toString());
@@ -139,7 +140,7 @@ public class InternalScriptEngineReport extends ScriptEngineReport
 
                     ParamReplacement param = ParamReplacementSvc.get().getHandlerInstance(ConsoleOutput.ID);
                     param.setName("console");
-                    param.addFile(console);
+                    param.addFile(FileSystemLike.toFile(console));
 
                     outputSubst.add(param);
                 }

--- a/api/src/org/labkey/api/reports/report/ScriptEngineReport.java
+++ b/api/src/org/labkey/api/reports/report/ScriptEngineReport.java
@@ -58,11 +58,14 @@ import org.labkey.api.reports.report.r.view.TextOutput;
 import org.labkey.api.reports.report.r.view.TsvOutput;
 import org.labkey.api.thumbnail.Thumbnail;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.Path;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.VBox;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.writer.ContainerUser;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
@@ -161,7 +164,7 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
             return engine.getFactory().getLanguageName();
         }
 
-        return "Script Engine Report";        
+        return "Script Engine Report";
         //throw new RuntimeException("No Script Engine is available for this Report");
     }
 
@@ -193,8 +196,8 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
      */
     public File createInputDataFile(@NotNull ViewContext context) throws SQLException, IOException, ValidationException
     {
-        File resultFile = new File(getReportDir(context.getContainer().getId()), DATA_INPUT);
-        ResultsFactory factory = ()-> {
+        FileLike resultFile = getReportDirFileLike(context.getContainer().getId()).resolveChild(DATA_INPUT);
+        ResultsFactory factory = () -> {
             try
             {
                 return generateResults(context, true);
@@ -204,24 +207,27 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
                 throw new RuntimeException(e);
             }
         };
-        return _createInputDataFile(context, factory, resultFile);
+        return _createInputDataFile(context, factory, FileSystemLike.toFile(resultFile));
     }
 
 
     /**
-     *
      * @param executingContainerId id of the container in which the report is running
      * @return directory, which has been created, to contain the generated report
-     *
+     * <p>
      * Note: This method used to stash results in members (_tempFolder and _tempFolderPipeline), but that no longer works
      * now that we cache reports between threads (e.g., Thread.currentThread().getId() is part of the path).
+     *
+     * Consider using the variant which returns a FileLike object
      */
+    @Deprecated
     public File getReportDir(@NotNull String executingContainerId)
     {
         boolean isPipeline = BooleanUtils.toBoolean(getDescriptor().getProperty(ScriptReportDescriptor.Prop.runInBackground));
         return getReportDir(executingContainerId, isPipeline);
     }
 
+    @Deprecated
     protected File getReportDir(@NotNull String executingContainerId, boolean isPipeline)
     {
 
@@ -247,21 +253,66 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
         return tempFolder;
     }
 
+    /**
+     * @param executingContainerId id of the container in which the report is running
+     * @return directory, which has been created, to contain the generated report
+     * <p>
+     * Note: This method used to stash results in members (_tempFolder and _tempFolderPipeline), but that no longer works
+     * now that we cache reports between threads (e.g., Thread.currentThread().getId() is part of the path).
+     */
+    public FileLike getReportDirFileLike(@NotNull String executingContainerId)
+    {
+        boolean isPipeline = BooleanUtils.toBoolean(getDescriptor().getProperty(ScriptReportDescriptor.Prop.runInBackground));
+        return getReportDirFileLike(executingContainerId, isPipeline);
+    }
+
+    protected FileLike getReportDirFileLike(@NotNull String executingContainerId, boolean isPipeline)
+    {
+        FileLike tempRoot = getTempRootFileLike(getDescriptor());
+        String reportId = FileUtil.makeLegalName(String.valueOf(getDescriptor().getReportId())).replaceAll(" ", "_");
+        FileLike tempFolder;
+
+        try
+        {
+            if (isPipeline)
+            {
+                String identifier = RReportJob.getJobIdentifier();
+                if (identifier != null)
+                    tempFolder = FileUtil.appendPath(tempRoot,
+                            Path.parse(executingContainerId + File.separator + "Report_" + reportId + File.separator + identifier));
+                else
+                    tempFolder = FileUtil.appendPath(tempRoot,
+                            Path.parse(executingContainerId + File.separator + "Report_" + reportId));
+            }
+            else
+                tempFolder = FileUtil.appendPath(tempRoot,
+                        Path.parse(executingContainerId + File.separator + "Report_" + reportId + File.separator + Thread.currentThread().getId()));
+
+            FileUtil.mkdirs(tempFolder);
+            return tempFolder;
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException("Unable to create the temporary report directory", e);
+        }
+    }
+
     public void deleteReportDir(@NotNull ContainerUser context)
     {
         boolean isPipeline = BooleanUtils.toBoolean(getDescriptor().getProperty(ScriptReportDescriptor.Prop.runInBackground));
 
-        File dir = getReportDir(context.getContainer().getId());
+        FileLike dir = getReportDirFileLike(context.getContainer().getId());
 
         if (!isPipeline)
-            dir = dir.getParentFile();
+            dir = dir.getParent();
 
-        FileUtil.deleteDir(dir);
+        FileUtil.deleteDir(dir.toNioPathForWrite(), null);
     }
 
     /**
      * Invoked from a maintenance task, clean up temporary report files and folders that are of a
      * certain age.
+     *
      * @param log
      */
     public static void scheduledFileCleanup(Logger log)
@@ -290,6 +341,7 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
     /**
      * Delete any thread specific subfolders if they are older than the
      * specified cutoff, and if there are no thread subfolders, delete the parent.
+     *
      * @param dir
      * @param cutoff
      */
@@ -379,11 +431,11 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
             throw UnexpectedException.wrap(sqlx);
         }
     }
-    
+
 
     private String oldLegalName(FieldKey fkey)
     {
-        String r = AliasManager.makeLegalName(StringUtils.join(fkey.getParts(),"_"), null, false, false);
+        String r = AliasManager.makeLegalName(StringUtils.join(fkey.getParts(), "_"), null, false, false);
         return ColumnInfo.propNameFromName(r).toLowerCase();
     }
 
@@ -418,7 +470,7 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
                         }
                     }
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -429,7 +481,7 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
             public List<ScriptOutput> cleanup(ScriptEngineReport report, ContainerUser context)
             {
                 if (report.shouldCleanup())
-                    FileUtil.deleteDir(new File(report.getReportDir(context.getContainer().getId()).getAbsolutePath()));
+                    FileUtil.deleteDir(report.getReportDirFileLike(context.getContainer().getId()).toNioPathForWrite(), null);
 
                 return scriptOutputs;
             }
@@ -457,7 +509,7 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
             public HttpView<?> cleanup(ScriptEngineReport report, ContainerUser context)
             {
                 if (report.shouldCleanup())
-                    view.addView(new TempFileCleanup(report.getReportDir(context.getContainer().getId()).getAbsolutePath()));
+                    view.addView(new TempFileCleanup(report.getReportDirFileLike(context.getContainer().getId())));
 
                 return view;
             }
@@ -472,7 +524,8 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
 
     public Thumbnail getThumbnail(List<ParamReplacement> parameters) throws IOException
     {
-        return handleParameters(this, parameters, new ParameterHandler<Thumbnail>(){
+        return handleParameters(this, parameters, new ParameterHandler<Thumbnail>()
+        {
             private Thumbnail _thumbnail = null;
 
             @Override
@@ -496,7 +549,7 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
 
     private static <K> K handleParameters(ScriptEngineReport report, Collection<ParamReplacement> parameters, ParameterHandler<K> handler) throws IOException
     {
-        String sections = (String)HttpView.currentContext().get(renderParam.showSection.name());
+        String sections = (String) HttpView.currentContext().get(renderParam.showSection.name());
         List<String> sectionNames = Collections.emptyList();
 
         if (sections != null)
@@ -522,6 +575,7 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
     private interface ParameterHandler<K>
     {
         boolean handleParameter(ViewContext context, Report report, ParamReplacement param, List<String> sectionNames) throws IOException;
+
         K cleanup(ScriptEngineReport report, ContainerUser context);
     }
 
@@ -544,8 +598,10 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
     {
         return createScript(engine, context, outputSubst, inputDataTsv, inputParameters, false);
     }
+
     /**
      * Create the script to be executed by the scripting engine
+     *
      * @param outputSubst
      * @return
      * @throws Exception
@@ -565,6 +621,7 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
 
     /**
      * Takes a script source, adds a prolog, processes any input and output replacement parameters
+     *
      * @param script
      * @param inputFile
      * @param outputSubst
@@ -608,14 +665,15 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
 
     protected String processOutputReplacements(ScriptEngine engine, String script, List<ParamReplacement> replacements, @NotNull ContainerUser context, boolean isRStudio) throws Exception
     {
-        return ParamReplacementSvc.get().processParamReplacement(script, getReportDir(context.getContainer().getId()), null, replacements, isRStudio);
+        FileLike reportDir = getReportDirFileLike(context.getContainer().getId());
+        return ParamReplacementSvc.get().processParamReplacement(script, FileSystemLike.toFile(reportDir), null, replacements, isRStudio);
     }
 
 
     @Override
     public ScriptReportDescriptor getDescriptor()
     {
-        return (ScriptReportDescriptor)super.getDescriptor();
+        return (ScriptReportDescriptor) super.getDescriptor();
     }
 
 
@@ -657,17 +715,17 @@ public abstract class ScriptEngineReport extends ScriptReport implements Report.
 
     protected static class TempFileCleanup extends HttpView
     {
-        private final String _path;
+        private final FileLike _dir;
 
-        public TempFileCleanup(String path)
+        public TempFileCleanup(FileLike dir)
         {
-            _path = path;
+            _dir = dir;
         }
 
         @Override
         protected void renderInternal(Object model, PrintWriter out)
         {
-            FileUtil.deleteDir(new File(_path));
+            FileUtil.deleteDir(_dir.toNioPathForWrite(), null);
         }
     }
 }

--- a/api/src/org/labkey/api/reports/report/ScriptReport.java
+++ b/api/src/org/labkey/api/reports/report/ScriptReport.java
@@ -68,6 +68,7 @@ import org.labkey.api.view.TabStripView;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.api.writer.VirtualFile;
+import org.labkey.vfs.FileLike;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -237,7 +238,7 @@ public abstract class ScriptReport extends AbstractReport
         }
     }
 
-
+    @Deprecated
     public static File getTempRoot(ReportDescriptor descriptor)
     {
         File tempRoot;
@@ -271,12 +272,50 @@ public abstract class ScriptReport extends AbstractReport
     }
 
     @NotNull
+    @Deprecated
     public static File getDefaultTempRoot()
     {
         File tempDir = new File(System.getProperty("java.io.tmpdir"));
         return new File(tempDir, REPORT_DIR);
     }
 
+    public static FileLike getTempRootFileLike(ReportDescriptor descriptor)
+    {
+        FileLike tempRoot;
+        boolean isPipeline = BooleanUtils.toBoolean(descriptor.getProperty(ScriptReportDescriptor.Prop.runInBackground));
+
+        try
+        {
+            if (isPipeline && descriptor.getContainerId() != null)
+            {
+                Container c = ContainerManager.getForId(descriptor.getContainerId());
+                PipeRoot root = PipelineService.get().findPipelineRoot(c);
+                tempRoot = root.getRootFileLike().resolveChild(REPORT_DIR);
+
+                if (!tempRoot.exists())
+                    FileUtil.mkdirs(tempRoot);
+            }
+            else
+            {
+                tempRoot = getDefaultTempRootFileLike();
+
+                if (!tempRoot.exists())
+                    FileUtil.mkdirs(tempRoot);
+            }
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException("Error setting up temp directory", e);
+        }
+
+        return tempRoot;
+    }
+
+    @NotNull
+    public static FileLike getDefaultTempRootFileLike()
+    {
+        return FileUtil.getTempDirectoryFileLike().resolveChild(REPORT_DIR);
+    }
 
     public abstract boolean supportsPipeline();
 

--- a/api/src/org/labkey/api/reports/report/r/RReport.java
+++ b/api/src/org/labkey/api/reports/report/r/RReport.java
@@ -47,7 +47,6 @@ import org.labkey.api.rstudio.RStudioService;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.thumbnail.Thumbnail;
-import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -58,6 +57,8 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.api.writer.DefaultContainerUser;
 import org.labkey.api.writer.PrintWriters;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 import org.springframework.validation.BindException;
 
 import javax.script.Bindings;
@@ -65,7 +66,6 @@ import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -607,7 +607,8 @@ public class RReport extends ExternalScriptEngineReport
     @Override
     protected String processOutputReplacements(ScriptEngine engine, String script, List<ParamReplacement> replacements, @NotNull ContainerUser context, boolean isRStudio) throws Exception
     {
-        File reportDir = getReportDir(context.getContainer().getId());
+        FileLike reportDirFileLike = getReportDirFileLike(context.getContainer().getId());
+        File reportDir = FileSystemLike.toFile(reportDirFileLike);
         RScriptEngine rengine = (RScriptEngine)engine;
         String localPath = getLocalPath(reportDir);
         String remoteRoot = rengine.getRemotePath(localPath);
@@ -624,7 +625,7 @@ public class RReport extends ExternalScriptEngineReport
     public String createScript(ScriptEngine engine, ViewContext context, List<ParamReplacement> outputSubst, File inputDataTsv, Map<String, Object> inputParameters, boolean isRStudio) throws Exception
     {
         String script = super.createScript(engine, context, outputSubst, inputDataTsv, inputParameters, isRStudio);
-        File inputData = new File(getReportDir(context.getContainer().getId()), DATA_INPUT);
+        FileLike inputData = getReportDirFileLike(context.getContainer().getId()).resolveChild(DATA_INPUT);
 
         /*
           for each included script, the source script is processed for input/output replacements
@@ -644,17 +645,13 @@ public class RReport extends ExternalScriptEngineReport
                     final String rName = report.getDescriptor().getProperty(ReportDescriptor.Prop.reportName);
                     final String rScript = report.getDescriptor().getProperty(ScriptReportDescriptor.Prop.script);
                     final String rExtension = ((RReport) report).getScriptFileExtension();
-                    final File rScriptFile = new File(getReportDir(context.getContainer().getId()), rName + rExtension);
+                    final FileLike rScriptFile = getReportDirFileLike(context.getContainer().getId()).resolveChild(rName + rExtension);
 
-                    String includedScript = processScript(engine, context, rScript, inputData, outputSubst, inputParameters, false, isRStudio);
+                    String includedScript = processScript(engine, context, rScript, FileSystemLike.toFile(inputData), outputSubst, inputParameters, false, isRStudio);
 
-                    try (PrintWriter pw = PrintWriters.getPrintWriter(rScriptFile))
+                    try (PrintWriter pw = PrintWriters.getPrintWriter(rScriptFile.toNioPathForWrite()))
                     {
                         pw.write(includedScript);
-                    }
-                    catch(IOException e)
-                    {
-                        ExceptionUtil.logExceptionToMothership(null, e);
                     }
                 }
             }
@@ -695,6 +692,20 @@ public class RReport extends ExternalScriptEngineReport
             reportDir = super.getReportDir(executingContainerId);
 
          return reportDir;
+    }
+
+    @Override
+    public FileLike getReportDirFileLike(@NotNull String executingContainerId)
+    {
+        File reportDir = null;
+
+        if (getKnitrFormat() != RReportDescriptor.KnitrFormat.None)
+            reportDir = getCacheDir(executingContainerId);
+
+        if (reportDir != null)
+            return FileSystemLike.wrapFile(reportDir);
+
+        return super.getReportDirFileLike(executingContainerId);
     }
 
     @Override

--- a/api/src/org/labkey/api/reports/report/r/RReportJob.java
+++ b/api/src/org/labkey/api/reports/report/r/RReportJob.java
@@ -41,6 +41,8 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.view.ViewContext;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.io.Serializable;
@@ -100,8 +102,8 @@ public class RReportJob extends PipelineJob implements Serializable
         if (report != null)
         {
             _jobIdentifier.set(getJobGUID());
-            File logFile = new File(report.getReportDir(executingContainerId), LOG_FILE_NAME);
-            setLogFile(logFile);
+            FileLike logFile = report.getReportDirFileLike(executingContainerId).resolveChild(LOG_FILE_NAME);
+            setLogFile(logFile.toNioPathForWrite());
         }
     }
 
@@ -269,7 +271,8 @@ public class RReportJob extends PipelineJob implements Serializable
 
         protected File inputFile(RReport report, @NotNull ViewContext context) throws Exception
         {
-            return new File(report.getReportDir(context.getContainer().getId()), RReport.DATA_INPUT);
+            FileLike inputFile = report.getReportDirFileLike(context.getContainer().getId()).resolveChild(RReport.DATA_INPUT);
+            return FileSystemLike.toFile(inputFile);
         }
 
         protected void processOutputs(RReport report, List<ParamReplacement> outputSubst) throws Exception
@@ -277,7 +280,8 @@ public class RReportJob extends PipelineJob implements Serializable
             if (outputSubst.size() > 0)
             {
                 // write the output substitution map to disk so we can render the view later
-                File reportDir = report.getReportDir(getJob().getContainerId());
+                FileLike reportDirFileLike = report.getReportDirFileLike(getJob().getContainerId());
+                File reportDir = FileSystemLike.toFile(reportDirFileLike);
                 File substitutionMap;
 
                 if (reportDir.getName().equals(getJobIdentifier()))

--- a/api/src/org/labkey/api/reports/report/r/view/KnitrOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/KnitrOutput.java
@@ -25,6 +25,8 @@ import org.labkey.api.thumbnail.Thumbnail;
 import org.labkey.api.util.ImageUtil;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -105,7 +107,8 @@ public class KnitrOutput extends HtmlOutput
             if (null != htmlIn)
             {
                 // replace all ${hrefout:<filename>} with the appropriate url
-                File reportDir = _report.getReportDir(this.getViewContext().getContainer().getId());
+                FileLike reportDirFileLike = _report.getReportDirFileLike(this.getViewContext().getContainer().getId());
+                File reportDir = FileSystemLike.toFile(reportDirFileLike);
                 String htmlOut = ParamReplacementSvc.get().processHrefParamReplacement(_report, htmlIn, reportDir);
                 htmlOut = ParamReplacementSvc.get().processRelativeHrefReplacement(
                         _report,

--- a/api/src/org/labkey/api/reports/report/view/RenderBackgroundRReportView.java
+++ b/api/src/org/labkey/api/reports/report/view/RenderBackgroundRReportView.java
@@ -22,6 +22,8 @@ import org.labkey.api.reports.report.r.ParamReplacementSvc;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.VBox;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -48,12 +50,12 @@ public class RenderBackgroundRReportView extends HttpView
             VBox view = new VBox();
             view.addView(new JspView<>("/org/labkey/api/reports/report/view/ajaxReportRenderBackground.jsp", _report));
 
-            File substitutionMap = new File(_report.getReportDir(this.getViewContext().getContainer().getId()), RReport.SUBSTITUTION_MAP);
+            FileLike substitutionMap = _report.getReportDirFileLike(this.getViewContext().getContainer().getId()).resolveChild(RReport.SUBSTITUTION_MAP);
 
             // if the job is complete, show the results of the job
             if (substitutionMap.exists())
             {
-                Collection<ParamReplacement> outputSubst = ParamReplacementSvc.get().fromFile(substitutionMap);
+                Collection<ParamReplacement> outputSubst = ParamReplacementSvc.get().fromFile(FileSystemLike.toFile(substitutionMap));
                 VBox innerView = new VBox();
                 view.addView(innerView);
                 RReport.renderViews(_report, view, outputSubst, false);

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -160,6 +160,8 @@ import org.labkey.api.view.WebPartView;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.query.DataViewsWebPartFactory;
 import org.labkey.query.persist.QueryManager;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 import org.springframework.beans.PropertyValue;
 import org.springframework.beans.PropertyValues;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -953,8 +955,8 @@ public class ReportsController extends SpringActionController
         public ApiResponse execute(ScriptReportBean bean, BindException errors) throws Exception
         {
             ScriptReport report = bean.getReport(getViewContext());
-            File logFile = new File(((RReport)report).getReportDir(this.getViewContext().getContainer().getId()), RReportJob.LOG_FILE_NAME);
-            PipelineStatusFile statusFile = PipelineService.get().getStatusFile(logFile);
+            FileLike logFile = ((RReport)report).getReportDirFileLike(this.getViewContext().getContainer().getId()).resolveChild(RReportJob.LOG_FILE_NAME);
+            PipelineStatusFile statusFile = PipelineService.get().getStatusFile(FileSystemLike.toFile(logFile));
 
             VBox vbox = new VBox();
 


### PR DESCRIPTION
#### Rationale
Removes the `File` constructor usage from the `ReportsController.GetBackgroundReportResultsAction` endpoint. 

Added a little more extensive refactor to `ScriptEngineReport.getReportDir` to create a variant that returns a `FileLike` object and convert most (but not all) prior usages to use the new version.