### PR TITLE
Add a "Delete All" button to our allow list pages

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -11121,6 +11121,28 @@ public class AdminController extends SpringActionController
         }
     }
 
+    @AdminConsoleAction
+    public static class DeleteAllValuesAction extends FormHandlerAction<AllowListForm>
+    {
+        @Override
+        public void validateCommand(AllowListForm form, Errors errors)
+        {
+        }
+
+        @Override
+        public boolean handlePost(AllowListForm form, BindException errors) throws Exception
+        {
+            form.getTypeEnum().setValues(Collections.emptyList(), getUser());
+            return true;
+        }
+
+        @Override
+        public URLHelper getSuccessURL(AllowListForm form)
+        {
+            return form.getTypeEnum().getSuccessURL(getContainer());
+        }
+    }
+
     public static class ExternalSourcesForm
     {
         private boolean _delete;

--- a/core/src/org/labkey/core/admin/AllowListType.java
+++ b/core/src/org/labkey/core/admin/AllowListType.java
@@ -48,10 +48,10 @@ public enum AllowListType
         }
 
         @Override
-        public void setValues(Collection<String> hosts, User user)
+        public void setValues(Collection<String> allowedHosts, User user)
         {
             WriteableAppProps props = AppProps.getWriteableInstance();
-            props.setExternalRedirectHosts(hosts);
+            props.setExternalRedirectHosts(allowedHosts);
             props.save(user);
         }
 
@@ -136,7 +136,7 @@ public enum AllowListType
 
     public abstract HtmlString getDescription();
     public abstract List<String> getValues();
-    public abstract void setValues(Collection<String> redirectHosts, User user);
+    public abstract void setValues(Collection<String> allowedValues, User user);
     public abstract void validateValueFormat(String value, BindException errors);
     public abstract HtmlString getTitle();
     public abstract HtmlString getLabel();

--- a/core/src/org/labkey/core/admin/existingListValues.jsp
+++ b/core/src/org/labkey/core/admin/existingListValues.jsp
@@ -21,6 +21,7 @@
 <%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.core.admin.AdminController.AllowListForm" %>
+<%@ page import="org.labkey.core.admin.AdminController.DeleteAllValuesAction" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
@@ -78,7 +79,7 @@
         %>
         <tr>
 
-            <td><input type="text" id="<%=h(inputNameExisting)%>" name="<%=h(inputNameExisting)%>" value="<%= h(value)%>" size="80"/></td>
+            <td><input type="text" id="<%=h(inputNameExisting)%>" name="<%=h(inputNameExisting)%>" value="<%=h(value)%>" size="80"<%=disabled(isTroubleshooter)%>/></td>
 
             <td><%=isTroubleshooter ? HtmlString.EMPTY_STRING : button("Delete").primary(true).onClick("return deleteExisting(\"" + h(value) + "\");") %>
 
@@ -95,7 +96,11 @@
             <input type="hidden" id="existingValues" name="existingValues" value="" />
             <tr>
                 <td></td>
-                <td><br/><input type="hidden" id="saveAll" name="saveAll"><%=isTroubleshooter ? button("Done").href(urlProvider(AdminUrls.class).getAdminConsoleURL()) : button("Save").primary(true).onClick("return saveAll();")%>
+                <td><br/>
+                    <input type="hidden" id="saveAll" name="saveAll">
+                    <%=isTroubleshooter ? button("Done").href(urlProvider(AdminUrls.class).getAdminConsoleURL()) : button("Save").primary(true).onClick("return saveAll();")%>
+                    <%=!isTroubleshooter ? button("Delete All").href(urlFor(DeleteAllValuesAction.class)).usePost("Are you sure you want to delete all the " + bean.getTypeEnum().getTitle() + "s?") : HtmlString.EMPTY_STRING%>
+                </td>
             </tr>
         <% } %>
 </labkey:form>

--- a/core/src/org/labkey/core/admin/existingListValues.jsp
+++ b/core/src/org/labkey/core/admin/existingListValues.jsp
@@ -99,7 +99,7 @@
                 <td><br/>
                     <input type="hidden" id="saveAll" name="saveAll">
                     <%=isTroubleshooter ? button("Done").href(urlProvider(AdminUrls.class).getAdminConsoleURL()) : button("Save").primary(true).onClick("return saveAll();")%>
-                    <%=!isTroubleshooter ? button("Delete All").href(urlFor(DeleteAllValuesAction.class)).usePost("Are you sure you want to delete all the " + bean.getTypeEnum().getTitle() + "s?") : HtmlString.EMPTY_STRING%>
+                    <%=!isTroubleshooter ? button("Delete All").href(urlFor(DeleteAllValuesAction.class)).usePost("Are you sure you want to delete all " + bean.getTypeEnum().getTitle() + "s?") : HtmlString.EMPTY_STRING%>
                 </td>
             </tr>
         <% } %>


### PR DESCRIPTION
#### Rationale
Add a "Delete All" button (and corresponding action) to the "Allowed Redirect Hosts" and "Allowed File Extensions" pages. Requested to assist with test clean up, this might be useful to admins as well.

Also, disable text fields for Troubleshooters.