### PR TITLE
Remove support for extra date/time parsing patterns

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -235,11 +235,6 @@ public class ApiModule extends CodeOnlyModule
             "Stage file uploads and downloads to temporary local file",
             "When using a non-local file system, using a specific API that requires a locally staged copy of the file as the source can sometimes be significantly faster than streaming the file directly to/from storage",
             false, false, FeatureType.Optional));
-
-        AdminConsole.addOptionalFeatureFlag(new OptionalFeatureFlag(FolderSettingsCache.EXTRA_PARSING_PATTERNS_FEATURE_FLAG,
-            "Restore ability to provide additional date and time parsing patterns",
-            "This option and all support for additional date and time parsing patterns will be removed in LabKey Server v25.4.",
-            false, false, FeatureType.Deprecated));
     }
 
     @NotNull

--- a/api/src/org/labkey/api/admin/FolderWriterImpl.java
+++ b/api/src/org/labkey/api/admin/FolderWriterImpl.java
@@ -131,18 +131,6 @@ public class FolderWriterImpl extends BaseFolderWriter
         if (null != defaultNumberFormat)
             folderXml.setDefaultNumberFormat(defaultNumberFormat);
 
-        String extraDateParsingPattern = props.getExtraDateParsingPatternStored();
-        if (null != extraDateParsingPattern)
-            folderXml.setExtraDateParsingPattern(extraDateParsingPattern);
-
-        String extraDateTimeParsingPattern = props.getExtraDateTimeParsingPatternStored();
-        if (null != extraDateTimeParsingPattern)
-            folderXml.setExtraDateTimeParsingPattern(extraDateTimeParsingPattern);
-
-        String extraTimeParsingPattern = props.getExtraTimeParsingPatternStored();
-        if (null != extraTimeParsingPattern)
-            folderXml.setExtraTimeParsingPattern(extraTimeParsingPattern);
-
         Boolean areRestricted = props.areRestrictedColumnsEnabledStored();
         if (null != areRestricted)
             folderXml.setRestrictedColumnsEnabled(areRestricted);

--- a/api/src/org/labkey/api/settings/FolderSettingsCache.java
+++ b/api/src/org/labkey/api/settings/FolderSettingsCache.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 public class FolderSettingsCache
 {
     private static final BlockingCache<Container, FolderSettings> CACHE = CacheManager.getBlockingCache(Constants.getMaxContainers(), CacheManager.DAY, "Folder settings", (c, argument) -> new FolderSettings(c));
-    public static final String EXTRA_PARSING_PATTERNS_FEATURE_FLAG = "extraDateTimeParsingPatterns";
 
     public static String getDefaultDateFormat(Container c)
     {
@@ -53,27 +52,6 @@ public class FolderSettingsCache
     public static String getDefaultNumberFormat(Container c)
     {
         return CACHE.get(c).getDefaultNumberFormat();
-    }
-
-    public static String getExtraDateParsingPattern(Container c)
-    {
-        return OptionalFeatureService.get().isFeatureEnabled(EXTRA_PARSING_PATTERNS_FEATURE_FLAG) ?
-            CACHE.get(c).getExtraDateParsingPattern() :
-            null;
-    }
-
-    public static String getExtraDateTimeParsingPattern(Container c)
-    {
-        return OptionalFeatureService.get().isFeatureEnabled(EXTRA_PARSING_PATTERNS_FEATURE_FLAG) ?
-            CACHE.get(c).getExtraDateTimeParsingPattern() :
-            null;
-    }
-
-    public static String getExtraTimeParsingPattern(Container c)
-    {
-        return OptionalFeatureService.get().isFeatureEnabled(EXTRA_PARSING_PATTERNS_FEATURE_FLAG) ?
-            CACHE.get(c).getExtraTimeParsingPattern() :
-            null;
     }
 
     public static boolean areRestrictedColumnsEnabled(Container c)
@@ -97,9 +75,6 @@ public class FolderSettingsCache
         private final String _defaultDateTimeFormat;
         private final String _defaultTimeFormat;
         private final String _defaultNumberFormat;
-        private final String _extraDateParsingPattern;
-        private final String _extraDateTimeParsingPattern;
-        private final String _extraTimeParsingPattern;
         private final boolean _restrictedColumnsEnabled;
 
         FolderSettings(Container c)
@@ -109,9 +84,6 @@ public class FolderSettingsCache
             _defaultDateTimeFormat = props.calculateDefaultDateTimeFormat();
             _defaultTimeFormat = props.calculateDefaultTimeFormat();
             _defaultNumberFormat = props.calculateDefaultNumberFormat();
-            _extraDateParsingPattern = props.calculateExtraDateParsingPattern();
-            _extraDateTimeParsingPattern = props.calculateExtraDateTimeParsingPattern();
-            _extraTimeParsingPattern = props.calculateExtraTimeParsingPattern();
             _restrictedColumnsEnabled = props.calculateRestrictedColumnsEnabled();
         }
 
@@ -133,21 +105,6 @@ public class FolderSettingsCache
         public String getDefaultTimeFormat()
         {
             return _defaultTimeFormat;
-        }
-
-        public String getExtraDateParsingPattern()
-        {
-            return _extraDateParsingPattern;
-        }
-
-        public String getExtraDateTimeParsingPattern()
-        {
-            return _extraDateTimeParsingPattern;
-        }
-
-        public String getExtraTimeParsingPattern()
-        {
-            return _extraTimeParsingPattern;
         }
 
         public boolean areRestrictedColumnsEnabled()

--- a/api/src/org/labkey/api/settings/LookAndFeelFolderProperties.java
+++ b/api/src/org/labkey/api/settings/LookAndFeelFolderProperties.java
@@ -22,9 +22,6 @@ import org.labkey.api.util.DateUtil;
 
 import java.util.Map;
 
-import static org.labkey.api.settings.LookAndFeelProperties.Properties.extraDateParsingPattern;
-import static org.labkey.api.settings.LookAndFeelProperties.Properties.extraDateTimeParsingPattern;
-import static org.labkey.api.settings.LookAndFeelProperties.Properties.extraTimeParsingPattern;
 import static org.labkey.api.settings.LookAndFeelProperties.Properties.restrictedColumnsEnabled;
 
 /**
@@ -181,66 +178,6 @@ public class LookAndFeelFolderProperties extends AbstractWriteableSettingsGroup
     public String getDefaultNumberFormatStored()
     {
         return getStoredValue(_c, defaultNumberFormatString);
-    }
-
-    // Returns inherited value from the cache
-    public String getExtraDateParsingPattern()
-    {
-        return FolderSettingsCache.getExtraDateParsingPattern(_c);
-    }
-
-    // Note: Should be called only by FolderSettingsCache; other callers use getExtraDateParsingPattern() instead.
-    public String calculateExtraDateParsingPattern()
-    {
-        // Look up this value starting from the current container
-        return lookupStringValue(_c, extraDateParsingPattern, null);
-    }
-
-    // Get the value that's actually stored in this container or null if inherited; don't look up the hierarchy.
-    // This is useful for export and showing inheritance status in the UI.
-    public String getExtraDateParsingPatternStored()
-    {
-        return getStoredValue(_c, extraDateParsingPattern);
-    }
-
-    // Returns inherited value from the cache
-    public String getExtraDateTimeParsingPattern()
-    {
-        return FolderSettingsCache.getExtraDateTimeParsingPattern(_c);
-    }
-
-    // Note: Should be called only by FolderSettingsCache; other callers use getExtraDateTimeParsingPattern() instead.
-    public String calculateExtraDateTimeParsingPattern()
-    {
-        // Look up this value starting from the current container
-        return lookupStringValue(_c, extraDateTimeParsingPattern, null);
-    }
-
-    // Get the value that's actually stored in this container or null if inherited; don't look up the hierarchy.
-    // This is useful for export and showing inheritance status in the UI.
-    public String getExtraDateTimeParsingPatternStored()
-    {
-        return getStoredValue(_c, extraDateTimeParsingPattern);
-    }
-
-    // Returns inherited value from the cache
-    public String getExtraTimeParsingPattern()
-    {
-        return FolderSettingsCache.getExtraTimeParsingPattern(_c);
-    }
-
-    // Note: Should be called only by FolderSettingsCache; other callers use getExtraTimeParsingPattern() instead.
-    public String calculateExtraTimeParsingPattern()
-    {
-        // Look up this value starting from the current container
-        return lookupStringValue(_c, extraTimeParsingPattern, null);
-    }
-
-    // Get the value that's actually stored in this container or null if inherited; don't look up the hierarchy.
-    // This is useful for export and showing inheritance status in the UI.
-    public String getExtraTimeParsingPatternStored()
-    {
-        return getStoredValue(_c, extraTimeParsingPattern);
     }
 
     // Returns inherited value from the cache

--- a/api/src/org/labkey/api/settings/LookAndFeelProperties.java
+++ b/api/src/org/labkey/api/settings/LookAndFeelProperties.java
@@ -108,9 +108,6 @@ public class LookAndFeelProperties extends LookAndFeelFolderProperties
         },
 
         dateParsingMode("Date parsing mode. Valid values: " + Arrays.toString(DateParsingMode.values())),
-        extraDateParsingPattern("Additional parsing pattern for dates"),
-        extraDateTimeParsingPattern("Additional parsing pattern for date-times"),
-        extraTimeParsingPattern("Additional parsing pattern for times"),
 
         restrictedColumnsEnabled("Restrict charting columns by measure and dimension flags"),
 

--- a/api/src/org/labkey/api/settings/WriteableFolderLookAndFeelProperties.java
+++ b/api/src/org/labkey/api/settings/WriteableFolderLookAndFeelProperties.java
@@ -25,9 +25,6 @@ import static org.labkey.api.settings.LookAndFeelFolderProperties.defaultDateTim
 import static org.labkey.api.settings.LookAndFeelFolderProperties.defaultNumberFormatString;
 import static org.labkey.api.settings.LookAndFeelFolderProperties.defaultTimeFormatString;
 import static org.labkey.api.settings.LookAndFeelProperties.LOOK_AND_FEEL_SET_NAME;
-import static org.labkey.api.settings.LookAndFeelProperties.Properties.extraDateParsingPattern;
-import static org.labkey.api.settings.LookAndFeelProperties.Properties.extraDateTimeParsingPattern;
-import static org.labkey.api.settings.LookAndFeelProperties.Properties.extraTimeParsingPattern;
 import static org.labkey.api.settings.LookAndFeelProperties.Properties.restrictedColumnsEnabled;
 
 // Handles only the properties that can be set at the folder level
@@ -147,75 +144,6 @@ public class WriteableFolderLookAndFeelProperties extends AbstractWriteableSetti
     {
         WriteableFolderLookAndFeelProperties props = LookAndFeelProperties.getWriteableFolderInstance(c);
         props.setDefaultNumberFormat(defaultNumberFormat);
-        props.save();
-    }
-
-    // Validate inside the set method, since this is called from multiple places
-    public void setExtraDateParsingPattern(String pattern) throws IllegalArgumentException
-    {
-        // Check for legal format
-        if (null != pattern)
-            FastDateFormat.getInstance(pattern);
-        storeStringValue(extraDateParsingPattern, pattern);
-    }
-
-    // Validate inside the set method, since this is called from multiple places
-    public void setExtraDateTimeParsingPattern(String pattern) throws IllegalArgumentException
-    {
-        // Check for legal format
-        if (null != pattern)
-            FastDateFormat.getInstance(pattern);
-        storeStringValue(extraDateTimeParsingPattern, pattern);
-    }
-
-    // Validate inside the set method, since this is called from multiple places
-    public void setExtraTimeParsingPattern(String pattern) throws IllegalArgumentException
-    {
-        // Check for legal format
-        if (null != pattern)
-            FastDateFormat.getInstance(pattern);
-        storeStringValue(extraTimeParsingPattern, pattern);
-    }
-
-    // Allows clearing the property to allow inheriting of this property alone
-    public void clearExtraDateParsingPattern()
-    {
-        remove(extraDateParsingPattern);
-    }
-
-    // Allows clearing the property to allow inheriting of this property alone
-    public void clearExtraDateTimeParsingPattern()
-    {
-        remove(extraDateTimeParsingPattern);
-    }
-
-    // Allows clearing the property to allow inheriting of this property alone
-    public void clearExtraTimeParsingPattern()
-    {
-        remove(extraTimeParsingPattern);
-    }
-
-    // Convenience method to support import: validate and save just this property
-    public static void saveExtraDateParsingPattern(Container c, String extraDateParsingPattern) throws IllegalArgumentException
-    {
-        WriteableFolderLookAndFeelProperties props = LookAndFeelProperties.getWriteableFolderInstance(c);
-        props.setExtraDateParsingPattern(extraDateParsingPattern);
-        props.save();
-    }
-
-    // Convenience method to support import: validate and save just this property
-    public static void saveExtraDateTimeParsingPattern(Container c, String extraDateTimeParsingPattern) throws IllegalArgumentException
-    {
-        WriteableFolderLookAndFeelProperties props = LookAndFeelProperties.getWriteableFolderInstance(c);
-        props.setExtraDateTimeParsingPattern(extraDateTimeParsingPattern);
-        props.save();
-    }
-
-    // Convenience method to support import: validate and save just this property
-    public static void saveExtraTimeParsingPattern(Container c, String extraTimeParsingPattern) throws IllegalArgumentException
-    {
-        WriteableFolderLookAndFeelProperties props = LookAndFeelProperties.getWriteableFolderInstance(c);
-        props.setExtraTimeParsingPattern(extraTimeParsingPattern);
         props.save();
     }
 

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -720,7 +720,7 @@ public class DateUtil
     @Deprecated
     public static long parseDateTime(Container c, String s)
     {
-        return parseDate(s);
+        return parseDateTime(s);
     }
 
     private static long parseDateTime(String s, MonthDayOption md)

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -30,7 +30,6 @@ import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.pipeline.PipelineJobService;
-import org.labkey.api.query.QueryService;
 import org.labkey.api.settings.DateParsingMode;
 import org.labkey.api.settings.FolderSettingsCache;
 import org.labkey.api.settings.LookAndFeelProperties;
@@ -701,20 +700,7 @@ public class DateUtil
         return getDateParser(pattern).parse(s);
     }
 
-    private static @NotNull Container getCurrentContainer()
-    {
-        // Yes, using ThreadLocal is unfortunate, but some code paths have no way to pass a Container through to the
-        // parsing methods (e.g., TableViewForm -> ConvertUtils and DataIterator -> JdbcType -> ConvertUtils)
-        Container c = (Container)QueryService.get().getEnvironment(QueryService.Environment.CONTAINER);
-
-        if (null == c)
-            c = ContainerManager.getRoot();
-
-        return c;
-    }
-
     // Lenient parsing using a variety of standard formats
-    @Deprecated  // Use version that takes a Container instead
     public static long parseDateTime(String s)
     {
         //Issue 30004: Remote servers cannot use the database to lookup MonthDayOption, so default to MONTH_DAY
@@ -725,16 +711,16 @@ public class DateUtil
             return parseDateTime(s, MonthDayOption.MONTH_DAY, true, null);
         }
 
-        return parseDateTime(getCurrentContainer(), s);
-    }
-
-    // Lenient parsing using a variety of standard formats
-    public static long parseDateTime(Container c, String s)
-    {
-        @Nullable String extraDateTimeParsingPattern = FolderSettingsCache.getExtraDateTimeParsingPattern(c);
         MonthDayOption monthDayOption = LookAndFeelProperties.getInstance(ContainerManager.getRoot()).getDateParsingMode().getDayMonth();
 
-        return parseDateTime(s, monthDayOption, true, extraDateTimeParsingPattern);
+        return parseDateTime(s, monthDayOption, true, null);
+    }
+
+    // TODO: Migrate callers and remove this variant
+    @Deprecated
+    public static long parseDateTime(Container c, String s)
+    {
+        return parseDate(s);
     }
 
     private static long parseDateTime(String s, MonthDayOption md)
@@ -766,19 +752,17 @@ public class DateUtil
     }
 
     // Lenient parsing using a variety of standard formats
-    @Deprecated  // Use version that takes a Container instead
     public static long parseDate(String s)
     {
-        return parseDate(getCurrentContainer(), s);
-    }
-
-    // Lenient parsing using a variety of standard formats
-    public static long parseDate(Container c, String s)
-    {
-        @Nullable String extraDateParsingPattern = FolderSettingsCache.getExtraDateParsingPattern(c);
         MonthDayOption monthDayOption = LookAndFeelProperties.getInstance(ContainerManager.getRoot()).getDateParsingMode().getDayMonth();
 
-        return parseDate(s, monthDayOption, extraDateParsingPattern);
+        return parseDate(s, monthDayOption, null);    }
+
+    // TODO: Migrate callers and remove this variant
+    @Deprecated
+    public static long parseDate(Container c, String s)
+    {
+        return parseDate(s);
     }
 
     private static long parseDate(String s, MonthDayOption md, @Nullable String extraParsingPattern)
@@ -860,38 +844,12 @@ public class DateUtil
     // parse time as Date on epoch 1970/1/1
     public static Time fromTimeString(@NotNull String s, boolean strict)
     {
-        return fromTimeString(s, getCurrentContainer(), strict);
+        return fromTimeString(s, strict, false);
     }
 
     // parse time as Date on epoch 1970/1/1
-    public static Time fromTimeString(@NotNull String s, boolean strict, boolean simpleParsingOnly /* for example, when infer domain field type*/)
+    public static Time fromTimeString(@NotNull String s, boolean strict, boolean simpleParsingOnly)
     {
-        return fromTimeString(s, getCurrentContainer(), strict, simpleParsingOnly);
-    }
-
-    // parse time as Date on epoch 1970/1/1
-    public static Time fromTimeString(@NotNull String s, Container container, boolean strict)
-    {
-        return fromTimeString(s, container, strict, false);
-    }
-
-    // parse time as Date on epoch 1970/1/1
-    public static Time fromTimeString(@NotNull String s, Container container, boolean strict, boolean simpleParsingOnly)
-    {
-        @Nullable String extraTimeParsingPattern = FolderSettingsCache.getExtraTimeParsingPattern(container);
-
-        // If provided, try the extra parsing pattern first
-        if (null != extraTimeParsingPattern)
-        {
-            try
-            {
-                return new Time(DateUtil.parseDateTime(s, extraTimeParsingPattern).getTime());
-            }
-            catch (ParseException ignored)
-            {
-            }
-        }
-
         try
         {
             return new Time(parseSimpleTime(s).getTime());
@@ -980,12 +938,6 @@ public class DateUtil
         return formatIsoDate(new Date());
     }
 
-    @Deprecated // Use formatIsoDate(Date);
-    public static String formatDateISO8601(@Nullable Date date)
-    {
-        return formatIsoDate(date);
-    }
-
     /**
      * Format date using ISO 8601 pattern. This is appropriate only for persisting dates in machine-readable form,
      * for example, for export or in filenames. Most callers should use formatDate(Container c, Date d) instead.
@@ -993,12 +945,6 @@ public class DateUtil
     public static String formatIsoDate(@Nullable Date date)
     {
         return formatDateTime(date, ISO_DATE_FORMAT_STRING);
-    }
-
-    @Deprecated // Use formatIsoDateShortTime(Date) instead
-    public static String formatDateTimeISO8601(Date date)
-    {
-        return formatIsoDateShortTime(date);
     }
 
     /**

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1282,7 +1282,6 @@ public class AdminController extends SpringActionController
         {
             return _returnUrl;
         }
-
     }
 
     @AdminConsoleAction(AdminOperationsPermission.class)
@@ -5563,12 +5562,6 @@ public class AdminController extends SpringActionController
         private boolean _defaultTimeFormatInherited;
         private String _defaultNumberFormat;
         private boolean _defaultNumberFormatInherited;
-        private String _extraDateParsingPattern;
-        private boolean _extraDateParsingPatternInherited;
-        private String _extraDateTimeParsingPattern;
-        private boolean _extraDateTimeParsingPatternInherited;
-        private String _extraTimeParsingPattern;
-        private boolean _extraTimeParsingPatternInherited;
         private boolean _restrictedColumnsEnabled;
         private boolean _restrictedColumnsEnabledInherited;
 
@@ -5660,72 +5653,6 @@ public class AdminController extends SpringActionController
             _defaultNumberFormatInherited = defaultNumberFormatInherited;
         }
 
-        public String getExtraDateParsingPattern()
-        {
-            return _extraDateParsingPattern;
-        }
-
-        @SuppressWarnings("unused")
-        public void setExtraDateParsingPattern(String extraDateParsingPattern)
-        {
-            _extraDateParsingPattern = extraDateParsingPattern;
-        }
-
-        public boolean isExtraDateParsingPatternInherited()
-        {
-            return _extraDateParsingPatternInherited;
-        }
-
-        @SuppressWarnings("unused")
-        public void setExtraDateParsingPatternInherited(boolean extraDateParsingPatternInherited)
-        {
-            _extraDateParsingPatternInherited = extraDateParsingPatternInherited;
-        }
-
-        public String getExtraDateTimeParsingPattern()
-        {
-            return _extraDateTimeParsingPattern;
-        }
-
-        @SuppressWarnings("unused")
-        public void setExtraDateTimeParsingPattern(String extraDateTimeParsingPattern)
-        {
-            _extraDateTimeParsingPattern = extraDateTimeParsingPattern;
-        }
-
-        public boolean isExtraDateTimeParsingPatternInherited()
-        {
-            return _extraDateTimeParsingPatternInherited;
-        }
-
-        @SuppressWarnings("unused")
-        public void setExtraDateTimeParsingPatternInherited(boolean extraDateTimeParsingPatternInherited)
-        {
-            _extraDateTimeParsingPatternInherited = extraDateTimeParsingPatternInherited;
-        }
-
-        public String getExtraTimeParsingPattern()
-        {
-            return _extraTimeParsingPattern;
-        }
-
-        @SuppressWarnings("UnusedDeclaration")
-        public void setExtraTimeParsingPattern(String extraTimeParsingPattern)
-        {
-            _extraTimeParsingPattern = extraTimeParsingPattern;
-        }
-
-        public boolean isExtraTimeParsingPatternInherited()
-        {
-            return _extraTimeParsingPatternInherited;
-        }
-
-        @SuppressWarnings("unused")
-        public void setExtraTimeParsingPatternInherited(boolean extraTimeParsingPatternInherited)
-        {
-            _extraTimeParsingPatternInherited = extraTimeParsingPatternInherited;
-        }
-
         public boolean areRestrictedColumnsEnabled()
         {
             return _restrictedColumnsEnabled;
@@ -5777,9 +5704,6 @@ public class AdminController extends SpringActionController
         validateAndSaveFormat(form.getDefaultDateTimeFormat(), form.isDefaultDateTimeFormatInherited(), props::clearDefaultDateTimeFormat, props::setDefaultDateTimeFormat, errors, "date-time display format");
         validateAndSaveFormat(form.getDefaultTimeFormat(), form.isDefaultTimeFormatInherited(), props::clearDefaultTimeFormat, props::setDefaultTimeFormat, errors, "time display format");
         validateAndSaveFormat(form.getDefaultNumberFormat(), form.isDefaultNumberFormatInherited(), props::clearDefaultNumberFormat, props::setDefaultNumberFormat, errors, "number display format");
-        validateAndSaveFormat(form.getExtraDateParsingPattern(), form.isExtraDateParsingPatternInherited(), props::clearExtraDateParsingPattern, props::setExtraDateParsingPattern, errors, "date parsing pattern");
-        validateAndSaveFormat(form.getExtraDateTimeParsingPattern(), form.isExtraDateTimeParsingPatternInherited(), props::clearExtraDateTimeParsingPattern, props::setExtraDateTimeParsingPattern, errors, "date-time parsing pattern");
-        validateAndSaveFormat(form.getExtraTimeParsingPattern(), form.isExtraTimeParsingPatternInherited(), props::clearExtraTimeParsingPattern, props::setExtraTimeParsingPattern, errors, "time parsing pattern");
 
         setProperty(form.isRestrictedColumnsEnabledInherited(), props::clearRestrictedColumnsEnabled, () -> props.setRestrictedColumnsEnabled(form.areRestrictedColumnsEnabled()));
 

--- a/core/src/org/labkey/core/admin/importer/FolderTypeImporterFactory.java
+++ b/core/src/org/labkey/core/admin/importer/FolderTypeImporterFactory.java
@@ -36,10 +36,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-/**
- * User: cnathe
- * Date: Apr 10, 2012
- */
 public class FolderTypeImporterFactory extends AbstractFolderImportFactory
 {
     @Override
@@ -67,18 +63,18 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
         {
             Container c = ctx.getContainer();
             Folder folderXml = ctx.getXml();
-            ctx.getLogger().debug("[" + c.getPath() + "] Importing folder properties from: " + root.getLocation());
+            ctx.getLogger().debug("[{}] Importing folder properties from: {}", c.getPath(), root.getLocation());
 
             if (folderXml.isSetDefaultDateFormat())
             {
                 try
                 {
-                    ctx.getLogger().debug("[" + c.getPath() + "] Default date format: " + folderXml.getDefaultDateFormat());
+                    ctx.getLogger().debug("[{}] Default date format: {}", c.getPath(), folderXml.getDefaultDateFormat());
                     WriteableFolderLookAndFeelProperties.saveDefaultDateFormat(c, folderXml.getDefaultDateFormat());
                 }
                 catch (IllegalArgumentException e)
                 {
-                    ctx.getLogger().warn("Illegal default date format specified: " + e.getMessage());
+                    ctx.getLogger().warn("Illegal default date format specified: {}", e.getMessage());
                 }
             }
 
@@ -86,12 +82,12 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
             {
                 try
                 {
-                    ctx.getLogger().debug("[" + c.getPath() + "] Default date-time format: " + folderXml.getDefaultDateTimeFormat());
+                    ctx.getLogger().debug("[{}] Default date-time format: {}", c.getPath(), folderXml.getDefaultDateTimeFormat());
                     WriteableFolderLookAndFeelProperties.saveDefaultDateTimeFormat(c, folderXml.getDefaultDateTimeFormat());
                 }
                 catch (IllegalArgumentException e)
                 {
-                    ctx.getLogger().warn("Illegal default date-time format specified: " + e.getMessage());
+                    ctx.getLogger().warn("Illegal default date-time format specified: {}", e.getMessage());
                 }
             }
 
@@ -99,18 +95,18 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
             {
                 try
                 {
-                    ctx.getLogger().debug("[" + c.getPath() + "] Default time format: " + folderXml.getDefaultTimeFormat());
+                    ctx.getLogger().debug("[{}] Default time format: {}", c.getPath(), folderXml.getDefaultTimeFormat());
                     WriteableFolderLookAndFeelProperties.saveDefaultTimeFormat(c, folderXml.getDefaultTimeFormat());
                 }
                 catch (IllegalArgumentException e)
                 {
-                    ctx.getLogger().warn("Illegal default time format specified: " + e.getMessage());
+                    ctx.getLogger().warn("Illegal default time format specified: {}", e.getMessage());
                 }
             }
 
             if (folderXml.isSetRestrictedColumnsEnabled())
             {
-                ctx.getLogger().debug("[" + c.getPath() + "] Restricted columns enabled: " + folderXml.getRestrictedColumnsEnabled());
+                ctx.getLogger().debug("[{}] Restricted columns enabled: {}", c.getPath(), folderXml.getRestrictedColumnsEnabled());
                 WriteableFolderLookAndFeelProperties.saveRestrictedColumnsEnabled(c, folderXml.getRestrictedColumnsEnabled());
             }
 
@@ -118,52 +114,30 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
             {
                 try
                 {
-                    ctx.getLogger().debug("[" + c.getPath() + "] Default number format: " + folderXml.getDefaultNumberFormat());
+                    ctx.getLogger().debug("[{}] Default number format: {}", c.getPath(), folderXml.getDefaultNumberFormat());
                     WriteableFolderLookAndFeelProperties.saveDefaultNumberFormat(c, folderXml.getDefaultNumberFormat());
                 }
                 catch (IllegalArgumentException e)
                 {
-                    ctx.getLogger().warn("Illegal default number format specified: " + e.getMessage());
+                    ctx.getLogger().warn("Illegal default number format specified: {}", e.getMessage());
                 }
             }
 
+            // For now, fail with a clear error if extra date/time parsing formats are specified.
+            // TODO: Remove these from the XSD.
             if (folderXml.isSetExtraDateParsingPattern())
             {
-                try
-                {
-                    ctx.getLogger().debug("[" + c.getPath() + "] Extra date parsing format: " + folderXml.getExtraDateParsingPattern());
-                    WriteableFolderLookAndFeelProperties.saveExtraDateParsingPattern(c, folderXml.getExtraDateParsingPattern());
-                }
-                catch (IllegalArgumentException e)
-                {
-                    ctx.getLogger().warn("Illegal default date format specified: " + e.getMessage());
-                }
+                ctx.getLogger().error("[{}] Extra date parsing format is not longer supported", c.getPath());
             }
 
             if (folderXml.isSetExtraDateTimeParsingPattern())
             {
-                try
-                {
-                    ctx.getLogger().debug("[" + c.getPath() + "] Extra date-time parsing format: " + folderXml.getExtraDateTimeParsingPattern());
-                    WriteableFolderLookAndFeelProperties.saveExtraDateTimeParsingPattern(c, folderXml.getExtraDateTimeParsingPattern());
-                }
-                catch (IllegalArgumentException e)
-                {
-                    ctx.getLogger().warn("Illegal default date-time format specified: " + e.getMessage());
-                }
+                ctx.getLogger().error("[{}] Extra date-time parsing format is not longer supported", c.getPath());
             }
 
             if (folderXml.isSetExtraTimeParsingPattern())
             {
-                try
-                {
-                    ctx.getLogger().debug("[" + c.getPath() + "] Extra time parsing format: " + folderXml.getExtraTimeParsingPattern());
-                    WriteableFolderLookAndFeelProperties.saveExtraTimeParsingPattern(c, folderXml.getExtraTimeParsingPattern());
-                }
-                catch (IllegalArgumentException e)
-                {
-                    ctx.getLogger().warn("Illegal extra time parsing format specified: " + e.getMessage());
-                }
+                ctx.getLogger().error("[{}] Extra time parsing format is not longer supported", c.getPath());
             }
 
             if (folderXml.isSetFolderType())
@@ -186,8 +160,8 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
 
                 if (null != folderType)
                 {
-                    ctx.getLogger().debug("[" + c.getPath() + "] Folder type: " + folderType.getName());
-                    ctx.getLogger().debug("[" + c.getPath() + "] Active modules: " + activeModules.stream().map(Module::getName).collect(Collectors.joining(", ")));
+                    ctx.getLogger().debug("[{}] Folder type: {}", c.getPath(), folderType.getName());
+                    ctx.getLogger().debug("[{}] Active modules: {}", c.getPath(), activeModules.stream().map(Module::getName).collect(Collectors.joining(", ")));
                     // It's sorta BrandNew, but not really; say it's not and SubImporter will handle container tabs correctly
                     BindException errors = new BindException(new Object(), "dummy");
                     c.setFolderType(folderType, ctx.getUser(), errors, activeModules);
@@ -198,7 +172,7 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
                 }
                 else
                 {
-                    ctx.getLogger().warn("Unknown folder type: '" + folderTypeXml.getName() + "'. Folder type and active modules not set.");
+                    ctx.getLogger().warn("Unknown folder type: '{}'. Folder type and active modules not set.", folderTypeXml.getName());
                 }
 
                 Module defaultModule = ModuleLoader.getInstance().getModule(folderTypeXml.getDefaultModule());
@@ -206,8 +180,8 @@ public class FolderTypeImporterFactory extends AbstractFolderImportFactory
                 {
                     c.setDefaultModule(defaultModule);
                 }
-                
-                ctx.getLogger().info("Done importing " + getDescription());
+
+                ctx.getLogger().info("Done importing {}", getDescription());
             }
         }
 

--- a/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
+++ b/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
@@ -25,9 +25,7 @@
 <%@ page import="org.labkey.api.security.permissions.ApplicationAdminPermission" %>
 <%@ page import="org.labkey.api.settings.AppProps" %>
 <%@ page import="org.labkey.api.settings.DateParsingMode" %>
-<%@ page import="org.labkey.api.settings.FolderSettingsCache" %>
 <%@ page import="org.labkey.api.settings.LookAndFeelProperties" %>
-<%@ page import="org.labkey.api.settings.OptionalFeatureService" %>
 <%@ page import="org.labkey.api.settings.Theme" %>
 <%@ page import="org.labkey.api.util.DOM" %>
 <%@ page import="org.labkey.api.util.DateUtil" %>
@@ -285,56 +283,9 @@
             "<tr valign=top class=\"labkey-row\"><td><code>,</code><td>Number<td>Yes<td>Grouping separator</tr>" +
             "</table>").append(sizingSuffix).getHtmlString();
 
-    HtmlString simpleDateDocHeader = HtmlString.unsafe("<br><br>The pattern string must be compatible with the format that the Java class " +
-            "<code>SimpleDateFormat</code> understands. For more information see the " +
-            "<a href=\"" + h(DateUtil.getSimpleDateFormatDocumentationURL()) + "\" target=\"blank\">documentation</a>. " +
-            "The following table has a partial guide to pattern symbols:<br/>" +
-            "<table class=\"labkey-data-region-legacy labkey-show-borders\">" +
-            "<tr class=\"labkey-frame\"><th align=left>Letter<th align=left>Date or Time Component<th align=left>Examples</tr>");
-
-    HtmlString dateDocs = HtmlString.unsafe(
-            "<tr class=\"labkey-row\"><td><code>G</code><td>Era designator<td><code>AD</code></tr>" +
-            "<tr class=\"labkey-alternate-row\"><td><code>y</code><td>Year<td><code>1996</code>; <code>96</code></tr>" +
-            "<tr class=\"labkey-row\"><td><code>M</code><td>Month in year<td><code>July</code>; <code>Jul</code>; <code>07</code></tr>" +
-            "<tr class=\"labkey-alternate-row\"><td><code>w</code><td>Week in year<td><code>27</code></td></tr>" +
-            "<tr class=\"labkey-row\"><td><code>W</code><td>Week in month<td><code>2</code></td></tr>" +
-            "<tr class=\"labkey-alternate-row\"><td><code>D</code><td>Day in year<td><code>189</code></td></tr>" +
-            "<tr class=\"labkey-row\"><td><code>d</code><td>Day in month<td><code>10</code></tr>" +
-            "<tr class=\"labkey-alternate-row\"><td><code>F</code><td>Day of week in month<td><code>2</code></tr>" +
-            "<tr class=\"labkey-row\"><td><code>E</code><td>Day in week<td><code>Tuesday</code>; <code>Tue</code></tr>");
-
-    HtmlString timeDocs = HtmlString.unsafe("<tr class=\"labkey-alternate-row\"><td><code>a</code><td>Am/pm marker<td><code>PM</code></tr>" +
-            "<tr class=\"labkey-row\"><td><code>H</code><td>Hour in day (0-23)<td><code>0</code></tr>" +
-            "<tr class=\"labkey-alternate-row\"><td><code>k</code><td>Hour in day (1-24)<td><code>24</code></tr>" +
-            "<tr class=\"labkey-row\"><td><code>K</code><td>Hour in am/pm (0-11)<td><code>0</code></tr>" +
-            "<tr class=\"labkey-alternate-row\"><td><code>h</code><td>Hour in am/pm (1-12)<td><code>12</code></tr>" +
-            "<tr class=\"labkey-row\"><td><code>m</code><td>Minute in hour<td><code>30</code></tr>" +
-            "<tr class=\"labkey-alternate-row\"><td><code>s</code><td>Second in minute<td><code>55</code></tr>" +
-            "<tr class=\"labkey-row\"><td><code>S</code><td>Millisecond<td><code>978</code></tr>");
-
     DOM.Renderable dateFormatHelp = HtmlStringBuilder.of(sizingPrefix).append("This format is applied when displaying a column that is defined with a date-only data type or annotated with the \"Date\" meta type. Most standard LabKey date columns use date-time data type (see below).").append(sizingSuffix);
     DOM.Renderable dateTimeFormatHelp = HtmlStringBuilder.of(sizingPrefix).append("This format is applied when displaying a column that is defined with a date-time data type or annotated with the \"DateTime\" meta type. Most standard LabKey date columns use this format.").append(sizingSuffix);
     DOM.Renderable timeFormatHelp = HtmlStringBuilder.of(sizingPrefix).append("This format is applied when displaying a column that is defined with a time data type or annotated with the \"Time\" meta type. Most standard LabKey time columns use this format.").append(sizingSuffix);
-
-    DOM.Renderable dateParsingHelp = HtmlStringBuilder.of(sizingPrefix)
-        .append("This pattern is attempted first when parsing text input for a column that is designated with a date-only data type or annotated with the \"Date\" meta type. Most standard LabKey date columns use date-time data type instead (see below).")
-        .append(simpleDateDocHeader)
-        .append(dateDocs)
-        .unsafeAppend("</table>")
-        .append(sizingSuffix);
-    DOM.Renderable dateTimeParsingHelp = HtmlStringBuilder.of(sizingPrefix)
-        .append("This pattern is attempted first when parsing text input for a column that is designated with a date-time data type or annotated with the \"DateTime\" meta type. Most standard LabKey date columns use this pattern.")
-        .append(simpleDateDocHeader)
-        .append(dateDocs)
-        .append(timeDocs)
-        .unsafeAppend("</table>")
-        .append(sizingSuffix);
-    DOM.Renderable timeParsingHelp = HtmlStringBuilder.of(sizingPrefix)
-        .append("This pattern is attempted first when parsing text input for a column that is designated with a time data type or annotated with the \"Time\" meta type. Most standard LabKey time columns use this pattern.")
-        .append(simpleDateDocHeader)
-        .append(timeDocs)
-        .unsafeAppend("</table>")
-        .append(sizingSuffix);
 %>
 <tr>
     <td<%=h(!folder ? " colspan=3" : "")%>>Customize date, time, and number display formats (<%=bean.helpLink%>)</td>
@@ -383,8 +334,7 @@
     <td>&nbsp;</td>
 </tr>
 <%
-    boolean includeParsingPatterns = OptionalFeatureService.get().isFeatureEnabled(FolderSettingsCache.EXTRA_PARSING_PATTERNS_FEATURE_FLAG);
-    if (c.isRoot() || includeParsingPatterns)
+    if (c.isRoot())
     {
 %>
 <tr>
@@ -405,30 +355,6 @@
         <label><input type="radio" name="<%=dateParsingMode%>" value="<%=DateParsingMode.US%>"<%=checked(mode == DateParsingMode.US)%>> <%=h(DateParsingMode.US.getDisplayString())%> </label><br>
         <label><input type="radio" name="<%=dateParsingMode%>" value="<%=DateParsingMode.NON_US%>"<%=checked(mode == DateParsingMode.NON_US)%>> <%=h(DateParsingMode.NON_US.getDisplayString())%> </label><br>
     </td>
-</tr>
-<%
-        }
-
-        if (includeParsingPatterns)
-        {
-%>
-<tr>
-    <td class="labkey-form-label"><label for="<%=extraDateParsingPattern%>">Additional parsing pattern for dates</label><%=helpPopup("Extra date parsing pattern", dateParsingHelp)%></td>
-    <% inherited = isInherited(laf.getExtraDateParsingPatternStored()); %>
-    <%=inheritCheckbox(inherited, extraDateParsingPattern)%>
-    <td><input type="text" id="<%=extraDateParsingPattern%>" name="<%=extraDateParsingPattern%>" size="<%=standardInputWidth%>" value="<%= h(laf.getExtraDateParsingPattern()) %>"<%=disabled(inherited)%>></td>
-</tr>
-<tr>
-    <td class="labkey-form-label"><label for="<%=extraDateTimeParsingPattern%>">Additional parsing pattern for date-times</label><%=helpPopup("Extra date-time parsing pattern", dateTimeParsingHelp, 300)%></td>
-    <% inherited = isInherited(laf.getExtraDateTimeParsingPatternStored()); %>
-    <%=inheritCheckbox(inherited, extraDateTimeParsingPattern)%>
-    <td><input type="text" id="<%=extraDateTimeParsingPattern%>"  name="<%=extraDateTimeParsingPattern%>" size="<%=standardInputWidth%>" value="<%= h(laf.getExtraDateTimeParsingPattern()) %>"<%=disabled(inherited)%>></td>
-</tr>
-<tr>
-    <td class="labkey-form-label"><label for="<%=extraTimeParsingPattern%>">Additional parsing pattern for times</label><%=helpPopup("Extra time parsing pattern", timeParsingHelp)%></td>
-    <% inherited = isInherited(laf.getExtraTimeParsingPatternStored()); %>
-    <%=inheritCheckbox(inherited, extraTimeParsingPattern)%>
-    <td><input type="text" id="<%=extraTimeParsingPattern%>" name="<%=extraTimeParsingPattern%>" size="<%=standardInputWidth%>" value="<%= h(laf.getExtraTimeParsingPattern()) %>"<%=disabled(inherited)%>></td>
 </tr>
 <%
         }


### PR DESCRIPTION
#### Rationale
We deprecated the extra date/time parsing patterns in 25.3; it's now time to remove this functionality. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=50435

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2401