### PR TITLE
Fix boosting search on material name

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -426,9 +426,11 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
 
         Map<String, Object> props = new HashMap<>();
         Set<String> identifiersHi = new HashSet<>();
+        Set<String> keyworksHi = new HashSet<>();
 
         // Name is identifier with the highest weight
         identifiersHi.add(getName());
+        keyworksHi.add(getName()); // support "Boosting syntax (^4)" on name
 
         // Add aliases in parentheses in the title
         StringBuilder title = new StringBuilder("Sample - " + getName());
@@ -459,7 +461,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
                 tableInfo = (ExpMaterialTableImpl) QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_SAMPLES).getTable(getSampleType().getName());
 
             if (tableInfo != null)
-                getCustomIndexValues(props, tableInfo, identifiersHi, jsonData);
+                getCustomIndexValues(props, tableInfo, identifiersHi, keyworksHi, jsonData);
         }
 
         props.put(SearchService.PROPERTY.jsonData.toString(), jsonData);
@@ -519,6 +521,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
             Map<String, Object> props,
             @NotNull ExpMaterialTableImpl table,
             Set<String> identifiersHi,
+            Set<String> keywordsHi,
             JSONObject jsonData
     )
     {
@@ -526,7 +529,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
         for (ExpMaterialTable.Column column : ExpMaterialTable.Column.values())
             skipColumns.add(column.name());
 
-        processIndexValues(props, table, skipColumns, identifiersHi, new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>(), jsonData);
+        processIndexValues(props, table, skipColumns, identifiersHi, new HashSet<>(), new HashSet<>(), keywordsHi, new HashSet<>(), new HashSet<>(), jsonData);
     }
 
     static final List<Pair<Integer,Long>> updateLastIndexedList = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
The recent change to switch from using properties instead of document body for storing material data is causing test failure when using "boosting" search syntax. Boosting syntax is used on document body and keywords, but not identifiers. 
[NotebookMediaReferenceTest.testValidPrefixCharacters](https://teamcity.labkey.org/viewLog.html?buildId=3497426&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId1125694475245455457)
[CrossFolderSearchTest.testCanSeeDataFromProject](https://teamcity.labkey.org/viewLog.html?buildId=3497426&buildTypeId=LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres&fromSakuraUI=true#testNameId-2514177101249914963)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6611

#### Changes
- Add name to document keywords
