### PR TITLE
Issue 52933: labkey.org raising repeated bogus 'base-uri' CSP reports

### DIFF
--- a/api/src/org/labkey/api/view/ViewHeadersAndMetaTestCase.jsp
+++ b/api/src/org/labkey/api/view/ViewHeadersAndMetaTestCase.jsp
@@ -84,7 +84,7 @@ This tests uses MockRequest to test some expected Headers and Meta tags for vari
 
     Map<String, String> getHeaders(String requestUri) throws ServletException, IOException, URISyntaxException
     {
-        URLHelper url = new URLHelper(AppProps.getInstance().getContextPath() + requestUri);
+        URLHelper url = new URLHelper(requestUri);
         var req = new _ForwardWrapper(url);
         var res = new _MockHeaderResponse();
         req.getRequestDispatcher(url.getLocalURIString()).forward(TestContext.get().getRequest(), res);

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -11938,6 +11938,17 @@ public class AdminController extends SpringActionController
                 JSONObject cspReport = jsonObj.optJSONObject("csp-report");
                 if (cspReport != null)
                 {
+                    String blockedUri = cspReport.optString("blocked-uri", null);
+
+                    // Issue 52933 - suppress base-uri problems from a crawler or bot on labkey.org
+                    if (blockedUri != null &&
+                            blockedUri.startsWith("https://labkey.org%2C") &&
+                            blockedUri.endsWith("undefined") &&
+                            !_log.isDebugEnabled())
+                    {
+                        return ret;
+                    }
+
                     String urlString = cspReport.optString("document-uri", null);
                     if (urlString != null)
                     {


### PR DESCRIPTION
#### Rationale
A bot is going wild crawling labkey.org, and spamming us about CSP problems of its own creation.

#### Changes
- Suppress the reports that can't be repro'd and are overwhelming the logs