### PR TITLE
missing .detach() when caching resultset

### DIFF
--- a/query/src/org/labkey/query/olap/BitSetQueryImpl.java
+++ b/query/src/org/labkey/query/olap/BitSetQueryImpl.java
@@ -2221,7 +2221,7 @@ public class BitSetQueryImpl
 
             logDebug("cache put: " + cacheKey);
             // CONSIDER: using short TTL since I don't _know_ that this query result is immutable
-            _resultsCache.put(cacheKey, ret, CacheManager.MINUTE);
+            _resultsCache.put(cacheKey, ret.detach(), CacheManager.MINUTE);
             return ret;
         }
 


### PR DESCRIPTION
#### Rationale
Fixes cache validation warning

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
