### PR TITLE
Remove Site Admins and Site Developers menu items

### DIFF
--- a/announcements/src/org/labkey/announcements/discussionMenu.jsp
+++ b/announcements/src/org/labkey/announcements/discussionMenu.jsp
@@ -30,7 +30,7 @@
 <%@ page import="java.util.List" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    DiscussionServiceImpl.PickerView me = (DiscussionServiceImpl.PickerView) HttpView.currentView();
+    DiscussionServiceImpl.PickerView me = HttpView.currentView();
     Container c = getContainer();
     User user = getUser();
 

--- a/api/src/org/labkey/api/data/MenuButton.java
+++ b/api/src/org/labkey/api/data/MenuButton.java
@@ -22,15 +22,10 @@ import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.PopupMenu;
-
-import java.io.IOException;
-import java.io.Writer;
+import org.labkey.api.writer.HtmlWriter;
 
 /**
  * A button that responds to a user click by popping up a drop-down menu.
- *
- * User: jeckels
- * Date: Nov 15, 2007
  */
 public class MenuButton extends ActionButton
 {
@@ -53,7 +48,7 @@ public class MenuButton extends ActionButton
     }
 
     @Override
-    public void render(RenderContext ctx, Writer out) throws IOException
+    public void render(RenderContext ctx, HtmlWriter out)
     {
         popupMenu.renderMenuButton(ctx, out, _requiresSelection, this);
 

--- a/api/src/org/labkey/api/security/impersonation/NotImpersonatingContext.java
+++ b/api/src/org/labkey/api/security/impersonation/NotImpersonatingContext.java
@@ -17,6 +17,7 @@ package org.labkey.api.security.impersonation;
 
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.GroupManager;
 import org.labkey.api.security.LoginUrls;
 import org.labkey.api.security.PrincipalArray;
@@ -89,23 +90,26 @@ public class NotImpersonatingContext implements ImpersonationContext
     @Override
     public void addMenu(NavTree menu, Container c, User user, ActionURL currentURL)
     {
-        @Nullable Container project = c.getProject();
+        if (ModuleLoader.getInstance().isStartupComplete())
+        {
+            @Nullable Container project = c.getProject();
 
-        // Must be site or project admin (folder admins can't impersonate)
-        if (user.hasRootAdminPermission() || (null != project && project.hasPermission(user, AdminPermission.class)))
-        {
-            NavTree impersonateMenu = new NavTree("Impersonate");
-            UserImpersonationContextFactory.addMenu(impersonateMenu);
-            GroupImpersonationContextFactory.addMenu(impersonateMenu);
-            RoleImpersonationContextFactory.addMenu(impersonateMenu);
-            menu.addChild(impersonateMenu);
-        }
-        // Or Impersonating Troubleshooter to impersonate site roles only
-        else if (null == project && user.hasRootPermission(CanImpersonatePrivilegedSiteRolesPermission.class))
-        {
-            NavTree impersonateMenu = new NavTree("Impersonate");
-            RoleImpersonationContextFactory.addMenu(impersonateMenu);
-            menu.addChild(impersonateMenu);
+            // Must be site or project admin (folder admins can't impersonate)
+            if (user.hasRootAdminPermission() || (null != project && project.hasPermission(user, AdminPermission.class)))
+            {
+                NavTree impersonateMenu = new NavTree("Impersonate");
+                UserImpersonationContextFactory.addMenu(impersonateMenu);
+                GroupImpersonationContextFactory.addMenu(impersonateMenu);
+                RoleImpersonationContextFactory.addMenu(impersonateMenu);
+                menu.addChild(impersonateMenu);
+            }
+            // Or Impersonating Troubleshooter to impersonate site roles only
+            else if (null == project && user.hasRootPermission(CanImpersonatePrivilegedSiteRolesPermission.class))
+            {
+                NavTree impersonateMenu = new NavTree("Impersonate");
+                RoleImpersonationContextFactory.addMenu(impersonateMenu);
+                menu.addChild(impersonateMenu);
+            }
         }
 
         NavTree signOut = new NavTree("Sign Out", PageFlowUtil.urlProvider(LoginUrls.class).getLogoutURL(c));

--- a/api/src/org/labkey/api/util/Button.java
+++ b/api/src/org/labkey/api/util/Button.java
@@ -267,7 +267,6 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
         private String typeCls;
         private boolean disableOnClick;
         private boolean dropdown;
-        private boolean enabled = true;
         private boolean submit;
 
         public ButtonBuilder(@NotNull String caption)
@@ -290,12 +289,6 @@ public class Button extends DisplayElement implements HasHtmlString, SafeToRende
         public ButtonBuilder disableOnClick(boolean disableOnClick)
         {
             this.disableOnClick = disableOnClick;
-            return this;
-        }
-
-        public ButtonBuilder enabled(boolean enabled)
-        {
-            this.enabled = enabled;
             return this;
         }
 

--- a/api/src/org/labkey/api/util/DisplayElementBuilder.java
+++ b/api/src/org/labkey/api/util/DisplayElementBuilder.java
@@ -45,6 +45,8 @@ public abstract class DisplayElementBuilder<T extends DisplayElement & HasHtmlSt
     String name;
     String target;
     String title;
+    boolean enabled = true;
+    Integer tabindex = null;
 
     public DisplayElementBuilder()
     {
@@ -173,6 +175,18 @@ public abstract class DisplayElementBuilder<T extends DisplayElement & HasHtmlSt
     public BUILDER style(String style)
     {
         this.style = style;
+        return getThis();
+    }
+
+    public BUILDER enabled(boolean enabled)
+    {
+        this.enabled = enabled;
+        return getThis();
+    }
+
+    public BUILDER tabindex(int tabindex)
+    {
+        this.tabindex = tabindex;
         return getThis();
     }
 

--- a/api/src/org/labkey/api/util/Link.java
+++ b/api/src/org/labkey/api/util/Link.java
@@ -30,10 +30,12 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.labkey.api.util.DOM.A;
+import static org.labkey.api.util.DOM.Attribute.disabled;
 import static org.labkey.api.util.DOM.Attribute.href;
 import static org.labkey.api.util.DOM.Attribute.name;
 import static org.labkey.api.util.DOM.Attribute.rel;
 import static org.labkey.api.util.DOM.Attribute.style;
+import static org.labkey.api.util.DOM.Attribute.tabindex;
 import static org.labkey.api.util.DOM.Attribute.target;
 import static org.labkey.api.util.DOM.Attribute.title;
 import static org.labkey.api.util.DOM.at;
@@ -93,6 +95,8 @@ public class Link extends DisplayElement implements HasHtmlString
                 .at(title, lb.title)
                 .at(style, lb.style)
                 .at(name, lb.name)
+                .at(tabindex, lb.tabindex)
+                .at(lb.enabled, disabled, true)
                 .data(null != lb.tooltip, "tt", "tooltip")
                 .data(null != lb.tooltip, "placement","top")
                 .data(null != lb.tooltip, "original-title", lb.tooltip),

--- a/api/src/org/labkey/api/view/NavTree.java
+++ b/api/src/org/labkey/api/view/NavTree.java
@@ -20,25 +20,29 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.Link.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
+import static org.labkey.api.util.DOM.I;
+import static org.labkey.api.util.DOM.cl;
+import static org.labkey.api.util.DOM.createHtmlFragment;
 
 /**
  * NavTree can be used three ways in different places in the product
- *
  * 1) as a single navigation element (no children)
  * 2) as a list of navigation elements (ignore the root node, use children as list of elements)
- * 3) as a tree, may be rendered as an tree, or menu
+ * 3) as a tree, may be rendered as a tree, or menu
  */
 
 public class NavTree implements Collapsible
@@ -146,7 +150,7 @@ public class NavTree implements Collapsible
         _imageCls = source._imageCls;
         _menuFilterItemCls = source._menuFilterItemCls;
 
-        _children.addAll(source._children.stream().map(NavTree::new).collect(Collectors.toList()));
+        _children.addAll(source._children.stream().map(NavTree::new).toList());
     }
 
 
@@ -288,7 +292,7 @@ public class NavTree implements Collapsible
     @Override
     public NavTree findSubtree(@Nullable String path)
     {
-        if (null == path || path.length() == 0 || "/".equals(path))
+        if (null == path || path.isEmpty() || "/".equals(path))
             return this;
 
         //use the escaped key for path matching, so that embedded / characters are escaped
@@ -649,24 +653,6 @@ public class NavTree implements Collapsible
         return sb;
     }
 
-    /**
-     * Generate a LinkBuilder from key properties of this NavTree.
-     * @return A LinkBuilder populated with properties from this NavTree
-     */
-    public LinkBuilder toLinkBuilder()
-    {
-        // Copy key properties. We could copy others, if needed by future code paths.
-        LinkBuilder lb = new LinkBuilder(_text).href(_href).onClick(_script);
-
-        if (_usePost)
-            lb.usePost(_confirmMessage);
-
-        if (isNoFollow())
-            lb.nofollow();
-
-        return lb;
-    }
-
     public static StringBuilder toJS(Collection<NavTree> list, @Nullable StringBuilder sb, boolean asMenu, boolean withIds)
     {
         if (null == sb)
@@ -684,5 +670,110 @@ public class NavTree implements Collapsible
         }
         sb.append("]");
         return sb;
+    }
+
+    /**
+     * Generate a LinkBuilder from key properties of this NavTree.
+     * @return A LinkBuilder populated with properties from this NavTree
+     */
+    public LinkBuilder toSimpleLinkBuilder()
+    {
+        // Copy key properties. We could copy others, if needed by future code paths.
+        LinkBuilder lb = new LinkBuilder(_text).href(_href).onClick(_script);
+
+        if (_usePost)
+            lb.usePost(_confirmMessage);
+
+        if (isNoFollow())
+            lb.nofollow();
+
+        return lb;
+    }
+
+    /**
+     * Generate a LinkBuilder from all properties of this NavTree.
+     * @return A LinkBuilder populated with properties from this NavTree
+     */
+    public LinkBuilder toLinkBuilder(@Nullable String cls)
+    {
+        // if the item is "selected" and doesn't have an image cls to use, provide our default
+        String itemImageCls = getImageCls();
+        if (isSelected() && null == itemImageCls)
+            itemImageCls = "fa fa-check-square-o";
+        HtmlStringBuilder html = HtmlStringBuilder.of();
+        if (null != itemImageCls)
+            html.append(createHtmlFragment(I(cl(itemImageCls))));
+        html.append(getText());
+
+        String styleStr = "";
+        if (null != itemImageCls)
+            styleStr += "padding-left: 0;";
+        if (isStrong())
+            styleStr += "font-weight: bold;";
+        if (isEmphasis())
+            styleStr += "font-style: italic;";
+
+        // NOTE: nofollow is not recommended as way to avoid crawling internal links
+        // instead let's use an onclick handler to "hide" the link
+        String dataQuery = null;
+        String href = getHref();
+        var config = HttpView.currentPageConfig();
+
+        if (null != href && null == getScript() && !isPost())
+        {
+            try
+            {
+                URLHelper url = new URLHelper(href);
+                boolean isLocal = null == url.getHost() && null == url.getScheme() && -1 == url.getPort();
+                if (isLocal)
+                {
+                    var context = HttpView.currentContext();
+
+                    // separate the path (into href) and query/fragment (into dataQuery) portions of URL
+                    var fragment = url.getFragment();
+                    url.setFragment(null);
+                    if (null != context && context.isRobot())
+                        url.addParameter(ActionURL.Param._noindex.name(), "1");
+                    dataQuery = StringUtils.trimToEmpty(url.getRawQuery());
+                    url.deleteParameters();
+                    if (!dataQuery.isEmpty())
+                        dataQuery = "?" + dataQuery;
+                    if (StringUtils.isNotEmpty(fragment))
+                        dataQuery += "#" + fragment;
+
+                    href = url.getLocalURIString();
+                    config.addHandlerForQuerySelector(
+                            "A.noFollowNavigate",
+                            "click",
+                            "window.location = this.href + this.dataset['query']; return false;");
+                    cls = StringUtils.trimToEmpty(cls) + " noFollowNavigate";
+                }
+            }
+            catch (URISyntaxException e)
+            {
+                // fall through
+            }
+        }
+
+        LinkBuilder builder = new LinkBuilder(html)
+            .id(config.makeId("popupMenuView"))
+            .target(getTarget())
+            .title(getDescription())
+            .tabindex(0)
+            .enabled(!isDisabled())
+            .clearClasses()
+            .href(null != href && !isPost() ? href : "#")
+            .onClick(getScript());
+
+        if (null != itemImageCls)
+            builder.style(styleStr);
+
+        if (cls != null)
+            builder.addClass(cls);
+
+        if (null != dataQuery)
+            builder.attributes(Map.of("data-query", dataQuery));
+
+        return builder;
     }
 }

--- a/api/src/org/labkey/api/view/PopupFolderNavView.java
+++ b/api/src/org/labkey/api/view/PopupFolderNavView.java
@@ -21,6 +21,7 @@ import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.writer.HtmlWriter;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -49,6 +50,7 @@ public class PopupFolderNavView extends PopupMenuView
         Container container = _context.getContainer();
         ActionURL startURL = PageFlowUtil.urlProvider(ProjectUrls.class).getStartURL(container);
         String pattern = startURL.getLocalURIString();
+        HtmlWriter out = HtmlWriter.of(oldWriter);
 
         for (NavTree child : tree.getChildren())
         {
@@ -63,7 +65,7 @@ public class PopupFolderNavView extends PopupMenuView
                 oldWriter.write("<a class=\"subexpand subexpand-target\" tabindex=\"0\"><i class=\"fa fa-chevron-right\"></i></a>");
                 oldWriter.write("<ul class=\"dropdown-layer-menu\">");
                 oldWriter.write("<li><a class=\"subcollapse\" tabindex=\"0\"><i class=\"fa fa-chevron-left\"></i>" + text + "</a></li>");
-                renderTreeDivider(oldWriter);
+                renderTreeDivider(out);
                 renderFolderNavTree(child, oldWriter);
                 oldWriter.write("</ul>");
                 oldWriter.write("</li>");

--- a/api/src/org/labkey/api/view/PopupFolderNavView.java
+++ b/api/src/org/labkey/api/view/PopupFolderNavView.java
@@ -40,7 +40,7 @@ public class PopupFolderNavView extends PopupMenuView
         renderFolderNavTree(ContainerManager.getProjectList(_context, true), out);
     }
 
-    private void renderFolderNavTree(NavTree tree, Writer out) throws IOException
+    private void renderFolderNavTree(NavTree tree, Writer oldWriter) throws IOException
     {
         if (tree == null)
             return;
@@ -58,19 +58,19 @@ public class PopupFolderNavView extends PopupMenuView
 
             if (child.hasChildren())
             {
-                out.write("<li class=\"dropdown-submenu " + (cls != null ? cls : "") + "\">");
-                renderLink(child, "subexpand-link " + (child.getHref() == null ? "lk-project-nav-disabled" : ""), out);
-                out.write("<a class=\"subexpand subexpand-target\" tabindex=\"0\"><i class=\"fa fa-chevron-right\"></i></a>");
-                out.write("<ul class=\"dropdown-layer-menu\">");
-                out.write("<li><a class=\"subcollapse\" tabindex=\"0\"><i class=\"fa fa-chevron-left\"></i>" + text + "</a></li>");
-                renderTreeDivider(out);
-                renderFolderNavTree(child, out);
-                out.write("</ul>");
-                out.write("</li>");
+                oldWriter.write("<li class=\"dropdown-submenu " + (cls != null ? cls : "") + "\">");
+                renderLink(child, "subexpand-link " + (child.getHref() == null ? "lk-project-nav-disabled" : ""), oldWriter);
+                oldWriter.write("<a class=\"subexpand subexpand-target\" tabindex=\"0\"><i class=\"fa fa-chevron-right\"></i></a>");
+                oldWriter.write("<ul class=\"dropdown-layer-menu\">");
+                oldWriter.write("<li><a class=\"subcollapse\" tabindex=\"0\"><i class=\"fa fa-chevron-left\"></i>" + text + "</a></li>");
+                renderTreeDivider(oldWriter);
+                renderFolderNavTree(child, oldWriter);
+                oldWriter.write("</ul>");
+                oldWriter.write("</li>");
             }
             else
             {
-                renderTreeItem(child, cls, out);
+                renderTreeItem(child, cls, oldWriter);
             }
         }
     }

--- a/api/src/org/labkey/api/view/PopupFolderNavView.java
+++ b/api/src/org/labkey/api/view/PopupFolderNavView.java
@@ -32,7 +32,6 @@ public class PopupFolderNavView extends PopupMenuView
 
     public PopupFolderNavView(ViewContext context)
     {
-        super();
         _context = context;
     }
 
@@ -61,7 +60,7 @@ public class PopupFolderNavView extends PopupMenuView
             if (child.hasChildren())
             {
                 oldWriter.write("<li class=\"dropdown-submenu " + (cls != null ? cls : "") + "\">");
-                renderLink(child, "subexpand-link " + (child.getHref() == null ? "lk-project-nav-disabled" : ""), oldWriter);
+                renderLink(child, "subexpand-link " + (child.getHref() == null ? "lk-project-nav-disabled" : ""), out);
                 oldWriter.write("<a class=\"subexpand subexpand-target\" tabindex=\"0\"><i class=\"fa fa-chevron-right\"></i></a>");
                 oldWriter.write("<ul class=\"dropdown-layer-menu\">");
                 oldWriter.write("<li><a class=\"subcollapse\" tabindex=\"0\"><i class=\"fa fa-chevron-left\"></i>" + text + "</a></li>");
@@ -72,7 +71,7 @@ public class PopupFolderNavView extends PopupMenuView
             }
             else
             {
-                renderTreeItem(child, cls, oldWriter);
+                renderTreeItem(child, cls, out);
             }
         }
     }

--- a/api/src/org/labkey/api/view/PopupHelpView.java
+++ b/api/src/org/labkey/api/view/PopupHelpView.java
@@ -19,6 +19,7 @@ package org.labkey.api.view;
 import org.labkey.api.announcements.api.Tour;
 import org.labkey.api.announcements.api.TourService;
 import org.labkey.api.data.Container;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.settings.AppProps;
@@ -29,7 +30,7 @@ import org.labkey.api.util.PageFlowUtil;
 import java.util.List;
 
 /**
- * The Help menu item that appears in the header and lets the user navigate to relevant documentation and other resources.
+ * The Help menu item that appears in the user menu and lets the user navigate to relevant documentation and other resources.
  */
 public class PopupHelpView extends PopupMenuView
 {
@@ -42,17 +43,19 @@ public class PopupHelpView extends PopupMenuView
 
     public static NavTree createNavTree(ViewContext context, HelpTopic topic)
     {
-        Container c = context.getContainer();
-        User user = context.getUser();
-
         NavTree menu = new NavTree("Help" + (AppProps.getInstance().isDevMode() && topic == HelpTopic.DEFAULT_HELP_TOPIC ? " (default)" : ""));
         menu.setId("helpMenu");
 
+        Container c = context.getContainer();
+        User user = context.getUser();
         LookAndFeelProperties laf = LookAndFeelProperties.getInstance(c);
 
-        String reportAProblemPath = laf.getReportAProblemPath();
-        if (reportAProblemPath != null && reportAProblemPath.trim().length() > 0 && !user.isGuest())
-            menu.addChild("Support", reportAProblemPath);
+        if (ModuleLoader.getInstance().isStartupComplete())
+        {
+            String reportAProblemPath = laf.getReportAProblemPath();
+            if (reportAProblemPath != null && !reportAProblemPath.trim().isEmpty() && !user.isGuest())
+                menu.addChild("Support", reportAProblemPath);
+        }
 
         if (laf.isHelpMenuEnabled())
             menu.addChild(topic.getNavTree("LabKey Documentation"));
@@ -65,7 +68,7 @@ public class PopupHelpView extends PopupMenuView
             {
                 List<Tour> tours = service.getApplicableTours(c);
 
-                if (tours.size() > 0)
+                if (!tours.isEmpty())
                 {
                     NavTree toursMenu = new NavTree("Tours");
                     for (Tour t : tours)

--- a/api/src/org/labkey/api/view/PopupMenu.java
+++ b/api/src/org/labkey/api/view/PopupMenu.java
@@ -20,13 +20,19 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.util.Button;
+import org.labkey.api.util.DOM;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.UniqueID;
+import org.labkey.api.writer.HtmlWriter;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.labkey.api.util.DOM.DIV;
+import static org.labkey.api.util.DOM.UL;
+import static org.labkey.api.util.DOM.cl;
 
 /**
  * A menu which is not fully rendered/visible at original page render time, but instead
@@ -106,15 +112,10 @@ public class PopupMenu extends DisplayElement
 
     public void render(Writer out) throws IOException
     {
-        renderMenuButton(out);
+        renderMenuButton(null, HtmlWriter.of(out), false, null);
     }
 
-    public void renderMenuButton(Writer out) throws IOException
-    {
-        renderMenuButton(null, out, false, null);
-    }
-
-    public void renderMenuButton(@Nullable RenderContext ctx, Writer out, boolean requiresSelection, @Nullable ActionButton button) throws IOException
+    public void renderMenuButton(@Nullable RenderContext ctx, HtmlWriter out, boolean requiresSelection, @Nullable ActionButton button)
     {
         if (null == _navTree.getText())
             return;
@@ -125,76 +126,79 @@ public class PopupMenu extends DisplayElement
         Map<String, String> attributes = new HashMap<>();
         String onClickScript = null;
 
-        out.append("<div class=\"lk-menu-drop dropdown\">");
         attributes.put("data-toggle", "dropdown");
 
-        String dataRegionName = null;
+        String dataRegionName;
 
         if (ctx != null && ctx.getCurrentRegion() != null)
             dataRegionName = ctx.getCurrentRegion().getName();
+        else
+            dataRegionName = null;
 
-        if (_buttonStyle == ButtonStyle.TEXTBUTTON)
-        {
-            assert !requiresSelection : "Only button-style popups can require selection.";
-            out.append(PageFlowUtil.link(_navTree.getText()).onClick(onClickScript).attributes(attributes).addClass("dropdown-toggle").toString());
-        }
-        else if (_buttonStyle == ButtonStyle.MENUBUTTON)
-        {
-            if (requiresSelection)
-                attributes.put("data-labkey-requires-selection", dataRegionName);
+        DIV(
+            cl("lk-menu-drop dropdown"),
+            (DOM.Renderable) ret -> {
 
-            Button.ButtonBuilder bldr = PageFlowUtil.button(_navTree.getText())
-                    .dropdown(true)
-                    .onClick(onClickScript)
-                    .attributes(attributes);
+                if (_buttonStyle == ButtonStyle.TEXTBUTTON)
+                {
+                    assert !requiresSelection : "Only button-style popups can require selection.";
+                    out.write(PageFlowUtil.link(_navTree.getText()).onClick(onClickScript).attributes(attributes).addClass("dropdown-toggle"));
+                }
+                else if (_buttonStyle == ButtonStyle.MENUBUTTON)
+                {
+                    if (requiresSelection)
+                        attributes.put("data-labkey-requires-selection", dataRegionName);
 
-            if (button != null)
-            {
-                // set additional properties from the button
-                bldr.iconCls(button.getIconCls());
-                bldr.tooltip(button.getTooltip());
+                    Button.ButtonBuilder bldr = PageFlowUtil.button(_navTree.getText())
+                        .dropdown(true)
+                        .onClick(onClickScript)
+                        .attributes(attributes);
+
+                    if (button != null)
+                    {
+                        // set additional properties from the button
+                        bldr.iconCls(button.getIconCls());
+                        bldr.tooltip(button.getTooltip());
+                    }
+
+                    out.write(bldr);
+                }
+                else if (_buttonStyle == ButtonStyle.IMAGE || _buttonStyle == ButtonStyle.IMAGE_AND_TEXT)
+                {
+                    assert !requiresSelection : "Only button-style popups can require selection.";
+                    if (_navTree.getImageCls() != null && !_navTree.getImageCls().isEmpty())
+                    {
+                        out.write(PageFlowUtil.generateDropDownFontIconImage(_navTree.getText(), "#",
+                            onClickScript, _navTree.getImageCls(), _imageId, attributes));
+                    }
+                    else
+                    {
+                        assert _navTree.getImageSrc() != null && !_navTree.getImageSrc().isEmpty() : "Must provide an image source or image cls for image based popups.";
+                        out.write(PageFlowUtil.generateDropDownImage(_navTree.getText(), "#",
+                            onClickScript, _navTree.getImageSrc(), _imageId, _navTree.getImageHeight(), _navTree.getImageWidth(), attributes));
+                    }
+
+                    if (_buttonStyle == ButtonStyle.IMAGE_AND_TEXT)
+                    {
+                        out.write(" ");
+                    }
+                }
+
+                if (_buttonStyle == ButtonStyle.TEXT || _buttonStyle == ButtonStyle.BOLDTEXT || _buttonStyle == ButtonStyle.IMAGE_AND_TEXT)
+                {
+                    assert !requiresSelection : "Only button-style popups can require selection.";
+                    out.write(PageFlowUtil.generateDropDownTextLink(_navTree.getText(), "#",
+                        onClickScript, _buttonStyle == ButtonStyle.BOLDTEXT, _offset, _navTree.getId(), attributes));
+                }
+
+                UL(
+                    cl("dropdown-menu dropdown-menu-left"),
+                    (DOM.Renderable) ret2 -> PopupMenuView.renderTree(_navTree, out)
+                ).appendTo(out);
+
+                return ret;
             }
-
-            out.append(bldr.toString());
-        }
-        else if (_buttonStyle == ButtonStyle.IMAGE || _buttonStyle == ButtonStyle.IMAGE_AND_TEXT)
-        {
-            assert !requiresSelection : "Only button-style popups can require selection.";
-            if (_navTree.getImageCls() != null && _navTree.getImageCls().length() > 0)
-            {
-                out.append(PageFlowUtil.generateDropDownFontIconImage(_navTree.getText(), "#",
-                        onClickScript, _navTree.getImageCls(), _imageId, attributes).toString());
-            }
-            else
-            {
-                assert _navTree.getImageSrc() != null && _navTree.getImageSrc().length() > 0 : "Must provide an image source or image cls for image based popups.";
-                out.append(PageFlowUtil.generateDropDownImage(_navTree.getText(), "#",
-                        onClickScript, _navTree.getImageSrc(), _imageId, _navTree.getImageHeight(), _navTree.getImageWidth(), attributes).toString());
-            }
-
-            if (_buttonStyle == ButtonStyle.IMAGE_AND_TEXT)
-            {
-                out.append(" ");
-            }
-        }
-
-        if (_buttonStyle == ButtonStyle.TEXT || _buttonStyle == ButtonStyle.BOLDTEXT || _buttonStyle == ButtonStyle.IMAGE_AND_TEXT)
-        {
-            assert !requiresSelection : "Only button-style popups can require selection.";
-            out.append(PageFlowUtil.generateDropDownTextLink(_navTree.getText(), "#",
-                    onClickScript, _buttonStyle == ButtonStyle.BOLDTEXT, _offset, _navTree.getId(), attributes).toString());
-        }
-
-        out.append("<ul class=\"dropdown-menu dropdown-menu-left\">");
-        try
-        {
-            PopupMenuView.renderTree(_navTree, out);
-        }
-        catch (Exception e)
-        {
-            throw new RuntimeException(e);
-        }
-        out.append("</ul></div>");
+        ).appendTo(out);
     }
 
     public Align getAlign()

--- a/api/src/org/labkey/api/view/PopupMenuView.java
+++ b/api/src/org/labkey/api/view/PopupMenuView.java
@@ -16,25 +16,22 @@
 
 package org.labkey.api.view;
 
-import lombok.SneakyThrows;
-import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.util.DOM;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.Link.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.element.Input;
 import org.labkey.api.writer.HtmlWriter;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.net.URISyntaxException;
-import java.util.Map;
 
+import static org.labkey.api.util.DOM.I;
 import static org.labkey.api.util.DOM.LI;
+import static org.labkey.api.util.DOM.UL;
 import static org.labkey.api.util.DOM.cl;
-import static org.labkey.api.util.DOM.createHtmlFragment;
 
 public class PopupMenuView extends HttpView<PopupMenu>
 {
@@ -94,98 +91,100 @@ public class PopupMenuView extends HttpView<PopupMenu>
         return getNavTree().hasChildren();
     }
 
-    @SneakyThrows
+    public static void renderTree(NavTree tree, Writer oldWriter) throws IOException
+    {
+        renderTree(tree, HtmlWriter.of(oldWriter));
+    }
+
     public static HtmlWriter renderTree(NavTree tree, HtmlWriter out)
     {
-        renderTree(tree, out, out.unwrap());
-        return out;
-    }
-
-    public static HtmlWriter renderTree(NavTree tree, Writer oldWriter) throws IOException
-    {
-        HtmlWriter out = HtmlWriter.of(oldWriter);
-        renderTree(tree, out, oldWriter);
-        return out;
-    }
-
-    private static void renderTree(NavTree tree, HtmlWriter out, Writer oldWriter) throws IOException
-    {
-        if (tree == null)
-            return;
-
-        // These flags act as a trimming boundaries for menu separators. They are used to prevent
-        // "empty" menu items between separators as well as prevent beginning or ending with a separator
-        boolean hasNonSeparatorItem = false;
-        boolean lastIsSeparator = false;
-        String treeItemCls = null;
-
-        for (NavTree child : tree.getChildren())
+        if (tree != null)
         {
-            // check if this is the first child with the menu filter cls, if so add the filter input item
-            if (child.getMenuFilterItemCls() != null)
+            // These flags act as a trimming boundaries for menu separators. They are used to prevent
+            // "empty" menu items between separators as well as prevent beginning or ending with a separator
+            boolean hasNonSeparatorItem = false;
+            boolean lastIsSeparator = false;
+            String treeItemCls = null;
+
+            for (NavTree child : tree.getChildren())
             {
-                if (treeItemCls == null || !treeItemCls.equals(child.getMenuFilterItemCls()))
+                // check if this is the first child with the menu filter cls, if so add the filter input item
+                if (child.getMenuFilterItemCls() != null)
                 {
-                    treeItemCls = child.getMenuFilterItemCls();
-                    renderMenuFilterInput(treeItemCls, out);
+                    if (treeItemCls == null || !treeItemCls.equals(child.getMenuFilterItemCls()))
+                    {
+                        treeItemCls = child.getMenuFilterItemCls();
+                        renderMenuFilterInput(treeItemCls, out);
+                    }
                 }
-            }
-            else
-            {
-                // clear the cls to stop the menu filter section, note that this means that menu filter items
-                // must be consecutively placed in the menu in order to work with the filter input
-                treeItemCls = null;
-            }
-
-            if (child.hasChildren())
-            {
-                if (lastIsSeparator)
+                else
                 {
-                    lastIsSeparator = false;
-                    renderTreeDivider(oldWriter);
-                }
-
-                hasNonSeparatorItem = true;
-                String text = PageFlowUtil.filter(child.getText());
-
-                oldWriter.write("<li class=\"dropdown-submenu\">");
-                oldWriter.write("<a class=\"subexpand subexpand-icon\" tabindex=\"0\">" + text + "<i class=\"fa fa-chevron-right\"></i></a>");
-                oldWriter.write("<ul class=\"dropdown-layer-menu\">");
-                oldWriter.write("<li><a class=\"subcollapse\" tabindex=\"0\"><i class=\"fa fa-chevron-left\"></i>" + text + "</a></li>");
-                renderTreeDivider(oldWriter);
-                renderTree(child, oldWriter);
-                oldWriter.write("</ul>");
-                oldWriter.write("</li>");
-            }
-            else if ("-".equals(child.getText()))
-            {
-                if (hasNonSeparatorItem)
-                    lastIsSeparator = true;
-            }
-            else
-            {
-                if (lastIsSeparator)
-                {
-                    lastIsSeparator = false;
-                    renderTreeDivider(oldWriter);
+                    // clear the cls to stop the menu filter section, note that this means that menu filter items
+                    // must be consecutively placed in the menu in order to work with the filter input
+                    treeItemCls = null;
                 }
 
-                hasNonSeparatorItem = true;
-                renderTreeItem(child, treeItemCls, oldWriter);
+                if (child.hasChildren())
+                {
+                    if (lastIsSeparator)
+                    {
+                        lastIsSeparator = false;
+                        renderTreeDivider(out);
+                    }
+
+                    hasNonSeparatorItem = true;
+
+                    LI(
+                        cl("dropdown-submenu"),
+                        new LinkBuilder(HtmlStringBuilder.of(child.getText()).append(DOM.createHtmlFragment(I(cl("fa fa-chevron-right")))))
+                            .clearClasses()
+                            .addClass("subexpand")
+                            .addClass("subexpand-icon")
+                            .tabindex(0),
+                        UL(
+                            cl("dropdown-layer-menu"),
+                            LI(
+                                new LinkBuilder(HtmlStringBuilder.of(DOM.createHtmlFragment(I(cl("fa fa-chevron-left")))).append(child.getText()))
+                                    .clearClasses()
+                                    .addClass("subcollapse")
+                                    .tabindex(0)
+                            ),
+                            (DOM.Renderable) ret -> {
+                                renderTreeDivider(out);
+                                renderTree(child, out);
+                                return ret;
+                            }
+                        )
+                    ).appendTo(out);
+                }
+                else if ("-".equals(child.getText()))
+                {
+                    if (hasNonSeparatorItem)
+                        lastIsSeparator = true;
+                }
+                else
+                {
+                    if (lastIsSeparator)
+                    {
+                        lastIsSeparator = false;
+                        renderTreeDivider(out);
+                    }
+
+                    hasNonSeparatorItem = true;
+                    renderTreeItem(child, treeItemCls, out);
+                }
             }
         }
+
+        return out;
     }
 
-    protected static void renderTreeItem(NavTree item, String cls, Writer out) throws IOException
+    protected static void renderTreeItem(NavTree item, @Nullable String cls, HtmlWriter out)
     {
-        out.write("<li");
-        if (item.isDisabled())
-            cls = cls != null ? cls + " disabled" : "disabled";
-        if (cls != null)
-            out.write(" class=\"" + cls + "\"");
-        out.write(">");
-        renderLink(item, null, out);
-        out.write("</li>");
+        LI(
+            cl(cls).cl(item.isDisabled(), "disabled"),
+            (DOM.Renderable) ret -> renderLink(item, cls, out)
+        ).appendTo(out);
     }
 
     protected static void renderTreeDivider(HtmlWriter out)
@@ -193,170 +192,10 @@ public class PopupMenuView extends HttpView<PopupMenu>
         LI(cl("divider")).appendTo(out);
     }
 
-    // TODO: Delegate to LinkBuilder instead of replicating all of its rendering code here.
-    // We can't call item.toLinkBuilder() because we may need to replace the HTML, and there's no setter for that.
-    protected static void renderLink(NavTree item, String cls, Writer oldWriter) throws IOException
+    protected static HtmlWriter renderLink(NavTree item, String cls, HtmlWriter out)
     {
-        // if the item is "selected" and doesn't have an image cls to use, provide our default
-        String itemImageCls = item.getImageCls();
-        if (item.isSelected() && null == itemImageCls)
-            itemImageCls = "fa fa-check-square-o";
-        HtmlStringBuilder html = HtmlStringBuilder.of();
-        if (null != itemImageCls)
-            html.append(createHtmlFragment(DOM.I(cl(itemImageCls))));
-        html.append(item.getText());
-
-        String styleStr = "";
-        if (null != itemImageCls)
-            styleStr += "padding-left: 0;";
-        if (item.isStrong())
-            styleStr += "font-weight: bold;";
-        if (item.isEmphasis())
-            styleStr += "font-style: italic;";
-
-        // NOTE: nofollow is not recommended as way to avoid crawling internal links
-        // instead let's use an onclick handler to "hide" the link
-        String dataQuery = null;
-        String href = item.getHref();
-        var config = HttpView.currentPageConfig();
-
-        if (null != href && null == item.getScript() && !item.isPost())
-        {
-            try
-            {
-                URLHelper url = new URLHelper(href);
-                boolean isLocal = null == url.getHost() && null == url.getScheme() && -1 == url.getPort();
-                if (isLocal)
-                {
-                    var context = HttpView.currentContext();
-
-                    // separate the path (into href) and query/fragment (into dataQuery) portions of URL
-                    var fragment = url.getFragment();
-                    url.setFragment(null);
-                    if (null != context && context.isRobot())
-                        url.addParameter(ActionURL.Param._noindex.name(), "1");
-                    dataQuery = StringUtils.trimToEmpty(url.getRawQuery());
-                    url.deleteParameters();
-                    if (!dataQuery.isEmpty())
-                        dataQuery = "?" + dataQuery;
-                    if (StringUtils.isNotEmpty(fragment))
-                        dataQuery += "#" + fragment;
-
-                    href = url.getLocalURIString();
-                    config.addHandlerForQuerySelector(
-                            "A.noFollowNavigate",
-                            "click",
-                            "window.location = this.href + this.dataset['query']; return false;");
-                    cls = StringUtils.trimToEmpty(cls) + " noFollowNavigate";
-                }
-            }
-            catch (URISyntaxException e)
-            {
-                // fall through
-            }
-        }
-
-        LinkBuilder builder = new LinkBuilder(html)
-            .id(config.makeId("popupMenuView"))
-            .target(item.getTarget())
-            .title(item.getDescription())
-            .tabindex(0)
-            .enabled(!item.isDisabled())
-            .clearClasses()
-            .href(null != href && !item.isPost() ? href : "#")
-            .onClick(item.getScript());
-
-        if (null != itemImageCls)
-            builder.style(styleStr);
-
-        if (cls != null)
-            builder.addClass(cls);
-
-        if (null != dataQuery)
-            builder.attributes(Map.of("data-query", dataQuery));
-
-        oldWriter.write(builder.toString());
-
-//        // if the item is "selected" and doesn't have an image cls to use, provide our default
-//        String itemImageCls = item.getImageCls();
-//        if (item.isSelected() && null == itemImageCls)
-//            itemImageCls = "fa fa-check-square-o";
-//
-//        String styleStr = "";
-//        if (null != itemImageCls)
-//            styleStr += "padding-left: 0;";
-//        if (item.isStrong())
-//            styleStr += "font-weight: bold;";
-//        if (item.isEmphasis())
-//            styleStr += "font-style: italic;";
-//
-//        // NOTE: nofollow is not recommended as way to avoid crawling internal links
-//        // instead let's use an onclick handler to "hide" the link
-//        String dataQuery = null;
-//        String href = item.getHref();
-//        var config = HttpView.currentPageConfig();
-//        if (null != href && null == item.getScript() && !item.isPost())
-//        {
-//            try
-//            {
-//                URLHelper url = new URLHelper(href);
-//                boolean isLocal = null == url.getHost() && null == url.getScheme() && -1 == url.getPort();
-//                if (isLocal)
-//                {
-//                    var context = HttpView.currentContext();
-//
-//                    // separate the path (into href) and query/fragment (into dataQuery) portions of URL
-//                    var fragment = url.getFragment();
-//                    url.setFragment(null);
-//                    if (null != context && context.isRobot())
-//                        url.addParameter(ActionURL.Param._noindex.name(), "1");
-//                    dataQuery = StringUtils.trimToEmpty(url.getRawQuery());
-//                    url.deleteParameters();
-//                    if (!dataQuery.isEmpty())
-//                        dataQuery = "?" + dataQuery;
-//                    if (StringUtils.isNotEmpty(fragment))
-//                        dataQuery += "#" + fragment;
-//
-//                    href = url.getLocalURIString();
-//                    config.addHandlerForQuerySelector(
-//                            "A.noFollowNavigate",
-//                            "click",
-//                            "window.location = this.href + this.dataset['query']; return false;");
-//                    cls = StringUtils.trimToEmpty(cls) + " noFollowNavigate";
-//                }
-//            }
-//            catch (URISyntaxException e)
-//            {
-//                // fall through
-//            }
-//        }
-//
-//        String id = config.makeId("popupMenuView");
-//        oldWriter.write("<a id='" + id + "'");
-//        if (null != cls)
-//            oldWriter.write(" class=\"" + cls + "\"");
-//        if (null != href && !item.isPost())
-//            oldWriter.write(" href=\"" + PageFlowUtil.filter(href) + "\"");
-//        else
-//            oldWriter.write(" href=\"#\"");
-//        if (null != dataQuery)
-//            oldWriter.write(" data-query=\"" + PageFlowUtil.filter(dataQuery) + "\"");
-//        if (null != item.getTarget())
-//            oldWriter.write(" target=\"" + item.getTarget() + "\"");
-//        if (null != item.getDescription())
-//            oldWriter.write(" title=\"" + PageFlowUtil.filter(item.getDescription()) + "\"");
-//        if (item.isDisabled())
-//            oldWriter.write(" disabled");
-//        oldWriter.write(" tabindex=\"0\"");
-//        oldWriter.write(" style=\"" + styleStr + "\"");
-//        if (item.isNoFollow())
-//            oldWriter.write(" rel=\"noFollow\"");
-//        oldWriter.write(">");
-//        if (null != itemImageCls)
-//            oldWriter.write("<i class=\"" + itemImageCls + "\"></i>");
-//        oldWriter.write(PageFlowUtil.filter(item.getText()));
-//        oldWriter.write("</a>");
-//        config.addHandler(id, "click", item.getScript());
+        out.write(item.toLinkBuilder(cls));
+        return out;
     }
 
     public static String getMenuFilterItemCls(NavTree tree)
@@ -364,7 +203,7 @@ public class PopupMenuView extends HttpView<PopupMenu>
         return PageFlowUtil.filter(tree.getText()).replaceAll("\\s", "-").toLowerCase() + "-item";
     }
 
-    private static void renderMenuFilterInput(String menuFilterItemCls, HtmlWriter out) throws IOException
+    private static void renderMenuFilterInput(String menuFilterItemCls, HtmlWriter out)
     {
         LI(
             cl("menu-filter-input"),

--- a/api/src/org/labkey/api/view/PopupMenuView.java
+++ b/api/src/org/labkey/api/view/PopupMenuView.java
@@ -18,6 +18,8 @@ package org.labkey.api.view;
 
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.util.DOM;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.Link.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
@@ -27,6 +29,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.net.URISyntaxException;
+
+import static org.labkey.api.util.DOM.cl;
+import static org.labkey.api.util.DOM.createHtmlFragment;
 
 public class PopupMenuView extends HttpView<PopupMenu>
 {
@@ -179,14 +184,55 @@ public class PopupMenuView extends HttpView<PopupMenu>
         out.write("<li class=\"divider\"></li>");
     }
 
-
-    // TODO: Delegate to LinkBuilder instead of replicating all of its rendering code here. Call item.toLinkBuilder().
+    // TODO: Delegate to LinkBuilder instead of replicating all of its rendering code here.
+    // We can't call item.toLinkBuilder() because we may need to replace the HTML, and there's no setter for that.
     protected static void renderLink(NavTree item, String cls, Writer oldWriter) throws IOException
     {
-        LinkBuilder builder = item.toLinkBuilder();
-//        oldWriter.write(builder.toString());
+        {
+            // if the item is "selected" and doesn't have an image cls to use, provide our default
+            String itemImageCls = item.getImageCls();
+            if (item.isSelected() && null == itemImageCls)
+                itemImageCls = "fa fa-check-square-o";
+            HtmlStringBuilder html = HtmlStringBuilder.of();
+            if (null != itemImageCls)
+                html.append(createHtmlFragment(DOM.I(cl(itemImageCls))));
+            html.append(item.getText());
 
-        var config = HttpView.currentPageConfig();
+            var config = HttpView.currentPageConfig();
+
+            LinkBuilder builder = new LinkBuilder(html)
+                .id(config.makeId("popupMenuView"))
+                .target(item.getTarget())
+                .title(item.getDescription())
+                .tabindex(0)
+                .enabled(!item.isDisabled())
+                .clearClasses();
+
+            // data-query
+            // href stuff
+            // onclick
+
+
+            String styleStr = "";
+            if (null != itemImageCls)
+                styleStr += "padding-left: 0;";
+            if (item.isStrong())
+                styleStr += "font-weight: bold;";
+            if (item.isEmphasis())
+                styleStr += "font-style: italic;";
+
+            if (null != itemImageCls)
+                builder.style(styleStr);
+
+            if (cls != null)
+                builder.addClass(cls);
+
+            String href = item.getHref();
+            builder.href(null != href && !item.isPost() ? href : "#");
+
+//            oldWriter.write(builder.toString());
+        }
+
         // if the item is "selected" and doesn't have an image cls to use, provide our default
         String itemImageCls = item.getImageCls();
         if (item.isSelected() && null == itemImageCls)
@@ -204,6 +250,7 @@ public class PopupMenuView extends HttpView<PopupMenu>
         // instead let's use an onclick handler to "hide" the link
         String dataQuery = null;
         String href = item.getHref();
+        var config = HttpView.currentPageConfig();
         if (null != href && null == item.getScript() && !item.isPost())
         {
             try
@@ -227,7 +274,7 @@ public class PopupMenuView extends HttpView<PopupMenu>
                         dataQuery += "#" + fragment;
 
                     href = url.getLocalURIString();
-                    HttpView.currentPageConfig().addHandlerForQuerySelector(
+                    config.addHandlerForQuerySelector(
                             "A.noFollowNavigate",
                             "click",
                             "window.location = this.href + this.dataset['query']; return false;");
@@ -265,7 +312,7 @@ public class PopupMenuView extends HttpView<PopupMenu>
             oldWriter.write("<i class=\"" + itemImageCls + "\"></i>");
         oldWriter.write(PageFlowUtil.filter(item.getText()));
         oldWriter.write("</a>");
-        HttpView.currentPageConfig().addHandler(id, "click", item.getScript());
+        config.addHandler(id, "click", item.getScript());
     }
 
     public static String getMenuFilterItemCls(NavTree tree)

--- a/api/src/org/labkey/api/view/PopupMenuView.java
+++ b/api/src/org/labkey/api/view/PopupMenuView.java
@@ -23,13 +23,16 @@ import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.Link.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.util.element.Input;
 import org.labkey.api.writer.HtmlWriter;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.net.URISyntaxException;
+import java.util.Map;
 
+import static org.labkey.api.util.DOM.LI;
 import static org.labkey.api.util.DOM.cl;
 import static org.labkey.api.util.DOM.createHtmlFragment;
 
@@ -94,11 +97,18 @@ public class PopupMenuView extends HttpView<PopupMenu>
     @SneakyThrows
     public static HtmlWriter renderTree(NavTree tree, HtmlWriter out)
     {
-        renderTree(tree, out.unwrap());
+        renderTree(tree, out, out.unwrap());
         return out;
     }
 
-    public static void renderTree(NavTree tree, Writer oldWriter) throws IOException
+    public static HtmlWriter renderTree(NavTree tree, Writer oldWriter) throws IOException
+    {
+        HtmlWriter out = HtmlWriter.of(oldWriter);
+        renderTree(tree, out, oldWriter);
+        return out;
+    }
+
+    private static void renderTree(NavTree tree, HtmlWriter out, Writer oldWriter) throws IOException
     {
         if (tree == null)
             return;
@@ -107,7 +117,6 @@ public class PopupMenuView extends HttpView<PopupMenu>
         // "empty" menu items between separators as well as prevent beginning or ending with a separator
         boolean hasNonSeparatorItem = false;
         boolean lastIsSeparator = false;
-
         String treeItemCls = null;
 
         for (NavTree child : tree.getChildren())
@@ -118,7 +127,7 @@ public class PopupMenuView extends HttpView<PopupMenu>
                 if (treeItemCls == null || !treeItemCls.equals(child.getMenuFilterItemCls()))
                 {
                     treeItemCls = child.getMenuFilterItemCls();
-                    renderMenuFilterInput(treeItemCls, oldWriter);
+                    renderMenuFilterInput(treeItemCls, out);
                 }
             }
             else
@@ -179,64 +188,23 @@ public class PopupMenuView extends HttpView<PopupMenu>
         out.write("</li>");
     }
 
-    protected static void renderTreeDivider(Writer out) throws IOException
+    protected static void renderTreeDivider(HtmlWriter out)
     {
-        out.write("<li class=\"divider\"></li>");
+        LI(cl("divider")).appendTo(out);
     }
 
     // TODO: Delegate to LinkBuilder instead of replicating all of its rendering code here.
     // We can't call item.toLinkBuilder() because we may need to replace the HTML, and there's no setter for that.
     protected static void renderLink(NavTree item, String cls, Writer oldWriter) throws IOException
     {
-        {
-            // if the item is "selected" and doesn't have an image cls to use, provide our default
-            String itemImageCls = item.getImageCls();
-            if (item.isSelected() && null == itemImageCls)
-                itemImageCls = "fa fa-check-square-o";
-            HtmlStringBuilder html = HtmlStringBuilder.of();
-            if (null != itemImageCls)
-                html.append(createHtmlFragment(DOM.I(cl(itemImageCls))));
-            html.append(item.getText());
-
-            var config = HttpView.currentPageConfig();
-
-            LinkBuilder builder = new LinkBuilder(html)
-                .id(config.makeId("popupMenuView"))
-                .target(item.getTarget())
-                .title(item.getDescription())
-                .tabindex(0)
-                .enabled(!item.isDisabled())
-                .clearClasses();
-
-            // data-query
-            // href stuff
-            // onclick
-
-
-            String styleStr = "";
-            if (null != itemImageCls)
-                styleStr += "padding-left: 0;";
-            if (item.isStrong())
-                styleStr += "font-weight: bold;";
-            if (item.isEmphasis())
-                styleStr += "font-style: italic;";
-
-            if (null != itemImageCls)
-                builder.style(styleStr);
-
-            if (cls != null)
-                builder.addClass(cls);
-
-            String href = item.getHref();
-            builder.href(null != href && !item.isPost() ? href : "#");
-
-//            oldWriter.write(builder.toString());
-        }
-
         // if the item is "selected" and doesn't have an image cls to use, provide our default
         String itemImageCls = item.getImageCls();
         if (item.isSelected() && null == itemImageCls)
             itemImageCls = "fa fa-check-square-o";
+        HtmlStringBuilder html = HtmlStringBuilder.of();
+        if (null != itemImageCls)
+            html.append(createHtmlFragment(DOM.I(cl(itemImageCls))));
+        html.append(item.getText());
 
         String styleStr = "";
         if (null != itemImageCls)
@@ -251,6 +219,7 @@ public class PopupMenuView extends HttpView<PopupMenu>
         String dataQuery = null;
         String href = item.getHref();
         var config = HttpView.currentPageConfig();
+
         if (null != href && null == item.getScript() && !item.isPost())
         {
             try
@@ -287,32 +256,107 @@ public class PopupMenuView extends HttpView<PopupMenu>
             }
         }
 
-        String id = config.makeId("popupMenuView");
-        oldWriter.write("<a id='" + id + "'");
-        if (null != cls)
-            oldWriter.write(" class=\"" + cls + "\"");
-        if (null != href && !item.isPost())
-            oldWriter.write(" href=\"" + PageFlowUtil.filter(href) + "\"");
-        else
-            oldWriter.write(" href=\"#\"");
-        if (null != dataQuery)
-            oldWriter.write(" data-query=\"" + PageFlowUtil.filter(dataQuery) + "\"");
-        if (null != item.getTarget())
-            oldWriter.write(" target=\"" + item.getTarget() + "\"");
-        if (null != item.getDescription())
-            oldWriter.write(" title=\"" + PageFlowUtil.filter(item.getDescription()) + "\"");
-        if (item.isDisabled())
-            oldWriter.write(" disabled");
-        oldWriter.write(" tabindex=\"0\"");
-        oldWriter.write(" style=\"" + styleStr + "\"");
-        if (item.isNoFollow())
-            oldWriter.write(" rel=\"noFollow\"");
-        oldWriter.write(">");
+        LinkBuilder builder = new LinkBuilder(html)
+            .id(config.makeId("popupMenuView"))
+            .target(item.getTarget())
+            .title(item.getDescription())
+            .tabindex(0)
+            .enabled(!item.isDisabled())
+            .clearClasses()
+            .href(null != href && !item.isPost() ? href : "#")
+            .onClick(item.getScript());
+
         if (null != itemImageCls)
-            oldWriter.write("<i class=\"" + itemImageCls + "\"></i>");
-        oldWriter.write(PageFlowUtil.filter(item.getText()));
-        oldWriter.write("</a>");
-        config.addHandler(id, "click", item.getScript());
+            builder.style(styleStr);
+
+        if (cls != null)
+            builder.addClass(cls);
+
+        if (null != dataQuery)
+            builder.attributes(Map.of("data-query", dataQuery));
+
+        oldWriter.write(builder.toString());
+
+//        // if the item is "selected" and doesn't have an image cls to use, provide our default
+//        String itemImageCls = item.getImageCls();
+//        if (item.isSelected() && null == itemImageCls)
+//            itemImageCls = "fa fa-check-square-o";
+//
+//        String styleStr = "";
+//        if (null != itemImageCls)
+//            styleStr += "padding-left: 0;";
+//        if (item.isStrong())
+//            styleStr += "font-weight: bold;";
+//        if (item.isEmphasis())
+//            styleStr += "font-style: italic;";
+//
+//        // NOTE: nofollow is not recommended as way to avoid crawling internal links
+//        // instead let's use an onclick handler to "hide" the link
+//        String dataQuery = null;
+//        String href = item.getHref();
+//        var config = HttpView.currentPageConfig();
+//        if (null != href && null == item.getScript() && !item.isPost())
+//        {
+//            try
+//            {
+//                URLHelper url = new URLHelper(href);
+//                boolean isLocal = null == url.getHost() && null == url.getScheme() && -1 == url.getPort();
+//                if (isLocal)
+//                {
+//                    var context = HttpView.currentContext();
+//
+//                    // separate the path (into href) and query/fragment (into dataQuery) portions of URL
+//                    var fragment = url.getFragment();
+//                    url.setFragment(null);
+//                    if (null != context && context.isRobot())
+//                        url.addParameter(ActionURL.Param._noindex.name(), "1");
+//                    dataQuery = StringUtils.trimToEmpty(url.getRawQuery());
+//                    url.deleteParameters();
+//                    if (!dataQuery.isEmpty())
+//                        dataQuery = "?" + dataQuery;
+//                    if (StringUtils.isNotEmpty(fragment))
+//                        dataQuery += "#" + fragment;
+//
+//                    href = url.getLocalURIString();
+//                    config.addHandlerForQuerySelector(
+//                            "A.noFollowNavigate",
+//                            "click",
+//                            "window.location = this.href + this.dataset['query']; return false;");
+//                    cls = StringUtils.trimToEmpty(cls) + " noFollowNavigate";
+//                }
+//            }
+//            catch (URISyntaxException e)
+//            {
+//                // fall through
+//            }
+//        }
+//
+//        String id = config.makeId("popupMenuView");
+//        oldWriter.write("<a id='" + id + "'");
+//        if (null != cls)
+//            oldWriter.write(" class=\"" + cls + "\"");
+//        if (null != href && !item.isPost())
+//            oldWriter.write(" href=\"" + PageFlowUtil.filter(href) + "\"");
+//        else
+//            oldWriter.write(" href=\"#\"");
+//        if (null != dataQuery)
+//            oldWriter.write(" data-query=\"" + PageFlowUtil.filter(dataQuery) + "\"");
+//        if (null != item.getTarget())
+//            oldWriter.write(" target=\"" + item.getTarget() + "\"");
+//        if (null != item.getDescription())
+//            oldWriter.write(" title=\"" + PageFlowUtil.filter(item.getDescription()) + "\"");
+//        if (item.isDisabled())
+//            oldWriter.write(" disabled");
+//        oldWriter.write(" tabindex=\"0\"");
+//        oldWriter.write(" style=\"" + styleStr + "\"");
+//        if (item.isNoFollow())
+//            oldWriter.write(" rel=\"noFollow\"");
+//        oldWriter.write(">");
+//        if (null != itemImageCls)
+//            oldWriter.write("<i class=\"" + itemImageCls + "\"></i>");
+//        oldWriter.write(PageFlowUtil.filter(item.getText()));
+//        oldWriter.write("</a>");
+//        config.addHandler(id, "click", item.getScript());
     }
 
     public static String getMenuFilterItemCls(NavTree tree)
@@ -320,10 +364,15 @@ public class PopupMenuView extends HttpView<PopupMenu>
         return PageFlowUtil.filter(tree.getText()).replaceAll("\\s", "-").toLowerCase() + "-item";
     }
 
-    private static void renderMenuFilterInput(String menuFilterItemCls, Writer out) throws IOException
+    private static void renderMenuFilterInput(String menuFilterItemCls, HtmlWriter out) throws IOException
     {
-        out.write("<li class=\"menu-filter-input\">");
-        out.write("<input type=\"text\" placeholder=\"Filter\" class=\"dropdown-menu-filter\" data-filter-item=\"" + menuFilterItemCls + "\"/>");
-        out.write("</li>");
+        LI(
+            cl("menu-filter-input"),
+            new Input.InputBuilder<>()
+                .type("text")
+                .placeholder("Filter")
+                .className("dropdown-menu-filter")
+                .addDataAttribute("filter-item", menuFilterItemCls)
+        ).appendTo(out);
     }
 }

--- a/api/src/org/labkey/api/view/PopupMenuView.java
+++ b/api/src/org/labkey/api/view/PopupMenuView.java
@@ -18,6 +18,7 @@ package org.labkey.api.view;
 
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.util.Link.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.writer.HtmlWriter;
@@ -92,7 +93,7 @@ public class PopupMenuView extends HttpView<PopupMenu>
         return out;
     }
 
-    public static void renderTree(NavTree tree, Writer out) throws IOException
+    public static void renderTree(NavTree tree, Writer oldWriter) throws IOException
     {
         if (tree == null)
             return;
@@ -112,7 +113,7 @@ public class PopupMenuView extends HttpView<PopupMenu>
                 if (treeItemCls == null || !treeItemCls.equals(child.getMenuFilterItemCls()))
                 {
                     treeItemCls = child.getMenuFilterItemCls();
-                    renderMenuFilterInput(treeItemCls, out);
+                    renderMenuFilterInput(treeItemCls, oldWriter);
                 }
             }
             else
@@ -127,20 +128,20 @@ public class PopupMenuView extends HttpView<PopupMenu>
                 if (lastIsSeparator)
                 {
                     lastIsSeparator = false;
-                    renderTreeDivider(out);
+                    renderTreeDivider(oldWriter);
                 }
 
                 hasNonSeparatorItem = true;
                 String text = PageFlowUtil.filter(child.getText());
 
-                out.write("<li class=\"dropdown-submenu\">");
-                out.write("<a class=\"subexpand subexpand-icon\" tabindex=\"0\">" + text + "<i class=\"fa fa-chevron-right\"></i></a>");
-                out.write("<ul class=\"dropdown-layer-menu\">");
-                out.write("<li><a class=\"subcollapse\" tabindex=\"0\"><i class=\"fa fa-chevron-left\"></i>" + text + "</a></li>");
-                renderTreeDivider(out);
-                renderTree(child, out);
-                out.write("</ul>");
-                out.write("</li>");
+                oldWriter.write("<li class=\"dropdown-submenu\">");
+                oldWriter.write("<a class=\"subexpand subexpand-icon\" tabindex=\"0\">" + text + "<i class=\"fa fa-chevron-right\"></i></a>");
+                oldWriter.write("<ul class=\"dropdown-layer-menu\">");
+                oldWriter.write("<li><a class=\"subcollapse\" tabindex=\"0\"><i class=\"fa fa-chevron-left\"></i>" + text + "</a></li>");
+                renderTreeDivider(oldWriter);
+                renderTree(child, oldWriter);
+                oldWriter.write("</ul>");
+                oldWriter.write("</li>");
             }
             else if ("-".equals(child.getText()))
             {
@@ -152,11 +153,11 @@ public class PopupMenuView extends HttpView<PopupMenu>
                 if (lastIsSeparator)
                 {
                     lastIsSeparator = false;
-                    renderTreeDivider(out);
+                    renderTreeDivider(oldWriter);
                 }
 
                 hasNonSeparatorItem = true;
-                renderTreeItem(child, treeItemCls, out);
+                renderTreeItem(child, treeItemCls, oldWriter);
             }
         }
     }
@@ -180,10 +181,13 @@ public class PopupMenuView extends HttpView<PopupMenu>
 
 
     // TODO: Delegate to LinkBuilder instead of replicating all of its rendering code here. Call item.toLinkBuilder().
-    protected static void renderLink(NavTree item, String cls, Writer out) throws IOException
+    protected static void renderLink(NavTree item, String cls, Writer oldWriter) throws IOException
     {
+        LinkBuilder builder = item.toLinkBuilder();
+//        oldWriter.write(builder.toString());
+
         var config = HttpView.currentPageConfig();
-        // if the item is "selected" and doesn't have have an image cls to use, provide our default
+        // if the item is "selected" and doesn't have an image cls to use, provide our default
         String itemImageCls = item.getImageCls();
         if (item.isSelected() && null == itemImageCls)
             itemImageCls = "fa fa-check-square-o";
@@ -237,30 +241,30 @@ public class PopupMenuView extends HttpView<PopupMenu>
         }
 
         String id = config.makeId("popupMenuView");
-        out.write("<a id='" + id + "'");
+        oldWriter.write("<a id='" + id + "'");
         if (null != cls)
-            out.write(" class=\"" + cls + "\"");
+            oldWriter.write(" class=\"" + cls + "\"");
         if (null != href && !item.isPost())
-            out.write(" href=\"" + PageFlowUtil.filter(href) + "\"");
+            oldWriter.write(" href=\"" + PageFlowUtil.filter(href) + "\"");
         else
-            out.write(" href=\"#\"");
+            oldWriter.write(" href=\"#\"");
         if (null != dataQuery)
-            out.write(" data-query=\"" + PageFlowUtil.filter(dataQuery) + "\"");
+            oldWriter.write(" data-query=\"" + PageFlowUtil.filter(dataQuery) + "\"");
         if (null != item.getTarget())
-            out.write(" target=\"" + item.getTarget() + "\"");
+            oldWriter.write(" target=\"" + item.getTarget() + "\"");
         if (null != item.getDescription())
-            out.write(" title=\"" + PageFlowUtil.filter(item.getDescription()) + "\"");
+            oldWriter.write(" title=\"" + PageFlowUtil.filter(item.getDescription()) + "\"");
         if (item.isDisabled())
-            out.write(" disabled");
-        out.write(" tabindex=\"0\"");
-        out.write(" style=\"" + styleStr + "\"");
+            oldWriter.write(" disabled");
+        oldWriter.write(" tabindex=\"0\"");
+        oldWriter.write(" style=\"" + styleStr + "\"");
         if (item.isNoFollow())
-            out.write(" rel=\"nofollow\"");
-        out.write(">");
+            oldWriter.write(" rel=\"noFollow\"");
+        oldWriter.write(">");
         if (null != itemImageCls)
-            out.write("<i class=\"" + itemImageCls + "\"></i>");
-        out.write(PageFlowUtil.filter(item.getText()));
-        out.write("</a>");
+            oldWriter.write("<i class=\"" + itemImageCls + "\"></i>");
+        oldWriter.write(PageFlowUtil.filter(item.getText()));
+        oldWriter.write("</a>");
         HttpView.currentPageConfig().addHandler(id, "click", item.getScript());
     }
 

--- a/api/src/org/labkey/api/view/PopupUserView.java
+++ b/api/src/org/labkey/api/view/PopupUserView.java
@@ -16,6 +16,7 @@
 package org.labkey.api.view;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.security.impersonation.ImpersonationContext;
 import org.labkey.api.security.SecurityUrls;
 import org.labkey.api.security.User;
@@ -49,17 +50,19 @@ public class PopupUserView extends PopupMenuView
         Container c = context.getContainer();
         ActionURL currentURL = context.getActionURL();
         NavTree tree = new NavTree();
-
         tree.setId("userMenu");
 
-        NavTree account = new NavTree("My Account", PageFlowUtil.urlProvider(UserUrls.class).getUserDetailsURL(c, user.getUserId(), currentURL));
-        tree.addChild(account);
-
-        ActionURL externalToolsViewURL = PageFlowUtil.urlProvider(SecurityUrls.class).getExternalToolsViewURL(user, c, currentURL);
-        if (null != externalToolsViewURL)
+        if (ModuleLoader.getInstance().isStartupComplete())
         {
-            NavTree externalToolSettings = new NavTree("External Tool Access", externalToolsViewURL);
-            tree.addChild(externalToolSettings);
+            NavTree account = new NavTree("My Account", PageFlowUtil.urlProvider(UserUrls.class).getUserDetailsURL(c, user.getUserId(), currentURL));
+            tree.addChild(account);
+
+            ActionURL externalToolsViewURL = PageFlowUtil.urlProvider(SecurityUrls.class).getExternalToolsViewURL(user, c, currentURL);
+            if (null != externalToolsViewURL)
+            {
+                NavTree externalToolSettings = new NavTree("External Tool Access", externalToolsViewURL);
+                tree.addChild(externalToolSettings);
+            }
         }
 
         // Delegate impersonate, stop impersonating, adjust impersonation, and sign out menu items to the current ImpersonationContext

--- a/api/src/org/labkey/api/view/ServletView.java
+++ b/api/src/org/labkey/api/view/ServletView.java
@@ -18,6 +18,8 @@ package org.labkey.api.view;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Map;
 
 
@@ -70,9 +72,9 @@ public class ServletView extends HttpView
     }
 
 
-    public String toString()
+    public @NotNull String toString()
     {
-        return super.toString() + " URL=" + String.valueOf(_pathname);
+        return super.toString() + " URL=" + _pathname;
     }
 
 

--- a/api/src/org/labkey/api/view/menu/SiteAdminMenu.java
+++ b/api/src/org/labkey/api/view/menu/SiteAdminMenu.java
@@ -16,7 +16,7 @@
 
 package org.labkey.api.view.menu;
 
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -34,11 +34,6 @@ import org.labkey.api.view.ViewContext;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * User: brittp
- * Date: Apr 9, 2007
- * Time: 9:51:20 AM
- */
 public class SiteAdminMenu extends NavTreeMenu
 {
     public SiteAdminMenu(ViewContext context)
@@ -57,12 +52,6 @@ public class SiteAdminMenu extends NavTreeMenu
             items.add(getAdminConsole(context));
 
         URLHelper returnUrl = context.getActionURL().getReturnUrl() == null ? context.getActionURL() : context.getActionURL().getReturnUrl();
-
-        if (user.hasSiteAdminPermission())
-        {
-            items.add(new NavTree("Site Admins", securityUrls.getManageGroupURL(root, "Administrators", returnUrl)));
-            items.add(new NavTree("Site Developers", securityUrls.getManageGroupURL(root, "Developers", returnUrl)));
-        }
 
         if (user.hasRootPermission(UserManagementPermission.class))
         {
@@ -84,8 +73,7 @@ public class SiteAdminMenu extends NavTreeMenu
         return getViewContext().getUser().hasRootPermission(TroubleshooterPermission.class);
     }
 
-    @Nullable
-    private static NavTree getAdminConsole(ViewContext context)
+    private static @NotNull NavTree getAdminConsole(ViewContext context)
     {
         AdminUrls adminUrls = PageFlowUtil.urlProvider(AdminUrls.class);
 

--- a/core/src/org/labkey/core/view/template/bootstrap/ViewServiceImpl.java
+++ b/core/src/org/labkey/core/view/template/bootstrap/ViewServiceImpl.java
@@ -38,6 +38,7 @@ import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import static org.labkey.api.util.PageFlowUtil.filter;
 import static org.labkey.api.util.PageFlowUtil.jsString;
@@ -116,7 +117,7 @@ public class ViewServiceImpl implements ViewService
         throw new IllegalStateException("Unknown FrameType");
     }
 
-    private abstract class AbstractFrame implements WebPartFrame
+    private abstract static class AbstractFrame implements WebPartFrame
     {
         protected final boolean _devMode = AppProps.getInstance().isDevMode();
         protected final ViewContext context;
@@ -139,7 +140,7 @@ public class ViewServiceImpl implements ViewService
         }
     }
 
-    private class FrameDiv extends AbstractFrame
+    private static class FrameDiv extends AbstractFrame
     {
         FrameDiv(ViewContext context, FrameConfig config)
         {
@@ -238,7 +239,7 @@ public class ViewServiceImpl implements ViewService
         }
     }
 
-    private class FrameNone extends AbstractFrame
+    private static class FrameNone extends AbstractFrame
     {
         FrameNone(ViewContext context, FrameConfig config)
         {
@@ -258,7 +259,7 @@ public class ViewServiceImpl implements ViewService
         }
     }
 
-    private class FrameTitle extends AbstractFrame
+    private static class FrameTitle extends AbstractFrame
     {
         FrameTitle(ViewContext context, FrameConfig config)
         {
@@ -292,7 +293,7 @@ public class ViewServiceImpl implements ViewService
         }
     }
 
-    private class FrameDialog extends AbstractFrame
+    private static class FrameDialog extends AbstractFrame
     {
         FrameDialog(ViewContext context, FrameConfig config)
         {
@@ -322,7 +323,7 @@ public class ViewServiceImpl implements ViewService
             }
 
             out.print("<div class=\"clearfix\"></div>");
-            out.print("</div><div class=\"" + StringUtils.defaultString(getConfig()._className,"") + " panel-body\">");
+            out.print("</div><div class=\"" + Objects.toString(getConfig()._className, "") + " panel-body\">");
         }
 
         @Override
@@ -426,11 +427,11 @@ public class ViewServiceImpl implements ViewService
             // Render custom buttons (e.g. wiki edit)
             if (config._floatingBtns != null)
             {
-                Iterator itr = config._floatingBtns.iterator();
+                Iterator<NavTree> itr = config._floatingBtns.iterator();
                 NavTree current;
                 while (itr.hasNext())
                 {
-                    current = (NavTree) itr.next();
+                    current = itr.next();
 
                     if (!current.hasChildren()) // floating dropdown not yet supported
                         renderCustomButton(current, out, true);
@@ -541,7 +542,7 @@ public class ViewServiceImpl implements ViewService
                         if (StringUtils.isNotEmpty(link.getHref()) || null != link.getScript())
                         {
                             // Display this NavTree as a simple link. Delegate to LinkBuilder to avoid replicating all its rendering code.
-                            final Link.LinkBuilder lb = link.toLinkBuilder();
+                            final Link.LinkBuilder lb = link.toSimpleLinkBuilder();
                             lb.clearClasses();
 
                             out.println(lb);
@@ -569,11 +570,11 @@ public class ViewServiceImpl implements ViewService
                 // Render specific parts first (e.g. wiki edit)
                 if (config._customMenus != null)
                 {
-                    Iterator itr = config._customMenus.iterator();
+                    Iterator<NavTree> itr = config._customMenus.iterator();
                     NavTree current;
                     while (itr.hasNext())
                     {
-                        current = (NavTree) itr.next();
+                        current = itr.next();
                         out.print(sep);
                         if (current.hasChildren())
                         {

--- a/core/src/org/labkey/core/view/template/bootstrap/header.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/header.jsp
@@ -29,6 +29,8 @@
 <%@ page import="org.labkey.api.settings.HeaderProperties" %>
 <%@ page import="org.labkey.api.settings.LookAndFeelProperties" %>
 <%@ page import="org.labkey.api.settings.TemplateResourceHandler" %>
+<%@ page import="org.labkey.api.util.DOM" %>
+<%@ page import="org.labkey.api.util.DOM.Renderable" %>
 <%@ page import="org.labkey.api.util.FolderDisplayMode" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.util.PageFlowUtil" %>
@@ -39,11 +41,16 @@
 <%@ page import="org.labkey.api.view.PopupAdminView" %>
 <%@ page import="org.labkey.api.view.PopupMenuView" %>
 <%@ page import="org.labkey.api.view.PopupUserView" %>
-<%@ page import="static org.labkey.api.view.template.WarningService.SESSION_WARNINGS_BANNER_KEY" %>
 <%@ page import="org.labkey.api.view.ViewContext" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.api.view.template.PageConfig" %>
 <%@ page import="org.labkey.core.view.template.bootstrap.Header" %>
+<%@ page import="static org.labkey.api.view.template.WarningService.SESSION_WARNINGS_BANNER_KEY" %>
+<%@ page import="static org.labkey.api.util.DOM.IMG" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.src" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.alt" %>
+<%@ page import="static org.labkey.api.util.DOM.A" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.href" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
@@ -53,60 +60,69 @@
         dependencies.add("internal/jQuery");
         dependencies.add("core/ProductNavigationHeader.js");
     }
+
+    Renderable getLogo(Container c, TemplateResourceHandler handler, String shortName, String logoHref, String className, boolean isStartupComplete)
+    {
+        Renderable logo = IMG(
+            DOM.at(src, handler.getURL(c), alt, shortName)
+        );
+
+        if (isStartupComplete)
+            logo = A(DOM.at(href, logoHref).cl(className), logo);
+
+        return logo;
+    }
 %>
 <%
-    Header me = (Header) HttpView.currentView();
+    Header me = HttpView.currentView();
     PageConfig pageConfig = me.getModelBean();
     Container c = getContainer();
     User user = getUser();
     boolean isRealUser = null != user && !user.isGuest();
     ViewContext context = getViewContext();
     LookAndFeelProperties laf = LookAndFeelProperties.getInstance(c);
-    boolean showSearch = hasUrlProvider(SearchUrls.class);
+    ModuleLoader moduleLoader = ModuleLoader.getInstance();
+    boolean isStartupComplete = moduleLoader.isStartupComplete();
+    boolean showSearch = isStartupComplete && hasUrlProvider(SearchUrls.class);
 
     HtmlView headerHtml = new HeaderProperties(getContainer()).getView();
-    String siteShortName = (laf.getShortName() != null && laf.getShortName().length() > 0) ? laf.getShortName() : null;
+    String siteShortName = (laf.getShortName() != null && !laf.getShortName().isEmpty()) ? laf.getShortName() : null;
 
-    ModuleLoader moduleLoader = ModuleLoader.getInstance();
-    final NavTree optionsMenu = PopupAdminView.createNavTree(context);
+    final NavTree optionsMenu = isStartupComplete ? PopupAdminView.createNavTree(context) : null;
     boolean hasPremiumModule = moduleLoader.hasModule("Premium");
     boolean isSMHostedOnly = !hasPremiumModule && moduleLoader.hasModule("SampleManagement");
     boolean showProductMenu =
-            // don't show product menu when starting up
-            isRealUser && moduleLoader.isStartupComplete() &&
-            // .. or if user does not have read permission
-            c.hasPermission(user, ReadPermission.class)
-            // show only for premium distributions or SM distributions
-                    && (hasPremiumModule || isSMHostedOnly)
-            // show only if configured to always be shown or shown to admins and this is an admin user
-                    && (laf.getApplicationMenuDisplayMode() == FolderDisplayMode.ALWAYS || c.hasPermission(user, AdminPermission.class));
+        // don't show product menu when starting up
+        isRealUser && isStartupComplete &&
+        // .. or if user does not have read permission
+        c.hasPermission(user, ReadPermission.class)
+        // show only for premium distributions or SM distributions
+                && (hasPremiumModule || isSMHostedOnly)
+        // show only if configured to always be shown or shown to admins and this is an admin user
+                && (laf.getApplicationMenuDisplayMode() == FolderDisplayMode.ALWAYS || c.hasPermission(user, AdminPermission.class));
 %>
 <div class="labkey-page-header">
     <div class="container clearfix">
         <div class="hidden-xs navbar-header">
-            <a class="brand-logo" href="<%=h(laf.getLogoHref())%>">
-                <img src="<%=h(TemplateResourceHandler.LOGO.getURL(c))%>" alt="<%=h(laf.getShortName())%>">
-            </a>
+            <%=getLogo(c, TemplateResourceHandler.LOGO, laf.getShortName(), laf.getLogoHref(), "brand-logo", isStartupComplete)%>
             <%-- _header.html overrides the server short name--%>
 <%
     if (headerHtml == null && siteShortName != null)
     {
         String displayedShortName = "LabKey Server".equals(siteShortName) ? "" : siteShortName;
 %>
-            <h4 class="brand-link"><a href="<%=h(laf.getLogoHref())%>"><%=h(displayedShortName)%></a></h4>
+            <h4 class="brand-link"><%=isStartupComplete ? link(displayedShortName, laf.getLogoHref()).clearClasses() : h(displayedShortName)%></h4>
 <%
     }
 %>
         </div>
         <div class="hidden-sm hidden-md hidden-lg navbar-header">
-            <a class="brand-logo-mobile" href="<%=h(laf.getLogoHref())%>">
-                <img src="<%=h(TemplateResourceHandler.LOGO_MOBILE.getURL(c))%>" alt="<%=h(laf.getShortName())%>">
-            </a>
+            <%=getLogo(c, TemplateResourceHandler.LOGO_MOBILE, laf.getShortName(), laf.getLogoHref(), "brand-logo-mobile", isStartupComplete)%>
 <%
     if (headerHtml == null && siteShortName != null)
     {
 %>
-            <h4 class="brand-link"><a href="<%=h(laf.getLogoHref())%>"><%=h(siteShortName)%></a></h4>
+            <h4 class="brand-link"><%=isStartupComplete ? link(siteShortName, laf.getLogoHref()) : h(siteShortName)%></h4>
 <%
     }
 %>
@@ -217,7 +233,7 @@
 <%
     }
 
-    if (me.getView("notifications") != null)
+    if (isStartupComplete && me.getView("notifications") != null)
     {
         include(me.getView("notifications"), out);
     }


### PR DESCRIPTION
#### Rationale
- We've decided to stop creating the "Site Admins" and "Site Developers groups". For now, just remove the menu items, to get the test infrastructure acclimated to this change. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=52166
- Render PopupMenuView using LinkBuilder instead of hand-coded HTML
- Suppress most links when server is starting up, since they all just redirect back to the upgrade page