### PR TITLE
Null check wiki version before rendering

### DIFF
--- a/wiki/src/org/labkey/wiki/WikiController.java
+++ b/wiki/src/org/labkey/wiki/WikiController.java
@@ -1224,7 +1224,8 @@ public class WikiController extends SpringActionController
                 WikiPrintBean printBean = new WikiPrintBean(version);
                 JspView<WikiPrintBean> view = new JspView<>("/org/labkey/wiki/view/wikiPrint.jsp", printBean);
                 // Render content early so we can set the dependencies on the view
-                printBean.setHtml(version.render(view, _wiki.lookupContainer(), _wiki));
+                if (version != null)
+                    printBean.setHtml(version.render(view, _wiki.lookupContainer(), _wiki));
                 view.setFrame(WebPartView.FrameType.NONE);
                 return view;
             }


### PR DESCRIPTION
#### Rationale
Crawler discovered an NPE when attempting to print a non-existent wiki. This was introduced in the related PR.

Repro: http://localhost:8080/home/wiki-page.view?name=non_existent_wiki&_print=1

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6492