### PR TITLE
Misc 25.5 assay related fixes for fields with special characters

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -2111,14 +2111,14 @@ public abstract class AbstractAssayProvider implements AssayProvider
 
         for (String fileField : fileFields)
         {
-            String columnName = assayResultTable.getSchema().getSqlDialect().getColumnSelectName(fileField);
-
-            TableSelector ts = new TableSelector(assayResultTable, assayResultTable.getColumns("rowid", "run", columnName), filter, null);
+            TableSelector ts = new TableSelector(assayResultTable, assayResultTable.getColumns("rowid", "run", fileField), filter, null);
             Map<String, Object>[] resultFiles = ts.getMapArray();
+            String columnAlias = assayResultTable.getColumn(fileField).getAlias(); // Issue 52888
+            String columnSelectName = assayResultTable.getColumn(fileField).getSelectName();
 
             for (Map<String, Object> resultRow : resultFiles)
             {
-                String sourceFileName = (String) resultRow.get(columnName);
+                String sourceFileName = (String) resultRow.get(columnAlias);
                 if (StringUtils.isEmpty(sourceFileName))
                     continue;
                 Integer resultRowId = (Integer) resultRow.get("rowid");
@@ -2149,7 +2149,7 @@ public abstract class AbstractAssayProvider implements AssayProvider
 
                     updateSql = new SQLFragment("UPDATE ").append(assayResultTable.getRealTable())
                             .append(" SET ")
-                            .append(columnName)
+                            .append(columnSelectName)
                             .append(" = ").appendValue(updatedFile.getAbsolutePath())
                             .append(" WHERE rowId = ").appendValue(resultRowId);
                     new SqlExecutor(assayResultTable.getSchema()).execute(updateSql);

--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -631,10 +631,11 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
             if (key == null || key.isEmpty())
                 return null;
 
-            // Issue 52119: account for leading/trailing single quotes and decode double quotes
+            // Issue 52119: account for leading/trailing single quotes and decode double quotes and %
             if (key.startsWith("'") && key.endsWith("'"))
                 key = key.substring(1, key.length()-1);
             key = key.replaceAll("%22", "\"");
+            key = key.replaceAll("%25", "%");
 
             return key;
         }


### PR DESCRIPTION
#### Rationale
Issue [52119](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52119): ImportRunApiAction fix to account for replacing %22 in run properties key
Issue [52888](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52888): App assay with results file field doesn't move files on run move when result file field has special characters in name

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/738
- https://github.com/LabKey/platform/pull/6585
- https://github.com/LabKey/limsModules/pull/1345

#### Changes
- ImportRunApiAction fix to account for replacing %22 in run properties key
- Assay run move result files to use columnInfo.getAlias() to get original file path from query results
