### PR TITLE
Define text encoder and decoder supplied by node in Jest/JSDOM environments

### DIFF
--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
-        "@labkey/test": "1.8.0",
+        "@labkey/test": "1.8.1-fb-node-text-encoder.0",
         "@types/jest": "29.5.14",
         "@types/react": "18.3.20",
         "@types/react-dom": "18.3.6",
@@ -2873,9 +2873,9 @@
       }
     },
     "node_modules/@labkey/test": {
-      "version": "1.8.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.8.0.tgz",
-      "integrity": "sha512-PkY0/ND2nU+oxXhp6/8YcWu7qI6KCNWgGFK/HoEvebz3Hyzj/uVNe5L9gm+fCp5pXMHgHk8FeX538+0T7ZD4eg==",
+      "version": "1.8.1-fb-node-text-encoder.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.8.1-fb-node-text-encoder.0.tgz",
+      "integrity": "sha512-P0/aMl0AwB2+lciITXWWcTCALGNZApBE4oqJ1yV5RmNPy/K9lBK4qjL/bZJydEAKmSfdtIYKXd3sgCzKgiPJdg==",
       "dev": true,
       "dependencies": {
         "properties-reader": "2.3.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
-        "@labkey/test": "1.8.1-fb-node-text-encoder.0",
+        "@labkey/test": "1.8.1",
         "@types/jest": "29.5.14",
         "@types/react": "18.3.20",
         "@types/react-dom": "18.3.6",
@@ -2873,9 +2873,9 @@
       }
     },
     "node_modules/@labkey/test": {
-      "version": "1.8.1-fb-node-text-encoder.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.8.1-fb-node-text-encoder.0.tgz",
-      "integrity": "sha512-P0/aMl0AwB2+lciITXWWcTCALGNZApBE4oqJ1yV5RmNPy/K9lBK4qjL/bZJydEAKmSfdtIYKXd3sgCzKgiPJdg==",
+      "version": "1.8.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/test/-/@labkey/test-1.8.1.tgz",
+      "integrity": "sha512-sCVOCr8eD4qf8Tf0zKlIhh91ziY+9lMXhSVTugjuaYskDUjzsaOAgaXAlgbIJdEevAU19qbIlF7lGOSJGKowhQ==",
       "dev": true,
       "dependencies": {
         "properties-reader": "2.3.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",
-    "@labkey/test": "1.8.1-fb-node-text-encoder.0",
+    "@labkey/test": "1.8.1",
     "@types/jest": "29.5.14",
     "@types/react": "18.3.20",
     "@types/react-dom": "18.3.6",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",
-    "@labkey/test": "1.8.0",
+    "@labkey/test": "1.8.1-fb-node-text-encoder.0",
     "@types/jest": "29.5.14",
     "@types/react": "18.3.20",
     "@types/react-dom": "18.3.6",


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-ui-components/pull/1781 for rationale

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1781
- https://github.com/LabKey/limsModules/pull/1359
- https://github.com/LabKey/platform/pull/6599

#### Changes
- Bump `@labkey/test`
- Rehydrate package-lock.json to ensure error is fixed (note: not difference here since this has already been rehydrated which caused this failure to be observed).