### PR TITLE
Avoid reflecting invalid URL parameter - prevent false positive

### DIFF
--- a/api/src/org/labkey/api/view/FileServlet.java
+++ b/api/src/org/labkey/api/view/FileServlet.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 public class FileServlet extends HttpServlet
 {
     private static final Logger _log = LogManager.getLogger(FileServlet.class);
-    private static final String PAGE_FLOW_ATTR = FileServlet.class.getName() + ".pageFlow";
 
     @Override
     protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -65,11 +64,6 @@ public class FileServlet extends HttpServlet
             request.setAttribute(ViewServlet.ORIGINAL_URL_URLHELPER, helper);
         }
 
-        //The servlet path looks like a pageflow. Stash this away so that
-        //handlers can create links to other static files.
-        //We assume that this servlet is mapped to /something/*
-        String servletPath = request.getServletPath();
-        request.setAttribute(PAGE_FLOW_ATTR, servletPath.substring(1));
         String dispatchUrl = extraPath + "/filecontent-sendFile.view?" + (null == fileNameParam ? "fileName=" + PageFlowUtil.encodeURIComponent(fileName) : "");
         // NOTE other parameters seem to get magically propagated...
         RequestDispatcher r = request.getRequestDispatcher(dispatchUrl);

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -351,8 +351,11 @@ public class DavController extends SpringActionController
             }
             catch (Exception ex)
             {
-                _log.error("unexpected exception", ex);
-                ExceptionUtil.logExceptionToMothership(request, ex);
+                if (!ExceptionUtil.isIgnorable(ex))
+                {
+                    _log.error("unexpected exception", ex);
+                    ExceptionUtil.logExceptionToMothership(request, ex);
+                }
                 _webdavresponse.sendError(WebdavStatus.SC_INTERNAL_SERVER_ERROR, ex);
             }
         }

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -344,14 +344,8 @@ public class DavController extends SpringActionController
             {
                 ExceptionUtil.doErrorRedirect(response, ex.getURL());
             }
-            catch (ConfigurationException ex)
-            {
-                _log.error("Unexpected exception, might be related to server configuration problems", ex);
-                _webdavresponse.sendError(WebdavStatus.SC_INTERNAL_SERVER_ERROR, ex);
-            }
             catch (Exception ex)
             {
-                ExceptionUtil.logExceptionToMothership(request, ex);
                 _webdavresponse.sendError(WebdavStatus.SC_INTERNAL_SERVER_ERROR, ex);
             }
         }
@@ -431,7 +425,12 @@ public class DavController extends SpringActionController
 
         WebdavStatus sendError(WebdavStatus status, Exception x)
         {
-            _log.error(x instanceof ConfigurationException ? "Configuration Exception" : "Unexpected exception", x);
+            ExceptionUtil.logExceptionToMothership(getRequest(), x);
+            if (x instanceof ConfigurationException)
+            {
+                // These exceptions are skipped in the logExceptionToMothership() call. They're useful to log here
+                _log.error("Unexpected exception, likely caused by server configuration problems", x);
+            }
             String message = x.getMessage() != null ? x.getMessage() : status.message;
             if (x instanceof ConfigurationException)
                 message += "\nThis may be a server configuration problem.  Contact the site administrator.";
@@ -501,10 +500,7 @@ public class DavController extends SpringActionController
             }
             catch (Exception x)
             {
-                if (!ExceptionUtil.isClientAbortException(x))
-                {
-                    _log.error("unexpected error", x);
-                }
+                ExceptionUtil.logExceptionToMothership(getRequest(), x);
             }
             return _status;
         }
@@ -518,7 +514,7 @@ public class DavController extends SpringActionController
             }
             catch (Exception x)
             {
-                _log.error("unexpected error", x);
+                ExceptionUtil.logExceptionToMothership(getRequest(), x);
             }
             _status = status;
             return status;
@@ -779,7 +775,6 @@ public class DavController extends SpringActionController
             }
             catch (ConfigurationException ex)
             {
-                _log.error("Unexpected exception, might be related to server configuration problems", ex);
                 getResponse().sendError(WebdavStatus.SC_INTERNAL_SERVER_ERROR, ex);
             }
             catch (DavException dex)

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -351,11 +351,7 @@ public class DavController extends SpringActionController
             }
             catch (Exception ex)
             {
-                if (!ExceptionUtil.isIgnorable(ex))
-                {
-                    _log.error("unexpected exception", ex);
-                    ExceptionUtil.logExceptionToMothership(request, ex);
-                }
+                ExceptionUtil.logExceptionToMothership(request, ex);
                 _webdavresponse.sendError(WebdavStatus.SC_INTERNAL_SERVER_ERROR, ex);
             }
         }

--- a/filecontent/src/org/labkey/filecontent/FileContentController.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentController.java
@@ -1466,8 +1466,14 @@ public class FileContentController extends SpringActionController
            if (null == renderAs)
                return FileContentController.RenderStyle.PAGE;
 
-           //Will throw illegal argument exception for other values...
-           return FileContentController.RenderStyle.valueOf(renderAs.toUpperCase());
+           try
+           {
+               return FileContentController.RenderStyle.valueOf(renderAs.toUpperCase());
+           }
+           catch (IllegalArgumentException e)
+           {
+               throw new NotFoundException("Invalid renderAs value");
+           }
        }
 
        public String getFileSet()


### PR DESCRIPTION
#### Rationale
A security scanner is tripping on a reflected, properly encoded URL parameter value. It's not especially helpful for users so we can just avoid including it on the 404.

#### Changes
- Simplify user-facing error message
- Eliminate long-unused HTTP attribute
- Improve error logging in DavController