### PR TITLE
Issue 52777: Don't decode column names that may contain substrings that look like encoded field key parts

### DIFF
--- a/api/src/org/labkey/api/data/ColumnHeaderType.java
+++ b/api/src/org/labkey/api/data/ColumnHeaderType.java
@@ -69,7 +69,7 @@ public enum ColumnHeaderType
             if (columnInfo != null)
             {
                 org.labkey.api.query.FieldKey fieldKey;
-                // Issue 52777. Don't decode the name that may contain substrings that look like encoded field key pars
+                // Issue 52777. Don't decode the name that may contain substrings that look like encoded field key parts
                 if (columnInfo.getFieldKey() != null)
                     fieldKey = columnInfo.getFieldKey();
                 else

--- a/api/src/org/labkey/api/data/ColumnHeaderType.java
+++ b/api/src/org/labkey/api/data/ColumnHeaderType.java
@@ -73,7 +73,7 @@ public enum ColumnHeaderType
                 if (columnInfo.getFieldKey() != null)
                     fieldKey = columnInfo.getFieldKey();
                 else
-                    fieldKey = org.labkey.api.query.FieldKey.fromParts(columnInfo.getName()); // HERE name is $BloodType
+                    fieldKey = org.labkey.api.query.FieldKey.fromParts(columnInfo.getName());
 
                 fieldKey = fixMissingValueIndicator(columnInfo, fieldKey);
                 name = fieldKey.toImportDisplayString();

--- a/api/src/org/labkey/api/data/ColumnHeaderType.java
+++ b/api/src/org/labkey/api/data/ColumnHeaderType.java
@@ -68,8 +68,12 @@ public enum ColumnHeaderType
             String name;
             if (columnInfo != null)
             {
-                name = columnInfo.getName();
-                org.labkey.api.query.FieldKey fieldKey = org.labkey.api.query.FieldKey.fromString(name);
+                org.labkey.api.query.FieldKey fieldKey;
+                // Issue 52777. Don't decode the name that may contain substrings that look like encoded field key pars
+                if (columnInfo.getFieldKey() != null)
+                    fieldKey = columnInfo.getFieldKey();
+                else
+                    fieldKey = org.labkey.api.query.FieldKey.fromParts(columnInfo.getName()); // HERE name is $BloodType
 
                 fieldKey = fixMissingValueIndicator(columnInfo, fieldKey);
                 name = fieldKey.toImportDisplayString();


### PR DESCRIPTION
#### Rationale
Issue [52777](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52777): When a column name has a substring that looks like an encoded illegal character for field keys, `FieldKey.fromString` will decode that name replacing, for example `$B` with `{`, resulting in a name that doesn't match any fields in the domain.  This change will avoid creating a new `FieldKey` if one already exists on the `columnInfo` and otherwise uses `FieldKey.fromParts` to get a field key from the column name, avoiding the unintentional decoding.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1405

#### Changes
- Update `ImportField.getText` with different resolution of columns to field keys.
