### PR TITLE
Update ActiveMQ to 5.18.7

### DIFF
--- a/pipeline/gradle.properties
+++ b/pipeline/gradle.properties
@@ -1,4 +1,4 @@
-activemqVersion=5.18.3
+activemqVersion=5.18.7
 
 geronimoJ2eeConnector15SpecVersion=1.0.1
 


### PR DESCRIPTION
#### Rationale
[CVE-2025-27533](https://github.com/advisories/GHSA-whxr-3p84-rf3c)

#### Related Pull Requests
- N/A

#### Changes
- Update ActiveMQ to 5.18.7
