### PR TITLE
Issue 52855: Missing Servlet API when extracting remote pipeline resources

### DIFF
--- a/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineServiceImpl.java
@@ -474,6 +474,7 @@ public class PipelineServiceImpl implements PipelineService, PipelineMXBean
                 Iterator<JarEntry> entries = j.entries().asIterator();
                 while (entries.hasNext())
                 {
+                    // Keep this code in sync with org.labkey.embedded.EmbeddedExtractor.extractExecutableJar()
                     JarEntry entry = entries.next();
                     if (entry.getName().contains("labkeyBootstrap") && entry.getName().toLowerCase().endsWith(".jar"))
                     {


### PR DESCRIPTION
#### Rationale
We have two places that extract JARs for remote pipeline scenarios. This one, used in our tests, and another used from the command line. They should be kept in sync.

#### Changes
- Pointer to the other spot