### PR TITLE
Issues 52580, 52701, 52626: Misc fixes for 25.5

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2655,6 +2655,7 @@ public class ExpDataIterators
                     _context.getErrors().addRowError(new ValidationException("No value provided for '" + _typeColName + "'."));
                 else
                 {
+                    // Issue 52626 and Issue 52609 - don't check folders during update
                     if (_isCrossFolder && _folderColIndex != null && !_context.getInsertOption().updateOnly)
                     {
                         String rowFolderId = StringUtils.trim((String) get(_folderColIndex));

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2655,7 +2655,7 @@ public class ExpDataIterators
                     _context.getErrors().addRowError(new ValidationException("No value provided for '" + _typeColName + "'."));
                 else
                 {
-                    if (_isCrossFolder && _folderColIndex != null)
+                    if (_isCrossFolder && _folderColIndex != null && !_context.getInsertOption().updateOnly)
                     {
                         String rowFolderId = StringUtils.trim((String) get(_folderColIndex));
                         if (!StringUtils.isEmpty(rowFolderId))
@@ -2881,6 +2881,8 @@ public class ExpDataIterators
             validFields.add(ALIQUOTED_FROM_INPUT);
             validFields.add("StorageUnit");
             validFields.add("Storage Unit");
+            validFields.add("StorageUnitLabel");
+            validFields.add("Storage Unit Label");
             // For consistency with other storage fields that are imported without spaces in the names
             validFields.add("EnteredStorage");
             List<Integer> fieldIndexes = new ArrayList<>();

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -9556,11 +9556,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                     for (ExpData data : classObjects)
                     {
                         Map<String, Object> oldRecordMap = new CaseInsensitiveHashMap<>();
-                        oldRecordMap.put("Container", sourceContainer.getName());
+                        oldRecordMap.put("Folder", sourceContainer.getName());
                         oldRecordMap.put("rowId", data.getRowId());
                         oldRows.add(oldRecordMap);
                         Map<String, Object> newRecordMap = new CaseInsensitiveHashMap<>();
-                        newRecordMap.put("Container", targetContainer.getName());
+                        newRecordMap.put("Folder", targetContainer.getName());
                         newRecordMap.put("rowId", data.getRowId());
                         newRows.add(newRecordMap);
                     }


### PR DESCRIPTION
#### Rationale
- Issue 52701: [Detailed audit log for move of a DataClasses between folders but does not include details of folder change](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52701)
- Issue 52626 [Cross sample update from file incorrectly warning about folder field](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52626) and [LKSM: Ignore Container and Folder column during sample type import/update](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52609)
- Issue 52580 [LKSM: During Cross Sample Type Import, Storage Unit Label isn't mapped](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52580)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1336

#### Changes
- Don't check values from the Container/Folder field during an update
- Pass StorageUnitLabel through in a cross-type or cross-folder import
- For Data class data updates, include Folder as an audit log field that may have changed, not Container
