### PR TITLE
Issue 52792: Query Snapshot doesn't update according to schedule

### DIFF
--- a/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
@@ -810,6 +810,9 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
 
             try
             {
+                QueryService.get().setEnvironment(QueryService.Environment.USER, _def.getModifiedBy());
+                QueryService.get().setEnvironment(QueryService.Environment.CONTAINER, _def.getContainer());
+
                 _def.setNextUpdate(null);
                 _def.save(_def.getModifiedBy());
 
@@ -838,6 +841,10 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
             catch(Exception e)
             {
                 ExceptionUtil.logExceptionToMothership(null, e);
+            }
+            finally
+            {
+                QueryService.get().clearEnvironment();
             }
         }
     }


### PR DESCRIPTION
#### Rationale
Background threads need to set their query environment for compliance-related logging purposes

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/211

#### Changes
- Note the user and container