### PR TITLE
Support rich text formatting in XLSX exports

### DIFF
--- a/api/src/org/labkey/api/data/DisplayColumn.java
+++ b/api/src/org/labkey/api/data/DisplayColumn.java
@@ -20,6 +20,8 @@ import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.apache.logging.log4j.Logger;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.HasViewContext;
@@ -57,6 +59,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -467,7 +470,7 @@ public abstract class DisplayColumn extends RenderColumn
      * Format the display value as text <i>only</i> if there is a text expression or format configured for
      * the display column (which includes any project date and number format settings),
      * otherwise return null.
-     *
+     * <p>
      * <b>No html encoding should be performed</b>
      * @see #getFormattedHtml(RenderContext)
      */
@@ -1377,6 +1380,11 @@ public abstract class DisplayColumn extends RenderColumn
     public String getExcelFormatString()
     {
         return _excelFormatString;
+    }
+
+    public ExcelColumn createExcelColumn(Map<ExcelColumn.ExcelFormatDescriptor, CellStyle> formatters, Workbook workbook)
+    {
+        return new ExcelColumn(this, formatters, workbook);
     }
 
     public void setExcelFormatString(String excelFormatString)

--- a/api/src/org/labkey/api/data/ExcelCellUtils.java
+++ b/api/src/org/labkey/api/data/ExcelCellUtils.java
@@ -1,5 +1,6 @@
 package org.labkey.api.data;
 
+import org.apache.poi.ss.usermodel.Row;
 import org.jetbrains.annotations.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
@@ -37,7 +38,7 @@ public class ExcelCellUtils
 
     public static int getSimpleType(DisplayColumn dc)
     {
-        Class valueClass = dc.getDisplayValueClass();
+        Class<?> valueClass = dc.getDisplayValueClass();
 
         if (Integer.class.isAssignableFrom(valueClass) || Integer.TYPE.isAssignableFrom(valueClass) ||
                 Long.class.isAssignableFrom(valueClass) || Long.TYPE.isAssignableFrom(valueClass) ||
@@ -188,6 +189,17 @@ public class ExcelCellUtils
                 if (s.length() > 32767)
                 {
                     s = s.substring(0, 32762) + "...";
+                }
+                // Ensure the row is tall enough to show the full values when there are newlines
+                int newlines = StringUtils.countMatches(s, '\n');
+                if (newlines > 0)
+                {
+                    Row row = cell.getRow();
+                    float minHeight = row.getSheet().getDefaultRowHeightInPoints() * newlines;
+                    if (row.getHeightInPoints() < minHeight)
+                    {
+                        row.setHeightInPoints(minHeight);
+                    }
                 }
 
                 cell.setCellValue(s);

--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -813,7 +813,7 @@ public class ExcelColumn extends RenderColumn
 
             BindException errors = new NullSafeBindException(new Object(), "command");
             QueryView view = us.createView(qf, errors);
-            ExcelWriter excel = view.getExcelWriter(ExcelWriter.ExcelDocumentType.xlsx);
+            ExcelWriter excel = view.getExcelWriter(ExcelWriter.ExcelDocumentType.xlsx, null);
             try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
             {
                 excel.renderWorkbook(baos);

--- a/api/src/org/labkey/api/data/ExcelColumn.java
+++ b/api/src/org/labkey/api/data/ExcelColumn.java
@@ -110,20 +110,20 @@ public class ExcelColumn extends RenderColumn
     private String _name = null;
     private String _caption = null;
     private final Map<ConditionalFormat, CellStyle> _formats = new HashMap<>();
-    private final Workbook _workbook;
+    protected final Workbook _workbook;
 
-    public static class ExcelFormatDescriptor extends Pair<Class, String>
+    public static class ExcelFormatDescriptor extends Pair<Class<?>, String>
     {
-        private ExcelFormatDescriptor(Class aClass, String format)
+        private ExcelFormatDescriptor(Class<?> aClass, String format)
         {
             super(aClass, format);
         }
     }
 
-    private DisplayColumn _dc;
+    protected final DisplayColumn _dc;
     private final Map<ExcelFormatDescriptor, CellStyle> _formatters;
 
-    ExcelColumn(DisplayColumn dc, Map<ExcelFormatDescriptor, CellStyle> formatters, Workbook workbook)
+    public ExcelColumn(DisplayColumn dc, Map<ExcelFormatDescriptor, CellStyle> formatters, Workbook workbook)
     {
         super();
         _dc = dc;
@@ -182,7 +182,7 @@ public class ExcelColumn extends RenderColumn
 
         if (_simpleType == ExcelCellUtils.TYPE_UNKNOWN)
         {
-            Class valueClass = dc.getDisplayValueClass();
+            Class<?> valueClass = dc.getDisplayValueClass();
             _log.error("init: Unknown Class " + valueClass + " " + getName());
         }
     }
@@ -266,7 +266,7 @@ public class ExcelColumn extends RenderColumn
         ColumnInfo columnInfo = _dc.getColumnInfo();
         Row rowObject = getRow(sheet, row);
 
-        Cell cell = null;
+        Cell cell;
         if (null == o)
         {
             // For null values, don't create the cell unless there's a conditional format that applies
@@ -291,7 +291,7 @@ public class ExcelColumn extends RenderColumn
                 if (_style != null)
                     cell.setCellStyle(_style);
 
-                Drawing drawing = (Drawing)ctx.get(ExcelWriter.SHEET_DRAWING);
+                Drawing<?> drawing = (Drawing<?>)ctx.get(ExcelWriter.SHEET_DRAWING);
                 if (drawing != null && _dc instanceof AbstractFileDisplayColumn)
                 {
                     String path = (String)o;
@@ -385,7 +385,7 @@ public class ExcelColumn extends RenderColumn
         }
         catch(ClassCastException cce)
         {
-            _log.error("Can't cast '" + o.toString() + "', class '" + o.getClass().getName() + "', to class corresponding to simple type '" + _simpleType + "'");
+            _log.error("Can't cast '" + o + "', class '" + o.getClass().getName() + "', to class corresponding to simple type '" + _simpleType + "'");
             _log.error("DisplayColumn.getCaption(): " + _dc.getCaption());
             _log.error("DisplayColumn.getClass().getName(): " + _dc.getClass().getName());
             _log.error("DisplayColumn.getDisplayValueClass(): " + _dc.getDisplayValueClass());
@@ -631,16 +631,14 @@ public class ExcelColumn extends RenderColumn
                 adjustedHeight = (int) (originalHeight * rowHeight / originalHeight);
             }
 
-            if (pict instanceof XSSFPicture)
+            if (pict instanceof XSSFPicture picture)
             {
-                XSSFPicture picture = (XSSFPicture) pict;
                 XSSFAnchor anchor = picture.getAnchor();
                 anchor.setDx2(adjustedWidth * Units.EMU_PER_POINT);
                 anchor.setDy2(adjustedHeight * Units.EMU_PER_POINT);
             }
-            else if (pict instanceof  HSSFPicture)
+            else if (pict instanceof HSSFPicture picture)
             {
-                HSSFPicture picture = (HSSFPicture) pict;
                 HSSFClientAnchor anchor = (HSSFClientAnchor) picture.getAnchor();
 
                 double xRatio = 1023.0 * PIXELS_TO_CHARACTERS / sheet.getColumnWidth(anchor.getCol2());
@@ -676,16 +674,12 @@ public class ExcelColumn extends RenderColumn
         if (0 == _autoSizeWidth)
             _autoSizeWidth = _caption != null ? _caption.length() : 10;  // Start with caption width as minimum
 
-        switch (_simpleType)
+        format = switch (_simpleType)
         {
-            case(ExcelCellUtils.TYPE_DATE):
-                format = FastDateFormat.getInstance(getFormatString());
-                break;
-            case(ExcelCellUtils.TYPE_INT):
-            case(ExcelCellUtils.TYPE_DOUBLE):
-                format = new DecimalFormat(getFormatString());
-                break;
-        }
+            case (ExcelCellUtils.TYPE_DATE) -> FastDateFormat.getInstance(getFormatString());
+            case (ExcelCellUtils.TYPE_INT), (ExcelCellUtils.TYPE_DOUBLE) -> new DecimalFormat(getFormatString());
+            default -> format;
+        };
 
         // Assumes column has same cell type from startRow to endRow, and that cell type matches the Excel column type (which it should, since we just wrote it)
         for (int row = startRow; row <= endRow; row++)
@@ -814,9 +808,7 @@ public class ExcelColumn extends RenderColumn
             qf.setSchemaName("lists");
             qf.setQueryName(LISTNAME);
             qf.setViewContext(ViewContext.getMockViewContext(TestContext.get().getUser(), getProject(), getProject().getStartURL(TestContext.get().getUser()), false));
-            List<FieldKey> fields = Arrays.stream(FIELDS).map(x -> {
-                return FieldKey.fromString(x[0].toString());
-            }).collect(Collectors.toList());
+            List<FieldKey> fields = Arrays.stream(FIELDS).map(x -> FieldKey.fromString(x[0].toString())).collect(Collectors.toList());
             qf.getQuerySettings().setFieldKeys(fields);
 
             BindException errors = new NullSafeBindException(new Object(), "command");

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -124,7 +124,8 @@ public class ExcelWriter implements ExportWriter
             {
                 // Always use a streaming workbook, set to flush to disk every 1,000 rows, #14960.
                 // Note: if we ever need a non-streaming workbook, create a new enum that constructs an XSSFWorkbook.
-                return new SXSSFWorkbook(1000){
+                // Need to use a shared strings table to support rich text formatting
+                return new SXSSFWorkbook(null,1000, false, true) {
                     @Override
                     public void close() throws IOException
                     {
@@ -570,7 +571,7 @@ public class ExcelWriter implements ExportWriter
 
         for (DisplayColumn dc : columns)
         {
-            ExcelColumn column = new ExcelColumn(dc, _formatters, workbook);
+            ExcelColumn column = dc.createExcelColumn(_formatters, workbook);
             if (column.isVisible(ctx))
             {
                 column.setAutoSize(_autoSize);

--- a/api/src/org/labkey/api/data/ExcelWriter.java
+++ b/api/src/org/labkey/api/data/ExcelWriter.java
@@ -124,8 +124,8 @@ public class ExcelWriter implements ExportWriter
             {
                 // Always use a streaming workbook, set to flush to disk every 1,000 rows, #14960.
                 // Note: if we ever need a non-streaming workbook, create a new enum that constructs an XSSFWorkbook.
-                // Need to use a shared strings table to support rich text formatting
-                return new SXSSFWorkbook(null,1000, false, true) {
+                return new SXSSFWorkbook(null, 1000)
+                {
                     @Override
                     public void close() throws IOException
                     {
@@ -138,7 +138,7 @@ public class ExcelWriter implements ExportWriter
             @Override
             public String getMimeType()
             {
-                return "application/" + ExcelFactory.SUB_TYPE_XSSF; 
+                return "application/" + ExcelFactory.SUB_TYPE_XSSF;
             }
 
             @Override
@@ -164,6 +164,54 @@ public class ExcelWriter implements ExportWriter
                     metadata.forEach(props::addProperty);
                 }
             }
+        },
+        xlsxSharedStrings
+        {
+            @Override
+            public Workbook createWorkbook()
+            {
+                // Always use a streaming workbook, set to flush to disk every 1,000 rows, #14960.
+                // Note: if we ever need a non-streaming workbook, create a new enum that constructs an XSSFWorkbook.
+                // Need to use a shared strings table to support rich text formatting
+                return new SXSSFWorkbook(null,1000, false, true) {
+                    @Override
+                    public void close() throws IOException
+                    {
+                        super.close();
+                        dispose(); // Required to clean up temp/poifiles, #46060
+                    }
+                };
+            }
+
+            @Override
+            public String getMimeType()
+            {
+                return xlsx.getMimeType();
+            }
+
+            @Override
+            public int getMaxRows()
+            {
+                return xlsx.getMaxRows();
+            }
+
+            @Override
+            public int getMaxColumns()
+            {
+                return xlsx.getMaxColumns();
+            }
+
+            @Override
+            public void setMetadata(Workbook workbook, Map<String, String> metadata)
+            {
+                xlsx.setMetadata(workbook, metadata);
+            }
+
+            @Override
+            public @Nullable String getFileExtension()
+            {
+                return xlsx.getFileExtension();
+            }
         };
 
         public abstract Workbook createWorkbook();
@@ -172,6 +220,11 @@ public class ExcelWriter implements ExportWriter
         public abstract int getMaxRows();
         public abstract int getMaxColumns();
         public abstract void setMetadata(Workbook workbook, Map<String, String> metadata);
+
+        public @Nullable String getFileExtension()
+        {
+            return name();
+        }
     }
 
     protected static final String SHEET_DRAWING = "~~excel-sheet-drawing~~";
@@ -622,7 +675,7 @@ public class ExcelWriter implements ExportWriter
         // so that your browser doesn't put the generated file into its cache
 
 
-        String filename = fullFileName == null ? FileUtil.makeFileNameWithTimestamp(filenamePrefix, docType.name()) : FileUtil.makeLegalName(fullFileName);
+        String filename = fullFileName == null ? FileUtil.makeFileNameWithTimestamp(filenamePrefix, docType.getFileExtension()) : FileUtil.makeLegalName(fullFileName);
         ResponseHelper.setContentDisposition(response, ResponseHelper.ContentDispositionType.attachment, filename);
 
         try

--- a/api/src/org/labkey/api/query/CrosstabView.java
+++ b/api/src/org/labkey/api/query/CrosstabView.java
@@ -39,10 +39,6 @@ import java.util.Map;
 
 /**
  * View class for rendering CrosstabTableInfos.
- *
- * User: Dave
- * Date: Jan 25, 2008
- * Time: 9:49:51 AM
  */
 public class CrosstabView extends QueryView
 {
@@ -235,7 +231,7 @@ public class CrosstabView extends QueryView
                     rowDimFilter.addClause(clause);
             }
 
-            if (aggFilter.getClauses().size() > 0)
+            if (!aggFilter.getClauses().isEmpty())
                 table.setAggregateFilter(aggFilter);
             view.getRenderContext().setBaseFilter(rowDimFilter);
         }
@@ -244,7 +240,7 @@ public class CrosstabView extends QueryView
     }
 
     @Override
-    public ExcelWriter getExcelWriter(ExcelWriter.ExcelDocumentType docType)
+    public ExcelWriter getExcelWriter(ExcelWriter.ExcelDocumentType docType, @Nullable Map<String, String> renameColumnMap) throws IOException
     {
         DataView view = createDataView();
         DataRegion rgn = view.getDataRegion();

--- a/api/src/org/labkey/api/query/QueryView.java
+++ b/api/src/org/labkey/api/query/QueryView.java
@@ -206,7 +206,7 @@ public class QueryView extends WebPartView<Object>
     private CustomView _customView;
     private UserSchema _schema;
     private Errors _errors;
-    private List<QueryException> _parseErrors = new ArrayList<>();
+    private final List<QueryException> _parseErrors = new ArrayList<>();
     private QuerySettings _settings;
     private boolean _showRecordSelectors = false;
 
@@ -272,8 +272,8 @@ public class QueryView extends WebPartView<Object>
     }
 
 
-    @Deprecated
     /** Use the constructor that takes an Errors object instead */
+    @Deprecated
     protected QueryView(UserSchema schema, QuerySettings settings)
     {
         this(schema, settings, null);
@@ -393,7 +393,7 @@ public class QueryView extends WebPartView<Object>
                     if (getUser().isPlatformDeveloper())
                     {
                         out.write(" ");
-                        out.print(PageFlowUtil.link(StringUtils.defaultString(resolveText, "resolve")).href(resolveURL));
+                        out.print(PageFlowUtil.link(Objects.toString(resolveText, "resolve")).href(resolveURL));
                     }
                 }
                 out.write("<br>");
@@ -729,8 +729,7 @@ public class QueryView extends WebPartView<Object>
         }
         if (parameterToAdd != null)
             url.addParameter(parameterToAdd, parameterValue);
-        ActionButton actionButton = new ActionButton(label, url);
-        return actionButton;
+        return new ActionButton(label, url);
     }
 
     protected String param(QueryParam param)
@@ -818,7 +817,7 @@ public class QueryView extends WebPartView<Object>
                 {
                     // Prepend source sort parameter before target's existing sort
                     String targetSort = target.getParameter(key);
-                    if (targetSort != null && targetSort.length() > 0)
+                    if (targetSort != null && !targetSort.isEmpty())
                         value = value + "," + targetSort;
                     target.replaceParameter(newKey, value);
                 }
@@ -1427,7 +1426,7 @@ public class QueryView extends WebPartView<Object>
         exportUrl.replaceParameter("scriptType","r");
         TextExportOptionsBean textBean = new TextExportOptionsBean(getDataRegionName(), getExportRegionName(), selectionKey,
                 getColumnHeaderType(), exportUrl, null, null);
-        HttpView exportView = rss.getExportToRStudioView(textBean);
+        HttpView<?> exportView = rss.getExportToRStudioView(textBean);
         if (exportView == null)
             return;
         exportButton.addSubPanel("RStudio", exportView);
@@ -1475,7 +1474,7 @@ public class QueryView extends WebPartView<Object>
         // if we are not rendering a report or not showing reports, we use the current view name to set the menu item
         // selection, an empty string denotes the default view, a customized default view will have a null name.
         if (_report == null || !_showReports)
-            current = (_customView != null) ? StringUtils.defaultString(_customView.getName(), "") : "";
+            current = (_customView != null) ? Objects.toString(_customView.getName(), "") : "";
 
         URLHelper target = urlChangeView();
         MenuButton button = new MenuButton("Grid Views");
@@ -1657,8 +1656,8 @@ public class QueryView extends WebPartView<Object>
 
     private static class WrappedItemFilter implements ReportService.ItemFilter
     {
-        private ReportService.ItemFilter _filter;
-        private Map<String, ViewOptions.ViewFilterItem> _filterItemMap = new HashMap<>();
+        private final ReportService.ItemFilter _filter;
+        private final Map<String, ViewOptions.ViewFilterItem> _filterItemMap = new HashMap<>();
 
 
         public WrappedItemFilter(ReportService.ItemFilter filter, QueryDefinition def)
@@ -1736,7 +1735,7 @@ public class QueryView extends WebPartView<Object>
                 url.replaceParameter(propName, filterType.name());
                 NavTree filterItem = new NavTree(filterType.toString(), url);
 
-                filterItem.setId(getBaseMenuId() + ":GridViews:Folder Filter:" + filterType.toString());
+                filterItem.setId(getBaseMenuId() + ":GridViews:Folder Filter:" + filterType);
 
                 if (selectedFilterType == filterType)
                 {
@@ -1835,7 +1834,7 @@ public class QueryView extends WebPartView<Object>
             if (view.getContainer() != null && !view.getContainer().equals(getContainer()))
                 description.append("Inherited from '").append(PageFlowUtil.filter(view.getContainer().getPath())).append("'");
 
-            if (description.length() > 0)
+            if (!description.isEmpty())
                 item.setDescription(description.toString());
 
             try
@@ -1900,7 +1899,7 @@ public class QueryView extends WebPartView<Object>
             }
         }
 
-        if (views.size() > 0)
+        if (!views.isEmpty())
             menu.addSeparator();
 
         for (Map.Entry<String, List<Report>> entry : views.entrySet())
@@ -1910,8 +1909,8 @@ public class QueryView extends WebPartView<Object>
             // sort the list of reports within each type grouping
             reports.sort((o1, o2) ->
             {
-                String n1 = StringUtils.defaultString(o1.getDescriptor().getReportName(), "");
-                String n2 = StringUtils.defaultString(o2.getDescriptor().getReportName(), "");
+                String n1 = Objects.toString(o1.getDescriptor().getReportName(), "");
+                String n2 = Objects.toString(o2.getDescriptor().getReportName(), "");
 
                 return n1.compareToIgnoreCase(n2);
             });
@@ -1959,7 +1958,7 @@ public class QueryView extends WebPartView<Object>
             }
         }
 
-        if (views.size() > 0)
+        if (!views.isEmpty())
             menu.addSeparator();
 
         for (Map.Entry<String, List<Report>> entry : views.entrySet())
@@ -1968,8 +1967,8 @@ public class QueryView extends WebPartView<Object>
 
             charts.sort((o1, o2) ->
             {
-                String n1 = StringUtils.defaultString(o1.getDescriptor().getReportName(), "");
-                String n2 = StringUtils.defaultString(o2.getDescriptor().getReportName(), "");
+                String n1 = Objects.toString(o1.getDescriptor().getReportName(), "");
+                String n2 = Objects.toString(o2.getDescriptor().getReportName(), "");
 
                 return n1.compareToIgnoreCase(n2);
             });
@@ -2149,7 +2148,7 @@ public class QueryView extends WebPartView<Object>
         }
 
         TableInfo table = getTable();
-        if (table instanceof FilteredTable && ((FilteredTable) table).hasRulesOmittedColumns())
+        if (table instanceof FilteredTable<?> ft && ft.hasRulesOmittedColumns())
         {
             rgn.addMessageSupplier(x -> List.of(new DataRegion.Message("PHI protected columns have been omitted", DataRegion.MessageType.WARNING, DataRegion.MessagePart.header)));
         }
@@ -2354,7 +2353,7 @@ public class QueryView extends WebPartView<Object>
         // make sure table has been instantiated
         getTable();
         List<QueryException> errors = getParseErrors();
-        if (errors.size() != 0)
+        if (!errors.isEmpty())
         {
             renderErrors(out, "Query '" + getQueryDef().getName() + "' has errors", errors);
             return;
@@ -2378,7 +2377,7 @@ public class QueryView extends WebPartView<Object>
         return getTsvWriter(headerType, Collections.emptyMap());
     }
 
-    protected TSVGridWriter getTsvWriter(ColumnHeaderType headerType, @NotNull Map<String, String> renameColumnMap) throws IOException
+    protected TSVGridWriter getTsvWriter(ColumnHeaderType headerType, @NotNull Map<String, String> renameColumnMap)
     {
         _exportView = true;
         DataView view = createDataView();
@@ -2448,15 +2447,10 @@ public class QueryView extends WebPartView<Object>
         return ret;
     }
 
-    public ExcelWriter getExcelWriter(ExcelWriter.ExcelDocumentType docType) throws IOException
-    {
-        return getExcelWriter(docType, null);
-    }
-
-    public ExcelWriter getExcelWriter(@NotNull ExcelExportConfig config) throws IOException
+    public final ExcelWriter getExcelWriter(@NotNull ExcelExportConfig config) throws IOException
     {
         // Call the appropriate overridden method
-        ExcelWriter ew = getExcelWriter(config.getDocType());
+        ExcelWriter ew = getExcelWriter(config.getDocType(), null);
         return configureExcelWriter(ew, config);
     }
 
@@ -2478,7 +2472,6 @@ public class QueryView extends WebPartView<Object>
      * Sets configuration settings for the provided ExcelWriter according the provided config and this QueryView
      * @param excelWriter to configure (CALLER TO CLOSE)
      * @param config additional properties to set on the writer
-     * @return
      */
     public ExcelWriter configureExcelWriter(ExcelWriter excelWriter, ExcelExportConfig config)
     {
@@ -2562,8 +2555,7 @@ public class QueryView extends WebPartView<Object>
                 if (col != null && col.isUserEditable())
                 {
                     fieldKeys.add(key);
-                    if (requiredCols.contains(key))
-                        requiredCols.remove(key);
+                    requiredCols.remove(key);
                 }
             }
 
@@ -2833,7 +2825,7 @@ public class QueryView extends WebPartView<Object>
             ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
             try (OutputStream stream = new BufferedOutputStream(byteStream))
             {
-                ExcelWriter ew = getExcelWriter(docType);
+                ExcelWriter ew = getExcelWriter(docType, null);
                 ew.setCaptionType(headerType);
                 ew.setShowInsertableColumnsOnly(false, null);
                 ew.setMetadata(metadata);
@@ -2956,7 +2948,7 @@ public class QueryView extends WebPartView<Object>
         {
             //table was null--try to get parse errors
             List<QueryException> errors = getParseErrors();
-            if (null != errors && errors.size() > 0)
+            if (null != errors && !errors.isEmpty())
                 throw errors.get(0);
         }
     }

--- a/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
@@ -895,7 +895,7 @@ public class ExpDataTableImpl extends ExpRunItemTableImpl<ExpDataTable.Column> i
                 assertEquals("Incorrect WebDavUrlRelative", tc.getUrlRelative(), webDavUrlRelative);
                 assertEquals("Incorrect WebDavUrl", tc.getUrl(), webDavUrl);
 
-                ExcelWriter excel = view.getExcelWriter(ExcelWriter.ExcelDocumentType.xlsx);
+                ExcelWriter excel = view.getExcelWriter(ExcelWriter.ExcelDocumentType.xlsx, null);
                 try (VirtualFile f = new MemoryVirtualFile())
                 {
                     try (OutputStream os = f.getOutputStream("excel.xlsx"))


### PR DESCRIPTION
#### Rationale
We now have use cases that desire rich text formatting in Excel exports. That requires the use of Excel's shared string table, which has memory tradeoffs. It also means that we need a way to inject the custom formatting on a per-column basis.

#### Changes
- New `xlsxSharedStrings` option for exporting Excel files
- Let `DisplayColumn` supply a customized `ExcelColumn` to handle rich text formatting
- Consolidate method overrides and steer subclassers in the right direction
- Expand rows to show full multi-line string values
- Misc code cleanup