### PR TITLE
Always filter to current container in `getExistingRowSelect` 

### DIFF
--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2599,7 +2599,7 @@ public class ExpDataIterators
                             _context.getErrors().addRowError(new ValidationException("Table for " + (_isSamples ? "sample type" : "dataclass") + " '" + typeData.dataType.getName() + "' not found."));
                             return totalRowCount;
                         }
-                        totalRowCount +=_importSplitFile(typeData, containerSplitFile.getValue(), splitContainer, dataTable);
+                        totalRowCount += _importSplitFile(typeData, containerSplitFile.getValue(), splitContainer, dataTable);
                     }
                     return totalRowCount;
                 }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -1085,12 +1085,12 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         return getMaterialMapsWithInput(keys, user, container, verifyNoCrossFolderData, verifyExisting, columns);
     }
 
-    private record ExistingRowSelect(TableInfo tableInfo, Set<String> columns, boolean includeParent, boolean addContainerFilter) {}
+    private record ExistingRowSelect(TableInfo tableInfo, Set<String> columns, boolean includeParent) {}
 
     private @NotNull ExistingRowSelect getExistingRowSelect(@Nullable Set<String> dataColumns)
     {
         if (!(getQueryTable() instanceof UpdateableTableInfo updatable) || dataColumns == null)
-            return new ExistingRowSelect(getQueryTable(), ALL_COLUMNS, true, false);
+            return new ExistingRowSelect(getQueryTable(), ALL_COLUMNS, true);
 
         CaseInsensitiveHashMap<String> remap = updatable.remapSchemaColumns();
         if (null == remap)
@@ -1126,7 +1126,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                 Map<String, String> importAliases = _sampleType.getImportAliases();
                 for (String col : dataColumns)
                 {
-                    if (!hasParentInput && ExperimentService.isInputOutputColumn(col) || equalsIgnoreCase("parent",col) || importAliases.containsKey(col))
+                    if (ExperimentService.isInputOutputColumn(col) || equalsIgnoreCase("parent",col) || importAliases.containsKey(col))
                     {
                         hasParentInput = true;
                         break;
@@ -1139,7 +1139,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             }
         }
 
-        return new ExistingRowSelect(selectTable, includedColumns, hasParentInput, isAllFromMaterialTable /* Unlike samples table, Materials table doesn't have container filter applied*/);
+        return new ExistingRowSelect(selectTable, includedColumns, hasParentInput);
     }
 
     private Map<Integer, Map<String, Object>> getMaterialMapsWithInput(Map<Integer, Map<String, Object>> keys, User user, Container container, boolean checkCrossFolderData, boolean verifyExisting, @Nullable Set<String> columns)
@@ -1148,7 +1148,6 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         ExistingRowSelect existingRowSelect = getExistingRowSelect(columns);
         TableInfo queryTableInfo = existingRowSelect.tableInfo;
         Set<String> selectColumns = existingRowSelect.columns;
-        boolean filterToCurrentContainer = existingRowSelect.addContainerFilter;
 
         Map<Integer, Map<String, Object>> sampleRows = new LinkedHashMap<>();
         Map<Integer, String> rowNumLsid = new HashMap<>();
@@ -1185,8 +1184,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         if (!rowIdRowNumMap.isEmpty())
         {
             SimpleFilter filter = new SimpleFilter(FieldKey.fromParts(ExpMaterialTable.Column.RowId), rowIdRowNumMap.keySet(), CompareType.IN);
-            if (filterToCurrentContainer)
-                filter.addCondition(FieldKey.fromParts("Container"), container);
+            filter.addCondition(FieldKey.fromParts("Container"), container);
             Map<String, Object>[] rows = new TableSelector(queryTableInfo, selectColumns, filter, null).getMapArray();
             for (Map<String, Object> row : rows)
             {
@@ -1208,8 +1206,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             allKeys.addAll(lsidRowNumMap.keySet());
 
             SimpleFilter filter = new SimpleFilter(FieldKey.fromParts(LSID), lsidRowNumMap.keySet(), CompareType.IN);
-            if (filterToCurrentContainer)
-                filter.addCondition(FieldKey.fromParts("Container"), container);
+            filter.addCondition(FieldKey.fromParts("Container"), container);
             Map<String, Object>[] rows = new TableSelector(queryTableInfo, selectColumns, filter, null).getMapArray();
             for (Map<String, Object> row : rows)
             {
@@ -1226,9 +1223,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             allKeys.addAll(nameRowNumMap.keySet());
             SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("MaterialSourceId"), sampleTypeId);
             filter.addCondition(FieldKey.fromParts("Name"), nameRowNumMap.keySet(), CompareType.IN);
-            if (filterToCurrentContainer)
-                filter.addCondition(FieldKey.fromParts("Container"), container);
-
+            filter.addCondition(FieldKey.fromParts("Container"), container);
             Map<String, Object>[] rows = new TableSelector(queryTableInfo, selectColumns, filter, null).getMapArray();
             for (Map<String, Object> row : rows)
             {


### PR DESCRIPTION
#### Rationale
Now that `queryTable` has a broader container filter applied to it for lookup resolution, we need to always filter to the current container when checking for existing records in order to detect duplicates.

#### Related Pull Requests
- #6614 

#### Changes
- Remove conditional for adding container to filter clause in `getMaterialMapsWithInput`
