### PR TITLE
Issue 52817: Use fieldKey label in hit selection criteria description

### DIFF
--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -1469,11 +1469,8 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
             @Override
             public String format(FieldKey fieldKey)
             {
-                var formatted = super.format(fieldKey);
-                var dotIndex = formatted.lastIndexOf('.');
-                if (dotIndex >= 0)
-                    formatted = formatted.substring(dotIndex + 1);
-                return formatted;
+                // Display the fieldKey label (as opposed to the toDisplayString()) for these criteria
+                return fieldKey.getLabel();
             }
         };
 


### PR DESCRIPTION
#### Rationale
Addresses [Issue 52817](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52817) where fieldKeys for hit criteria selection we're not being properly parsed for inclusion in the criteria description.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1330

#### Changes
- Display the fieldKey label (as opposed to the `toDisplayString()`) for these criteria
