### PR TITLE
Issue 52616: LKSM: When two lineage alias columns are in a file we silently ignore one

### DIFF
--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -73,6 +73,7 @@ public class DataIteratorUtil
 {
     public static final String DATA_SOURCE = "dataSource";
     public static final String ETL_DATA_SOURCE = "etl";
+    public static final String DUPLICATE_COLUMN_IN_DATA_ERROR = "Two columns mapped to target column '%s'. Check the column names and import aliases for your data.";
 
     private static final Logger LOG = LogManager.getLogger(DataIteratorUtil.class);
 
@@ -297,7 +298,7 @@ public class DataIteratorUtil
                 }
                 if (count > 1)
                 {
-                    setupError.addGlobalError("Two columns mapped to target column " + e.getKey().toString() + ". Check the column names and import aliases for your data.");
+                    setupError.addGlobalError(String.format(DUPLICATE_COLUMN_IN_DATA_ERROR, e.getKey().getParent() != null ? e.getKey().toString(): e.getKey().getName()));
                     break;
                 }
             }

--- a/api/src/org/labkey/api/dataiterator/MapDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/MapDataIterator.java
@@ -88,10 +88,7 @@ public interface MapDataIterator extends DataIterator
                 _findMap.put(in.getColumnInfo(i).getName(),i);
             }
             if (null != duplicates)
-            {
-                var ex = new IllegalStateException("Data has duplicate columns: '" + StringUtils.join(duplicates.toArray(), ", ") + "'");
-                ExceptionUtil.logExceptionToMothership(HttpView.currentRequest(), ex, true);
-            }
+                LOGGER.warn("Data has duplicate columns: '" + StringUtils.join(duplicates.toArray(), ", ") + "'");
         }
 
         @Override

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -94,6 +94,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
 import static org.labkey.api.data.ColumnRenderPropertiesImpl.STORAGE_UNIQUE_ID_SEQUENCE_PREFIX;
+import static org.labkey.api.dataiterator.DataIteratorUtil.DUPLICATE_COLUMN_IN_DATA_ERROR;
 import static org.labkey.api.exp.api.ColumnExporter.FILE_ROOT_SUBSTITUTION;
 
 /**
@@ -1136,7 +1137,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                 if (skipOnce)
                 {
                     if (skipped.contains(name))
-                        throw new ApiUsageException("Two columns mapped to target column " + name + ". Check the column names and import aliases for your data.");
+                        throw new ApiUsageException(String.format(DUPLICATE_COLUMN_IN_DATA_ERROR, name));
                     skipped.add(name);
                 }
                 continue;

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.attachments.AttachmentFile;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
@@ -1118,13 +1119,28 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
 
     public void selectAll(@NotNull Set<String> skipColumns, @NotNull Map<String, String> translations)
     {
+        selectAll(skipColumns, translations, true);
+    }
+
+    public void selectAll(@NotNull Set<String> skipColumns, @NotNull Map<String, String> translations, boolean skipOnce)
+    {
+        Set<String> skipped = new CaseInsensitiveHashSet();
         Map<String, Integer> aliasColumns = new HashMap<>();
         for (int i = 1; i <= _data.getColumnCount(); i++)
         {
             ColumnInfo c = _data.getColumnInfo(i);
             String name = c.getName();
             if (skipColumns.contains(name))
+            {
+                // if >1 columns found for the same skip column, this could be a data issue
+                if (skipOnce)
+                {
+                    if (skipped.contains(name))
+                        throw new ApiUsageException("Two columns mapped to target column " + name + ". Check the column names and import aliases for your data.");
+                    skipped.add(name);
+                }
                 continue;
+            }
 
             addColumn(c, i);
             if (translations.containsKey(name))

--- a/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
+++ b/api/src/org/labkey/api/dataiterator/StandardDataIteratorBuilder.java
@@ -45,6 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.api.dataiterator.DataIteratorUtil.DUPLICATE_COLUMN_IN_DATA_ERROR;
+
 /**
  * Helper for code that does not use QueryUpdateService
  *
@@ -223,7 +225,7 @@ public class StandardDataIteratorBuilder implements DataIteratorBuilder
             if (null != to && _convertTypes)
             {
                 if (!unusedCols.containsKey(to.target.getFieldKey()))
-                    setupError.addGlobalError("Two columns mapped to target column " + to.target.getName() + ". Check the column names and import aliases for your data.");
+                    setupError.addGlobalError(String.format(DUPLICATE_COLUMN_IN_DATA_ERROR, to.target.getName()));
                 unusedCols.remove(to.target.getFieldKey());
                 to.indexFrom = i;
                 Integer indexMv = null==to.target.getMvColumnName() ? null : sourceColumnsMap.get(to.target.getMvColumnName().getName());

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -327,6 +327,11 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         return hasPermission(user, context.getInsertOption().updateOnly ? UpdatePermission.class : InsertPermission.class);
     }
 
+    // override this
+    protected void preImportDIBValidation(DataIteratorBuilder in)
+    {
+    }
+
     protected int _importRowsUsingDIB(User user, Container container, DataIteratorBuilder in, @Nullable final ArrayList<Map<String, Object>> outputRows, DataIteratorContext context, @Nullable Map<String, Object> extraScriptContext)
     {
         if (!hasImportRowsPermission(user, container, context))
@@ -340,6 +345,8 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         {
             context.setDataSource((String) extraScriptContext.get(DataIteratorUtil.DATA_SOURCE));
         }
+
+        preImportDIBValidation(in);
 
         boolean skipTriggers = context.getConfigParameterBoolean(ConfigParameters.SkipTriggers) || context.isCrossTypeImport() || context.isCrossFolderImport();
         boolean hasTableScript = hasTableScript(container);

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -77,6 +77,8 @@ import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.ontology.OntologyService;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
+import org.labkey.api.reader.ColumnDescriptor;
+import org.labkey.api.reader.DataLoader;
 import org.labkey.api.reader.TabLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
@@ -101,10 +103,12 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -328,7 +332,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
     }
 
     // override this
-    protected void preImportDIBValidation(DataIteratorBuilder in)
+    protected void preImportDIBValidation(@Nullable Collection<String> inputColumns)
     {
     }
 
@@ -346,7 +350,23 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
             context.setDataSource((String) extraScriptContext.get(DataIteratorUtil.DATA_SOURCE));
         }
 
-        preImportDIBValidation(in);
+        List<String> columns = new ArrayList<>();
+        if (in instanceof DataLoader dataLoader)
+        {
+            ColumnDescriptor[] allColumns;
+            try
+            {
+                allColumns = dataLoader.getColumns();
+                for (ColumnDescriptor columnDescriptor : allColumns)
+                    columns.add(columnDescriptor.name);
+            }
+            catch (IOException exception)
+            {
+                throw new UncheckedIOException(exception);
+            }
+        }
+
+        preImportDIBValidation(columns);
 
         boolean skipTriggers = context.getConfigParameterBoolean(ConfigParameters.SkipTriggers) || context.isCrossTypeImport() || context.isCrossFolderImport();
         boolean hasTableScript = hasTableScript(container);
@@ -535,6 +555,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
                 colNames.addAll(row.keySet());
         }
 
+        preImportDIBValidation(colNames);
         return MapDataIterator.of(colNames, rows, debugName);
     }
 

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -874,9 +874,17 @@ public class ExpDataIterators
                 return pre;
             }
 
+            ValidationException setupError = new ValidationException();
+            DataIterator post;
             if (context.getInsertOption() == QueryUpdateService.InsertOption.UPDATE)
-                return LoggingDataIterator.wrap(new ImportWithUpdateDerivationDataIterator(pre, context, _container, _user, _currentDataType, _isSample, _checkRequiredParents));
-            return LoggingDataIterator.wrap(new DerivationDataIterator(pre, context, _container, _user, _currentDataType, _isSample, _skipAliquot));
+                post = new ImportWithUpdateDerivationDataIterator(pre, context, setupError, _container, _user, _currentDataType, _isSample, _checkRequiredParents);
+            else
+                post = new DerivationDataIterator(pre, context, setupError, _container, _user, _currentDataType, _isSample, _skipAliquot);
+
+            if (setupError.hasErrors())
+                return LoggingDataIterator.wrap(ErrorIterator.wrap(post, context, false, setupError));
+
+            return LoggingDataIterator.wrap(post);
         }
     }
 
@@ -992,7 +1000,7 @@ public class ExpDataIterators
         final boolean _isSample;
         final TSVWriter _tsvWriter;
 
-        protected DerivationDataIteratorBase(DataIterator di, DataIteratorContext context, Container container, User user, ExpObject currentDataType, boolean isSample, boolean checkRequiredParent)
+        protected DerivationDataIteratorBase(DataIterator di, DataIteratorContext context, ValidationException setupError, Container container, User user, ExpObject currentDataType, boolean isSample, boolean checkRequiredParent)
         {
             super(di);
             _context = context;
@@ -1034,6 +1042,7 @@ public class ExpDataIterators
             _container = container;
             _user = user;
 
+            Set<String> duplicateInputColumns = getDuplicateParentColumns(map.keySet());
             for (Map.Entry<String, Integer> entry : map.entrySet())
             {
                 String name = entry.getKey();
@@ -1042,6 +1051,9 @@ public class ExpDataIterators
                     _parentCols.put(entry.getValue(), entry.getKey());
                     if (requiredParents.contains(name))
                         _requiredParentCols.put(entry.getValue(), entry.getKey());
+
+                    if (duplicateInputColumns.contains(entry.getKey()))
+                        setupError.addGlobalError("Two columns mapped to target column " + entry.getKey() + ". Check the column names and import aliases for your data.");
                 }
             }
 
@@ -1053,6 +1065,35 @@ public class ExpDataIterators
                     throw new UnsupportedOperationException();
                 }
             };
+        }
+
+        private @NotNull Set<String> getDuplicateParentColumns(Set<String> allColumns)
+        {
+            try
+            {
+                Map<String, String> parentAliasColumnMap = new CaseInsensitiveHashMap<>();
+                if (_currentSampleType != null)
+                    parentAliasColumnMap.putAll(_currentSampleType.getImportAliases());
+                if (_currentDataClass != null)
+                    parentAliasColumnMap.putAll(_currentDataClass.getImportAliases());
+
+                Set<String> seenColumns = new CaseInsensitiveHashSet();
+                Set<String> duplicateColumns = new CaseInsensitiveHashSet();
+                for (String columnName : allColumns)
+                {
+                    if (parentAliasColumnMap.containsKey(columnName))
+                        columnName = parentAliasColumnMap.get(columnName);
+                    if (seenColumns.contains(columnName))
+                        duplicateColumns.add(columnName);
+                    seenColumns.add(columnName);
+                }
+                return duplicateColumns;
+
+            }
+            catch (IOException ignore)
+            {
+                return Collections.emptySet();
+            }
         }
 
         private BatchValidationException getErrors()
@@ -1206,9 +1247,9 @@ public class ExpDataIterators
 
         final List<String> _candidateAliquotNames; // used to check if a name is an aliquot, with absent "AliquotedFrom". used for merge only
 
-        protected DerivationDataIterator(DataIterator di, DataIteratorContext context, Container container, User user, ExpObject currentDataType, boolean isSample, boolean skipAliquot)
+        protected DerivationDataIterator(DataIterator di, DataIteratorContext context, ValidationException setupError, Container container, User user, ExpObject currentDataType, boolean isSample, boolean skipAliquot)
         {
-            super(di, context, container, user, currentDataType, isSample, false /* for insert/merge, required parents are always checked in StandardDataIteratorBuilder */);
+            super(di, context, setupError, container, user, currentDataType, isSample, false /* for insert/merge, required parents are always checked in StandardDataIteratorBuilder */);
             _skipAliquot = skipAliquot || context.getConfigParameterBoolean(SampleTypeService.ConfigParameters.DeferAliquotRuns);
 
             Map<String, Integer> map = DataIteratorUtil.createColumnNameMap(di);
@@ -1395,9 +1436,9 @@ public class ExpDataIterators
 
         final boolean _useLsid;
 
-        protected ImportWithUpdateDerivationDataIterator(DataIterator di, DataIteratorContext context, Container container, User user, ExpObject currentDataType, boolean isSample, boolean checkRequiredParent)
+        protected ImportWithUpdateDerivationDataIterator(DataIterator di, DataIteratorContext context, ValidationException setupError, Container container, User user, ExpObject currentDataType, boolean isSample, boolean checkRequiredParent)
         {
-            super(di, context, container, user, currentDataType, isSample, checkRequiredParent);
+            super(di, context, setupError, container, user, currentDataType, isSample, checkRequiredParent);
 
             Map<String, Integer> map = DataIteratorUtil.createColumnNameMap(di);
             _parentNames = new LinkedHashMap<>();

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -874,17 +874,9 @@ public class ExpDataIterators
                 return pre;
             }
 
-            ValidationException setupError = new ValidationException();
-            DataIterator post;
             if (context.getInsertOption() == QueryUpdateService.InsertOption.UPDATE)
-                post = new ImportWithUpdateDerivationDataIterator(pre, context, setupError, _container, _user, _currentDataType, _isSample, _checkRequiredParents);
-            else
-                post = new DerivationDataIterator(pre, context, setupError, _container, _user, _currentDataType, _isSample, _skipAliquot);
-
-            if (setupError.hasErrors())
-                return LoggingDataIterator.wrap(ErrorIterator.wrap(post, context, false, setupError));
-
-            return LoggingDataIterator.wrap(post);
+                return LoggingDataIterator.wrap(new ImportWithUpdateDerivationDataIterator(pre, context, _container, _user, _currentDataType, _isSample, _checkRequiredParents));
+            return LoggingDataIterator.wrap(new DerivationDataIterator(pre, context, _container, _user, _currentDataType, _isSample, _skipAliquot));
         }
     }
 
@@ -1000,7 +992,7 @@ public class ExpDataIterators
         final boolean _isSample;
         final TSVWriter _tsvWriter;
 
-        protected DerivationDataIteratorBase(DataIterator di, DataIteratorContext context, ValidationException setupError, Container container, User user, ExpObject currentDataType, boolean isSample, boolean checkRequiredParent)
+        protected DerivationDataIteratorBase(DataIterator di, DataIteratorContext context, Container container, User user, ExpObject currentDataType, boolean isSample, boolean checkRequiredParent)
         {
             super(di);
             _context = context;
@@ -1042,7 +1034,6 @@ public class ExpDataIterators
             _container = container;
             _user = user;
 
-            Set<String> duplicateInputColumns = getDuplicateParentColumns(map.keySet());
             for (Map.Entry<String, Integer> entry : map.entrySet())
             {
                 String name = entry.getKey();
@@ -1051,9 +1042,6 @@ public class ExpDataIterators
                     _parentCols.put(entry.getValue(), entry.getKey());
                     if (requiredParents.contains(name))
                         _requiredParentCols.put(entry.getValue(), entry.getKey());
-
-                    if (duplicateInputColumns.contains(entry.getKey()))
-                        setupError.addGlobalError("Two columns mapped to target column " + entry.getKey() + ". Check the column names and import aliases for your data.");
                 }
             }
 
@@ -1065,35 +1053,6 @@ public class ExpDataIterators
                     throw new UnsupportedOperationException();
                 }
             };
-        }
-
-        private @NotNull Set<String> getDuplicateParentColumns(Set<String> allColumns)
-        {
-            try
-            {
-                Map<String, String> parentAliasColumnMap = new CaseInsensitiveHashMap<>();
-                if (_currentSampleType != null)
-                    parentAliasColumnMap.putAll(_currentSampleType.getImportAliases());
-                if (_currentDataClass != null)
-                    parentAliasColumnMap.putAll(_currentDataClass.getImportAliases());
-
-                Set<String> seenColumns = new CaseInsensitiveHashSet();
-                Set<String> duplicateColumns = new CaseInsensitiveHashSet();
-                for (String columnName : allColumns)
-                {
-                    if (parentAliasColumnMap.containsKey(columnName))
-                        columnName = parentAliasColumnMap.get(columnName);
-                    if (seenColumns.contains(columnName))
-                        duplicateColumns.add(columnName);
-                    seenColumns.add(columnName);
-                }
-                return duplicateColumns;
-
-            }
-            catch (IOException ignore)
-            {
-                return Collections.emptySet();
-            }
         }
 
         private BatchValidationException getErrors()
@@ -1247,9 +1206,9 @@ public class ExpDataIterators
 
         final List<String> _candidateAliquotNames; // used to check if a name is an aliquot, with absent "AliquotedFrom". used for merge only
 
-        protected DerivationDataIterator(DataIterator di, DataIteratorContext context, ValidationException setupError, Container container, User user, ExpObject currentDataType, boolean isSample, boolean skipAliquot)
+        protected DerivationDataIterator(DataIterator di, DataIteratorContext context, Container container, User user, ExpObject currentDataType, boolean isSample, boolean skipAliquot)
         {
-            super(di, context, setupError, container, user, currentDataType, isSample, false /* for insert/merge, required parents are always checked in StandardDataIteratorBuilder */);
+            super(di, context, container, user, currentDataType, isSample, false /* for insert/merge, required parents are always checked in StandardDataIteratorBuilder */);
             _skipAliquot = skipAliquot || context.getConfigParameterBoolean(SampleTypeService.ConfigParameters.DeferAliquotRuns);
 
             Map<String, Integer> map = DataIteratorUtil.createColumnNameMap(di);
@@ -1436,9 +1395,9 @@ public class ExpDataIterators
 
         final boolean _useLsid;
 
-        protected ImportWithUpdateDerivationDataIterator(DataIterator di, DataIteratorContext context, ValidationException setupError, Container container, User user, ExpObject currentDataType, boolean isSample, boolean checkRequiredParent)
+        protected ImportWithUpdateDerivationDataIterator(DataIterator di, DataIteratorContext context, Container container, User user, ExpObject currentDataType, boolean isSample, boolean checkRequiredParent)
         {
-            super(di, context, setupError, container, user, currentDataType, isSample, checkRequiredParent);
+            super(di, context, container, user, currentDataType, isSample, checkRequiredParent);
 
             Map<String, Integer> map = DataIteratorUtil.createColumnNameMap(di);
             _parentNames = new LinkedHashMap<>();

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -1529,10 +1529,9 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         }
 
         @Override
-        protected void preImportDIBValidation(DataIteratorBuilder in)
+        protected void preImportDIBValidation(@Nullable Collection<String> inputColumns)
         {
-            if (in instanceof DataLoader dataLoader)
-                ExperimentServiceImpl.get().checkDuplicateParentColumns(dataLoader, _dataClass);
+            ExperimentServiceImpl.get().checkDuplicateParentColumns(inputColumns, _dataClass);
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -103,6 +103,7 @@ import org.labkey.api.query.UserIdForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.query.column.BuiltInColumnTypes;
+import org.labkey.api.reader.DataLoader;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
@@ -1525,6 +1526,13 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 if (auditType != null && auditType != AuditBehaviorType.NONE)
                     context.setSelectIds(true); // select rowId for QueryUpdateAuditEvent.rowPk
             }
+        }
+
+        @Override
+        protected void preImportDIBValidation(DataIteratorBuilder in)
+        {
+            if (in instanceof DataLoader dataLoader)
+                ExperimentServiceImpl.get().checkDuplicateParentColumns(dataLoader, _dataClass);
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -297,6 +297,7 @@ import static org.labkey.api.data.NameGenerator.ANCESTOR_INPUT_PREFIX_DATA;
 import static org.labkey.api.data.NameGenerator.ANCESTOR_INPUT_PREFIX_MATERIAL;
 import static org.labkey.api.data.NameGenerator.EXPERIMENTAL_ALLOW_GAP_COUNTER;
 import static org.labkey.api.data.NameGenerator.EXPERIMENTAL_WITH_COUNTER;
+import static org.labkey.api.dataiterator.DataIteratorUtil.DUPLICATE_COLUMN_IN_DATA_ERROR;
 import static org.labkey.api.exp.OntologyManager.getTinfoObject;
 import static org.labkey.api.exp.XarContext.XAR_JOB_ID_NAME;
 import static org.labkey.api.exp.api.ExpProtocol.ApplicationType.ExperimentRun;
@@ -10097,7 +10098,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (ExperimentService.isInputOutputColumn(columnName) || "parent".equalsIgnoreCase(columnName))
             {
                 if (seenColumns.contains(columnName))
-                    throw new ApiUsageException("Two columns mapped to target column " + columnName + ". Check the column names and import aliases for your data.");
+                    throw new ApiUsageException(String.format(DUPLICATE_COLUMN_IN_DATA_ERROR, columnName));
                 seenColumns.add(columnName);
             }
         }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -201,6 +201,8 @@ import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.SimpleValidationError;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.reader.ColumnDescriptor;
+import org.labkey.api.reader.DataLoader;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.User;
@@ -252,6 +254,7 @@ import org.springframework.dao.PessimisticLockingFailureException;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.Path;
@@ -10065,6 +10068,39 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             }
         }
         return fileResults;
+    }
+
+    public void checkDuplicateParentColumns(@NotNull DataLoader dataLoader, @Nullable ExpObject currentDataType)
+    {
+        ColumnDescriptor[] allColumns;
+        Map<String, String> parentAliasColumnMap = new CaseInsensitiveHashMap<>();
+        try
+        {
+            allColumns = dataLoader.getColumns();
+
+            if (currentDataType instanceof ExpDataClass dataClass)
+                parentAliasColumnMap.putAll(dataClass.getImportAliases());
+            else if (currentDataType instanceof ExpSampleType sampleType)
+                parentAliasColumnMap.putAll(sampleType.getImportAliases());
+        }
+        catch (IOException exception)
+        {
+            throw new UncheckedIOException(exception);
+        }
+
+        Set<String> seenColumns = new CaseInsensitiveHashSet();
+        for (ColumnDescriptor columnDescriptor : allColumns)
+        {
+            String columnName = columnDescriptor.name;
+            if (parentAliasColumnMap.containsKey(columnName))
+                columnName = parentAliasColumnMap.get(columnName);
+            if (ExperimentService.isInputOutputColumn(columnName) || "parent".equalsIgnoreCase(columnName))
+            {
+                if (seenColumns.contains(columnName))
+                    throw new ApiUsageException("Two columns mapped to target column " + columnName + ". Check the column names and import aliases for your data.");
+                seenColumns.add(columnName);
+            }
+        }
     }
 
     public static class TestCase extends Assert

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -10071,14 +10071,14 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         return fileResults;
     }
 
-    public void checkDuplicateParentColumns(@NotNull DataLoader dataLoader, @Nullable ExpObject currentDataType)
+    public void checkDuplicateParentColumns(@Nullable Collection<String> inputColumns, @Nullable ExpObject currentDataType)
     {
-        ColumnDescriptor[] allColumns;
+        if (inputColumns == null || currentDataType == null)
+            return;
+
         Map<String, String> parentAliasColumnMap = new CaseInsensitiveHashMap<>();
         try
         {
-            allColumns = dataLoader.getColumns();
-
             if (currentDataType instanceof ExpDataClass dataClass)
                 parentAliasColumnMap.putAll(dataClass.getImportAliases());
             else if (currentDataType instanceof ExpSampleType sampleType)
@@ -10090,9 +10090,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
 
         Set<String> seenColumns = new CaseInsensitiveHashSet();
-        for (ColumnDescriptor columnDescriptor : allColumns)
+        for (String inputColName : inputColumns)
         {
-            String columnName = columnDescriptor.name;
+            String columnName = inputColName;
             if (parentAliasColumnMap.containsKey(columnName))
                 columnName = parentAliasColumnMap.get(columnName);
             if (ExperimentService.isInputOutputColumn(columnName) || "parent".equalsIgnoreCase(columnName))

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -367,6 +367,13 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     }
 
     @Override
+    protected void preImportDIBValidation(DataIteratorBuilder in)
+    {
+        if (in instanceof DataLoader dataLoader)
+            ExperimentServiceImpl.get().checkDuplicateParentColumns(dataLoader, _sampleType);
+    }
+
+    @Override
     public DataIteratorBuilder createImportDIB(User user, Container container, DataIteratorBuilder data, DataIteratorContext context)
     {
         assert context.isCrossTypeImport() || _sampleType != null : "SampleType required for insert/update, but not required for read/delete";

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -367,10 +367,9 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
     }
 
     @Override
-    protected void preImportDIBValidation(DataIteratorBuilder in)
+    protected void preImportDIBValidation(@Nullable Collection<String> inputColumns)
     {
-        if (in instanceof DataLoader dataLoader)
-            ExperimentServiceImpl.get().checkDuplicateParentColumns(dataLoader, _sampleType);
+        ExperimentServiceImpl.get().checkDuplicateParentColumns(inputColumns, _sampleType);
     }
 
     @Override

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4470,6 +4470,7 @@ public class QueryController extends SpringActionController
                 }
                 if (null != jsonObj)
                 {
+                    // TODO: validate duplicate keys with different cases don't exist in data ('Name' vs 'name') (Issue 52616)
                     Map<String, Object> rowMap = null == f ? new CaseInsensitiveHashMap<>() : f.getRowMap();
                     // Use shallow copy since jsonObj.toMap() will translate contained JSONObjects into Maps, which we don't want
                     JsonUtil.fillMapShallow(jsonObj, rowMap);


### PR DESCRIPTION
#### Rationale
A change was introduced in #6213 to report exception when duplicate columns are detected and we have seen a handful exceptions since. Those exceptions helped uncover issues when we are not handling duplicate columns well, but it also adds noise to the reporting since most of the time it's due to user error that's handled as expected by the app (failed import attempt). This PR revert the change to log exceptions for duplicate columns. It also adds some additional checks for previously missed duplicate detections. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1760
- https://github.com/LabKey/labkey-ui-premium/pull/723
- https://github.com/LabKey/platform/pull/6496
- https://github.com/LabKey/limsModules/pull/1282

#### Changes
- don't report duplicate column warnings to mothership
- add check for duplicate columns during SimpleTranslator.selectAll within skipColumns, since those won't be detected later due to being skipped here
- check for duplicate parent columns from user input for samples and dataclass 
