### PR TITLE
Issue 52666: Check column remapping when looking for columns to not update

### DIFF
--- a/api/src/org/labkey/api/data/StatementUtils.java
+++ b/api/src/org/labkey/api/data/StatementUtils.java
@@ -864,8 +864,14 @@ public class StatementUtils
             for (int i = 0; i < cols.size(); i++)
             {
                 FieldKey fk = cols.get(i).getFieldKey();
-                if (keys.containsKey(fk) || null != _dontUpdateColumnNames && _dontUpdateColumnNames.contains(cols.get(i).getName()))
+                if (keys.containsKey(fk))
                     continue;
+
+                // Issue 52666: Check column remapping when looking for columns to not update
+                String colName = cols.get(i).getName();
+                if (_dontUpdateColumnNames.contains(colName) || (remap.containsKey(colName) && _dontUpdateColumnNames.contains(remap.get(colName))))
+                    continue;
+
                 sqlfUpdate.append(comma);
                 comma = ", ";
                 sqlfUpdate.appendIdentifier(cols.get(i).getSelectName());

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
@@ -67,7 +67,6 @@
 <%@ page import="org.labkey.api.query.QueryService" %>
 <%@ page import="org.labkey.api.query.SchemaKey" %>
 <%@ page import="org.labkey.api.query.UserSchema" %>
-<%@ page import="org.labkey.api.reader.MapLoader" %>
 <%@ page import="static java.util.Collections.emptyList" %>
 <%@ page import="org.labkey.api.security.SecurityManager" %>
 <%@ page import="org.labkey.api.security.User" %>
@@ -102,6 +101,9 @@
 <%@ page import="org.labkey.api.action.ApiUsageException" %>
 <%@ page import="org.labkey.api.search.SearchService" %>
 <%@ page import="java.util.concurrent.TimeUnit" %>
+<%@ page import="org.labkey.api.dataiterator.MapDataIterator" %>
+<%@ page import="org.labkey.api.exp.query.ExpSchema" %>
+<%@ page import="org.jetbrains.annotations.NotNull" %>
 
 <%@ page extends="org.labkey.api.jsp.JspTest.BVT" %>
 
@@ -231,6 +233,7 @@ public void testDataClass() throws Exception
 {
     final User user = TestContext.get().getUser();
     final Container sub = ContainerManager.createContainer(c, "sub", TestContext.get().getUser());
+    final String dataClassName = "testing";
 
     List<GWTPropertyDescriptor> props = new ArrayList<>();
     props.add(new GWTPropertyDescriptor("aa", "int"));
@@ -242,16 +245,13 @@ public void testDataClass() throws Exception
     DataClassDomainKindProperties options = new DataClassDomainKindProperties();
     options.setNameExpression("JUNIT-${genId}-${aa}");
 
-    final ExpDataClassImpl dataClass = ExperimentServiceImpl.get().createDataClass(c, user, "testing", options, props, indices, null, null);
+    final ExpDataClassImpl dataClass = ExperimentServiceImpl.get().createDataClass(c, user, dataClassName, options, props, indices, null, null);
     assertNotNull(dataClass);
 
     final Domain domain = dataClass.getDomain();
     assertNotNull(domain);
 
-    UserSchema schema = QueryService.get().getUserSchema(user, c, helper.expDataSchemaKey);
-    TableInfo table = schema.getTable("testing");
-    assertNotNull("data class not in query schema", table);
-
+    TableInfo table = getDataClassTable(dataClassName);
     String expectedName = "JUNIT-1-20";
     testNameExpressionGeneration(dataClass, table, expectedName);
     testInsertDuplicate(dataClass, table);
@@ -373,8 +373,7 @@ private void testBulkImport(ExpDataClassImpl dataClass, TableInfo table, User us
     row.put("alias", "a,b,c");
     rows.add(row);
 
-    MapLoader mapLoader = new MapLoader(rows);
-    int count = table.getUpdateService().loadRows(user, c, mapLoader, new DataIteratorContext(), null);
+    int count = table.getUpdateService().loadRows(user, c, MapDataIterator.of(rows), new DataIteratorContext(), null);
     assertEquals(2, count);
     assertEquals(2, dataClass.getDatas().size());
 
@@ -492,16 +491,12 @@ private void verifyAliasesViaSelectRows(String schemaName, String queryName, int
 private void testEmptyInsert(ExpDataClassImpl dataClass, TableInfo table, User user) throws Exception
 {
     List<Map<String, Object>> rows = new ArrayList<>();
-    MapLoader b = new MapLoader(rows);
-
     BatchValidationException errors = new BatchValidationException();
-    int count = table.getUpdateService().importRows(user, c, b, errors, null, null);
+    int count = table.getUpdateService().importRows(user, c, MapDataIterator.of(rows), errors, null, null);
     if (errors.hasErrors())
         throw errors;
     assertEquals(0, count);
 }
-
-
 
 @Test
 public void testDataClassFromTemplate() throws Exception
@@ -553,11 +548,8 @@ public void testDataClassFromTemplate() throws Exception
     Lookup lookup = new Lookup(c, "lists", listName);
     ConceptURIProperties.setLookup(c, "http://cpas.labkey.com/Experiment#Testing", lookup);
 
-    UserSchema schema = QueryService.get().getUserSchema(user, c, helper.expDataSchemaKey);
-    TableInfo table = schema.getTable(domainName);
-    assertNotNull("data class not in query schema", table);
-
     // verify that the lookup from the ConceptURI mapping is applied as a FK to the column
+    TableInfo table = getDataClassTable(domainName);
     TableInfo aaLookupTable = table.getColumn("aa").getFkTableInfo();
     assertNotNull(aaLookupTable);
     assertEquals("lists", aaLookupTable.getPublicSchemaName());
@@ -701,15 +693,15 @@ public void testContainerDelete() throws Exception
 {
     final User user = TestContext.get().getUser();
     final Container sub = ContainerManager.createContainer(c, "sub", user);
+    final String dataClassName = "testing";
 
     List<GWTPropertyDescriptor> props = new ArrayList<>();
     props.add(new GWTPropertyDescriptor("aa", "int"));
 
-    final ExpDataClassImpl dataClass = ExperimentServiceImpl.get().createDataClass(c, user, "testing", null, props, emptyList(), null, null);
+    final ExpDataClassImpl dataClass = ExperimentServiceImpl.get().createDataClass(c, user, dataClassName, null, props, emptyList(), null, null);
     final int dataClassId = dataClass.getRowId();
 
-    UserSchema schema = QueryService.get().getUserSchema(user, c, helper.expDataSchemaKey);
-    TableInfo table = schema.getTable("testing");
+    TableInfo table = getDataClassTable(dataClassName);
 
     // setup: insert into junit container
     int dataRowId1;
@@ -1039,26 +1031,32 @@ public void testInsertOptionUpdate() throws Exception
     List<GWTPropertyDescriptor> props = new ArrayList<>();
     props.add(new GWTPropertyDescriptor("prop", "string"));
 
-    ExpDataClass dataClass = ExperimentServiceImpl.get().createDataClass(c, user, dataClassName, null, props, emptyList(), null, null);
-    List<Map<String, Object>> rowsToAdd = new ArrayList<>();
-    rowsToAdd.add(CaseInsensitiveHashMap.of("name", "D-1", "prop", "a"));
-    rowsToAdd.add(CaseInsensitiveHashMap.of("name", "D-1-d", "prop", "c"));
-    rowsToAdd.add(CaseInsensitiveHashMap.of("name", "D-2", "prop", "b"));
+    String longFieldName = "Field100 ABCDEFGHIJKLMNOPQRSTUVWXYZ%()=+-[]_|*`'\":;<>?!@#^AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSTTU)";
+    props.add(new GWTPropertyDescriptor(longFieldName, "string"));
 
-    UserSchema schema = QueryService.get().getUserSchema(user, c, helper.expDataSchemaKey);
-    TableInfo table = schema.getTable(dataClassName);
+    ExperimentServiceImpl.get().createDataClass(c, user, dataClassName, null, props, emptyList(), null, null);
+    List<Map<String, Object>> rowsToAdd = new ArrayList<>();
+    rowsToAdd.add(CaseInsensitiveHashMap.of("name", "D-1", "prop", "a", longFieldName, "Very"));
+    rowsToAdd.add(CaseInsensitiveHashMap.of("name", "D-1-d", "prop", "c", longFieldName, "Long"));
+    rowsToAdd.add(CaseInsensitiveHashMap.of("name", "D-2", "prop", "b", longFieldName, "Field"));
+
+    TableInfo table = getDataClassTable(dataClassName);
     QueryUpdateService qus = table.getUpdateService();
+    assertNotNull(qus);
+
+    String longFieldAlias = table.getColumn(longFieldName).getAlias();
+    assertFalse("Unexpected long field alias", longFieldName.equalsIgnoreCase(longFieldAlias));
 
     DataIteratorContext context = new DataIteratorContext();
     context.setInsertOption(QueryUpdateService.InsertOption.IMPORT);
 
-    var count = qus.loadRows(user, c, new MapLoader(rowsToAdd), context, null);
+    var count = qus.loadRows(user, c, MapDataIterator.of(rowsToAdd), context, null);
     assertFalse(context.getErrors().hasErrors());
-    assertEquals(count,3);
+    assertEquals(3, count);
 
     TableInfo dataInputTInfo = ((ExperimentServiceImpl) ExperimentService.get()).getTinfoExperimentRunDataInputs();
     SimpleFilter filter = SimpleFilter.createContainerFilter(c);
-    TableSelector ts = new TableSelector(dataInputTInfo, TableSelector.ALL_COLUMNS, filter, null);
+    TableSelector ts = new TableSelector(dataInputTInfo, filter, null);
     int inputCount =  (int) ts.getRowCount();
 
     // update regular properties as well as datainputs
@@ -1068,23 +1066,33 @@ public void testInsertOptionUpdate() throws Exception
     rowsToUpdate.add(CaseInsensitiveHashMap.of("name", "D-2", "prop", "b1", "DataInputs/DataClassWithImportOption", null));
 
     context.setInsertOption(QueryUpdateService.InsertOption.UPDATE);
-    count = qus.loadRows(user, c, new MapLoader(rowsToUpdate), context, null);
+    count = qus.loadRows(user, c, MapDataIterator.of(rowsToUpdate), context, null);
 
     assertFalse(context.getErrors().hasErrors());
-    assertEquals(count,3);
+    assertEquals(3, count);
 
     Set<String> columnNames = new HashSet<>();
     columnNames.add("Name");
     columnNames.add("prop");
+    columnNames.add(longFieldName);
 
     List<Map<String,Object>> rows = Arrays.asList(new TableSelector(table, columnNames, null, new Sort("Name")).getMapArray());
     assertEquals("a1", rows.get(0).get("prop"));
     assertEquals("c1", rows.get(1).get("prop"));
     assertEquals("b1", rows.get(2).get("prop"));
+    assertEquals("Very", rows.get(0).get(longFieldAlias));
+    assertEquals("Long", rows.get(1).get(longFieldAlias));
+    assertEquals("Field", rows.get(2).get(longFieldAlias));
 
-    ts = new TableSelector(dataInputTInfo, TableSelector.ALL_COLUMNS, filter, null);
+    ts = new TableSelector(dataInputTInfo, filter, null);
     int newInputCount =  (int) ts.getRowCount();
     assertEquals(inputCount + 1, newInputCount);
+}
+
+private @NotNull TableInfo getDataClassTable(String dataClassName)
+{
+    UserSchema schema = QueryService.get().getUserSchema(TestContext.get().getUser(), c, ExpSchema.SCHEMA_EXP_DATA);
+    return schema.getTableOrThrow(dataClassName);
 }
 
 %>

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
@@ -87,11 +87,12 @@
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.Set" %>
-<%@ page import="org.labkey.api.reader.MapLoader" %>
 <%@ page import="org.labkey.api.action.ApiUsageException" %>
 <%@ page import="org.labkey.api.exp.api.ExpLineageService" %>
 <%@ page import="org.labkey.api.search.SearchService" %>
 <%@ page import="java.util.concurrent.TimeUnit" %>
+<%@ page import="org.jetbrains.annotations.NotNull" %>
+<%@ page import="org.labkey.api.dataiterator.MapDataIterator" %>
 
 <%@ page extends="org.labkey.api.jsp.JspTest.BVT" %>
 
@@ -728,7 +729,7 @@ public void testUpdateSomeParents() throws Exception
     rows.add(CaseInsensitiveHashMap.of("name", "C1", "MaterialInputs/Parent1Samples", "P1-1")); // change one parent but not the other
     rows.add(CaseInsensitiveHashMap.of("name", "C4", "MaterialInputs/Parent1Samples", null)); // remove one parent but not the other
 
-    svc.mergeRows(user, c, new MapLoader(rows), errors, null, null);
+    svc.mergeRows(user, c, MapDataIterator.of(rows), errors, null, null);
     assertFalse(errors.hasErrors());
 
     ExpLineage lineage = ExpLineageService.get().getLineage(c, user, C1, opts);
@@ -745,7 +746,7 @@ public void testUpdateSomeParents() throws Exception
     rows.add(CaseInsensitiveHashMap.of("name", "C4", "MaterialInputs/Parent1Samples", "P1-1", "MaterialInputs/Parent2Samples", "P2-1")); // change both parents
     rows.add(CaseInsensitiveHashMap.of("name", "C2", "MaterialInputs/Parent1Samples", "", "MaterialInputs/Parent2Samples", null)); // remove both parents
 
-    svc.mergeRows(user, c, new MapLoader(rows), errors, null, null);
+    svc.mergeRows(user, c, MapDataIterator.of(rows), errors, null, null);
     assertFalse(errors.hasErrors());
 
     lineage = ExpLineageService.get().getLineage(c, user, C2, opts);
@@ -1049,7 +1050,7 @@ public void testDetailedAuditLog() throws Exception
     // and since merge is a different code path...
     rows.clear(); errors.clear();
     rows.add(PageFlowUtil.mapInsensitive("Name", "A1", "Measure", "Merged", "Value", 3.0));
-    int count = qus.mergeRows(user, c, new MapLoader(rows), errors, config, null);
+    int count = qus.mergeRows(user, c, MapDataIterator.of(rows), errors, config, null);
     assertEquals(1, count);
     // check audit log
     events = AuditLogService.get().getAuditEvents(c,user,SampleTimelineAuditEvent.EVENT_TYPE,f,new Sort("-RowId"));
@@ -1144,12 +1145,16 @@ public void testExpMaterialPermissions() throws Exception
     assertEquals("Failed to delete material via QUS", 1, rows.size());
 }
 
+private @NotNull TableInfo getSampleTypeTable(String sampleType)
+{
+    UserSchema schema = QueryService.get().getUserSchema(TestContext.get().getUser(), c, SamplesSchema.SCHEMA_SAMPLES);
+    return schema.getTableOrThrow(sampleType);
+}
+
 private List<Map<String,Object>> getSampleRows(String sampleType)
 {
-    User user = TestContext.get().getUser();
-
-    TableInfo tInfo = QueryService.get().getUserSchema(user, c, SamplesSchema.SCHEMA_NAME).getTable(sampleType);
-    return Arrays.asList(new TableSelector(tInfo, TableSelector.ALL_COLUMNS, null, new Sort("Name")).getMapArray());
+    TableInfo table = getSampleTypeTable(sampleType);
+    return Arrays.asList(new TableSelector(table, null, new Sort("Name")).getMapArray());
 }
 
 @Test
@@ -1161,35 +1166,45 @@ public void testInsertOptionUpdate() throws Exception
     List<GWTPropertyDescriptor> props = new ArrayList<>();
     props.add(new GWTPropertyDescriptor("name", "string"));
     props.add(new GWTPropertyDescriptor("intVal", "int"));
-    var requiredCol = new GWTPropertyDescriptor("RequiredCol", "string");
+
+    String requiredColName = "RequiredCol";
+    var requiredCol = new GWTPropertyDescriptor(requiredColName, "string");
     requiredCol.setRequired(true);
     props.add(requiredCol);
+
+    String longFieldName = "Field100 ABCDEFGHIJKLMNOPQRSTUVWXYZ%()=+-[]_|*`'\":;<>?!@#^AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSTTU)";
+    props.add(new GWTPropertyDescriptor(longFieldName, "string"));
 
     final String sampleTypeName = "TestSamplesWithRequired";
     SampleTypeService.get().createSampleType(c, user, sampleTypeName, null, props, Collections.emptyList(), -1, -1, -1, -1, null);
 
-    UserSchema schema = QueryService.get().getUserSchema(user, c, SchemaKey.fromParts("Samples"));
-    TableInfo table = schema.getTable(sampleTypeName);
+    TableInfo table = getSampleTypeTable(sampleTypeName);
     QueryUpdateService qus = table.getUpdateService();
+    assertNotNull(qus);
+
+    String longFieldAlias = table.getColumn(longFieldName).getAlias();
+    assertFalse("Unexpected long field alias", longFieldName.equalsIgnoreCase(longFieldAlias));
 
     // import samples
     List<Map<String, Object>> rowsToAdd = new ArrayList<>();
-    rowsToAdd.add(CaseInsensitiveHashMap.of("name", "S-1", "intVal", 10, "AliquotedFrom", null, "RequiredCol", "a"));
-    rowsToAdd.add(CaseInsensitiveHashMap.of("name", null, "intVal", null, "AliquotedFrom", "S-1", "RequiredCol", null));
-    rowsToAdd.add(CaseInsensitiveHashMap.of("name", "S-2", "intVal", 20, "AliquotedFrom", null, "RequiredCol", "b"));
+    rowsToAdd.add(CaseInsensitiveHashMap.of("name", "S-1", "intVal", 10, "AliquotedFrom", null, requiredColName, "a", longFieldName, "Very"));
+    rowsToAdd.add(CaseInsensitiveHashMap.of("name", null, "intVal", null, "AliquotedFrom", "S-1", requiredColName, null, longFieldName, "Long"));
+    rowsToAdd.add(CaseInsensitiveHashMap.of("name", "S-2", "intVal", 20, "AliquotedFrom", null, requiredColName, "b", longFieldName, "Field"));
 
     DataIteratorContext context = new DataIteratorContext();
     context.setInsertOption(QueryUpdateService.InsertOption.IMPORT);
-    var count = qus.loadRows(user, c, new MapLoader(rowsToAdd), context, null);
+    var count = qus.loadRows(user, c, MapDataIterator.of(rowsToAdd), context, null);
 
     assertFalse(context.getErrors().hasErrors());
-    assertEquals(count,3);
+    assertEquals("Unexpected count from IMPORT on loadRows()", 3, count);
+
     var rows = getSampleRows(sampleTypeName);
     assertEquals("S-1", rows.get(0).get("name"));
     assertEquals(1, rows.get(0).get("aliquotcount"));
     assertEquals(0.0, rows.get(0).get("aliquotvolume"));
     assertEquals(0, rows.get(0).get("availablealiquotcount"));
     assertEquals(0.0, rows.get(0).get("availablealiquotvolume"));
+    assertEquals(String.format("Failed insert for field \"%s\"", longFieldName), "Very", rows.get(0).get(longFieldAlias));
 
     assertEquals("S-1-1", rows.get(1).get("name"));
     assertEquals(10, rows.get(1).get("intVal"));
@@ -1197,13 +1212,17 @@ public void testInsertOptionUpdate() throws Exception
     assertNull(rows.get(1).get("aliquotvolume"));
     assertNull(rows.get(1).get("availablealiquotcount"));
     assertNull(rows.get(1).get("availablealiquotvolume"));
+    // TODO: I cannot figure out what is happening here. Row values are getting cross-mapped during insert. Both requiredColName and longFieldName values are incorrect.
+//    assertNull(rows.get(1).get(requiredColName)); // Is returning "a"
+//    assertEquals(String.format("Failed insert for field \"%s\"", longFieldName), "Long", rows.get(1).get(longFieldAlias)); // Is returning "Very"
 
     assertEquals("S-2", rows.get(2).get("name"));
-    assertEquals("b", rows.get(2).get("RequiredCol"));
+    assertEquals("b", rows.get(2).get(requiredColName));
     assertEquals(0, rows.get(2).get("aliquotcount"));
     assertEquals(0.0, rows.get(2).get("aliquotvolume"));
     assertEquals(0, rows.get(2).get("availablealiquotcount"));
     assertEquals(0.0, rows.get(2).get("availablealiquotvolume"));
+    assertEquals(String.format("Failed insert for field \"%s\"", longFieldName), "Field", rows.get(2).get(longFieldAlias));
 
     // Update samples using data iterator
     // -- AliquotedFrom is not needed for update
@@ -1214,10 +1233,11 @@ public void testInsertOptionUpdate() throws Exception
     rowsToUpdate.add(CaseInsensitiveHashMap.of("name", "S-2", "intVal", 200));
 
     context.setInsertOption(QueryUpdateService.InsertOption.UPDATE);
-    count = qus.loadRows(user, c, new MapLoader(rowsToUpdate), context, null);
+    count = qus.loadRows(user, c, MapDataIterator.of(rowsToUpdate), context, null);
 
     assertFalse(context.getErrors().hasErrors());
-    assertEquals(count,3);
+    assertEquals("Unexpected count from UPDATE on loadRows()", 3, count);
+
     rows = getSampleRows(sampleTypeName);
     // test existing row value is updated
     assertEquals(100, rows.get(0).get("intVal"));
@@ -1225,22 +1245,27 @@ public void testInsertOptionUpdate() throws Exception
     assertEquals(0.0, rows.get(0).get("aliquotvolume"));
     assertEquals(0, rows.get(0).get("availablealiquotcount"));
     assertEquals(0.0, rows.get(0).get("availablealiquotvolume"));
+    assertEquals(String.format("Data for field \"%s\" unexpectedly changed", longFieldName), "Very", rows.get(0).get(longFieldAlias));
+
     assertEquals(100, rows.get(1).get("intVal"));
-    assertEquals("a", rows.get(1).get("RequiredCol")); // absent columns are not blanked out
+    assertEquals("a", rows.get(1).get(requiredColName)); // absent columns are not blanked out
     final String aliquotedFromLSID = (String) rows.get(1).get("AliquotedFromLSID");
     assertEquals(true, rows.get(1).get("IsAliquot"));
     assertEquals(100, rows.get(1).get("intVal"));
+//    assertEquals(String.format("Data for field \"%s\" unexpectedly changed", longFieldName), "Long", rows.get(1).get(longFieldAlias));
+
     assertEquals(200, rows.get(2).get("intVal"));
-    assertEquals("b", rows.get(2).get("RequiredCol")); // absent columns are not blanked out
+    assertEquals("b", rows.get(2).get(requiredColName)); // absent columns are not blanked out
     assertEquals(0, rows.get(2).get("aliquotcount"));
     assertEquals(0.0, rows.get(2).get("aliquotvolume"));
     assertEquals(0, rows.get(2).get("availablealiquotcount"));
     assertEquals(0.0, rows.get(2).get("availablealiquotvolume"));
+    assertEquals(String.format("Data for field \"%s\" unexpectedly changed", longFieldName), "Field", rows.get(2).get(longFieldAlias));
 
     // update a sample that doesn't exist should throw error
     rowsToUpdate = new ArrayList<>();
     rowsToUpdate.add(CaseInsensitiveHashMap.of("name", "S-1-absent", "intVal", 100));
-    qus.loadRows(user, c, new MapLoader(rowsToUpdate), context, null);
+    qus.loadRows(user, c, MapDataIterator.of(rowsToUpdate), context, null);
     assertTrue(context.getErrors().hasErrors());
     String msg = context.getErrors().getRowErrors().size() > 0 ? context.getErrors().getRowErrors().get(0).toString() : "no message";
     assertTrue(msg.contains("Sample does not exist: S-1-absent."));
@@ -1251,7 +1276,7 @@ public void testInsertOptionUpdate() throws Exception
     Map<Enum, Object> auditOptions = new HashMap<>();
     auditOptions.put(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior, AuditBehaviorType.DETAILED);
     context.setConfigParameters(auditOptions);
-    qus.loadRows(user, c, new MapLoader(rowsToUpdate), context, null);
+    qus.loadRows(user, c, MapDataIterator.of(rowsToUpdate), context, null);
     assertTrue(context.getErrors().hasErrors());
     msg = context.getErrors().getRowErrors().size() > 0 ? context.getErrors().getRowErrors().get(0).toString() : "no message";
     assertTrue(msg.contains("Sample does not exist: S-1-absent."));
@@ -1264,14 +1289,12 @@ public void testInsertOptionUpdate() throws Exception
 
     context = new DataIteratorContext();
     context.setInsertOption(QueryUpdateService.InsertOption.UPDATE);
-    qus.loadRows(user, c, new MapLoader(rowsToUpdate), context, null);
+    qus.loadRows(user, c, MapDataIterator.of(rowsToUpdate), context, null);
     assertFalse(context.getErrors().hasErrors());
     assertEquals(count,3);
     rows = getSampleRows(sampleTypeName);
     assertNull(rows.get(0).get("AliquotedFromLSID"));
     assertEquals(aliquotedFromLSID, rows.get(1).get("AliquotedFromLSID"));
     assertNull(rows.get(2).get("AliquotedFromLSID"));
-
 }
-
 %>

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
@@ -1204,6 +1204,7 @@ public void testInsertOptionUpdate() throws Exception
     assertEquals(0.0, rows.get(0).get("aliquotvolume"));
     assertEquals(0, rows.get(0).get("availablealiquotcount"));
     assertEquals(0.0, rows.get(0).get("availablealiquotvolume"));
+    assertEquals("a", rows.get(0).get(requiredColName));
     assertEquals(String.format("Failed insert for field \"%s\"", longFieldName), "Very", rows.get(0).get(longFieldAlias));
 
     assertEquals("S-1-1", rows.get(1).get("name"));
@@ -1212,9 +1213,8 @@ public void testInsertOptionUpdate() throws Exception
     assertNull(rows.get(1).get("aliquotvolume"));
     assertNull(rows.get(1).get("availablealiquotcount"));
     assertNull(rows.get(1).get("availablealiquotvolume"));
-    // TODO: I cannot figure out what is happening here. Row values are getting cross-mapped during insert. Both requiredColName and longFieldName values are incorrect.
-//    assertNull(rows.get(1).get(requiredColName)); // Is returning "a"
-//    assertEquals(String.format("Failed insert for field \"%s\"", longFieldName), "Long", rows.get(1).get(longFieldAlias)); // Is returning "Very"
+    assertEquals("Expected aliquot parent values to be copied into aliquot", "a", rows.get(1).get(requiredColName));
+    assertEquals("Expected aliquot parent values to be copied into aliquot", "Very", rows.get(1).get(longFieldAlias));
 
     assertEquals("S-2", rows.get(2).get("name"));
     assertEquals("b", rows.get(2).get(requiredColName));
@@ -1252,7 +1252,7 @@ public void testInsertOptionUpdate() throws Exception
     final String aliquotedFromLSID = (String) rows.get(1).get("AliquotedFromLSID");
     assertEquals(true, rows.get(1).get("IsAliquot"));
     assertEquals(100, rows.get(1).get("intVal"));
-//    assertEquals(String.format("Data for field \"%s\" unexpectedly changed", longFieldName), "Long", rows.get(1).get(longFieldAlias));
+    assertEquals(String.format("Data for field \"%s\" unexpectedly changed", longFieldName), "Very", rows.get(1).get(longFieldAlias));
 
     assertEquals(200, rows.get(2).get("intVal"));
     assertEquals("b", rows.get(2).get(requiredColName)); // absent columns are not blanked out


### PR DESCRIPTION
#### Rationale
This addresses [Issue 52666](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52666) by checking for remapped columns when processing which columns to not update in `StatementUtils`.

#### Changes
- Check remapped columns collection when looking for columns to not update
- Unit tests for sample types, data classes
