### PR TITLE
More File constructor conversions

### DIFF
--- a/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
+++ b/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
@@ -827,13 +827,13 @@ public class TsvDataExchangeHandler implements DataExchangeHandler
     }
 
     @Nullable
-    public static File getWorkingDirectory(ProtocolIdForm form, User u)
+    public static FileLike getWorkingDirectory(ProtocolIdForm form, User u)
     {
         Pair<Container, File> containerFilePair = workingDirectories.get(form.getUploadAttemptID());
         if (containerFilePair != null
                 && containerFilePair.first.hasPermission("TsvDataExchangeHandler.getWorkingDirectory()", u, ReadPermission.class))
         {
-            return containerFilePair.second;
+            return new FileSystemLike.Builder(containerFilePair.second).tempDir().root();
         }
         return null;
     }

--- a/api/src/org/labkey/api/study/actions/TransformResultsAction.java
+++ b/api/src/org/labkey/api/study/actions/TransformResultsAction.java
@@ -15,19 +15,18 @@
  */
 package org.labkey.api.study.actions;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.labkey.api.assay.actions.BaseAssayAction;
 import org.labkey.api.assay.actions.ProtocolIdForm;
 import org.labkey.api.qc.TsvDataExchangeHandler;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.InsertPermission;
-import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URIUtil;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
-
-import jakarta.servlet.http.HttpServletResponse;
-import java.io.File;
 
 /**
  * Created by Marty on 11/16/2015.
@@ -39,14 +38,15 @@ public class TransformResultsAction extends BaseAssayAction<TransformResultsActi
     @Override
     public ModelAndView getView(TransformResultsForm form, BindException errors) throws Exception
     {
-        File transformDir = TsvDataExchangeHandler.getWorkingDirectory(form, getUser());
+        FileLike transformDir = TsvDataExchangeHandler.getWorkingDirectory(form, getUser());
         if (null != transformDir)
         {
-            File downloadFile = new File(transformDir, form.getName());
-            if(URIUtil.isDescendant(FileUtil.resolveFile(new File(transformDir.getParent())).toURI(), FileUtil.resolveFile(downloadFile).toURI()))
+            FileLike downloadFile = transformDir.resolveChild(form.getName());
+            // isn't this always true?
+            if(URIUtil.isDescendant(transformDir.toURI(), downloadFile.toURI()))
             {
                 HttpServletResponse response = getViewContext().getResponse();
-                PageFlowUtil.streamFile(response, downloadFile, true);
+                PageFlowUtil.streamFile(response, FileSystemLike.toFile(downloadFile), true);
             }
         }
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -17,6 +17,10 @@
 package org.labkey.experiment.controllers.exp;
 
 import au.com.bytecode.opencsv.CSVWriter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -59,8 +63,29 @@ import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.data.ActionButton;
+import org.labkey.api.data.BaseColumnInfo;
+import org.labkey.api.data.ButtonBar;
+import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.*;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.DataRegion;
+import org.labkey.api.data.DataRegionSelection;
+import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.ExcelWriter;
+import org.labkey.api.data.MenuButton;
+import org.labkey.api.data.NameGenerator;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.ShowRows;
+import org.labkey.api.data.SimpleDisplayColumn;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.TSVWriter;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.exp.AbstractParameter;
 import org.labkey.api.exp.DeleteForm;
@@ -78,7 +103,28 @@ import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.ProtocolApplicationParameter;
 import org.labkey.api.exp.XarContext;
-import org.labkey.api.exp.api.*;
+import org.labkey.api.exp.api.DataClassDomainKindProperties;
+import org.labkey.api.exp.api.ExpData;
+import org.labkey.api.exp.api.ExpDataClass;
+import org.labkey.api.exp.api.ExpExperiment;
+import org.labkey.api.exp.api.ExpLineageOptions;
+import org.labkey.api.exp.api.ExpMaterial;
+import org.labkey.api.exp.api.ExpMaterialRunInput;
+import org.labkey.api.exp.api.ExpObject;
+import org.labkey.api.exp.api.ExpProtocol;
+import org.labkey.api.exp.api.ExpProtocolApplication;
+import org.labkey.api.exp.api.ExpRun;
+import org.labkey.api.exp.api.ExpRunAttachmentParent;
+import org.labkey.api.exp.api.ExpRunEditor;
+import org.labkey.api.exp.api.ExpRunItem;
+import org.labkey.api.exp.api.ExpSampleType;
+import org.labkey.api.exp.api.ExperimentJSONConverter;
+import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.api.ExperimentUrls;
+import org.labkey.api.exp.api.NameExpressionOptionService;
+import org.labkey.api.exp.api.ResolveLsidsForm;
+import org.labkey.api.exp.api.SampleTypeDomainKind;
+import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.list.ListService;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainKind;
@@ -196,7 +242,29 @@ import org.labkey.api.view.ViewServlet;
 import org.labkey.api.view.WebPartView;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.view.template.PageConfig;
-import org.labkey.experiment.*;
+import org.labkey.experiment.ChooseExperimentTypeBean;
+import org.labkey.experiment.ConfirmDeleteView;
+import org.labkey.experiment.CustomPropertiesView;
+import org.labkey.experiment.DataClassWebPart;
+import org.labkey.experiment.DerivedSamplePropertyHelper;
+import org.labkey.experiment.DotGraph;
+import org.labkey.experiment.ExpDataFileListener;
+import org.labkey.experiment.ExperimentRunDisplayColumn;
+import org.labkey.experiment.ExperimentRunGraph;
+import org.labkey.experiment.LineageGraphDisplayColumn;
+import org.labkey.experiment.MissingFilesCheckInfo;
+import org.labkey.experiment.MoveRunsBean;
+import org.labkey.experiment.ParentChildView;
+import org.labkey.experiment.ProtocolApplicationDisplayColumn;
+import org.labkey.experiment.ProtocolDisplayColumn;
+import org.labkey.experiment.ProtocolWebPart;
+import org.labkey.experiment.RunGroupWebPart;
+import org.labkey.experiment.SampleTypeDisplayColumn;
+import org.labkey.experiment.SampleTypeWebPart;
+import org.labkey.experiment.StandardAndCustomPropertiesView;
+import org.labkey.experiment.XarExportPipelineJob;
+import org.labkey.experiment.XarExportType;
+import org.labkey.experiment.XarExporter;
 import org.labkey.experiment.api.ClosureQueryHelper;
 import org.labkey.experiment.api.DataClass;
 import org.labkey.experiment.api.DataClassDomainKind;
@@ -220,6 +288,7 @@ import org.labkey.experiment.lineage.ExpLineageServiceImpl;
 import org.labkey.experiment.pipeline.ExperimentPipelineJob;
 import org.labkey.experiment.types.TypesController;
 import org.labkey.experiment.xar.XarExportSelection;
+import org.labkey.vfs.FileLike;
 import org.springframework.beans.PropertyValue;
 import org.springframework.beans.PropertyValues;
 import org.springframework.validation.BindException;
@@ -230,10 +299,6 @@ import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.imageio.ImageIO;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.BufferedOutputStream;
@@ -6530,8 +6595,8 @@ public class ExperimentController extends SpringActionController
                     // TODO: Configure module resources with the appropriate log location per container
                     if (form.getModule() != null)
                     {
-                        File logFile = new File(form.getPipeRoot(getContainer()).getRootPath(), "module-resource-xar.log");
-                        job.setLogFile(logFile.toPath());
+                        FileLike logFile = form.getPipeRoot(getContainer()).getLogDirectoryFileLike(true).resolveChild("module-resource-xar.log");
+                        job.setLogFile(logFile.toNioPathForWrite());
                     }
 
                     PipelineService.get().queueJob(job);
@@ -6570,8 +6635,8 @@ public class ExperimentController extends SpringActionController
                 // TODO: Configure module resources with the appropriate log location per container
                 if (form.getModule() != null)
                 {
-                    File logFile = new File(form.getPipeRoot(getContainer()).getLogDirectory(), "module-resource-xar.log");
-                    job.setLogFile(logFile);
+                    FileLike logFile = form.getPipeRoot(getContainer()).getLogDirectoryFileLike(true).resolveChild("module-resource-xar.log");
+                    job.setLogFile(logFile.toNioPathForWrite());
                 }
 
                 PipelineService.get().queueJob(job);

--- a/specimen/src/org/labkey/specimen/pipeline/SpecimenReloadTask.java
+++ b/specimen/src/org/labkey/specimen/pipeline/SpecimenReloadTask.java
@@ -27,6 +27,8 @@ import org.labkey.api.study.SpecimenService;
 import org.labkey.api.study.SpecimenTransform;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.File;
 import java.util.Collections;
@@ -56,8 +58,8 @@ public class SpecimenReloadTask extends PipelineJob.Task<SpecimenReloadTask.Fact
             PipeRoot root = PipelineService.get().findPipelineRoot(job.getContainer());
             if (root != null)
             {
-                File archive = new File(root.getRootPath(), FileUtil.makeFileNameWithTimestamp("specimen_reload", transform.getFileType().getDefaultSuffix()));
-
+                FileLike archiveFileLike = root.getRootFileLike().resolveChild(FileUtil.makeFileNameWithTimestamp("specimen_reload", transform.getFileType().getDefaultSuffix()));
+                File archive = FileSystemLike.toFile(archiveFileLike);
                 transform.importFromExternalSource(job, support.getExternalImportConfig(), archive);
 
                 support.setSpecimenArchive(archive);


### PR DESCRIPTION
#### Rationale
Convert a handful of controller actions to use `FileLike` instead of `File(String, String)`.