### PR TITLE
Conditionalize rendering of the "Customize" menu item

### DIFF
--- a/api/src/org/labkey/api/data/DisplayColumn.java
+++ b/api/src/org/labkey/api/data/DisplayColumn.java
@@ -144,7 +144,7 @@ public abstract class DisplayColumn extends RenderColumn
     /*
         Note: DataRegion plus its subclasses and the vast majority of DisplayColumn (and subclasses) have been rewritten
         to use HtmlWriter, DOM, and builders instead of String-based HTML generation. They also no longer throw
-        IOException. The deprecated renderGridCellContents() variant below that take both Writer and HtmlWriter is
+        IOException. The deprecated renderGridCellContents() variant below that takes both Writer and HtmlWriter is
         temporary, present only until its overrides are migrated to use HtmlWriter, DOM, and builders, and adjusted to
         override the corresponding non-Writer variant. Once migrated, the deprecated method will be removed and the
         non-deprecated variant will be made abstract.

--- a/api/src/org/labkey/api/view/BaseWebPartFactory.java
+++ b/api/src/org/labkey/api/view/BaseWebPartFactory.java
@@ -37,11 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * User: brittp
- * Date: Nov 1, 2005
- * Time: 5:09:48 PM
- */
 public abstract class BaseWebPartFactory implements WebPartFactory
 {
     private static final Logger LOG = LogHelper.getLogger(Portal.class, "Creates web parts based on configurations");
@@ -126,7 +121,7 @@ public abstract class BaseWebPartFactory implements WebPartFactory
     @Override
     public HttpView<?> getEditView(WebPart webPart, ViewContext context)
     {
-        return null;
+        throw new IllegalStateException("Editable webparts must implement getEditView()");
     }
 
     @Override

--- a/api/src/org/labkey/api/view/ColorPickerDisplayColumn.java
+++ b/api/src/org/labkey/api/view/ColorPickerDisplayColumn.java
@@ -27,6 +27,7 @@ import static org.labkey.api.util.DOM.Attribute.style;
 import static org.labkey.api.util.DOM.DIV;
 import static org.labkey.api.util.DOM.SCRIPT;
 import static org.labkey.api.util.DOM.at;
+import static org.labkey.api.util.DOM.id;
 
 /**
  * {@link org.labkey.api.data.DisplayColumn} that shows an ExtJS-based color picker component for insert/update forms
@@ -76,6 +77,6 @@ public class ColorPickerDisplayColumn extends DataColumn
                 "   });\n")
         ).appendTo(out);
 
-        DIV(renderId).appendTo(out);
+        DIV(id(renderId)).appendTo(out);
     }
 }

--- a/api/src/org/labkey/api/view/WebPartFactory.java
+++ b/api/src/org/labkey/api/view/WebPartFactory.java
@@ -28,8 +28,6 @@ import java.util.Set;
 /**
  * Factory for creating {@link WebPartView} instances. Used to assemble portal pages, where admins can add, remove,
  * and configure their desired web parts.
- * User: matthewb
- * Date: Oct 16, 2008
  */
 public interface WebPartFactory
 {

--- a/core/src/org/labkey/core/admin/DisplayFormatAnalyzer.java
+++ b/core/src/org/labkey/core/admin/DisplayFormatAnalyzer.java
@@ -5,7 +5,6 @@ import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.action.UrlProvider;
 import org.labkey.api.admin.AdminUrls;
-import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.PropertyManager;

--- a/issues/src/org/labkey/issue/view/IssuesListView.java
+++ b/issues/src/org/labkey/issue/view/IssuesListView.java
@@ -72,9 +72,9 @@ public class IssuesListView extends VBox
     }
 
 
-    public static class IssuesListConfig extends HttpView
+    public static class IssuesListConfig extends HttpView<Object>
     {
-        private Portal.WebPart _webPart;
+        private final Portal.WebPart _webPart;
 
         public IssuesListConfig(Portal.WebPart webPart)
         {
@@ -84,7 +84,7 @@ public class IssuesListView extends VBox
         @Override
         protected void renderInternal(Object model, PrintWriter out) throws Exception
         {
-            JspView view = new JspView<>("/org/labkey/issue/view/issueListWebPartConfig.jsp", _webPart);
+            JspView<Portal.WebPart> view = new JspView<>("/org/labkey/issue/view/issueListWebPartConfig.jsp", _webPart);
             include(view);
         }
     }

--- a/issues/src/org/labkey/issue/view/IssuesSummaryWebPartFactory.java
+++ b/issues/src/org/labkey/issue/view/IssuesSummaryWebPartFactory.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.view.BaseWebPartFactory;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
+import org.labkey.api.view.NavTree;
 import org.labkey.api.view.Portal;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartView;
@@ -56,7 +57,15 @@ public class IssuesSummaryWebPartFactory extends BaseWebPartFactory
             view = new SummaryWebPart(issueDefName, propertyMap);
         else
         {
-            view = new HtmlView(IssuesController.getUndefinedIssueListMessage(context, issueDefName));
+            view = new HtmlView(IssuesController.getUndefinedIssueListMessage(context, issueDefName)) {
+                @Override
+                public void setCustomize(NavTree tree)
+                {
+                    // Add "Customize" menu only if there are issue list defs in this container (consistent with getEditView() below)
+                    if (!IssueManager.getIssueListDefs(context.getContainer()).isEmpty())
+                        super.setCustomize(tree);
+                }
+            };
             view.setFrame(WebPartView.FrameType.PORTAL);
             String title = IssueManager.getEntryTypeNames(context.getContainer(), IssueListDef.DEFAULT_ISSUE_LIST_NAME).pluralName + " Summary";
             view.setTitle(title);

--- a/issues/src/org/labkey/issue/view/IssuesWebPartFactory.java
+++ b/issues/src/org/labkey/issue/view/IssuesWebPartFactory.java
@@ -19,13 +19,14 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.view.BaseWebPartFactory;
 import org.labkey.api.view.HtmlView;
-import org.labkey.api.view.HttpView;
+import org.labkey.api.view.NavTree;
 import org.labkey.api.view.Portal;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartView;
 import org.labkey.issue.IssuesController;
 import org.labkey.issue.model.IssueListDef;
 import org.labkey.issue.model.IssueManager;
+import org.labkey.issue.view.IssuesListView.IssuesListConfig;
 
 import java.util.Map;
 
@@ -40,7 +41,7 @@ public class IssuesWebPartFactory extends BaseWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext context, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext context, @NotNull Portal.WebPart webPart)
     {
         Map<String, String> properties = webPart.getPropertyMap();
         String issueDefName = properties.get(IssuesListView.ISSUE_LIST_DEF_NAME);
@@ -48,13 +49,23 @@ public class IssuesWebPartFactory extends BaseWebPartFactory
         if (issueDefName == null)
             issueDefName = IssueManager.getDefaultIssueListDefName(context.getContainer());
 
-        WebPartView view;
+        WebPartView<?> view;
 
         if (issueDefName != null)
+        {
             view = new IssuesListView(issueDefName);
+        }
         else
         {
-            view = new HtmlView(IssuesController.getUndefinedIssueListMessage(context, issueDefName));
+            view = new HtmlView(IssuesController.getUndefinedIssueListMessage(context, issueDefName)) {
+                @Override
+                public void setCustomize(NavTree tree)
+                {
+                    // Add "Customize" menu only if there are issue list defs in this container (consistent with getEditView() below)
+                    if (!IssueManager.getIssueListDefs(context.getContainer()).isEmpty())
+                        super.setCustomize(tree);
+                }
+            };
             String title = IssueManager.getEntryTypeNames(context.getContainer(), IssueListDef.DEFAULT_ISSUE_LIST_NAME).pluralName + " List";
             view.setTitle(title);
         }
@@ -77,10 +88,10 @@ public class IssuesWebPartFactory extends BaseWebPartFactory
 
     @Override
     @Nullable
-    public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+    public IssuesListConfig getEditView(Portal.WebPart webPart, ViewContext context)
     {
         if (!IssueManager.getIssueListDefs(context.getContainer()).isEmpty())
-            return new IssuesListView.IssuesListConfig(webPart);
+            return new IssuesListConfig(webPart);
         else
             return null;
     }


### PR DESCRIPTION
#### Rationale
The "Issues List" and "Issues Summary" webparts always displayed the "Customize" menu, even when no issue definitions were present in the container. Choosing to "Customize" in that case resulted in a redirect back to the portal page, with no explanation. This PR suppresses the "Customize" menu when no definitions are present. These appear to be the only webparts that conditionalize getEditView().

Also, throw from `BaseWebPartFactory.getEditView()`; any editable webpart needs to override this method.

And clean up some warnings.

And fix ColorPickerDisplayColumn (used by TargetedMS).