### PR TITLE
Issue 52271: List PK name gets truncated on table create

### DIFF
--- a/core/src/org/labkey/core/query/UserAuditProvider.java
+++ b/core/src/org/labkey/core/query/UserAuditProvider.java
@@ -31,7 +31,6 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.UserIdForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.UserManager;
-import org.labkey.api.util.PageFlowUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,7 +38,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * User: klum

--- a/list/src/org/labkey/list/model/IntegerListDomainKind.java
+++ b/list/src/org/labkey/list/model/IntegerListDomainKind.java
@@ -23,11 +23,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-/**
- * User: Nick
- * Date: 5/9/13
- * Time: 12:57 PM
- */
 public class IntegerListDomainKind extends ListDomainKind
 {
     protected static final String NAMESPACE_PREFIX = "IntList";
@@ -45,9 +40,11 @@ public class IntegerListDomainKind extends ListDomainKind
 
 
     @Override
-    PropertyStorageSpec getKeyProperty(ListDefinition list)
+    PropertyStorageSpec getKeyProperty(ListDefinition list, String columnStorageName)
     {
-        PropertyStorageSpec key = new PropertyStorageSpec(list.getKeyName(), JdbcType.INTEGER);
+        // See Issue 52271. Consider: Are there any other PropertyDescriptor properties that need to be copied into this
+        // PropertyStorageSpec?
+        PropertyStorageSpec key = new PropertyStorageSpec(columnStorageName, JdbcType.INTEGER);
         key.setPrimaryKey(true);
 
         if (list.getKeyType().equals(ListDefinition.KeyType.AutoIncrementInteger))

--- a/list/src/org/labkey/list/model/IntegerListDomainKind.java
+++ b/list/src/org/labkey/list/model/IntegerListDomainKind.java
@@ -40,11 +40,11 @@ public class IntegerListDomainKind extends ListDomainKind
 
 
     @Override
-    PropertyStorageSpec getKeyProperty(ListDefinition list, String columnStorageName)
+    PropertyStorageSpec getKeyProperty(ListDefinition list, String storageColumnName)
     {
         // See Issue 52271. Consider: Are there any other PropertyDescriptor properties that need to be copied into this
         // PropertyStorageSpec?
-        PropertyStorageSpec key = new PropertyStorageSpec(columnStorageName, JdbcType.INTEGER);
+        PropertyStorageSpec key = new PropertyStorageSpec(storageColumnName, JdbcType.INTEGER);
         key.setPrimaryKey(true);
 
         if (list.getKeyType().equals(ListDefinition.KeyType.AutoIncrementInteger))

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -86,11 +86,6 @@ import java.util.stream.Collectors;
 
 import static org.labkey.api.exp.property.DomainTemplate.findProperty;
 
-/**
- * User: Nick
- * Date: 5/8/13
- * Time: 4:12 PM
- */
 public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindProperties>
 {
     /*
@@ -229,7 +224,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
         {
             if (pd.getName().equalsIgnoreCase(list.getKeyName()))
             {
-                PropertyStorageSpec key = this.getKeyProperty(list);
+                PropertyStorageSpec key = getKeyProperty(list, pd.getStorageColumnName());
                 assert key.isPrimaryKey();
                 _list = null;
                 return key;
@@ -238,7 +233,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
         return super.getPropertySpec(pd, domain);
     }
 
-    abstract PropertyStorageSpec getKeyProperty(ListDefinition list);
+    abstract PropertyStorageSpec getKeyProperty(ListDefinition list, String storageColumnName);
 
     abstract KeyType getDefaultKeyType();
 

--- a/list/src/org/labkey/list/model/PicklistDomainKind.java
+++ b/list/src/org/labkey/list/model/PicklistDomainKind.java
@@ -41,6 +41,4 @@ public class PicklistDomainKind extends IntegerListDomainKind
         Container c = domain.getContainer();
         return c.hasPermission("ListDomainKind.canEditDefinition for picklist", user, ManagePicklistsPermission.class);
     }
-
-
 }

--- a/list/src/org/labkey/list/model/VarcharListDomainKind.java
+++ b/list/src/org/labkey/list/model/VarcharListDomainKind.java
@@ -22,11 +22,6 @@ import org.labkey.api.exp.list.ListDefinition;
 import java.util.Collection;
 import java.util.Collections;
 
-/**
- * User: Nick
- * Date: 5/9/13
- * Time: 12:57 PM
- */
 public class VarcharListDomainKind extends ListDomainKind
 {
     protected static final String NAMESPACE_PREFIX = "VarList";
@@ -40,9 +35,11 @@ public class VarcharListDomainKind extends ListDomainKind
     }
 
     @Override
-    PropertyStorageSpec getKeyProperty(ListDefinition list)
+    PropertyStorageSpec getKeyProperty(ListDefinition list, String columnStorageName)
     {
-        PropertyStorageSpec key = new PropertyStorageSpec(list.getKeyName(), JdbcType.VARCHAR);
+        // See Issue 52271. Consider: Are there any other PropertyDescriptor properties that need to be copied into this
+        // PropertyStorageSpec?
+        PropertyStorageSpec key = new PropertyStorageSpec(columnStorageName, JdbcType.VARCHAR);
         key.setPrimaryKey(true);
         return key;
     }

--- a/list/src/org/labkey/list/model/VarcharListDomainKind.java
+++ b/list/src/org/labkey/list/model/VarcharListDomainKind.java
@@ -35,11 +35,11 @@ public class VarcharListDomainKind extends ListDomainKind
     }
 
     @Override
-    PropertyStorageSpec getKeyProperty(ListDefinition list, String columnStorageName)
+    PropertyStorageSpec getKeyProperty(ListDefinition list, String storageColumnName)
     {
         // See Issue 52271. Consider: Are there any other PropertyDescriptor properties that need to be copied into this
         // PropertyStorageSpec?
-        PropertyStorageSpec key = new PropertyStorageSpec(columnStorageName, JdbcType.VARCHAR);
+        PropertyStorageSpec key = new PropertyStorageSpec(storageColumnName, JdbcType.VARCHAR);
         key.setPrimaryKey(true);
         return key;
     }


### PR DESCRIPTION
#### Rationale
Attempting to create a list PK with a name that's > 63 UTF-8 bytes on PosgreSQL results in a list where rows can't be updated or deleted because the storage column name is getting ignored at creation time, resulting in silent truncation on PostgreSQL. When `ListDomainKind.getPropertySpec()` sees the PK `PropertyDescriptor`, it creates a new `PropertyStorageSpec` of the appropriate data type based on key type. The problem is it sets the new PropertyStorageSpec name to the column name, not the PD's storageColumnName (which has been made "legal", truncating as appropriate).

ListDomainKind is the only DomainKind with special handling in getPropertySpec(), so I believe this issue is isolated to lists.