### PR TITLE
Issue 52416: Remember trusted devices to reduce frequency of 2FA prompts

### DIFF
--- a/api/src/org/labkey/api/action/HasViewContext.java
+++ b/api/src/org/labkey/api/action/HasViewContext.java
@@ -18,11 +18,6 @@ package org.labkey.api.action;
 
 import org.labkey.api.view.ViewContext;
 
-/**
- * User: matthewb
- * Date: May 21, 2007
- * Time: 3:45:43 PM
- */
 public interface HasViewContext
 {
     void setViewContext(ViewContext context);

--- a/api/src/org/labkey/api/security/AuthenticationConfiguration.java
+++ b/api/src/org/labkey/api/security/AuthenticationConfiguration.java
@@ -204,7 +204,7 @@ public interface AuthenticationConfiguration<AP extends AuthenticationProvider> 
 
         URLHelper getRedirectURL(User candidate, Container c);
 
-        boolean isRequired(User user);
+        @Nullable String getNotRequiredMessage(User user, HttpServletRequest request);
 
         enum RequiredFor
         {

--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -1515,15 +1515,24 @@ public class AuthenticationManager
                 if (null == secondaryAuthUser)
                 {
                     SecondaryAuthenticationProvider<?> provider = configuration.getAuthenticationProvider();
-                    boolean bypass = provider.bypass();
-                    boolean notRequired = bypass || !configuration.isRequired(primaryAuthUser);
+                    boolean notRequired;
+                    if (provider.bypass())
+                    {
+                        _log.info("Per application.properties configuration, bypassing secondary authentication for provider: {}", provider.getClass());
+                        notRequired = true;
+                    }
+                    else
+                    {
+                        String notRequiredMessage = configuration.getNotRequiredMessage(primaryAuthUser, request);
+                        notRequired = notRequiredMessage != null;
+                        if (notRequired)
+                        {
+                            _log.debug("Bypassing secondary authentication since the authenticated user, \"{}\", {}", primaryAuthUser.getDisplayName(null), notRequiredMessage);
+                        }
+                    }
+
                     if (notRequired)
                     {
-                        if (bypass)
-                            _log.info("Per application.properties configuration, bypassing secondary authentication for provider: " + provider.getClass());
-                        else
-                            _log.debug("Bypassing secondary authentication since authenticated user lacks the \"Require Secondary Authentication\" role: " + primaryAuthUser.getDisplayName(null));
-
                         setSecondaryAuthenticationUser(session, configuration.getRowId(), primaryAuthUser);
                         continue;
                     }

--- a/api/src/org/labkey/api/security/AuthenticationProvider.java
+++ b/api/src/org/labkey/api/security/AuthenticationProvider.java
@@ -20,7 +20,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONArray;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ObjectFactory;
 import org.labkey.api.module.ModuleLoader;
@@ -78,14 +77,14 @@ public interface AuthenticationProvider
     }
 
     /**
-     * Returns a JSONArray of the field descriptors for the required provider-specific settings. JSON metadata is a small
+     * Returns a list of the field descriptors for the required provider-specific settings. JSON metadata is a small
      * subset of our standard column metadata (e.g., what getQueryDetails.api returns).
      *
-     * @return A JSONArray of field descriptors or null if this provider doesn't have any custom fields
+     * @return A list of field descriptors or null if this provider doesn't have any custom fields
      */
-    default @NotNull JSONArray getSettingsFields()
+    default @NotNull List<SettingsField> getSettingsFields()
     {
-        return new JSONArray();
+        return List.of();
     }
 
     @NotNull String getName();
@@ -242,18 +241,16 @@ public interface AuthenticationProvider
 
         /**
          * Bypass authentication from this provider. Might be configured via context.bypass2FA=true property in
-         * application.properties to temporarily not require secondary authentication if this has been misconfigured or
+         * application.properties to temporarily not require secondary authentication if this has been misconfigured, or
          * a 3rd party service provider is unavailable.
          */
         boolean bypass();
 
-        default JSONArray addRequiredForField(JSONArray fields, String name)
+        default SettingsField getRequiredForField(String name)
         {
-            return fields
-                .put(OptionsField.of(REQUIRED_FOR, "Require " + name + " for:", "Specifying the role option allows for a progressive roll-out of " + name + " to site users.", true, "all")
-                    .addOption("all", "All users")
-                    .addOption("role", "Only users assigned the \"Require Secondary Authentication\" site role")
-                );
+            return OptionsField.of(REQUIRED_FOR, "Require " + name + " for:", "Specifying the role option allows for a progressive roll-out of " + name + " to site users.", true, "all")
+                .addOption("all", "All users")
+                .addOption("role", "Only users assigned the \"Require Secondary Authentication\" site role");
         }
 
         @Override

--- a/api/src/org/labkey/api/security/BaseSecondaryAuthenticationConfiguration.java
+++ b/api/src/org/labkey/api/security/BaseSecondaryAuthenticationConfiguration.java
@@ -1,7 +1,9 @@
 package org.labkey.api.security;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.EnumUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.security.AuthenticationConfiguration.SecondaryAuthenticationConfiguration;
 import org.labkey.api.security.AuthenticationProvider.SecondaryAuthenticationProvider;
 
@@ -21,9 +23,9 @@ public abstract class BaseSecondaryAuthenticationConfiguration<AP extends Second
     }
 
     @Override
-    public boolean isRequired(User user)
+    public @Nullable String getNotRequiredMessage(User user, HttpServletRequest request)
     {
-        return _requiredFor.isRequired(user);
+        return _requiredFor.isRequired(user) ? null : "lacks the \"Require Secondary Authentication\" role";
     }
 
     @Override

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -167,7 +167,6 @@ public class SecurityManager
     static final String NULL_PRINCIPAL_ERROR_MESSAGE = "Null principal not allowed";
     static final String ALREADY_A_MEMBER_ERROR_MESSAGE = "Principal is already a member of this group";
     static final String ADD_GROUP_TO_ITSELF_ERROR_MESSAGE = "Can't add a group to itself";
-    static final String ADD_TO_SYSTEM_GROUP_ERROR_MESSAGE = "Can't add a group to a system group";
     static final String ADD_SYSTEM_GROUP_ERROR_MESSAGE = "Can't add a system group to another group";
     static final String DIFFERENT_PROJECTS_ERROR_MESSAGE = "Can't add a project group to a group in a different project";
     static final String PROJECT_TO_SITE_ERROR_MESSAGE = "Can't add a project group to a site group";

--- a/api/src/org/labkey/api/security/SettingsField.java
+++ b/api/src/org/labkey/api/security/SettingsField.java
@@ -26,6 +26,7 @@ public class SettingsField extends HashMap<String, Object>
 
         return sf;
     }
+
     public static SettingsField of(@NotNull String name, @NotNull FieldType type, @NotNull String caption, @NotNull String description, boolean required, Object defaultValue)
     {
         SettingsField sf = of(name, type, caption, required, defaultValue);
@@ -36,10 +37,7 @@ public class SettingsField extends HashMap<String, Object>
 
     public static SettingsField of(@NotNull String name, @NotNull FieldType type, @NotNull String caption, boolean required, Object defaultValue)
     {
-        SettingsField sf = new SettingsField();
-        sf.put("name", name);
-        sf.put("type", type.toString());
-        sf.put("caption", caption);
+        SettingsField sf = of(name, type, caption);
         sf.put("required", required);
         sf.put("defaultValue", defaultValue);
 

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -836,7 +836,7 @@ public class PageFlowUtil
 
     public static int[] toInts(Collection<String> strings)
     {
-        return toInts(strings.toArray(new String[strings.size()]));
+        return toInts(strings.toArray(new String[0]));
     }
 
     public static int[] toInts(String[] strings)

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -2566,7 +2566,7 @@ public class LoginController extends SpringActionController
             if (null != testLink)
                 m.put("testLink", testLink);
             m.put("settingsFields", ap.getSettingsFields());
-            m.put("allowInsert", ap.allowInsert());  // TODO: Update client to gray out disallowed providers
+            m.put("allowInsert", ap.allowInsert());
             return m;
         }
     }

--- a/core/src/org/labkey/core/view/template/bootstrap/header.jsp
+++ b/core/src/org/labkey/core/view/template/bootstrap/header.jsp
@@ -283,7 +283,7 @@
 <%
     }
 
-    if (PageFlowUtil.isPageAdminMode(getViewContext()))
+    if (isStartupComplete && PageFlowUtil.isPageAdminMode(getViewContext()))
     {
         ActionURL exitUrl = urlProvider(ProjectUrls.class).getTogglePageAdminModeURL(c, getActionURL());
 %>

--- a/devtools/src/org/labkey/devtools/authentication/TestSecondaryProvider.java
+++ b/devtools/src/org/labkey/devtools/authentication/TestSecondaryProvider.java
@@ -17,12 +17,14 @@ package org.labkey.devtools.authentication;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONArray;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.AuthenticationProvider.SecondaryAuthenticationProvider;
 import org.labkey.api.security.ConfigurationSettings;
+import org.labkey.api.security.SettingsField;
 import org.labkey.api.view.ActionURL;
 import org.labkey.devtools.authentication.TestSecondaryController.TestSecondarySaveConfigurationAction;
+
+import java.util.List;
 
 public class TestSecondaryProvider implements SecondaryAuthenticationProvider<TestSecondaryConfiguration>
 {
@@ -61,9 +63,9 @@ public class TestSecondaryProvider implements SecondaryAuthenticationProvider<Te
     }
 
     @Override
-    public @NotNull JSONArray getSettingsFields()
+    public @NotNull List<SettingsField> getSettingsFields()
     {
-        return addRequiredForField(new JSONArray(), "Test 2FA");
+        return List.of(getRequiredForField("Test 2FA"));
     }
 
     @Override

--- a/devtools/src/org/labkey/devtools/authentication/TestSsoProvider.java
+++ b/devtools/src/org/labkey/devtools/authentication/TestSsoProvider.java
@@ -16,7 +16,6 @@
 package org.labkey.devtools.authentication;
 
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONArray;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.AuthenticationProvider.SSOAuthenticationProvider;
 import org.labkey.api.security.ConfigurationSettings;
@@ -24,9 +23,8 @@ import org.labkey.api.security.SettingsField;
 import org.labkey.api.view.ActionURL;
 import org.labkey.devtools.authentication.TestSsoController.TestSsoSaveConfigurationAction;
 
-/**
- * Created by adam on 6/5/2016.
- */
+import java.util.List;
+
 public class TestSsoProvider implements SSOAuthenticationProvider<TestSsoConfiguration>
 {
     public static final String NAME = "TestSSO";
@@ -64,10 +62,11 @@ public class TestSsoProvider implements SSOAuthenticationProvider<TestSsoConfigu
     }
 
     @Override
-    public @NotNull JSONArray getSettingsFields()
+    public @NotNull List<SettingsField> getSettingsFields()
     {
-        return new JSONArray()
-            .put(SettingsField.of("autoRedirect", SettingsField.FieldType.checkbox, "Default to this TestSSO configuration", "Redirects the login page directly to the TestSSO page instead of requiring the user to click on a logo.", false, false))
-            .put(SettingsField.getStandardDomainField());
+        return List.of(
+            SettingsField.of("autoRedirect", SettingsField.FieldType.checkbox, "Default to this TestSSO configuration", "Redirects the login page directly to the TestSSO page instead of requiring the user to click on a logo.", false, false),
+            SettingsField.getStandardDomainField()
+        );
     }
 }


### PR DESCRIPTION
#### Rationale
TOTP adds security, but it can be annoying to provide these codes on every login. Administrators may want to give users the option of remembering trusted browsers for a period of time (e.g., 7 days, 30 days, or forever).

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52416

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/272