### PR TITLE
Misc 25.5 assay result issue fixes (assay result delete rows issue 51126, assay unresolved sample lookup issue 52745)

### DIFF
--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -387,7 +387,7 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
             for (DomainProperty dp : datatableInfo.getDomain().getNonBaseProperties())
             {
                 if (AssaySampleLookupContext.checkSampleLookup(container, user, dp).isLookup())
-                    _assaySampleLookupContext.trackSampleLookupChange(container, user, datatableInfo, datatableInfo.getColumn("SampleId"), run);
+                    _assaySampleLookupContext.trackSampleLookupChange(container, user, datatableInfo, datatableInfo.getColumn(dp.getName()), run);
             }
         }
 
@@ -400,6 +400,7 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
         var result = super.deleteRows(user, container, keys, configParameters, extraScriptContext);
 
         BatchValidationException errors = new BatchValidationException();
+        errors.setExtraContext(extraScriptContext);
         _assaySampleLookupContext.syncLineage(container, user, errors);
         if (errors.hasErrors())
             throw errors;

--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -381,6 +381,29 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
             }
         }
 
+        // Issue 51126: need to track and resync run/sample lineage on delete in the same way we do for update
+        if (datatableInfo.getDomain() != null)
+        {
+            for (DomainProperty dp : datatableInfo.getDomain().getNonBaseProperties())
+            {
+                if (AssaySampleLookupContext.checkSampleLookup(container, user, dp).isLookup())
+                    _assaySampleLookupContext.trackSampleLookupChange(container, user, datatableInfo, datatableInfo.getColumn("SampleId"), run);
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<Map<String, Object>> deleteRows(User user, Container container, List<Map<String, Object>> keys, @Nullable Map<Enum, Object> configParameters, @Nullable Map<String, Object> extraScriptContext) throws InvalidKeyException, BatchValidationException, QueryUpdateServiceException, SQLException
+    {
+        var result = super.deleteRows(user, container, keys, configParameters, extraScriptContext);
+
+        BatchValidationException errors = new BatchValidationException();
+        _assaySampleLookupContext.syncLineage(container, user, errors);
+        if (errors.hasErrors())
+            throw errors;
+
         return result;
     }
 

--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -385,10 +385,7 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
         if (datatableInfo.getDomain() != null)
         {
             for (DomainProperty dp : datatableInfo.getDomain().getNonBaseProperties())
-            {
-                if (AssaySampleLookupContext.checkSampleLookup(container, user, dp).isLookup())
-                    _assaySampleLookupContext.trackSampleLookupChange(container, user, datatableInfo, datatableInfo.getColumn(dp.getName()), run);
-            }
+                _assaySampleLookupContext.trackSampleLookupChange(container, user, datatableInfo, datatableInfo.getColumn(dp.getName()), run);
         }
 
         return result;

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -258,7 +258,9 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 String rootMaterialRowIdField = ExprColumn.STR_TABLE_ALIAS + "." + Column.RootMaterialRowId.name();
                 String rowIdField = ExprColumn.STR_TABLE_ALIAS + "." + Column.RowId.name();
                 ExprColumn columnInfo = new ExprColumn(this, FieldKey.fromParts(Column.IsAliquot.name()), new SQLFragment(
-                        "(CASE WHEN (" + rootMaterialRowIdField + " = " + rowIdField + ") THEN ").append(getSqlDialect().getBooleanFALSE()).append(" ELSE ").append(getSqlDialect().getBooleanTRUE()).append(" END)"), JdbcType.BOOLEAN);
+                        "(CASE WHEN (" + rootMaterialRowIdField + " = " + rowIdField + ") THEN ").append(getSqlDialect().getBooleanFALSE())
+                        .append(" WHEN ").append(rowIdField).append(" IS NOT NULL THEN ").append(getSqlDialect().getBooleanTRUE()) // Issue 52745
+                        .append(" ELSE NULL END)"), JdbcType.BOOLEAN);
                 columnInfo.setLabel("Is Aliquot");
                 columnInfo.setDescription("Identifies if the material is a sample or an aliquot");
                 columnInfo.setUserEditable(false);
@@ -791,8 +793,9 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
             sql = new SQLFragment()
                     .append("CASE WHEN EXISTS (")
                     .append(existsSubquery)
-                    .append(") THEN 'Plated' ELSE 'Not Plated'")
-                    .append(" END");
+                    .append(") THEN 'Plated' ")
+                    .append("WHEN ").append(ExprColumn.STR_TABLE_ALIAS).append(".RowId").append(" IS NOT NULL THEN 'Not Plated' ")// Issue 52745
+                    .append("ELSE NULL END");
         }
         else
         {


### PR DESCRIPTION
#### Rationale
Issue [51126](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51126): AssayResultUpdateService to call syncLineage() on assay result delete rows when sample lookup column exists
- The related PR fixed the issue where assay run / sample lineage information was resynced after rows for the assay result table were updated (which might have changed a sample lookup value). This PR fixes the related case where we need to resync the lineage info for an assay run / sample after a row is delete from an assay result for a run.

Issue [52745](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52745): The values of some sample fields can successfully be added to assay results grid even if user does not have permissions to view the sample
- This PR adds SQL null checks for the ExprColumn cases for sample lookups so that we don't show the "default" value for the expression if there is no matching sample for the rowid (i.e. unresolved sample)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/5903
- https://github.com/LabKey/platform/pull/6609
- https://github.com/LabKey/limsModules/pull/1372

#### Changes
- AssayResultUpdateService to call syncLineage() on assay result delete rows when sample lookup column exists
- ExprColumn null check for various sample lookup fields (IsAliquot, IsPlated, StorageStatus)
