### PR TITLE
Fix list import unit tests

### DIFF
--- a/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/ExistingRecordDataIterator.java
@@ -321,9 +321,6 @@ public abstract class ExistingRecordDataIterator extends WrapperDataIterator
             // fetch N new rows into the existingRecords map
             Pair<SQLFragment, Map<Integer, String>> selectRowsSql = getSelectExistingSql(50);
 
-            if (_context.getErrors().hasErrors())
-                return;
-
             SQLFragment select = selectRowsSql.first;
             Map<Integer, String> rowNumContainers = selectRowsSql.second;
             var list = new SqlSelector(target.getSchema(), select, QueryLogging.noValidationNeededQueryLogging()).getArrayList(Map.class);


### PR DESCRIPTION
#### Rationale
ExistingRecordDataIterator was modified to skip fetching data when there is error in the current context, as part of merge conflict resolution from 25.3 to 25.5. This "optimization" is not working well for Lists, which has failFast set to false, resulting in undesired error msg. 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6634

#### Changes
- Don't skip existing record fetch on encounter of error to support failFast=false (lists).
