### PR TITLE
Don't pass already rendered errors into GridView during publish confirm

### DIFF
--- a/api/src/org/labkey/api/study/publish/AbstractPublishConfirmAction.java
+++ b/api/src/org/labkey/api/study/publish/AbstractPublishConfirmAction.java
@@ -242,7 +242,7 @@ public abstract class AbstractPublishConfirmAction<FORM extends PublishConfirmFo
         settings.setSelectionKey(form.getDataRegionSelectionKey());
         if (form.getContainerFilterName() != null)
             settings.setContainerFilterName(form.getContainerFilterName());
-        PublishResultsQueryView queryView = new PublishResultsQueryView(schema, settings, errors,
+        PublishResultsQueryView queryView = new PublishResultsQueryView(schema, settings, null, // The JspView renders errors, so don't pass them into QueryView
                 getPublishSource(form),
                 getObjectIdFieldKey(form),
                 _allObjects, _targetStudy, _postedTargetStudies, _postedVisits, _postedDates, _postedPtids,


### PR DESCRIPTION
#### Rationale
Publish confirm action JSP handles errors by rendering them above the grid and then expecting the grid to still render, so pass null for errors into QueryView to prevent DataRegion from re-rendering them in place of the grid.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6501