### PR TITLE
Remove special permissions from users active column

### DIFF
--- a/core/src/org/labkey/core/query/UsersTable.java
+++ b/core/src/org/labkey/core/query/UsersTable.java
@@ -265,7 +265,6 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
             _illegalColumns = Sets.newCaseInsensitiveHashSet();
             if (!getUser().hasRootPermission(UserManagementPermission.class) && !getContainer().hasPermission(getUser(), AdminPermission.class))
             {
-                _illegalColumns.add("Active");
                 _illegalColumns.add("HasPassword");
             }
         }


### PR DESCRIPTION
#### Rationale
As discussed, there are no known reasons this column should have different permissions than other columns in the user table. This removes it from admin only check.

#### Changes
- Remove active column from admin permission check
