### PR TITLE
more usages of BaseColumnInfo.createNotInDatabase()

### DIFF
--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -313,12 +313,15 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         // TODO ensure all aliases in table constructor and get rid of lazy evaluation here so we don't have to avoid checkLocked()
         if (_alias == null)
         {
-            var legal = AliasManager.makeLegalName(getFieldKey(), getSqlDialect());
             // there are BaseColumnInfo instances that are not part of a database table (e.g., for a DataLoader)
             // these don't really need an alias, but we need something here
             SqlDialect dialect = getSqlDialect();
             if (null == dialect)
-                return new NotInDatabaseIdentifier(legal);
+            {
+                // CONSIDER set _alias if locked? always set?
+                return new NotInDatabaseIdentifier(getName());
+            }
+            var legal = AliasManager.makeLegalName(getFieldKey(), getSqlDialect());
             _alias = getSqlDialect().makeDatabaseIdentifier(legal);
         }
         return _alias;

--- a/api/src/org/labkey/api/reader/DataLoader.java
+++ b/api/src/org/labkey/api/reader/DataLoader.java
@@ -1015,12 +1015,12 @@ public abstract class DataLoader implements Iterable<Map<String, Object>>, Loade
         public ColumnInfo getColumnInfo(int i)
         {
             if (i == 0)
-                return new BaseColumnInfo(ROWNUMBER_COLUMNNAME, JdbcType.INTEGER);
+                return BaseColumnInfo.createNotInDatabase(ROWNUMBER_COLUMNNAME, JdbcType.INTEGER);
             ColumnDescriptor d = _columns[i-1];
             JdbcType type = JdbcType.valueOf(d.clazz);
             if (null == type)
                 type = JdbcType.VARCHAR;
-            var ret = new BaseColumnInfo(d.name, type);
+            var ret = BaseColumnInfo.createNotInDatabase(d.name, type);
             if (null != d.propertyURI)
                 ret.setPropertyURI(d.propertyURI);
             return ret;

--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -618,7 +618,7 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
 
         int translatePtid(Integer indexPtidInput, User user) throws ValidationException
         {
-            ColumnInfo col = new BaseColumnInfo(_datasetDefinition.getStudy().getSubjectColumnName(), JdbcType.VARCHAR);
+            ColumnInfo col = BaseColumnInfo.createNotInDatabase(_datasetDefinition.getStudy().getSubjectColumnName(), JdbcType.VARCHAR);
             ParticipantIdImportHelper piih = new ParticipantIdImportHelper(_datasetDefinition.getStudy(), user, _datasetDefinition);
             Callable call = piih.getCallable(getInput(), indexPtidInput);
             return addColumn(col, call);
@@ -626,14 +626,14 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
 
         int addLSID()
         {
-            ColumnInfo col = new BaseColumnInfo("lsid", JdbcType.VARCHAR);
+            ColumnInfo col = BaseColumnInfo.createNotInDatabase("lsid", JdbcType.VARCHAR);
             indexLSIDOutput = addColumn(col, new LSIDColumn());
             return indexLSIDOutput;
         }
 
         int addParticipantSequenceNum()
         {
-            var col = new BaseColumnInfo("participantsequencenum", JdbcType.VARCHAR);
+            var col = BaseColumnInfo.createNotInDatabase("participantsequencenum", JdbcType.VARCHAR);
             return addColumn(col, new ParticipantSequenceNumColumn());
         }
 


### PR DESCRIPTION

#### Rationale
Fix ETLRemoteSourceTest
also fix the null check in BaseColumnInfo.getAlias()

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
