### PR TITLE
Issue 52368: Unable to determine ordering for sample type imports error when importing to multiple sample types and including simple lineage

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -3039,8 +3039,11 @@ public class ExpDataIterators
                     if (typeData.dependencyIndexes.containsKey(index) && _dataIdIndex >= 0)
                     {
                         String parentTypeName = typeData.dependencyIndexes.get(index);
-                        _orderDependencies.computeIfAbsent(typeData.dataType.getName(), i -> new HashSet<>()).add(parentTypeName);
                         _parentIdsPerType.computeIfAbsent(parentTypeName, k -> new HashSet<>()).add(data.toString());
+                        // Issue 52368: "Unable to determine ordering for sample type imports." error when importing to multiple sample types and including simple lineage
+                        // skip dependencies for self type
+                        if (!typeData.dataType.getName().equals(parentTypeName))
+                            _orderDependencies.computeIfAbsent(typeData.dataType.getName(), i -> new HashSet<>()).add(parentTypeName);
                     }
                 }
             });


### PR DESCRIPTION
#### Rationale
When creating a parent and a child sample at the same time using cross folder import, a circular dependency is falsely reported. 

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- exclude current data type relationship from dependency check
