### PR TITLE
Request a clean shutdown for job-based external processes before forcibly killing

### DIFF
--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -98,6 +98,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 public class PipelineJobServiceImpl implements PipelineJobService
@@ -285,7 +286,20 @@ public class PipelineJobServiceImpl implements PipelineJobService
         {
             for (Process p : processes)
             {
-                p.destroyForcibly();
+                // First try a normal shutdown
+                p.destroy();
+                try
+                {
+                    // Wait in the hopes it will terminate gracefully
+                    p.waitFor(5, TimeUnit.SECONDS);
+
+                    // Make sure it dies
+                    if (p.isAlive())
+                    {
+                        p.destroyForcibly();
+                    }
+                }
+                catch (InterruptedException ignored) {}
             }
         }
 

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -291,7 +291,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
                 try
                 {
                     // Wait in the hopes it will terminate gracefully
-                    p.waitFor(5, TimeUnit.SECONDS);
+                    p.waitFor(15, TimeUnit.SECONDS);
 
                     // Make sure it dies
                     if (p.isAlive())


### PR DESCRIPTION
#### Rationale
Some external processes are responsive to polite requests to shut down. This is comparable to a `SIGTERM` vs a `SIGKILL` signal.

#### Changes
- Send a termination request
- Wait up to 15 seconds
- Forcibly kill