### PR TITLE
Test updates for AutoLinkToStudyTest.testPredefinedDatasetCategories

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
@@ -306,15 +306,10 @@ public class AutoLinkToStudyTest extends BaseWebDriverTest
         categoryWindow.clickButton("New Category", 0);
         WebElement newCategoryField = Locator.input("label").withAttributeContaining("id", "textfield").notHidden().waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT);
         actionClear(newCategoryField);
+        sleep(500);
         newCategoryField.sendKeys(name);
         newCategoryField.sendKeys(Keys.ENTER);
-        sleep(1000);
-        if(!newCategoryField.getText().equals(name))
-        {
-            //retry again after wait.
-            newCategoryField.sendKeys(name);
-            newCategoryField.sendKeys(Keys.ENTER);
-        }
+        sleep(500);
         waitForElement(Ext4Helper.Locators.window("Manage Categories").append("//div").withText(name));
         clickButton("Done", 0);
         _extHelper.waitForExtDialogToDisappear("Manage Categories");

--- a/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
@@ -310,7 +310,6 @@ public class AutoLinkToStudyTest extends BaseWebDriverTest
         newCategoryField.sendKeys(name);
         sleep(500);
         newCategoryField.sendKeys(Keys.ENTER);
-        sleep(500);
         waitForElement(Ext4Helper.Locators.window("Manage Categories").append("//div").withText(name));
         clickButton("Done", 0);
         _extHelper.waitForExtDialogToDisappear("Manage Categories");

--- a/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
@@ -308,10 +308,10 @@ public class AutoLinkToStudyTest extends BaseWebDriverTest
         actionClear(newCategoryField);
         newCategoryField.sendKeys(name);
         newCategoryField.sendKeys(Keys.ENTER);
+        sleep(1000);
         if(!newCategoryField.getText().equals(name))
         {
             //retry again after wait.
-            sleep(1000);
             newCategoryField.sendKeys(name);
             newCategoryField.sendKeys(Keys.ENTER);
         }

--- a/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
@@ -308,6 +308,7 @@ public class AutoLinkToStudyTest extends BaseWebDriverTest
         actionClear(newCategoryField);
         sleep(500);
         newCategoryField.sendKeys(name);
+        sleep(500);
         newCategoryField.sendKeys(Keys.ENTER);
         sleep(500);
         waitForElement(Ext4Helper.Locators.window("Manage Categories").append("//div").withText(name));

--- a/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
@@ -308,6 +308,13 @@ public class AutoLinkToStudyTest extends BaseWebDriverTest
         actionClear(newCategoryField);
         newCategoryField.sendKeys(name);
         newCategoryField.sendKeys(Keys.ENTER);
+        if(!newCategoryField.getText().equals(name))
+        {
+            //retry again after wait.
+            sleep(1000);
+            newCategoryField.sendKeys(name);
+            newCategoryField.sendKeys(Keys.ENTER);
+        }
         waitForElement(Ext4Helper.Locators.window("Manage Categories").append("//div").withText(name));
         clickButton("Done", 0);
         _extHelper.waitForExtDialogToDisappear("Manage Categories");


### PR DESCRIPTION
#### Rationale
AutoLinkToStudyTest.testPredefinedDatasetCategories has been failing on SQLServer on teamcity with below error. Hopefully the workaround does the trick.

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/bf8e3cf9-d35e-487c-9bed-46ea8348e637" />

<img width="716" alt="image" src="https://github.com/user-attachments/assets/12f37c7d-ea24-4143-8735-6eb8e822ef3c" />

Teamcity failure link : https://teamcity.labkey.org/buildConfiguration/LabKey_253Release_Community_DailySqlServer/3466075?buildTab=tests&name=AutoLinkToStudyTest.testPredefinedDatasetCategories

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
