### PR TITLE
Issue 51126: AssayResultUpdateService.updateRow fix to account for TableSelector getMap() returning column alias

### DIFF
--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -274,9 +274,8 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
 
             if (col != null)
             {
-                String entryKey = col.getAlias().getId(); // getRow() ends up using TableSelector.getMap() which is keyed by column alias
-                Object oldValue = originalRow.get(entryKey);
-                Object newValue = updatedValues.get(entryKey);
+                Object oldValue = col.getValue(originalRow);
+                Object newValue = col.getValue(updatedValues);
                 boolean hasValueChanged = !Objects.equals(oldValue, newValue);
 
                 if (hasValueChanged)
@@ -284,7 +283,7 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
 
                 TableInfo fkTableInfo = col.getFkTableInfo();
                 // Don't follow the lookup for specimen IDs, since their FK is very special and based on target study, etc
-                if (hasValueChanged && fkTableInfo != null && !AbstractAssayProvider.SPECIMENID_PROPERTY_NAME.equalsIgnoreCase(entryKey))
+                if (hasValueChanged && fkTableInfo != null && !AbstractAssayProvider.SPECIMENID_PROPERTY_NAME.equalsIgnoreCase(col.getName()))
                 {
                     // Do type conversion in case there's a mismatch in the lookup source and target columns
                     ColumnInfo fkTablePkCol = fkTableInfo.getPkColumns().get(0);

--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -266,7 +266,7 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
         Map<String, Object> updatedValues = getRow(user, container, oldRow);
 
         StringBuilder sb = new StringBuilder("Data row, id " + oldRow.get("RowId") + ", edited in " + run.getProtocol().getName() + ".");
-        for (Map.Entry<String, Object> entry : updatedValues.entrySet())
+        for (Map.Entry<String, Object> entry : result.entrySet())
         {
             // Also check for properties
             TableInfo table = getQueryTable();
@@ -274,8 +274,9 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
 
             if (col != null)
             {
-                Object oldValue = originalRow.get(entry.getKey());
-                Object newValue = entry.getValue();
+                String entryKey = col.getAlias().getId(); // getRow() ends up using TableSelector.getMap() which is keyed by column alias
+                Object oldValue = originalRow.get(entryKey);
+                Object newValue = updatedValues.get(entryKey);
                 boolean hasValueChanged = !Objects.equals(oldValue, newValue);
 
                 if (hasValueChanged)
@@ -283,7 +284,7 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
 
                 TableInfo fkTableInfo = col.getFkTableInfo();
                 // Don't follow the lookup for specimen IDs, since their FK is very special and based on target study, etc
-                if (hasValueChanged && fkTableInfo != null && !AbstractAssayProvider.SPECIMENID_PROPERTY_NAME.equalsIgnoreCase(entry.getKey()))
+                if (hasValueChanged && fkTableInfo != null && !AbstractAssayProvider.SPECIMENID_PROPERTY_NAME.equalsIgnoreCase(entryKey))
                 {
                     // Do type conversion in case there's a mismatch in the lookup source and target columns
                     ColumnInfo fkTablePkCol = fkTableInfo.getPkColumns().get(0);


### PR DESCRIPTION
#### Rationale
Issue [51126](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51126): LKSM: Remapping assay results to a new sample disallows delete of old sample

This issue regressed recently after the TableSelector getMap() change to the key used for the map. The code was using the keys of the map to call TableInfo.getColumn() to identify which field values changed in the assay result row so that the assay run syncLineage could be called. Since getColumn() looks for columns by name or fieldKey, this regressed for cases where the sample lookup field had special characters, meaning that the column.getName() does not equal column.getAlias().

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6636
- https://github.com/LabKey/limsModules/pull/1390

#### Changes
- AssayResultUpdateService.updateRow to use the updateRow result map key to get the ColumnInfo
