### PR TITLE
Add dirty handling to allow list admin pages

### DIFF
--- a/api/src/org/labkey/api/collections/ArrayListMap.java
+++ b/api/src/org/labkey/api/collections/ArrayListMap.java
@@ -55,8 +55,8 @@ public class ArrayListMap<K, V> extends AbstractMap<K, V> implements Iterable<V>
 
     public static class FindMap<K> implements Map<K,Integer>
     {
-        final Map<K,Integer> _map;
-        int _max = -1;
+        private final Map<K,Integer> _map;
+        private int _max = -1;
 
         public FindMap(Map<K,Integer> wrap)
         {

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -56,7 +56,7 @@ public class ContentSecurityPolicyFilter implements Filter
     // Lock that protects the static data structures below
     private static final Object ALLOWED_SOURCES_LOCK = new Object();
     private static final Map<Directive, SetValuedMap<String, String>> ALLOWED_SOURCES = new HashMap<>();
-    // Regenerate and stash on every "allowed source" change as a convenience (so every filter don't need to recalculate
+    // Regenerate and stash on every "allowed source" change as a convenience (so every filter doesn't need to recalculate
     // it on every init() and change)
     private static Map<String, String> ALLOWED_SOURCES_SUBSTITUTION_MAP = Collections.emptyMap();
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -11790,7 +11790,6 @@ public class AdminController extends SpringActionController
     @RequiresPermission(AdminPermission.class)
     public static class AdjustSystemTimestampsAction extends FormViewAction<AdjustTimestampsForm>
     {
-
         @Override
         public void addNavTrail(NavTree root)
         {

--- a/core/src/org/labkey/core/admin/AllowListType.java
+++ b/core/src/org/labkey/core/admin/AllowListType.java
@@ -5,14 +5,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.labkey.api.action.LabKeyError;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.WriteableAppProps;
-import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.URLHelper;
@@ -20,7 +18,6 @@ import org.labkey.api.view.ActionURL;
 import org.springframework.validation.BindException;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -96,12 +93,13 @@ public enum AllowListType
         {
             return HtmlString.unsafe("""
                 <div style="width: 700px">
-                    <div>
-                        This list is the set of file extensions that LabKey will accept for uploads. Any extension that is not in this list will be rejected, this includes multiple extensions. For example, .gz is not sufficient to allow .tar.gz; you must specify .tar.gz. If the list is empty, then this check is ignored.
-                    </div>
-                    <div>
-                    e.g., .tsv, .csv, .tar.gz, .sky.zip, etc.
-                    </div>
+                    <p>
+                        Specify a list of file extensions to restrict the file types that LabKey will accept for uploads.
+                        Add the extensions one-by-one via the "Extension" box below. Any extension that is not in the
+                        list below will be rejected. Multiple extensions must be provided explicitly; for example,
+                        specify ".tar.gz" to allow those files (".gz" is not sufficient). If the list is empty, then
+                        all file types will be allowed.
+                    </p>
                 </div>
                 """);
         }

--- a/core/src/org/labkey/core/admin/AllowListType.java
+++ b/core/src/org/labkey/core/admin/AllowListType.java
@@ -94,11 +94,11 @@ public enum AllowListType
             return HtmlString.unsafe("""
                 <div style="width: 700px">
                     <p>
-                        Specify a list of file extensions to restrict the file types that LabKey will accept for uploads.
-                        Add the extensions one-by-one via the "Extension" box below. Any extension that is not in the
-                        list below will be rejected. Multiple extensions must be provided explicitly; for example,
-                        specify ".tar.gz" to allow those files (".gz" is not sufficient). If the list is empty, then
-                        all file types will be allowed.
+                        Restrict the file types that LabKey will accept for uploads by specifying a list of all allowed
+                        file extensions. Add the extensions one-by-one via the "Extension" box. Any extension that is
+                        not in the list below will be rejected. Multiple extensions must be provided explicitly; for
+                        example, specify ".tar.gz" to allow those files (".gz" is not sufficient). If the list is empty
+                        then all file types will be allowed.
                     </p>
                 </div>
                 """);

--- a/core/src/org/labkey/core/admin/addNewExternalSource.jsp
+++ b/core/src/org/labkey/core/admin/addNewExternalSource.jsp
@@ -94,7 +94,7 @@
         ExternalSourcesForm form = (ExternalSourcesForm)getModelBean();
         Directive directive = EnumUtils.getEnum(Directive.class, form.getNewDirective());
 %>
-<labkey:form method="post" name="addNewHost">
+<labkey:form name="addNewHost" id="form-addNewHost" method="post">
     <table>
         <tr>
             <td><label class="labkey-form-label">Directive</label></td>
@@ -114,10 +114,17 @@
             <td><input name="newHost" id="newHostTextField" size="75" /></td>
         </tr>
         <tr>
-            <td><br/><input type="hidden" id="saveNew" name="saveNew" value="true"><%= button("Add").submit(true) %></td>
+            <td><br/><input type="hidden" id="saveNew" name="saveNew" value="true"><%=button("Add").submit(true).onClick("_form.setClean()")%></td>
         </tr>
     </table>
 </labkey:form>
 <%
     }
 %>
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    let _form;
+
+    LABKEY.Utils.onReady(function() {
+        _form = new LABKEY.Form({formElement: 'form-addNewHost'});
+    });
+</script>

--- a/core/src/org/labkey/core/admin/addNewListValue.jsp
+++ b/core/src/org/labkey/core/admin/addNewListValue.jsp
@@ -40,17 +40,24 @@
     else
     {
 %>
-<labkey:form method="post">
+<labkey:form id="form-addValue" method="post">
     <table>
         <tr>
             <td class="labkey-form-label"><label for="newValueTextField"><%=bean.getTypeEnum().getLabel()%></label></td>
             <td><input name="newValue" id="newValueTextField" size="75" /></td>
         </tr>
         <tr>
-            <td><br/><input type="hidden" id="saveNew" name="saveNew" value="true"><%= button("Save").submit(true) %></td>
+            <td><br/><input type="hidden" id="saveNew" name="saveNew" value="true"><%=button("Save").submit(true).onClick("_form.setClean()")%></td>
         </tr>
     </table>
 </labkey:form>
 <%
     }
 %>
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    let _form;
+
+    LABKEY.Utils.onReady(function() {
+        _form = new LABKEY.Form({formElement: 'form-addValue'});
+    });
+</script>

--- a/core/src/org/labkey/core/admin/customizeSite.jsp
+++ b/core/src/org/labkey/core/admin/customizeSite.jsp
@@ -33,10 +33,10 @@
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.Objects" %>
+<%@ page import="java.util.TreeMap" %>
 <%@ page import="static org.labkey.api.security.SecurityManager.SECONDS_PER_DAY" %>
 <%@ page import="static org.labkey.api.util.ExceptionReportingLevel.*" %>
 <%@ page import="static org.labkey.api.settings.SiteSettingsProperties.*" %>
-<%@ page import="java.util.TreeMap" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%=formatMissedErrors("form")%>

--- a/core/src/org/labkey/core/admin/existingExternalSources.jsp
+++ b/core/src/org/labkey/core/admin/existingExternalSources.jsp
@@ -31,9 +31,13 @@
     boolean isTroubleshooter = !c.hasPermission(getUser(), ApplicationAdminPermission.class);
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    let _formExisting;
+
+    LABKEY.Utils.onReady(function() {
+        _formExisting = new LABKEY.Form({formElement: 'form-existingValues'});
+    });
 
     function deleteExisting(valueToDelete) {
-
         document.getElementById("delete").value = true;
         document.getElementById("saveAll").value = false;
         document.getElementById("existingValue").value = valueToDelete;
@@ -41,7 +45,6 @@
     }
 
     function saveAll() {
-
         //clicking on save will save all the values - changed and unchanged values
         let num = 1;
         let directiveId = "directive" + num;
@@ -59,10 +62,11 @@
         document.getElementById("saveAll").value = true;
         document.getElementById("existingValues").value = values;
         document.forms["existingValues"].submit();
+        _formExisting.setClean();
     }
 </script>
 
-<labkey:form method="post" name="existingValues">
+<labkey:form name="existingValues" id="form-existingValues" method="post">
 
 <%
     ExternalSourcesForm bean = (ExternalSourcesForm) HttpView.currentModel();
@@ -96,7 +100,7 @@
                 button("Delete")
                     .primary(true)
                     .onClick("return deleteExisting(" +
-                        q(sub.directive() + "|" + sub.host()) + // Using | separator is safe because directive name never contains it
+                        q(sub.directive() + "|" + sub.host()) + // Using | separator is safe because the directive name never contains |
                         ");") %>
 
             </td>

--- a/core/src/org/labkey/core/admin/existingListValues.jsp
+++ b/core/src/org/labkey/core/admin/existingListValues.jsp
@@ -102,8 +102,19 @@
                 <td><br/>
                     <input type="hidden" id="saveAll" name="saveAll">
                     <%=isTroubleshooter ? button("Done").href(urlProvider(AdminUrls.class).getAdminConsoleURL()) : button("Save").primary(true).onClick("return saveAll();")%>
-                    <%=!isTroubleshooter ? button("Delete All").href(urlFor(DeleteAllValuesAction.class).addParameter("type", bean.getTypeEnum().name()))
-                            .onClick("_formExisting.setClean(); return LABKEY.Utils.confirmAndPost('" + h("Are you sure you want to delete all " + bean.getTypeEnum().getTitle() + "s") + "', this.href);") : HtmlString.EMPTY_STRING%>
+                    <%=isTroubleshooter ? HtmlString.EMPTY_STRING :
+                            button("Delete All")
+                                .href(urlFor(DeleteAllValuesAction.class)
+                                .addParameter("type", bean.getTypeEnum().name()))
+                                // Can't use LABKEY.Utils.confirmAndPost() below because it always returns false, and we need to preserve the dirty state in the cancel case
+                                .onClick(
+                                    "if (confirm(" + q("Are you sure you want to delete all " + bean.getTypeEnum().getTitle() + "s") + "))\n" +
+                                    "{\n" +
+                                    "    _formExisting.setClean();\n" +
+                                    "    LABKEY.Utils.postToAction(this.href);\n" +
+                                    "}\n" +
+                                    "return false;"
+                                )%>
                 </td>
             </tr>
         <% } %>

--- a/core/src/org/labkey/core/admin/existingListValues.jsp
+++ b/core/src/org/labkey/core/admin/existingListValues.jsp
@@ -29,9 +29,13 @@
     boolean isTroubleshooter = !c.hasPermission(getUser(), ApplicationAdminPermission.class);
 %>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    let _formExisting;
+
+    LABKEY.Utils.onReady(function() {
+        _formExisting = new LABKEY.Form({formElement: 'form-existingValues'});
+    });
 
     function deleteExisting(valueToDelete) {
-
         document.getElementById("delete").value = true;
         document.getElementById("saveAll").value = false;
         document.getElementById("existingValue").value = valueToDelete;
@@ -39,7 +43,6 @@
     }
 
     function saveAll() {
-
         //clicking on save will save all the values - changed and unchanged values
         var num = 1;
         var inputNameExisting = "existingValue" + num;
@@ -55,11 +58,11 @@
         document.getElementById("saveAll").value = true;
         document.getElementById("existingValues").value = values;
         document.forms["existingValues"].submit();
+        _formExisting.setClean();
     }
 </script>
 
-<labkey:form method="post" name="existingValues">
-
+<labkey:form name="existingValues" id="form-existingValues" method="post">
     <%
         AllowListForm bean = (AllowListForm) HttpView.currentModel();
     %>
@@ -99,7 +102,8 @@
                 <td><br/>
                     <input type="hidden" id="saveAll" name="saveAll">
                     <%=isTroubleshooter ? button("Done").href(urlProvider(AdminUrls.class).getAdminConsoleURL()) : button("Save").primary(true).onClick("return saveAll();")%>
-                    <%=!isTroubleshooter ? button("Delete All").href(urlFor(DeleteAllValuesAction.class).addParameter("type", bean.getTypeEnum().name())).usePost("Are you sure you want to delete all " + bean.getTypeEnum().getTitle() + "s?") : HtmlString.EMPTY_STRING%>
+                    <%=!isTroubleshooter ? button("Delete All").href(urlFor(DeleteAllValuesAction.class).addParameter("type", bean.getTypeEnum().name()))
+                            .onClick("_formExisting.setClean(); return LABKEY.Utils.confirmAndPost('" + h("Are you sure you want to delete all " + bean.getTypeEnum().getTitle() + "s") + "', this.href);") : HtmlString.EMPTY_STRING%>
                 </td>
             </tr>
         <% } %>

--- a/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
+++ b/core/src/org/labkey/core/admin/lookAndFeelProperties.jsp
@@ -444,15 +444,17 @@
 </table>
 </labkey:form>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    let _form;
+
     LABKEY.Utils.onReady(function() {
+        _form = new LABKEY.Form({ formElement: 'form-preferences'});
+
         if (<%=hasBadFormats%>)
         {
             // Show the date-time display format warning
             document.getElementById("dateFormatWarning").style.display='';
         }
     });
-
-    const _form = new LABKEY.Form({ formElement: 'form-preferences'});
 
     function confirmReset()
     {

--- a/experiment/src/org/labkey/experiment/api/ExpProvisionedTableTestHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ExpProvisionedTableTestHelper.java
@@ -70,7 +70,7 @@ public class ExpProvisionedTableTestHelper
         return propertyURIs;
     }
 
-    public List<Map<String, Object>> buildRows(ArrayListMap row)
+    public List<Map<String, Object>> buildRows(ArrayListMap<String, Object> row)
     {
         List<Map<String, Object>> rows = new ArrayList<>();
         rows.add(row);
@@ -144,5 +144,4 @@ public class ExpProvisionedTableTestHelper
         for (String e : expected)
             Assert.assertTrue("Failed to find '" + e + "' in multivalue '" + s + "'", s.contains(e));
     }
-
 }


### PR DESCRIPTION
#### Rationale
It's nice to warn users when navigating away may cause data loss. Add dirty handling to the Allowed External Redirect Hosts, Allowed External Resource Hosts, and Allowed File Extensions pages. Clarify file extensions instructions.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53039
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53038