### PR TITLE
tableselector results

### DIFF
--- a/api/src/org/labkey/api/data/BaseSelector.java
+++ b/api/src/org/labkey/api/data/BaseSelector.java
@@ -282,13 +282,13 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
      * A very simple Iterator that returns the ResultSet on each call to {@code next()}. (Compare with {@link ResultSetIterator},
      * which returns a {@code Map<String, Object>} on each call to {@code next()}).
      */
-    private class SimpleResultSetIterator implements Iterator<ResultSet>
+    class SimpleResultSetIterator<RS extends ResultSet> implements Iterator<RS>
     {
-        private final ResultSetIteratorHelper _iter;
+        private final ResultSetIteratorHelper<RS> _iter;
 
-        private SimpleResultSetIterator(ResultSet rs)
+        SimpleResultSetIterator(RS rs)
         {
-            _iter = new ResultSetIteratorHelper(rs);
+            _iter = new ResultSetIteratorHelper<>(rs);
         }
 
         @Override
@@ -305,7 +305,7 @@ public abstract class BaseSelector<SELECTOR extends BaseSelector<?>> extends Jdb
         }
 
         @Override
-        public ResultSet next()
+        public RS next()
         {
             try
             {

--- a/api/src/org/labkey/api/data/ResultSetIteratorHelper.java
+++ b/api/src/org/labkey/api/data/ResultSetIteratorHelper.java
@@ -24,14 +24,14 @@ import java.util.Iterator;
  * Wraps a JDBC {@link ResultSet} to provide a simple {@link Iterator}-like object. Does not implement Iterator, because
  * these methods throw {@link SQLException}.
  */
-public class ResultSetIteratorHelper
+public class ResultSetIteratorHelper<RS extends ResultSet>
 {
-    private final ResultSet _rs;
+    private final RS _rs;
 
     private boolean _didNext = false;
     private boolean _hasNext = false;
 
-    public ResultSetIteratorHelper(ResultSet rs)
+    public ResultSetIteratorHelper(RS rs)
     {
         _rs = rs;
     }
@@ -48,7 +48,7 @@ public class ResultSetIteratorHelper
         return _hasNext;
     }
 
-    public ResultSet next() throws SQLException
+    public RS next() throws SQLException
     {
         if (!_didNext)
         {

--- a/api/src/org/labkey/api/data/TableSelector.java
+++ b/api/src/org/labkey/api/data/TableSelector.java
@@ -37,6 +37,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -44,8 +45,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFactory, TableSelector> implements ResultsFactory
 {
@@ -235,10 +238,22 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
     }
 
     @Override
-    public TableResultSet getResultSet(boolean cache, boolean scrollable)
+    public Results getResultSet(boolean cache, boolean scrollable)
     {
         ensureStableColumnOrder("getResultSet()");
-        return super.getResultSet(cache, scrollable);
+        return getResults(cache, scrollable);
+    }
+
+    @Override
+    public Results getResultSet(boolean cache)
+    {
+        return getResults(cache, false);
+    }
+
+    @Override
+    public Results getResultSet()
+    {
+        return getResults(true, false);
     }
 
     @Override
@@ -246,6 +261,31 @@ public class TableSelector extends SqlExecutingSelector<TableSelector.TableSqlFa
     {
         ensureStableColumnOrder("resultSetStream()");
         return super.resultSetStream();
+    }
+
+    public Stream<Results> resultsStream(boolean cached)
+    {
+        return streamResults(SimpleResultSetIterator::new, cached);
+    }
+
+    private <T> Stream<T> streamResults(Function<Results, Iterator<T>> function, boolean cached)
+    {
+        return getStandardResultSetFactory(cached).handleResultSet((incoming, conn) -> {
+            // For convenience, we don't require closing Streams over cached result sets, so set the CachedResultSet to not validate.
+            Results rs = getResults(cached);
+            Iterable<T> iterable = () -> function.apply(rs);
+            return StreamSupport.stream(iterable.spliterator(), false)
+                    .onClose(() -> {
+                        try
+                        {
+                            rs.close();
+                        }
+                        catch (SQLException e)
+                        {
+                            throw getExceptionFramework().translate(getScope(), "Attempting to close() ResultSet and Connection", e);
+                        }
+                    });
+        });
     }
 
     /**


### PR DESCRIPTION
#### Rationale
TableSelector is based on ColumnInfo, so always return a Results instead of a ResultSet.

Small refactor, should help wean some use cases off of getAlias().  More to come.


#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
