### PR TITLE
Restrict assay schedule inserts for dataspace folders.

### DIFF
--- a/study/api-src/org/labkey/api/studydesign/query/AssaySpecimenTable.java
+++ b/study/api-src/org/labkey/api/studydesign/query/AssaySpecimenTable.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.studydesign.query;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.query.AliasedColumn;
@@ -24,6 +25,7 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.column.BuiltInColumnTypes;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 
 import static org.labkey.api.studydesign.query.StudyDesignQuerySchema.STUDY_DESIGN_ASSAYS_TABLE_NAME;
 import static org.labkey.api.studydesign.query.StudyDesignQuerySchema.STUDY_DESIGN_LABS_TABLE_NAME;
@@ -97,6 +99,16 @@ public class AssaySpecimenTable extends StudyDesignBaseTable
     public QueryUpdateService getUpdateService()
     {
         return new DefaultQueryUpdateService(this, this.getRealTable());
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        checkedPermissions.add(perm);
+        // Most tables should not be editable in Dataspace
+        if (!perm.equals(ReadPermission.class) && getContainer().isDataspace())
+            return false;
+        return hasPermissionOverridable(user, perm);
     }
 
     @Override

--- a/study/api-src/org/labkey/api/studydesign/query/AssaySpecimenVisitTable.java
+++ b/study/api-src/org/labkey/api/studydesign/query/AssaySpecimenVisitTable.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.studydesign.query;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
@@ -26,6 +27,7 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.column.BuiltInColumnTypes;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 
 /**
  * User: cnathe
@@ -64,6 +66,16 @@ public class AssaySpecimenVisitTable extends StudyDesignBaseTable
                 addWrapColumn(baseColumn);
             }
         }
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        checkedPermissions.add(perm);
+        // Most tables should not be editable in Dataspace
+        if (!perm.equals(ReadPermission.class) && getContainer().isDataspace())
+            return false;
+        return hasPermissionOverridable(user, perm);
     }
 
     @Override

--- a/study/test/src/org/labkey/test/tests/study/StudyDataspaceTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDataspaceTest.java
@@ -33,6 +33,7 @@ import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.PostgresOnlyTest;
 import org.labkey.test.util.StudyHelper;
 import org.openqa.selenium.WebElement;
 
@@ -45,7 +46,7 @@ import static org.junit.Assert.assertEquals;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
-public class StudyDataspaceTest extends StudyBaseTest
+public class StudyDataspaceTest extends StudyBaseTest implements PostgresOnlyTest
 {
     protected final String FOLDER_STUDY1 = "Study 1";
     protected final String FOLDER_STUDY2 = "Study 2";


### PR DESCRIPTION
#### Rationale
The assay schedule tables (`AssaySpecimenTable` and `AssaySpecimenVisitTable`) needed some additional permission checks to prevent insert/update at the project root for folders that were configured as shared study datasets. This check had previously been performed in `BaseStudyTable` but wasn't preserved when they were moved into the study design query schema.

Additionally, the study design module is postgres only and since much of the `StudyDataspaceTest` tests the study design functionality, the test is being switched to postgres only as well. With recent changes, there are no clients that are running the combination of SQL server with the new module.