### PR TITLE
Issue 52592: resolve correct unassigned samples folder column

### DIFF
--- a/api/src/org/labkey/api/exp/query/ExpMaterialTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpMaterialTable.java
@@ -17,6 +17,7 @@
 package org.labkey.api.exp.query;
 
 import org.labkey.api.data.UpdateableTableInfo;
+import org.labkey.api.query.FieldKey;
 
 public interface ExpMaterialTable extends ExpTable<ExpMaterialTable.Column>, UpdateableTableInfo
 {
@@ -60,7 +61,12 @@ public interface ExpMaterialTable extends ExpTable<ExpMaterialTable.Column>, Upd
         SourceProtocolLSID,
         StoredAmount,
         Units,
-        IsPlated,
+        IsPlated;
+
+        public FieldKey fieldKey()
+        {
+            return FieldKey.fromParts(name());
+        }
     }
 
     default void setSupportTableRules(boolean supportTableRules)


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/limsModules/pull/1358 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/740
- https://github.com/LabKey/limsModules/pull/1358
- https://github.com/LabKey/platform/pull/6598

#### Changes
- Add `ExpMaterialTable.Column.fieldKey()` utility
