### PR TITLE
Fix UserTest - restore custom user table fields

### DIFF
--- a/core/resources/schemas/core.xml
+++ b/core/resources/schemas/core.xml
@@ -226,6 +226,12 @@
         <inputLength>36</inputLength>
         <isReadOnly>true</isReadOnly>
         <isHidden>true</isHidden>
+        <description>The user's unique entity id.</description>
+        <fk>
+          <fkTable>object</fkTable>
+          <fkColumnName>ObjectURI</fkColumnName>
+          <fkDbSchema>exp</fkDbSchema>
+        </fk>
       </column>
       <column columnName="CreatedBy">
         <columnTitle>Created By</columnTitle>


### PR DESCRIPTION
#### Rationale
My change in https://github.com/LabKey/platform/pull/6678 that cleaned up bogus UserSchema lookups removed a declaration that the core.Users and SiteUser tables rely on to wire up admin-defined field tests. This broke UserTest.

#### Changes
- Retain the DbSchema-level lookup definition on `core.Users.EntityId`