### PR TITLE
Support long domain names

### DIFF
--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -1424,7 +1424,7 @@ public class DomainImpl implements Domain
             }
         }
 
-        final String storageName = _storageNameGenerator.generateName(fuzz(pd.getName()));
+        final String storageName = _storageNameGenerator.generateColumnName(fuzz(pd.getName()));
         pd.setStorageColumnName(storageName);
     }
 

--- a/experiment/src/org/labkey/experiment/api/property/StorageNameGenerator.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageNameGenerator.java
@@ -43,23 +43,28 @@ public class StorageNameGenerator
     }
 
     /**
-     * Generate a table storage name based on the provided candidate name. If needed, the name is truncated based on
-     * dialect-specific rules.
+     * Generate a table storage name based on the provided candidate name, reserving room for the "_pk" suffix.
      */
     public String generateTableName(String candidateName)
     {
-        return generateName(candidateName, TABLE_RESERVED_LENGTH);
+        // TODO: Switch to calling generateName(), but that requires downstream work to make the name "legal"
+        String tableName = _dialect.makeLegalName(candidateName.toLowerCase(), true, TABLE_RESERVED_LENGTH);
+        tableName = tableName.replaceAll("_+", "_");
+        return tableName;
     }
 
     /**
-     * Generate a column storage name based on the provided candidate name. If needed, the name is truncated based on
-     * dialect-specific rules and uniquified with an incrementing suffix (1, 2, 3, ...).
+     * Generate a column storage name based on the provided candidate name, reserving room for MV and uniquifying suffixes.
      */
     public String generateColumnName(String candidateName)
     {
         return generateName(candidateName, COLUMN_RESERVED_LENGTH);
     }
 
+    /**
+     * Generate a storage name based on the provided candidate name. If needed, the name is truncated using
+     * dialect-specific rules and uniquified with an incrementing suffix (1, 2, 3, ...).
+     */
     private String generateName(String candidateName, int reserved)
     {
         String legalName = _dialect.truncate(candidateName, reserved);

--- a/experiment/src/org/labkey/experiment/api/property/StorageNameGenerator.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageNameGenerator.java
@@ -23,7 +23,9 @@ import java.util.stream.Collectors;
 public class StorageNameGenerator
 {
     // Leave room for MV suffix in case the column is changed to MV later and leave room for uniquifying suffix
-    private static final int RESERVED_LENGTH = OntologyManager.MV_INDICATOR_SUFFIX.length() + 1 + 3;
+    private static final int COLUMN_RESERVED_LENGTH = OntologyManager.MV_INDICATOR_SUFFIX.length() + 1 + 3;
+    // Reserve three characters for "_pk"
+    private static final int TABLE_RESERVED_LENGTH = 3;
 
     private final SqlDialect _dialect;
     private final Set<String> _names = new CaseInsensitiveHashSet();
@@ -41,12 +43,26 @@ public class StorageNameGenerator
     }
 
     /**
-     * Generate a storage name based on the provided candidate name. If needed, the name is truncated based on
+     * Generate a table storage name based on the provided candidate name. If needed, the name is truncated based on
+     * dialect-specific rules.
+     */
+    public String generateTableName(String candidateName)
+    {
+        return generateName(candidateName, TABLE_RESERVED_LENGTH);
+    }
+
+    /**
+     * Generate a column storage name based on the provided candidate name. If needed, the name is truncated based on
      * dialect-specific rules and uniquified with an incrementing suffix (1, 2, 3, ...).
      */
-    public String generateName(String candidateName)
+    public String generateColumnName(String candidateName)
     {
-        String legalName = _dialect.truncate(candidateName, RESERVED_LENGTH);
+        return generateName(candidateName, COLUMN_RESERVED_LENGTH);
+    }
+
+    private String generateName(String candidateName, int reserved)
+    {
+        String legalName = _dialect.truncate(candidateName, reserved);
         String ret = legalName;
 
         for (int i = 1; _names.contains(ret); i++)
@@ -93,10 +109,10 @@ public class StorageNameGenerator
             for (int i = 1; i < count; i++)
             {
                 String candidate = candidateSupplier.apply(i);
-                String generated = generator.generateName(candidate);
+                String generated = generator.generateColumnName(candidate);
                 boolean exists = uniqueNames.contains(candidate);
 
-                if (exists || dialect.isIdentifierTooLong(candidate + StringUtils.repeat("x", RESERVED_LENGTH)))
+                if (exists || dialect.isIdentifierTooLong(candidate + StringUtils.repeat("x", COLUMN_RESERVED_LENGTH)))
                     assertNotEquals(candidate, generated);
                 else
                     assertEquals(candidate, generated);

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -563,9 +563,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
     {
         String rawTableName = String.format("c%sd%s_%s", domain.getContainer().getRowId(), domain.getTypeId(), domain.getName());
         SqlDialect dialect = kind.getScope().getSqlDialect();
-        String tableName = new StorageNameGenerator(dialect).generateTableName(rawTableName.toLowerCase());
-        tableName = tableName.replaceAll("_+", "_"); // TODO: This is fairly pointless now since we no longer replace chars with underscore
-        return tableName;
+        return new StorageNameGenerator(dialect).generateTableName(rawTableName);
     }
 
     /**

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -551,8 +551,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
         TableChange propChange = new TableChange(domain, ChangeType.ChangeColumnTypes);
 
         Set<String> base = Sets.newCaseInsensitiveHashSet();
-        kind.getBaseProperties(domain).forEach(s ->
-                base.add(s.getName()));
+        kind.getBaseProperties(domain).forEach(s -> base.add(s.getName()));
 
         if (!base.contains(prop.getName()))
             propChange.addColumn(prop.getPropertyDescriptor());
@@ -565,7 +564,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
         String rawTableName = String.format("c%sd%s_%s", domain.getContainer().getRowId(), domain.getTypeId(), domain.getName());
         SqlDialect dialect = kind.getScope().getSqlDialect();
         String tableName = new StorageNameGenerator(dialect).generateTableName(rawTableName.toLowerCase());
-        tableName = tableName.replaceAll("_+", "_");
+        tableName = tableName.replaceAll("_+", "_"); // TODO: This is fairly pointless now since we no longer replace chars with underscore
         return tableName;
     }
 

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -564,9 +564,9 @@ public class StorageProvisionerImpl implements StorageProvisioner
     {
         String rawTableName = String.format("c%sd%s_%s", domain.getContainer().getRowId(), domain.getTypeId(), domain.getName());
         SqlDialect dialect = kind.getScope().getSqlDialect();
-        String alias = AliasManager.makeLegalName(rawTableName.toLowerCase(), dialect);
-        alias = alias.replaceAll("_+", "_");
-        return alias;
+        String tableName = new StorageNameGenerator(dialect).generateTableName(rawTableName.toLowerCase());
+        tableName = tableName.replaceAll("_+", "_");
+        return tableName;
     }
 
     /**


### PR DESCRIPTION
#### Rationale
Long domain names are now causing failures when attempting to create the corresponding PK. Storage provisioner generates a legal table name and then tacks on "_pk" to produce the PK name. This fails, since we now truncate names to the full allowed length by default, there ain't no room for "_pk." It should use StorageNameGenerator (not AliasManager) but more importantly it needs to reserve 3 characters for the suffix.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6498