### PR TITLE
Fix logging level for BatchValidationException in ReformatAction

### DIFF
--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -44,6 +44,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.TSVWriter;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.gwt.server.BaseRemoteService;
+import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.ColumnDescriptor;
@@ -1654,8 +1655,8 @@ public class PlateController extends SpringActionController
             }
             catch (Exception e)
             {
-                if (e instanceof ValidationException ve)
-                    LOG.debug("Request failed due to a validation exception", ve);
+                if (e instanceof ValidationException || e instanceof BatchValidationException)
+                    LOG.debug("Request failed due to a validation exception", e);
                 else
                     LOG.error("Request failed due to an exception", e);
                 String message = "Failed to reformat plates.";


### PR DESCRIPTION
#### Rationale
During my testing, I found that reformatting plates with mismatched well data will log an error. Bad client input shouldn't cause the server to log an error.

```
org.labkey.api.query.BatchValidationException: Replicate group "R1" contains mismatched well data. Ensure all data aligns for the replicates declared in these wells.
	at org.labkey.assay.plate.PlateManager.reformat(PlateManager.java:4436) ~[assay-25.4-SNAPSHOT.jar:?]
	at org.labkey.assay.PlateController$ReformatAction.execute(PlateController.java:1652) [assay-25.4-SNAPSHOT.jar:?]
```

#### Related Pull Requests
- #6202 

#### Changes
- Fix logging level for BatchValidationException in ReformatAction (ERROR -> DEBUG)
