### PR TITLE
52733: anchor tag is getting the wrong attribute

### DIFF
--- a/api/src/org/labkey/api/util/LinkBuilder.java
+++ b/api/src/org/labkey/api/util/LinkBuilder.java
@@ -152,7 +152,7 @@ public class LinkBuilder extends DisplayElementBuilder<LinkBuilder.Link, LinkBui
                     .at(DOM.Attribute.style, lb.style)
                     .at(DOM.Attribute.name, lb.name)
                     .at(DOM.Attribute.tabindex, lb.tabindex)
-                    .at(lb.enabled, disabled, true)
+                    .at(!lb.enabled, disabled, true)
                     .data(null != lb.tooltip, "tt", "tooltip")
                     .data(null != lb.tooltip, "placement","top")
                     .data(null != lb.tooltip, "original-title", lb.tooltip),


### PR DESCRIPTION
#### Rationale
tracking issue : https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52733

The logic for adding the disabled attributed was inverted.