### PR TITLE
Make assay/sample publish confirmation actions POST-only

### DIFF
--- a/api/src/org/labkey/api/study/publish/AbstractPublishConfirmAction.java
+++ b/api/src/org/labkey/api/study/publish/AbstractPublishConfirmAction.java
@@ -28,6 +28,7 @@ import org.labkey.api.data.DataRegionSelection;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.MethodsAllowed;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.study.Dataset;
@@ -57,6 +58,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.api.util.HttpUtil.Method.POST;
+
+@MethodsAllowed(POST)
 @RequiresPermission(InsertPermission.class)
 public abstract class AbstractPublishConfirmAction<FORM extends PublishConfirmForm> extends FormViewAction<FORM>
 {

--- a/study/src/org/labkey/study/assay/AssayPublishConfirmAction.java
+++ b/study/src/org/labkey/study/assay/AssayPublishConfirmAction.java
@@ -32,7 +32,6 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
-import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
@@ -58,7 +57,7 @@ public class AssayPublishConfirmAction extends AbstractPublishConfirmAction<Assa
         private ExpProtocol _protocol;
         private AssayProvider _provider;
 
-        ExpProtocol getProtocol()
+        @NotNull ExpProtocol getProtocol()
         {
             if (_protocol == null)
             {
@@ -289,9 +288,6 @@ public class AssayPublishConfirmAction extends AbstractPublishConfirmAction<Assa
     @Override
     public ModelAndView getView(AssayPublishConfirmForm form, boolean reshow, BindException errors) throws Exception
     {
-        if (form.getProtocol() == null)
-            return HtmlView.err("Could not resolve the source protocol.");
-
         return super.getView(form, reshow, errors);
     }
 

--- a/study/src/org/labkey/study/assay/AssayPublishConfirmAction.java
+++ b/study/src/org/labkey/study/assay/AssayPublishConfirmAction.java
@@ -35,9 +35,7 @@ import org.labkey.api.view.DataView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
-import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
-import org.springframework.web.servlet.ModelAndView;
 
 import java.util.HashMap;
 import java.util.List;
@@ -283,18 +281,6 @@ public class AssayPublishConfirmAction extends AbstractPublishConfirmAction<Assa
     protected ActionURL linkToStudy(AssayPublishConfirmForm form, Container targetStudy, Map<Integer, PublishKey> publishData, List<String> publishErrors)
     {
         return form.getProvider().linkToStudy(getUser(), getContainer(), _protocol, targetStudy, form.getAutoLinkCategory(), publishData, publishErrors);
-    }
-
-    @Override
-    public ModelAndView getView(AssayPublishConfirmForm form, boolean reshow, BindException errors) throws Exception
-    {
-        return super.getView(form, reshow, errors);
-    }
-
-    @Override
-    public boolean handlePost(AssayPublishConfirmForm form, BindException errors) throws Exception
-    {
-        return super.handlePost(form, errors);
     }
 
     @Override

--- a/study/src/org/labkey/study/controllers/publish/SampleTypePublishConfirmAction.java
+++ b/study/src/org/labkey/study/controllers/publish/SampleTypePublishConfirmAction.java
@@ -27,7 +27,6 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
-import org.springframework.web.servlet.ModelAndView;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -198,12 +197,6 @@ public class SampleTypePublishConfirmAction extends AbstractPublishConfirmAction
                 sampleType.getName(),
                 Pair.of(Dataset.PublishSource.SampleType, sampleType.getRowId()),
                 dataMaps, ROW_ID, errors);
-    }
-
-    @Override
-    public ModelAndView getView(SampleTypePublishConfirmForm form, boolean reshow, BindException errors) throws Exception
-    {
-        return super.getView(form, reshow, errors);
     }
 
     @Override

--- a/study/src/org/labkey/study/controllers/publish/SampleTypePublishConfirmAction.java
+++ b/study/src/org/labkey/study/controllers/publish/SampleTypePublishConfirmAction.java
@@ -23,7 +23,6 @@ import org.labkey.api.study.publish.PublishKey;
 import org.labkey.api.study.publish.StudyPublishService;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
-import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.springframework.validation.BindException;
@@ -204,9 +203,6 @@ public class SampleTypePublishConfirmAction extends AbstractPublishConfirmAction
     @Override
     public ModelAndView getView(SampleTypePublishConfirmForm form, boolean reshow, BindException errors) throws Exception
     {
-        if (_sampleType == null)
-            return HtmlView.err("Could not resolve the source Sample Type.");
-
         return super.getView(form, reshow, errors);
     }
 


### PR DESCRIPTION
#### Rationale
Confirmation actions often require significant context from the source page. Supporting GET requests for them is virtually useless and trips up the crawler.

```
java.lang.NullPointerException: Cannot invoke "org.labkey.api.exp.api.ExpProtocol.getName()" because "protocol" is null
Current URL: /Dataset%20Download%20Test/publish-assayPublishConfirm.view?userId=%22%3E%27%3E%27%22%3C%2Fscript%3E%3Cimg%20src%3D%22x%22%20onerror%3D%22alert(%278(%27)%22%3E&rowId=25&_dc=371&.lastFilter=true&pk=2&webPartId=84&schemaName=assay&rootset=1&t=sitegroups&type=Deprecated
Current user: teamcity@labkey.test
java.lang.NullPointerException: Cannot invoke "org.labkey.api.exp.api.ExpProtocol.getName()" because "protocol" is null
	at org.labkey.api.assay.AssayProtocolSchema.schemaName(AssayProtocolSchema.java:137) ~[api-25.6-SNAPSHOT.jar:?]
	at org.labkey.api.assay.AssayProtocolSchema.<init>(AssayProtocolSchema.java:142) ~[api-25.6-SNAPSHOT.jar:?]
	at org.labkey.assay.TSVProtocolSchema.<init>(TSVProtocolSchema.java:79) ~[assay-25.6-SNAPSHOT.jar:?]
	at org.labkey.assay.TsvAssayProvider.createProtocolSchema(TsvAssayProvider.java:316) ~[assay-25.6-SNAPSHOT.jar:?]
	at org.labkey.study.assay.AssayPublishConfirmAction.getUserSchema(AssayPublishConfirmAction.java:162) ~[study-25.6-SNAPSHOT.jar:?]
	at org.labkey.study.assay.AssayPublishConfirmAction.getUserSchema(AssayPublishConfirmAction.java:50) ~[study-25.6-SNAPSHOT.jar:?]
	at org.labkey.api.study.publish.AbstractPublishConfirmAction.getView(AbstractPublishConfirmAction.java:231) ~[api-25.6-SNAPSHOT.jar:?]
	at org.labkey.study.assay.AssayPublishConfirmAction.getView(AssayPublishConfirmAction.java:295) ~[study-25.6-SNAPSHOT.jar:?]
	at org.labkey.study.assay.AssayPublishConfirmAction.getView(AssayPublishConfirmAction.java:50) ~[study-25.6-SNAPSHOT.jar:?]
	at org.labkey.api.action.FormViewAction.handleRequest(FormViewAction.java:110) ~[api-25.6-SNAPSHOT.jar:?]
```

#### Related Pull Requests
- N/A

#### Changes
- Make `publish-sampleTypePublishConfirm` and `publish-assayPublishConfirm` actions POST-only
