### PR TITLE
Issue 52922: Samples with blank sample id in the file are getting ignored

### DIFF
--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -257,6 +257,10 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                 comma = "\n,";
                 for (int p = 0; p < pkColumns.size(); p++)
                 {
+                    // Issue 52922: Rows with blank key in the file are getting ignored in update from file
+                    if (pkSuppliers.get(p).get() == null)
+                        _context.getErrors().addRowError(new ValidationException(pkColumns.get(p).getColumnName() + " value not provided on row " + lastPrefetchRowNumber));
+
                     sqlf.append(",?");
                     sqlf.add(pkSuppliers.get(p).get());
                 }
@@ -371,7 +375,13 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
                     lastPrefetchRowNumber = (Integer) _delegate.get(0);
                     Map<String,Object> keyMap = CaseInsensitiveHashMap.of();
                     for (int p=0 ; p<pkColumns.size() ; p++)
+                    {
+                        // Issue 52922: Rows with blank key in the file are getting ignored in update from file
+                        if (pkSuppliers.get(p).get() == null)
+                            _context.getErrors().addRowError(new ValidationException(pkColumns.get(p).getColumnName() + " value not provided on row " + lastPrefetchRowNumber));
+
                         keyMap.put(pkColumns.get(p).getColumnName(), pkSuppliers.get(p).get());
+                    }
                     keysMap.put(lastPrefetchRowNumber, keyMap);
                     existingRecords.put(lastPrefetchRowNumber, Map.of());
                 }

--- a/api/src/org/labkey/api/dataiterator/SampleUpdateAddColumnsDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/SampleUpdateAddColumnsDataIterator.java
@@ -129,7 +129,7 @@ public class SampleUpdateAddColumnsDataIterator extends WrapperDataIterator
             else if (keyObj instanceof Number)
                 key = keyObj.toString();
             if (StringUtils.isEmpty(key))
-                throw new IllegalArgumentException("Key value not provided on row " + lastPrefetchRowNumber);
+                throw new IllegalArgumentException(KEY_COLUMN_NAME + " value not provided on row " + lastPrefetchRowNumber);
 
             rowKeyMap.put(lastPrefetchRowNumber, key);
             keyRowMap.put(key, lastPrefetchRowNumber);

--- a/experiment/src/client/test/integration/DataClassCrud.ispec.ts
+++ b/experiment/src/client/test/integration/DataClassCrud.ispec.ts
@@ -1,4 +1,4 @@
-import { hookServer, RequestOptions, successfulResponse } from '@labkey/test';
+import { ExperimentCRUDUtils, hookServer, RequestOptions, successfulResponse } from '@labkey/test';
 import mock from 'mock-fs';
 import {
     checkDomainName,
@@ -226,6 +226,101 @@ describe('Data Class Designer', () => {
             expect(removedDataType).toEqual(0);
         });
     });
+
+});
+
+describe('Import with update / merge', () => {
+   it ("Issue 52922: Blank sample id in the file are getting ignored in update from file", async () => {
+       const BLANK_KEY_UPDATE_ERROR_NO_EXPRESSION = 'Missing value for required property: Name';
+       const BLANK_KEY_UPDATE_ERROR_WITH_EXPRESSION = 'Name value not provided on row ';
+       const BOGUS_KEY_UPDATE_ERROR = 'Data not found for ';
+       const CROSS_FOLDER_UPDATE_NOT_SUPPORTED_ERROR = "Data doesn't belong to folder ";
+
+       const dataType = "NoExpressionNameRequired52922";
+       const createPayload = {
+           kind: 'DataClass',
+           domainDesign: { name: dataType, fields: [{ name: 'Prop' }] },
+           options: {
+               name: dataType,
+           }
+       };
+       await server.post('property', 'createDomain', createPayload,
+           {...topFolderOptions, ...designerReaderOptions}).expect(successfulResponse);
+       const dataName = "Data1";
+       await ExperimentCRUDUtils.insertRows(server, [{
+           name: dataName,
+           description: 'created'
+       }], 'exp.data', dataType, topFolderOptions, editorUserOptions);
+
+       // Issue 52922: Blank / bogus  id in the file are getting ignored in update from file
+       let blankKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataType, "UPDATE", topFolderOptions, editorUserOptions);
+       expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR_NO_EXPRESSION) > -1).toBeTruthy();
+       blankKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataType, "UPDATE", subfolder1Options, editorUserOptions);
+       expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR_NO_EXPRESSION) > -1).toBeTruthy();
+       blankKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\n\tisBlank", dataType, "UPDATE", topFolderOptions, editorUserOptions);
+       expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR_NO_EXPRESSION) > -1).toBeTruthy();
+       blankKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataType, "MERGE", topFolderOptions, editorUserOptions);
+       expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR_NO_EXPRESSION) > -1).toBeTruthy();
+       blankKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataType, "MERGE", subfolder1Options, editorUserOptions);
+       expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR_NO_EXPRESSION) > -1).toBeTruthy();
+       blankKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\n\tisBlank", dataType, "MERGE", topFolderOptions, editorUserOptions);
+       expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR_NO_EXPRESSION) > -1).toBeTruthy();
+       // bogus name
+       let bogusKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nbogus\tisBogus", dataType, "UPDATE", topFolderOptions, editorUserOptions);
+       expect(bogusKeyProvidedError.text.indexOf(BOGUS_KEY_UPDATE_ERROR) > -1).toBeTruthy();
+       bogusKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nData1\tNotblank\nbogus\tisBogus", dataType, "UPDATE", topFolderOptions, editorUserOptions);
+       expect(bogusKeyProvidedError.text.indexOf(BOGUS_KEY_UPDATE_ERROR) > -1).toBeTruthy();
+
+       const dataTypeWithExpression = "WithExpressionNameNotRequired52922";
+       let createPayloadWithExpression = {
+           kind: 'DataClass',
+           domainDesign: { name: dataTypeWithExpression, fields: [{ name: 'Prop' }] },
+           options: {
+               name: dataTypeWithExpression,
+               nameExpression: 'Src-${genId}',
+
+           }
+       };
+       await server.post('property', 'createDomain', createPayloadWithExpression,
+           {...topFolderOptions, ...designerReaderOptions}).expect(successfulResponse);
+       await ExperimentCRUDUtils.insertRows(server, [{
+           name: dataName,
+           description: 'created'
+       }], 'exp.data', dataTypeWithExpression, topFolderOptions, editorUserOptions);
+
+       // blank name
+       blankKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataTypeWithExpression, "UPDATE", topFolderOptions, editorUserOptions);
+       expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR_WITH_EXPRESSION + 2) > -1).toBeTruthy();
+       blankKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataTypeWithExpression, "UPDATE", subfolder1Options, editorUserOptions);
+       expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR_WITH_EXPRESSION + 2) > -1).toBeTruthy();
+       blankKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\n\tisBlank", dataTypeWithExpression, "UPDATE", topFolderOptions, editorUserOptions);
+       expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR_WITH_EXPRESSION + 1) > -1).toBeTruthy();
+
+       // merge with blank name for data type with naming expression should not fail
+       let successResp = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataTypeWithExpression, "MERGE", topFolderOptions, editorUserOptions);
+       expect(successResp.text.indexOf('"success" : true') > -1).toBeTruthy();
+       successResp = await ExperimentCRUDUtils.importData(server, "Name\tDescription\n\tisBlank", dataTypeWithExpression, "MERGE", topFolderOptions, editorUserOptions);
+       expect(successResp.text.indexOf('"success" : true') > -1).toBeTruthy();
+       successResp = await ExperimentCRUDUtils.importData(server, "Name\tDescription\n\tisBlank", dataTypeWithExpression, "MERGE", subfolder1Options, editorUserOptions);
+       expect(successResp.text.indexOf('"success" : true') > -1).toBeTruthy();
+
+       // cross folder update not supported when folder type is "Collaboration"
+       let crossFolderErrorResp = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataTypeWithExpression, "MERGE", subfolder1Options, editorUserOptions);
+       expect(crossFolderErrorResp.text.indexOf(CROSS_FOLDER_UPDATE_NOT_SUPPORTED_ERROR) > -1).toBeTruthy();
+       crossFolderErrorResp = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataTypeWithExpression, "UPDATE", subfolder1Options, editorUserOptions);
+       expect(crossFolderErrorResp.text.indexOf(CROSS_FOLDER_UPDATE_NOT_SUPPORTED_ERROR) > -1).toBeTruthy();
+
+       // bogus name
+       bogusKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nbogus\tisBogus", dataTypeWithExpression, "UPDATE", topFolderOptions, editorUserOptions);
+       expect(bogusKeyProvidedError.text.indexOf(BOGUS_KEY_UPDATE_ERROR) > -1).toBeTruthy();
+       bogusKeyProvidedError = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nData1\tNotblank\nbogus\tisBogus", dataTypeWithExpression, "UPDATE", topFolderOptions, editorUserOptions);
+       expect(bogusKeyProvidedError.text.indexOf(BOGUS_KEY_UPDATE_ERROR) > -1).toBeTruthy();
+
+       // merge with bogus name should create a new data and not fail
+       successResp = await ExperimentCRUDUtils.importData(server, "Name\tDescription\nData1\tNotblank\nbogusShouldCreate\tisBogus", dataTypeWithExpression, "MERGE", topFolderOptions, editorUserOptions);
+       expect(successResp.text.indexOf('"success" : true') > -1).toBeTruthy();
+
+   });
 
 });
 

--- a/experiment/src/client/test/integration/SampleTypeCrud.ispec.ts
+++ b/experiment/src/client/test/integration/SampleTypeCrud.ispec.ts
@@ -313,6 +313,81 @@ describe('Sample Type Designer', () => {
 });
 
 
+describe('Import with update / merge', () => {
+    it ("Issue 52922: Blank sample id in the file are getting ignored in update from file", async () => {
+        const BLANK_KEY_UPDATE_ERROR = 'Name value not provided on row ';
+        const BLANK_KEY_MERGE_ERROR_NO_EXPRESSION = 'SampleID or Name is required for sample on row';
+        const BOGUS_KEY_UPDATE_ERROR = 'Sample does not exist: bogus.';
+        const CROSS_FOLDER_UPDATE_NOT_SUPPORTED_ERROR = "Sample does not belong to ";
+
+        const dataType = SAMPLE_ALIQUOT_IMPORT_NO_NAME_PATTERN_NAME;
+        const dataName = "Data1";
+        await ExperimentCRUDUtils.insertRows(server, [{
+            name: dataName,
+            description: 'created'
+        }], 'samples', dataType, topFolderOptions, editorUserOptions);
+
+        // Issue 52922: Blank / bogus  id in the file are getting ignored in update from file
+        let blankKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataType, "UPDATE", topFolderOptions, editorUserOptions);
+        expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR + 2) > -1).toBeTruthy();
+        blankKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataType, "UPDATE", subfolder1Options, editorUserOptions);
+        expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR + 2) > -1).toBeTruthy();
+        blankKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\n\tisBlank", dataType, "UPDATE", topFolderOptions, editorUserOptions);
+        expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR + 1) > -1).toBeTruthy();
+        blankKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataType, "MERGE", topFolderOptions, editorUserOptions);
+        expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_MERGE_ERROR_NO_EXPRESSION) > -1).toBeTruthy();
+        blankKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataType, "MERGE", subfolder1Options, editorUserOptions);
+        expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_MERGE_ERROR_NO_EXPRESSION) > -1).toBeTruthy();
+        blankKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\n\tisBlank", dataType, "MERGE", topFolderOptions, editorUserOptions);
+        expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_MERGE_ERROR_NO_EXPRESSION) > -1).toBeTruthy();
+        // bogus name
+        let bogusKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nbogus\tisBogus", dataType, "UPDATE", topFolderOptions, editorUserOptions);
+        expect(bogusKeyProvidedError.text.indexOf(BOGUS_KEY_UPDATE_ERROR) > -1).toBeTruthy();
+        bogusKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nData1\tNotblank\nbogus\tisBogus", dataType, "UPDATE", topFolderOptions, editorUserOptions);
+        expect(bogusKeyProvidedError.text.indexOf(BOGUS_KEY_UPDATE_ERROR) > -1).toBeTruthy();
+
+        const dataTypeWithExpression = SAMPLE_ALIQUOT_IMPORT_TYPE_NAME;
+        await ExperimentCRUDUtils.insertRows(server, [{
+            name: dataName,
+            description: 'created'
+        }], 'samples', dataTypeWithExpression, topFolderOptions, editorUserOptions);
+
+        // blank name
+        blankKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataTypeWithExpression, "UPDATE", topFolderOptions, editorUserOptions);
+        expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR + 2) > -1).toBeTruthy();
+        blankKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataTypeWithExpression, "UPDATE", subfolder1Options, editorUserOptions);
+        expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR + 2) > -1).toBeTruthy();
+        blankKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\n\tisBlank", dataTypeWithExpression, "UPDATE", topFolderOptions, editorUserOptions);
+        expect(blankKeyProvidedError.text.indexOf(BLANK_KEY_UPDATE_ERROR + 1) > -1).toBeTruthy();
+
+        // merge with blank name for data type with naming expression should not fail
+        let successResp = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataTypeWithExpression, "MERGE", topFolderOptions, editorUserOptions);
+        expect(successResp.text.indexOf('"success" : true') > -1).toBeTruthy();
+        successResp = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\n\tisBlank", dataTypeWithExpression, "MERGE", topFolderOptions, editorUserOptions);
+        expect(successResp.text.indexOf('"success" : true') > -1).toBeTruthy();
+        successResp = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\n\tisBlank", dataTypeWithExpression, "MERGE", subfolder1Options, editorUserOptions);
+        expect(successResp.text.indexOf('"success" : true') > -1).toBeTruthy();
+
+        // cross folder update not supported when folder type is "Collaboration"
+        let crossFolderUpdateErrorResp = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nData1\tNotblank", dataTypeWithExpression, "UPDATE", subfolder1Options, editorUserOptions);
+        expect(crossFolderUpdateErrorResp.text.indexOf(CROSS_FOLDER_UPDATE_NOT_SUPPORTED_ERROR) > -1).toBeTruthy();
+        let crossFolderMergeErrorResp = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nData1\tNotblank\n\tisBlank", dataTypeWithExpression, "MERGE", subfolder1Options, editorUserOptions);
+        expect(crossFolderMergeErrorResp.text.indexOf(CROSS_FOLDER_UPDATE_NOT_SUPPORTED_ERROR) > -1).toBeTruthy();
+
+        // bogus name
+        bogusKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nbogus\tisBogus", dataTypeWithExpression, "UPDATE", topFolderOptions, editorUserOptions);
+        expect(bogusKeyProvidedError.text.indexOf(BOGUS_KEY_UPDATE_ERROR) > -1).toBeTruthy();
+        bogusKeyProvidedError = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nData1\tNotblank\nbogus\tisBogus", dataTypeWithExpression, "UPDATE", topFolderOptions, editorUserOptions);
+        expect(bogusKeyProvidedError.text.indexOf(BOGUS_KEY_UPDATE_ERROR) > -1).toBeTruthy();
+
+        // merge with bogus name should create a new data and not fail
+        successResp = await ExperimentCRUDUtils.importSample(server, "Name\tDescription\nData1\tNotblank\nbogusShouldCreate\tisBogus", dataTypeWithExpression, "MERGE", topFolderOptions, editorUserOptions);
+        expect(successResp.text.indexOf('"success" : true') > -1).toBeTruthy();
+
+    });
+
+});
+
 
 describe('Aliquot crud', () => {
     describe("SMAliquotImportExportTest", () => {

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2665,7 +2665,7 @@ public class ExpDataIterators
             }
             if (!notFoundIds.isEmpty())
             {
-                _context.getErrors().addRowError(new ValidationException(_isSamples ? "Samples" : "Data" + " not found for " + StringUtils.join(notFoundIds, ",")));
+                _context.getErrors().addRowError(new ValidationException(_isSamples ? "Samples" : "Data" + " not found for " + StringUtils.join(notFoundIds, ", ")));
                 return false;
             }
 

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2665,7 +2665,7 @@ public class ExpDataIterators
             }
             if (!notFoundIds.isEmpty())
             {
-                _context.getErrors().addRowError(new ValidationException(_isSamples ? "Samples" : "Data" + " not found for " + StringUtils.join(notFoundIds, ", ")));
+                _context.getErrors().addRowError(new ValidationException((_isSamples ? "Samples" : "Data") + " not found for " + StringUtils.join(notFoundIds, ", ")));
                 return false;
             }
 

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -3099,7 +3099,7 @@ public class ExpDataIterators
                 else if (index == _dataIdIndex && _isCrossFolderUpdate)
                 {
                     // Issue 52922: Samples with blank sample id in the file are getting ignored
-                    throw new IllegalArgumentException("Key value not provided on row " + get(0));
+                    throw new IllegalArgumentException("Name value not provided on row " + get(0));
                 }
             });
             typeData.dataRows.add(StringUtils.join(dataRow, "\t"));

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2646,9 +2646,12 @@ public class ExpDataIterators
             }
 
             Map<String, Object>[] rows = new TableSelector(tableInfo, Set.of("name", "container"), filter, null).getMapArray();
+
+            Set<String> notFoundIds = new HashSet<>(typeData.dataIds);
             for (Map<String, Object> row : rows)
             {
                 String name = (String) row.get("name");
+                notFoundIds.remove(name);
                 String dataContainer = (String) row.get("container");
                 int sampleRowId = typeData.dataIds.indexOf(name) + 1 /* header row */;
 
@@ -2659,6 +2662,11 @@ public class ExpDataIterators
                 }
 
                 containerRows.get(dataContainer).add(sampleRowId);
+            }
+            if (!notFoundIds.isEmpty())
+            {
+                _context.getErrors().addRowError(new ValidationException(_isSamples ? "Samples" : "Data" + " not found for " + StringUtils.join(notFoundIds)));
+                return false;
             }
 
             if (!hasCrossFolderData)

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -3096,6 +3096,11 @@ public class ExpDataIterators
                         _parentIdsPerType.computeIfAbsent(parentTypeName, k -> new HashSet<>()).add(data.toString());
                     }
                 }
+                else if (index == _dataIdIndex && _isCrossFolderUpdate)
+                {
+                    // Issue 52922: Samples with blank sample id in the file are getting ignored
+                    throw new IllegalArgumentException("Key value not provided on row " + get(0));
+                }
             });
             typeData.dataRows.add(StringUtils.join(dataRow, "\t"));
         }

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2665,7 +2665,7 @@ public class ExpDataIterators
             }
             if (!notFoundIds.isEmpty())
             {
-                _context.getErrors().addRowError(new ValidationException(_isSamples ? "Samples" : "Data" + " not found for " + StringUtils.join(notFoundIds)));
+                _context.getErrors().addRowError(new ValidationException(_isSamples ? "Samples" : "Data" + " not found for " + StringUtils.join(notFoundIds, ",")));
                 return false;
             }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -1242,9 +1242,8 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
         if (checkCrossFolderData && !allKeys.isEmpty())
         {
-            ContainerFilter allCf = ContainerFilter.current(container); // use a relaxed CF to find existing data from cross containers
-            if (container.isProductFoldersEnabled())
-                allCf = new ContainerFilter.AllInProjectPlusShared(container, user);
+            // Issue 52922: cross folder merge without Product Folders enabled silently ignores the cross folder row update
+            ContainerFilter allCf = new ContainerFilter.AllInProjectPlusShared(container, user); // use a relaxed CF to find existing data from cross containers
 
             SimpleFilter existingDataFilter = new SimpleFilter(FieldKey.fromParts("MaterialSourceId"), sampleTypeId);
             existingDataFilter.addCondition(FieldKey.fromParts("Container"), allCf.getIds(), CompareType.IN);


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6603
- https://github.com/LabKey/limsModules/pull/1367

#### Changes
- Add a check for null PK values in ExistingDataIterator to fail the import for update / merge
- Add null check for key values during cross folder file split step
