### PR TITLE
Assorted exceptions exposed by a new crawler

### DIFF
--- a/core/src/org/labkey/core/admin/MenuViewFactory.java
+++ b/core/src/org/labkey/core/admin/MenuViewFactory.java
@@ -16,6 +16,7 @@
 package org.labkey.core.admin;
 
 import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.collections.ResultSetRowMapFactory;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.Container;
@@ -57,7 +58,7 @@ public class MenuViewFactory
 {
     private static final int MAX_PER_COLUMN = 20;
 
-    public static WebPartView createMenuQueryView(ViewContext context, String title, final CustomizeMenuForm form)
+    public static WebPartView<?> createMenuQueryView(ViewContext context, String title, final CustomizeMenuForm form)
     {
         if (null != StringUtils.trimToNull(form.getFolderName()))
         {
@@ -167,7 +168,7 @@ public class MenuViewFactory
         }
         else
         {
-            WebPartView view = new WebPartView(title) {
+            return new WebPartView<>(title) {
                 @Override
                 protected void renderView(Object model, PrintWriter out)
                 {
@@ -176,15 +177,14 @@ public class MenuViewFactory
                     out.write("</td></tr></table>");
                 }
             };
-            return view;
         }
     }
 
-    public static WebPartView createMenuFolderView(final ViewContext context, String title, final CustomizeMenuForm form)
+    public static WebPartView<?> createMenuFolderView(final ViewContext context, String title, final CustomizeMenuForm form)
     {
         // If rootPath is "", then use current context's container
         String rootPath = form.getRootFolder();
-        Container rootFolder = (0 == rootPath.compareTo("")) ? context.getContainer() : ContainerManager.getForPath(rootPath);
+        Container rootFolder = StringUtils.isBlank(rootPath) ? context.getContainer() : ContainerManager.getForPath(rootPath);
         final User user = context.getUser();
         List<Container> containersTemp;
         if (null != rootFolder)
@@ -221,7 +221,7 @@ public class MenuViewFactory
 
         final Collection<Container> containers = containersTemp;
 
-        WebPartView view = new WebPartView(title) {
+        WebPartView<?> view = new WebPartView<>(title) {
             @Override
             protected void renderView(Object model, PrintWriter out)
             {
@@ -246,8 +246,15 @@ public class MenuViewFactory
                         ActionURL actionURL;
                         if (null != expr)
                         {
-                            actionURL = new ActionURL(expr.getSource());
-                            actionURL.setContainer(container);
+                            try
+                            {
+                                actionURL = new ActionURL(expr.getSource());
+                                actionURL.setContainer(container);
+                            }
+                            catch (IllegalArgumentException e)
+                            {
+                                throw new ApiUsageException("Invalid source URL", e);
+                            }
                         }
                         else
                         {

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2610,7 +2610,7 @@ public class QueryController extends SpringActionController
             for (int i = 0; i < jsonViews.length(); i++)
             {
                 final JSONObject jsonView = jsonViews.getJSONObject(i);
-                String viewName = jsonView.optString("name");
+                String viewName = jsonView.optString("name", null);
                 if (viewName == null)
                     throw new NotFoundException("'name' is required all views'");
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2610,7 +2610,9 @@ public class QueryController extends SpringActionController
             for (int i = 0; i < jsonViews.length(); i++)
             {
                 final JSONObject jsonView = jsonViews.getJSONObject(i);
-                String viewName = jsonView.getString("name");
+                String viewName = jsonView.optString("name");
+                if (viewName == null)
+                    throw new NotFoundException("'name' is required all views'");
 
                 boolean shared = jsonView.optBoolean("shared", false);
                 boolean replace = jsonView.optBoolean("replace", true); // "replace" was the default before the flag is introduced

--- a/query/src/org/labkey/query/view/CustomViewSetKey.java
+++ b/query/src/org/labkey/query/view/CustomViewSetKey.java
@@ -93,7 +93,9 @@ public class CustomViewSetKey implements Serializable
         {
             return Collections.emptyMap();
         }
-        return Collections.unmodifiableMap(map);
+
+        // Copy to avoid ConcurrentModificationExceptions
+        return Collections.unmodifiableMap(new HashMap<>(map));
     }
 
     static public void deleteCustomViewFromSession(HttpServletRequest request, QueryDefinition queryDef, String name)


### PR DESCRIPTION
#### Rationale
A new crawler is tickling us in new and exciting ways

Issue 52761: ConcurrentModificationException from org.labkey.query.QueryDefinitionImpl.getCustomViews()
Issue 52759: NullPointerException in org.labkey.core.admin.MenuViewFactory.createMenuFolderView()
Issue 52758: JSONException from org.labkey.query.controllers.QueryController$SaveQueryViewsAction.execute()

#### Changes
- Simple null checks and other improvements to error handling