### PR TITLE
Eliminate class-loading deadlock warning in ContainerFilter

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -375,7 +375,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 domain = provider.getResultsDomain(protocol);
 
                 AssayProtocolSchema assayProtocolSchema = provider.createProtocolSchema(user, protocol.getContainer(), protocol, null);
-                TableInfo assayDataTable = assayProtocolSchema.createDataTable(ContainerFilter.EVERYTHING_UNSAFE, false);
+                TableInfo assayDataTable = assayProtocolSchema.createDataTable(ContainerFilter.getUnsafeEverythingFilter(), false);
                 if (assayDataTable != null)
                 {
                     ColumnInfo lsidCol = assayDataTable.getColumn(assayResultLsidFieldKey);

--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -517,7 +517,20 @@ public abstract class ContainerFilter
     }
 
     /** Use this with extreme caution - this doesn't check permissions */
+    @Deprecated(forRemoval = true) // Use getUnsafeEverythingFilter() instead TODO: Remove
     public static final ContainerFilter EVERYTHING_UNSAFE = new InternalNoContainerFilter();
+
+    private static ContainerFilter _everythingUnsafe = null;
+
+    /** Use this with extreme caution - this doesn't check permissions! */
+    public static synchronized ContainerFilter getUnsafeEverythingFilter()
+    {
+        if (_everythingUnsafe == null)
+        {
+            _everythingUnsafe = new InternalNoContainerFilter();
+        }
+        return _everythingUnsafe;
+    }
 
     public static class ContainerFilterWithPermission extends ContainerFilter
     {
@@ -1346,7 +1359,7 @@ public abstract class ContainerFilter
             assertEquals(current(home, user).getCacheKey(), current(home, user).getCacheKey());
             assertNotEquals(current(home, user).getCacheKey(), current(test, user).getCacheKey());
 
-            assertEquals(EVERYTHING_UNSAFE.getCacheKey(), new InternalNoContainerFilter().getCacheKey());
+            assertEquals(getUnsafeEverythingFilter().getCacheKey(), new InternalNoContainerFilter().getCacheKey());
 
             assertEquals(new CurrentPlusExtras(home, user, shared).getCacheKey(), new CurrentPlusExtras(home, user, shared).getCacheKey());
             assertNotEquals(new CurrentPlusExtras(home, user, shared).getCacheKey(), new CurrentPlusExtras(test, user, shared).getCacheKey());

--- a/api/src/org/labkey/api/exp/property/DomainPropertyAuditProvider.java
+++ b/api/src/org/labkey/api/exp/property/DomainPropertyAuditProvider.java
@@ -124,7 +124,7 @@ public class DomainPropertyAuditProvider extends AbstractAuditTypeProvider
                         public TableInfo getLookupTableInfo()
                         {
                             DomainAuditProvider provider = new DomainAuditProvider();
-                            TableInfo table = provider.createTableInfo(getUserSchema(), ContainerFilter.EVERYTHING_UNSAFE);
+                            TableInfo table = provider.createTableInfo(getUserSchema(), ContainerFilter.getUnsafeEverythingFilter());
                             return table;
                         }
                     });

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -1240,7 +1240,7 @@ public class DomainUtil
         if (domain != null && domain.getDomainKind() != null)
         {
             // using ContainerFilter.EVERYTHING to account for /Shared domains
-            TableInfo domainTable = domain.getDomainKind().getTableInfo(user, domain.getContainer(), domain, ContainerFilter.EVERYTHING_UNSAFE);
+            TableInfo domainTable = domain.getDomainKind().getTableInfo(user, domain.getContainer(), domain, ContainerFilter.getUnsafeEverythingFilter());
             if (domainTable != null && domainTable.getUpdateService() != null)
             {
                 // we need to make all the row updates for this domain property at one time to prevent the

--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -551,7 +551,7 @@ public class ExpSchema extends AbstractExpSchema
             @Override
             public TableInfo getLookupTableInfo()
             {
-                return getTable(TableType.Protocols.toString(), ContainerFilter.EVERYTHING_UNSAFE);
+                return getTable(TableType.Protocols.toString(), ContainerFilter.getUnsafeEverythingFilter());
             }
         };
     }

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -114,7 +114,7 @@ public class SamplesSchema extends AbstractExpSchema
 
         if (studyLinkedSamples)
         {
-            this.setContainerFilter(ContainerFilter.EVERYTHING_UNSAFE);
+            this.setContainerFilter(ContainerFilter.getUnsafeEverythingFilter());
             this.withLinkToStudyColumns = false;
             this.supportTableRules = false;
             this.contextualRoles = Set.of(RoleManager.getRole(ReaderRole.class));

--- a/api/src/org/labkey/api/query/PrincipalIdForeignKey.java
+++ b/api/src/org/labkey/api/query/PrincipalIdForeignKey.java
@@ -36,7 +36,7 @@ public class PrincipalIdForeignKey extends LookupForeignKey
     {
         TableInfo tinfoUsersData = CoreSchema.getInstance().getTableInfoPrincipals();
         FilteredTable<UserSchema> ret = new FilteredTable<>(tinfoUsersData, _userSchema);
-        ret.setContainerFilter(ContainerFilter.EVERYTHING_UNSAFE);
+        ret.setContainerFilter(ContainerFilter.getUnsafeEverythingFilter());
         ret.addWrapColumn(tinfoUsersData.getColumn("UserId"));
         ret.addColumn(ret.wrapColumn("Name", tinfoUsersData.getColumn("Name")));
         ret.setTitleColumn("Name");

--- a/api/src/org/labkey/api/study/assay/SpecimenForeignKey.java
+++ b/api/src/org/labkey/api/study/assay/SpecimenForeignKey.java
@@ -149,7 +149,7 @@ public class SpecimenForeignKey extends LookupForeignKey
         if (null == _assayDataTable)
         {
             AssayProtocolSchema assaySchema = _provider.createProtocolSchema(_schema.getUser(), _schema.getContainer(), _protocol, null);
-            _assayDataTable = assaySchema.createDataTable(ContainerFilter.EVERYTHING_UNSAFE);
+            _assayDataTable = assaySchema.createDataTable(ContainerFilter.getUnsafeEverythingFilter());
         }
 
         FieldKey specimenFK = _tableMetadata.getSpecimenIDFieldKey();

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1762,7 +1762,7 @@ public class AssayController extends SpringActionController
             ExpProtocol protocol = service.getExpProtocol(form.getProtocolId());
             AssayProvider provider = AssayService.get().getProvider(protocol);
             AssaySchema schema = provider.createProtocolSchema(getUser(), getContainer(), protocol, null);
-            TableInfo tableInfo = schema.getTableOrThrow(AssayProtocolSchema.DATA_TABLE_NAME, ContainerFilter.EVERYTHING_UNSAFE);
+            TableInfo tableInfo = schema.getTableOrThrow(AssayProtocolSchema.DATA_TABLE_NAME, ContainerFilter.getUnsafeEverythingFilter());
 
             // need to query to get the dataIds for the data rowIds so that we can check container permissions on that exp.data table
             SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("RowId"), allowedIds, CompareType.IN);

--- a/assay/src/org/labkey/assay/AssayUpgradeCode.java
+++ b/assay/src/org/labkey/assay/AssayUpgradeCode.java
@@ -330,7 +330,7 @@ public class AssayUpgradeCode implements UpgradeCode
                             ContainerManager.getRoot(),
                             User.getAdminServiceUser(),
                             plateSetRowId,
-                            ContainerFilter.EVERYTHING_UNSAFE
+                            ContainerFilter.getUnsafeEverythingFilter()
                     );
                     String lineagePath = lineage.getSeedPath();
 
@@ -676,7 +676,7 @@ public class AssayUpgradeCode implements UpgradeCode
 
             for (Integer plateSetId : plateSetIds)
             {
-                PlateSet plateSet = PlateService.get().getPlateSet(ContainerFilter.EVERYTHING_UNSAFE, plateSetId);
+                PlateSet plateSet = PlateService.get().getPlateSet(ContainerFilter.getUnsafeEverythingFilter(), plateSetId);
                 if (plateSet == null)
                     throw new IllegalStateException("updateBuiltInColumns: Plate Set with plate of id " + plateSetId + " not found.");
 

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -548,7 +548,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         for (ExpProtocol protocol : protocols)
         {
             AssayProtocolSchema assayProtocolSchema = provider.createProtocolSchema(user, protocol.getContainer(), protocol, null);
-            TableInfo assayDataTable = assayProtocolSchema.createDataTable(ContainerFilter.EVERYTHING_UNSAFE, false);
+            TableInfo assayDataTable = assayProtocolSchema.createDataTable(ContainerFilter.getUnsafeEverythingFilter(), false);
             if (assayDataTable != null)
             {
                 ColumnInfo dataIdCol = assayDataTable.getColumn("DataId");
@@ -612,7 +612,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         for (ExpProtocol protocol : protocols)
         {
             AssayProtocolSchema assayProtocolSchema = provider.createProtocolSchema(user, protocol.getContainer(), protocol, null);
-            TableInfo assayDataTable = assayProtocolSchema.createDataTable(ContainerFilter.EVERYTHING_UNSAFE, false);
+            TableInfo assayDataTable = assayProtocolSchema.createDataTable(ContainerFilter.getUnsafeEverythingFilter(), false);
             if (assayDataTable != null)
             {
                 ColumnInfo dataIdCol = assayDataTable.getColumn("DataId");
@@ -3192,7 +3192,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                             if (plateSet == null)
                                 throw new ValidationException(String.format("Failed to mark hits. Unable to resolve plate set for \"%s\" result (Row Id %d)", protocol.getName(), resultId));
 
-                            PlateSetLineage lineage = getPlateSetLineage(container, user, plateSet.getRowId(), ContainerFilter.EVERYTHING_UNSAFE);
+                            PlateSetLineage lineage = getPlateSetLineage(container, user, plateSet.getRowId(), ContainerFilter.getUnsafeEverythingFilter());
                             String plateSetPath = lineage.getSeedPath();
 
                             cache.put(plateId, Pair.of(plate.getContainer().getEntityId(), plateSetPath));
@@ -3342,7 +3342,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         for (ExpProtocol protocol : protocols)
         {
             AssayProtocolSchema assayProtocolSchema = provider.createProtocolSchema(user, protocol.getContainer(), protocol, null);
-            TableInfo assayDataTable = assayProtocolSchema.createDataTable(ContainerFilter.EVERYTHING_UNSAFE, false);
+            TableInfo assayDataTable = assayProtocolSchema.createDataTable(ContainerFilter.getUnsafeEverythingFilter(), false);
 
             if (assayDataTable != null)
             {

--- a/audit/src/org/labkey/audit/query/AuditLogUnionTable.java
+++ b/audit/src/org/labkey/audit/query/AuditLogUnionTable.java
@@ -62,7 +62,7 @@ public class AuditLogUnionTable extends FilteredTable<AuditQuerySchema>
 
         public AuditUnionTable(@NotNull UserSchema schema, ContainerFilter cf)
         {
-            super(AuditSchema.getInstance().getSchema(), AuditQuerySchema.AUDIT_TABLE_NAME, schema, ContainerFilter.EVERYTHING_UNSAFE);
+            super(AuditSchema.getInstance().getSchema(), AuditQuerySchema.AUDIT_TABLE_NAME, schema, ContainerFilter.getUnsafeEverythingFilter());
 
             _query = new SQLFragment();
             _query.appendComment("<AuditUnionTableInfo>", getSchema().getSqlDialect());

--- a/core/src/org/labkey/core/query/CoreQuerySchema.java
+++ b/core/src/org/labkey/core/query/CoreQuerySchema.java
@@ -315,7 +315,7 @@ public class CoreQuerySchema extends UserSchema
     public TableInfo getPrincipals()
     {
         TableInfo principalsBase = CoreSchema.getInstance().getTableInfoPrincipals();
-        FilteredTable<CoreQuerySchema> principals = new FilteredTable<>(principalsBase, this, ContainerFilter.EVERYTHING_UNSAFE);
+        FilteredTable<CoreQuerySchema> principals = new FilteredTable<>(principalsBase, this, ContainerFilter.getUnsafeEverythingFilter());
 
         //we expose userid, name and type via query
         var col = principals.wrapColumn(principalsBase.getColumn("UserId"));

--- a/experiment/src/org/labkey/experiment/ParentChildView.java
+++ b/experiment/src/org/labkey/experiment/ParentChildView.java
@@ -142,7 +142,7 @@ public class ParentChildView extends VBox
         QueryView queryView = new QueryView(schema, settings, null);
         // Issue 38018: Sample Type: Multiple data inputs from different containers are not shown in the Parent Data grid
         // Use ContainerFilter.EVERYTHING - We've already set an IN clause that restricts us to showing just data that we have permission to view
-        queryView.setContainerFilter(ContainerFilter.EVERYTHING_UNSAFE);
+        queryView.setContainerFilter(ContainerFilter.getUnsafeEverythingFilter());
         TableInfo table = queryView.getTable();
 
         CustomView v = queryView.getCustomView();
@@ -225,7 +225,7 @@ public class ParentChildView extends VBox
             protected TableInfo createTable()
             {
                 // Use ContainerFilter.EVERYTHING - We've already set an IN clause that restricts us to showing just data that we have permission to view
-                ExpMaterialTable table = ExperimentServiceImpl.get().createMaterialTable(getSchema(), ContainerFilter.EVERYTHING_UNSAFE, st);
+                ExpMaterialTable table = ExperimentServiceImpl.get().createMaterialTable(getSchema(), ContainerFilter.getUnsafeEverythingFilter(), st);
                 table.populate();
 
                 List<FieldKey> defaultVisibleColumns = new ArrayList<>();

--- a/query/src/org/labkey/query/sql/CalculatedColumnTestCase.jsp
+++ b/query/src/org/labkey/query/sql/CalculatedColumnTestCase.jsp
@@ -394,7 +394,7 @@ UserSchema getUserSchema(String columns) throws Exception
 TableInfo getUserTableInfo(String columns) throws Exception
 {
     UserSchema userSchema = getUserSchema(columns);
-    return userSchema.getTable("R", ContainerFilter.EVERYTHING_UNSAFE, true, false);
+    return userSchema.getTable("R", ContainerFilter.getUnsafeEverythingFilter(), true, false);
 }
 
 

--- a/query/src/org/labkey/query/sql/QValuesTable.java
+++ b/query/src/org/labkey/query/sql/QValuesTable.java
@@ -62,7 +62,7 @@ public class QValuesTable extends QTable
     @Override
     public ContainerFilter.Type getContainerFilterType()
     {
-        return ContainerFilter.EVERYTHING_UNSAFE.getType();
+        return ContainerFilter.getUnsafeEverythingFilter().getType();
     }
 
     class _QueryRelation extends AbstractQueryRelation

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -189,7 +189,7 @@ public class SearchModule extends DefaultModule
             // Report the total number of search entries in the audit log
             User user = new LimitedUser(User.getSearchUser(), CanSeeAuditLogRole.class);
             UserSchema auditSchema = AuditLogService.get().createSchema(user, ContainerManager.getRoot());
-            TableInfo auditTable = auditSchema.getTableOrThrow(SearchAuditProvider.EVENT_TYPE, ContainerFilter.EVERYTHING_UNSAFE);
+            TableInfo auditTable = auditSchema.getTableOrThrow(SearchAuditProvider.EVENT_TYPE, ContainerFilter.getUnsafeEverythingFilter());
 
             long count = new TableSelector(auditTable).getRowCount();
             return Collections.singletonMap("fullTextSearches", count);

--- a/study/src/org/labkey/study/assay/query/PublishAuditProvider.java
+++ b/study/src/org/labkey/study/assay/query/PublishAuditProvider.java
@@ -127,7 +127,7 @@ public class PublishAuditProvider extends AbstractAuditTypeProvider implements A
                 {
                     // lookup to SampleType by ID
                     col.setLabel("Sample Type ID");
-                    col.setFk(QueryForeignKey.from(getUserSchema(), ContainerFilter.EVERYTHING_UNSAFE).schema(ExpSchema.SCHEMA_NAME).table(ExpSchema.TableType.SampleSets));
+                    col.setFk(QueryForeignKey.from(getUserSchema(), ContainerFilter.getUnsafeEverythingFilter()).schema(ExpSchema.SCHEMA_NAME).table(ExpSchema.TableType.SampleSets));
 
                     // ExpSampleTypeTableImpl uses a details URL with the current Container as the URL's fixed
                     // container context, but we would like to use the audit event row's container column instead.

--- a/study/src/org/labkey/study/query/AssayDatasetTable.java
+++ b/study/src/org/labkey/study/query/AssayDatasetTable.java
@@ -302,7 +302,7 @@ public class AssayDatasetTable extends LinkedDatasetTable
             }
             AssayProtocolSchema schema = provider.createProtocolSchema(_userSchema.getUser(), protocol.getContainer(), protocol, getContainer());
             schema.addContextualRole(RoleManager.getRole(ReaderRole.class));
-            _assayResultTable = schema.createDataTable(ContainerFilter.EVERYTHING_UNSAFE, false);
+            _assayResultTable = schema.createDataTable(ContainerFilter.getUnsafeEverythingFilter(), false);
             schema.overlayMetadata(_assayResultTable, AssayProtocolSchema.DATA_TABLE_NAME);
         }
         return _assayResultTable;

--- a/study/src/org/labkey/study/query/DatasetQueryView.java
+++ b/study/src/org/labkey/study/query/DatasetQueryView.java
@@ -846,7 +846,7 @@ public class DatasetQueryView extends StudyQueryView
             public SQLFragment getValidationSql(Container container, User user, ExpProtocol protocol, TableInfo dataTable)
             {
                 var sqs = StudyQuerySchema.createSchema(_dataset.getStudy(), user, null);
-                TableInfo datasetTable = sqs.getDatasetTable(_dataset, ContainerFilter.EVERYTHING_UNSAFE);
+                TableInfo datasetTable = sqs.getDatasetTable(_dataset, ContainerFilter.getUnsafeEverythingFilter());
 
                 String studyVisit = _dataset.getStudy().getTimepointType().isVisitBased() ? "SequenceNum" : "Date";
                 if (datasetTable instanceof FilteredTable<?> filteredTable)
@@ -869,7 +869,7 @@ public class DatasetQueryView extends StudyQueryView
             @Override
             public @Nullable ContainerFilter getContainerFilter()
             {
-                return ContainerFilter.EVERYTHING_UNSAFE;
+                return ContainerFilter.getUnsafeEverythingFilter();
             }
         }
     }

--- a/study/src/org/labkey/study/query/SampleDatasetTable.java
+++ b/study/src/org/labkey/study/query/SampleDatasetTable.java
@@ -124,7 +124,7 @@ public class SampleDatasetTable extends LinkedDatasetTable
                 // It is easier to handle these changes on the construction-side, so we use a helper schema
                 // CONSIDER: do we need a version of getTable() that allows passing custom options?
                 var noLinks = Objects.requireNonNull(samplesSchema.getSchema(SamplesSchema.STUDY_LINKED_SCHEMA_NAME));
-                _sampleTable = Objects.requireNonNull(noLinks.getTable(sampleType.getName(), ContainerFilter.EVERYTHING_UNSAFE));
+                _sampleTable = Objects.requireNonNull(noLinks.getTable(sampleType.getName(), ContainerFilter.getUnsafeEverythingFilter()));
             }
             else
             {

--- a/study/src/org/labkey/study/query/VialTable.java
+++ b/study/src/org/labkey/study/query/VialTable.java
@@ -52,7 +52,7 @@ public class VialTable extends BaseStudyTable
                 TableInfo tableInfo = schema.getTable(StudyQuerySchema.SIMPLE_SPECIMEN_TABLE_NAME);
                 if (tableInfo instanceof ContainerFilterable)
                 {
-                    ((ContainerFilterable) tableInfo).setContainerFilter(ContainerFilter.EVERYTHING_UNSAFE);    // TODO: what would this do without provisioned?
+                    ((ContainerFilterable) tableInfo).setContainerFilter(ContainerFilter.getUnsafeEverythingFilter());    // TODO: what would this do without provisioned?
                 }
                 return tableInfo;
             }


### PR DESCRIPTION
#### Rationale
The "class-loading deadlock" warning on our `InternalNoContainerFilter` static member variable is disconcerting. Accessing via a lazily initialized synchronized method eliminates the risk and the warning.
