### PR TITLE
Destination folder does not exist on MOVE for collections

### DIFF
--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -3835,7 +3835,7 @@ public class DavController extends SpringActionController
             WebdavResource dest = resolvePath(destinationPath);
             if (null == dest || dest.getPath().equals(src.getPath()))
                 throw new DavException(WebdavStatus.SC_FORBIDDEN);
-            checkAllowedFileName(dest.getName(), !dest.isCollection());
+            checkAllowedFileName(dest.getName(), !src.isCollection());
 
             boolean overwrite = getOverwriteParameter(false);
             boolean exists = dest.exists();


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=52552

The [change](https://github.com/LabKey/platform/pull/6043) to reject file extensions broke `webdav MOVE` operations for collections because the destination won't exist.
