### PR TITLE
Interrupting the thread is causing problems - revert

### DIFF
--- a/api/src/org/labkey/api/data/TransactionFilter.java
+++ b/api/src/org/labkey/api/data/TransactionFilter.java
@@ -116,7 +116,6 @@ public class TransactionFilter implements Filter
                                         PipelineJobService.get().killProcessesForThread(thread);
                                     }
                                 }
-                                thread.interrupt();
                             }
                         }
                         try


### PR DESCRIPTION
#### Rationale
My attempt to `interrupt()` long-running, possibly hung requests is causing problems, likely by leaving those threads in an interrupted state indefinitely.

https://github.com/LabKey/platform/pull/6479

```
java.lang.InterruptedException: null
	at java.base/java.lang.Object.wait(Native Method) ~[?:?]
	at org.labkey.api.data.AsyncQueryRequest.waitForResult(AsyncQueryRequest.java:159) ~[api-25.4-SNAPSHOT.jar:?]
	at org.labkey.api.data.TableSelector.getResultsAsync(TableSelector.java:386) ~[api-25.4-SNAPSHOT.jar:?]
	at org.labkey.api.data.RenderContext.select(RenderContext.java:549) ~[api-25.4-SNAPSHOT.jar:?]
	at org.labkey.api.data.RenderContext.getResults(RenderContext.java:327) ~[api-25.4-SNAPSHOT.jar:?]
	at org.labkey.api.data.DataRegion.getResults(DataRegion.java:816) ~[api-25.4-SNAPSHOT.jar:?]
	at org.labkey.api.data.DataRegion.getResults(DataRegion.java:796) ~[api-25.4-SNAPSHOT.jar:?]
	at org.labkey.api.action.ApiQueryResponse.getResults(ApiQueryResponse.java:276) ~[api-25.4-SNAPSHOT.jar:?]
	at org.labkey.api.action.ApiQueryResponse.render(ApiQueryResponse.java:155) [api-25.4-SNAPSHOT.jar:?]
```

#### Changes
- Stop interrupting ourselves