### PR TITLE
Issue 53167: LKS Chart wizard page can give JS error when selecting Line chart type if LABKEY object doesn't have core moduleContext

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.44.1"
+        "@labkey/components": "6.44.2"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2223,9 +2223,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.44.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.1.tgz",
-      "integrity": "sha512-Ljba1rrMDvCY2JKJbBEs51dUCjJyFCRsrDupIhng7Qp1xgY0LqaCIp1SiqLKEdzoR7uMuVE8KlUoCUN3g7Qqpg==",
+      "version": "6.44.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.2.tgz",
+      "integrity": "sha512-p7+HVHn4KK4DIUEK/+qYSBLZKWKDCSv9G0NCtg3VpdrYO2X9ewuo7JtzjOZnTaql/gPFidWEUlFverlysjLGpg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.41.2",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.44.0"
+        "@labkey/components": "6.44.0-exceptionsCAN256.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2223,9 +2223,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.44.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.0.tgz",
-      "integrity": "sha512-xWvBq7DQjqA/o0ghN/SYj+APNtWMBSr9n1CUMvc3t3X85KNbdxOajSwSKhQQWZdxJ3XP2gCzV9GzrJVtwokdHw==",
+      "version": "6.44.0-exceptionsCAN256.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.0-exceptionsCAN256.0.tgz",
+      "integrity": "sha512-slc5iT7CirONs5WuZQlxl1wOD1qiynbWIa1PZ5ssPM8NJfCtQqGck7UNAbrErQJFwolcs6lvXY3uj4G+mCM02Q==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.41.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.43.1"
+        "@labkey/components": "6.43.3-exceptionsCAN256.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2181,9 +2181,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.41.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.41.0.tgz",
-      "integrity": "sha512-FWhELnNLkTVNNGXOnPHFoLb/CvPKVnibvVnINGETh1rBUmp8UdGrSV2OuhhPEkuGoi/SGp2zI3dkkSYjRR20Eg=="
+      "version": "1.41.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.41.1.tgz",
+      "integrity": "sha512-5CaGXA0Z2m/D7lDf8F8gZugQVxcWURpRsEdU+Xc/xn4Vz5ZdLjfgzyD87WsEtwNEi0Ed8Lw/BpsToFh80g+3IA=="
     },
     "node_modules/@labkey/build": {
       "version": "8.5.0",
@@ -2223,12 +2223,12 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.43.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.43.1.tgz",
-      "integrity": "sha512-Rh/Pq8BwhwI0Iz8s9iR+ygucGrf0xGLDyria574ZgYLhih7DtKuN38isxQAkfBwzDf3/TBgF9Vxm4z7TmAn/yA==",
+      "version": "6.43.3-exceptionsCAN256.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.43.3-exceptionsCAN256.0.tgz",
+      "integrity": "sha512-sp/hbjSAI/k7KwC8NxeAn3UgsRQ9AZLeOHH0HHFEXCc3+S840Dvn3ZxJHFysg8PYn5d9TuSCcvvp28WUMcffRQ==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.41.0",
+        "@labkey/api": "1.41.1",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.44.0"
+    "@labkey/components": "6.44.0-exceptionsCAN256.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.43.1"
+    "@labkey/components": "6.43.3-exceptionsCAN256.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.44.1"
+    "@labkey/components": "6.44.2"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.44.0",
+        "@labkey/components": "6.44.0-exceptionsCAN256.0",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3029,9 +3029,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.44.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.0.tgz",
-      "integrity": "sha512-xWvBq7DQjqA/o0ghN/SYj+APNtWMBSr9n1CUMvc3t3X85KNbdxOajSwSKhQQWZdxJ3XP2gCzV9GzrJVtwokdHw==",
+      "version": "6.44.0-exceptionsCAN256.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.0-exceptionsCAN256.0.tgz",
+      "integrity": "sha512-slc5iT7CirONs5WuZQlxl1wOD1qiynbWIa1PZ5ssPM8NJfCtQqGck7UNAbrErQJFwolcs6lvXY3uj4G+mCM02Q==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.41.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.44.1",
+        "@labkey/components": "6.44.2",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3029,9 +3029,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.44.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.1.tgz",
-      "integrity": "sha512-Ljba1rrMDvCY2JKJbBEs51dUCjJyFCRsrDupIhng7Qp1xgY0LqaCIp1SiqLKEdzoR7uMuVE8KlUoCUN3g7Qqpg==",
+      "version": "6.44.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.2.tgz",
+      "integrity": "sha512-p7+HVHn4KK4DIUEK/+qYSBLZKWKDCSv9G0NCtg3VpdrYO2X9ewuo7JtzjOZnTaql/gPFidWEUlFverlysjLGpg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.41.2",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.43.2",
+        "@labkey/components": "6.43.3-exceptionsCAN256.0",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3029,9 +3029,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.43.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.43.2.tgz",
-      "integrity": "sha512-f2rv0XIDCRW44CWM1wFik3PMLqBgmmpr50FIVH9FApL+CK5hDK+MNx5gkad3OjWMeOkFq9KD4bIOAPFJIrTMEw==",
+      "version": "6.43.3-exceptionsCAN256.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.43.3-exceptionsCAN256.0.tgz",
+      "integrity": "sha512-sp/hbjSAI/k7KwC8NxeAn3UgsRQ9AZLeOHH0HHFEXCc3+S840Dvn3ZxJHFysg8PYn5d9TuSCcvvp28WUMcffRQ==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.41.1",

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.44.1",
+    "@labkey/components": "6.44.2",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.43.2",
+    "@labkey/components": "6.43.3-exceptionsCAN256.0",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.44.0",
+    "@labkey/components": "6.44.0-exceptionsCAN256.0",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.43.2"
+        "@labkey/components": "6.43.3-exceptionsCAN256.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2842,9 +2842,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.43.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.43.2.tgz",
-      "integrity": "sha512-f2rv0XIDCRW44CWM1wFik3PMLqBgmmpr50FIVH9FApL+CK5hDK+MNx5gkad3OjWMeOkFq9KD4bIOAPFJIrTMEw==",
+      "version": "6.43.3-exceptionsCAN256.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.43.3-exceptionsCAN256.0.tgz",
+      "integrity": "sha512-sp/hbjSAI/k7KwC8NxeAn3UgsRQ9AZLeOHH0HHFEXCc3+S840Dvn3ZxJHFysg8PYn5d9TuSCcvvp28WUMcffRQ==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.41.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.44.0"
+        "@labkey/components": "6.44.0-exceptionsCAN256.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2842,9 +2842,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.44.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.0.tgz",
-      "integrity": "sha512-xWvBq7DQjqA/o0ghN/SYj+APNtWMBSr9n1CUMvc3t3X85KNbdxOajSwSKhQQWZdxJ3XP2gCzV9GzrJVtwokdHw==",
+      "version": "6.44.0-exceptionsCAN256.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.0-exceptionsCAN256.0.tgz",
+      "integrity": "sha512-slc5iT7CirONs5WuZQlxl1wOD1qiynbWIa1PZ5ssPM8NJfCtQqGck7UNAbrErQJFwolcs6lvXY3uj4G+mCM02Q==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.41.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.44.1"
+        "@labkey/components": "6.44.2"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2842,9 +2842,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.44.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.1.tgz",
-      "integrity": "sha512-Ljba1rrMDvCY2JKJbBEs51dUCjJyFCRsrDupIhng7Qp1xgY0LqaCIp1SiqLKEdzoR7uMuVE8KlUoCUN3g7Qqpg==",
+      "version": "6.44.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.2.tgz",
+      "integrity": "sha512-p7+HVHn4KK4DIUEK/+qYSBLZKWKDCSv9G0NCtg3VpdrYO2X9ewuo7JtzjOZnTaql/gPFidWEUlFverlysjLGpg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.41.2",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.44.1"
+    "@labkey/components": "6.44.2"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.43.2"
+    "@labkey/components": "6.43.3-exceptionsCAN256.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.44.0"
+    "@labkey/components": "6.44.0-exceptionsCAN256.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.43.1"
+        "@labkey/components": "6.43.3-exceptionsCAN256.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2357,9 +2357,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.41.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.41.0.tgz",
-      "integrity": "sha512-FWhELnNLkTVNNGXOnPHFoLb/CvPKVnibvVnINGETh1rBUmp8UdGrSV2OuhhPEkuGoi/SGp2zI3dkkSYjRR20Eg=="
+      "version": "1.41.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.41.1.tgz",
+      "integrity": "sha512-5CaGXA0Z2m/D7lDf8F8gZugQVxcWURpRsEdU+Xc/xn4Vz5ZdLjfgzyD87WsEtwNEi0Ed8Lw/BpsToFh80g+3IA=="
     },
     "node_modules/@labkey/build": {
       "version": "8.5.0",
@@ -2399,12 +2399,12 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.43.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.43.1.tgz",
-      "integrity": "sha512-Rh/Pq8BwhwI0Iz8s9iR+ygucGrf0xGLDyria574ZgYLhih7DtKuN38isxQAkfBwzDf3/TBgF9Vxm4z7TmAn/yA==",
+      "version": "6.43.3-exceptionsCAN256.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.43.3-exceptionsCAN256.0.tgz",
+      "integrity": "sha512-sp/hbjSAI/k7KwC8NxeAn3UgsRQ9AZLeOHH0HHFEXCc3+S840Dvn3ZxJHFysg8PYn5d9TuSCcvvp28WUMcffRQ==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.41.0",
+        "@labkey/api": "1.41.1",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.44.0"
+        "@labkey/components": "6.44.0-exceptionsCAN256.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2399,9 +2399,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.44.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.0.tgz",
-      "integrity": "sha512-xWvBq7DQjqA/o0ghN/SYj+APNtWMBSr9n1CUMvc3t3X85KNbdxOajSwSKhQQWZdxJ3XP2gCzV9GzrJVtwokdHw==",
+      "version": "6.44.0-exceptionsCAN256.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.0-exceptionsCAN256.0.tgz",
+      "integrity": "sha512-slc5iT7CirONs5WuZQlxl1wOD1qiynbWIa1PZ5ssPM8NJfCtQqGck7UNAbrErQJFwolcs6lvXY3uj4G+mCM02Q==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.41.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.44.1"
+        "@labkey/components": "6.44.2"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2399,9 +2399,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.44.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.1.tgz",
-      "integrity": "sha512-Ljba1rrMDvCY2JKJbBEs51dUCjJyFCRsrDupIhng7Qp1xgY0LqaCIp1SiqLKEdzoR7uMuVE8KlUoCUN3g7Qqpg==",
+      "version": "6.44.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.44.2.tgz",
+      "integrity": "sha512-p7+HVHn4KK4DIUEK/+qYSBLZKWKDCSv9G0NCtg3VpdrYO2X9ewuo7JtzjOZnTaql/gPFidWEUlFverlysjLGpg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.41.2",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.43.1"
+    "@labkey/components": "6.43.3-exceptionsCAN256.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.44.0"
+    "@labkey/components": "6.44.0-exceptionsCAN256.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.44.1"
+    "@labkey/components": "6.44.2"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/visualization/resources/web/vis/chartWizard/chartTypePanel.js
+++ b/visualization/resources/web/vis/chartWizard/chartTypePanel.js
@@ -901,7 +901,7 @@ Ext4.define('LABKEY.vis.ChartTypeFieldSelectionsPanel', {
             // special case for trendline field, only visible for LIMS+ when premium module is available
             let hidden = false;
             if (field.name === 'trendline') {
-                const hasChartBuilding = LABKEY.getModuleContext('core').productFeatures?.indexOf('ChartBuilding') !== -1;
+                const hasChartBuilding = LABKEY.getModuleContext('core')?.productFeatures?.indexOf('ChartBuilding') !== -1;
                 const hasPremium = LABKEY.getModuleContext('api').moduleNames.indexOf('premium') !== -1;
                 hidden = !hasPremium || !hasChartBuilding;
             }


### PR DESCRIPTION
#### Rationale
Issue [53164](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53164): LKS new assay design page gives JS error if no specialty assay providers available for server
Issue [53167](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53167): LKS Chart wizard page can give JS error when selecting Line chart type if LABKEY object doesn't have core moduleContext

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1802

#### Changes
- update @labkey/components package version
- chartTypePanel.js to add null check for core moduleContext
