### PR TITLE
Ignore JSONException caused by bad client input

### DIFF
--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -803,7 +803,10 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
                 // Just the PK and version values
                 _oldValues = new JSONObject(oldValues).toMap();
             }
-            catch (JSONException ignore) {}
+            catch (JSONException e)
+            {
+                _log.debug("Failed to parse '.oldValues' JSON", e);
+            }
         }
     }
 

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.labkey.api.action.BaseViewAction;
 import org.labkey.api.action.HasBindParameters;
@@ -797,8 +798,12 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         String oldValues = request.getParameter(DataRegion.OLD_VALUES_NAME);
         if (null != StringUtils.trimToNull(oldValues))
         {
-            // Just the PK and version values
-            _oldValues = new JSONObject(oldValues).toMap();
+            try
+            {
+                // Just the PK and version values
+                _oldValues = new JSONObject(oldValues).toMap();
+            }
+            catch (JSONException ignore) {}
         }
     }
 


### PR DESCRIPTION
#### Rationale
The crawler triggered an error by hitting `dataset-insert.view` with an invalid `.oldValues` parameter. I considered throwing an `ApiUsageException` but this parameter seems to be for internal usage so I don't think that would be especially useful.
```
org.json.JSONException: A JSONObject text must begin with '{' at 1 [character 2 line 1]
	at org.json.JSONTokener.syntaxError(JSONTokener.java:536) ~[json-20250107.jar:?]
	at org.json.JSONObject.<init>(JSONObject.java:233) ~[json-20250107.jar:?]
	at org.json.JSONObject.<init>(JSONObject.java:481) ~[json-20250107.jar:?]
	at org.json.JSONObject.<init>(JSONObject.java:458) ~[json-20250107.jar:?]
	at org.labkey.api.data.TableViewForm.setViewContext(TableViewForm.java:801) ~[api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.query.QueryUpdateForm.<init>(QueryUpdateForm.java:55) ~[api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.study.InsertUpdateAction.getUpdateForm(InsertUpdateAction.java:97) ~[study_api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.study.InsertUpdateAction.getView(InsertUpdateAction.java:166) ~[study_api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.study.InsertUpdateAction.getView(InsertUpdateAction.java:78) ~[study_api-25.5-SNAPSHOT.jar:?]
```

#### Related Pull Requests
- N/A

#### Changes
- Ignore JSONException caused by bad client input
