### PR TITLE
Issue 52325: False error on calculated column referencing another field with a slash in its name

### DIFF
--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -8088,7 +8088,7 @@ public class QueryController extends SpringActionController
             if (json.has("expression"))
                 setExpression(json.getString("expression"));
             if (json.has("phiColumns"))
-                setPhiColumns(json.getJSONArray("phiColumns").toList().stream().map(s -> FieldKey.fromString(s.toString())).collect(Collectors.toList()));
+                setPhiColumns(json.getJSONArray("phiColumns").toList().stream().map(s -> FieldKey.fromParts(s.toString())).collect(Collectors.toList()));
             if (json.has("columnMap"))
             {
                 JSONObject columnMap = json.getJSONObject("columnMap");
@@ -8096,11 +8096,11 @@ public class QueryController extends SpringActionController
                 {
                     try
                     {
-                        getColumnMap().put(FieldKey.fromString(key), JdbcType.valueOf(String.valueOf(columnMap.get(key))));
+                        getColumnMap().put(FieldKey.fromParts(key), JdbcType.valueOf(String.valueOf(columnMap.get(key))));
                     }
                     catch (IllegalArgumentException iae)
                     {
-                        getColumnMap().put(FieldKey.fromString(key), JdbcType.OTHER);
+                        getColumnMap().put(FieldKey.fromParts(key), JdbcType.OTHER);
                     }
                 }
             }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52325
ParseCalculatedColumnAction is provided a columnMap of just the fields in the given domain so use FieldKey.fromParts(key), if we use FieldKey.fromString(key) then the "/" characters of the field name are not encoded.

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/197

#### Changes
- FieldKey.fromParts(key) for columnMap key
