### PR TITLE
Fix sample name generation with parent input

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -2041,9 +2041,9 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
             String generatedName = null;
             if (isAliquot && aliquotNameGenerator != null)
-                generatedName = nextName(map, null, null, _extraPropsFns, aliquotNameGenerator);
+                generatedName = nextName(map, parentDatas, parentSamples, _extraPropsFns, aliquotNameGenerator);
             else if (!isAliquot)
-                generatedName = nextName(map, null, null, _extraPropsFns, null);
+                generatedName = nextName(map, parentDatas, parentSamples, _extraPropsFns, null);
 
             return generatedName;
         }


### PR DESCRIPTION
#### Rationale
Parent inputs are dropped unintentionally during the recent refactoring of naming expression, as revealed by a TC failure:
[RecipeTest.recipeAPITest](https://teamcity.labkey.org/viewLog.html?buildId=3506473&buildTypeId=LabkeyTrunk_GitPostgres&fromSakuraUI=true#testNameId-3949444687935145192)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6628

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
