### PR TITLE
Switch links over pipeline grid back to unstyled text

### DIFF
--- a/api/src/org/labkey/api/audit/AuditTypeEvent.java
+++ b/api/src/org/labkey/api/audit/AuditTypeEvent.java
@@ -72,6 +72,7 @@ public class AuditTypeEvent
         _projectId = container.getProject();
     }
 
+    /** Important for reflection-based instantiation */
     public AuditTypeEvent(){}
 
     public long getRowId()

--- a/api/src/org/labkey/api/audit/ClientApiAuditProvider.java
+++ b/api/src/org/labkey/api/audit/ClientApiAuditProvider.java
@@ -32,7 +32,6 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.util.PageFlowUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -161,10 +160,9 @@ public class ClientApiAuditProvider extends AbstractAuditTypeProvider implements
         private int _int2;
         private int _int3;
 
-        public ClientApiAuditEvent()
-        {
-            super();
-        }
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
+        public ClientApiAuditEvent() {}
 
         public ClientApiAuditEvent(Container container, String comment)
         {

--- a/api/src/org/labkey/api/audit/DetailedAuditTypeEvent.java
+++ b/api/src/org/labkey/api/audit/DetailedAuditTypeEvent.java
@@ -7,9 +7,8 @@ public class DetailedAuditTypeEvent extends AuditTypeEvent
     private String _oldRecordMap;
     private String _newRecordMap;
 
-    public DetailedAuditTypeEvent()
-    {
-    }
+    /** Important for reflection-based instantiation */
+    public DetailedAuditTypeEvent() {}
 
     public DetailedAuditTypeEvent(String eventType, Container container, String comment)
     {

--- a/api/src/org/labkey/api/audit/ExperimentAuditEvent.java
+++ b/api/src/org/labkey/api/audit/ExperimentAuditEvent.java
@@ -16,10 +16,9 @@ public class ExperimentAuditEvent extends AuditTypeEvent
     private String _message;
     private Integer _qcState;
 
-    public ExperimentAuditEvent()
-    {
-        super();
-    }
+    /** Important for reflection-based instantiation */
+    @SuppressWarnings("unused")
+    public ExperimentAuditEvent() {}
 
     public ExperimentAuditEvent(Container container, String comment)
     {

--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -88,10 +88,8 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
     private String _metadata;
     private String _inventoryUpdateType;
 
-    public SampleTimelineAuditEvent()
-    {
-        super();
-    }
+    /** Important for reflection-based instantiation */
+    public SampleTimelineAuditEvent() {}
 
     public SampleTimelineAuditEvent(Container container, String comment)
     {

--- a/api/src/org/labkey/api/audit/provider/FileSystemAuditProvider.java
+++ b/api/src/org/labkey/api/audit/provider/FileSystemAuditProvider.java
@@ -107,6 +107,7 @@ public class FileSystemAuditProvider extends AbstractAuditTypeProvider implement
         private String _file;           // the file name
         private String _resourcePath;   // the webdav resource path
 
+        /** Important for reflection-based instantiation */
         public FileSystemAuditEvent()
         {
             super();

--- a/api/src/org/labkey/api/audit/provider/GroupAuditProvider.java
+++ b/api/src/org/labkey/api/audit/provider/GroupAuditProvider.java
@@ -224,10 +224,9 @@ public class GroupAuditProvider extends AbstractAuditTypeProvider implements Aud
 
         private final Map<String, Object> _messageElements = new HashMap<>();
 
-        public GroupAuditEvent()
-        {
-            super();
-        }
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
+        public GroupAuditEvent() {}
 
         public GroupAuditEvent(Container container, String comment)
         {

--- a/api/src/org/labkey/api/audit/provider/ModulePropertiesAuditProvider.java
+++ b/api/src/org/labkey/api/audit/provider/ModulePropertiesAuditProvider.java
@@ -87,10 +87,9 @@ public class ModulePropertiesAuditProvider extends AbstractAuditTypeProvider imp
         private Object _oldValue;
         private Object _newValue;
 
-        public ModulePropertiesAuditEvent()
-        {
-
-        }
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
+        public ModulePropertiesAuditEvent() {}
 
         public ModulePropertiesAuditEvent(Container container, String comment)
         {

--- a/api/src/org/labkey/api/audit/provider/SiteSettingsAuditProvider.java
+++ b/api/src/org/labkey/api/audit/provider/SiteSettingsAuditProvider.java
@@ -113,10 +113,9 @@ public class SiteSettingsAuditProvider extends AbstractAuditTypeProvider impleme
     {
         private String _changes;
 
-        public SiteSettingsAuditEvent()
-        {
-            super();
-        }
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
+        public SiteSettingsAuditEvent() {}
 
         public SiteSettingsAuditEvent(Container container, String comment)
         {

--- a/api/src/org/labkey/api/security/AuthenticationSettingsAuditTypeProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationSettingsAuditTypeProvider.java
@@ -86,11 +86,9 @@ public class AuthenticationSettingsAuditTypeProvider extends AbstractAuditTypePr
     {
         private String _changes;
 
-        @SuppressWarnings("unused") // Invoked via reflection
-        public AuthSettingsAuditEvent()
-        {
-            super();
-        }
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
+        public AuthSettingsAuditEvent() {}
 
         public AuthSettingsAuditEvent(String comment)
         {

--- a/api/src/org/labkey/api/security/UserManager.java
+++ b/api/src/org/labkey/api/security/UserManager.java
@@ -1104,10 +1104,9 @@ public class UserManager
 
         private final Map<String, Object> _messageElements = new LinkedHashMap<>();
 
-        public UserAuditEvent()
-        {
-            super();
-        }
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
+        public UserAuditEvent() {}
 
         public UserAuditEvent(Container container, String comment, User modifiedUser)
         {

--- a/api/src/org/labkey/api/study/security/SecurityEscalationAuditProvider.java
+++ b/api/src/org/labkey/api/study/security/SecurityEscalationAuditProvider.java
@@ -213,6 +213,8 @@ public abstract class SecurityEscalationAuditProvider extends AbstractAuditTypeP
         private int escalatingUser;
         private int level;
 
+        public SecurityEscalationEvent() {}
+
         // It is essential that you set the container and event type, otherwise the Audit Log will fail at
         // runtime (silently in the case of the "eventType" and noisily in the case of the container).
         public SecurityEscalationEvent(String eventType, Container container, String comment) {

--- a/api/src/org/labkey/api/study/security/SecurityEscalationAuditProvider.java
+++ b/api/src/org/labkey/api/study/security/SecurityEscalationAuditProvider.java
@@ -213,6 +213,7 @@ public abstract class SecurityEscalationAuditProvider extends AbstractAuditTypeP
         private int escalatingUser;
         private int level;
 
+        /** Important for reflection-based instantiation */
         public SecurityEscalationEvent() {}
 
         // It is essential that you set the container and event type, otherwise the Audit Log will fail at

--- a/api/src/org/labkey/api/study/security/StudySecurityEscalationAuditProvider.java
+++ b/api/src/org/labkey/api/study/security/StudySecurityEscalationAuditProvider.java
@@ -52,6 +52,8 @@ public class StudySecurityEscalationAuditProvider extends SecurityEscalationAudi
 
     public static class StudySecurityEscalationEvent extends SecurityEscalationEvent
     {
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
         public StudySecurityEscalationEvent() {}
 
         public StudySecurityEscalationEvent(Container container, String comment)

--- a/api/src/org/labkey/api/study/security/StudySecurityEscalationAuditProvider.java
+++ b/api/src/org/labkey/api/study/security/StudySecurityEscalationAuditProvider.java
@@ -52,6 +52,8 @@ public class StudySecurityEscalationAuditProvider extends SecurityEscalationAudi
 
     public static class StudySecurityEscalationEvent extends SecurityEscalationEvent
     {
+        public StudySecurityEscalationEvent() {}
+
         public StudySecurityEscalationEvent(Container container, String comment)
         {
             super(EVENT_TYPE, container, comment);

--- a/audit/src/org/labkey/audit/model/LogManager.java
+++ b/audit/src/org/labkey/audit/model/LogManager.java
@@ -251,13 +251,13 @@ public class LogManager
         for (PropertyStorageSpec prop : domainKind.getBaseProperties(domain))
         {
             Object value = values.get(prop.getName());
-            if (prop.getJdbcType().isText() && value instanceof String)
+            if (prop.getJdbcType().isText() && value instanceof String s)
             {
                 int scale = prop.getSize();
-                if (((String)value).length() > scale)
+                if (s.length() > scale)
                 {
                     _log.warn("Audit field input : \n" + prop.getName() + "\nexceeded the maximum length : " + scale);
-                    String trimmed = ((String)value).substring(0, scale-3) + "...";
+                    String trimmed = s.substring(0, scale-3) + "...";
                     values.put(prop.getName(), trimmed);
                     changed = true;
                 }
@@ -269,17 +269,17 @@ public class LogManager
             // For now, only check for string length like we were doing for the old audit event fields
             PropertyDescriptor pd = dp.getPropertyDescriptor();
             Object value = values.get(dp.getName());
-            if (pd.isStringType() && value instanceof String)
+            if (pd.isStringType() && value instanceof String s)
             {
                 int scale = dp.getScale();
-                if (scale > 0 && ((String)value).length() > scale)
+                if (scale > 0 && s.length() > scale)
                 {
                     _log.warn("Audit field input : \n" + pd.getName() + "\nexceeded the maximum length : " + scale);
                     String trimmed;
                     if (scale > 100)
-                        trimmed = ((String)value).substring(0, scale-3) + "...";
+                        trimmed = s.substring(0, scale-3) + "...";
                     else
-                        trimmed = ((String) value).substring(0, scale);
+                        trimmed = s.substring(0, scale);
                     values.put(pd.getName(), trimmed);
                     changed = true;
                 }

--- a/list/src/org/labkey/list/model/ListAuditProvider.java
+++ b/list/src/org/labkey/list/model/ListAuditProvider.java
@@ -153,10 +153,9 @@ public class ListAuditProvider extends AbstractAuditTypeProvider implements Audi
         private String _listItemEntityId;
         private String _listName;
 
-        public ListAuditEvent()
-        {
-            super();
-        }
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
+        public ListAuditEvent() {}
 
         public ListAuditEvent(Container container, String comment, ListDefinitionImpl list)
         {

--- a/pipeline/src/org/labkey/pipeline/status/StatusDataRegion.java
+++ b/pipeline/src/org/labkey/pipeline/status/StatusDataRegion.java
@@ -63,7 +63,7 @@ public class StatusDataRegion extends DataRegion
             cl(selected, "labkey-frame"),
             HtmlString.NBSP,
             HtmlString.NBSP,
-            new Link.LinkBuilder(text).href(url),
+            new Link.LinkBuilder(text).href(url).clearClasses(),
             HtmlString.NBSP,
             HtmlString.NBSP
         ).appendTo(out);

--- a/query/src/org/labkey/query/audit/QueryExportAuditProvider.java
+++ b/query/src/org/labkey/query/audit/QueryExportAuditProvider.java
@@ -155,10 +155,9 @@ public class QueryExportAuditProvider extends AbstractAuditTypeProvider implemen
         private String _detailsUrl;
         private int _dataRowCount;
 
-        public QueryExportAuditEvent()
-        {
-            super();
-        }
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
+        public QueryExportAuditEvent() {}
 
         public QueryExportAuditEvent(Container container, String comment)
         {

--- a/query/src/org/labkey/query/audit/QueryUpdateAuditProvider.java
+++ b/query/src/org/labkey/query/audit/QueryUpdateAuditProvider.java
@@ -213,10 +213,9 @@ public class QueryUpdateAuditProvider extends AbstractAuditTypeProvider implemen
         private String _schemaName;
         private String _queryName;
 
-        public QueryUpdateAuditEvent()
-        {
-            super();
-        }
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
+        public QueryUpdateAuditEvent() {}
 
         public QueryUpdateAuditEvent(Container container, String comment)
         {

--- a/query/src/org/labkey/query/reports/ReportAuditProvider.java
+++ b/query/src/org/labkey/query/reports/ReportAuditProvider.java
@@ -84,9 +84,9 @@ public class ReportAuditProvider extends AbstractAuditTypeProvider
         private String reportKey;
         private String reportType;
 
-        public ReportAuditEvent()
-        {
-        }
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
+        public ReportAuditEvent() {}
 
         public ReportAuditEvent(@NotNull ReportDB report, @NotNull ReportDescriptor descriptor, Container container, String comment)
         {

--- a/search/src/org/labkey/search/audit/SearchAuditProvider.java
+++ b/search/src/org/labkey/search/audit/SearchAuditProvider.java
@@ -103,10 +103,9 @@ public class SearchAuditProvider extends AbstractAuditTypeProvider implements Au
     {
         private String _query;
 
-        public SearchAuditEvent()
-        {
-            super();
-        }
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
+        public SearchAuditEvent() {}
 
         public SearchAuditEvent(Container container, String comment)
         {

--- a/study/src/org/labkey/study/dataset/DatasetAuditProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetAuditProvider.java
@@ -194,10 +194,9 @@ public class DatasetAuditProvider extends AbstractAuditTypeProvider implements A
         private boolean _hasDetails;
         private String _lsid;
 
-        public DatasetAuditEvent()
-        {
-            super();
-        }
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
+        public DatasetAuditEvent() {}
 
         public DatasetAuditEvent(Container container, String comment, int datasetId)
         {


### PR DESCRIPTION
#### Rationale
Improvements to HTML generation switched the links over the pipeline job grid to styled text links instead of plain links

#### Changes
- Strip the class so the links render as they did before
- Comments about the need for no-arg audit event constructors