### PR TITLE
Fix multi-valued input form fields

### DIFF
--- a/api/src/org/labkey/api/data/MultiValuedDisplayColumn.java
+++ b/api/src/org/labkey/api/data/MultiValuedDisplayColumn.java
@@ -18,6 +18,7 @@ package org.labkey.api.data;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.DOM;
 import org.labkey.api.writer.HtmlWriter;
 
 import java.util.ArrayList;
@@ -27,6 +28,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static org.labkey.api.util.DOM.TD;
 
 /**
  * Wraps any DisplayColumn and causes it to render each value separately. Often used in conjunction with
@@ -208,5 +211,19 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
     public Object getInputValue(RenderContext ctx)
     {
         return values(ctx, _column::getInputValue);
+    }
+
+    // This override matches the DisplayColumn.renderInputCell() implementation. It's necessary to cancel out
+    // DisplayColumnDecorator's override.
+    @Override
+    public void renderInputCell(RenderContext ctx, HtmlWriter out)
+    {
+        TD(
+            getInputAttributes(),
+            (DOM.Renderable) ret -> {
+                renderInputHtml(ctx, out, getInputValue(ctx));
+                return ret;
+            }
+        ).appendTo(out);
     }
 }

--- a/api/src/org/labkey/api/data/MultiValuedDisplayColumn.java
+++ b/api/src/org/labkey/api/data/MultiValuedDisplayColumn.java
@@ -213,8 +213,8 @@ public class MultiValuedDisplayColumn extends DisplayColumnDecorator implements 
         return values(ctx, _column::getInputValue);
     }
 
-    // This override matches the DisplayColumn.renderInputCell() implementation. It's necessary to cancel out
-    // DisplayColumnDecorator's override.
+    // Issue 52983: This override matches the DisplayColumn.renderInputCell() implementation.
+    // It's necessary to cancel out DisplayColumnDecorator's override.
     @Override
     public void renderInputCell(RenderContext ctx, HtmlWriter out)
     {

--- a/experiment/src/org/labkey/experiment/api/AliasDisplayColumnFactory.java
+++ b/experiment/src/org/labkey/experiment/api/AliasDisplayColumnFactory.java
@@ -38,7 +38,7 @@ class AliasDisplayColumnFactory implements DisplayColumnFactory
 
                             sb.append(delim);
                             sb.append(name);
-                            delim = ",";
+                            delim = ", ";
                         }
                     }
                 }


### PR DESCRIPTION
#### Rationale
The cell line update form stopped rendering the multi-valued alias field correctly. A `DisplayColumn` refactor a couple months ago removed a method override in `MultiValuedDisplayColumn`; this puts it back.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52983

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6674
- https://github.com/LabKey/limsModules/pull/1414
- https://github.com/LabKey/testAutomation/pull/2451