### PR TITLE
QC state handling for dataset updates

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
+++ b/study/src/org/labkey/study/model/DatasetDataIteratorBuilder.java
@@ -366,9 +366,9 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         if (needsQC == Boolean.TRUE)
         {
             Integer indexInputQCState = findColumnInMap(inputMap, table.getColumn(DatasetTableImpl.QCSTATE_ID_COLNAME));
-            Integer indexInputQCText = inputMap.get(DatasetTableImpl.QCSTATE_LABEL_COLNAME);
             if (null == indexInputQCState)
             {
+                Integer indexInputQCText = inputMap.get(DatasetTableImpl.QCSTATE_LABEL_COLNAME);
                 int indexText = null == indexInputQCText ? -1 : indexInputQCText;
                 it.addQCStateColumn(indexText,  DatasetDefinition.getQCStateURI(), defaultQC);
             }
@@ -557,8 +557,10 @@ public class DatasetDataIteratorBuilder implements DataIteratorBuilder
         {
             var qcCol = new BaseColumnInfo("QCState", JdbcType.INTEGER);
             qcCol.setPropertyURI(uri);
-            Callable qcCall = new QCStateColumn(index, defaultQCState);
-            return addColumn(qcCol, qcCall);
+            QCStateImportHelper qcih = new QCStateImportHelper(user, _datasetDefinition, true, defaultQCState);
+            Callable call = qcih.getCallable(getInput(), index);
+
+            return addColumn(qcCol, call);
         }
 
         int addFileColumn(String name, int index, String fileRootPath)

--- a/study/src/org/labkey/study/model/QCStateImportHelper.java
+++ b/study/src/org/labkey/study/model/QCStateImportHelper.java
@@ -1,0 +1,80 @@
+package org.labkey.study.model;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.dataiterator.DataIterator;
+import org.labkey.api.qc.DataState;
+import org.labkey.api.qc.QCStateManager;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.security.User;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class QCStateImportHelper
+{
+    private User _user;
+    private DatasetDefinition _datasetDefinition;
+    private DataState _defaultQCState;
+    private Map<String, DataState> _qcLabels;
+    private boolean _autoCreate;
+
+    public QCStateImportHelper(User user, DatasetDefinition datasetDefinition, boolean autoCreate, DataState defaultQCState)
+    {
+        _user = user;
+        _datasetDefinition = datasetDefinition;
+        _autoCreate = autoCreate;
+        _defaultQCState = defaultQCState;
+        _qcLabels = new CaseInsensitiveHashMap<>();
+        for (DataState state : QCStateManager.getInstance().getStates(_datasetDefinition.getContainer()))
+            _qcLabels.put(state.getLabel(), state);
+    }
+
+    public Callable<Object> getCallable(
+            @NotNull final DataIterator it,
+            @Nullable final Integer indexInputQCState
+    )
+    {
+        return () -> {
+
+            Object currentStateObj = indexInputQCState < 1 ? null : it.get(indexInputQCState);
+            String currentStateLabel = null == currentStateObj ? null : currentStateObj.toString();
+
+            return translateQCState(currentStateLabel);
+        };
+    }
+
+    public Integer translateQCState(@Nullable String currentStateLabel) throws ValidationException
+    {
+        if (currentStateLabel != null)
+        {
+            DataState state = _qcLabels.get(currentStateLabel);
+            if (null == state)
+            {
+                if (!_autoCreate)
+                {
+                    throw new ValidationException("QC State not found: " + currentStateLabel);
+                }
+                else
+                {
+
+                    DataState newState = new DataState();
+                    // default to public data:
+                    newState.setPublicData(true);
+                    newState.setLabel(currentStateLabel);
+                    newState.setContainer(_datasetDefinition.getContainer());
+                    newState = StudyManager.getInstance().insertQCState(_user, newState);
+                    _qcLabels.put(newState.getLabel(), newState);
+                    return newState.getRowId();
+                }
+            }
+            return state.getRowId();
+        }
+        else if (_defaultQCState != null)
+        {
+            return _defaultQCState.getRowId();
+        }
+        return null;
+    }
+}

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -77,6 +77,7 @@ import org.labkey.study.model.DatasetDomainKind;
 import org.labkey.study.model.DatasetLsidImportHelper;
 import org.labkey.study.model.ParticipantIdImportHelper;
 import org.labkey.study.model.ParticipantSeqNumImportHelper;
+import org.labkey.study.model.QCStateImportHelper;
 import org.labkey.study.model.SecurityType;
 import org.labkey.study.model.SequenceNumImportHelper;
 import org.labkey.study.model.StudyImpl;
@@ -656,6 +657,9 @@ public class DatasetUpdateService extends DefaultQueryUpdateService
         Object inputManagedKey = DatasetDataIteratorBuilder.findColumnInMap(row, managedKeyColumn);
         if (inputManagedKey == null)
             inputManagedKey = DatasetDataIteratorBuilder.findColumnInMap(oldRow, managedKeyColumn);
+        Integer inputQCState = (Integer)DatasetDataIteratorBuilder.findColumnInMap(row, table.getColumn(DatasetTableImpl.QCSTATE_ID_COLNAME));
+        if (inputQCState == null)
+            inputQCState = (Integer)DatasetDataIteratorBuilder.findColumnInMap(oldRow, table.getColumn(DatasetTableImpl.QCSTATE_ID_COLNAME));
 
         SequenceNumImportHelper snih = new SequenceNumImportHelper(_dataset.getStudy(), _dataset);
         Double sequenceNum = snih.translateSequenceNum(inputSeqNum, inputDate);
@@ -670,6 +674,15 @@ public class DatasetUpdateService extends DefaultQueryUpdateService
         DatasetLsidImportHelper dlih = new DatasetLsidImportHelper(_dataset);
         String lsid = dlih.translateLsid(subjectId, sequenceNum, inputDate, inputManagedKey, null);
 
+        // handle default QC states
+        if (inputQCState == null)
+        {
+            String inputQCText = (String)DatasetDataIteratorBuilder.findColumnInMap(row, table.getColumn(DatasetTableImpl.QCSTATE_LABEL_COLNAME));
+            QCStateImportHelper qcih = new QCStateImportHelper(user, _dataset, true, StudyManager.getInstance().getDefaultQCState(_dataset.getStudy()));
+            Integer qcState = qcih.translateQCState(inputQCText);
+            if (qcState != null)
+                row.put(DatasetTableImpl.QCSTATE_ID_COLNAME, qcState);
+        }
         row.put(DatasetDomainKind.LSID, lsid);
         row.put(DatasetDomainKind.PARTICIPANTSEQUENCENUM, participantSeqNum);
         row.put(DatasetDomainKind.PARTICIPANTID, subjectId);

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -658,8 +658,6 @@ public class DatasetUpdateService extends DefaultQueryUpdateService
         if (inputManagedKey == null)
             inputManagedKey = DatasetDataIteratorBuilder.findColumnInMap(oldRow, managedKeyColumn);
         Integer inputQCState = (Integer)DatasetDataIteratorBuilder.findColumnInMap(row, table.getColumn(DatasetTableImpl.QCSTATE_ID_COLNAME));
-        if (inputQCState == null)
-            inputQCState = (Integer)DatasetDataIteratorBuilder.findColumnInMap(oldRow, table.getColumn(DatasetTableImpl.QCSTATE_ID_COLNAME));
 
         SequenceNumImportHelper snih = new SequenceNumImportHelper(_dataset.getStudy(), _dataset);
         Double sequenceNum = snih.translateSequenceNum(inputSeqNum, inputDate);


### PR DESCRIPTION
#### Rationale
The recent refactor of dataset updates broke a few tests around QC state handling. In particular, a study can be configured to set a default QC state for a row on insert or update. This special handling needs to be factored out so it can be used in both insert and update cases.