### PR TITLE
Avoid logging UnauthorizedException visiting exp.Files as reader

### DIFF
--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -70,6 +70,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
+import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.RandomSiteSettingsPropertyHandler;
 import org.labkey.api.settings.StartupPropertyEntry;
@@ -1461,6 +1462,11 @@ public class FileContentServiceImpl implements FileContentService, WarningProvid
         if (qus == null)
         {
             throw new IllegalArgumentException("getUpdateServer() returned null from " + table);
+        }
+        if (!container.hasPermission(user, InsertPermission.class))
+        {
+            // Could also swap in a service user, like User.getAdminServiceUser()
+            return;
         }
 
         synchronized (_fileDataUpToDateCache)

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -1457,16 +1457,12 @@ public class FileContentServiceImpl implements FileContentService, WarningProvid
     public void ensureFileData(@NotNull ExpDataTable table)
     {
         Container container = table.getUserSchema().getContainer();
-        User user = table.getUserSchema().getUser();
+        // The current user may not have insert permission, and they didn't necessarily upload the files anyway
+        User user = User.getAdminServiceUser();
         QueryUpdateService qus = table.getUpdateService();
         if (qus == null)
         {
             throw new IllegalArgumentException("getUpdateServer() returned null from " + table);
-        }
-        if (!container.hasPermission(user, InsertPermission.class))
-        {
-            // Could also swap in a service user, like User.getAdminServiceUser()
-            return;
         }
 
         synchronized (_fileDataUpToDateCache)


### PR DESCRIPTION
#### Rationale
```
org.labkey.api.view.UnauthorizedException: You do not have permission to insert data into this table.
	at org.labkey.api.query.AbstractQueryUpdateService._insertRowsUsingInsertRow(AbstractQueryUpdateService.java:560) ~[api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.query.AbstractQueryUpdateService.insertRows(AbstractQueryUpdateService.java:673) ~[api-25.5-SNAPSHOT.jar:?]
	at org.labkey.filecontent.FileContentServiceImpl.ensureFileData(FileContentServiceImpl.java:1543) [filecontent-25.5-SNAPSHOT.jar:?]
	at org.labkey.experiment.api.ExpFilesTableImpl.getFromSQL(ExpFilesTableImpl.java:64) [experiment-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.query.FilteredTable.getFromSQL(FilteredTable.java:516) [api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.data.AbstractTableInfo.getFromSQLExpanded(AbstractTableInfo.java:407) [api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.data.AbstractTableInfo.getFromSQL(AbstractTableInfo.java:402) [api-25.5-SNAPSHOT.jar:?]
	at org.labkey.query.sql.QuerySelectView.getSelectSQL(QuerySelectView.java:336) [query-25.5-SNAPSHOT.jar:?]
	at org.labkey.query.sql.QuerySelectView.getSql(QuerySelectView.java:163) [query-25.5-SNAPSHOT.jar:?]
	at org.labkey.query.QueryServiceImpl$SelectBuilderImpl.buildSqlFragment(QueryServiceImpl.java:2865) [query-25.5-SNAPSHOT.jar:?]
	at org.labkey.query.controllers.QueryController$SelectDistinctAction.getDistinctSql(QueryController.java:3818) [query-25.5-SNAPSHOT.jar:?]
	at org.labkey.query.controllers.QueryController$SelectDistinctAction.execute(QueryController.java:3731) [query-25.5-SNAPSHOT.jar:?]
	at org.labkey.query.controllers.QueryController$SelectDistinctAction.execute(QueryController.java:3721) [query-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.action.BaseApiAction.handlePost(BaseApiAction.java:240) [api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.action.ReadOnlyApiAction.handleGet(ReadOnlyApiAction.java:46) [api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.action.BaseApiAction.handleRequest(BaseApiAction.java:132) [api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.action.BaseViewAction.handleRequest(BaseViewAction.java:190) [api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.action.ReadOnlyApiAction.handleRequest(ReadOnlyApiAction.java:40) [api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.action.SpringActionController.handleRequest(SpringActionController.java:527) [api-25.5-SNAPSHOT.jar:?]
	at org.labkey.api.module.DefaultModule.dispatch(DefaultModule.java:1124) [api-25.5-SNAPSHOT.jar:?]
```

#### Changes
- Avoid doing the work to enumerate files and insert them into `exp.Data` when the user doesn't have permissions