### PR TITLE
Fix Issue 52884

### DIFF
--- a/api/src/org/labkey/api/attachments/AttachmentService.java
+++ b/api/src/org/labkey/api/attachments/AttachmentService.java
@@ -77,6 +77,8 @@ public interface AttachmentService
 
     void deleteAttachments(Collection<AttachmentParent> parents);
 
+    void validateAttachmentSizes(AttachmentParent parent, List<AttachmentFile> files) throws IOException;
+
     /**
      * Deletes the attachments with the given names from the given AttachmentParent.
      * @param parent: The AttachmentParent to delete files from

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -245,6 +245,30 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
         return null;
     }
 
+    private void validateAttachmentSize(AttachmentFile file) throws IOException
+    {
+        int maxSize = AppProps.getInstance().getMaxBLOBSize();
+        if (file.getSize() > maxSize)
+        {
+            throw new AttachmentService.FileTooLargeException(file, maxSize);
+        }
+    }
+
+    @Override
+    public void validateAttachmentSizes(AttachmentParent parent, List<AttachmentFile> files) throws IOException
+    {
+        File fileLocation = parent instanceof AttachmentDirectory ? ((AttachmentDirectory) parent).getFileSystemDirectory() : null;
+
+        // Only validate if we're putting the file in the database
+        if (null == fileLocation)
+        {
+            for (AttachmentFile file : files)
+            {
+                validateAttachmentSize(file);
+            }
+        }
+    }
+
 
     @Override
     public synchronized void addAttachments(AttachmentParent parent, List<AttachmentFile> files, @NotNull User user) throws IOException
@@ -275,12 +299,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
             HashMap<String, Object> hm = new HashMap<>();
             if (null == fileLocation)
             {
-                int maxSize = AppProps.getInstance().getMaxBLOBSize();
-                if (file.getSize() > maxSize)
-                {
-                    throw new AttachmentService.FileTooLargeException(file, maxSize);
-                }
-
+                validateAttachmentSize(file);
                 hm.put("Document", file);
             }
             else


### PR DESCRIPTION
#### Rationale
This PR addresses [Issue 52884](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52884) by adding a new public method, validateAttachmentSizes, to the AttachmentService, allowing the GlobalAttachmentManager (see linked PR) can validate file sizes before attempting to process files.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6711
- https://github.com/LabKey/limsModules/pull/1436

#### Changes
- AttachmentService: add validateAttachmentSizes
