### PR TITLE
Switch to passing containerId as path instead of parameter

### DIFF
--- a/wiki/src/org/labkey/wiki/WikiController.java
+++ b/wiki/src/org/labkey/wiki/WikiController.java
@@ -1388,7 +1388,6 @@ public class WikiController extends SpringActionController
         public final ActionURL compareLink;         //base url for comparing to another version
 
         public HtmlString html = null;
-        public Set<ClientDependencies> dependencies = Set.of();
 
         private VersionBean(Wiki wiki, WikiVersion wikiVersion, BaseWikiPermissions perms)
         {
@@ -1888,14 +1887,7 @@ public class WikiController extends SpringActionController
         @Override
         public ApiResponse execute(ContainerForm form, BindException errors)
         {
-            if (null == form.getId() || form.getId().isEmpty())
-                throw new IllegalArgumentException("The id parameter must be set to a valid container id!");
-
-            Container container = ContainerManager.getForId(form.getId());
-            if (null == container)
-                throw new IllegalArgumentException("The container id '" + form.getId() + "' is not valid.");
-            
-            Map<String, String> wikiMap = WikiSelectManager.getNameTitleMap(container);
+            Map<String, String> wikiMap = WikiSelectManager.getNameTitleMap(getContainer());
             if (null == wikiMap)
                 return new ApiSimpleResponse("pages", null);
 
@@ -2749,7 +2741,7 @@ public class WikiController extends SpringActionController
     }
 
     @RequiresLogin
-    public class SetTocPreferenceAction extends MutatingApiAction<SetTocPreferenceForm>
+    public static class SetTocPreferenceAction extends MutatingApiAction<SetTocPreferenceForm>
     {
         public static final String PROP_TOC_DISPLAYED = "displayToc";
 

--- a/wiki/src/org/labkey/wiki/view/customizeWiki.jsp
+++ b/wiki/src/org/labkey/wiki/view/customizeWiki.jsp
@@ -59,7 +59,8 @@ function updatePageList()
         select.options[select.options.length] = new Option('loading...', '', true, true);
 
         LABKEY.Ajax.request({
-            url: LABKEY.ActionURL.buildURL('wiki', 'getPages.api', undefined, { id: containerId }),
+            // Issue 52992: Use containerId as the containerPath, which is one of the supported URL structures
+            url: LABKEY.ActionURL.buildURL('wiki', 'getPages.api', containerId),
             method: 'GET',
             success: onSuccess.bind(this, containerId),
             failure: onError


### PR DESCRIPTION
#### Rationale
We can eliminate the need for the containerId parameter by just sending requests directly to the target container

#### Changes
- Use containerId as path instead of GET parameter