### PR TITLE
Correctly register saved hosts with the ContentSecurityPolicyFilter

### DIFF
--- a/core/src/org/labkey/core/security/AllowedExternalResourceHosts.java
+++ b/core/src/org/labkey/core/security/AllowedExternalResourceHosts.java
@@ -92,7 +92,7 @@ public class AllowedExternalResourceHosts
             return;
         }
 
-        list.forEach(sub -> ContentSecurityPolicyFilter.registerAllowedSources(sub.directive(), sub.host()));
+        list.forEach(sub -> ContentSecurityPolicyFilter.registerAllowedSources(sub.directive(), "External Sources", sub.host()));
         LOG.debug("Registered [{}] as allowed external sources", list);
     }
 


### PR DESCRIPTION
#### Rationale
Admin-allowed hosts were not getting correctly registered with ContentSecurityPolicyFilter on server startup. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52569

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6359