### PR TITLE
Ensure that QueryView always has a non-null Errors

### DIFF
--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -282,7 +282,8 @@ public class QueryView extends WebPartView<Object>
     public QueryView(UserSchema schema, QuerySettings settings, @Nullable Errors errors)
     {
         this(schema);
-        _errors = errors;
+        // TODO: stop passing in null Errors. For now, new one up if null.
+        _errors = errors != null ? errors : new BindException(new Object(), "form");
         if (null != settings)
             setSettings(settings);
     }


### PR DESCRIPTION
#### Rationale
Some code paths initialize `QueryView._errors` to null, which is not helpful

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52661

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6501