### PR TITLE
Allow recovery from bad grid view filters

### DIFF
--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -69,6 +69,7 @@ import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.template.PageConfig;
 import org.labkey.api.visualization.VisualizationUrls;
+import org.springframework.validation.Errors;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -944,11 +945,18 @@ public class DataRegion extends DisplayElement
             out.write("You do not have permission to read this data");
             return;
         }
+
         Results results = null;
         try
         {
             boolean showParameterForm = false;
-            if (usesResultSet())
+            Errors errors = ctx.getErrors();
+
+            if (errors != null && errors.hasErrors())
+            {
+                errors.getAllErrors().forEach(err -> addError(err.getDefaultMessage()));
+            }
+            else if (usesResultSet())
             {
                 try
                 {
@@ -964,10 +972,7 @@ public class DataRegion extends DisplayElement
                 }
                 catch (SQLException | RuntimeSQLException | IllegalArgumentException | ConversionException x)
                 {
-                    _errorCreatingResults = true;
-                    _showPagination = false;
-                    _allowHeaderLock = false;
-                    addMessage(new Message(x.getMessage(), MessageType.ERROR, MessagePart.header));
+                    addError(x.getMessage());
                 }
             }
 
@@ -984,6 +989,14 @@ public class DataRegion extends DisplayElement
         {
             ResultSetUtil.close(results);
         }
+    }
+
+    private void addError(String message)
+    {
+        _errorCreatingResults = true;
+        _showPagination = false;
+        _allowHeaderLock = false;
+        addMessage(new Message(message, MessageType.ERROR, MessagePart.header));
     }
 
     private void _renderParameterForm(RenderContext ctx, Writer out) throws IOException

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -2319,7 +2319,7 @@ public class QueryView extends WebPartView<Object>
                 }
                 catch (ConversionException e)
                 {
-                    _errors.reject(ERROR_MSG, "Invalid view filter: " + e.getMessage());
+                    _errors.reject(ERROR_MSG, "Invalid grid view filter: " + e.getMessage());
                 }
                 sort.addURLSort(customViewUrl, getDataRegionName());
             }

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -18,6 +18,7 @@ package org.labkey.api.query;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -132,6 +133,8 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
+
+import static org.labkey.api.action.SpringActionController.ERROR_MSG;
 
 /**
  * View that generates the majority of standard data grids/tables in the LabKey Server UI.
@@ -2310,7 +2313,14 @@ public class QueryView extends WebPartView<Object>
 
             if (customViewUrl != null)
             {
-                filter.addUrlFilters(customViewUrl, getDataRegionName());
+                try
+                {
+                    filter.addUrlFilters(customViewUrl, getDataRegionName());
+                }
+                catch (ConversionException e)
+                {
+                    _errors.reject(ERROR_MSG, "Invalid view filter: " + e.getMessage());
+                }
                 sort.addURLSort(customViewUrl, getDataRegionName());
             }
 


### PR DESCRIPTION
#### Rationale
An invalid parameter in a grid view filter blocks editing and deleting of that view. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52661

This PR catches view filter conversion exceptions and adds them as errors that the grid renders, which matches the behavior of URL filters.

Before:

![image](https://github.com/user-attachments/assets/74031971-4da2-4e17-bef9-6f783fbf9342)

After:

![image](https://github.com/user-attachments/assets/3581921f-642c-4e7a-bfa4-fe60f5295ea8)
