### PR TITLE
Issue 52963: CSP template is not always being fully substituted

### DIFF
--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -69,6 +69,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -256,9 +257,9 @@ public class NameGenerator
     private final FieldKeyStringExpression _parsedNameExpression;
 
 
-    public record SampleNameExpressionSummary(boolean hasProjectSampleCounter, boolean hasProjectSampleRootCounter, long minProjectSampleCounter, long minProjectSampleRootCounter) {};
+    public record SampleNameExpressionSummary(boolean hasProjectSampleCounter, boolean hasProjectSampleRootCounter, long minProjectSampleCounter, long minProjectSampleRootCounter) {}
 
-    public record ExpressionSummary(SampleNameExpressionSummary sampleSummary, boolean hasDateBasedSampleCounter, boolean hasParentInputs, boolean hasParentLookup, boolean hasAncestorSearch) {};
+    public record ExpressionSummary(SampleNameExpressionSummary sampleSummary, boolean hasDateBasedSampleCounter, boolean hasParentInputs, boolean hasParentLookup, boolean hasAncestorSearch) {}
 
     // extracted from name expression after parsing
     private ExpressionSummary _expressionSummary;
@@ -666,7 +667,7 @@ public class NameGenerator
             }
 
             if (!openIndexes.isEmpty())
-                unmatchedOpen.addAll(openIndexes.stream().map(index -> index+1).collect(Collectors.toList()));
+                unmatchedOpen.addAll(openIndexes.stream().map(index -> index+1).toList());
             start = subInd;
         }
         if (!unmatchedOpen.isEmpty())
@@ -726,9 +727,8 @@ public class NameGenerator
                 }
             }
         }
-        else if (value instanceof Collection)
+        else if (value instanceof Collection<?> coll)
         {
-            Collection<?> coll = (Collection)value;
             values = coll.stream().map(String::valueOf);
         }
         else if (value instanceof JSONArray jsonArray)
@@ -755,12 +755,7 @@ public class NameGenerator
         if (!isParentInputToken(fieldParts.get(0), importAliases, false))
             return false;
 
-        if (fieldParts.size() == 2 && isParentInputWithDataType(fieldParts.toArray(String[]::new), currentDataTypeName, false, container, user))
-        {
-            return false;
-        }
-
-        return true;
+        return fieldParts.size() != 2 || !isParentInputWithDataType(fieldParts.toArray(String[]::new), currentDataTypeName, false, container, user);
     }
 
     public static boolean isAncestorSearch(List<String> fieldParts, @Nullable Map<String, String> importAliases, Container container, User user)
@@ -1083,7 +1078,10 @@ public class NameGenerator
                 for (SubstitutionFormat format : formats)
                 {
                     if (format == dailySampleCount || format == weeklySampleCount || format == monthlySampleCount || format == yearlySampleCount)
+                    {
                         hasDateBasedSampleCounterFormat = true;
+                        break;
+                    }
                 }
 
                 String sTok = QueryKey.decodePart(token.toString());
@@ -1145,7 +1143,7 @@ public class NameGenerator
                                 }
 
                                 if (!isColPresent)
-                                    _syntaxErrors.add("Invalid substitution token: ${" + token.toString() + "}.");
+                                    _syntaxErrors.add("Invalid substitution token: ${" + token + "}.");
                                 else if (pt != null)
                                     previewCtx.put(fieldName, getNamePartPreviewValue(pt, fieldName));
                             }
@@ -1265,7 +1263,7 @@ public class NameGenerator
                 List<String> fieldParts = fieldKey.getParts();
 
                 if (hasParentInputs && fieldParts.size() == 3)
-                    continue;;
+                    continue;
 
                 assert _validateSyntax || fieldParts.size() == 2;
 
@@ -1354,7 +1352,7 @@ public class NameGenerator
                 {
                     if (!lookupExist)
                     {
-                        _syntaxErrors.add("Lookup field does not exist: " + fieldKey.toString());
+                        _syntaxErrors.add("Lookup field does not exist: " + fieldKey);
                     }
                     else if (pt != null)
                     {
@@ -1851,12 +1849,12 @@ public class NameGenerator
             // allow using alternative expression for evaluation.
             // for example, use AliquotNameExpression instead of NameExpression if sample is aliquot
             FieldKeyStringExpression expression = altExpression != null ? altExpression : _parsedNameExpression;
-            String name = null;
+            String name;
             if (expression instanceof NameGenerationExpression)
                 name = ((NameGenerationExpression) expression).eval(ctx, _prefixCounterSequences);
             else
                 name = expression.eval(ctx);
-            if (name == null || name.length() == 0)
+            if (name == null || name.isEmpty())
                 throw new IllegalArgumentException("The data provided are not sufficient to create a name using the naming pattern '" + expression.getSource() + "'.  Check the pattern syntax and data values.");
 
             return name;
@@ -2360,9 +2358,7 @@ public class NameGenerator
                         if (parentImportAliases.containsKey(colName))
                             inputs.computeIfAbsent(colName,  (s) -> new LinkedHashSet<>()).addAll(parents);
                         Optional<Map.Entry<String, String>> aliasEntry = parentImportAliases.entrySet().stream().filter(entry -> entry.getValue().equalsIgnoreCase(colName)).findFirst();
-                        aliasEntry.ifPresent(entry -> {
-                            inputs.computeIfAbsent(entry.getKey(),  (s) -> new LinkedHashSet<>()).addAll(parents);
-                        });
+                        aliasEntry.ifPresent(entry -> inputs.computeIfAbsent(entry.getKey(),  (s) -> new LinkedHashSet<>()).addAll(parents));
                     }
                 }
             }
@@ -2465,7 +2461,7 @@ public class NameGenerator
             _parsedExpression = new ArrayList<>();
             int start = 0;
             int openIndex;
-            int openCount = 0;
+            int openCount;
             final String openTag = "${";
             final char closeTag = '}';
 
@@ -2540,7 +2536,6 @@ public class NameGenerator
          *
          * @param context The map of values to evaluate from
          * @param prefixCounterSequences if prefixCounterSequences is null, dont' use cache. Otherwise, put counter DBSequence in cache for reuse
-         * @return
          */
         public String eval(Map context, @Nullable Map<String, Map<String, DbSequence>> prefixCounterSequences)
         {
@@ -2644,7 +2639,7 @@ public class NameGenerator
         private DbSequence getCounterSeq(String prefixRaw, @Nullable Map<String, DbSequence> counterSequences, boolean noCache)
         {
             String prefix = prefixRaw.trim().toLowerCase(); // Issue 49338: withCounter should be case-insensitive
-            DbSequence counterSeq = null;
+            DbSequence counterSeq;
             if (noCache || !counterSequences.containsKey(prefix))
             {
                 long existingCount = -1;
@@ -2694,7 +2689,7 @@ public class NameGenerator
 
 
                 boolean noCache = counterSequences == null;
-                DbSequence counterSeq = null;
+                DbSequence counterSeq;
 
                 if (_strictIncremental || ExperimentService.get().useStrictCounter())
                 {
@@ -2741,7 +2736,7 @@ public class NameGenerator
         }
     }
 
-    public class NameGenerationException extends Exception
+    public static class NameGenerationException extends Exception
     {
         private final int _rowNumber;
 
@@ -2763,7 +2758,7 @@ public class NameGenerator
         }
     }
 
-    public class DuplicateNameException extends NameGenerationException
+    public static class DuplicateNameException extends NameGenerationException
     {
         private final String _name;
 
@@ -2787,7 +2782,7 @@ public class NameGenerator
         @Test
         public void testDateFormats()
         {
-            Date d = new GregorianCalendar(2011, 11, 3, 8, 30, 15).getTime();
+            Date d = new GregorianCalendar(2011, Calendar.DECEMBER, 3, 8, 30, 15).getTime();
             java.sql.Date donly = new java.sql.Date(d.getTime());
             Time t = new Time(d.getTime());
             Map<Object, Object> m = new HashMap<>();

--- a/api/src/org/labkey/api/util/StringExpressionFactory.java
+++ b/api/src/org/labkey/api/util/StringExpressionFactory.java
@@ -1329,17 +1329,22 @@ public class StringExpressionFactory
             Map<Object,Object> m = new HashMap<>();
 
             FieldKeyStringExpression original = new FieldKeyStringExpression("details.view?id=${rowid}&title=${title}");
-            m.put(FieldKey.fromParts("lookup","rowid"), "BUG");
+            m.put(FieldKey.fromParts("lookup","rowid"), 6);
             m.put(FieldKey.fromParts("lookup"), 5);
             m.put(FieldKey.fromParts("lookup","title"), "title one");
+
+            // Approach #1 - prefix explicitly, column by column
             Map<FieldKey,FieldKey> remap = new HashMap<>();
             remap.put(FieldKey.fromParts("rowid"), FieldKey.fromParts("lookup"));
             remap.put(FieldKey.fromParts("title"), FieldKey.fromParts("lookup", "title"));
-
             FieldKeyStringExpression remapped = original.remapFieldKeys(null, remap);
-
             assertNull(original.eval(m));
             assertEquals("details.view?id=5&title=title%20one", remapped.eval(m));
+
+            // Approach #2 - remap everything with a prefix
+            remapped = original.remapFieldKeys(FieldKey.fromParts("lookup"), null);
+            assertNull(original.eval(m));
+            assertEquals("details.view?id=6&title=title%20one", remapped.eval(m));
         }
 
 

--- a/api/src/org/labkey/api/util/StringExpressionFactory.java
+++ b/api/src/org/labkey/api/util/StringExpressionFactory.java
@@ -1328,15 +1328,18 @@ public class StringExpressionFactory
         {
             Map<Object,Object> m = new HashMap<>();
 
-            FieldKeyStringExpression e = new FieldKeyStringExpression("details.view?id=${rowid}&title=${title}");
-            m.put(FieldKey.fromParts("A","rowid"), "BUG");
-            m.put(new FieldKey(null, "lookup"), 5);
-            m.put(FieldKey.fromParts("A","title"), "title one");
+            FieldKeyStringExpression original = new FieldKeyStringExpression("details.view?id=${rowid}&title=${title}");
+            m.put(FieldKey.fromParts("lookup","rowid"), "BUG");
+            m.put(FieldKey.fromParts("lookup"), 5);
+            m.put(FieldKey.fromParts("lookup","title"), "title one");
             Map<FieldKey,FieldKey> remap = new HashMap<>();
-            remap.put(new FieldKey(null,"rowid"), new FieldKey(null,"lookup"));
+            remap.put(FieldKey.fromParts("rowid"), FieldKey.fromParts("lookup"));
+            remap.put(FieldKey.fromParts("title"), FieldKey.fromParts("lookup", "title"));
 
-            e.remapFieldKeys(null, remap);
-            assertEquals("whoknows", e.eval(m));
+            FieldKeyStringExpression remapped = original.remapFieldKeys(null, remap);
+
+            assertNull(original.eval(m));
+            assertEquals("details.view?id=5&title=title%20one", remapped.eval(m));
         }
 
 

--- a/api/src/org/labkey/api/util/StringExpressionFactory.java
+++ b/api/src/org/labkey/api/util/StringExpressionFactory.java
@@ -107,7 +107,7 @@ public class StringExpressionFactory
         if (!expMatcher.find())
             return new ConstantStringExpression(str);
 
-        String key = "simple:" + str + "(" + urlEncodeSubstitutions + ")";
+        String key = "simple:" + str + "(" + urlEncodeSubstitutions + ", " + nullValueBehavior + ", " + allowSideEffects + ")";
 
         StringExpression expr = templates.get(key);
         if (null != expr)

--- a/api/src/org/labkey/api/util/StringExpressionFactory.java
+++ b/api/src/org/labkey/api/util/StringExpressionFactory.java
@@ -16,8 +16,6 @@
 package org.labkey.api.util;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
@@ -34,7 +32,6 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.view.ActionURL;
 import org.labkey.data.xml.StringExpressionType;
 
@@ -44,6 +41,7 @@ import java.net.URISyntaxException;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -61,9 +59,6 @@ import static org.labkey.api.data.AbstractTableInfo.LINK_DISABLER;
 
 /**
  * Factory for creating {@link StringExpression} instances from a string that defines the pattern.
- * User: migra
- * Date: Dec 28, 2004
- *
  * TODO: Use a real expression or interpolation library:
  *  - JEXL: http://commons.apache.org/proper/commons-jexl/
  *  - Unified Expression Language: http://juel.sourceforge.net/index.html
@@ -72,8 +67,6 @@ import static org.labkey.api.data.AbstractTableInfo.LINK_DISABLER;
  */
 public class StringExpressionFactory
 {
-    private static final Logger LOG = LogManager.getLogger(StringExpressionFactory.class);
-
     private static final Cache<String, StringExpression> templates = CacheManager.getCache(5000, CacheManager.DAY, "StringExpression templates");
     private static final Cache<String, StringExpression> templatesUrl = CacheManager.getCache(10000, CacheManager.DAY, "StringExpression template URLs");
 
@@ -121,19 +114,14 @@ public class StringExpressionFactory
 
 
     /**
-     * HANDLES three cases
-     *
+     * HANDLES three cases:
      *  a) http[s]://*?param=${Column}
-     *
      *  b) /Controller/Action.view?param=${Column}
      *     /Controller-Action.view?param=${Column}
      *     org.labkey.module.Controller$Action.class?param=${Column}\s
      *     special w/ some container support
-     *
      *  c) freeform, whatever
-     *
      * CONSIDER javascript: (permissions!)
-     *
      */
     public static StringExpression createURL(String str)
     {
@@ -1222,9 +1210,8 @@ public class StringExpressionFactory
 
             for (StringPart stringPart : clone.getParsedExpression())
             {
-                if (stringPart instanceof FieldPart)
+                if (stringPart instanceof FieldPart fieldPart)
                 {
-                    FieldPart fieldPart = (FieldPart)stringPart;
                     // Removes the parent if the first part of the FieldKey matches the parent name
                     FieldKey newFieldKey = fieldPart._key.removeParent(parentName);
                     if (newFieldKey != null)
@@ -1341,12 +1328,15 @@ public class StringExpressionFactory
         {
             Map<Object,Object> m = new HashMap<>();
 
-            FieldKeyStringExpression fkse = new FieldKeyStringExpression("details.view?id=${rowid}&title=${title}");
+            FieldKeyStringExpression e = new FieldKeyStringExpression("details.view?id=${rowid}&title=${title}");
             m.put(FieldKey.fromParts("A","rowid"), "BUG");
             m.put(new FieldKey(null, "lookup"), 5);
             m.put(FieldKey.fromParts("A","title"), "title one");
             Map<FieldKey,FieldKey> remap = new HashMap<>();
             remap.put(new FieldKey(null,"rowid"), new FieldKey(null,"lookup"));
+
+            e.remapFieldKeys(null, remap);
+            assertEquals("whoknows", e.eval(m));
         }
 
 
@@ -1378,7 +1368,7 @@ public class StringExpressionFactory
         @Test
         public void testDateFormats()
         {
-            Date d = new GregorianCalendar(2011, 11, 3).getTime();
+            Date d = new GregorianCalendar(2011, Calendar.DECEMBER, 3).getTime();
             Map<Object, Object> m = new HashMap<>();
             m.put("d", d);
 
@@ -1511,6 +1501,54 @@ public class StringExpressionFactory
         }
 
         @Test
+        public void testOptions()
+        {
+            Map<Object, Object> partialMap = new HashMap<>();
+            partialMap.put("a", "%A");
+            partialMap.put("null", null);
+            Map<Object, Object> fullMap = new HashMap<>(partialMap);
+            fullMap.put("b", "B");
+
+            final String expression = "${a}${b}${null}";
+
+            // NullResult is the default NullValueBehavior
+            StringExpression e = StringExpressionFactory.create(expression, false);
+            assertNull(e.eval(partialMap));
+            assertNull(e.eval(fullMap));
+            e = StringExpressionFactory.create(expression, true);
+            assertNull(e.eval(partialMap));
+            assertNull(e.eval(fullMap));
+
+            e = StringExpressionFactory.create(expression, false, AbstractStringExpression.NullValueBehavior.ReplaceNullWithBlank);
+            assertNull(e.eval(partialMap));
+            assertEquals("%AB", e.eval(fullMap));
+            e = StringExpressionFactory.create(expression, true, AbstractStringExpression.NullValueBehavior.ReplaceNullWithBlank);
+            assertNull(e.eval(partialMap));
+            assertEquals("%25AB", e.eval(fullMap));
+
+            e = StringExpressionFactory.create(expression, false, AbstractStringExpression.NullValueBehavior.OutputNull);
+            assertNull(e.eval(partialMap));
+            assertEquals("%ABnull", e.eval(fullMap));
+            e = StringExpressionFactory.create(expression, true, AbstractStringExpression.NullValueBehavior.OutputNull);
+            assertNull(e.eval(partialMap));
+            assertEquals("%25ABnull", e.eval(fullMap));
+
+            e = StringExpressionFactory.create(expression, false, AbstractStringExpression.NullValueBehavior.ReplaceNullAndMissingWithBlank);
+            assertEquals("%A", e.eval(partialMap));
+            assertEquals("%AB", e.eval(fullMap));
+            e = StringExpressionFactory.create(expression, true, AbstractStringExpression.NullValueBehavior.ReplaceNullAndMissingWithBlank);
+            assertEquals("%25A", e.eval(partialMap));
+            assertEquals("%25AB", e.eval(fullMap));
+
+            e = StringExpressionFactory.create(expression, false, AbstractStringExpression.NullValueBehavior.KeepSubstitution);
+            assertEquals("%A${b}${null}", e.eval(partialMap));
+            assertEquals("%AB${null}", e.eval(fullMap));
+            e = StringExpressionFactory.create(expression, true, AbstractStringExpression.NullValueBehavior.KeepSubstitution);
+            assertEquals("%25A${b}${null}", e.eval(partialMap));
+            assertEquals("%25AB${null}", e.eval(fullMap));
+        }
+
+        @Test
         public void testUndefined()
         {
             Map<Object, Object> m = new HashMap<>();
@@ -1527,7 +1565,7 @@ public class StringExpressionFactory
                 // SimpleStringExpression default behavior is to emit blank for null values
                 StringExpression se1 = new SimpleStringExpression("${null}", false);
                 String s1 = se1.eval(m);
-                assertEquals(null, s1);
+                assertNull(s1);
 
                 // For backwards compatibility, FieldKeyStringExpression default behavior is to emit empty string for null values
                 FieldKeyStringExpression se2 = new FieldKeyStringExpression("${null}");
@@ -1537,14 +1575,14 @@ public class StringExpressionFactory
                 // ... but can be overridden to emit a null result
                 FieldKeyStringExpression se3 = new FieldKeyStringExpression("${null}", true, AbstractStringExpression.NullValueBehavior.NullResult);
                 String s3 = se3.eval(m);
-                assertEquals(null, s3);
+                assertNull(s3);
             }
 
             {
                 // Undefined values always result in a null result
                 StringExpression se1 = new FieldKeyStringExpression("${doesNotExist}");
                 String s1 = se1.eval(m);
-                assertEquals(null, s1);
+                assertNull(s1);
 
                 // ... unless it has a defaultValue
                 StringExpression se2 = new FieldKeyStringExpression("${doesNotExist:defaultValue('fred')}");
@@ -1557,8 +1595,6 @@ public class StringExpressionFactory
         public void testCreateUrl()
         {
             Container container = JunitUtil.getTestContainer();
-            String containerPath = container.getPath();
-            String contextPath = AppProps.getInstance().getContextPath();
             ActionURL url = new ActionURL("controller","action",container);
             ActionURL urlBegin = new ActionURL("project","begin",container);
             String s;

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -392,9 +392,7 @@ public class ContentSecurityPolicyFilter implements Filter
                     verifySubstitutionInPolicyExpressions(".SOURCES}", 0);
                     // Should have been substitution in init()
                     verifySubstitutionInPolicyExpressions("${CSP.REPORT.PARAMS}", 0);
-                    // A single substitution parameter (${REQUEST.SCRIPT.NONCE}) should remain
-                    verifySubstitutionInPolicyExpressions("${REQUEST.SCRIPT.NONCE}", 1);
-                    verifySubstitutionInPolicyExpressions("${", 1);
+                    verifySubstitutionInPolicyExpressions("${", 0);
 
                     // Now unregister and register sources for each Directive, testing expectations along the way
                     unregisterAllowedSources(Directive.Connection, "foo");

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -209,7 +209,7 @@ public class ContentSecurityPolicyFilter implements Filter
                 .eval(ALLOWED_SOURCES_SUBSTITUTION_MAP);
         }
 
-        _policyExpression = StringExpressionFactory.create(allowSubstitutedPolicy, false, NullValueBehavior.KeepSubstitution);
+        _policyExpression = StringExpressionFactory.create(allowSubstitutedPolicy, false, NullValueBehavior.ReplaceNullAndMissingWithBlank);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We can't rely on registrations for CSP directives to correctly substitute the CSP template

#### Changes
- Fix caching to avoid reusing StringExpressions that want different behavior
- Substitute with blanks in the CSP