### PR TITLE
Skip the study design related tests if the module is not deployed

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
@@ -163,6 +163,7 @@ public class StudyPublishTest extends StudyPHIExportTest
     private final String SUB_FOLDER_NAME = "PublishedSubStudy";
     private static final String PUBLISH_FOLDER_ADMIN = "publish_admin@study.test";
     private static final String PUBLISH_SUB_FOLDER_ADMIN = "publishsub_admin@study.test";
+    private boolean _studyDesignModulePresent;
 
     // enum to help determine the study publish location
     public enum PublishLocation
@@ -184,6 +185,8 @@ public class StudyPublishTest extends StudyPHIExportTest
     @Override
     protected void doCreateSteps()
     {
+        _studyDesignModulePresent =  _studyHelper.isModulePresent("StudyDesign");
+
         // fail fast if R is not configured
         RReportHelper _rReportHelper = new RReportHelper(this);
         _rReportHelper.ensureRConfig();
@@ -883,8 +886,12 @@ public class StudyPublishTest extends StudyPHIExportTest
 
         // Study Objects
         waitForElement(Locator.xpath("//div[@class = 'labkey-nav-page-header'][text() = 'Study Objects']"));
-        verifyPublishWizardSelectedCheckboxes(StudyHelper.Panel.studyObjects, "Assay Schedule", "Cohort Settings", "Custom Participant View",
-                "Participant Comment Settings", "Permissions for Custom Study Security", "Protocol Documents", "Treatment Data");
+        if (_studyDesignModulePresent)
+            verifyPublishWizardSelectedCheckboxes(StudyHelper.Panel.studyObjects, "Assay Schedule", "Cohort Settings", "Custom Participant View",
+                    "Participant Comment Settings", "Permissions for Custom Study Security", "Protocol Documents", "Treatment Data");
+        else
+            verifyPublishWizardSelectedCheckboxes(StudyHelper.Panel.studyObjects, "Cohort Settings", "Custom Participant View",
+                    "Participant Comment Settings", "Permissions for Custom Study Security", "Protocol Documents");
         clickButton("Next", 0);
 
         // Lists

--- a/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
@@ -74,6 +74,7 @@ public class StudySimpleExportTest extends StudyBaseTest
     public static final String NOTIFICATION_EMAIL = "specimen-test@simpleexport.test";
     private final String FOLDER_SCOPE = "folder";
     private final String PROJECT_SCOPE = "project";
+    private boolean _studyDesignModulePresent;
 
     @Override
     protected BrowserType bestBrowser()
@@ -123,10 +124,12 @@ public class StudySimpleExportTest extends StudyBaseTest
     {
         super.initializeFolder();
 
+        _studyDesignModulePresent =  _studyHelper.isModulePresent("StudyDesign");
         clickProject(getProjectName());
         goToFolderManagement().goToFolderTypeTab();
         checkCheckbox(Locator.radioButtonByNameAndValue("folderType", "Study"));
-        checkCheckbox(Locator.checkboxByNameAndValue("activeModules", "StudyDesign"));
+        if (_studyDesignModulePresent)
+            checkCheckbox(Locator.checkboxByNameAndValue("activeModules", "StudyDesign"));
         clickButton("Update Folder");
 
         // click button to create manual study
@@ -134,7 +137,7 @@ public class StudySimpleExportTest extends StudyBaseTest
         // use all of the default study settings
         clickButton("Create Study");
         clickFolder(getFolderName());
-        if (_studyHelper.isModulePresent("StudyDesign"))
+        if (_studyDesignModulePresent)
             _containerHelper.enableModule("StudyDesign");
     }
 
@@ -692,6 +695,12 @@ public class StudySimpleExportTest extends StudyBaseTest
         final String FOLDER_NAME_2 = "Study Design Data2";
 
         log("StudyDesign Tables");
+
+        if (!_studyDesignModulePresent)
+        {
+            log("StudyDesignModule not present, skipping verifyStudyDesignTables test");
+            return;
+        }
         goToProjectHome();
         clickFolder(getFolderName());
 
@@ -958,6 +967,11 @@ public class StudySimpleExportTest extends StudyBaseTest
         final String FOLDER_NAME = "Study Design ExData";
 
         log("StudyDesign Extensible Tables");
+        if (!_studyDesignModulePresent)
+        {
+            log("StudyDesignModule not present, skipping verifyStudyDesignExtensibleTables test");
+            return;
+        }
         goToProjectHome();
         clickFolder(getFolderName());
 


### PR DESCRIPTION
#### Rationale
Fixes to the `StudyPublishTest` and `StudySimpleExportTest` for SQL server. 

The new `StudyDesign` module is postgres only. The tests needed to be modified to handle the case where the module isn't deployed and conditionally test the study design specific features.