### PR TITLE
Issue 52485: App admins can create and edit shorturls but can't view

### DIFF
--- a/core/src/org/labkey/core/query/ShortUrlTableInfo.java
+++ b/core/src/org/labkey/core/query/ShortUrlTableInfo.java
@@ -20,6 +20,7 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
+import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.util.DOM;
 import org.labkey.api.util.HtmlString;
@@ -190,6 +191,6 @@ public class ShortUrlTableInfo extends FilteredTable<CoreQuerySchema>
 
     public static boolean canDisplayTable(@NotNull UserPrincipal user, @NotNull Container container)
     {
-        return container.isRoot() && container.hasPermission(user, AdminOperationsPermission.class);
+        return container.isRoot() && container.hasPermission(user, ApplicationAdminPermission.class);
     }
 }


### PR DESCRIPTION
#### Rationale
We should be consistent in terms of permissions needed to manage short URLs

[Issue 52485](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52485)

#### Changes
- Use the correct permission class for checking access to the ShortUrl