### PR TITLE
Issue 52570: Assay run move to include source and target containers in the audit event message

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -2111,14 +2111,13 @@ public abstract class AbstractAssayProvider implements AssayProvider
 
         for (String fileField : fileFields)
         {
+            var fileColumn = assayResultTable.getColumn(fileField);
             TableSelector ts = new TableSelector(assayResultTable, assayResultTable.getColumns("rowid", "run", fileField), filter, null);
             Map<String, Object>[] resultFiles = ts.getMapArray();
-            String columnAlias = assayResultTable.getColumn(fileField).getAlias(); // Issue 52888
-            String columnSelectName = assayResultTable.getColumn(fileField).getSelectName();
 
             for (Map<String, Object> resultRow : resultFiles)
             {
-                String sourceFileName = (String) resultRow.get(columnAlias);
+                String sourceFileName = (String) fileColumn.getValue(resultRow);
                 if (StringUtils.isEmpty(sourceFileName))
                     continue;
                 Integer resultRowId = (Integer) resultRow.get("rowid");
@@ -2147,9 +2146,11 @@ public abstract class AbstractAssayProvider implements AssayProvider
 
                     fileContentService.fireFileMoveEvent(sourceFile.toPath(), updatedFile.toPath(), user, sourceContainer, targetContainer);
 
+                    var realTable = assayResultTable.getRealTable();
+                    var realFileColumn = realTable.getColumn(fileField);
                     updateSql = new SQLFragment("UPDATE ").append(assayResultTable.getRealTable())
                             .append(" SET ")
-                            .append(columnSelectName)
+                            .appendIdentifier(realFileColumn.getSelectName())
                             .append(" = ").appendValue(updatedFile.getAbsolutePath())
                             .append(" WHERE rowId = ").appendValue(resultRowId);
                     new SqlExecutor(assayResultTable.getSchema()).execute(updateSql);

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -994,8 +994,9 @@ public interface ExperimentService extends ExperimentRunTypeSource
 
     HttpView<?> createFileExportView(Container container, User user, String defaultFilenamePrefix);
 
-    void auditRunEvent(User user, ExpProtocol protocol, ExpRun run, @Nullable ExpExperiment runGroup, String message);
-    void auditRunEvent(User user, ExpProtocol protocol, ExpRun run, @Nullable ExpExperiment runGroup, String message, String userComment);
+    void auditRunEvent(User user, ExpProtocol protocol, ExpRun run, @Nullable ExpExperiment runGroup, String comment);
+    void auditRunEvent(User user, ExpProtocol protocol, ExpRun run, @Nullable ExpExperiment runGroup, String comment, String userComment);
+    void auditRunEvent(User user, ExpProtocol protocol, ExpRun run, @Nullable ExpExperiment runGroup, String comment, String userComment, @Nullable String message);
 
     List<? extends ExpExperiment> getMatchingBatches(String name, Container container, ExpProtocol protocol);
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -424,6 +424,12 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public void auditRunEvent(User user, ExpProtocol protocol, ExpRun run, @Nullable ExpExperiment runGroup, String comment, String userComment)
     {
+        auditRunEvent(user, protocol, run, runGroup, comment, userComment, null);
+    }
+
+    @Override
+    public void auditRunEvent(User user, ExpProtocol protocol, ExpRun run, @Nullable ExpExperiment runGroup, String comment, String userComment, @Nullable String message)
+    {
         Container c = run != null ? run.getContainer() : protocol.getContainer();
         ExperimentAuditEvent event = new ExperimentAuditEvent(c, comment);
         event.setUserComment(userComment);
@@ -433,7 +439,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (run != null)
             event.setRunLsid(run.getLSID());
         event.setProtocolRun(ExperimentAuditProvider.getKey3(protocol, run));
-
+        if (message != null)
+            event.setMessage(message);
         AuditLogService.get().addEvent(user, event);
     }
 
@@ -9777,7 +9784,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                         for (ExpRun run : runs)
                         {
                             run.setContainer(targetContainer);
-                            auditRunEvent(user, protocol, run, null, "Assay run was moved.", userComment);
+
+                            // Issue 52570: include source and target containers in the audit event message
+                            String message = String.format("Moved from %s to %s", container.getPath(), targetContainer.getPath());
+                            auditRunEvent(user, protocol, run, null, "Assay run was moved.", userComment, message);
                         }
                     }
                 }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52570

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1361

#### Changes
- include source and target containers in the audit event message
