### PR TITLE
Prevent ClassCastException in AssayPublishConfirmAction

### DIFF
--- a/study/src/org/labkey/study/assay/AssayPublishConfirmAction.java
+++ b/study/src/org/labkey/study/assay/AssayPublishConfirmAction.java
@@ -35,6 +35,7 @@ import org.labkey.api.view.DataView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
+import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 
 import java.util.HashMap;
@@ -281,6 +282,12 @@ public class AssayPublishConfirmAction extends AbstractPublishConfirmAction<Assa
     protected ActionURL linkToStudy(AssayPublishConfirmForm form, Container targetStudy, Map<Integer, PublishKey> publishData, List<String> publishErrors)
     {
         return form.getProvider().linkToStudy(getUser(), getContainer(), _protocol, targetStudy, form.getAutoLinkCategory(), publishData, publishErrors);
+    }
+
+    @Override // Override to prevent ClassCastException
+    public boolean handlePost(AssayPublishConfirmForm form, BindException errors) throws Exception
+    {
+        return super.handlePost(form, errors);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Removing the override of `getPost` is causing a `ClassCastException` when visiting the assay publish page.

```
java.lang.ClassCastException: class org.labkey.api.study.publish.PublishConfirmForm cannot be cast to class org.labkey.study.assay.AssayPublishConfirmAction$AssayPublishConfirmForm (org.labkey.api.study.publish.PublishConfirmForm and org.labkey.study.assay.AssayPublishConfirmAction$AssayPublishConfirmForm are in unnamed module of loader org.labkey.embedded.LabKeySpringBootClassLoader @4dad0eed)
	at org.labkey.study.assay.AssayPublishConfirmAction.validateCommand(AssayPublishConfirmAction.java:47) ~[study-25.6-SNAPSHOT.jar:?]
	at org.labkey.api.action.FormViewAction.validate(FormViewAction.java:160) ~[api-25.6-SNAPSHOT.jar:?]
	at org.labkey.api.action.FormViewAction.handleRequest(FormViewAction.java:84) ~[api-25.6-SNAPSHOT.jar:?]
	at org.labkey.api.action.FormViewAction.handleRequest(FormViewAction.java:70) ~[api-25.6-SNAPSHOT.jar:?]
	at org.labkey.api.action.BaseViewAction.handleRequest(BaseViewAction.java:190) ~[api-25.6-SNAPSHOT.jar:?]
```

#### Related Pull Requests
- #6691 

#### Changes
- Override 'handlePost' to prevent ClassCastException
