### PR TITLE
Pass something other than 'null' in the template name when not provided

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2196,7 +2196,7 @@ public class QueryController extends SpringActionController
                     .setIncludeColumns(form.getIncludeColumns())
                     .setExcludeColumns(form.getExcludeColumns())
                     .setRenamedColumns(form.getRenameColumnMap())
-                    .setPrefix(form.getFilenamePrefix() + "_Template") // Issue 48028: Change template file names
+                    .setPrefix((StringUtils.isEmpty(form.getFilenamePrefix()) ? "Import" : form.getFilenamePrefix()) + "_Template") // Issue 48028: Change template file names
             );
         }
     }


### PR DESCRIPTION
This is something I noticed a while ago. I assume it was a change related to issue 48028, but I dont think I can view that issue. I had intellij open when I noticed it again, so here's a potential fix. 

At some point in the past, the default behavior changed around generating excel templates. LabKey has been generating files with the name "null_Template_XXXX-XX-XX.xlsx'. This happens when the caller does not provide fileNamePrefix to ExportExcelAction. That's great; however, the default codepath to generate a table's template URL doesnt do this either (see QueryController.urlCreateExcelTemplate, ~line 565). One of these two should set a reasonable default for the excel file name.

This PR changes ExportExcelAction to use "Import" as the default term for the excel file when none is provided. I dont really care what term we use, but 'null' isnt a great choice.