### PR TITLE
Fix MenuButton

### DIFF
--- a/api/src/org/labkey/api/data/MenuButton.java
+++ b/api/src/org/labkey/api/data/MenuButton.java
@@ -24,6 +24,9 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.PopupMenu;
 import org.labkey.api.writer.HtmlWriter;
 
+import java.io.IOException;
+import java.io.Writer;
+
 /**
  * A button that responds to a user click by popping up a drop-down menu.
  */
@@ -45,6 +48,12 @@ public class MenuButton extends ActionButton
         {
             navTree.setId(menuId);
         }
+    }
+
+    @Override
+    public void render(RenderContext ctx, Writer out) throws IOException
+    {
+        render(ctx, HtmlWriter.of(out));
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Menu buttons on the ETL configuration and wiki history pages broke due to related PR; need to keep the old render() method until there are no more callers.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6504