### PR TITLE
Remove obsolete file root upgrade path

### DIFF
--- a/api/src/org/labkey/api/admin/AdminUrls.java
+++ b/api/src/org/labkey/api/admin/AdminUrls.java
@@ -61,7 +61,7 @@ public interface AdminUrls extends UrlProvider
     ActionURL getCreateFolderURL(Container c, @Nullable ActionURL returnUrl);
     ActionURL getMemTrackerURL();
     ActionURL getCustomizeEmailURL(Container c, Class<? extends EmailTemplate> selectedTemplate, URLHelper returnUrl);
-    ActionURL getFilesSiteSettingsURL(boolean upgrade);
+    ActionURL getFilesSiteSettingsURL();
     ActionURL getSessionLoggingURL();
     ActionURL getTrackedAllocationsViewerURL();
     ActionURL getSystemMaintenanceURL();

--- a/core/src/org/labkey/core/admin/AbstractFileSiteSettingsAction.java
+++ b/core/src/org/labkey/core/admin/AbstractFileSiteSettingsAction.java
@@ -16,26 +16,14 @@
 package org.labkey.core.admin;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.labkey.api.action.FormViewAction;
 import org.labkey.api.action.SpringActionController;
-import org.labkey.api.attachments.Attachment;
-import org.labkey.api.attachments.AttachmentDirectory;
-import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.provider.SiteSettingsAuditProvider;
-import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.CoreSchema;
-import org.labkey.api.data.SqlExecutor;
-import org.labkey.api.data.TableInfo;
-import org.labkey.api.exp.api.ExpData;
-import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.premium.PremiumService;
 import org.labkey.api.security.User;
-import org.labkey.api.security.UserManager;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.RandomStartupProperties;
 import org.labkey.api.settings.WriteableAppProps;
@@ -47,10 +35,6 @@ import org.springframework.validation.Errors;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.labkey.api.files.FileContentService.UPLOADED_FILE;
 
 /**
  * User: jeckels
@@ -58,7 +42,6 @@ import static org.labkey.api.files.FileContentService.UPLOADED_FILE;
  */
 public abstract class AbstractFileSiteSettingsAction<FormType extends FileSettingsForm> extends FormViewAction<FormType>
 {
-    private static Logger _log = LogManager.getLogger(FilesSiteSettingsAction.class);
     protected FileContentService _svc = FileContentService.get();
 
     public AbstractFileSiteSettingsAction(Class<FormType> commandClass)
@@ -74,13 +57,14 @@ public abstract class AbstractFileSiteSettingsAction<FormType extends FileSettin
         {
             File f = new File(webRoot);
 
-            try {
+            try
+            {
                 boolean isNewRoot = isNewRoot(_svc.getSiteDefaultRoot(), f);
                 if (!NetworkDrive.exists(f) || !f.isDirectory())
                 {
                     errors.reject(SpringActionController.ERROR_MSG, "File root '" + webRoot + "' does not appear to be a valid directory accessible to the server at " + getViewContext().getRequest().getServerName() + ".");
                 }
-                else if (isNewRoot && !form.isUpgrade())
+                else if (isNewRoot)
                 {
                     // if this is a new root, make sure it is empty
                     String[] children = f.list();
@@ -120,11 +104,7 @@ public abstract class AbstractFileSiteSettingsAction<FormType extends FileSettin
             _svc.setSiteDefaultRoot(FileUtil.getAbsoluteCaseSensitiveFile(new File(form.getRootPath())), getUser());
         _svc.setWebfilesEnabled(form.isWebfilesEnabled(), getUser());
 
-        if (form.isUpgrade())
-        {
-            upgradeExistingFileSets();
-        }
-        else if (isNewRoot(prev, _svc.getSiteDefaultRoot()))
+        if (isNewRoot(prev, _svc.getSiteDefaultRoot()))
         {
             _svc.moveFileRoot(prev, _svc.getSiteDefaultRoot(), getUser(), getContainer());
         }
@@ -172,169 +152,4 @@ public abstract class AbstractFileSiteSettingsAction<FormType extends FileSettin
             props.save(user);
         }
     }
-
-    private void upgradeExistingFileSets()
-    {
-        _log.info("Upgrading existing file roots to @files");
-
-        Map<String, Container> fileSets = new HashMap<>();
-        findExistingFileSets(ContainerManager.getRoot(), fileSets);
-
-        for (Map.Entry<String, Container> entry : fileSets.entrySet())
-        {
-            File dir = new File(entry.getKey());
-            if (dir.exists() && dir.isDirectory())
-            {
-                if (dir.getParent() != null && !dir.getParent().equals(_svc.getFolderName(FileContentService.ContentType.files)))
-                {
-                    File dest = new File(dir, _svc.getFolderName(FileContentService.ContentType.files));
-
-                    try {
-                        for (File child : dir.listFiles())
-                        {
-                            // don't move server managed folders
-                            if (allowCopy(child, entry.getValue()))
-                            {
-                                _log.info("moving " + child.getPath() + " to " + dest.getPath());
-
-                                // attempt a rename, if that fails try the more expensive file by file copy
-                                File newChild = new File(dest, child.getName());
-                                if (!child.renameTo(newChild))
-                                {
-                                    if (!dest.exists())
-                                        FileUtil.mkdirs(dest);
-
-                                    FileUtil.copyBranch(child, dest);
-                                    if (child.isDirectory())
-                                        FileUtil.deleteDir(child);
-                                    else
-                                        child.delete();
-                                }
-                            }
-                        }
-                    }
-                    catch (IOException e)
-                    {
-                        _log.error("error occurred upgrading existing file roots", e);
-                    }
-                }
-            }
-
-            // after the files have been moved, transfer metadata from the old attachment documents into the
-            // exp data table and delete the old attachment records
-            Container c = entry.getValue();
-            try
-            {
-                if (!_svc.isUseDefaultRoot(c))
-                {
-                    // prior to 10.1 there were no default roots, everything was an override
-                    AttachmentDirectory root = _svc.getMappedAttachmentDirectory(c, false);
-
-                    if (root != null)
-                    {
-                        for (Attachment a : AttachmentService.get().getAttachments(root))
-                        {
-                            File file = a.getFile();
-                            if (file != null && file.exists() && a.getCreatedBy() != 0)
-                            {
-                                User user = UserManager.getUser(a.getCreatedBy());
-                                ExpData data = ExperimentService.get().getExpDataByURL(file, c);
-
-                                if ((user != null && !user.isGuest()) && data == null)
-                                {
-                                    data = ExperimentService.get().createData(c, UPLOADED_FILE);
-                                    data.setDataFileURI(file.toURI());
-                                    data.setName(file.getName());
-                                    data.save(user);
-                                }
-                            }
-                        }
-                        // remove the old attachments
-                        TableInfo tInfo = CoreSchema.getInstance().getTableInfoDocuments();
-                        new SqlExecutor(tInfo.getSchema()).execute("DELETE FROM " + tInfo + " WHERE Parent = ?", root.getEntityId());
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                _log.error("error occurred migrating file content metadata to WebDav", e);
-            }
-        }
-    }
-
-    private boolean allowCopy(File child, Container c)
-    {
-        String name = child.getName();
-
-        if (_svc.getFolderName(FileContentService.ContentType.files).equals(name))
-            return false;
-
-        if (child.isDirectory() && !child.getName().equals(".deleted"))
-            return false;
-/*
-        // don't copy server managed folders
-        if (child.isDirectory() && c.hasChild(name))
-        {
-            return false;
-        }
-*/
-        return true;
-    }
-
-    private void findExistingFileSets(Container c, Map<String, Container> fileSets)
-    {
-        if (c == null) return;
-
-        try {
-            AttachmentDirectory root = _svc.getMappedAttachmentDirectory(c, false);
-            if (root != null)
-            {
-                addTo(root.getFileSystemDirectory(), c, fileSets);
-            }
-
-/*
-            for (AttachmentDirectory fileSet : getRegisteredDirectories(c))
-            {
-                addTo(fileSet.getFileSystemDirectory(), c, fileSets);
-            }
-
-            PipeRoot pipeRoot = PipelineService.get().findPipelineRoot(c);
-            if (pipeRoot != null)
-            {
-                addTo(pipeRoot.getRootPath(), c, fileSets);
-            }
-*/
-
-            for (Container child : c.getChildren())
-                findExistingFileSets(child, fileSets);
-        }
-        catch (Exception e)
-        {
-            _log.error("error occurred upgrading existing file sets", e);
-        }
-    }
-
-    private void addTo(File dir, Container c, Map<String, Container> fileSets)
-    {
-        try {
-            if (dir.exists())
-            {
-                if (_svc.getFolderName(FileContentService.ContentType.files).equals(dir.getName()))
-                {
-                    dir = dir.getParentFile();
-                    if (dir == null || !dir.exists())
-                        return;
-                }
-                String path = dir.getCanonicalPath();
-
-                if (!fileSets.containsKey(path))
-                    fileSets.put(path, c);
-            }
-        }
-        catch (IOException e)
-        {
-            _log.error("error occurred getting existing filesets", e);
-        }
-    }
-
 }

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -843,14 +843,9 @@ public class AdminController extends SpringActionController
         }
 
         @Override
-        public ActionURL getFilesSiteSettingsURL(boolean upgrade)
+        public ActionURL getFilesSiteSettingsURL()
         {
-            ActionURL url = new ActionURL(FilesSiteSettingsAction.class, ContainerManager.getRoot());
-
-            if (upgrade)
-                url.addParameter("upgrade", true);
-
-            return url;
+            return new ActionURL(FilesSiteSettingsAction.class, ContainerManager.getRoot());
         }
 
         @Override

--- a/core/src/org/labkey/core/admin/FileSettingsForm.java
+++ b/core/src/org/labkey/core/admin/FileSettingsForm.java
@@ -18,7 +18,6 @@ package org.labkey.core.admin;
 public class FileSettingsForm
 {
     private String _rootPath;
-    private boolean _upgrade;
     private boolean _webfilesEnabled;
     private boolean _fileUploadDisabled;
     private boolean _invalidUploadBlocked;
@@ -32,16 +31,6 @@ public class FileSettingsForm
     public void setRootPath(String rootPath)
     {
         _rootPath = rootPath;
-    }
-
-    public boolean isUpgrade()
-    {
-        return _upgrade;
-    }
-
-    public void setUpgrade(boolean upgrade)
-    {
-        _upgrade = upgrade;
     }
 
     public boolean isWebfilesEnabled()

--- a/core/src/org/labkey/core/admin/FilesSiteSettingsAction.java
+++ b/core/src/org/labkey/core/admin/FilesSiteSettingsAction.java
@@ -54,9 +54,6 @@ public class FilesSiteSettingsAction extends AbstractFileSiteSettingsAction<File
     @Override
     public ModelAndView getView(FileSettingsForm form, boolean reshow, BindException errors) throws Exception
     {
-        if (form.isUpgrade())
-            getPageConfig().setTemplate(PageConfig.Template.Dialog);
-
         if (!reshow)
         {
             File root = _svc.getSiteDefaultRoot();
@@ -76,10 +73,7 @@ public class FilesSiteSettingsAction extends AbstractFileSiteSettingsAction<File
     @Override
     public ActionURL getSuccessURL(FileSettingsForm form)
     {
-        if (form.isUpgrade())
-            return PageFlowUtil.urlProvider(AdminUrls.class).getCustomizeSiteURL(true);
-        else
-            return PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL();
+        return PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL();
     }
 
     @Override
@@ -97,8 +91,6 @@ public class FilesSiteSettingsAction extends AbstractFileSiteSettingsAction<File
             User user = TestContext.get().getUser();
             assertTrue(user.hasSiteAdminPermission());
 
-            // @AdminConsoleAction
-            // @RequiresPermission(AdminOperationsPermission.class)
             assertForAdminOperationsPermission(ContainerManager.getRoot(), user,
                 new FilesSiteSettingsAction()
             );

--- a/core/src/org/labkey/core/admin/UpdateFilePathsAction.java
+++ b/core/src/org/labkey/core/admin/UpdateFilePathsAction.java
@@ -138,13 +138,13 @@ public class UpdateFilePathsAction extends FormViewAction<UpdateFilePathsAction.
     public void addNavTrail(NavTree root)
     {
         root.addChild("Admin Console", PageFlowUtil.urlProvider(AdminUrls.class).getAdminConsoleURL());
-        root.addChild("Files", PageFlowUtil.urlProvider(AdminUrls.class).getFilesSiteSettingsURL(false));
+        root.addChild("Files", PageFlowUtil.urlProvider(AdminUrls.class).getFilesSiteSettingsURL());
         root.addChild("Update File Paths");
     }
 
     @Override
     public URLHelper getSuccessURL(UpdateFilePathsForm updateFilePathsForm)
     {
-        return PageFlowUtil.urlProvider(AdminUrls.class).getFilesSiteSettingsURL(false);
+        return PageFlowUtil.urlProvider(AdminUrls.class).getFilesSiteSettingsURL();
     }
 }

--- a/core/src/org/labkey/core/admin/view/filesSiteSettings.jsp
+++ b/core/src/org/labkey/core/admin/view/filesSiteSettings.jsp
@@ -44,24 +44,12 @@
 
 <labkey:errors/>
 <labkey:form action="<%=urlFor(FilesSiteSettingsAction.class)%>" method="post">
-    <input type="hidden" name="upgrade" value="<%=bean.isUpgrade()%>">
     <table class="lk-fields-table" style="width: 80%">
         <tr><td colspan="2"><h4>Site-Level File Root</h4></td></tr>
         <tr><td colspan="2" class="labkey-title-area-line"></td></tr>
-
-        <% if (bean.isUpgrade()) { %>
-        <tr><td colspan="2">Set the site-level root for this server installation, or use the default provided. If the
-            location does not exist, LabKey Server will create it for you.<br/><br/>
-            When a site-level file root is set, each folder for every project has a corresponding subdirectory in the file system.
-            LabKey Server allows you to upload and process your data files, including assay and
-            study-related files. By default, LabKey Server stores your files in a standard directory structure. You can
-            override this location for each project if you wish.
-            </td></tr>
-        <% } else { %>
         <tr><td colspan="2">When a site-level file root is set, each folder for every project has a corresponding subdirectory in the file system.
             If the root is changed, all files will be automatically moved to the new location. If files have been moved through other means, it is also
             possible to <a href="<%= h(new ActionURL(UpdateFilePathsAction.class, getContainer())) %>">update paths stored in the database</a>.</td></tr>
-        <% } %>
         <tr><td>&nbsp;</td></tr>
 
         <%
@@ -76,14 +64,6 @@
             <td><input type="text" name="rootPath" size="64" value="<%=h(bean.getRootPath())%>"></td>
         </tr>
         <tr>
-        <%
-            if (bean.isUpgrade()) {
-        %>
-            <tr><td>&nbsp;</td></tr>
-            <td><%= button("Next").submit(true) %></td>
-        <%
-            } else {
-        %>
             <tr><td colspan="2"><h4>Alternative Webfiles Root</h4></td></tr>
             <tr><td colspan="2" class="labkey-title-area-line"></td></tr>
             <tr><td colspan="2">Site level setting to enable/disable alternative webdav tree: _webfiles.</td></tr>
@@ -117,12 +97,7 @@
         <td><%= button("Save").submit(true) %>&nbsp;
                     <%= button("Cancel").href(urlProvider(AdminUrls.class).getAdminConsoleURL()) %>
                 </td>
-        <%
-            }
-        %>
         </tr>
-
-
     </table>
 </labkey:form>
 
@@ -137,155 +112,152 @@
 %>
 
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
-    var isUpgrade = <%=bean.isUpgrade()%>;
-
     Ext4.onReady(function(){
 
         // show the file root browser
-        if (!isUpgrade)
-        {
-            Ext4.QuickTips.init();
+        Ext4.QuickTips.init();
 
-            var store = Ext4.create('Ext.data.TreeStore', {
-                fields: ['name', 'path', 'default', 'browseURL', 'configureURL'],
-                proxy: {
-                    type: 'ajax',
-                    extraParams: {excludeNotInFolderNav: true},
-                    url: LABKEY.ActionURL.buildURL("filecontent", "fileContentSummary", this.container)
-                },
-                folderSort: true,
-                autoLoad: true
-            });
-
-            var tree = Ext4.create('Ext.tree.Panel', {
-                useArrows: true,
-                rootVisible: false,
-                store: store,
-                multiSelect: false,
-                singleExpand: false,
-
-                autoScroll:true,
-                columns:[{
-                    xtype: 'treecolumn',
-                    header:'Project',
-                    width:330,
-                    dataIndex:'name',
-                },{
-                    header:'Directory',
-                    width:420,
-                    dataIndex:'path',
-                    renderer: 'htmlEncode'
-                },{
-                    header:'Default',
-                    width:75,
-                    dataIndex:'default'
-                }],
-                tbar: [{
-                    text:'Expand All',
-                    tooltip: {text:'Expands all containers', title:'Expand All'},
-                    handler: function(button, event) {button.up('treepanel').expandAll();}
-                },{
-                    text:'Collapse All',
-                    tooltip: {text:'Collapses all containers', title:'Collapse All'},
-                    handler: function(button, event) {button.up('treepanel').collapseAll();}
-                },{
-                    text: 'Show Overridden Only',
-                    tooltip: {text: 'Will show only nodes that have custom file or pipeline roots', title: 'Show Overridden Only'},
-                    showOverridesOnly: false,
-                    handler: function(button){
-                        var tree = button.up('treepanel');
-                        var showOverridesOnly = !button.showOverridesOnly;
-
-                        if (showOverridesOnly){
-                            button.setText('Show All');
-                            button.setTooltip({
-                                text: 'Will show all containers, including those that use a default file root',
-                                title: 'Show All'
-                            });
-                        }
-                        else {
-                            button.setText('Show Overridden Only');
-                            button.setTooltip({
-                                text: 'Will show only nodes that have custom file or pipeline roots',
-                                title: 'Show Overridden Only'
-                            });
-                        }
-                        button.showOverridesOnly = showOverridesOnly;
-
-                        tree.store.proxy.extraParams.showOverridesOnly = showOverridesOnly;
-                        tree.store.load();
-                    }
-                },{
-                    text:'Configure Selected',
-                    tooltip: {text:'Configure settings for the selected root', title:'Configure Selected'},
-                    listeners:{
-                        click:function(button, event) {
-                            var selected = tree.getSelectionModel().getSelection();
-                            if (selected.length){
-                                var node = selected[0];
-                                if (node.get('configureURL')){
-                                    window.location = node.get('configureURL');
-                                }
-                            }
-                            else {
-                                Ext4.Msg.alert('Error', 'No nodes selected');
-                            }
-                        },
-                        scope:this
-                    }
-                },{
-                    text:'Browse Selected',
-                    tooltip: {text:'Browse files from the selected root', title:'Browse Selected'},
-                    listeners:{
-                        click:function(button, event) {
-                            var tree = button.up('treepanel');
-                            var selected = tree.getSelectionModel().getSelection();
-                            if (selected.length){
-                                tree.browseSelected(selected[0]);
-                            }
-                            else {
-                                Ext4.Msg.alert('Error', 'No nodes selected');
-                            }
-                        }
-                    }
-                }],
-                listeners: {
-                    itemdblclick: function(panel, node, item){
-                        this.browseSelected(node);
-                    }
-                },
-                browseSelected: function(node){
-                    if (node.get('browseURL')){
-                        window.location = node.get('browseURL');
-                    }
-                }
+        var store = Ext4.create('Ext.data.TreeStore', {
+            fields: ['name', 'path', 'default', 'browseURL', 'configureURL'],
+            proxy: {
+                type: 'ajax',
+                extraParams: { excludeNotInFolderNav: true },
+                url: LABKEY.ActionURL.buildURL("filecontent", "fileContentSummary", this.container)
+            },
+            folderSort: true,
+            autoLoad: true
         });
 
-            var panel = Ext4.create('Ext.panel.Panel', {
-                layout: 'fit',
-                renderTo: 'viewsGrid',
-                items: [tree],
-                height: 500
-            });
-        }
+        var tree = Ext4.create('Ext.tree.Panel', {
+            useArrows: true,
+            rootVisible: false,
+            store: store,
+            multiSelect: false,
+            singleExpand: false,
+
+            autoScroll: true,
+            columns: [{
+                xtype: 'treecolumn',
+                header: 'Project',
+                width: 330,
+                dataIndex: 'name',
+            }, {
+                header: 'Directory',
+                width: 420,
+                dataIndex: 'path',
+                renderer: 'htmlEncode'
+            }, {
+                header: 'Default',
+                width: 75,
+                dataIndex: 'default'
+            }],
+            tbar: [{
+                text: 'Expand All',
+                tooltip: { text: 'Expands all containers', title: 'Expand All' },
+                handler: function (button, event) {
+                    button.up('treepanel').expandAll();
+                }
+            }, {
+                text: 'Collapse All',
+                tooltip: { text: 'Collapses all containers', title: 'Collapse All' },
+                handler: function (button, event) {
+                    button.up('treepanel').collapseAll();
+                }
+            }, {
+                text: 'Show Overridden Only',
+                tooltip: {
+                    text: 'Will show only nodes that have custom file or pipeline roots',
+                    title: 'Show Overridden Only'
+                },
+                showOverridesOnly: false,
+                handler: function (button) {
+                    var tree = button.up('treepanel');
+                    var showOverridesOnly = !button.showOverridesOnly;
+
+                    if (showOverridesOnly) {
+                        button.setText('Show All');
+                        button.setTooltip({
+                            text: 'Will show all containers, including those that use a default file root',
+                            title: 'Show All'
+                        });
+                    } else {
+                        button.setText('Show Overridden Only');
+                        button.setTooltip({
+                            text: 'Will show only nodes that have custom file or pipeline roots',
+                            title: 'Show Overridden Only'
+                        });
+                    }
+                    button.showOverridesOnly = showOverridesOnly;
+
+                    tree.store.proxy.extraParams.showOverridesOnly = showOverridesOnly;
+                    tree.store.load();
+                }
+            }, {
+                text: 'Configure Selected',
+                tooltip: { text: 'Configure settings for the selected root', title: 'Configure Selected' },
+                listeners: {
+                    click: function (button, event) {
+                        var selected = tree.getSelectionModel().getSelection();
+                        if (selected.length) {
+                            var node = selected[0];
+                            if (node.get('configureURL')) {
+                                window.location = node.get('configureURL');
+                            }
+                        } else {
+                            Ext4.Msg.alert('Error', 'No nodes selected');
+                        }
+                    },
+                    scope: this
+                }
+            }, {
+                text: 'Browse Selected',
+                tooltip: { text: 'Browse files from the selected root', title: 'Browse Selected' },
+                listeners: {
+                    click: function (button, event) {
+                        var tree = button.up('treepanel');
+                        var selected = tree.getSelectionModel().getSelection();
+                        if (selected.length) {
+                            tree.browseSelected(selected[0]);
+                        } else {
+                            Ext4.Msg.alert('Error', 'No nodes selected');
+                        }
+                    }
+                }
+            }],
+            listeners: {
+                itemdblclick: function (panel, node, item) {
+                    this.browseSelected(node);
+                }
+            },
+            browseSelected: function (node) {
+                if (node.get('browseURL')) {
+                    window.location = node.get('browseURL');
+                }
+            }
+        });
+
+        Ext4.create('Ext.panel.Panel', {
+            layout: 'fit',
+            renderTo: 'viewsGrid',
+            items: [tree],
+            height: 500
+        });
     });
 </script>
 
-<% if (!bean.isUpgrade()) { %>
-    <table width="80%">
-        <tr><td colspan="2"><h4>Summary View for File Directories</h4></td></tr>
-        <tr><td colspan="2" class="labkey-title-area-line"></td></tr>
-        <tr><td>File directories, named file sets and pipeline directories can be viewed on a project/folder basis. The 'Default' column for @files
-            indicates whether the directory is derived from the site-level file root (set above) or has been overridden. The 'Default' column for @pipeline
-            indicates whether the directory is the same as the @files directory or has been overridden. To view or
-            manage files in a directory, double click on a row or click on the 'Browse Selected' button. To configure an
-            @file or an @pipeline directory, select the directory and click on the 'Configure Selected' button in the toolbar.
-        </td></tr>
-        <tr><td>For a complete list of all file paths referenced in the LabKey database, please use the <a href="<%=h(new ActionURL(FileListAction.class, ContainerManager.getRoot()))%>">Files List</a>.
-        </td></tr>
-        <tr><td>&nbsp;</td></tr>
-        <tr><td><div id="viewsGrid" class="extContainer"></div></td></tr>
-    </table>
-<% } %>
+<table width="80%">
+    <tr><td colspan="2"><h4>Summary View for File Directories</h4></td></tr>
+    <tr><td colspan="2" class="labkey-title-area-line"></td></tr>
+    <tr><td>File directories, named file sets and pipeline directories can be viewed on a project/folder basis. The 'Default' column for @files
+        indicates whether the directory is derived from the site-level file root (set above) or has been overridden. The 'Default' column for @pipeline
+        indicates whether the directory is the same as the @files directory or has been overridden. To view or
+        manage files in a directory, double click on a row or click on the 'Browse Selected' button. To configure an
+        @file or an @pipeline directory, select the directory and click on the 'Configure Selected' button in the toolbar.
+    </td></tr>
+    <tr><td>For a complete list of all file paths referenced in the LabKey database, please use the <a href="<%=h(new ActionURL(FileListAction.class, ContainerManager.getRoot()))%>">Files List</a>.
+    </td></tr>
+    <tr><td>&nbsp;</td></tr>
+    <tr><td><div id="viewsGrid" class="extContainer"></div></td></tr>
+</table>
 
 

--- a/core/src/org/labkey/core/admin/view/updateFilePaths.jsp
+++ b/core/src/org/labkey/core/admin/view/updateFilePaths.jsp
@@ -75,7 +75,7 @@
         </tr>
         <tr>
             <td></td>
-            <td><labkey:button text="Submit" /> <labkey:button text="Cancel" href="<%= PageFlowUtil.urlProvider(AdminUrls.class).getFilesSiteSettingsURL(false) %>" /></td>
+            <td><labkey:button text="Submit" /> <labkey:button text="Cancel" href="<%= PageFlowUtil.urlProvider(AdminUrls.class).getFilesSiteSettingsURL() %>" /></td>
         </tr>
     </table>
 

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -1674,7 +1674,7 @@ public class FileContentServiceImpl implements FileContentService, WarningProvid
     {
         if (_problematicFileRootMessage != null && context != null && ContainerManager.getRoot().hasPermission(context.getUser(), AdminOperationsPermission.class))
         {
-            warnings.add(DOM.createHtmlFragment(_problematicFileRootMessage, " ", DOM.A(at(href, PageFlowUtil.urlProvider(AdminUrls.class).getFilesSiteSettingsURL(false)), "Configure File System Access")));
+            warnings.add(DOM.createHtmlFragment(_problematicFileRootMessage, " ", DOM.A(at(href, PageFlowUtil.urlProvider(AdminUrls.class).getFilesSiteSettingsURL()), "Configure File System Access")));
         }
         else if (showAllWarnings)
         {


### PR DESCRIPTION
#### Rationale
I encountered this when I was working on the `File` constructor conversions. I think this code was created to handle the pivot to the `@files` namespace for servers with existing file sets and can safely be removed now. I wasn't able to find anywhere in the code where we hit that action with the upgrade parameter set, but see if you agree with my conclusion.

![image](https://github.com/user-attachments/assets/b1fc1adf-e9f4-47da-bb89-39f809339cab)
