### PR TITLE
Avoid ConversionException on invalid hideCreateButton value

### DIFF
--- a/core/src/org/labkey/core/project/projects.jsp
+++ b/core/src/org/labkey/core/project/projects.jsp
@@ -48,6 +48,7 @@
 <%@ page import="java.util.Set" %>
 <%@ page import="java.util.stream.Collectors" %>
 <%@ page import="static org.apache.commons.lang3.StringUtils.isBlank" %>
+<%@ page import="org.apache.commons.beanutils.ConversionException" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
     @Override
@@ -178,7 +179,14 @@
     } // !containers.isEmpty()
 %>
     <div><%
-        if (Boolean.TRUE != JdbcType.BOOLEAN.convert(properties.get("hideCreateButton")))
+        Boolean hideCreateButton = false;
+        try
+        {
+            hideCreateButton = (Boolean) JdbcType.BOOLEAN.convert(properties.get("hideCreateButton"));
+        }
+        catch (ConversionException ignored) {}
+
+        if (Boolean.TRUE != hideCreateButton)
         {
             boolean isProject = StringUtils.equals("project",properties.get("containerTypes"));
             Container c = isProject ? ContainerManager.getRoot() : target;


### PR DESCRIPTION
#### Rationale
Invalid values for the hideCreateButton attribute on a project webpart wiki inclusion cause a `ConversionException

#### Changes
- Catch the exception and default to showing the button