### PR TITLE
Clean up after DisplayColumn refactor

### DIFF
--- a/api/src/org/labkey/api/data/AbstractExcelDisplayColumn.java
+++ b/api/src/org/labkey/api/data/AbstractExcelDisplayColumn.java
@@ -1,0 +1,136 @@
+package org.labkey.api.data;
+
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.view.ActionURL;
+import org.labkey.api.writer.HtmlWriter;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public abstract class AbstractExcelDisplayColumn extends DisplayColumn
+{
+    private final Class<?> _valueClass;
+
+    public AbstractExcelDisplayColumn(String name, String caption, Class<?> valueClass)
+    {
+        setName(name);
+        setCaption(caption);
+        _valueClass = valueClass;
+    }
+
+    @Override
+    public Class<?> getValueClass()
+    {
+        return _valueClass;
+    }
+
+    //NOTE: Methods below are unimplemented, just abstract in base class
+
+    @Override
+    public void renderGridCellContents(RenderContext ctx, HtmlWriter out)
+    {
+        throw new UnsupportedOperationException("This is for excel only.");
+    }
+
+    @Override
+    public void renderGridCellContents(RenderContext ctx, Writer oldWriter, HtmlWriter out)
+    {
+        throw new UnsupportedOperationException("This is for excel only.");
+    }
+
+    @Override
+    public void renderDetailsCellContents(RenderContext ctx, HtmlWriter out)
+    {
+        throw new UnsupportedOperationException("This is for excel only.");
+    }
+
+    @Override
+    public void renderDetailsCellContents(RenderContext ctx, Writer oldWriter, HtmlWriter out)
+    {
+        throw new UnsupportedOperationException("This is for excel only.");
+    }
+
+    @Override
+    public void renderInputHtml(RenderContext ctx, HtmlWriter out, Object value)
+    {
+        throw new UnsupportedOperationException("This is for excel only.");
+    }
+
+    @Override
+    protected void renderInputHtml(RenderContext ctx, Writer oldWriter, HtmlWriter out, Object value) throws IOException
+    {
+        throw new UnsupportedOperationException("This is for excel only.");
+    }
+
+    @Override
+    public HtmlString getTitle(RenderContext ctx)
+    {
+        throw new UnsupportedOperationException("This is for excel only.");
+    }
+
+    @Override
+    public boolean isSortable()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isFilterable()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isEditable()
+    {
+        return false;
+    }
+
+    @Override
+    public String getFilterOnClick(RenderContext ctx)
+    {
+        throw new UnsupportedOperationException("This is for excel only.");
+    }
+
+    @Override
+    public void setURL(ActionURL url)
+    {
+        throw new UnsupportedOperationException("This is for excel only.");
+    }
+
+    @Override
+    public void setURL(String url)
+    {
+        throw new UnsupportedOperationException("This is for excel only.");
+    }
+
+    @Override
+    public String getURL()
+    {
+        return null;
+    }
+
+    @Override
+    public String renderURL(RenderContext ctx)
+    {
+        return null;
+    }
+
+    @Override
+    public boolean isQueryColumn()
+    {
+        return false;
+    }
+
+    @Override
+    public ColumnInfo getColumnInfo()
+    {
+        return null;
+    }
+
+    @Override
+    public void render(RenderContext ctx, HtmlWriter out)
+    {
+        throw new UnsupportedOperationException("This is for excel only.");
+    }
+}

--- a/api/src/org/labkey/api/data/ArrayExcelWriter.java
+++ b/api/src/org/labkey/api/data/ArrayExcelWriter.java
@@ -2,11 +2,7 @@ package org.labkey.api.data;
 
 import org.apache.poi.ss.usermodel.Sheet;
 import org.labkey.api.reader.ColumnDescriptor;
-import org.labkey.api.util.HtmlString;
-import org.labkey.api.view.ActionURL;
-import org.labkey.api.writer.HtmlWriter;
 
-import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,125 +41,20 @@ public class ArrayExcelWriter extends ExcelWriter
         }
     }
 
-    public class ArrayDisplayColumn extends DisplayColumn
+    public class ArrayDisplayColumn extends AbstractExcelDisplayColumn
     {
-        Class<?> valueClass;
-        int position;
+        private final int _position;
 
         public ArrayDisplayColumn(String name, Class<?> valueClass, int position)
         {
-            this(name, name, valueClass, position);
-        }
-
-        public ArrayDisplayColumn(String name, String caption, Class<?> valueClass, int position)
-        {
-            setName(name);
-            setCaption(caption);
-            this.valueClass = valueClass;
-            this.position = position;
+            super(name, name, valueClass);
+            _position = position;
         }
 
         @Override
         public Object getValue(RenderContext ctx)
         {
-            return data.get(currentRow)[position];
-        }
-
-        @Override
-        public Class<?> getValueClass()
-        {
-            return valueClass; 
-        }
-
-        //NOTE: Methods beyond here are unimplemented, just abstract in base class
-        @Override
-        public void renderGridCellContents(RenderContext ctx, Writer oldWriter, HtmlWriter out)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void renderDetailsCellContents(RenderContext ctx, Writer oldWriter, HtmlWriter out)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public HtmlString getTitle(RenderContext ctx)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public boolean isSortable()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isFilterable()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isEditable()
-        {
-            return false;
-        }
-
-        @Override
-        public String getFilterOnClick(RenderContext ctx)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void renderInputHtml(RenderContext ctx, HtmlWriter out, Object value)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void setURL(ActionURL url)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void setURL(String url)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public String getURL()
-        {
-            return null;
-        }
-
-        @Override
-        public String renderURL(RenderContext ctx)
-        {
-            return null;
-        }
-
-        @Override
-        public boolean isQueryColumn()
-        {
-            return false;
-        }
-
-        @Override
-        public ColumnInfo getColumnInfo()
-        {
-            return null;
-        }
-
-        @Override
-        public void render(RenderContext ctx, HtmlWriter out)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
+            return data.get(currentRow)[_position];
         }
     }
 }

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -1765,10 +1765,10 @@ public class DataRegion extends DisplayElement
         if (name != null)
         {
             // Add attribute used by test locators
-            attributes.add(AttributeValue.of("data-region-form", name));
+            attributes.add(AttributeValue.data("region-form", name));
         }
 
-        attributes.add(AttributeValue.of("class", "form-horizontal" + (mode == MODE_DETAILS ? " form-mode-details" : "")));
+        attributes.add(AttributeValue.cl("form-horizontal" + (mode == MODE_DETAILS ? " form-mode-details" : "")));
 
         String actionAttr = null == getFormActionUrl() ? "" : getFormActionUrl().getLocalURIString();
         switch (mode)

--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -1268,11 +1268,9 @@ public class DataRegion extends DisplayElement
 
     protected HtmlWriter renderCenterContent(RenderContext ctx, HtmlWriter out, boolean showRecordSelectors, List<DisplayColumn> renderers, int colCount)
     {
-        // For now, add lk-region-name AND data-region-name attributes for test locators. TODO: Migrate to "data-*" only.
         TABLE(
             cl("table-condensed labkey-data-region").cl(isShowBorders(), "table-bordered").
             data("region-name", getName()).
-            lk("region-name", getName()). // TODO: Remove this after all tests check for the "data-" attribute instead of "lk-"
             id(getDomId()),
             (Renderable) ret -> renderTableContent(ctx, out, showRecordSelectors, renderers, colCount)
         ).appendTo(out);
@@ -1766,8 +1764,7 @@ public class DataRegion extends DisplayElement
         String name = getName();
         if (name != null)
         {
-            // For now, add lk-region-form AND data-region-from attributes for test locators. TODO: Migrate to "data-*" only.
-            attributes.add(AttributeValue.of("lk-region-form", name));
+            // Add attribute used by test locators
             attributes.add(AttributeValue.of("data-region-form", name));
         }
 

--- a/api/src/org/labkey/api/data/DisplayColumnDecorator.java
+++ b/api/src/org/labkey/api/data/DisplayColumnDecorator.java
@@ -57,6 +57,12 @@ public class DisplayColumnDecorator extends DisplayColumn
     }
 
     @Override
+    public void renderInputHtml(RenderContext ctx, HtmlWriter out, Object value)
+    {
+        _column.renderInputHtml(ctx, out, value);
+    }
+
+    @Override
     public HtmlString getTitle(RenderContext ctx)
     {
         return _column.getTitle(ctx);
@@ -78,12 +84,6 @@ public class DisplayColumnDecorator extends DisplayColumn
     public boolean isEditable()
     {
         return _column.isEditable();
-    }
-
-    @Override
-    public void renderInputHtml(RenderContext ctx, HtmlWriter out, Object value)
-    {
-        _column.renderInputHtml(ctx, out, value);
     }
 
     @Override

--- a/api/src/org/labkey/api/util/DOM.java
+++ b/api/src/org/labkey/api/util/DOM.java
@@ -504,16 +504,6 @@ public class DOM
             return this;
         }
 
-        // TODO: Remove after "lk-" attributes are migrated to "data-"
-        @Deprecated
-        public _Attributes lk(String lkKey, Object value)
-        {
-            if (null == expandos)
-                expandos = new ArrayList<>();
-            expandos.add(new Pair<>("lk-" + lkKey, value));
-            return this;
-        }
-
         public _Attributes cl(String...names)
         {
             if (null != names)
@@ -605,11 +595,6 @@ public class DOM
                     throw new IllegalStateException("expected Attribute or String");
                 if (sk.startsWith("data-"))
                     ret.data(sk.substring("data-".length()), v);
-                // Temporarily allow arbitrary "lk-" attributes. TODO: Switch all to "data-", however, there are MANY
-                // tests looking for "lk-*", so the approach is for the product to add both "data-" and "lk-" to keep
-                // tests passing for now but migrate them to check "data-"
-                else if (sk.startsWith("lk-"))
-                    ret.lk(sk.substring("lk-".length()), v);
                 else
                     ret.at(Attribute.valueOf(sk), v);
             }
@@ -620,9 +605,8 @@ public class DOM
     /* copy attributes, useful for extended/custom elements */
     public static _Attributes at(Attributes attrsIn)
     {
-        if (!(attrsIn instanceof _Attributes))
+        if (!(attrsIn instanceof _Attributes in))
             throw new UnsupportedOperationException();
-        _Attributes in = (_Attributes)attrsIn;
         _Attributes copy = new _Attributes();
         copy.attrs.addAll(in.attrs);
         copy.classes.addAll(in.classes);

--- a/api/src/org/labkey/api/writer/HtmlWriter.java
+++ b/api/src/org/labkey/api/writer/HtmlWriter.java
@@ -116,12 +116,14 @@ public class HtmlWriter implements Appendable
             return new AttributeValue(attribute.name(), value);
         }
 
-        public static AttributeValue of(String name, String value)
+        public static AttributeValue cl(String className)
         {
-            if (!name.equals("class") && !name.startsWith("data-"))
-                throw new IllegalStateException("Illegal attribute name: " + name);
+            return new AttributeValue("class", className);
+        }
 
-            return new AttributeValue(name, value);
+        public static AttributeValue data(String name, String value)
+        {
+            return new AttributeValue("data-" + name, value);
         }
 
         private String name()

--- a/api/src/org/labkey/api/writer/HtmlWriter.java
+++ b/api/src/org/labkey/api/writer/HtmlWriter.java
@@ -118,8 +118,7 @@ public class HtmlWriter implements Appendable
 
         public static AttributeValue of(String name, String value)
         {
-            // TODO: eliminate "lk-" option after tests are migrated to use "data-" only
-            if (!name.equals("class") && !name.startsWith("data-") && !name.startsWith("lk-"))
+            if (!name.equals("class") && !name.startsWith("data-"))
                 throw new IllegalStateException("Illegal attribute name: " + name);
 
             return new AttributeValue(name, value);

--- a/core/src/org/labkey/core/user/securityAccess.jsp
+++ b/core/src/org/labkey/core/user/securityAccess.jsp
@@ -79,7 +79,7 @@
     However, if this account were re-enabled, it would have the following permissions.</div>
 <% } %>
 
-<table id="<%=h(accessRegion.getDomId())%>" lk-region-name="<%=h(accessRegion.getName())%>" data-region-name="<%=h(accessRegion.getName())%>" class="labkey-data-region-legacy labkey-show-borders">
+<table id="<%=h(accessRegion.getDomId())%>" data-region-name="<%=h(accessRegion.getName())%>" class="labkey-data-region-legacy labkey-show-borders">
     <colgroup><col><col><col></colgroup>
     <tr id="dataregion_column_header_row_access">
         <th>&nbsp;</th>

--- a/study/api-src/org/labkey/api/study/MapArrayExcelWriter.java
+++ b/study/api-src/org/labkey/api/study/MapArrayExcelWriter.java
@@ -17,17 +17,13 @@
 package org.labkey.api.study;
 
 import org.apache.poi.ss.usermodel.Sheet;
-import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.AbstractExcelDisplayColumn;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.ExcelColumn;
 import org.labkey.api.data.ExcelWriter;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.reader.ColumnDescriptor;
-import org.labkey.api.util.HtmlString;
-import org.labkey.api.view.ActionURL;
-import org.labkey.api.writer.HtmlWriter;
 
-import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -57,20 +53,11 @@ public class MapArrayExcelWriter extends ExcelWriter
         }
     }
 
-    public class MapArrayDisplayColumn extends DisplayColumn
+    public class MapArrayDisplayColumn extends AbstractExcelDisplayColumn
     {
-        Class<?> valueClass;
-
         public MapArrayDisplayColumn(String name, Class<?> valueClass)
         {
-            this(name, name, valueClass);
-        }
-
-        public MapArrayDisplayColumn(String name, String caption, Class<?> valueClass)
-        {
-            setName(name);
-            setCaption(caption);
-            this.valueClass = valueClass;
+            super(name, name, valueClass);
         }
 
         @Override
@@ -78,104 +65,6 @@ public class MapArrayExcelWriter extends ExcelWriter
         {
             //Ignore the context.
             return maps.get(currentRow).get(getName());
-        }
-
-        @Override
-        public Class<?> getValueClass()
-        {
-            return valueClass; 
-        }
-
-
-        //NOTE: Methods beyond here are unimplemented, just abstract in base class!
-        @Override
-        public void renderGridCellContents(RenderContext ctx, Writer oldWriter, HtmlWriter out)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void renderDetailsCellContents(RenderContext ctx, Writer oldWriter, HtmlWriter out)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public HtmlString getTitle(RenderContext ctx)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public boolean isSortable()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isFilterable()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isEditable()
-        {
-            return false;
-        }
-
-        @Override
-        public String getFilterOnClick(RenderContext ctx)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void renderInputHtml(RenderContext ctx, HtmlWriter out, Object value)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void setURL(ActionURL url)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public void setURL(String url)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
-        }
-
-        @Override
-        public String getURL()
-        {
-            return null;
-        }
-
-        @Override
-        public String renderURL(RenderContext ctx)
-        {
-            return null;
-        }
-
-        @Override
-        public boolean isQueryColumn()
-        {
-            return false;
-        }
-
-        @Override
-        public ColumnInfo getColumnInfo()
-        {
-            return null;
-        }
-
-        @Override
-        public void render(RenderContext ctx, HtmlWriter out)
-        {
-            throw new UnsupportedOperationException("This is for excel only.");
         }
     }
 }


### PR DESCRIPTION
#### Rationale
Tests are no longer querying the obsolete "lk-\*" attributes; they've all been converted to use "data-\*" attributes instead

Extract common code out of `ArrayDisplayColumn` and `MapArrayDisplayColumn` into `AbstractExcelDisplayColumn`

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6434x