### PR TITLE
Adding expand before verifying that fields are present.

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -142,7 +142,8 @@ public class StudyDatasetsTest extends BaseWebDriverTest
         String datasetA = TestDataGenerator.randomDomainName();
         createDataset(datasetA, null);
 
-        renameDataset("Invalid StudyDatasetVisit name '" + badDataSetName + "'. StudyDatasetVisit name must start with a letter or a number.", datasetA, badDataSetName, datasetA, badDataSetName, "XTest", "YTest", "ZTest");
+        renameDataset("Invalid StudyDatasetVisit name '" + badDataSetName + "'. StudyDatasetVisit name must start with a letter or a number.", datasetA, badDataSetName, datasetA, badDataSetName,
+                "XTest", "YTest", "ZTest");
 
         String datasetAUpdated = TestDataGenerator.randomDomainName();
         datasetAUpdated = " " + datasetAUpdated + " "; // assure we trim leading and trailing spaces even if passed in
@@ -238,6 +239,10 @@ public class StudyDatasetsTest extends BaseWebDriverTest
         editDatasetPage
             .setName(newName)
             .setDatasetLabel(newLabel);
+
+          editDatasetPage
+                .getFieldsPanel()
+                .expand();
 
         for (String fieldName : fieldNames)
         {


### PR DESCRIPTION
#### Rationale
Recently test started failing on teamcity while waiting for the field name to appear.  Expanding the field panel should wait for it appear.

<img width="847" alt="image" src="https://github.com/user-attachments/assets/11261a93-3c90-4f7d-b5ae-1d755d7e34b0" />

Teamcity failure link : https://teamcity.labkey.org/buildConfiguration/LabKey_253Release_Premium_CommunitySqlserver_DailyESqlserver/3438753

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
