### PR TITLE
Issue 52506 and 52507: add rowId to source detail audit record and throw error if importing into a sibling container

### DIFF
--- a/api/src/org/labkey/api/exp/query/ExpSchema.java
+++ b/api/src/org/labkey/api/exp/query/ExpSchema.java
@@ -74,7 +74,7 @@ public class ExpSchema extends AbstractExpSchema
     public static final SchemaKey SCHEMA_EXP_DATA = SchemaKey.fromString(SCHEMA_EXP, ExpSchema.NestedSchemas.data.name());
     public static final SchemaKey SCHEMA_EXP_MATERIALS = SchemaKey.fromString(SCHEMA_EXP, ExpSchema.NestedSchemas.materials.name());
 
-    private static final Set<String> ADDITIONAL_SOURCES_AUDIT_FIELDS = new CaseInsensitiveHashSet("Name");
+    private static final Set<String> ADDITIONAL_SOURCES_AUDIT_FIELDS = new CaseInsensitiveHashSet("Name", "RowId");
 
     public enum NestedSchemas
     {

--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -28,6 +28,7 @@ import org.labkey.api.audit.DetailedAuditTypeEvent;
 import org.labkey.api.audit.SampleTimelineAuditEvent;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
@@ -285,7 +286,7 @@ public class AuditLogImpl implements AuditLogService, StartupListener
                 {
                     if (detailedEvent.getNewRecordMap() != null)
                     {
-                        Map<String, String> newRecord = AbstractAuditTypeProvider.decodeFromDataMap(detailedEvent.getNewRecordMap());
+                        Map<String, String> newRecord = new CaseInsensitiveHashMap<>(AbstractAuditTypeProvider.decodeFromDataMap(detailedEvent.getNewRecordMap()));
                         if (newRecord.containsKey("RowId"))
                             sourceIds.add(Integer.valueOf(newRecord.get("RowId")));
                         else if (newRecord.containsKey("LSID"))
@@ -301,7 +302,7 @@ public class AuditLogImpl implements AuditLogService, StartupListener
             events.forEach((event) -> {
                 if (event.getNewRecordMap() != null)
                 {
-                    Map<String, String> newRecord = AbstractAuditTypeProvider.decodeFromDataMap(event.getNewRecordMap());
+                    Map<String, String> newRecord = new CaseInsensitiveHashMap<>(AbstractAuditTypeProvider.decodeFromDataMap(event.getNewRecordMap()));
                     if (newRecord.containsKey("RowId"))
                         sourceIds.add(Integer.valueOf(newRecord.get("RowId")));
                     else if (newRecord.containsKey("LSID"))

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2667,6 +2667,11 @@ public class ExpDataIterators
                                 _context.getErrors().addRowError(new ValidationException("Invalid value '" + rowFolderId +"' provided for '" + getColumnInfo(_folderColIndex).getName() + "'."));
                                 return true;
                             }
+                            else if (_container.getEntityId() != targetContainer.getEntityId() && !_container.hasAncestor(targetContainer) && !targetContainer.hasAncestor(_container))
+                            {
+                                _context.getErrors().addRowError(new ValidationException("Import or update from folder " + _container.getName() + " into folder " + targetContainer.getName() + " not allowed."));
+                                return true;
+                            }
                         }
                     }
 

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -90,6 +90,7 @@ import org.labkey.api.query.FileColumnValueMapper;
 import org.labkey.api.query.QueryDefinition;
 import org.labkey.api.query.QueryException;
 import org.labkey.api.query.QueryKey;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.UserSchema;
@@ -2412,6 +2413,7 @@ public class ExpDataIterators
 
     public static class MultiDataTypeCrossProjectDataIterator extends WrapperDataIterator
     {
+        private static final String INVALID_FOLDER_MESSAGE = "Import or update from folder %s into folder %s is not allowed. Either you lack the proper permissions or data from that folder is not visible here.";
         private static final Set<String> IGNORED_FIELD_NAMES = Set.of("lsid", "genid");
         private static final Set<String> SAMPLE_TYPE_FIELD_NAMES = Set.of("SampleType", "Sample Type");
         private static final Set<String> CONTAINER_FIELD_NAMES = Set.of("Container", "Folder");
@@ -2509,7 +2511,12 @@ public class ExpDataIterators
                 {
                     ContainerFilter cf = ContainerFilter.current(container, user);
                     if (container.isProductFoldersEnabled())
-                        cf = new ContainerFilter.AllInProjectPlusShared(container, user);
+                    {
+                        if (container.isProject())
+                            cf = new ContainerFilter.AllInProjectPlusShared(container, user);
+                        else if (!QueryService.get().isProductFoldersDataListingScopedToProject())
+                            cf = new ContainerFilter.CurrentPlusProjectAndShared(container, user);
+                    }
                     Collection<GUID> validContainerIds =  cf.getIds();
                     if (cf instanceof ContainerFilter.ContainerFilterWithPermission cfp)
                     {
@@ -2664,12 +2671,7 @@ public class ExpDataIterators
                             targetContainer = _containerMap.get(rowFolderId);
                             if (targetContainer == null)
                             {
-                                _context.getErrors().addRowError(new ValidationException("Invalid value '" + rowFolderId +"' provided for '" + getColumnInfo(_folderColIndex).getName() + "'."));
-                                return true;
-                            }
-                            else if (_container.getEntityId() != targetContainer.getEntityId() && !_container.hasAncestor(targetContainer) && !targetContainer.hasAncestor(_container))
-                            {
-                                _context.getErrors().addRowError(new ValidationException("Import or update from folder " + _container.getName() + " into folder " + targetContainer.getName() + " not allowed. Change to a folder where data from " + targetContainer.getName() + " is visible."));
+                                _context.getErrors().addRowError(new ValidationException(String.format(INVALID_FOLDER_MESSAGE, _container.getName(), rowFolderId)));
                                 return true;
                             }
                         }
@@ -3041,7 +3043,7 @@ public class ExpDataIterators
                     if (container == null)
                     {
                         Container folder = ContainerManager.getForId(containerId);
-                        _context.getErrors().addRowError(new ValidationException("You don't have the required permission to update " + (_isSamples ? "samples" : "data") + " in the folder: " + (folder != null ? folder.getName() : containerId)));
+                        _context.getErrors().addRowError(new ValidationException(String.format(INVALID_FOLDER_MESSAGE, _container.getName(), (folder != null ? folder.getName() : containerId))));
                         return;
                     }
 

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2415,7 +2415,7 @@ public class ExpDataIterators
 
     public static class MultiDataTypeCrossProjectDataIterator extends WrapperDataIterator
     {
-        private static final String INVALID_FOLDER_MESSAGE = "Import or update from folder %s into folder %s is not allowed. Either you lack the proper permissions or data from that folder is not visible here.";
+        private static final String INVALID_FOLDER_MESSAGE = "Import or update of data in folder %s from folder %s is not allowed. Verify the folder exists, you have proper permissions, and data from that folder is visible here.";
         private static final Set<String> IGNORED_FIELD_NAMES = Set.of("lsid", "genid");
         private static final Set<String> SAMPLE_TYPE_FIELD_NAMES = Set.of("SampleType", "Sample Type");
         private static final Set<String> CONTAINER_FIELD_NAMES = Set.of("Container", "Folder");
@@ -2673,7 +2673,7 @@ public class ExpDataIterators
                             targetContainer = _containerMap.get(rowFolderId);
                             if (targetContainer == null)
                             {
-                                _context.getErrors().addRowError(new ValidationException(String.format(INVALID_FOLDER_MESSAGE, _container.getName(), rowFolderId)));
+                                _context.getErrors().addRowError(new ValidationException(String.format(INVALID_FOLDER_MESSAGE, rowFolderId, _container.getName())));
                                 return true;
                             }
                         }
@@ -3049,7 +3049,7 @@ public class ExpDataIterators
                     if (container == null)
                     {
                         Container folder = ContainerManager.getForId(containerId);
-                        _context.getErrors().addRowError(new ValidationException(String.format(INVALID_FOLDER_MESSAGE, _container.getName(), (folder != null ? folder.getName() : containerId))));
+                        _context.getErrors().addRowError(new ValidationException(String.format(INVALID_FOLDER_MESSAGE, (folder != null ? folder.getName() : containerId), _container.getName())));
                         return;
                     }
 

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2669,7 +2669,7 @@ public class ExpDataIterators
                             }
                             else if (_container.getEntityId() != targetContainer.getEntityId() && !_container.hasAncestor(targetContainer) && !targetContainer.hasAncestor(_container))
                             {
-                                _context.getErrors().addRowError(new ValidationException("Import or update from folder " + _container.getName() + " into folder " + targetContainer.getName() + " not allowed."));
+                                _context.getErrors().addRowError(new ValidationException("Import or update from folder " + _container.getName() + " into folder " + targetContainer.getName() + " not allowed. Change to a folder where data from " + targetContainer.getName() + " is visible."));
                                 return true;
                             }
                         }


### PR DESCRIPTION
#### Rationale
- Issue 52506 - [LKSM: Issues with importing into a different container than your current context](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52506)
- Issue 52507 -[LKSM: Success after updating Sources via file prompts to select them but doesn't select](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52507)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1349

#### Changes
- Include RowId as one of the detailed audit record fields so the "select them in the grid" functionality, that filters using RowId will work
- If importing or updating data into a sibling container, throw an error 
