### PR TITLE
Issue 52666: Improvements to the lost values report

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -277,8 +277,6 @@ import static org.labkey.api.query.QueryImportPipelineJob.QUERY_IMPORT_PIPELINE_
 import static org.labkey.api.query.QueryImportPipelineJob.QUERY_IMPORT_PIPELINE_PROVIDER_PARAM;
 import static org.labkey.api.util.DOM.A;
 import static org.labkey.api.util.DOM.Attribute.action;
-import static org.labkey.api.util.DOM.Attribute.border;
-import static org.labkey.api.util.DOM.Attribute.cellpadding;
 import static org.labkey.api.util.DOM.Attribute.href;
 import static org.labkey.api.util.DOM.Attribute.id;
 import static org.labkey.api.util.DOM.Attribute.method;
@@ -433,6 +431,7 @@ public class ExperimentController extends SpringActionController
 
     public record Field(String domainURI, String domainName, String name, Container container) {}
     public record MiniMaterial(int rowId, String name) {}
+    public record TimelineSummary(MiniMaterial miniMaterial, String mostRecentValue) {}
 
     @RequiresPermission(SiteAdminPermission.class)
     public static class ReportLostFieldValuesAction extends SimpleViewAction<Object>
@@ -442,21 +441,21 @@ public class ExperimentController extends SpringActionController
         {
             // Find all the fields that could have lost data due to issue 52666
             TableInfo t = new ExpSchema(getUser(), ContainerManager.getRoot()).getTable(ExpSchema.TableType.Fields.name(), ContainerFilter.EVERYTHING);
-            List<Field> problematicFields = new TableSelector(t, new SimpleFilter(FieldKey.fromParts("StorageColumnNameMatch"), false), null).getArrayList(Field.class);
+            List<Field> fields = new TableSelector(t, new SimpleFilter(FieldKey.fromParts("StorageColumnNameMatch"), false), null).getArrayList(Field.class);
 
             // Prep audit table for querying
             UserSchema auditSchema = AuditLogService.get().createSchema(getUser(), ContainerManager.getRoot());
             TableInfo sampleTimelineTable = auditSchema.getTable(SampleTimelineAuditEvent.EVENT_TYPE, ContainerFilter.EVERYTHING);
 
-            Map<Pair<ExpSampleType, String>, List<Pair<MiniMaterial, String>>> summaries = new HashMap<>();
+            Map<Pair<ExpSampleType, String>, List<TimelineSummary>> summaries = new HashMap<>();
 
-            Map<Field, Pair<Long, Long>> otherProblematicFields = new LinkedHashMap<>();
+            Map<Field, Pair<Long, Long>> problematicFields = new LinkedHashMap<>();
 
-            for (Field problematicField : problematicFields)
+            for (Field field : fields)
             {
-                String domainURI = problematicField.domainURI;
-                String name = problematicField.name;
-                Container container = problematicField.container;
+                String domainURI = field.domainURI;
+                String name = field.name;
+                Container container = field.container;
                 Domain domain = PropertyService.get().getDomain(container, domainURI);
                 if (domain != null && domain.getDomainKind() != null)
                 {
@@ -470,7 +469,7 @@ public class ExperimentController extends SpringActionController
                         // Find samples that current have no value for the field with potential for data loss
                         List<MiniMaterial> materialsWithNulls = new TableSelector(table, new HashSet<>(List.of("RowId", "Name")), new SimpleFilter(new CompareType.CompareClause(FieldKey.fromParts(name), CompareType.ISBLANK, null)), null).getArrayList(MiniMaterial.class);
 
-                        List<Pair<MiniMaterial, String>> fixupsNeeded = new ArrayList<>();
+                        List<TimelineSummary> fixupsNeeded = new ArrayList<>();
 
                         // For each sample without a value today, check the audit history
                         for (MiniMaterial material : materialsWithNulls)
@@ -484,6 +483,7 @@ public class ExperimentController extends SpringActionController
                                 Map<String, String> newValues = new CaseInsensitiveHashMap<>(AbstractAuditTypeProvider.decodeFromDataMap(event.getNewRecordMap()));
                                 if (newValues.containsKey(name))
                                 {
+                                    // Will be the empty string if the value was intentionally set to blank
                                     mostRecentValue = newValues.get(name);
                                 }
                             }
@@ -491,7 +491,7 @@ public class ExperimentController extends SpringActionController
                             // it's most likely a lost value
                             if (mostRecentValue != null && !mostRecentValue.isEmpty())
                             {
-                                fixupsNeeded.add(Pair.of(material, mostRecentValue));
+                                fixupsNeeded.add(new TimelineSummary(material, mostRecentValue));
                             }
                         }
                         if (!fixupsNeeded.isEmpty())
@@ -499,43 +499,38 @@ public class ExperimentController extends SpringActionController
                             summaries.put(Pair.of(sampleType, name), fixupsNeeded);
                         }
                     }
-                    else
+
+                    Long totalRows = null;
+                    Long emptyRows = null;
+                    if (table != null)
                     {
-                        if (table != null)
-                        {
-                            long totalRows = new TableSelector(table).getRowCount();
-                            long emptyRows = new TableSelector(table, new SimpleFilter(new CompareType.CompareClause(FieldKey.fromParts(name), CompareType.ISBLANK, null)), null).getRowCount();
-                            otherProblematicFields.put(problematicField, Pair.of(totalRows, emptyRows));
-                        }
-                        else
-                        {
-                            otherProblematicFields.put(problematicField, null);
-                        }
+                        totalRows = new TableSelector(table).getRowCount();
+                        emptyRows = new TableSelector(table, new SimpleFilter(new CompareType.CompareClause(FieldKey.fromParts(name), CompareType.ISBLANK, null)), null).getRowCount();
                     }
+                    problematicFields.put(field, Pair.of(totalRows, emptyRows));
                 }
             }
 
             return new HtmlView("Fixups Needed",
                 DOM.createHtmlFragment(
+                        DOM.H2("Potentially Problematic Fields"),
+                        DOM.TABLE(at(cl("table-condensed", "labkey-data-region", "table-bordered")),
+                                DOM.THEAD(DOM.TH("Domain Name"), DOM.TH("Domain URI"), DOM.TH("Field Name"), DOM.TH("Container"), DOM.TH("Total Rows"), DOM.TH("Rows with Nulls")),
+                                problematicFields.entrySet().stream().map(e -> {
+                                            Field f = e.getKey();
+                                            Pair<Long, Long> counts = e.getValue();
+                                            return DOM.TR(DOM.TD(f.domainName), DOM.TD(f.domainURI), DOM.TD(f.name), DOM.TD(f.container.getPath(), DOM.TD(counts.first), DOM.TD(counts.second)));
+                                        }
+                                )),
                         DOM.H2("Sample Types"),
                         summaries.entrySet().stream().map(e ->
                             DOM.DIV(
                                     DOM.H4(e.getKey().first.getName()),
                                     DOM.TABLE(at(cl("table-condensed", "labkey-data-region", "table-bordered")),
                                             DOM.THEAD(DOM.TH("SampleID"), DOM.TH(e.getKey().second)),
-                                            e.getValue().stream().map(p ->
-                                                        DOM.TR(DOM.TD(p.first.name), DOM.TD(p.second)))
-                                    ))),
-                    DOM.H2("Other Potentially Problematic Fields"),
-                    DOM.TABLE(at(cl("table-condensed", "labkey-data-region", "table-bordered")),
-                            DOM.THEAD(DOM.TH("Domain Name"), DOM.TH("Domain URI"), DOM.TH("Field Name"), DOM.TH("Container"), DOM.TH("Total Rows"), DOM.TH("Rows with Nulls")),
-                            otherProblematicFields.entrySet().stream().map(e -> {
-                                Field f = e.getKey();
-                                Pair<Long, Long> counts = e.getValue();
-                                return DOM.TR(DOM.TD(f.domainName), DOM.TD(f.domainURI), DOM.TD(f.name), DOM.TD(f.container.getPath(), DOM.TD(counts.first), DOM.TD(counts.second)));
-
-                            }
-                    ))));
+                                            e.getValue().stream().map(summary ->
+                                                        DOM.TR(DOM.TD(summary.miniMaterial.name), DOM.TD(summary.mostRecentValue)))
+                                    )))));
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
Small improvements to new report that helps track down potentially lost values on very long field names

#### Changes
- Avoid NPE if `TableInfo` can't be resolved
- Show sample type fields like other fields