### PR TITLE
Issue 52774: Naming Expression with default value that contains special characters aren't generated as expected

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -2429,6 +2429,7 @@ public class NameGenerator
         return expression.replaceAll("%", "%25").replaceAll("[+]", "%2B");
     }
 
+    // Issue 52774: Naming Expression with default value that contains special characters aren't generated as expected
     public static String decodeNamingPart(@Nullable String expression)
     {
         if (expression == null)

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -2418,6 +2418,38 @@ public class NameGenerator
         }
     }
 
+    // Issue 51109: Name Pattern using lineage doesn't like sample type names that contain a '+'
+    // parsePart assumes encoded expression
+    // QueryKey.decode calls PageFlowUtil.decode, which can't handle '%' and '+'
+    public static String encodeNamingPart(@Nullable String expression)
+    {
+        if (expression == null)
+            return null;
+
+        return expression.replaceAll("%", "%25").replaceAll("[+]", "%2B");
+    }
+
+    public static String decodeNamingPart(@Nullable String expression)
+    {
+        if (expression == null)
+            return null;
+
+        return expression.replaceAll("%2B", "+").replaceAll("%25", "%");
+    }
+
+    public static class NameExpressionPart extends StringExpressionFactory.FieldPart
+    {
+        public NameExpressionPart(@NotNull String s, boolean urlEncodeSubstitutions)
+        {
+            super(s, urlEncodeSubstitutions, true);
+        }
+
+        @Override
+        public String getExpressionParam(String param)
+        {
+            return decodeNamingPart(param);
+        }
+    }
     /**
      *  Same as FieldKeyExpression, but supports :withCounter syntax
      */
@@ -2457,12 +2489,6 @@ public class NameGenerator
         public static NameGenerationExpression create(String source, boolean urlEncodeSubstitutions, NullValueBehavior nullValueBehavior, boolean allowSideEffects, Container container, Function<String, Long> getNonConflictCountFn, String counterSeqPrefix, boolean validateSyntax)
         {
             return new NameGenerationExpression(source, urlEncodeSubstitutions, nullValueBehavior, allowSideEffects, container, getNonConflictCountFn, counterSeqPrefix, validateSyntax);
-        }
-
-        @Override
-        protected boolean isBackslashEscape()
-        {
-            return true;
         }
 
         public List<String> getSyntaxErrors()
@@ -2508,10 +2534,19 @@ public class NameGenerator
                 expression = expression.replaceAll(ANCESTOR_INPUT_PREFIX_DATA.replace("[", "\\["), ANCESTOR_INPUT_PREFIX_DATA_NOSLASH);
             }
 
-            expression = expression.replaceAll("%", "%25");
-            expression = expression.replaceAll("[+]", "%2B");
+            expression = encodeNamingPart(expression);
 
-            return super.parsePart(expression);
+            // override FieldKeyStringExpression.parsePart to use NameExpressionPart instead of FieldPart
+            if (StringExpressionFactory.RenderContextPart.SUPPORTED_SUBSTITUTIONS.contains(expression))
+                return new StringExpressionFactory.RenderContextPart(expression);
+            try
+            {
+                return new NameExpressionPart(expression, isUrlEncodeSubstitutions());
+            }
+            catch (IllegalArgumentException x)
+            {
+                return new StringExpressionFactory.ConstantPart("${" + expression + "}");
+            }
         }
 
         public static int findFirstOpenOrCloseTag(String str, String target, int startIndex)

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -2442,7 +2442,7 @@ public class NameGenerator
     {
         public NameExpressionPart(@NotNull String s, boolean urlEncodeSubstitutions)
         {
-            super(s, urlEncodeSubstitutions, true);
+            super(s, urlEncodeSubstitutions, true /*support escaping using backslash*/);
         }
 
         @Override

--- a/api/src/org/labkey/api/util/StringExpressionFactory.java
+++ b/api/src/org/labkey/api/util/StringExpressionFactory.java
@@ -33,7 +33,6 @@ import org.labkey.api.data.StopIteratingException;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.query.QueryKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.view.ActionURL;
@@ -369,7 +368,7 @@ public class StringExpressionFactory
                 if (rest.startsWith("defaultValue('") && rest.endsWith("')"))
                 {
                     String param = rest.substring("defaultValue('".length(), rest.length() - "')".length());
-                    format = new SubstitutionFormat.DefaultSubstitutionFormat(param);
+                    format = new SubstitutionFormat.DefaultSubstitutionFormat(getExpressionParam(param));
                 }
                 else if ((rest.startsWith("minValue('") && rest.endsWith("')")
                     || (rest.startsWith("minValue(") && rest.endsWith(")"))))
@@ -379,34 +378,34 @@ public class StringExpressionFactory
                         param = rest.substring("minValue('".length(), rest.length() - "')".length());
                     else if (rest.startsWith("minValue(") && rest.endsWith(")"))
                         param = rest.substring("minValue(".length(), rest.length() - ")".length());
-                    format = new SubstitutionFormat.MinValueSubstitutionFormat(param);
+                    format = new SubstitutionFormat.MinValueSubstitutionFormat(getExpressionParam(param));
                 }
                 else if (rest.startsWith("number('") && rest.endsWith("')"))
                 {
                     // TODO: Without a format string parameter, use container default number format
                     String param = rest.substring("number('".length(), rest.length() - "')".length());
-                    format = new SubstitutionFormat.NumberSubstitutionFormat(param);
+                    format = new SubstitutionFormat.NumberSubstitutionFormat(getExpressionParam(param));
                 }
                 else if (rest.startsWith("date('") && rest.endsWith("')"))
                 {
                     String param = rest.substring("date('".length(), rest.length() - "')".length());
-                    format = createDateSubstitutionFormat(param);
+                    format = createDateSubstitutionFormat(getExpressionParam(param));
                 }
                 else if (rest.startsWith("prefix('") && rest.endsWith("')"))
                 {
                     String param = rest.substring("prefix('".length(), rest.length() - "')".length());
-                    format = new SubstitutionFormat.JoinSubstitutionFormat("", param, "");
+                    format = new SubstitutionFormat.JoinSubstitutionFormat("", getExpressionParam(param), "");
                 }
                 else if (rest.startsWith("suffix('") && rest.endsWith("')"))
                 {
                     String param = rest.substring("suffix('".length(), rest.length() - "')".length());
-                    format = new SubstitutionFormat.JoinSubstitutionFormat("", "", param);
+                    format = new SubstitutionFormat.JoinSubstitutionFormat("", "", getExpressionParam(param));
                 }
                 else if (rest.startsWith("join('") && rest.endsWith("')"))
                 {
                     // TODO: Support three parameter variation
                     String param = rest.substring("join('".length(), rest.length() - "')".length());
-                    format = new SubstitutionFormat.JoinSubstitutionFormat(param, "", "");
+                    format = new SubstitutionFormat.JoinSubstitutionFormat(getExpressionParam(param), "", "");
                 }
                 else
                 {
@@ -428,6 +427,11 @@ public class StringExpressionFactory
                 _formats = Collections.singleton(urlEncodeSubstitutions ? SubstitutionFormat.urlEncode : SubstitutionFormat.passThrough);
             else
                 _formats = Collections.unmodifiableList(formats);
+        }
+
+        protected String getExpressionParam(String param)
+        {
+            return param;
         }
 
         public SubstitutePart(String value, SubstitutionFormat sf)
@@ -532,7 +536,7 @@ public class StringExpressionFactory
         };
     }
 
-    private static class RenderContextPart extends SubstitutePart
+    public static class RenderContextPart extends SubstitutePart
     {
         public enum Substitution
         {
@@ -1135,9 +1139,9 @@ public class StringExpressionFactory
             return new FieldKeyStringExpression(source, urlEncodeSubstitutions, nullValueBehavior, allowSideEffects);
         }
 
-        protected boolean isBackslashEscape()
+        public boolean isUrlEncodeSubstitutions()
         {
-            return false;
+            return _urlEncodeSubstitutions;
         }
 
         @Override
@@ -1148,7 +1152,7 @@ public class StringExpressionFactory
                 return new RenderContextPart(expr);
             try
             {
-                return new FieldPart(expr, _urlEncodeSubstitutions, isBackslashEscape());
+                return new FieldPart(expr, _urlEncodeSubstitutions, false);
             }
             catch (IllegalArgumentException x)
             {


### PR DESCRIPTION
#### Rationale
Issue revealed by fuzz test failure with url like characters (%, +) in defaultValue in naming expression. [SampleTypeNameExpressionTest.testMaterialInputsExpressionWithParentAliasData](https://teamcity.labkey.org/viewLog.html?buildId=3456581&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId2392957849536281483), [SampleTypeNameExpressionTest.testParentAliasExpression](https://teamcity.labkey.org/viewLog.html?buildId=3456581&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId5210230046498880137), [SampleTypeNameExpressionTest.testInputsExpression](https://teamcity.labkey.org/viewLog.html?buildId=3456581&buildTypeId=LabkeyTrunk_DailyPostgres_2&fromSakuraUI=true#testNameId3858827256529902907) (develop pg)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6539
- https://github.com/LabKey/testAutomation/pull/2400

#### Changes
- decode previously encoded url strings in naming expression format processing
- Created NameExpressionPart to handle naming expression parts
