### PR TITLE
Improve error messaging for invalid pivot query

### DIFF
--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -720,7 +720,7 @@ public class DomainUtil
 
         // Issue 48810: if not creating from templateInfo, validate reserved field names based on domainKind
         boolean strictFieldValidation = arguments != null ? (Boolean) arguments.getOrDefault("strictFieldValidation", true) : true;
-        DomainKind validateDomainKind = templateInfo == null && strictFieldValidation ? kind : null;
+        DomainKind<?> validateDomainKind = templateInfo == null && strictFieldValidation ? kind : null;
 
         ValidationException ve = DomainUtil.validateProperties(null, domain, validateDomainKind, null, user);
         if (ve.hasErrors())
@@ -1109,7 +1109,7 @@ public class DomainUtil
                     errors.addError(new PropertyValidationError(msg, from.getName(), from.getPropertyId()));
                 }
             }
-            Lookup lu = new Lookup(c, from.getLookupSchema(), from.getLookupQuery());
+            Lookup lu = new Lookup(c, SchemaKey.fromString(from.getLookupSchema()), from.getLookupQuery());
             to.setLookup(lu);
         }
         else
@@ -1316,7 +1316,7 @@ public class DomainUtil
         }
     }
 
-    private static String getDomainErrorMessage(@Nullable GWTDomain domain, String message)
+    private static String getDomainErrorMessage(@Nullable GWTDomain<?> domain, String message)
     {
         if (domain != null && domain.getName() != null)
         {
@@ -1331,7 +1331,7 @@ public class DomainUtil
      * @param domain The updated domain to validate
      * @return List of errors strings found during the validation
      */
-    public static ValidationException validateProperties(@Nullable Domain domain, @NotNull GWTDomain updates, @Nullable DomainKind domainKind, @Nullable GWTDomain orig, @Nullable User user)
+    public static ValidationException validateProperties(@Nullable Domain domain, @NotNull GWTDomain<?> updates, @Nullable DomainKind domainKind, @Nullable GWTDomain<?> orig, @Nullable User user)
     {
         Set<String> reservedNames = null != domainKind ? new CaseInsensitiveHashSet(domainKind.getReservedPropertyNames(domain, user, domain == null))
                 : new CaseInsensitiveHashSet(updates.getReservedFieldNames());
@@ -1340,10 +1340,8 @@ public class DomainUtil
         ValidationException exception = new ValidationException();
         Map<Integer, String> propertyIdNameMap = getOriginalFieldPropertyIdNameMap(orig);//key: orig property id, value : orig field name
 
-        for (Object f : updates.getFields(true))
+        for (GWTPropertyDescriptor field : updates.getFields(true))
         {
-            GWTPropertyDescriptor field = (GWTPropertyDescriptor)f;
-
             String name = field.getName();
 
             if (null == name || name.trim().isEmpty())
@@ -1413,15 +1411,14 @@ public class DomainUtil
     }
 
     @Nullable
-    private static Map<Integer, String> getOriginalFieldPropertyIdNameMap(@Nullable GWTDomain orig)
+    private static Map<Integer, String> getOriginalFieldPropertyIdNameMap(@Nullable GWTDomain<?> orig)
     {
         if (null != orig)
         {
             Map<Integer, String> propertyIdMap = new HashMap<>();
 
-            for (Object f : orig.getFields())
+            for (GWTPropertyDescriptor origField : orig.getFields())
             {
-                GWTPropertyDescriptor origField = (GWTPropertyDescriptor) f;
                 propertyIdMap.put(origField.getPropertyId(), origField.getName());
             }
             return propertyIdMap;

--- a/api/src/org/labkey/api/visualization/VisualizationProvider.java
+++ b/api/src/org/labkey/api/visualization/VisualizationProvider.java
@@ -18,6 +18,7 @@ package org.labkey.api.visualization;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
+import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
@@ -34,6 +35,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -341,7 +343,8 @@ public abstract class VisualizationProvider<SchemaType extends UserSchema>
 
         public void setFilters(String[] filters)
         {
-            _filters = filters;
+            // Strip out nulls
+            _filters = Arrays.stream(filters).filter(Objects::nonNull).toArray(String[]::new);
         }
 
         public boolean isDateMeasures()
@@ -415,7 +418,10 @@ public abstract class VisualizationProvider<SchemaType extends UserSchema>
         {
             String[] parts = filter.split("\\|");
 
-            assert(parts.length >= 2) : "Invalid filter value";
+            if (parts.length < 2)
+            {
+                throw new ApiUsageException("Invalid filter value");
+            }
 
             _schema = parts[0];
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -3813,54 +3813,54 @@ public class QueryController extends SpringActionController
                 return null;
             }
 
-            SimpleFilter filter = getFilterFromQueryForm(form);
-
-            // Strip out filters on columns that don't exist - issue 21669
-            service.ensureRequiredColumns(table, columns.values(), filter, null, new HashSet<>());
-            QueryLogging queryLogging = new QueryLogging();
-            QueryService.SelectBuilder builder = service.getSelectBuilder(table)
-                    .columns(columns.values())
-                    .filter(filter)
-                    .queryLogging(queryLogging)
-                    .distinct(true);
-            SQLFragment selectSql = builder.buildSqlFragment();
-
-            // TODO: queryLogging.isShouldAudit() is always false at this point.
-            // The only place that seems to set this is ComplianceQueryLoggingProfileListener.queryInvoked()
-            if (queryLogging.isShouldAudit() && null != queryLogging.getExceptionToThrowIfLoggingIsEnabled())
-            {
-                // this is probably a more helpful message
-                errors.reject(ERROR_MSG, "Cannot choose values from a column that requires logging.");
-                return null;
-            }
-
-            // Regenerate the column since the alias may have changed after call to getSelectSQL()
-            columns = service.getColumns(table, settings.getFieldKeys());
-            var colGetAgain = columns.get(settings.getFieldKeys().get(0));
-            // I don't believe the above comment, so here's an assert
-            assert(colGetAgain.getAlias().equals(col.getAlias()));
-
-            SQLFragment sql = new SQLFragment("SELECT " + table.getSqlDialect().getColumnSelectName(col.getAlias()) + " AS value FROM (");
-            sql.append(selectSql);
-            sql.append(") S ORDER BY value");
-
-            sql = table.getSqlDialect().limitRows(sql, settings.getMaxRows());
-
-            // 18875: Support Parameterized queries in Select Distinct
-            Map<String, Object> _namedParameters = settings.getQueryParameters();
-
             try
             {
+                SimpleFilter filter = getFilterFromQueryForm(form);
+
+                // Strip out filters on columns that don't exist - issue 21669
+                service.ensureRequiredColumns(table, columns.values(), filter, null, new HashSet<>());
+                QueryLogging queryLogging = new QueryLogging();
+                QueryService.SelectBuilder builder = service.getSelectBuilder(table)
+                        .columns(columns.values())
+                        .filter(filter)
+                        .queryLogging(queryLogging)
+                        .distinct(true);
+                SQLFragment selectSql = builder.buildSqlFragment();
+
+                // TODO: queryLogging.isShouldAudit() is always false at this point.
+                // The only place that seems to set this is ComplianceQueryLoggingProfileListener.queryInvoked()
+                if (queryLogging.isShouldAudit() && null != queryLogging.getExceptionToThrowIfLoggingIsEnabled())
+                {
+                    // this is probably a more helpful message
+                    errors.reject(ERROR_MSG, "Cannot choose values from a column that requires logging.");
+                    return null;
+                }
+
+                // Regenerate the column since the alias may have changed after call to getSelectSQL()
+                columns = service.getColumns(table, settings.getFieldKeys());
+                var colGetAgain = columns.get(settings.getFieldKeys().get(0));
+                // I don't believe the above comment, so here's an assert
+                assert(colGetAgain.getAlias().equals(col.getAlias()));
+
+                SQLFragment sql = new SQLFragment("SELECT " + table.getSqlDialect().getColumnSelectName(col.getAlias()) + " AS value FROM (");
+                sql.append(selectSql);
+                sql.append(") S ORDER BY value");
+
+                sql = table.getSqlDialect().limitRows(sql, settings.getMaxRows());
+
+                // 18875: Support Parameterized queries in Select Distinct
+                Map<String, Object> _namedParameters = settings.getQueryParameters();
+
                 service.bindNamedParameters(sql, _namedParameters);
                 service.validateNamedParameters(sql);
+
+                return new SqlSelector(table.getSchema().getScope(), sql, queryLogging);
             }
             catch (ConversionException | QueryService.NamedParameterNotProvided e)
             {
                 errors.reject(ERROR_MSG, e.getMessage());
                 return null;
             }
-
-            return new SqlSelector(table.getSchema().getScope(), sql, queryLogging);
         }
     }
 

--- a/query/src/org/labkey/query/sql/QueryPivot.java
+++ b/query/src/org/labkey/query/sql/QueryPivot.java
@@ -262,19 +262,26 @@ public class QueryPivot extends AbstractQueryRelation
                     fromForPivotValues.releaseAllSelected(this);
                     fromForPivotValues._distinct = null;
                 }
-                _pivotColumn.addRef(this);
-                if (null == fromForPivotValues._having)
+                if (_pivotColumn != null)
                 {
-                    fromForPivotValues._groupBy.releaseFieldRefs(fromForPivotValues._groupBy);
-                    fromForPivotValues._groupBy = null;
+                    _pivotColumn.addRef(this);
+                    if (null == fromForPivotValues._having)
+                    {
+                        fromForPivotValues._groupBy.releaseFieldRefs(fromForPivotValues._groupBy);
+                        fromForPivotValues._groupBy = null;
+                    }
+                    fromForPivotValues._allowStructuralOptimization = false;
+                    fromSql = fromForPivotValues.getFromSql();
+                    // the fields and columns are shared, to be safe fix up reference counts
+                    _from._groupBy.addFieldRefs(_from._groupBy);
+                    if (null != _from._distinct)
+                        _from.markAllSelected(_from._distinct);
+                    _from.markAllSelected(this);
                 }
-                fromForPivotValues._allowStructuralOptimization = false;
-                fromSql = fromForPivotValues.getFromSql();
-                // the fields and columns are shared, to be safe fix up reference counts
-                _from._groupBy.addFieldRefs(_from._groupBy);
-                if (null != _from._distinct)
-                    _from.markAllSelected(_from._distinct);
-                _from.markAllSelected(this);
+                else
+                {
+                    fromSql = null;
+                }
             }
             else
             {

--- a/visualization/src/org/labkey/visualization/VisualizationServiceImpl.java
+++ b/visualization/src/org/labkey/visualization/VisualizationServiceImpl.java
@@ -16,7 +16,6 @@
 package org.labkey.visualization;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -104,7 +103,7 @@ public class VisualizationServiceImpl implements VisualizationService
     @Override
     public Map<Pair<FieldKey, ColumnInfo>, QueryDefinition> getDimensions(Container c, User u, MeasureSetRequest measureRequest)
     {
-        VisualizationProvider provider = getProvider(c, u, measureRequest);
+        VisualizationProvider<?> provider = getProvider(c, u, measureRequest);
         return provider.getDimensions(measureRequest.getQueryName());
     }
 
@@ -119,7 +118,7 @@ public class VisualizationServiceImpl implements VisualizationService
             for (String filter : measureRequest.getFilters())
             {
                 MeasureFilter mf = new MeasureFilter(filter);
-                VisualizationProvider provider = getProvider(c, u, mf);
+                VisualizationProvider<?> provider = getProvider(c, u, mf);
 
                 if (measureRequest.isZeroDateMeasures())
                 {
@@ -151,7 +150,7 @@ public class VisualizationServiceImpl implements VisualizationService
         else
         {
             // get all tables in this container
-            for (VisualizationProvider provider : createVisualizationProviders(c, u, measureRequest.isShowHidden()).values())
+            for (VisualizationProvider<?> provider : createVisualizationProviders(c, u, measureRequest.isShowHidden()).values())
             {
                 if (measureRequest.isZeroDateMeasures())
                     measures.putAll(provider.getZeroDateMeasures(VisualizationProvider.QueryType.all));
@@ -173,13 +172,13 @@ public class VisualizationServiceImpl implements VisualizationService
     }
 
 
-    private Map<String, ? extends VisualizationProvider> createVisualizationProviders(Container c, User u, boolean showHidden)
+    private Map<String, ? extends VisualizationProvider<?>> createVisualizationProviders(Container c, User u, boolean showHidden)
     {
-        Map<String, VisualizationProvider> result = new HashMap<>();
+        Map<String, VisualizationProvider<?>> result = new HashMap<>();
         DefaultSchema defaultSchema = DefaultSchema.get(u, c);
         for (QuerySchema querySchema : defaultSchema.getSchemas(showHidden))
         {
-            VisualizationProvider provider = querySchema.createVisualizationProvider();
+            VisualizationProvider<?> provider = querySchema.createVisualizationProvider();
             if (provider != null)
             {
                 result.put(querySchema.getName(), provider);
@@ -190,21 +189,21 @@ public class VisualizationServiceImpl implements VisualizationService
 
 
     @NotNull
-    private VisualizationProvider getProvider(Container c, User u, MeasureFilter mf)
+    private VisualizationProvider<?> getProvider(Container c, User u, MeasureFilter mf)
     {
         return getProvider(c, u, mf.getSchema());
     }
 
 
     @NotNull
-    private VisualizationProvider getProvider(Container c, User u, MeasureSetRequest measureRequest)
+    private VisualizationProvider<?> getProvider(Container c, User u, MeasureSetRequest measureRequest)
     {
         return getProvider(c, u, measureRequest.getSchemaName());
     }
 
 
     @NotNull
-    private VisualizationProvider getProvider(Container c, User u, String schema)
+    private VisualizationProvider<?> getProvider(Container c, User u, String schema)
     {
         UserSchema userSchema = QueryService.get().getUserSchema(u, c, schema);
         if (userSchema == null)
@@ -212,7 +211,7 @@ public class VisualizationServiceImpl implements VisualizationService
             throw new IllegalArgumentException("No measure schema found for " + schema);
         }
 
-        VisualizationProvider provider = userSchema.createVisualizationProvider();
+        VisualizationProvider<?> provider = userSchema.createVisualizationProvider();
         if (provider == null)
         {
             throw new IllegalArgumentException("No measure provider found for schema " + userSchema.getSchemaPath());
@@ -245,7 +244,7 @@ public class VisualizationServiceImpl implements VisualizationService
     {
         List<Map<String, Object>> measuresJSON = new ArrayList<>();
         Map<QueryDefinition, TableInfo> _tableInfoMap = new HashMap<>();
-        Map<String, VisualizationProvider> _schemaVisualizationProviderMap = new HashMap<>();
+        Map<String, VisualizationProvider<?>> _schemaVisualizationProviderMap = new HashMap<>();
         int count = 1;
 
         for (Map.Entry<Pair<FieldKey, ColumnInfo>, QueryDefinition> entry : cols.entrySet())


### PR DESCRIPTION
#### Rationale
Improve error message in schema browser when a pivot query doesn't have matching select and pivot columns

https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=41235
https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=41233
https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=41232

#### Changes
- Avoid NPE and return intended pivot error
- Better handling for bogus values related to visualization providers
- Minor code cleanup in DomainUtil