### PR TITLE
Issue 52748: NPE from AdminController$LogClientExceptionAction

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10539,7 +10539,11 @@ public class AdminController extends SpringActionController
                 form.getUsername()
             );
 
-            return success(Map.of("errorCode", errorCode, "loggedToMothership", errorCode != null));
+            Map<String, Object> results = new HashMap<>();
+            results.put("errorCode", errorCode);
+            results.put("loggedToMothership", errorCode != null);
+
+            return success(results);
         }
     }
 


### PR DESCRIPTION
#### Rationale
IntelliJ's warning was correct - `errorCode` can be null, and that makes `Map.of()` upset.

#### Changes
- Use a `HashMap` which is null-tolerant