### PR TITLE
Issue 52854: Add www.googletagmanager.com to img-src CSP when Google Analytics is enabled

### DIFF
--- a/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
@@ -117,10 +117,12 @@ public class AnalyticsServiceImpl implements AnalyticsService
     public void resetCSP()
     {
         ContentSecurityPolicyFilter.unregisterAllowedSources(Directive.Connection, ANALYTICS_CSP_KEY);
+        ContentSecurityPolicyFilter.unregisterAllowedSources(Directive.Image, ANALYTICS_CSP_KEY);
 
         if (getTrackingStatus().contains(TrackingStatus.ga4FullUrl))
         {
             ContentSecurityPolicyFilter.registerAllowedSources(Directive.Connection, ANALYTICS_CSP_KEY, "https://*.googletagmanager.com", "https://*.google-analytics.com", "https://*.analytics.google.com");
+            ContentSecurityPolicyFilter.registerAllowedSources(Directive.Image, ANALYTICS_CSP_KEY, "https://www.googletagmanager.com");
         }
     }
 

--- a/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
+++ b/core/src/org/labkey/core/analytics/AnalyticsServiceImpl.java
@@ -20,6 +20,8 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.analytics.AnalyticsService;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.PropertyManager;
 import org.labkey.api.data.PropertyManager.WritablePropertyMap;
 import org.labkey.api.module.ModuleLoader;
@@ -164,15 +166,19 @@ public class AnalyticsServiceImpl implements AnalyticsService
             Container c = ContainerManager.getRoot();
             makeWriteable(c);
 
-            String statusString = StringUtils.trimToNull(StringUtils.join(trackingStatus.toArray(), SEPARATOR));
-            storeStringValue(AnalyticsProperty.trackingStatus.toString(), statusString);
-            storeStringValue(AnalyticsProperty.measurementId.toString(), StringUtils.trimToNull(measurementId));
-            storeStringValue(AnalyticsProperty.trackingScript.toString(), StringUtils.trimToNull(script));
+            try (DbScope.Transaction t = CoreSchema.getInstance().getScope().ensureTransaction())
+            {
+                String statusString = StringUtils.trimToNull(StringUtils.join(trackingStatus.toArray(), SEPARATOR));
+                storeStringValue(AnalyticsProperty.trackingStatus.toString(), statusString);
+                storeStringValue(AnalyticsProperty.measurementId.toString(), StringUtils.trimToNull(measurementId));
+                storeStringValue(AnalyticsProperty.trackingScript.toString(), StringUtils.trimToNull(script));
+
+                save();
+                writeAuditLogEvent(c, user);
+                t.commit();
+            }
 
             get().resetCSP();
-
-            save();
-            writeAuditLogEvent(c, user);
         }
     }
 


### PR DESCRIPTION
#### Rationale
Enabling Google Analytics reporting should automatically handle all of the CSP settings required

#### Changes
- Add URL to `img-src`
- Ensure audit log entry is transacted
- Reset CSP after the save so the right settings are applied
