### PR TITLE
Issue 52561: LKSM: Moving aliquots into a subfolder with required MaterialInputs errors

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -6883,17 +6883,21 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 Table.update(user, getTinfoData(), ((ExpDataImpl)outputData).getDataObject(), outputData.getRowId());
             }
 
-            boolean hasMissingRequiredParent = false;
-            for (String required : requiredDataTypes)
+            // Issue 52561: LKSM: Moving aliquots into a subfolder with required MaterialInputs errors
+            if (!isSampleAliquot(run.getProtocol()))
             {
-                if (!inputDataTypes.contains(required))
+                boolean hasMissingRequiredParent = false;
+                for (String required : requiredDataTypes)
                 {
-                    hasMissingRequiredParent = true;
-                    break;
+                    if (!inputDataTypes.contains(required))
+                    {
+                        hasMissingRequiredParent = true;
+                        break;
+                    }
                 }
+                if (hasMissingRequiredParent)
+                    throw new ExperimentException("Inputs are required: " + String.join(",", requiredDataTypes));
             }
-            if (hasMissingRequiredParent)
-                throw new ExperimentException("Inputs are required: " + String.join(",", requiredDataTypes));
 
             initializeProtocolApplication(protApp3, date, action3, run, outputProtocol, context);
             protApp3.save(user);


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- skip required lineage check for aliquot exp run