### PR TITLE
Mechanism to limit the JSON length as input to APIs

### DIFF
--- a/api/src/org/labkey/api/action/BaseApiAction.java
+++ b/api/src/org/labkey/api/action/BaseApiAction.java
@@ -32,6 +32,7 @@ import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryException;
 import org.labkey.api.query.RuntimeValidationException;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.reader.StrictBoundedReader;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.HttpUtil;
 import org.labkey.api.util.JsonUtil;
@@ -502,13 +503,20 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
         return _requestedApiVersion < 0 ? 0 : _requestedApiVersion;
     }
 
+    protected long getMaximumJsonInputLength()
+    {
+        JsonInputLimit limitAnnotation = getClass().getAnnotation(JsonInputLimit.class);
+        return limitAnnotation == null ? JsonInputLimit.DEFAULT : limitAnnotation.value();
+    }
 
     private @Nullable JSONObject getJsonObject() throws IOException
     {
-        try (Reader r = getViewContext().getRequest().getReader())
+        long maxLength = getMaximumJsonInputLength();
+        try (Reader r = getViewContext().getRequest().getReader();
+            Reader jsonReader = maxLength > 0 ? new StrictBoundedReader(r, maxLength) : r)
         {
             JSONTokener tokener = new JSONTokener(r);
-            return tokener.more() ? new JSONObject(new JSONTokener(r)) : null;
+            return tokener.more() ? new JSONObject(new JSONTokener(jsonReader)) : null;
         }
     }
 

--- a/api/src/org/labkey/api/action/JsonInputLimit.java
+++ b/api/src/org/labkey/api/action/JsonInputLimit.java
@@ -1,0 +1,16 @@
+package org.labkey.api.action;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/** Sets a limit for the length in characters of the JSON string that an API is willing to consume */
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface JsonInputLimit
+{
+    /** No limit */
+    long DEFAULT = -1;
+
+    long value() default DEFAULT;
+}

--- a/api/src/org/labkey/api/reader/StrictBoundedReader.java
+++ b/api/src/org/labkey/api/reader/StrictBoundedReader.java
@@ -1,0 +1,99 @@
+package org.labkey.api.reader;
+
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * Restricts the Reader to a character limit. Throws an exception when the limit is exceeded.
+ * Similar to Apache's BoundedReader, which silently truncates.
+ */
+public class StrictBoundedReader extends Reader
+{
+    private final Reader in;
+    private final long maxChars;
+    private long charsRead = 0;
+    private boolean closed = false;
+
+    public static class LimitExceededException extends IOException
+    {
+        public LimitExceededException(String message)
+        {
+            super(message);
+            
+        }
+    }
+
+    public StrictBoundedReader(Reader in, long maxChars)
+    {
+        if (in == null)
+        {
+            throw new NullPointerException("Reader cannot be null");
+        }
+        if (maxChars < 0)
+        {
+            throw new IllegalArgumentException("maxChars must be non-negative");
+        }
+        this.in = in;
+        this.maxChars = maxChars;
+    }
+
+    @Override
+    public int read() throws IOException
+    {
+        ensureOpen();
+        if (charsRead >= maxChars)
+        {
+            throw new LimitExceededException("Character read limit of " + maxChars + " exceeded");
+        }
+        int result = in.read();
+        if (result != -1)
+        {
+            charsRead++;
+        }
+        return result;
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException
+    {
+        ensureOpen();
+        if (charsRead >= maxChars)
+        {
+            throw new LimitExceededException("Character read limit of " + maxChars + " exceeded");
+        }
+
+        long remaining = maxChars - charsRead;
+        int toRead = (int) Math.min(len, remaining);
+        int numRead = in.read(cbuf, off, toRead);
+
+        if (numRead > 0)
+        {
+            charsRead += numRead;
+        }
+
+        if (charsRead > maxChars)
+        {
+            throw new LimitExceededException("Character read limit of " + maxChars + " exceeded");
+        }
+
+        return numRead;
+    }
+
+    private void ensureOpen() throws IOException
+    {
+        if (closed)
+        {
+            throw new IOException("Reader is closed");
+        }
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        if (!closed)
+        {
+            in.close();
+            closed = true;
+        }
+    }
+}

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -2387,7 +2387,7 @@ public class QueryController extends SpringActionController
     }
 
     // Uck. Supports the old and new view designer.
-    protected Map<String, Object> saveCustomView(Container container, QueryDefinition queryDef,
+    protected JSONObject saveCustomView(Container container, QueryDefinition queryDef,
                                                  String regionName, String viewName, boolean replaceExisting,
                                                  boolean share, boolean inherit,
                                                  boolean session, boolean saveFilter,
@@ -2480,7 +2480,7 @@ public class QueryController extends SpringActionController
                     try
                     {
                         view.delete(getUser(), getViewContext().getRequest());
-                        Map<String, Object> ret = saveCustomView(container, queryDef, regionName, viewName, replaceExisting, share, inherit, session, saveFilter, hidden, jsonView, returnUrl, errors);
+                        JSONObject ret = saveCustomView(container, queryDef, regionName, viewName, replaceExisting, share, inherit, session, saveFilter, hidden, jsonView, returnUrl, errors);
                         success = !errors.hasErrors() && ret != null;
                         return success ? ret : null;
                     }
@@ -2552,7 +2552,7 @@ public class QueryController extends SpringActionController
             }
         }
 
-        Map<String, Object> ret = new HashMap<>();
+        JSONObject ret = new JSONObject();
         ret.put("redirect", returnUrl);
         if (view != null)
             ret.put("view", CustomViewUtil.toMap(view, getUser(), true));
@@ -2574,6 +2574,7 @@ public class QueryController extends SpringActionController
 
     @RequiresPermission(ReadPermission.class)
     @Action(ActionType.Configure.class)
+    @JsonInputLimit(100_000)
     public class SaveQueryViewsAction extends MutatingApiAction<SimpleApiJsonForm>
     {
         @Override
@@ -2598,10 +2599,10 @@ public class QueryController extends SpringActionController
             if (queryDef == null)
                 throw new NotFoundException("query not found");
 
-            Map<String, Object> response = new HashMap<>();
+            JSONObject response = new JSONObject();
             response.put(QueryParam.schemaName.toString(), schemaName);
             response.put(QueryParam.queryName.toString(), queryName);
-            List<Map<String, Object>> views = new ArrayList<>();
+            JSONArray views = new JSONArray();
             response.put("views", views);
 
             ActionURL redirect = null;
@@ -2637,7 +2638,7 @@ public class QueryController extends SpringActionController
                     throw new NotFoundException("No such container: " + containerPath);
                 }
 
-                Map<String, Object> savedView = saveCustomView(
+                JSONObject savedView = saveCustomView(
                         container, queryDef, QueryView.DATAREGIONNAME_DEFAULT, viewName, replace,
                         shared, inherit, session, true, hidden, jsonView, null, errors);
 
@@ -2645,7 +2646,7 @@ public class QueryController extends SpringActionController
                 {
                     if (redirect == null)
                         redirect = (ActionURL)savedView.get("redirect");
-                    views.add((Map<String, Object>)savedView.get("view"));
+                    views.put(savedView.getJSONObject("view"));
                 }
             }
 


### PR DESCRIPTION
#### Rationale
Accepting massive JSON inputs can be bad for server health.

#### Changes
- New annotation option for limiting the maximum length of JSON