### PR TITLE
Issues 52506 and 52507 follow up

### DIFF
--- a/audit/src/org/labkey/audit/AuditController.java
+++ b/audit/src/org/labkey/audit/AuditController.java
@@ -388,7 +388,7 @@ public class AuditController extends SpringActionController
             if (form.isSampleType())
                 rowIds = AuditLogImpl.get().getTransactionSampleIds(form.getTransactionAuditId(), ElevatedUser.ensureCanSeeAuditLogRole(getContainer(), getUser()), getContainer(), cf);
             else
-                rowIds = AuditLogImpl.get().getTransactionSourceIds(form.getTransactionAuditId(), getUser(), getContainer(), cf);
+                rowIds = AuditLogImpl.get().getTransactionSourceIds(form.getTransactionAuditId(), ElevatedUser.ensureCanSeeAuditLogRole(getContainer(), getUser()), getContainer(), cf);
 
             ApiSimpleResponse response = new ApiSimpleResponse();
             response.put("success", true);

--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -304,9 +304,9 @@ public class AuditLogImpl implements AuditLogService, StartupListener
                 if (event.getNewRecordMap() != null)
                 {
                     Map<String, String> newRecord = new CaseInsensitiveHashMap<>(AbstractAuditTypeProvider.decodeFromDataMap(event.getNewRecordMap()));
-                    if (newRecord.containsKey("RowId"))
+                    if (newRecord.containsKey("RowId") && !StringUtils.isEmpty(newRecord.get("RowId")))
                         sourceIds.add(Integer.valueOf(newRecord.get("RowId")));
-                    else if (newRecord.containsKey("LSID"))
+                    else if (newRecord.containsKey("LSID") && !StringUtils.isEmpty(newRecord.get("LSID")))
                         lsids.add(newRecord.get("LSID"));
 
                 }

--- a/audit/src/org/labkey/audit/AuditLogImpl.java
+++ b/audit/src/org/labkey/audit/AuditLogImpl.java
@@ -17,6 +17,7 @@
 package org.labkey.audit;
 
 import jakarta.servlet.ServletContext;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.SpringActionController;
@@ -287,9 +288,9 @@ public class AuditLogImpl implements AuditLogService, StartupListener
                     if (detailedEvent.getNewRecordMap() != null)
                     {
                         Map<String, String> newRecord = new CaseInsensitiveHashMap<>(AbstractAuditTypeProvider.decodeFromDataMap(detailedEvent.getNewRecordMap()));
-                        if (newRecord.containsKey("RowId"))
+                        if (newRecord.containsKey("RowId") && !StringUtils.isEmpty(newRecord.get("RowId")))
                             sourceIds.add(Integer.valueOf(newRecord.get("RowId")));
-                        else if (newRecord.containsKey("LSID"))
+                        else if (newRecord.containsKey("LSID") && !StringUtils.isEmpty(newRecord.get("LSID")))
                             lsids.add(newRecord.get("LSID"));
                     }
                 }

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2514,9 +2514,12 @@ public class ExpDataIterators
                     ContainerFilter cf = ContainerFilter.current(container, user);
                     if (container.isProductFoldersEnabled())
                     {
+                        // Note that this is slightly different than our treatment of lookups:
+                        //    - when in a project, we allow import or update to all subfolders,
+                        //    - when in a folder, we only allow references to data up the folder tree
                         if (container.isProject())
                             cf = new ContainerFilter.AllInProjectPlusShared(container, user);
-                        else if (!QueryService.get().isProductFoldersDataListingScopedToProject())
+                        else
                             cf = new ContainerFilter.CurrentPlusProjectAndShared(container, user);
                     }
                     Collection<GUID> validContainerIds =  cf.getIds();

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2514,7 +2514,7 @@ public class ExpDataIterators
                     ContainerFilter cf = ContainerFilter.current(container, user);
                     if (container.isProductFoldersEnabled())
                     {
-                        // Note that this is slightly different than our treatment of lookups:
+                        // Note that this is slightly different from our treatment of lookups:
                         //    - when in a project, we allow import or update to all subfolders,
                         //    - when in a folder, we only allow references to data up the folder tree
                         if (container.isProject())


### PR DESCRIPTION
#### Rationale
- Issue [52506](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52506) - Remove check for experimental feature flag when getting container filter for cross-folder import
- Issue [52507](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52507) - We want to assure the "select them in the grid" link in success messages work for non-admin users.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1389

#### Changes
- Use elevated user when getting the data class row ids from a transaction id
- Remove check for project-only data experimental feature flag when getting valid containers for cross-folder import
