### PR TITLE
Delete actions fail due to the IndexWriter closing

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExperimentListener.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentListener.java
@@ -16,7 +16,6 @@
 package org.labkey.api.exp.api;
 
 import org.labkey.api.data.Container;
-import org.labkey.api.data.DbScope.CommitTaskOption;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.security.User;
 
@@ -24,14 +23,8 @@ import java.util.List;
 
 public interface ExperimentListener
 {
-    /** Called after an experiment is deleted */
+    /** Called after an experiment is deleted (in-transaction). */
     default void afterExperimentDeleted(Container c, User user, ExpExperiment experiment) { }
-
-    /** Allows the listener to determine when the action should be executed relative to the transaction */
-    default CommitTaskOption afterExperimentDeleteCommitOption()
-    {
-        return CommitTaskOption.IMMEDIATE;
-    }
 
     /** Called after an experiment is saved (post-transaction). */
     default void afterExperimentSaved(Container c, User user, ExpExperiment experiment) { }
@@ -41,14 +34,8 @@ public interface ExperimentListener
 
     default void beforeProtocolsDeleted(Container c, User user, List<? extends ExpProtocol> protocols) { }
 
-    /** Called after an experiment run is deleted. */
+    /** Called after an experiment run is deleted (in-transaction). */
     default void afterRunDelete(ExpProtocol protocol, ExpRun run, User user) { }
-
-    /** Allows the listener to determine when the action should be executed relative to the transaction */
-    default CommitTaskOption afterRunDeleteCommitOption()
-    {
-        return CommitTaskOption.IMMEDIATE;
-    }
 
     /** Called after an experiment run is saved (post-transaction). */
     default void afterRunSaved(Container container, User user, ExpProtocol protocol, ExpRun run) { }

--- a/api/src/org/labkey/api/exp/api/ExperimentListener.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentListener.java
@@ -16,6 +16,7 @@
 package org.labkey.api.exp.api;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.data.DbScope.CommitTaskOption;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.security.User;
 
@@ -23,8 +24,14 @@ import java.util.List;
 
 public interface ExperimentListener
 {
-    /** Called after an experiment is deleted (in-transaction). */
+    /** Called after an experiment is deleted */
     default void afterExperimentDeleted(Container c, User user, ExpExperiment experiment) { }
+
+    /** Allows the listener to determine when the action should be executed relative to the transaction */
+    default CommitTaskOption afterExperimentDeleteCommitOption()
+    {
+        return CommitTaskOption.IMMEDIATE;
+    }
 
     /** Called after an experiment is saved (post-transaction). */
     default void afterExperimentSaved(Container c, User user, ExpExperiment experiment) { }
@@ -34,8 +41,14 @@ public interface ExperimentListener
 
     default void beforeProtocolsDeleted(Container c, User user, List<? extends ExpProtocol> protocols) { }
 
-    /** Called after an experiment run is deleted (in-transaction). */
+    /** Called after an experiment run is deleted. */
     default void afterRunDelete(ExpProtocol protocol, ExpRun run, User user) { }
+
+    /** Allows the listener to determine when the action should be executed relative to the transaction */
+    default CommitTaskOption afterRunDeleteCommitOption()
+    {
+        return CommitTaskOption.IMMEDIATE;
+    }
 
     /** Called after an experiment run is saved (post-transaction). */
     default void afterRunSaved(Container container, User user, ExpProtocol protocol, ExpRun run) { }

--- a/assay/src/org/labkey/assay/AssayExperimentListener.java
+++ b/assay/src/org/labkey/assay/AssayExperimentListener.java
@@ -1,6 +1,7 @@
 package org.labkey.assay;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.data.DbScope.CommitTaskOption;
 import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
@@ -18,6 +19,12 @@ public class AssayExperimentListener implements ExperimentListener
     }
 
     @Override
+    public CommitTaskOption afterExperimentDeleteCommitOption()
+    {
+        return CommitTaskOption.POSTCOMMIT;
+    }
+
+    @Override
     public void afterExperimentSaved(Container c, User user, ExpExperiment experiment)
     {
         AssayManager.get().indexAssayBatch(experiment.getRowId());
@@ -27,6 +34,12 @@ public class AssayExperimentListener implements ExperimentListener
     public void afterRunDelete(ExpProtocol protocol, ExpRun run, User user)
     {
         AssayManager.get().deindexAssayRuns(List.of(run));
+    }
+
+    @Override
+    public CommitTaskOption afterRunDeleteCommitOption()
+    {
+        return CommitTaskOption.POSTCOMMIT;
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayExperimentListener.java
+++ b/assay/src/org/labkey/assay/AssayExperimentListener.java
@@ -1,6 +1,7 @@
 package org.labkey.assay;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DbScope.CommitTaskOption;
 import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -16,7 +17,7 @@ public class AssayExperimentListener implements ExperimentListener
     @Override
     public void afterExperimentDeleted(Container c, User user, ExpExperiment experiment)
     {
-        ExperimentService.get().getSchema().getScope().getCurrentTransaction().addCommitTask(() ->
+        DbScope.getLabKeyScope().addCommitTask(() ->
             AssayManager.get().deindexAssayBatches(List.of(experiment)),
             CommitTaskOption.POSTCOMMIT
         );
@@ -31,7 +32,7 @@ public class AssayExperimentListener implements ExperimentListener
     @Override
     public void afterRunDelete(ExpProtocol protocol, ExpRun run, User user)
     {
-        ExperimentService.get().getSchema().getScope().getCurrentTransaction().addCommitTask(() ->
+        DbScope.getLabKeyScope().addCommitTask(() ->
             AssayManager.get().deindexAssayRuns(List.of(run)),
             CommitTaskOption.POSTCOMMIT
         );

--- a/assay/src/org/labkey/assay/AssayExperimentListener.java
+++ b/assay/src/org/labkey/assay/AssayExperimentListener.java
@@ -6,6 +6,7 @@ import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentListener;
+import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.security.User;
 
 import java.util.List;
@@ -15,13 +16,10 @@ public class AssayExperimentListener implements ExperimentListener
     @Override
     public void afterExperimentDeleted(Container c, User user, ExpExperiment experiment)
     {
-        AssayManager.get().deindexAssayBatches(List.of(experiment));
-    }
-
-    @Override
-    public CommitTaskOption afterExperimentDeleteCommitOption()
-    {
-        return CommitTaskOption.POSTCOMMIT;
+        ExperimentService.get().getSchema().getScope().getCurrentTransaction().addCommitTask(() ->
+            AssayManager.get().deindexAssayBatches(List.of(experiment)),
+            CommitTaskOption.POSTCOMMIT
+        );
     }
 
     @Override
@@ -33,13 +31,10 @@ public class AssayExperimentListener implements ExperimentListener
     @Override
     public void afterRunDelete(ExpProtocol protocol, ExpRun run, User user)
     {
-        AssayManager.get().deindexAssayRuns(List.of(run));
-    }
-
-    @Override
-    public CommitTaskOption afterRunDeleteCommitOption()
-    {
-        return CommitTaskOption.POSTCOMMIT;
+        ExperimentService.get().getSchema().getScope().getCurrentTransaction().addCommitTask(() ->
+            AssayManager.get().deindexAssayRuns(List.of(run)),
+            CommitTaskOption.POSTCOMMIT
+        );
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -3713,52 +3713,44 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     private void deleteRun(ExpRunImpl run, List<ExpDataImpl> datasToDelete, User user, String userComment)
     {
-        try (DbScope.Transaction transaction = ensureTransaction())
+        for (ExperimentListener listener : _listeners)
         {
-            for (ExperimentListener listener : _listeners)
-            {
-                listener.beforeRunDelete(run.getProtocol(), run, user);
-            }
+            listener.beforeRunDelete(run.getProtocol(), run, user);
+        }
 
-            // Note: At the moment, FlowRun is the only example of an ExpRun attachment parent, but we're keeping this general
-            // so other cases can be added in the future
-            AttachmentService.get().deleteAttachments(new ExpRunAttachmentParent(run));
+        // Note: At the moment, FlowRun is the only example of an ExpRun attachment parent, but we're keeping this general
+        // so other cases can be added in the future
+        AttachmentService.get().deleteAttachments(new ExpRunAttachmentParent(run));
 
-            // remove edges prior to deleting protocol applications
-            // Calling deleteProtocolApplications calls ExperimentService.beforeDeleteData() which
-            // eventually calls AbstractAssayTsvDataHandler.beforeDeleteData() to clean up any assay results
-            // as well as the exp.object for the assay result rows.  The assay result rows will have an
-            // output exp.edge created by the provenance module.
-            removeEdgesForRun(run.getRowId());
+        // remove edges prior to deleting protocol applications
+        // Calling deleteProtocolApplications calls ExperimentService.beforeDeleteData() which
+        // eventually calls AbstractAssayTsvDataHandler.beforeDeleteData() to clean up any assay results
+        // as well as the exp.object for the assay result rows.  The assay result rows will have an
+        // output exp.edge created by the provenance module.
+        removeEdgesForRun(run.getRowId());
 
-            run.deleteProtocolApplications(datasToDelete, user);
+        run.deleteProtocolApplications(datasToDelete, user);
 
-            SQLFragment sql = new SQLFragment("DELETE FROM exp.RunList WHERE ExperimentRunId = ?").add(run.getRowId()).appendEOS();
-            sql.append("\nUPDATE exp.ExperimentRun SET ReplacedByRunId = NULL WHERE ReplacedByRunId = ?").add(run.getRowId()).appendEOS();
-            sql.append("\nDELETE FROM ").append(getTinfoEdge()).append(" WHERE runId = ?").add(run.getRowId()).appendEOS();
-            sql.append("\nDELETE FROM exp.ExperimentRun WHERE RowId = ?").add(run.getRowId()).appendEOS();
+        SQLFragment sql = new SQLFragment("DELETE FROM exp.RunList WHERE ExperimentRunId = ?").add(run.getRowId()).appendEOS();
+        sql.append("\nUPDATE exp.ExperimentRun SET ReplacedByRunId = NULL WHERE ReplacedByRunId = ?").add(run.getRowId()).appendEOS();
+        sql.append("\nDELETE FROM ").append(getTinfoEdge()).append(" WHERE runId = ?").add(run.getRowId()).appendEOS();
+        sql.append("\nDELETE FROM exp.ExperimentRun WHERE RowId = ?").add(run.getRowId()).appendEOS();
 
-            new SqlExecutor(getExpSchema()).execute(sql);
+        new SqlExecutor(getExpSchema()).execute(sql);
 
-            // delete run properties and all children
-            OntologyManager.deleteOntologyObject(run.getLSID(), run.getContainer(), true);
+        // delete run properties and all children
+        OntologyManager.deleteOntologyObject(run.getLSID(), run.getContainer(), true);
 
-            final ExpProtocolImpl protocol = run.getProtocol();
-            if (protocol == null)
-            {
-                throw new IllegalStateException("Could not resolve protocol for run LSID " + run.getLSID() + " with protocol LSID " + run.getDataObject().getProtocolLSID());
-            }
-            auditRunEvent(user, protocol, run, null, "Run deleted", userComment);
+        ExpProtocolImpl protocol = run.getProtocol();
+        if (protocol == null)
+        {
+            throw new IllegalStateException("Could not resolve protocol for run LSID " + run.getLSID() + " with protocol LSID " + run.getDataObject().getProtocolLSID() );
+        }
+        auditRunEvent(user, protocol, run, null, "Run deleted", userComment);
 
-            for (ExperimentListener listener : _listeners)
-            {
-                transaction.addCommitTask(() ->
-                    listener.afterRunDelete(protocol, run, user),
-                    listener.afterRunDeleteCommitOption()
-                );
-            }
-
-            transaction.commit();
+        for (ExperimentListener listener : _listeners)
+        {
+            listener.afterRunDelete(protocol, run, user);
         }
     }
 
@@ -5397,7 +5389,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                     documentIds.add(data.getDocumentId());
                 }
 
-                transaction.addCommitTask(() -> ss.deleteResources(documentIds),POSTCOMMIT);
+                transaction.addCommitTask(() -> ss.deleteResources(documentIds), POSTCOMMIT);
             }
 
             transaction.commit();
@@ -5461,10 +5453,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
             for (ExperimentListener listener : _listeners)
             {
-                t.addCommitTask(() ->
-                    listener.afterExperimentDeleted(c, user, experiment),
-                    listener.afterExperimentDeleteCommitOption()
-                );
+                listener.afterExperimentDeleted(c, user, experiment);
             }
 
             t.commit();

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -3713,44 +3713,52 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     private void deleteRun(ExpRunImpl run, List<ExpDataImpl> datasToDelete, User user, String userComment)
     {
-        for (ExperimentListener listener : _listeners)
+        try (DbScope.Transaction transaction = ensureTransaction())
         {
-            listener.beforeRunDelete(run.getProtocol(), run, user);
-        }
+            for (ExperimentListener listener : _listeners)
+            {
+                listener.beforeRunDelete(run.getProtocol(), run, user);
+            }
 
-        // Note: At the moment, FlowRun is the only example of an ExpRun attachment parent, but we're keeping this general
-        // so other cases can be added in the future
-        AttachmentService.get().deleteAttachments(new ExpRunAttachmentParent(run));
+            // Note: At the moment, FlowRun is the only example of an ExpRun attachment parent, but we're keeping this general
+            // so other cases can be added in the future
+            AttachmentService.get().deleteAttachments(new ExpRunAttachmentParent(run));
 
-        // remove edges prior to deleting protocol applications
-        // Calling deleteProtocolApplications calls ExperimentService.beforeDeleteData() which
-        // eventually calls AbstractAssayTsvDataHandler.beforeDeleteData() to clean up any assay results
-        // as well as the exp.object for the assay result rows.  The assay result rows will have an
-        // output exp.edge created by the provenance module.
-        removeEdgesForRun(run.getRowId());
+            // remove edges prior to deleting protocol applications
+            // Calling deleteProtocolApplications calls ExperimentService.beforeDeleteData() which
+            // eventually calls AbstractAssayTsvDataHandler.beforeDeleteData() to clean up any assay results
+            // as well as the exp.object for the assay result rows.  The assay result rows will have an
+            // output exp.edge created by the provenance module.
+            removeEdgesForRun(run.getRowId());
 
-        run.deleteProtocolApplications(datasToDelete, user);
+            run.deleteProtocolApplications(datasToDelete, user);
 
-        SQLFragment sql = new SQLFragment("DELETE FROM exp.RunList WHERE ExperimentRunId = ?").add(run.getRowId()).appendEOS();
-        sql.append("\nUPDATE exp.ExperimentRun SET ReplacedByRunId = NULL WHERE ReplacedByRunId = ?").add(run.getRowId()).appendEOS();
-        sql.append("\nDELETE FROM ").append(getTinfoEdge()).append(" WHERE runId = ?").add(run.getRowId()).appendEOS();
-        sql.append("\nDELETE FROM exp.ExperimentRun WHERE RowId = ?").add(run.getRowId()).appendEOS();
+            SQLFragment sql = new SQLFragment("DELETE FROM exp.RunList WHERE ExperimentRunId = ?").add(run.getRowId()).appendEOS();
+            sql.append("\nUPDATE exp.ExperimentRun SET ReplacedByRunId = NULL WHERE ReplacedByRunId = ?").add(run.getRowId()).appendEOS();
+            sql.append("\nDELETE FROM ").append(getTinfoEdge()).append(" WHERE runId = ?").add(run.getRowId()).appendEOS();
+            sql.append("\nDELETE FROM exp.ExperimentRun WHERE RowId = ?").add(run.getRowId()).appendEOS();
 
-        new SqlExecutor(getExpSchema()).execute(sql);
+            new SqlExecutor(getExpSchema()).execute(sql);
 
-        // delete run properties and all children
-        OntologyManager.deleteOntologyObject(run.getLSID(), run.getContainer(), true);
+            // delete run properties and all children
+            OntologyManager.deleteOntologyObject(run.getLSID(), run.getContainer(), true);
 
-        ExpProtocolImpl protocol = run.getProtocol();
-        if (protocol == null)
-        {
-            throw new IllegalStateException("Could not resolve protocol for run LSID " + run.getLSID() + " with protocol LSID " + run.getDataObject().getProtocolLSID() );
-        }
-        auditRunEvent(user, protocol, run, null, "Run deleted", userComment);
+            final ExpProtocolImpl protocol = run.getProtocol();
+            if (protocol == null)
+            {
+                throw new IllegalStateException("Could not resolve protocol for run LSID " + run.getLSID() + " with protocol LSID " + run.getDataObject().getProtocolLSID());
+            }
+            auditRunEvent(user, protocol, run, null, "Run deleted", userComment);
 
-        for (ExperimentListener listener : _listeners)
-        {
-            listener.afterRunDelete(run.getProtocol(), run, user);
+            for (ExperimentListener listener : _listeners)
+            {
+                transaction.addCommitTask(() ->
+                    listener.afterRunDelete(protocol, run, user),
+                    listener.afterRunDeleteCommitOption()
+                );
+            }
+
+            transaction.commit();
         }
     }
 
@@ -5388,7 +5396,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 {
                     documentIds.add(data.getDocumentId());
                 }
-                ss.deleteResources(documentIds);
+
+                transaction.addCommitTask(() -> ss.deleteResources(documentIds),POSTCOMMIT);
             }
 
             transaction.commit();
@@ -5452,7 +5461,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
             for (ExperimentListener listener : _listeners)
             {
-                listener.afterExperimentDeleted(c, user, experiment);
+                t.addCommitTask(() ->
+                    listener.afterExperimentDeleted(c, user, experiment),
+                    listener.afterExperimentDeleteCommitOption()
+                );
             }
 
             t.commit();

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -69,11 +69,12 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public class SearchModule extends DefaultModule
 {
     private static final Logger LOG = LogHelper.getLogger(SearchModule.class, "Search module startup issues");
+    public static final String NAME = "Search";
 
     @Override
     public String getName()
     {
-        return "Search";
+        return NAME;
     }
 
     @Override

--- a/search/src/org/labkey/search/model/WritableIndexManagerImpl.java
+++ b/search/src/org/labkey/search/model/WritableIndexManagerImpl.java
@@ -33,8 +33,10 @@ import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.labkey.api.search.SearchService;
+import org.labkey.api.usageMetrics.SimpleMetricsService;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.ExceptionUtil;
+import org.labkey.search.SearchModule;
 import org.quartz.DateBuilder;
 import org.quartz.Job;
 import org.quartz.JobBuilder;
@@ -194,7 +196,10 @@ class WritableIndexManagerImpl extends IndexManager implements WritableIndexMana
                 throw new ConfigurationException("Unable to write to search index, Disk is full", e);
             }
             else
-                throw e;  //TODO Should we just ignore this --  it is typically caused by either the server shutting down or the index being deleted.
+            {
+                _log.error("Indexing error deleting {} indexer is already closed", StringUtils.trimToEmpty(currentId), e);
+                SimpleMetricsService.get().increment(SearchModule.NAME,"Delete", "IndexAlreadyClosed");
+            }
         }
         catch (Throwable e)
         {

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -2560,7 +2560,7 @@ public class StudyManager
         try (Transaction transaction = StudySchema.getInstance().getScope().ensureTransaction())
         {
             if (!ds.canDeleteDefinition(user))
-                throw new IllegalStateException("Can't delete dataset: " + ds.getName());
+                throw new UnauthorizedException("Can't delete dataset: " + ds.getName());
 
             // When the dataset is deleted, the provenance rows should be cleaned up
             ProvenanceService pvs = ProvenanceService.get();

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -2557,75 +2557,81 @@ public class StudyManager
      */
     public void deleteDataset(StudyImpl study, User user, DatasetDefinition ds, boolean performStudyResync)
     {
-        assert StudySchema.getInstance().getSchema().getScope().isTransactionActive();
+        try (Transaction transaction = StudySchema.getInstance().getScope().ensureTransaction())
+        {
+            if (!ds.canDeleteDefinition(user))
+                throw new IllegalStateException("Can't delete dataset: " + ds.getName());
 
-        if (!ds.canDeleteDefinition(user))
-            throw new IllegalStateException("Can't delete dataset: " + ds.getName());
+            // When the dataset is deleted, the provenance rows should be cleaned up
+            ProvenanceService pvs = ProvenanceService.get();
 
-        // When the dataset is deleted, the provenance rows should be cleaned up
-        ProvenanceService pvs = ProvenanceService.get();
+            Collection<String> allDatasetLsids = pvs.getDatasetProvenanceLsids(user, ds);
 
-        Collection<String> allDatasetLsids = pvs.getDatasetProvenanceLsids(user, ds);
+            allDatasetLsids.forEach(lsid -> {
+                Set<Integer> protocolApplications = pvs.getProtocolApplications(lsid);
 
-        allDatasetLsids.forEach(lsid -> {
-            Set<Integer> protocolApplications = pvs.getProtocolApplications(lsid);
+                OntologyObject expObject = OntologyManager.getOntologyObject(null, lsid);
+                if (null != expObject)
+                {
+                    pvs.deleteObjectProvenance(expObject.getObjectId());
+                }
 
-            OntologyObject expObject = OntologyManager.getOntologyObject(null, lsid);
-            if (null != expObject)
+                if (!protocolApplications.isEmpty())
+                {
+                    ExperimentService expService = ExperimentService.get();
+                    protocolApplications.forEach(protocolApp -> {
+                        ExpRun run = expService.getExpProtocolApplication(protocolApp).getRun();
+                        expService.deleteExperimentRunsByRowIds(study.getContainer(), user, run.getRowId());
+                    });
+                }
+            });
+
+
+            deleteDatasetType(study, user, ds);
+            try
             {
-                pvs.deleteObjectProvenance(expObject.getObjectId());
+                QuerySnapshotDefinition def = QueryService.get().getSnapshotDef(study.getContainer(), StudySchema.getInstance().getSchemaName(), ds.getName());
+                if (def != null)
+                    def.delete(user);
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+            new SqlExecutor(StudySchema.getInstance().getSchema()).execute("DELETE FROM " + SCHEMA.getTableInfoVisitMap() + "\n" +
+                    "WHERE Container=? AND DatasetId=?", study.getContainer(), ds.getDatasetId());
+
+            // UNDONE: This is broken
+            // _datasetHelper.delete(ds);
+            new SqlExecutor(StudySchema.getInstance().getSchema()).execute("DELETE FROM " + StudySchema.getInstance().getTableInfoDataset() + "\n" +
+                    "WHERE Container=? AND DatasetId=?", study.getContainer(), ds.getDatasetId());
+            _datasetHelper.clearCache(study.getContainer());
+
+            SecurityPolicyManager.deletePolicy(ds);
+
+            if (safeIntegersEqual(ds.getDatasetId(), study.getParticipantCohortDatasetId()))
+                CohortManager.getInstance().setManualCohortAssignment(study, user, Collections.emptyMap());
+
+            if (performStudyResync)
+            {
+                // This dataset may have contained the only references to some subjects or visits; as a result, we need
+                // to re-sync the participant and participant/visit tables.  (Issue 12447)
+                // Don't provide the deleted dataset in the list of modified datasets; deletion doesn't count as a modification
+                // within VisitManager, and passing in the empty set ensures that all subject/visit info will be recalculated.
+                getVisitManager(study).updateParticipantVisits(user, Collections.emptySet());
             }
 
-            if (!protocolApplications.isEmpty())
-            {
-                ExperimentService expService = ExperimentService.get();
-                protocolApplications.forEach(protocolApp -> {
-                    ExpRun run = expService.getExpProtocolApplication(protocolApp).getRun();
-                    expService.deleteExperimentRunsByRowIds(study.getContainer(), user, run.getRowId());
-                });
-            }
-        });
+            SchemaKey schemaPath = SchemaKey.fromParts(SCHEMA.getSchemaName());
+            QueryService.get().fireQueryDeleted(user, study.getContainer(), null, schemaPath, Collections.singleton(ds.getName()));
+            new DatasetDefinition.DatasetAuditHandler(ds).addAuditEvent(user, study.getContainer(), AuditBehaviorType.DETAILED, "Dataset deleted: " + ds.getName(), null);
 
+            transaction.addCommitTask(() ->
+                unindexDataset(ds),
+                CommitTaskOption.POSTCOMMIT
+            );
 
-        deleteDatasetType(study, user, ds);
-        try
-        {
-            QuerySnapshotDefinition def = QueryService.get().getSnapshotDef(study.getContainer(), StudySchema.getInstance().getSchemaName(), ds.getName());
-            if (def != null)
-                def.delete(user);
+            transaction.commit();
         }
-        catch (Exception e)
-        {
-            throw new RuntimeException(e);
-        }
-        new SqlExecutor(StudySchema.getInstance().getSchema()).execute("DELETE FROM " + SCHEMA.getTableInfoVisitMap() + "\n" +
-                "WHERE Container=? AND DatasetId=?", study.getContainer(), ds.getDatasetId());
-
-        // UNDONE: This is broken
-        // _datasetHelper.delete(ds);
-        new SqlExecutor(StudySchema.getInstance().getSchema()).execute("DELETE FROM " + StudySchema.getInstance().getTableInfoDataset() + "\n" +
-                "WHERE Container=? AND DatasetId=?", study.getContainer(), ds.getDatasetId());
-        _datasetHelper.clearCache(study.getContainer());
-
-        SecurityPolicyManager.deletePolicy(ds);
-
-        if (safeIntegersEqual(ds.getDatasetId(), study.getParticipantCohortDatasetId()))
-            CohortManager.getInstance().setManualCohortAssignment(study, user, Collections.emptyMap());
-
-        if (performStudyResync)
-        {
-            // This dataset may have contained the only references to some subjects or visits; as a result, we need
-            // to re-sync the participant and participant/visit tables.  (Issue 12447)
-            // Don't provide the deleted dataset in the list of modified datasets; deletion doesn't count as a modification
-            // within VisitManager, and passing in the empty set ensures that all subject/visit info will be recalculated.
-            getVisitManager(study).updateParticipantVisits(user, Collections.emptySet());
-        }
-
-        SchemaKey schemaPath = SchemaKey.fromParts(SCHEMA.getSchemaName());
-        QueryService.get().fireQueryDeleted(user, study.getContainer(), null, schemaPath, Collections.singleton(ds.getName()));
-        new DatasetDefinition.DatasetAuditHandler(ds).addAuditEvent(user, study.getContainer(), AuditBehaviorType.DETAILED, "Dataset deleted: " + ds.getName(),null);
-
-        unindexDataset(ds);
     }
 
     /** delete a dataset type and data


### PR DESCRIPTION
#### Rationale
[Secure Issue 51952](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=51952): Delete actions fail to the indexWriter closing

#### Related PRs
- https://github.com/LabKey/platform/pull/6442 -- Initial CR and comments

#### Changes
- Move delete event listeners to Commit task
- Adjust AlreadyClosedException handling
