### PR TITLE
Issue 52728: LKSM: Update from file with duplicate rows is only updating once.

### DIFF
--- a/announcements/src/org/labkey/announcements/query/AnnouncementSubscriptionTable.java
+++ b/announcements/src/org/labkey/announcements/query/AnnouncementSubscriptionTable.java
@@ -36,6 +36,7 @@ import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
 
@@ -179,7 +180,7 @@ public class AnnouncementSubscriptionTable extends AbstractSubscriptionTable
         }
 
         @Override
-        protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, @Nullable Map<Enum, Object> configParameters) throws InvalidKeyException
+        protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, @Nullable Map<Enum, Object> configParameters) throws InvalidKeyException, ValidationException
         {
             Map<String, Object> existingRow = getRow(user, container, oldRow);
             if (existingRow != null)
@@ -189,6 +190,7 @@ public class AnnouncementSubscriptionTable extends AbstractSubscriptionTable
                 Map<String, Object> pks = new CaseInsensitiveHashMap<>();
                 pks.put("UserId", oldTargets.getKey().getUserId());
                 pks.put("MessageId", oldTargets.getValue().getRowId());
+                checkDuplicateUpdate(pks);
                 Table.update(user, getRealTable(), createDatabaseMap(newTargets), pks);
             }
 

--- a/announcements/src/org/labkey/announcements/query/ForumSubscriptionTable.java
+++ b/announcements/src/org/labkey/announcements/query/ForumSubscriptionTable.java
@@ -35,6 +35,7 @@ import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.UserIdQueryForeignKey;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.UserPrincipal;
@@ -263,7 +264,7 @@ public class ForumSubscriptionTable extends AbstractSubscriptionTable
         }
 
         @Override
-        protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, @Nullable Map<Enum, Object> configParameters) throws InvalidKeyException
+        protected Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, @Nullable Map<Enum, Object> configParameters) throws InvalidKeyException, ValidationException
         {
             Map<String, Object> existingRow = getRow(user, container, oldRow);
             if (existingRow != null)
@@ -275,6 +276,7 @@ public class ForumSubscriptionTable extends AbstractSubscriptionTable
                 pks.put("Container", oldTargets.getContainer().getEntityId());
                 pks.put("Type", "messages");
                 pks.put("SrcIdentifier", oldTargets.getSrcIdentifier());
+                checkDuplicateUpdate(pks);
                 Table.update(user, CoreSchema.getInstance().getTableInfoEmailPrefs(), createDatabaseMap(user, row, newTargets), pks);
             }
 

--- a/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
@@ -238,12 +238,17 @@ public class DataIteratorContext
         _alternateKeys.addAll(alternateKeys);
     }
 
+    public boolean shouldCancel()
+    {
+        if (!_errors.hasErrors())
+            return false;
+        return _failFast || _errors.getRowErrors().size() > _maxRowErrors;
+    }
+
     /** if this etl should be killed, will execute <code>throw _errors;</code> */
     public void checkShouldCancel() throws BatchValidationException
     {
-        if (!_errors.hasErrors())
-            return;
-        if (_failFast || _errors.getRowErrors().size() > _maxRowErrors)
+        if (shouldCancel())
             throw _errors;
     }
 

--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -262,7 +262,9 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                 for (int p = 0; p < pkColumns.size(); p++)
                 {
                     sqlf.append(",?");
-                    sqlf.add(pkSuppliers.get(p).get());
+                    Object pkVal = pkSuppliers.get(p).get();
+                    sqlf.add(pkVal);
+                    pkKeys.add(pkVal.toString());
                 }
                 sqlf.append(")");
                 String pkKey = StringUtils.join(pkKeys, ", ");

--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -173,7 +173,7 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
         if (!_context.getErrors().hasErrors() && ret && !pkColumns.isEmpty())
         {
             prefetchExisting();
-            if (_context.getErrors().hasErrors())
+            if (_context.shouldCancel())
                 return false;
         }
         return ret;

--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -65,7 +65,7 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
     final boolean _checkCrossFolderData;
     final boolean _verifyExisting;
 
-    final Set<String> _pkKeysSeen = new HashSet<>();
+    final Set<Object> _pkKeysSeen = new HashSet<>();
 
     final DataIteratorContext _context;
 
@@ -267,10 +267,9 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                     pkKeys.add(pkVal.toString());
                 }
                 sqlf.append(")");
-                String pkKey = StringUtils.join(pkKeys, ", ");
-                if (_pkKeysSeen.contains(pkKey))
-                    _context.getErrors().addRowError(new ValidationException("Duplicate key provided: " + pkKey));
-                _pkKeysSeen.add(pkKey);
+                if (_pkKeysSeen.contains(pkKeys))
+                    _context.getErrors().addRowError(new ValidationException("Duplicate key provided: " + StringUtils.join(pkKeys, ", ")));
+                _pkKeysSeen.add(pkKeys);
                 rowNumContainers.put(lastPrefetchRowNumber, container);
             }
             while (--rows > 0 && _delegate.next());
@@ -388,10 +387,9 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                         pkKeys.add(pkVal.toString());
                     }
 
-                    String pkKey = StringUtils.join(pkKeys, ", ");
-                    if (_pkKeysSeen.contains(pkKey))
-                        _context.getErrors().addRowError(new ValidationException("Duplicate key provided: " + pkKey));
-                    _pkKeysSeen.add(pkKey);
+                    if (_pkKeysSeen.contains(pkKeys))
+                        _context.getErrors().addRowError(new ValidationException("Duplicate key provided: " + StringUtils.join(pkKeys, ", ")));
+                    _pkKeysSeen.add(pkKeys);
 
                     keysMap.put(lastPrefetchRowNumber, keyMap);
                     existingRecords.put(lastPrefetchRowNumber, Map.of());

--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -63,6 +64,8 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
     final Container c;
     final boolean _checkCrossFolderData;
     final boolean _verifyExisting;
+
+    final Set<String> _pkKeysSeen = new HashSet<>();
 
     final DataIteratorContext _context;
 
@@ -255,12 +258,17 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
 
                 sqlf.append(comma).append("(").appendValue(lastPrefetchRowNumber);
                 comma = "\n,";
+                List<String> pkKeys = new ArrayList<>();
                 for (int p = 0; p < pkColumns.size(); p++)
                 {
                     sqlf.append(",?");
                     sqlf.add(pkSuppliers.get(p).get());
                 }
                 sqlf.append(")");
+                String pkKey = StringUtils.join(pkKeys, ", ");
+                if (_pkKeysSeen.contains(pkKey))
+                    _context.getErrors().addRowError(new ValidationException("Duplicate key provided: " + pkKey));
+                _pkKeysSeen.add(pkKey);
                 rowNumContainers.put(lastPrefetchRowNumber, container);
             }
             while (--rows > 0 && _delegate.next());
@@ -370,8 +378,19 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                 {
                     lastPrefetchRowNumber = (Integer) _delegate.get(0);
                     Map<String,Object> keyMap = CaseInsensitiveHashMap.of();
+                    List<String> pkKeys = new ArrayList<>();
                     for (int p=0 ; p<pkColumns.size() ; p++)
-                        keyMap.put(pkColumns.get(p).getColumnName(), pkSuppliers.get(p).get());
+                    {
+                        Object pkVal = pkSuppliers.get(p).get();
+                        keyMap.put(pkColumns.get(p).getColumnName(), pkVal);
+                        pkKeys.add(pkVal.toString());
+                    }
+
+                    String pkKey = StringUtils.join(pkKeys, ", ");
+                    if (_pkKeysSeen.contains(pkKey))
+                        _context.getErrors().addRowError(new ValidationException("Duplicate key provided: " + pkKey));
+                    _pkKeysSeen.add(pkKey);
+
                     keysMap.put(lastPrefetchRowNumber, keyMap);
                     existingRecords.put(lastPrefetchRowNumber, Map.of());
                 }

--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -65,11 +65,12 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
     final boolean _checkCrossFolderData;
     final boolean _verifyExisting;
 
+    final Set<String> _sharedKeys = new CaseInsensitiveHashSet(); // common keys, such as data.classId, material.MaterialSourceId
     final Set<Object> _pkKeysSeen = new HashSet<>();
 
     final DataIteratorContext _context;
 
-    ExistingRecordDataIterator(DataIterator in, TableInfo target, @Nullable Set<String> keys, boolean useMark, DataIteratorContext context, boolean detailed)
+    ExistingRecordDataIterator(DataIterator in, TableInfo target, @Nullable Set<String> keys, @Nullable Set<String> sharedKeys, boolean useMark, DataIteratorContext context, boolean detailed)
     {
         super(in);
         _context = context;
@@ -93,6 +94,9 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
         containerCol = map.get("Container");
 
         Collection<String> keyNames = null==keys ? target.getPkColumnNames() : keys;
+
+        if (sharedKeys != null)
+            _sharedKeys.addAll(sharedKeys);
 
         _dataColumnNames.addAll(detailed ? map.keySet() : keyNames);
 
@@ -179,6 +183,13 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
         return ret;
     }
 
+    protected void checkDuplicateKeys(List<String> pkKeys)
+    {
+        Object pkKeysObj = pkKeys.size() == 1 ? pkKeys.get(0) : pkKeys;
+        if (_pkKeysSeen.contains(pkKeysObj))
+            _context.getErrors().addRowError(new ValidationException("Duplicate key provided: " + StringUtils.join(pkKeys, ", ")));
+        _pkKeysSeen.add(pkKeysObj);
+    }
 
     @Override
     public boolean supportsGetExistingRecord()
@@ -197,10 +208,10 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
 
     public static DataIteratorBuilder createBuilder(DataIteratorBuilder dib, TableInfo target, @Nullable Set<String> keys)
     {
-        return createBuilder(dib, target, keys, false);
+        return createBuilder(dib, target, keys, null, false);
     }
 
-    public static DataIteratorBuilder createBuilder(DataIteratorBuilder dib, TableInfo target, @Nullable Set<String> keys, boolean useGetRows)
+    public static DataIteratorBuilder createBuilder(DataIteratorBuilder dib, TableInfo target, @Nullable Set<String> keys, @Nullable Set<String> sharedKeys, boolean useGetRows)
     {
         return context ->
         {
@@ -218,9 +229,9 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                     auditType = target.getAuditBehavior((AuditBehaviorType) context.getConfigParameter(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior));
                 boolean detailed = auditType == DETAILED;
                 if (useGetRows)
-                    return new ExistingDataIteratorsGetRows(new CachingDataIterator(di), target, keys, context, detailed);
+                    return new ExistingDataIteratorsGetRows(new CachingDataIterator(di), target, keys, sharedKeys, context, detailed);
                 else
-                    return new ExistingDataIteratorsTableInfo(new CachingDataIterator(di), target, keys, context, detailed);
+                    return new ExistingDataIteratorsTableInfo(new CachingDataIterator(di), target, keys, sharedKeys, context, detailed);
             }
             return di;
         };
@@ -232,9 +243,9 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
     {
         final Set<String> allowedContainers = new HashSet<>();
 
-        ExistingDataIteratorsTableInfo(CachingDataIterator in, TableInfo target, @Nullable Set<String> keys, DataIteratorContext context, boolean detailed)
+        ExistingDataIteratorsTableInfo(CachingDataIterator in, TableInfo target, @Nullable Set<String> keys, @Nullable Set<String> sharedKeys, DataIteratorContext context, boolean detailed)
         {
-            super(in, target, keys, true, context, detailed);
+            super(in, target, keys, sharedKeys, true, context, detailed);
             if (c != null)
                 allowedContainers.add(c.getId());
         }
@@ -264,12 +275,11 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                     sqlf.append(",?");
                     Object pkVal = pkSuppliers.get(p).get();
                     sqlf.add(pkVal);
-                    pkKeys.add(pkVal.toString());
+                    if (!_sharedKeys.contains(pkColumns.get(p).getColumnName()))
+                        pkKeys.add(pkVal.toString());
                 }
                 sqlf.append(")");
-                if (_pkKeysSeen.contains(pkKeys))
-                    _context.getErrors().addRowError(new ValidationException("Duplicate key provided: " + StringUtils.join(pkKeys, ", ")));
-                _pkKeysSeen.add(pkKeys);
+                checkDuplicateKeys(pkKeys);
                 rowNumContainers.put(lastPrefetchRowNumber, container);
             }
             while (--rows > 0 && _delegate.next());
@@ -356,9 +366,9 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
     {
         final QueryUpdateService qus;
 
-        ExistingDataIteratorsGetRows(CachingDataIterator in, TableInfo target, @Nullable Set<String> keys, DataIteratorContext context, boolean detailed)
+        ExistingDataIteratorsGetRows(CachingDataIterator in, TableInfo target, @Nullable Set<String> keys, @Nullable Set<String> sharedKeys, DataIteratorContext context, boolean detailed)
         {
-            super(in, target, keys, true, context, detailed);
+            super(in, target, keys, sharedKeys, true, context, detailed);
             qus = target.getUpdateService();
         }
 
@@ -384,12 +394,11 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                     {
                         Object pkVal = pkSuppliers.get(p).get();
                         keyMap.put(pkColumns.get(p).getColumnName(), pkVal);
-                        pkKeys.add(pkVal.toString());
+                        if (!_sharedKeys.contains(pkColumns.get(p).getColumnName()))
+                            pkKeys.add(pkVal.toString());
                     }
 
-                    if (_pkKeysSeen.contains(pkKeys))
-                        _context.getErrors().addRowError(new ValidationException("Duplicate key provided: " + StringUtils.join(pkKeys, ", ")));
-                    _pkKeysSeen.add(pkKeys);
+                    checkDuplicateKeys(pkKeys);
 
                     keysMap.put(lastPrefetchRowNumber, keyMap);
                     existingRecords.put(lastPrefetchRowNumber, Map.of());
@@ -438,7 +447,7 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
             assertFalse(di.supportsGetExistingRecord());
             var context = new DataIteratorContext();
             context.setInsertOption(QueryUpdateService.InsertOption.INSERT);
-            DataIterator existing = new ExistingDataIteratorsTableInfo(new CachingDataIterator(di), CoreSchema.getInstance().getTableInfoModules(), null, context, true);
+            DataIterator existing = new ExistingDataIteratorsTableInfo(new CachingDataIterator(di), CoreSchema.getInstance().getTableInfoModules(), null, null, context, true);
             assertTrue(existing.supportsGetExistingRecord());
             return existing;
         }

--- a/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
+++ b/api/src/org/labkey/api/dataiterator/TriggerDataBuilderHelper.java
@@ -152,7 +152,7 @@ public class TriggerDataBuilderHelper
             else if (context.getInsertOption().mergeRows && !_target.supportsInsertOption(QueryUpdateService.InsertOption.MERGE))
                 return LoggingDataIterator.wrap(new BeforeIterator(coerce, context));
 
-            coerce = ExistingRecordDataIterator.createBuilder(coerce, _target, mergeKeys, true).getDataIterator(context);
+            coerce = ExistingRecordDataIterator.createBuilder(coerce, _target, mergeKeys, null, true).getDataIterator(context);
             return LoggingDataIterator.wrap(new BeforeIterator(new CachingDataIterator(coerce), context));
         }
     }

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -107,6 +107,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -780,6 +781,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         // TODO: Support update/delete without selecting the existing row -- unfortunately, we currently get the existing row to check its container matches the incoming container
         boolean streaming = false; //_queryTable.canStreamTriggers(container) && _queryTable.getAuditBehavior() != AuditBehaviorType.NONE;
 
+        Set<Object> updatedRows = new HashSet<>();
         for (int i = 0; i < rows.size(); i++)
         {
             Map<String, Object> row = rows.get(i);
@@ -805,6 +807,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
                 {
                     result.add(updatedRow);
                     oldRows.add(oldRow);
+                    checkDuplicateUpdate(updatedRows, updatedRow, container);
                 }
             }
             catch (ValidationException vex)
@@ -832,6 +835,11 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         addAuditEvent(user, container, QueryService.AuditAction.UPDATE, configParameters, result, oldRows);
 
         return result;
+    }
+
+    protected void checkDuplicateUpdate(@NotNull Set<Object> updatedRows, @NotNull Map<String, Object> updatedRow, @NotNull Container container) throws InvalidKeyException
+    {
+
     }
 
     @Override

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -112,6 +112,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
@@ -138,6 +140,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
      *  If a subclass wants to disable some of these features (w/o subclassing), put flags here...
      */
     protected boolean _enableExistingRecordsDataIterator = true;
+    protected Set<Object> _previouslyUpdatedRows = new HashSet<>();
 
     protected AbstractQueryUpdateService(TableInfo queryTable)
     {
@@ -149,6 +152,11 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
     protected TableInfo getQueryTable()
     {
         return _queryTable;
+    }
+
+    public @NotNull Set<Object> getPreviouslyUpdatedRows()
+    {
+        return _previouslyUpdatedRows == null ? new HashSet<>() : _previouslyUpdatedRows;
     }
 
     @Override
@@ -781,7 +789,6 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         // TODO: Support update/delete without selecting the existing row -- unfortunately, we currently get the existing row to check its container matches the incoming container
         boolean streaming = false; //_queryTable.canStreamTriggers(container) && _queryTable.getAuditBehavior() != AuditBehaviorType.NONE;
 
-        Set<Object> updatedRows = new HashSet<>();
         for (int i = 0; i < rows.size(); i++)
         {
             Map<String, Object> row = rows.get(i);
@@ -807,7 +814,6 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
                 {
                     result.add(updatedRow);
                     oldRows.add(oldRow);
-                    checkDuplicateUpdate(updatedRows, updatedRow, container);
                 }
             }
             catch (ValidationException vex)
@@ -837,9 +843,41 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         return result;
     }
 
-    protected void checkDuplicateUpdate(@NotNull Set<Object> updatedRows, @NotNull Map<String, Object> updatedRow, @NotNull Container container) throws InvalidKeyException
+    protected void checkDuplicateUpdate(Object pkVals) throws ValidationException
     {
+        if (pkVals == null)
+            return;
 
+        Set<Object> updatedRows = getPreviouslyUpdatedRows();
+
+        Object[] keysObj;
+        if (pkVals.getClass().isArray())
+            keysObj = (Object[]) pkVals;
+        else if (pkVals instanceof Map map)
+        {
+            List<Object> orderedKeyVals = new ArrayList<>();
+            SortedSet<String> sortedKeys = new TreeSet<>(map.keySet());
+            for (String key : sortedKeys)
+                orderedKeyVals.add(map.get(key));
+            keysObj = orderedKeyVals.toArray();
+        }
+        else
+            keysObj = new Object[]{pkVals};
+
+        if (keysObj.length == 1)
+        {
+            if (updatedRows.contains(keysObj[0]))
+                throw new ValidationException("Duplicate key provided: " + keysObj[0]);
+            updatedRows.add(keysObj[0]);
+            return;
+        }
+
+        List<String> keys = new ArrayList<>();
+        for (Object key : keysObj)
+            keys.add(String.valueOf(key));
+        if (updatedRows.contains(keys))
+            throw new ValidationException("Duplicate key provided: " + StringUtils.join(keys, ", "));
+        updatedRows.add(keys);
     }
 
     @Override

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -1334,6 +1334,15 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
             // test new row
             assertEquals("THREE", rows.get(3).get("s"));
             assertNull(rows.get(3).get("i"));
+
+            // merge should fail if duplicate keys are provided
+            errors = new BatchValidationException();
+            mergeRows = new ArrayList<Map<String,Object>>();
+            mergeRows.add(CaseInsensitiveHashMap.of(pkName,2,colName,"TWO-UP-2"));
+            mergeRows.add(CaseInsensitiveHashMap.of(pkName,2,colName,"TWO-UP-UP-2"));
+            qus.mergeRows(user, c, MapDataIterator.of(mergeRows.get(0).keySet(), mergeRows), errors, null, null);
+            assertTrue(errors.hasErrors());
+            assertTrue("Duplicate key error: " + errors.getMessage(), errors.getMessage().contains("Duplicate key provided: 2"));
         }
 
         @Test
@@ -1371,6 +1380,35 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
             updateRows.add(CaseInsensitiveHashMap.of(pkName,2,colName,"TWO-UP-2"));
             count = qus.loadRows(user, c, MapDataIterator.of(updateRows.get(0).keySet(), updateRows), context, null);
             assertTrue(context.getErrors().hasErrors());
+
+            // Issue 52728: update should fail if duplicate key is provide
+            updateRows = new ArrayList<Map<String,Object>>();
+            updateRows.add(CaseInsensitiveHashMap.of(pkName,2,colName,"TWO-UP-2"));
+            updateRows.add(CaseInsensitiveHashMap.of(pkName,2,colName,"TWO-UP-UP-2"));
+
+            // use DIB
+            context = new DataIteratorContext();
+            context.setInsertOption(InsertOption.UPDATE);
+            qus.loadRows(user, c, MapDataIterator.of(updateRows.get(0).keySet(), updateRows), context, null);
+            assertTrue(context.getErrors().hasErrors());
+            assertTrue("Duplicate key error: " + context.getErrors().getMessage(), context.getErrors().getMessage().contains("Duplicate key provided: 2"));
+
+            // use updateRows
+            if (!_useAlias) // _update using alias is not supported
+            {
+                BatchValidationException errors = new BatchValidationException();
+                try
+                {
+                    qus.updateRows(user, c, updateRows, null, errors, null, null);
+                }
+                catch (Exception e)
+                {
+
+                }
+                assertTrue(errors.hasErrors());
+                assertTrue("Duplicate key error: " + errors.getMessage(), errors.getMessage().contains("Duplicate key provided: 2"));
+
+            }
         }
 
         @Test

--- a/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
@@ -588,6 +588,8 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
             throw e.getLastRowError();
         }
 
+        checkDuplicateUpdate(keys);
+
         return Table.update(user, getDbTable(), row, keys); // Cache-invalidation handled in caller (TreatmentManager.saveAssaySpecimen())
     }
 
@@ -721,28 +723,6 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
             return Table.delete(getDbTable(), SimpleFilter.createContainerFilter(container));
 
        return Table.delete(getDbTable());
-    }
-
-    @Override
-    protected void checkDuplicateUpdate(@NotNull Set<Object> updatedRows, @NotNull Map<String, Object> updatedRow, @NotNull Container container) throws InvalidKeyException
-    {
-        Object[] keysObj = getKeys(updatedRow, container);
-        if (keysObj == null)
-            return;
-        if (keysObj.length == 1)
-        {
-            if (updatedRows.contains(keysObj[0]))
-                throw new InvalidKeyException("Duplicate key provided: " + keysObj[0]);
-            updatedRows.add(keysObj[0]);
-            return;
-        }
-
-        List<String> keys = new ArrayList<>();
-        for (Object key : keysObj)
-            keys.add(String.valueOf(key));
-        if (updatedRows.contains(keys))
-            throw new InvalidKeyException("Duplicate key provided: " + StringUtils.join(keys, ", "));
-        updatedRows.add(keys);
     }
 
     protected Object[] getKeys(Map<String, Object> map, Container container) throws InvalidKeyException

--- a/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
@@ -17,6 +17,7 @@ package org.labkey.api.query;
 
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.attachments.AttachmentFile;
@@ -720,6 +721,28 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
             return Table.delete(getDbTable(), SimpleFilter.createContainerFilter(container));
 
        return Table.delete(getDbTable());
+    }
+
+    @Override
+    protected void checkDuplicateUpdate(@NotNull Set<Object> updatedRows, @NotNull Map<String, Object> updatedRow, @NotNull Container container) throws InvalidKeyException
+    {
+        Object[] keysObj = getKeys(updatedRow, container);
+        if (keysObj == null)
+            return;
+        if (keysObj.length == 1)
+        {
+            if (updatedRows.contains(keysObj[0]))
+                throw new InvalidKeyException("Duplicate key provided: " + keysObj[0]);
+            updatedRows.add(keysObj[0]);
+            return;
+        }
+
+        List<String> keys = new ArrayList<>();
+        for (Object key : keysObj)
+            keys.add(String.valueOf(key));
+        if (updatedRows.contains(keys))
+            throw new InvalidKeyException("Duplicate key provided: " + StringUtils.join(keys, ", "));
+        updatedRows.add(keys);
     }
 
     protected Object[] getKeys(Map<String, Object> map, Container container) throws InvalidKeyException

--- a/experiment/src/client/test/integration/DataClassCrud.ispec.ts
+++ b/experiment/src/client/test/integration/DataClassCrud.ispec.ts
@@ -1,4 +1,4 @@
-import { hookServer, RequestOptions, successfulResponse } from '@labkey/test';
+import { ExperimentCRUDUtils, hookServer, RequestOptions, successfulResponse } from '@labkey/test';
 import mock from 'mock-fs';
 import {
     checkDomainName,
@@ -9,7 +9,7 @@ import {
     initProject,
     verifyRequiredLineageInsertUpdate,
 } from './utils';
-import { DATA_CLASS_DESIGNER_ROLE } from '@labkey/components';
+import { caseInsensitive, DATA_CLASS_DESIGNER_ROLE } from '@labkey/components';
 const server = hookServer(process.env);
 const PROJECT_NAME = 'DataClassCrudJestProject';
 
@@ -234,4 +234,108 @@ describe('Data Class - Required Lineage', () => {
         await verifyRequiredLineageInsertUpdate(server, false, false, topFolderOptions, subfolder1Options, designerReaderOptions, readerUserOptions, editorUserOptions, adminOptions);
     });
 
+});
+
+describe('CRUD actions', () => {
+
+    it("Issue 52728: don't allow updating the same data twice", async () => {
+        const dataType = "TestIssue52728";
+        const createPayload = {
+            kind: 'DataClass',
+            domainDesign: { name: dataType, fields: [{ name: 'Prop' }] },
+            options: {
+                name: dataType,
+            }
+        };
+
+        await server.post('property', 'createDomain', createPayload,
+            {...topFolderOptions, ...designerReaderOptions}).expect(successfulResponse);
+
+        let errorResp;
+        await server.post('query', 'insertRows', {
+            schemaName: 'exp.data',
+            queryName: dataType,
+            rows: [{
+                name: 'duplicateShouldFail',
+            },{
+                name: 'duplicateShouldFail',
+            }]
+        }, { ...topFolderOptions, ...editorUserOptions }).expect((result) => {
+            errorResp = JSON.parse(result.text);
+            expect(errorResp.exception.indexOf('duplicate key') > -1).toBeTruthy();
+        });
+        // import
+        errorResp = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nduplicateShouldFail\tbad\nduplicateShouldFail\tbad", dataType, "IMPORT", topFolderOptions, editorUserOptions);
+        expect(errorResp.text.indexOf('duplicate key') > -1).toBeTruthy();
+
+        // merge
+        const duplicateKeyErrorPrefix = 'Duplicate key provided: ';
+        errorResp = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nduplicateShouldFail\tbad\nduplicateShouldFail\tbad", dataType, "MERGE", topFolderOptions, editorUserOptions);
+        expect(errorResp.text.indexOf(duplicateKeyErrorPrefix + 'duplicateShouldFail') > -1).toBeTruthy();
+
+        const dataName1 = "up-dataId-1";
+        const dataName2 = "up-dataId-2";
+        const dataRows = await ExperimentCRUDUtils.insertRows(server, [{
+            name: dataName1,
+            description: 'created'
+        },{
+            name: dataName2,
+            description: 'created'
+        }], 'exp.data', dataType, topFolderOptions, editorUserOptions);
+
+        const data1RowId = caseInsensitive(dataRows[0], 'rowId');
+        const data1Lsid = caseInsensitive(dataRows[0], 'lsid');
+        const data2RowId = caseInsensitive(dataRows[1], 'rowId');
+        const data2Lsid = caseInsensitive(dataRows[1], 'lsid');
+
+        // update data2 twice using updateRows, using rowId
+        await server.post('query', 'updateRows', {
+            schemaName: 'exp.data',
+            queryName: dataType,
+            rows: [{
+                description: 'update',
+                rowId: data1RowId
+            },{
+                description: 'update',
+                rowId: data2RowId
+            },{
+                description: 'update',
+                rowId: data2RowId
+            }]
+        }, { ...topFolderOptions, ...editorUserOptions }).expect((result) => {
+            errorResp = JSON.parse(result.text);
+            expect(errorResp['exception']).toBe('Duplicate key provided: ' + data2RowId);
+        });
+
+        // update data2 twice using updateRows, using lsid (data iterator)
+        await server.post('query', 'updateRows', {
+            schemaName: 'exp.data',
+            queryName: dataType,
+            rows: [{
+                description: 'update',
+                lsid: data1Lsid
+            },{
+                description: 'update',
+                lsid: data2Lsid
+            },{
+                description: 'update',
+                lsid: data2Lsid
+            }]
+        }, { ...topFolderOptions, ...editorUserOptions }).expect((result) => {
+            errorResp = JSON.parse(result.text);
+            expect(errorResp['exception']).toBe('Duplicate key provided: ' + data2Lsid);
+        });
+
+        errorResp = await ExperimentCRUDUtils.importData(server, "Name\tDescription\n" + dataName1 + "\tupdate\n" + dataName2 + "\tupdate\n" + dataName2 + "\tupdate", dataType, "UPDATE", topFolderOptions, editorUserOptions);
+        expect(errorResp.text.indexOf('Duplicate key provided: ' + dataName2) > -1).toBeTruthy();
+
+        errorResp = await ExperimentCRUDUtils.importData(server, "Name\tDescription\n" + dataName1 + "\tupdate\n" + dataName2 + "\tupdate\n" + dataName2 + "\tupdate", dataType, "MERGE", topFolderOptions, editorUserOptions);
+        expect(errorResp.text.indexOf('Duplicate key provided: ' + dataName2) > -1).toBeTruthy();
+
+        // confirm rows are not updated
+        let dataResults = await ExperimentCRUDUtils.getRows(server, [data1RowId, data2RowId], 'exp.data', dataType, 'rowId,description', topFolderOptions, adminOptions);
+        expect(caseInsensitive(dataResults[0], 'description')).toBe('created');
+        expect(caseInsensitive(dataResults[1], 'description')).toBe('created');
+
+    });
 });

--- a/experiment/src/client/test/integration/DataClassCrud.ispec.ts
+++ b/experiment/src/client/test/integration/DataClassCrud.ispec.ts
@@ -236,7 +236,7 @@ describe('Data Class - Required Lineage', () => {
 
 });
 
-describe('CRUD actions', () => {
+describe('Duplicate IDs', () => {
 
     it("Issue 52728: don't allow updating the same data twice", async () => {
         const dataType = "TestIssue52728";

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -145,6 +145,7 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
@@ -3023,8 +3024,12 @@ public class ExpDataIterators
                 {
                     String name = (String) row.get("name");
                     String dataContainer = (String) row.get("container");
-                    int dataRowId = typeData.dataIds.indexOf(name);
-                    containerRows.computeIfAbsent(dataContainer, k -> new ArrayList<>()).add(dataRowId);
+                    // could be updating the same data multiple times in a single import, the import will later be rejected
+                    List<Integer> dataRowIds =
+                            IntStream.range(0, typeData.dataIds.size()).boxed()
+                                    .filter(i -> typeData.dataIds.get(i).equals(name))
+                                    .toList();
+                    containerRows.computeIfAbsent(dataContainer, k -> new ArrayList<>()).addAll(dataRowIds);
                 }
 
                 for (String containerId : containerRows.keySet())

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -78,6 +78,7 @@ import org.labkey.api.exp.api.SimpleRunRecord;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.query.AbstractExpSchema;
 import org.labkey.api.exp.query.DataClassUserSchema;
+import org.labkey.api.exp.query.ExpDataClassDataTable;
 import org.labkey.api.exp.query.ExpDataTable;
 import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.ExpSchema;
@@ -2351,7 +2352,7 @@ public class ExpDataIterators
 
             // Since we support detailed audit logging add the ExistingRecordDataIterator here just before TableInsertDataIterator
             // this is a NOOP unless we are merging/updating and detailed logging is enabled
-            DataIteratorBuilder step2a = ExistingRecordDataIterator.createBuilder(step1, _expTable, keyColumns, true);
+            DataIteratorBuilder step2a = ExistingRecordDataIterator.createBuilder(step1, _expTable, keyColumns, Set.of(ExpMaterialTable.Column.MaterialSourceId.name(), ExpDataClassDataTable.Column.ClassId.name()), true);
 
             // Add RootMaterialRowId if it does not exist
             DataIteratorBuilder step2b = ctx -> {

--- a/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunTableImpl.java
@@ -1066,6 +1066,7 @@ public class ExpRunTableImpl extends ExpTableImpl<ExpRunTable.Column> implements
                     }
                 }
 
+                checkDuplicateUpdate(run.getRowId());
                 run.save(user);
 
                 String auditUserComment = configParameters == null ? null : (String) configParameters.get(DetailedAuditLogDataIterator.AuditConfigs.AuditUserComment);

--- a/specimen/src/org/labkey/specimen/query/SpecimenUpdateService.java
+++ b/specimen/src/org/labkey/specimen/query/SpecimenUpdateService.java
@@ -325,7 +325,7 @@ public class SpecimenUpdateService extends AbstractQueryUpdateService
 
     @Override
     public List<Map<String, Object>> updateRows(User user, Container container, List<Map<String, Object>> rows, List<Map<String, Object>> oldKeys, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
-            throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
+            throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException // TODO
     {
         if (oldKeys != null && rows.size() != oldKeys.size())
             throw new IllegalArgumentException("rows and oldKeys are required to be the same length, but were " + rows.size() + " and " + oldKeys + " in length, respectively");
@@ -340,6 +340,14 @@ public class SpecimenUpdateService extends AbstractQueryUpdateService
             Map<String, Object> row = rows.get(i);
             Map<String, Object> keys = oldKeys == null ? row : oldKeys.get(i);
             long rowId = keyFromMap(keys);
+            try
+            {
+                checkDuplicateUpdate(rowId);
+            }
+            catch (ValidationException e)
+            {
+                throw new BatchValidationException(e);
+            }
             rowIds.add(rowId);
             uniqueRows.put(rowId, row);
         }

--- a/specimen/src/org/labkey/specimen/query/SpecimenUpdateService.java
+++ b/specimen/src/org/labkey/specimen/query/SpecimenUpdateService.java
@@ -325,7 +325,7 @@ public class SpecimenUpdateService extends AbstractQueryUpdateService
 
     @Override
     public List<Map<String, Object>> updateRows(User user, Container container, List<Map<String, Object>> rows, List<Map<String, Object>> oldKeys, BatchValidationException errors, @Nullable Map<Enum, Object> configParameters, Map<String, Object> extraScriptContext)
-            throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException // TODO
+            throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
     {
         if (oldKeys != null && rows.size() != oldKeys.size())
             throw new IllegalArgumentException("rows and oldKeys are required to be the same length, but were " + rows.size() + " and " + oldKeys + " in length, respectively");

--- a/study/src/org/labkey/study/query/CohortUpdateService.java
+++ b/study/src/org/labkey/study/query/CohortUpdateService.java
@@ -114,6 +114,7 @@ public class CohortUpdateService extends AbstractQueryUpdateService
             throws InvalidKeyException, ValidationException
     {
         int rowId = oldRow != null ? keyFromMap(oldRow) : keyFromMap(row);
+        checkDuplicateUpdate(rowId);
         CohortImpl cohort = StudyManager.getInstance().getCohortForRowId(container, user, rowId);
         if (cohort == null)
             throw new IllegalArgumentException("No cohort found for rowId: " + rowId);

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -585,6 +585,7 @@ public class DatasetUpdateService extends AbstractQueryUpdateService
         aliasColumns(_columnMapping, row);
 
         String lsid = keyFromMap(oldRow);
+        checkDuplicateUpdate(lsid);
         // Make sure we've found the original participant before doing the update
         String oldParticipant = getParticipant(oldRow, user, container);
         String newLsid = null;


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6571
- https://github.com/LabKey/limsModules/pull/1352
- https://github.com/LabKey/testAutomation/pull/2421

#### Changes
- Added checkDuplicateUpdate to `updateRow` in various QUS so the same rows cannot be updated in the same updateRows call
- Modified `ExistingRecordDataIterator` to check for previously seen keys so the same rows are not provided during update/merge
- Add junit test coverage for updating/merging the same list rows using updateRows and DIB
