### PR TITLE
ExpSearchable: common implementation for indexable experiment objects

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpData.java
+++ b/api/src/org/labkey/api/exp/api/ExpData.java
@@ -35,7 +35,7 @@ import java.sql.SQLException;
 /**
  * Represents a virtual experiment object. Typically, a file on disk, but could be something pointed at by any URI including S3 objects.
  */
-public interface ExpData extends ExpRunItem, ExpSearchable
+public interface ExpData extends ExpRunItem
 {
     String DEFAULT_CPAS_TYPE = "Data";
     String DATA_INPUT_PARENT = "DataInputs";

--- a/api/src/org/labkey/api/exp/api/ExpData.java
+++ b/api/src/org/labkey/api/exp/api/ExpData.java
@@ -35,7 +35,7 @@ import java.sql.SQLException;
 /**
  * Represents a virtual experiment object. Typically, a file on disk, but could be something pointed at by any URI including S3 objects.
  */
-public interface ExpData extends ExpRunItem
+public interface ExpData extends ExpRunItem, ExpSearchable
 {
     String DEFAULT_CPAS_TYPE = "Data";
     String DATA_INPUT_PARENT = "DataInputs";

--- a/api/src/org/labkey/api/exp/api/ExpDataClass.java
+++ b/api/src/org/labkey/api/exp/api/ExpDataClass.java
@@ -34,7 +34,7 @@ import java.util.function.Function;
 /**
  * Category of {@link ExpData}, extended by a Domain with custom properties. Data version of an {@link ExpSampleType}.
  */
-public interface ExpDataClass extends ExpObject
+public interface ExpDataClass extends ExpObject, ExpSearchable
 {
     String NEW_DATA_CLASS_ALIAS_VALUE = "{{this_data_class}}";
     String SEQUENCE_PREFIX = "org.labkey.experiment.api.DataClass";

--- a/api/src/org/labkey/api/exp/api/ExpMaterial.java
+++ b/api/src/org/labkey/api/exp/api/ExpMaterial.java
@@ -27,7 +27,7 @@ import java.util.Date;
 import java.util.Map;
 
 /** Represents a physical object in the experiment data model - typically a sample or specimen */
-public interface ExpMaterial extends ExpRunItem
+public interface ExpMaterial extends ExpRunItem, ExpSearchable
 {
     String DEFAULT_CPAS_TYPE = "Material";
     String MATERIAL_INPUT_PARENT = "MaterialInputs";
@@ -83,5 +83,4 @@ public interface ExpMaterial extends ExpRunItem
     Date getMaterialExpDate();
 
     ActionURL detailsURL(Container container, boolean checkForOverride);
-
 }

--- a/api/src/org/labkey/api/exp/api/ExpMaterial.java
+++ b/api/src/org/labkey/api/exp/api/ExpMaterial.java
@@ -27,7 +27,7 @@ import java.util.Date;
 import java.util.Map;
 
 /** Represents a physical object in the experiment data model - typically a sample or specimen */
-public interface ExpMaterial extends ExpRunItem, ExpSearchable
+public interface ExpMaterial extends ExpRunItem
 {
     String DEFAULT_CPAS_TYPE = "Material";
     String MATERIAL_INPUT_PARENT = "MaterialInputs";

--- a/api/src/org/labkey/api/exp/api/ExpObject.java
+++ b/api/src/org/labkey/api/exp/api/ExpObject.java
@@ -65,7 +65,6 @@ public interface ExpObject extends Identifiable, Comparable<ExpObject>
     void setComment(User user, String comment) throws ValidationException;
     /** @param index only a suggestion as not all implementations handle indexing - primarily used to suppress duplicate indexing with a false value */
     default void setComment(User user, String comment, boolean index) throws ValidationException
-
     {
         setComment(user, comment);
     }

--- a/api/src/org/labkey/api/exp/api/ExpRunItem.java
+++ b/api/src/org/labkey/api/exp/api/ExpRunItem.java
@@ -22,12 +22,8 @@ import org.labkey.api.exp.Identifiable;
 import java.util.Collection;
 import java.util.List;
 
-/**
- * Input or output of a run, like a data file or a material.
- * User: jeckels
- * Date: Jul 28, 2008
- */
-public interface ExpRunItem extends ExpObject, Identifiable
+/** Input or output of a run, like a data file or a material. */
+public interface ExpRunItem extends ExpObject, ExpSearchable, Identifiable
 {
     String INPUT_PARENT = "Inputs";
     String INPUTS_PREFIX_LC = (INPUT_PARENT + "/").toLowerCase();
@@ -53,9 +49,9 @@ public interface ExpRunItem extends ExpObject, Identifiable
      */
     Integer getRunId();
 
-    /** @return all of the protocol applications that reference this data/material as input */
+    /** @return all the protocol applications that reference this data/material as input */
     List<? extends ExpProtocolApplication> getTargetApplications();
-    /** @return all of the protocol applications that reference this data/material as input */
+    /** @return all the protocol applications that reference this data/material as input */
     List<? extends ExpRun> getTargetRuns();
 
     void setSourceApplication(ExpProtocolApplication sourceApplication);

--- a/api/src/org/labkey/api/exp/api/ExpSampleType.java
+++ b/api/src/org/labkey/api/exp/api/ExpSampleType.java
@@ -40,7 +40,7 @@ import java.util.function.Function;
  * A collection of {@link ExpMaterial}, with a custom {@link Domain} for additional properties.
  * Material version of {@link ExpDataClass}
  */
-public interface ExpSampleType extends ExpObject
+public interface ExpSampleType extends ExpObject, ExpSearchable
 {
     String SEQUENCE_PREFIX = "org.labkey.experiment.api.MaterialSource";
     String ALIQUOTED_FROM_EXPRESSION = "${AliquotedFrom}";
@@ -55,7 +55,7 @@ public interface ExpSampleType extends ExpObject
     List<? extends ExpMaterial> getSamples(Container c, @Nullable ContainerFilter cf);
 
     /** number of samples in the given container **/
-    public long getSamplesCount(Container c, @Nullable ContainerFilter cf);
+    long getSamplesCount(Container c, @Nullable ContainerFilter cf);
 
     /** Returns the sample in the given container with the given name */
     ExpMaterial getSample(Container c, String name);

--- a/api/src/org/labkey/api/exp/api/ExpSearchable.java
+++ b/api/src/org/labkey/api/exp/api/ExpSearchable.java
@@ -1,6 +1,8 @@
 package org.labkey.api.exp.api;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.webdav.WebdavResource;
@@ -35,7 +37,8 @@ public interface ExpSearchable
             task = ss.defaultTask();
         }
 
-        var doc = createIndexDocument(table);
+        var expScope = DbSchema.get("exp", DbSchemaType.Module).getScope();
+        var doc = expScope.executeWithRetryReadOnly((tx) -> createIndexDocument(table));
         if (doc != null)
             task.addResource(doc, priority == null ? SearchService.PRIORITY.item : priority);
     }

--- a/api/src/org/labkey/api/exp/api/ExpSearchable.java
+++ b/api/src/org/labkey/api/exp/api/ExpSearchable.java
@@ -1,0 +1,42 @@
+package org.labkey.api.exp.api;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.search.SearchService;
+import org.labkey.api.webdav.WebdavResource;
+
+public interface ExpSearchable
+{
+    @Nullable WebdavResource createIndexDocument(@Nullable TableInfo table);
+
+    default void index()
+    {
+        index(null);
+    }
+
+    default void index(@Nullable SearchService.IndexTask task)
+    {
+        index(task, null);
+    }
+
+    default void index(@Nullable SearchService.IndexTask task, @Nullable SearchService.PRIORITY priority)
+    {
+        index(task, priority, null);
+    }
+
+    default void index(@Nullable SearchService.IndexTask task, @Nullable SearchService.PRIORITY priority, @Nullable TableInfo table)
+    {
+        if (task == null)
+        {
+            SearchService ss = SearchService.get();
+            if (null == ss)
+                return;
+
+            task = ss.defaultTask();
+        }
+
+        var doc = createIndexDocument(table);
+        if (doc != null)
+            task.addResource(doc, priority == null ? SearchService.PRIORITY.item : priority);
+    }
+}

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -356,7 +356,7 @@ public class ExperimentModule extends SpringModule
                 if (data == null)
                     return null;
 
-                return data.createDocument();
+                return data.createIndexDocument(null);
             }
 
             @Override

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -153,10 +153,6 @@ import static org.labkey.api.exp.query.ExpDataClassDataTable.Column.QueryableInp
 import static org.labkey.api.exp.query.ExpDataClassDataTable.Column.RowId;
 import static org.labkey.experiment.ExpDataIterators.incrementCounts;
 
-/**
- * User: kevink
- * Date: 9/29/15
- */
 public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassDataTable.Column> implements ExpDataClassDataTable
 {
     private final @NotNull ExpDataClassImpl _dataClass;
@@ -935,7 +931,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                             searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
                                     scope.executeWithRetryReadOnly(tx -> {
                                         for (ExpDataImpl expData : experimentServiceImpl.getExpDatas(sublist))
-                                            expData.index(searchService.defaultTask(), this);
+                                            expData.index(searchService.defaultTask(), null, this);
                                         return (Void) null;
                                     }))
                     );
@@ -945,7 +941,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                             searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
                                     scope.executeWithRetryReadOnly(tx -> {
                                         for (ExpDataImpl expData : experimentServiceImpl.getExpDatasByLSID(sublist))
-                                            expData.index(searchService.defaultTask(), this);
+                                            expData.index(searchService.defaultTask(), null, this);
                                         return (Void) null;
                                     }))
                     );
@@ -1431,7 +1427,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                                 searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
                                 {
                                     for (ExpDataImpl expData : ExperimentServiceImpl.get().getExpDatas(sublist))
-                                        expData.index(null, _expDataClassDataTableImpl);
+                                        expData.index(null, null, _expDataClassDataTableImpl);
                                 })
                         );
                     }, DbScope.CommitTaskOption.POSTCOMMIT);
@@ -1604,6 +1600,5 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
             return new TableSelector(ExperimentService.get().getTinfoData(), filter, null).exists();
         }
-
     }
 }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
@@ -53,6 +53,7 @@ import org.labkey.api.util.Path;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.webdav.SimpleDocumentResource;
+import org.labkey.api.webdav.WebdavResource;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.experiment.controllers.exp.ExperimentController;
 import org.springframework.web.servlet.mvc.Controller;
@@ -67,10 +68,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-/**
- * User: kevink
- * Date: 9/21/15
- */
 public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> implements ExpDataClass
 {
     public static final String NAMESPACE_PREFIX = "DataClass";
@@ -189,7 +186,6 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
         return ExpSchema.DataClassCategoryType.sources.name().equalsIgnoreCase(getCategory());
     }
 
-
     @Nullable
     @Override
     public ExpSampleType getSampleType()
@@ -217,7 +213,7 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
     @Override
     public ExpDataImpl getData(Container c, String name)
     {
-        return ExperimentServiceImpl.get().getExpData(this, /*c, */ name);
+        return ExperimentServiceImpl.get().getExpData(this, name);
     }
 
     @Override
@@ -254,7 +250,6 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
     {
         return urlFor(ExperimentController.ShowDataClassAction.class, getContainer());
     }
-
 
     @Override
     public void save(User user)
@@ -355,7 +350,6 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
     @Override
     public ActionURL urlShowHistory()
     {
-        //return urlFor(ExperimentController.HistoryDataClassAction.class, c);
         return null;
     }
 
@@ -373,33 +367,23 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
         return ret;
     }
 
-    public void index(SearchService.IndexTask task)
+    /**
+     * @return null if the parent container is no longer available
+     */
+    @Override
+    public @Nullable WebdavResource createIndexDocument(@Nullable TableInfo table)
     {
-        if (task == null)
-        {
-            SearchService ss = SearchService.get();
-            if (null == ss)
-                return;
-            task = ss.defaultTask();
-        }
+        var container = getContainer();
+        if (container == null)
+            return null;
 
-        final SearchService.IndexTask indexTask = task;
-        final ExpDataClassImpl me = this;
-        indexTask.addRunnable(
-                () -> me.indexDataClass(indexTask)
-                , SearchService.PRIORITY.bulk
-        );
-    }
-
-    private void indexDataClass(SearchService.IndexTask indexTask)
-    {
         ExperimentUrls urlProvider = PageFlowUtil.urlProvider(ExperimentUrls.class);
         ActionURL url = null;
 
         if (urlProvider != null)
         {
-            url = urlProvider.getShowDataClassURL(getContainer(), getRowId());
-            url.setExtraPath(getContainer().getId());
+            url = urlProvider.getShowDataClassURL(container, getRowId());
+            url.setExtraPath(container.getId());
         }
 
         Map<String, Object> props = new HashMap<>();
@@ -419,8 +403,9 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
         props.put(SearchService.PROPERTY.identifiersHi.toString(), StringUtils.join(identifiersHi, " "));
 
         String body = StringUtils.isNotBlank(getDescription()) ? getDescription() : "";
-        SimpleDocumentResource sdr = new SimpleDocumentResource(new Path(getDocumentId()), getDocumentId(),
-                getContainer().getId(), "text/plain",
+
+        return new SimpleDocumentResource(new Path(getDocumentId()), getDocumentId(),
+                container.getId(), "text/plain",
                 body, url,
                 getCreatedBy(), getCreated(),
                 getModifiedBy(), getModified(),
@@ -432,8 +417,6 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
                 ExperimentServiceImpl.get().setDataClassLastIndexed(getRowId(), ms);
             }
         };
-
-        indexTask.addResource(sdr, SearchService.PRIORITY.item);
     }
 
     public String getDocumentTitle()

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -723,7 +723,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
             identifiersHi.addAll(aliases);
         }
 
-        ExpDataClassImpl dc = getDataClass();
+        ExpDataClassImpl dc = getDataClass(User.getSearchUser());
         if (dc != null)
         {
             ActionURL show = new ActionURL(ExperimentController.ShowDataClassAction.class, container).addParameter("rowId", dc.getRowId());

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -250,7 +250,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
     public void save(User user)
     {
         // Replace the default "Data" cpastype if the Data belongs to a DataClass
-        ExpDataClassImpl dataClass = getDataClass(null);
+        ExpDataClassImpl dataClass = getDataClass();
         if (dataClass != null && ExpData.DEFAULT_CPAS_TYPE.equals(getCpasType()))
            setCpasType(dataClass.getLSID());
 
@@ -382,7 +382,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         if (result != null)
             return result;
 
-        ExpDataClass dataClass = getDataClass(null);
+        ExpDataClass dataClass = getDataClass();
         if (dataClass != null)
             return dataClass.getLSID();
 
@@ -525,7 +525,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
     public String getDocumentId()
     {
         String dataClassName = "-";
-        ExpDataClass dc = getDataClass(null);
+        ExpDataClass dc = getDataClass();
         if (dc != null)
             dataClassName = dc.getName();
         // why not just data:rowId?
@@ -538,6 +538,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         return getObjectProperties(getDataClass());
     }
 
+    @Override
     public Map<String, ObjectProperty> getObjectProperties(@Nullable User user)
     {
         return getObjectProperties(getDataClass(user));
@@ -583,7 +584,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
             return null;
 
         ExpDataClass dc = null;
-        if (dataClassName.length() > 0 && !dataClassName.equals("-"))
+        if (!StringUtils.isEmpty(dataClassName) && !dataClassName.equals("-"))
         {
             String dcKey = containerId + '-' + dataClassName;
             dc = dcCache.computeIfAbsent(dcKey, (x) -> ExperimentServiceImpl.get().getDataClass(c, dataClassName));
@@ -722,13 +723,8 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
             identifiersHi.addAll(aliases);
         }
 
-        ExpDataClassImpl dc = getDataClass(null);
-        if (tableInfo == null && dc != null)
-        {
-            tableInfo = QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_EXP_DATA).getTable(dc.getName());
-        }
-
-        if (null != dc)
+        ExpDataClassImpl dc = getDataClass();
+        if (dc != null)
         {
             ActionURL show = new ActionURL(ExperimentController.ShowDataClassAction.class, container).addParameter("rowId", dc.getRowId());
             NavTree t = new NavTree(dc.getName(), show);
@@ -737,10 +733,13 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
 
             props.put(DataSearchResultTemplate.PROPERTY, dc.getName());
             body.append(dc.getName());
-        }
 
-        if (tableInfo instanceof ExpDataClassDataTableImpl expDataClassDataTable)
-        {
+            if (tableInfo == null)
+                tableInfo = QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_EXP_DATA).getTable(dc.getName());
+
+            if (!(tableInfo instanceof ExpDataClassDataTableImpl expDataClassDataTable))
+                throw new IllegalArgumentException(String.format("Unable to index data class item in %s. Table must be an instance of %s", dc.getName(), ExpDataClassDataTableImpl.class.getName()));
+
             // Collect other text columns and lookup display columns
             getIndexValues(props, expDataClassDataTable, identifiersHi, identifiersMed, identifiersLo, keywordsHi, keywordsMed, keywordsLo, jsonData);
         }
@@ -785,7 +784,6 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
             getModified()
         );
     }
-
 
     private static void appendTokens(StringBuilder sb, Collection<String> toks)
     {

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -23,8 +23,6 @@ import org.json.JSONObject;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlSelector;
@@ -96,10 +94,12 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.exp.query.ExpSchema.SCHEMA_EXP_DATA;
+
 public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
 {
-
-    public enum DataOperations {
+    public enum DataOperations
+    {
         Edit("editing", UpdatePermission.class),
         EditLineage("editing lineage", UpdatePermission.class),
         Delete("deleting", DeletePermission.class),
@@ -178,7 +178,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         super.setComment(user, comment);
 
         if (index)
-            index(null, null);
+            index();
     }
 
     @Override
@@ -207,7 +207,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
     {
         ExpDataClassImpl dc = getDataClass(user);
         if (dc != null)
-            return new QueryRowReference(getContainer(), ExpSchema.SCHEMA_EXP_DATA, dc.getName(), FieldKey.fromParts(ExpDataTable.Column.RowId), getRowId());
+            return new QueryRowReference(getContainer(), SCHEMA_EXP_DATA, dc.getName(), FieldKey.fromParts(ExpDataTable.Column.RowId), getRowId());
 
         // Issue 40123: see MedImmuneDataHandler MEDIMMUNE_DATA_TYPE, this claims the "Data" namespace
         DataType type = getDataType();
@@ -266,7 +266,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
                 Table.insert(user, dataClass.getTinfo(), map);
             }
         }
-        index(null, null);
+        index();
     }
 
     @Override
@@ -423,7 +423,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
     @Nullable
     public ExpDataClassImpl getDataClass(@Nullable User user)
     {
-        if (_object.getClassId() != null)
+        if (_object.getClassId() != null && getContainer() != null)
         {
             if (user == null)
                 return ExperimentServiceImpl.get().getDataClass(getContainer(), _object.getClassId());
@@ -679,29 +679,13 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         return FileContentService.get().getWebDavUrl(path, c, type);
     }
 
-    public void index(SearchService.IndexTask task, @Nullable ExpDataClassDataTableImpl tableInfo)
+    @Override
+    public @Nullable WebdavResource createIndexDocument(@Nullable TableInfo tableInfo)
     {
-        if (task == null)
-        {
-            SearchService ss = SearchService.get();
-            if (null == ss)
-                return;
-            task = ss.defaultTask();
-        }
+        Container container = getContainer();
+        if (container == null)
+            return null;
 
-        var expScope = DbSchema.get("exp", DbSchemaType.Module).getScope();
-        var doc = expScope.executeWithRetryReadOnly((tx) -> createDocument(tableInfo));
-
-        task.addResource(doc, SearchService.PRIORITY.item);
-    }
-
-    public WebdavResource createDocument()
-    {
-        return createDocument(null);
-    }
-
-    public WebdavResource createDocument(@Nullable ExpDataClassDataTableImpl tableInfo)
-    {
         Map<String, Object> props = new HashMap<>();
         JSONObject jsonData = new JSONObject();
         Set<String> keywordsHi = new HashSet<>();
@@ -741,12 +725,12 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         ExpDataClassImpl dc = getDataClass(null);
         if (tableInfo == null && dc != null)
         {
-            tableInfo = (ExpDataClassDataTableImpl) QueryService.get().getUserSchema(User.getSearchUser(), getContainer(), "exp.data").getTable(dc.getName());
+            tableInfo = QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_EXP_DATA).getTable(dc.getName());
         }
 
         if (null != dc)
         {
-            ActionURL show = new ActionURL(ExperimentController.ShowDataClassAction.class, getContainer()).addParameter("rowId", dc.getRowId());
+            ActionURL show = new ActionURL(ExperimentController.ShowDataClassAction.class, container).addParameter("rowId", dc.getRowId());
             NavTree t = new NavTree(dc.getName(), show);
             String nav = NavTree.toJS(Collections.singleton(t), null, false, true).toString();
             props.put(SearchService.PROPERTY.navtrail.toString(), nav);
@@ -755,10 +739,10 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
             body.append(dc.getName());
         }
 
-        if (tableInfo != null)
+        if (tableInfo instanceof ExpDataClassDataTableImpl expDataClassDataTable)
         {
             // Collect other text columns and lookup display columns
-            getIndexValues(props, tableInfo, identifiersHi, identifiersMed, identifiersLo, keywordsHi, keywordsMed, keywordsLo, jsonData);
+            getIndexValues(props, expDataClassDataTable, identifiersHi, identifiersMed, identifiersLo, keywordsHi, keywordsMed, keywordsLo, jsonData);
         }
 
         // === Stored, not indexed
@@ -770,7 +754,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         props.put(SearchService.PROPERTY.jsonData.toString(), jsonData);
 
         ActionURL view = ExperimentController.ExperimentUrlsImpl.get().getDataDetailsURL(this);
-        view.setExtraPath(getContainer().getId());
+        view.setExtraPath(container.getId());
         String docId = getDocumentId();
 
         // Generate a summary explicitly instead of relying on a summary to be extracted
@@ -790,7 +774,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
             getRowId(),
             new Path(docId),
             docId,
-            getContainer().getId(),
+            container.getId(),
             "text/plain",
             body.toString(),
             view,

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -400,8 +400,10 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
             if (tableInfo == null)
                 tableInfo = QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_SAMPLES).getTable(getSampleType().getName());
 
-            if (tableInfo instanceof ExpMaterialTableImpl expMaterialTable)
-                getCustomIndexValues(props, expMaterialTable, identifiersHi, keyworksHi, jsonData);
+            if (!(tableInfo instanceof ExpMaterialTableImpl expMaterialTable))
+                throw new IllegalArgumentException(String.format("Unable to index material in %s. Table must be an instance of %s", getSampleType().getName(), ExpMaterialTableImpl.class.getName()));
+
+            getCustomIndexValues(props, expMaterialTable, identifiersHi, keyworksHi, jsonData);
         }
 
         props.put(SearchService.PROPERTY.jsonData.toString(), jsonData);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -395,20 +395,20 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
 
         // Add all String and Integer custom property descriptions and values to body
         JSONObject jsonData = new JSONObject();
-        if (null != getSampleType())
+        ExpSampleType st = getSampleType();
+        if (null != st)
         {
             if (tableInfo == null)
-                tableInfo = QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_SAMPLES).getTable(getSampleType().getName());
+                tableInfo = QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_SAMPLES).getTable(st.getName());
 
             if (!(tableInfo instanceof ExpMaterialTableImpl expMaterialTable))
-                throw new IllegalArgumentException(String.format("Unable to index material in %s. Table must be an instance of %s", getSampleType().getName(), ExpMaterialTableImpl.class.getName()));
+                throw new IllegalArgumentException(String.format("Unable to index material in %s. Table must be an instance of %s", st.getName(), ExpMaterialTableImpl.class.getName()));
 
             getCustomIndexValues(props, expMaterialTable, identifiersHi, keyworksHi, jsonData);
         }
 
         props.put(SearchService.PROPERTY.jsonData.toString(), jsonData);
 
-        ExpSampleType st = getSampleType();
         if (null != st)
         {
             if (st.isMedia())

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -69,8 +69,6 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.webdav.SimpleDocumentResource;
 import org.labkey.api.webdav.WebdavResource;
-import org.labkey.experiment.CustomProperties;
-import org.labkey.experiment.CustomPropertyRenderer;
 import org.labkey.experiment.controllers.exp.ExperimentController;
 
 import java.util.ArrayList;
@@ -316,7 +314,8 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
                 SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(st, SampleTypeServiceImpl.SampleChangeType.insert);
             }
         }
-        index(null, null);
+
+        index();
     }
 
     @Override
@@ -350,76 +349,17 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
         return getTargetRuns(ExperimentServiceImpl.get().getTinfoMaterialInput(), "MaterialId");
     }
 
-    private static final Map<String, CustomPropertyRenderer> RENDERER_MAP = new HashMap<>()
-    {
-        @Override
-        public CustomPropertyRenderer get(Object key)
-        {
-            // Special renderer used only for indexing material custom properties
-            return new CustomPropertyRenderer()
-            {
-                @Override
-                public boolean shouldRender(ObjectProperty prop, List<ObjectProperty> siblingProperties)
-                {
-                    Object value = prop.value();
-
-                    // For now, index only non-null Strings and Integers
-                    return (value instanceof String || value instanceof Integer);
-                }
-
-                @Override
-                public String getDescription(ObjectProperty prop, List<ObjectProperty> siblingProperties)
-                {
-                    PropertyDescriptor pd = OntologyManager.getPropertyDescriptor(prop.getPropertyURI(), prop.getContainer());
-                    String name = prop.getName();
-                    if (pd != null)
-                        name = pd.getLabel() != null ? pd.getLabel() : pd.getName();
-                    return name;
-                }
-
-                @Override
-                public String getValue(ObjectProperty prop, List<ObjectProperty> siblingProperties, Container c)
-                {
-                    return prop.value().toString();
-                }
-            };
-        }
-    };
-
-    public void index(@Nullable SearchService.IndexTask task, @Nullable ExpMaterialTableImpl tableInfo)
+    @Override
+    public @Nullable WebdavResource createIndexDocument(@Nullable TableInfo tableInfo)
     {
         // Big hack to prevent study specimens and bogus samples created from some plate assays (Issue 46037)
         // from being indexed as samples
         if (StudyService.SPECIMEN_NAMESPACE_PREFIX.equals(getLSIDNamespacePrefix()) || ExpMaterial.DEFAULT_CPAS_TYPE.equals(getCpasType()))
-        {
-            return;
-        }
-        if (task == null)
-        {
-            SearchService ss = SearchService.get();
-            if (null == ss)
-                return;
-            task = ss.defaultTask();
-        }
+            return null;
 
-        // do the least possible amount of work here
-        final SearchService.IndexTask indexTask = task;
-        var document = createIndexDocument(tableInfo);
-        if (document != null)
-        {
-            indexTask.addResource(document, SearchService.PRIORITY.item);
-        }
-    }
-
-    /** returns null if the parent container is no longer available */
-    @Nullable
-    public WebdavResource createIndexDocument(@Nullable ExpMaterialTableImpl tableInfo)
-    {
         Container container = getContainer();
         if (container == null)
-        {
             return null;
-        }
 
         ActionURL url = PageFlowUtil.urlProvider(ExperimentUrls.class).getMaterialDetailsURL(this);
         url.setExtraPath(container.getId());
@@ -458,10 +398,10 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
         if (null != getSampleType())
         {
             if (tableInfo == null)
-                tableInfo = (ExpMaterialTableImpl) QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_SAMPLES).getTable(getSampleType().getName());
+                tableInfo = QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_SAMPLES).getTable(getSampleType().getName());
 
-            if (tableInfo != null)
-                getCustomIndexValues(props, tableInfo, identifiersHi, keyworksHi, jsonData);
+            if (tableInfo instanceof ExpMaterialTableImpl expMaterialTable)
+                getCustomIndexValues(props, expMaterialTable, identifiersHi, keyworksHi, jsonData);
         }
 
         props.put(SearchService.PROPERTY.jsonData.toString(), jsonData);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1604,7 +1604,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                             searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
                             {
                                 for (ExpMaterialImpl expMaterial : experimentServiceImpl.getExpMaterials(sublist))
-                                    expMaterial.index(searchService.defaultTask(), this);
+                                    expMaterial.index(searchService.defaultTask(), null, this);
                             })
                         );
 
@@ -1612,7 +1612,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                                 searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
                                 {
                                     for (ExpMaterialImpl expMaterial : experimentServiceImpl.getExpMaterialsByLsid(sublist))
-                                        expMaterial.index(searchService.defaultTask(), this);
+                                        expMaterial.index(searchService.defaultTask(), null, this);
                                 })
                         );
                     }, DbScope.CommitTaskOption.POSTCOMMIT)

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -16,12 +16,10 @@
 
 package org.labkey.experiment.api;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
@@ -70,6 +68,7 @@ import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.webdav.SimpleDocumentResource;
+import org.labkey.api.webdav.WebdavResource;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.experiment.controllers.exp.ExperimentController;
 
@@ -966,39 +965,25 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         return "SampleType " + getName() + " in " + getContainer().getPath();
     }
 
-    public void index(SearchService.IndexTask task)
+    @Override
+    public @Nullable WebdavResource createIndexDocument(@Nullable TableInfo table)
     {
         // Big hack to prevent study specimens from being indexed as part of sample types
         // Check needed on restart, as all documents are enumerated.
         if (StudyService.SPECIMEN_NAMESPACE_PREFIX.equals(getLSIDNamespacePrefix()))
-        {
-            return;
-        }
-        if (task == null)
-        {
-            SearchService ss = SearchService.get();
-            if (null == ss)
-                return;
-            task = ss.defaultTask();
-        }
+            return null;
 
-        final SearchService.IndexTask indexTask = task;
-        final ExpSampleTypeImpl me = this;
-        indexTask.addRunnable(
-                () -> me.indexSampleType(indexTask)
-                , SearchService.PRIORITY.bulk
-        );
-    }
+        var container = getContainer();
+        if (container == null)
+            return null;
 
-    private void indexSampleType(SearchService.IndexTask indexTask)
-    {
         ExperimentUrls urlProvider = PageFlowUtil.urlProvider(ExperimentUrls.class);
         ActionURL url = null;
 
         if (urlProvider != null)
         {
             url = urlProvider.getShowSampleTypeURL(this);
-            url.setExtraPath(getContainer().getId());
+            url.setExtraPath(container.getId());
         }
 
         Map<String, Object> props = new HashMap<>();
@@ -1018,8 +1003,9 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         props.put(SearchService.PROPERTY.identifiersHi.toString(), StringUtils.join(identifiersHi, " "));
 
         String body = StringUtils.isNotBlank(getDescription()) ? getDescription() : "";
-        SimpleDocumentResource sdr = new SimpleDocumentResource(new Path(getDocumentId()), getDocumentId(),
-                getContainer().getId(), "text/plain",
+
+        return new SimpleDocumentResource(new Path(getDocumentId()), getDocumentId(),
+                container.getId(), "text/plain",
                 body, url,
                 getCreatedBy(), getCreated(),
                 getModifiedBy(), getModified(),
@@ -1031,8 +1017,6 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
                 ExperimentServiceImpl.get().setMaterialSourceLastIndexed(getRowId(), ms);
             }
         };
-
-        indexTask.addResource(sdr, SearchService.PRIORITY.item);
     }
 
     public String getDocumentId()

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -982,7 +982,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         task.addRunnable(() -> {
             for (ExpSampleTypeImpl sampleType : getIndexableSampleTypes(c, modifiedSince))
             {
-                sampleType.index(task);
+                sampleType.index(task, SearchService.PRIORITY.bulk);
             }
         }, SearchService.PRIORITY.bulk);
 
@@ -991,7 +991,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         task.addRunnable(() -> {
             for (ExpDataClassImpl dataClass : getIndexableDataClasses(c, modifiedSince))
             {
-                dataClass.index(task);
+                dataClass.index(task, SearchService.PRIORITY.bulk);
             }
         }, SearchService.PRIORITY.bulk);
 
@@ -1040,11 +1040,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         List<Material> materials = selector.getArrayList(Material.class);
         materials.forEach(m -> {
             ExpMaterialImpl expMaterial = new ExpMaterialImpl(m);
-            var doc = expMaterial.createIndexDocument(null);
-            if (doc != null)
-            {
-                task.addResource(doc, SearchService.PRIORITY.bulk);
-            }
+            expMaterial.index(task, SearchService.PRIORITY.bulk);
             maxRowIdProcessed.setValue(Math.max(maxRowIdProcessed.getValue(), expMaterial.getRowId()));
         });
 
@@ -1081,7 +1077,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         List<Data> data = selector.getArrayList(Data.class);
         data.forEach(d -> {
             ExpDataImpl expData = new ExpDataImpl(d);
-            task.addResource(expData.createDocument(), SearchService.PRIORITY.bulk);
+            expData.index(task, SearchService.PRIORITY.bulk);
             maxRowIdProcessed.setValue(Math.max(maxRowIdProcessed.getValue(), expData.getRowId()));
         });
 
@@ -1221,7 +1217,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         SearchService.IndexTask task = ss.defaultTask();
 
         Runnable r = () -> {
-
             Domain d = dataClass.getDomain();
             if (d == null)
                 return; // Domain may be null if the DataClass has been deleted
@@ -1232,7 +1227,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
             indexDataClass(dataClass, task);
             indexDataClassData(dataClass, task);
-
         };
 
         task.addRunnable(r, SearchService.PRIORITY.bulk);
@@ -1257,7 +1251,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         scope.executeWithRetryReadOnly(tx ->
             new SqlSelector(scope, sql).forEachBatch(Data.class, 1000, batch ->
                     task.addRunnable(() -> batch.forEach(data ->
-                        new ExpDataImpl(data).index(task, null)),
+                        new ExpDataImpl(data).index(task)),
                     SearchService.PRIORITY.bulk)
         ));
     }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -250,15 +250,12 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         SearchService.IndexTask task = ss.defaultTask();
 
         Runnable r = () -> {
-
             indexSampleType(sampleType, task);
             indexSampleTypeMaterials(sampleType, task);
-
         };
 
         task.addRunnable(r, SearchService.PRIORITY.bulk);
     }
-
 
     private void indexSampleType(ExpSampleType sampleType, SearchService.IndexTask task)
     {
@@ -295,7 +292,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             for (Material m : batch)
             {
                 ExpMaterialImpl impl = new ExpMaterialImpl(m);
-                impl.index(task, null /* null tableInfo since samples may belong to multiple containers*/);
+                impl.index(task, null, null /* null tableInfo since samples may belong to multiple containers*/);
             }
         });
     }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -532,7 +532,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                             searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
                             {
                                 for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterials(sublist))
-                                    expMaterial.index(searchService.defaultTask(), tableInfo);
+                                    expMaterial.index(searchService.defaultTask(), null, tableInfo);
                             })
                     );
                 }, DbScope.CommitTaskOption.POSTCOMMIT);


### PR DESCRIPTION
#### Rationale
Coalesce logic and behaviors for search indexing experiment objects.

#### Changes
- Introduce new implementation interface in `ExpSearchable`
- Refactor usages to produce a search document and absolve them of adding task resources
- Avoid NPEs in index resolution when the results of `getContainer()` is null.
