### PR TITLE
Migrate to renderGridCellContents(RenderContext, HtmlWriter)

### DIFF
--- a/api/src/org/labkey/api/data/AbstractFileDisplayColumn.java
+++ b/api/src/org/labkey/api/data/AbstractFileDisplayColumn.java
@@ -281,7 +281,7 @@ public abstract class AbstractFileDisplayColumn extends DataColumn
             if (null != filename)
             {
                 // Existing value, so tell the user the file name, allow the file to be removed, and a new file uploaded
-                renderThumbnailAndRemoveLink(out, ctx, filename, input.build().toString());
+                renderThumbnailAndRemoveLink(out, ctx, filename, input);
             }
             else
             {
@@ -302,8 +302,7 @@ public abstract class AbstractFileDisplayColumn extends DataColumn
         return "Previous file " + filename + " will be removed.";
     }
 
-    // TODO: filePicker should be a builder or HtmlString or something sensible like that
-    private void renderThumbnailAndRemoveLink(HtmlWriter out, RenderContext ctx, String filename, String filePicker)
+    private void renderThumbnailAndRemoveLink(HtmlWriter out, RenderContext ctx, String filename, InputBuilder<?> filePicker)
     {
         String divId = GUID.makeGUID();
         String linkId = "remove" + divId;

--- a/api/src/org/labkey/api/data/JavaScriptDisplayColumn.java
+++ b/api/src/org/labkey/api/data/JavaScriptDisplayColumn.java
@@ -64,7 +64,7 @@ public class JavaScriptDisplayColumn extends DataColumn
     }
 
     @Override
-    public void renderGridCellContents(RenderContext ctx, Writer oldWriter, HtmlWriter out) throws IOException
+    public void renderGridCellContents(RenderContext ctx, HtmlWriter out)
     {
         Object o = getValue(ctx);
 
@@ -75,13 +75,13 @@ public class JavaScriptDisplayColumn extends DataColumn
             if (_onClickExpression != null)
                 onClick = StringUtils.trim(_onClickExpression.eval(ctx));
 
-            renderLink(oldWriter, getFormattedHtml(ctx), onClick, _linkClassName);
+            renderLink(out, getFormattedHtml(ctx), onClick, _linkClassName);
         }
         else
-            oldWriter.write("&nbsp;");
+            out.write(HtmlString.NBSP);
     }
 
-    protected void renderLink(Writer out, HtmlString html, @Nullable String onClick, @Nullable String linkClassName)
+    protected void renderLink(HtmlWriter out, HtmlString html, @Nullable String onClick, @Nullable String linkClassName)
     {
         LinkBuilder builder = new LinkBuilder(html)
             .href("#")

--- a/api/src/org/labkey/api/view/PopupMenu.java
+++ b/api/src/org/labkey/api/view/PopupMenu.java
@@ -113,7 +113,12 @@ public class PopupMenu extends DisplayElement
 
     public void render(Writer out) throws IOException
     {
-        renderMenuButton(null, HtmlWriter.of(out), false, null);
+        render(HtmlWriter.of(out));
+    }
+
+    public void render(HtmlWriter out)
+    {
+        renderMenuButton(null, out, false, null);
     }
 
     public void renderMenuButton(@Nullable RenderContext ctx, HtmlWriter out, boolean requiresSelection, @Nullable ActionButton button)


### PR DESCRIPTION
#### Rationale
Server-side HTML generation wants to use DOM, builders, and HtmlWriter