### PR TITLE
Try getting user email from cookie if not logged in

### DIFF
--- a/core/resources/views/login.html
+++ b/core/resources/views/login.html
@@ -9,7 +9,7 @@
             <a href="login-resetPassword.view">Forgot password</a>
         </div>
         <input id="password" name="password" type="password" class="input-block" tabindex="2" autocomplete="off">
-        <input tabindex="3" type="checkbox" name="remember" id="remember"  checked> Remember my email address
+        <input tabindex="3" type="checkbox" name="remember" id="remember" checked> Remember my email address
         <div class="termsOfUseSection" hidden>
             <div class="auth-header auth-item">Terms of Use</div>
             <div class="toucontent auth-item termsOfUseContent"></div>

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -316,6 +316,7 @@ import org.labkey.bootstrap.ExplodedModuleService;
 import org.labkey.core.admin.miniprofiler.MiniProfilerController;
 import org.labkey.core.admin.sitevalidation.SiteValidationJob;
 import org.labkey.core.admin.sql.SqlScriptController;
+import org.labkey.core.login.LoginController;
 import org.labkey.core.portal.CollaborationFolderType;
 import org.labkey.core.portal.ProjectController;
 import org.labkey.core.query.CoreQuerySchema;
@@ -12014,7 +12015,14 @@ public class AdminController extends SpringActionController
                             boolean forwarded = jsonObj.optBoolean("forwarded", false);
                             if (!forwarded)
                             {
-                                jsonObj.put("user", getUser().getEmail());
+                                User user = getUser();
+                                String email = null;
+                                // If the user is not logged in, we may still be able to snag the email address from our cookie
+                                if (user.isGuest())
+                                    email = LoginController.getEmailFromCookie(getViewContext().getRequest());
+                                if (null == email)
+                                    email = user.getEmail();
+                                jsonObj.put("user", email);
                                 String ipAddress = request.getHeader("X-FORWARDED-FOR");
                                 if (ipAddress == null)
                                     ipAddress = request.getRemoteAddr();

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -11998,7 +11998,7 @@ public class AdminController extends SpringActionController
             if (PageFlowUtil.isRobotUserAgent(userAgent) && !_log.isDebugEnabled())
                 return ret;
 
-            // NOTE User will always be "guest". Seems like a bad design to force the server to accept guest w/o CSRF here.
+            // NOTE User may be "guest", and will always be guest if being relayed to labkey.org
             var jsonObj = form.getJsonObject();
             if (null != jsonObj)
             {

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -1143,7 +1143,7 @@ public class LoginController extends SpringActionController
     }
 
     @Nullable
-    private String getEmailFromCookie(HttpServletRequest request)
+    public static String getEmailFromCookie(HttpServletRequest request)
     {
         String email = null;
         Cookie[] cookies = request.getCookies();


### PR DESCRIPTION
#### Rationale
We'd like to identify the end user when pages like login, reset password, etc. report CSP violations. In most cases, the user won't be logged in when accessing these pages, but there's a decent chance our email cookie holds the user's address, so check for it before falling reporting "guest".

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6692