### PR TITLE
Selenium test for Issue 52536: Sample Manager: time format HH:mm:ss.SSS issues

### DIFF
--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -929,6 +929,11 @@ public class DateUtil
         return ISO_DATE_TIME_FORMAT_STRING;
     }
 
+    public static String getJsonTimeFormatString()
+    {
+        return ISO_LONG_TIME_FORMAT_STRING;
+    }
+
     /**
      * Format current date using ISO 8601 pattern. This is appropriate only for persisting dates in machine-readable
      * form, for example, for export or in filenames. Most callers should use formatDate(Container c) instead.
@@ -1121,18 +1126,12 @@ public class DateUtil
     }
 
     private static final FastDateFormat jsonDateFormat = FastDateFormat.getInstance(getJsonDateTimeFormatString());
-    private static final FastDateFormat jsonTimeFormat = FastDateFormat.getInstance(ISO_TIME_FORMAT_STRING);
+    private static final FastDateFormat jsonTimeFormat = FastDateFormat.getInstance(getJsonTimeFormatString());
 
     public static String formatJsonDateTime(Date date)
     {
         if (date instanceof Time)
-        {
-            ViewContext context = HttpView.currentContext();
-            if (context != null && context.getContainer() != null)
-                return FastDateFormat.getInstance(FolderSettingsCache.getDefaultTimeFormat(context.getContainer())).format(date);
-
             return jsonTimeFormat.format(date);
-        }
 
         return jsonDateFormat.format(date);
     }


### PR DESCRIPTION
#### Rationale
`formatJsonDateTime` uses container's time format to format query response json values. This is problematic when the folder level precision is less than field level format precision. For example, when folder time format is "HH:mm" but a field has format "HH:mm:ss.SSS", form data during edit would show 00.000 as ss.SSS. 

Test coverage is added in related [pr](https://github.com/LabKey/limsModules/pull/1356)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6597
- https://github.com/LabKey/limsModules/pull/1356

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
