### PR TITLE
Null check field map before using it

### DIFF
--- a/api/src/org/labkey/api/data/MultiValuedRenderContext.java
+++ b/api/src/org/labkey/api/data/MultiValuedRenderContext.java
@@ -110,12 +110,15 @@ public class MultiValuedRenderContext extends RenderContextDecorator
             if ("".equals(value))
                 value = null;
 
-            ColumnInfo columnInfo = getFieldMap().get(key);
-            // The value was concatenated with others, so it's become a string.
-            // Do conversion to switch it back to the expected type.
-            if (value != null && columnInfo != null && !columnInfo.getJavaClass().isInstance(value))
+            if (getFieldMap() != null)
             {
-                value = ConvertUtils.convert(value.toString(), columnInfo.getJavaClass());
+                ColumnInfo columnInfo = getFieldMap().get(key);
+                // The value was concatenated with others, so it's become a string.
+                // Do conversion to switch it back to the expected type.
+                if (value != null && columnInfo != null && !columnInfo.getJavaClass().isInstance(value))
+                {
+                    value = ConvertUtils.convert(value.toString(), columnInfo.getJavaClass());
+                }
             }
         }
         else


### PR DESCRIPTION
#### Rationale
After merging the related PR, OConnorExperimentTest started failing when attempting to render a multi-valued field while rendering a bulk edit page. This seems to fix it.

https://teamcity.labkey.org/buildConfiguration/bt401/3514983

I can't explain with certainty what changed here, but here's my guess, based on what I've seen:
- Previously (25.3) the RenderContext passed to MutiValuedRenderContext failed to resolve ParentExperiments/Container and ParentExperiments/ExperimentNumber (in MultiValueRenderContext constructor)
- `MultiValuedDisplayColumn.values()` then saw only null values for these field keys, so next() returned false, bypassing calls to the passed in Function
- Early in 25.4, a display column refactor caused us to bypass the MV getInputValue() code path entirely
- Later, Matt made changes that populated more values into the context (??)
- Nick & I just fixed the bypass with #6674, so MV getInputValue() code path is live again. It now resolves those field keys and invokes MultiValuedRenderContext.get(), which unconditionally uses the field map, causing an NPE in this case.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6674