### PR TITLE
Show the length of the field name in the exp.Fields query

### DIFF
--- a/experiment/src/org/labkey/experiment/api/BaseFieldsTable.java
+++ b/experiment/src/org/labkey/experiment/api/BaseFieldsTable.java
@@ -31,6 +31,7 @@ public abstract class BaseFieldsTable extends FilteredTable<ExpSchema>
         addWrapColumn(_rootTable.getColumn("Label"));
         addWrapColumn(_rootTable.getColumn("Description"));
         addWrapColumn(_rootTable.getColumn("RangeURI"));
+        addWrapColumn(_rootTable.getColumn("StorageColumnName"));
     }
 
     protected MutableColumnInfo addColumn(String name, JdbcType type)

--- a/experiment/src/org/labkey/experiment/api/FieldsTable.java
+++ b/experiment/src/org/labkey/experiment/api/FieldsTable.java
@@ -17,6 +17,7 @@ public class FieldsTable extends BaseFieldsTable
 
         addColumn("AlphaNumeric", JdbcType.BOOLEAN).setDescription("Name contains only alphabetic and numeric characters plus underscore");
         addColumn("SpecialCharacters", JdbcType.BOOLEAN).setDescription("Name contains any of these specific punctuation characters: / \"&\\$}~,.");
+        addColumn("FieldNameLength", JdbcType.INTEGER).setDescription("Number of characters in the field name");
     }
 
     @Override
@@ -25,6 +26,7 @@ public class FieldsTable extends BaseFieldsTable
         // Note that within a range expression, LIKE wildcards (such as underscore) don't need to be escaped
         addBooleanPatternColumn(sql, "pd.Name NOT", "%[^A-Za-z0-9_]%", "AlphaNumeric");
         addBooleanPatternColumn(sql, "pd.Name", "%[/ \"&\\\\$}~,.]%", "SpecialCharacters");
+        sql.append(", ").append(getSqlDialect().getVarcharLengthFunction()).append("(pd.Name) AS FieldNameLength");
     }
 
     private void addBooleanPatternColumn(SQLFragment sql, String expression, String pattern, String name)

--- a/experiment/src/org/labkey/experiment/api/FieldsTable.java
+++ b/experiment/src/org/labkey/experiment/api/FieldsTable.java
@@ -18,15 +18,21 @@ public class FieldsTable extends BaseFieldsTable
         addColumn("AlphaNumeric", JdbcType.BOOLEAN).setDescription("Name contains only alphabetic and numeric characters plus underscore");
         addColumn("SpecialCharacters", JdbcType.BOOLEAN).setDescription("Name contains any of these specific punctuation characters: / \"&\\$}~,.");
         addColumn("FieldNameLength", JdbcType.INTEGER).setDescription("Number of characters in the field name");
+        addColumn("StorageColumnNameMatch", JdbcType.BOOLEAN).setDescription("Whether the storage column in the database matches the field name");
     }
 
     @Override
     protected void addColumnSQL(SQLFragment sql)
     {
         // Note that within a range expression, LIKE wildcards (such as underscore) don't need to be escaped
-        addBooleanPatternColumn(sql, "pd.Name NOT", "%[^A-Za-z0-9_]%", "AlphaNumeric");
-        addBooleanPatternColumn(sql, "pd.Name", "%[/ \"&\\\\$}~,.]%", "SpecialCharacters");
-        sql.append(", ").append(getSqlDialect().getVarcharLengthFunction()).append("(pd.Name) AS FieldNameLength");
+        addBooleanPatternColumn(sql, "pd.Name NOT", "%[^A-Za-z0-9_]%", "AlphaNumeric\n");
+        addBooleanPatternColumn(sql, "pd.Name", "%[/ \"&\\\\$}~,.]%", "SpecialCharacters\n");
+        sql.append(", ").
+                append(getSqlDialect().getVarcharLengthFunction()).
+                append("(pd.Name) AS FieldNameLength\n");
+        sql.append(", ").
+                append(getSqlDialect().wrapBooleanExpression(new SQLFragment("pd.StorageColumnName IS NULL OR pd.Name = pd.StorageColumnName"))).
+                append(" AS StorageColumnNameMatch\n");
     }
 
     private void addBooleanPatternColumn(SQLFragment sql, String expression, String pattern, String name)

--- a/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
@@ -38,11 +38,15 @@ import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ConditionalFormat;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
 import org.labkey.api.exceptions.OptimisticConflictException;
 import org.labkey.api.exp.ChangePropertyDescriptorException;
 import org.labkey.api.exp.DomainDescriptor;
@@ -64,21 +68,25 @@ import org.labkey.api.exp.property.IPropertyValidator;
 import org.labkey.api.exp.property.Lookup;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.property.ValidatorKind;
+import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.exp.xar.LsidUtils;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.gwt.client.assay.model.GWTPropertyDescriptorMixin;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.ontology.OntologyService;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
+import org.labkey.api.security.UserManager;
 import org.labkey.api.usageMetrics.UsageMetricsProvider;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.URIUtil;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.experiment.api.VocabularyDomainKind;
+import org.labkey.experiment.controllers.exp.ExperimentController;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -651,6 +659,9 @@ public class PropertyServiceImpl implements PropertyService, UsageMetricsProvide
         DbSchema schema = ExperimentService.get().getSchema();
         String lengthFn = schema.getSqlDialect().getVarcharLengthFunction();
 
+        TableInfo t = new ExpSchema(User.getAdminServiceUser(), ContainerManager.getRoot()).getTable(ExpSchema.TableType.Fields.name(), ContainerFilter.EVERYTHING);
+        long storageColumnNameMismatches = new TableSelector(t, new SimpleFilter(FieldKey.fromParts("StorageColumnNameMatch"), false), null).getRowCount();
+
         return Map.of(
                 "propertyValidators", Map.of(
                         "byType", new SqlSelector(schema,
@@ -677,7 +688,8 @@ public class PropertyServiceImpl implements PropertyService, UsageMetricsProvide
                 "propertyCountsByConcept", stripUriPrefixes(new SqlSelector(schema,
                         new SQLFragment("SELECT CASE WHEN ConceptURI IS NULL THEN 'null' ELSE ConceptURI END, COUNT(*) AS Count FROM exp.PropertyDescriptor GROUP BY ConceptURI")
                 ).getValueMap()),
-                        "conditionalFormattingFields", new SqlSelector(schema, new SQLFragment("SELECT COUNT (DISTINCT propertyid) from exp.conditionalformat")).getObject(Long.class)
+                        "conditionalFormattingFields", new SqlSelector(schema, new SQLFragment("SELECT COUNT (DISTINCT propertyid) from exp.conditionalformat")).getObject(Long.class),
+                "storageColumnNameMismatches", storageColumnNameMismatches
         );
     }
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -55,8 +55,11 @@ import org.labkey.api.assay.security.DesignAssayPermission;
 import org.labkey.api.attachments.AttachmentParent;
 import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.attachments.BaseDownloadAction;
+import org.labkey.api.audit.AbstractAuditTypeProvider;
 import org.labkey.api.audit.AuditLogService;
+import org.labkey.api.audit.SampleTimelineAuditEvent;
 import org.labkey.api.audit.TransactionAuditProvider;
+import org.labkey.api.audit.query.DefaultAuditSchema;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
@@ -143,6 +146,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.SampleWorkflowDeletePermission;
+import org.labkey.api.security.permissions.SiteAdminPermission;
 import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.settings.AppProps;
@@ -422,6 +426,80 @@ public class ExperimentController extends SpringActionController
             setHelpTopic("runGroups");
             addRootNavTrail(root);
             root.addChild("Run Groups");
+        }
+    }
+
+    @RequiresPermission(SiteAdminPermission.class)
+    public static class ReportLostFieldValuesAction extends SimpleViewAction<Object>
+    {
+        @Override
+        public ModelAndView getView(Object o, BindException errors) throws Exception
+        {
+            // Find all of the fields that could have lost data due to issue 52666
+            TableInfo t = new ExpSchema(getUser(), ContainerManager.getRoot()).getTable(ExpSchema.TableType.Fields.name(), ContainerFilter.EVERYTHING);
+            Collection<Map<String, Object>> problematicFields = new TableSelector(t, new SimpleFilter(FieldKey.fromParts("StorageColumnNameMatch"), false), null).getMapCollection();
+
+            // Prep audit table for querying
+            UserSchema auditSchema = AuditLogService.get().createSchema(getUser(), ContainerManager.getRoot());
+            TableInfo sampleTimelineTable = auditSchema.getTable(SampleTimelineAuditEvent.EVENT_TYPE, ContainerFilter.EVERYTHING);
+
+            Map<Pair<ExpSampleType, String>, List<Pair<Integer, String>>> summaries = new HashMap<>();
+
+            for (Map<String, Object> problematicField : problematicFields)
+            {
+                String domainURI = (String) problematicField.get("DomainURI");
+                String name = (String) problematicField.get("Name");
+                Container container = ContainerManager.getForId((String) problematicField.get("Container"));
+                Domain domain = PropertyService.get().getDomain(container, domainURI);
+                // Drill into sample types
+                if (domain != null && domain.getDomainKind() != null && domain.getDomainKind().getClass().equals(SampleTypeDomainKind.class))
+                {
+                    ExpSampleType sampleType = SampleTypeService.get().getSampleType(domainURI);
+
+                    // Find samples that current have no value for the field with potential for data loss
+                    TableInfo sampleTable = domain.getDomainKind().getTableInfo(getUser(), container, domain, ContainerFilter.EVERYTHING);
+                    List<Integer> idsWithNulls = new TableSelector(sampleTable, Collections.singleton("RowId"), new SimpleFilter(new CompareType.CompareClause(FieldKey.fromParts(name), CompareType.ISBLANK, null)), null).getArrayList(Integer.class);
+
+                    List<Pair<Integer, String>> fixupsNeeded = new ArrayList<>();
+
+                    // For each sample without a value today, check the audit history
+                    for (Integer id : idsWithNulls)
+                    {
+                        // Order by RowId to get them in the sequence they happened in
+                        var events = new TableSelector(sampleTimelineTable, new SimpleFilter(FieldKey.fromParts("SampleId"), id), new Sort("RowId")).getArrayList(SampleTimelineAuditEvent.class);
+                        // Remember the most recently set value
+                        String mostRecentValue = null;
+                        for (SampleTimelineAuditEvent event : events)
+                        {
+                            Map<String, String> newValues = new CaseInsensitiveHashMap<>(AbstractAuditTypeProvider.decodeFromDataMap(event.getNewRecordMap()));
+                            if (newValues.containsKey(name))
+                            {
+                                mostRecentValue = newValues.get(name);
+                            }
+                        }
+                        // If the value had been set before, and its most recent insert/update wasn't setting it blank,
+                        // it's most likely a lost value
+                        if (mostRecentValue != null && !mostRecentValue.isEmpty())
+                        {
+                            fixupsNeeded.add(Pair.of(id, mostRecentValue));
+                        }
+                    }
+                    if (!fixupsNeeded.isEmpty())
+                    {
+                        summaries.put(Pair.of(sampleType, name), fixupsNeeded);
+                    }
+                }
+            }
+
+            return new HtmlView("Fixups Needed", DOM.UL(summaries.entrySet().stream().map(e ->
+                    LI(e.getKey().first.getName() + ":" + e.getKey().second, DOM.UL(e.getValue().stream().map(p ->
+                            LI(ExperimentService.get().getExpMaterial(p.first).getName() + ": " + p.second)))))));
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+            root.addChild("Lost to the void");
         }
     }
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -277,6 +277,8 @@ import static org.labkey.api.query.QueryImportPipelineJob.QUERY_IMPORT_PIPELINE_
 import static org.labkey.api.query.QueryImportPipelineJob.QUERY_IMPORT_PIPELINE_PROVIDER_PARAM;
 import static org.labkey.api.util.DOM.A;
 import static org.labkey.api.util.DOM.Attribute.action;
+import static org.labkey.api.util.DOM.Attribute.border;
+import static org.labkey.api.util.DOM.Attribute.cellpadding;
 import static org.labkey.api.util.DOM.Attribute.href;
 import static org.labkey.api.util.DOM.Attribute.id;
 import static org.labkey.api.util.DOM.Attribute.method;
@@ -429,77 +431,117 @@ public class ExperimentController extends SpringActionController
         }
     }
 
+    public record Field(String domainURI, String domainName, String name, Container container) {}
+    public record MiniMaterial(int rowId, String name) {}
+
     @RequiresPermission(SiteAdminPermission.class)
     public static class ReportLostFieldValuesAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
         {
-            // Find all of the fields that could have lost data due to issue 52666
+            // Find all the fields that could have lost data due to issue 52666
             TableInfo t = new ExpSchema(getUser(), ContainerManager.getRoot()).getTable(ExpSchema.TableType.Fields.name(), ContainerFilter.EVERYTHING);
-            Collection<Map<String, Object>> problematicFields = new TableSelector(t, new SimpleFilter(FieldKey.fromParts("StorageColumnNameMatch"), false), null).getMapCollection();
+            List<Field> problematicFields = new TableSelector(t, new SimpleFilter(FieldKey.fromParts("StorageColumnNameMatch"), false), null).getArrayList(Field.class);
 
             // Prep audit table for querying
             UserSchema auditSchema = AuditLogService.get().createSchema(getUser(), ContainerManager.getRoot());
             TableInfo sampleTimelineTable = auditSchema.getTable(SampleTimelineAuditEvent.EVENT_TYPE, ContainerFilter.EVERYTHING);
 
-            Map<Pair<ExpSampleType, String>, List<Pair<Integer, String>>> summaries = new HashMap<>();
+            Map<Pair<ExpSampleType, String>, List<Pair<MiniMaterial, String>>> summaries = new HashMap<>();
 
-            for (Map<String, Object> problematicField : problematicFields)
+            Map<Field, Pair<Long, Long>> otherProblematicFields = new LinkedHashMap<>();
+
+            for (Field problematicField : problematicFields)
             {
-                String domainURI = (String) problematicField.get("DomainURI");
-                String name = (String) problematicField.get("Name");
-                Container container = ContainerManager.getForId((String) problematicField.get("Container"));
+                String domainURI = problematicField.domainURI;
+                String name = problematicField.name;
+                Container container = problematicField.container;
                 Domain domain = PropertyService.get().getDomain(container, domainURI);
-                // Drill into sample types
-                if (domain != null && domain.getDomainKind() != null && domain.getDomainKind().getClass().equals(SampleTypeDomainKind.class))
+                if (domain != null && domain.getDomainKind() != null)
                 {
-                    ExpSampleType sampleType = SampleTypeService.get().getSampleType(domainURI);
+                    TableInfo table = domain.getDomainKind().getTableInfo(getUser(), container, domain, ContainerFilter.EVERYTHING);
 
-                    // Find samples that current have no value for the field with potential for data loss
-                    TableInfo sampleTable = domain.getDomainKind().getTableInfo(getUser(), container, domain, ContainerFilter.EVERYTHING);
-                    List<Integer> idsWithNulls = new TableSelector(sampleTable, Collections.singleton("RowId"), new SimpleFilter(new CompareType.CompareClause(FieldKey.fromParts(name), CompareType.ISBLANK, null)), null).getArrayList(Integer.class);
-
-                    List<Pair<Integer, String>> fixupsNeeded = new ArrayList<>();
-
-                    // For each sample without a value today, check the audit history
-                    for (Integer id : idsWithNulls)
+                    // Drill into sample types
+                    if (domain.getDomainKind().getClass().equals(SampleTypeDomainKind.class))
                     {
-                        // Order by RowId to get them in the sequence they happened in
-                        var events = new TableSelector(sampleTimelineTable, new SimpleFilter(FieldKey.fromParts("SampleId"), id), new Sort("RowId")).getArrayList(SampleTimelineAuditEvent.class);
-                        // Remember the most recently set value
-                        String mostRecentValue = null;
-                        for (SampleTimelineAuditEvent event : events)
+                        ExpSampleType sampleType = SampleTypeService.get().getSampleType(domainURI);
+
+                        // Find samples that current have no value for the field with potential for data loss
+                        List<MiniMaterial> materialsWithNulls = new TableSelector(table, new HashSet<>(List.of("RowId", "Name")), new SimpleFilter(new CompareType.CompareClause(FieldKey.fromParts(name), CompareType.ISBLANK, null)), null).getArrayList(MiniMaterial.class);
+
+                        List<Pair<MiniMaterial, String>> fixupsNeeded = new ArrayList<>();
+
+                        // For each sample without a value today, check the audit history
+                        for (MiniMaterial material : materialsWithNulls)
                         {
-                            Map<String, String> newValues = new CaseInsensitiveHashMap<>(AbstractAuditTypeProvider.decodeFromDataMap(event.getNewRecordMap()));
-                            if (newValues.containsKey(name))
+                            // Order by RowId to get them in the sequence they happened in
+                            var events = new TableSelector(sampleTimelineTable, new SimpleFilter(FieldKey.fromParts("SampleId"), material.rowId), new Sort("RowId")).getArrayList(SampleTimelineAuditEvent.class);
+                            // Remember the most recently set value
+                            String mostRecentValue = null;
+                            for (SampleTimelineAuditEvent event : events)
                             {
-                                mostRecentValue = newValues.get(name);
+                                Map<String, String> newValues = new CaseInsensitiveHashMap<>(AbstractAuditTypeProvider.decodeFromDataMap(event.getNewRecordMap()));
+                                if (newValues.containsKey(name))
+                                {
+                                    mostRecentValue = newValues.get(name);
+                                }
+                            }
+                            // If the value had been set before, and its most recent insert/update wasn't setting it blank,
+                            // it's most likely a lost value
+                            if (mostRecentValue != null && !mostRecentValue.isEmpty())
+                            {
+                                fixupsNeeded.add(Pair.of(material, mostRecentValue));
                             }
                         }
-                        // If the value had been set before, and its most recent insert/update wasn't setting it blank,
-                        // it's most likely a lost value
-                        if (mostRecentValue != null && !mostRecentValue.isEmpty())
+                        if (!fixupsNeeded.isEmpty())
                         {
-                            fixupsNeeded.add(Pair.of(id, mostRecentValue));
+                            summaries.put(Pair.of(sampleType, name), fixupsNeeded);
                         }
                     }
-                    if (!fixupsNeeded.isEmpty())
+                    else
                     {
-                        summaries.put(Pair.of(sampleType, name), fixupsNeeded);
+                        if (table != null)
+                        {
+                            long totalRows = new TableSelector(table).getRowCount();
+                            long emptyRows = new TableSelector(table, new SimpleFilter(new CompareType.CompareClause(FieldKey.fromParts(name), CompareType.ISBLANK, null)), null).getRowCount();
+                            otherProblematicFields.put(problematicField, Pair.of(totalRows, emptyRows));
+                        }
+                        else
+                        {
+                            otherProblematicFields.put(problematicField, null);
+                        }
                     }
                 }
             }
 
-            return new HtmlView("Fixups Needed", DOM.UL(summaries.entrySet().stream().map(e ->
-                    LI(e.getKey().first.getName() + ":" + e.getKey().second, DOM.UL(e.getValue().stream().map(p ->
-                            LI(ExperimentService.get().getExpMaterial(p.first).getName() + ": " + p.second)))))));
+            return new HtmlView("Fixups Needed",
+                DOM.createHtmlFragment(
+                        DOM.H2("Sample Types"),
+                        summaries.entrySet().stream().map(e ->
+                            DOM.DIV(
+                                    DOM.H4(e.getKey().first.getName()),
+                                    DOM.TABLE(at(cl("table-condensed", "labkey-data-region", "table-bordered")),
+                                            DOM.THEAD(DOM.TH("SampleID"), DOM.TH(e.getKey().second)),
+                                            e.getValue().stream().map(p ->
+                                                        DOM.TR(DOM.TD(p.first.name), DOM.TD(p.second)))
+                                    ))),
+                    DOM.H2("Other Potentially Problematic Fields"),
+                    DOM.TABLE(at(cl("table-condensed", "labkey-data-region", "table-bordered")),
+                            DOM.THEAD(DOM.TH("Domain Name"), DOM.TH("Domain URI"), DOM.TH("Field Name"), DOM.TH("Container"), DOM.TH("Total Rows"), DOM.TH("Rows with Nulls")),
+                            otherProblematicFields.entrySet().stream().map(e -> {
+                                Field f = e.getKey();
+                                Pair<Long, Long> counts = e.getValue();
+                                return DOM.TR(DOM.TD(f.domainName), DOM.TD(f.domainURI), DOM.TD(f.name), DOM.TD(f.container.getPath(), DOM.TD(counts.first), DOM.TD(counts.second)));
+
+                            }
+                    ))));
         }
 
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("Lost to the void");
+            root.addChild("Accidentally Nulled Field Report");
         }
     }
 


### PR DESCRIPTION
#### Rationale
Add some reporting to help identify fields that may have a storage mismatch

#### Changes
- Add a FieldNameLength column and other calculated values to the exp.Fields query
- Metric to report the number of fields with a storage column name mismatch
- Rudimentary report for lost values in sample types