### PR TITLE
Issue 52886: Assure detailed audit log captures differences for long field names

### DIFF
--- a/api/src/org/labkey/api/data/FieldKeyRowMap.java
+++ b/api/src/org/labkey/api/data/FieldKeyRowMap.java
@@ -125,7 +125,7 @@ public class FieldKeyRowMap implements Map<FieldKey, Object>
         return map;
     }
 
-    public static Map<String, Object> toColumnNameMap(Map<FieldKey, Object> rowMap)
+    public static Map<String, Object> toNameMap(Map<FieldKey, Object> rowMap)
     {
         Map<String, Object> map = new CaseInsensitiveHashMap<>();
         rowMap.forEach((key, value) -> {

--- a/api/src/org/labkey/api/data/FieldKeyRowMap.java
+++ b/api/src/org/labkey/api/data/FieldKeyRowMap.java
@@ -16,6 +16,7 @@
 package org.labkey.api.data;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.query.FieldKey;
 
 import java.sql.SQLException;
@@ -26,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-class FieldKeyRowMap implements Map<FieldKey, Object>
+public class FieldKeyRowMap implements Map<FieldKey, Object>
 {
     private final Results _results;
 
@@ -121,6 +122,19 @@ class FieldKeyRowMap implements Map<FieldKey, Object>
         for (FieldKey key : _results.getFieldIndexMap().keySet())
             map.add(new Entry(key));
 
+        return map;
+    }
+
+    public static Map<String, Object> toStringMap(Map<FieldKey, Object> rowMap)
+    {
+        Map<String, Object> map = new CaseInsensitiveHashMap<>();
+        rowMap.forEach((key, value) -> {
+            if (key.getParent() != null)
+                throw new IllegalArgumentException("Multi-part field key '" + key + "' cannot be used as key in string map since it may not be unique.");
+            if (map.containsKey(key.toString()))
+                throw new IllegalArgumentException("Duplicate key '" + key + "' found in fieldKey map.");
+            map.put(key.toString(), value);
+        });
         return map;
     }
 

--- a/api/src/org/labkey/api/data/FieldKeyRowMap.java
+++ b/api/src/org/labkey/api/data/FieldKeyRowMap.java
@@ -125,15 +125,15 @@ public class FieldKeyRowMap implements Map<FieldKey, Object>
         return map;
     }
 
-    public static Map<String, Object> toStringMap(Map<FieldKey, Object> rowMap)
+    public static Map<String, Object> toColumnNameMap(Map<FieldKey, Object> rowMap)
     {
         Map<String, Object> map = new CaseInsensitiveHashMap<>();
         rowMap.forEach((key, value) -> {
             if (key.getParent() != null)
                 throw new IllegalArgumentException("Multi-part field key '" + key + "' cannot be used as key in string map since it may not be unique.");
-            if (map.containsKey(key.toString()))
+            if (map.containsKey(key.getName()))
                 throw new IllegalArgumentException("Duplicate key '" + key + "' found in fieldKey map.");
-            map.put(key.toString(), value);
+            map.put(key.getName(), value);
         });
         return map;
     }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -1299,7 +1299,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             try (var results = selector.getResults()) {
                 if (results.next())
                 {
-                    return FieldKeyRowMap.toColumnNameMap(results.getFieldKeyRowMap());
+                    return FieldKeyRowMap.toNameMap(results.getFieldKeyRowMap());
                 }
             }
             return Collections.emptyMap();

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -1262,10 +1262,10 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             }
             catch (SQLException e)
             {
-                String key = rowId == null ? "rowId (" + rowId + ")" : "";
+                String key = rowId != null ? "rowId (" + rowId + ")" : "";
                 if (key.isEmpty() && lsid != null)
                     key = "lsid (" + lsid + ")";
-                if (key.isEmpty() && name != null)
+                if (key.isEmpty())
                     key = "name (" + name + ")";
                 throw new InvalidKeyException("Unable to select data for provided " + key);
             }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -1299,7 +1299,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             try (var results = selector.getResults()) {
                 if (results.next())
                 {
-                    return FieldKeyRowMap.toStringMap(results.getFieldKeyRowMap());
+                    return FieldKeyRowMap.toColumnNameMap(results.getFieldKeyRowMap());
                 }
             }
             return Collections.emptyMap();

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -26,7 +26,6 @@ import org.labkey.api.attachments.AttachmentFile;
 import org.labkey.api.attachments.AttachmentParent;
 import org.labkey.api.attachments.AttachmentParentFactory;
 import org.labkey.api.attachments.AttachmentService;
-import org.labkey.api.collections.ArrayListMap;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.Sets;
@@ -40,13 +39,13 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
+import org.labkey.api.data.FieldKeyRowMap;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
-import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -1246,7 +1245,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         {
             aliasColumns(_columnMapping, keys);
 
-            Integer rowid = (Integer)JdbcType.INTEGER.convert(keys.get(Column.RowId.name()));
+            Integer rowId = (Integer)JdbcType.INTEGER.convert(keys.get(Column.RowId.name()));
             String lsid = (String)JdbcType.VARCHAR.convert(keys.get(Column.LSID.name()));
             String name = (String)JdbcType.VARCHAR.convert(keys.get(Name.name()));
             Integer classId = (Integer)JdbcType.INTEGER.convert(keys.get(Column.ClassId.name()));
@@ -1254,22 +1253,22 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             if (classId == null)
                 classId = _dataClass.getRowId();
 
-            if (null==rowid && null==lsid && null == name)
+            if (null == rowId && null == lsid && null == name)
                 throw new InvalidKeyException("Value must be supplied for key field 'rowid' or 'lsid' or 'name'", keys);
 
-            Map<String,Object> row = _select(container, rowid, lsid, name, classId, allowCrossContainer);
-
-            //PostgreSQL includes a column named _row for the row index, but since this is selecting by
-            //primary key, it will always be 1, which is not only unnecessary, but confusing, so strip it
-            if (null != row)
+            try
             {
-                if (row instanceof ArrayListMap arrayListMap)
-                    arrayListMap.getFindMap().remove("_row");
-                else
-                    row.remove("_row");
+                return _select(container, rowId, lsid, name, classId, allowCrossContainer);
             }
-
-            return row;
+            catch (SQLException e)
+            {
+                String key = rowId == null ? "rowId (" + rowId + ")" : "";
+                if (key.isEmpty() && lsid != null)
+                    key = "lsid (" + lsid + ")";
+                if (key.isEmpty() && name != null)
+                    key = "name (" + name + ")";
+                throw new InvalidKeyException("Unable to select data for provided " + key);
+            }
         }
 
         @Override
@@ -1278,31 +1277,32 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             throw new IllegalStateException();
         }
 
-        protected Map<String, Object> _select(Container container, Integer rowid, String lsid, String name, Integer classId, boolean allowCrossContainer) throws ConversionException
+        protected Map<String, Object> _select(Container container, Integer rowid, String lsid, String name, Integer classId, boolean allowCrossContainer) throws SQLException
         {
             if (null == rowid && null == lsid && (null == name || null == classId))
                 return null;
 
-            TableInfo d = getDbTable();
-            TableInfo t = _dataClassDataTableSupplier.get();
-
-            SQLFragment sql = new SQLFragment()
-                    .append("SELECT t.*, d.RowId, d.Name, d.ClassId, d.Container, d.Description, d.CreatedBy, d.Created, d.ModifiedBy, d.Modified")
-                    .append(" FROM ").append(d, "d")
-                    .append(" LEFT OUTER JOIN ").append(t, "t")
-                    .append(" ON d.lsid = t.lsid WHERE ");
-
+            SimpleFilter filter = new SimpleFilter();
             if (null != rowid)
-                sql.append("d.rowid=?").add(rowid);
+                filter.addCondition(FieldKey.fromParts("rowId"), rowid);
             else if (null != lsid)
-                sql.append("d.lsid=?").add(lsid);
+                filter.addCondition(FieldKey.fromParts("lsid"), lsid);
             else
-                sql.append("d.classid=? AND d.name=?").add(classId).add(name);
-
+                filter.addCondition(FieldKey.fromParts("classid"), classId)
+                        .addCondition(FieldKey.fromParts("name"), name);
             if (!allowCrossContainer)
-                sql.append(" AND d.Container=?").add(container.getEntityId());
+                filter.addCondition(FieldKey.fromParts("Folder"), container.getEntityId());
 
-            return new SqlSelector(getDbTable().getSchema(), sql).getMap();
+            TableInfo queryTable = getQueryTable();
+            TableSelector selector = new TableSelector(queryTable, filter, null);
+
+            try (var results = selector.getResults()) {
+                if (results.next())
+                {
+                    return FieldKeyRowMap.toStringMap(results.getFieldKeyRowMap());
+                }
+            }
+            return Collections.emptyMap();
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
@@ -21,6 +21,9 @@
 <%@ page import="org.junit.Before" %>
 <%@ page import="org.junit.Test" %>
 <%@ page import="org.labkey.api.action.ApiUsageException" %>
+<%@ page import="org.labkey.api.audit.AuditLogService" %>
+<%@ page import="org.labkey.api.audit.AuditTypeEvent" %>
+<%@ page import="org.labkey.api.audit.DetailedAuditTypeEvent" %>
 <%@ page import="org.labkey.api.collections.ArrayListMap" %>
 <%@ page import="org.labkey.api.collections.CaseInsensitiveHashMap" %>
 <%@ page import="org.labkey.api.data.ColumnInfo" %>
@@ -37,6 +40,7 @@
 <%@ page import="org.labkey.api.data.TableInfo" %>
 <%@ page import="org.labkey.api.data.TableSelector" %>
 <%@ page import="org.labkey.api.dataiterator.DataIteratorContext" %>
+<%@ page import="org.labkey.api.dataiterator.DetailedAuditLogDataIterator" %>
 <%@ page import="org.labkey.api.dataiterator.MapDataIterator" %>
 <%@ page import="org.labkey.api.exp.ExperimentException" %>
 <%@ page import="org.labkey.api.exp.ObjectProperty" %>
@@ -59,6 +63,7 @@
 <%@ page import="org.labkey.api.exp.property.PropertyService" %>
 <%@ page import="org.labkey.api.exp.query.ExpDataTable" %>
 <%@ page import="org.labkey.api.exp.query.ExpSchema" %>
+<%@ page import="org.labkey.api.gwt.client.AuditBehaviorType" %>
 <%@ page import="org.labkey.api.gwt.client.model.GWTDomain" %>
 <%@ page import="org.labkey.api.gwt.client.model.GWTIndex" %>
 <%@ page import="org.labkey.api.gwt.client.model.GWTPropertyDescriptor" %>
@@ -94,13 +99,14 @@
 <%@ page import="java.util.Collection" %>
 <%@ page import="java.util.Collections" %>
 <%@ page import="java.util.HashSet" %>
+<%@ page import="static java.util.Collections.emptyList" %>
+<%@ page import="static org.junit.Assert.*" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.Set" %>
 <%@ page import="java.util.concurrent.TimeUnit" %>
 <%@ page import="java.util.stream.Collectors" %>
-<%@ page import="static java.util.Collections.emptyList" %>
-<%@ page import="static org.junit.Assert.*" %>
+<%@ page import="static org.labkey.api.util.PageFlowUtil.encodeURIComponent" %>
 <%@ page extends="org.labkey.api.jsp.JspTest.BVT" %>
 
 <%!
@@ -145,7 +151,7 @@ public void nameNotNull() throws Exception
     }
 }
 
-    @Test // Issue 51321
+@Test // Issue 51321
 public void reservedNameFirst() throws Exception
 {
     final User user = TestContext.get().getUser();
@@ -1092,6 +1098,69 @@ private @NotNull TableInfo getDataClassTable(String dataClassName)
 {
     UserSchema schema = QueryService.get().getUserSchema(TestContext.get().getUser(), c, ExpSchema.SCHEMA_EXP_DATA);
     return schema.getTableOrThrow(dataClassName);
+}
+
+@Test // Issue 52886
+public void testUpdateAuditForLongField() throws Exception
+{
+    User user = TestContext.get().getUser();
+
+    String dataClassName = "DataClassesWithLongFields";
+    String fieldName = "longField " + StringUtils.repeat("AB CD", 20);
+
+    ExpDataClassImpl dataClass = ExperimentServiceImpl.get().createDataClass(c, user, dataClassName, null,
+            List.of(new GWTPropertyDescriptor(fieldName, "string")), emptyList(), null, null);
+    assertNotNull(dataClass);
+
+    List<Map<String, Object>> rowsToAdd = new ArrayList<>();
+    rowsToAdd.add(CaseInsensitiveHashMap.of("name", "A-1", "prop", "a", fieldName, "Initial"));
+    TableInfo table = getDataClassTable(dataClassName);
+    QueryUpdateService qus = table.getUpdateService();
+    assertNotNull(qus);
+    DataIteratorContext context = new DataIteratorContext();
+    context.setInsertOption(QueryUpdateService.InsertOption.IMPORT);
+    context.getConfigParameters().put(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior, AuditBehaviorType.DETAILED);
+    var count = qus.loadRows(user, c, MapDataIterator.of(rowsToAdd), context, null);
+    assertFalse("Unexpected errors from import", context.getErrors().hasErrors());
+    assertEquals("Number of rows inserted not as expected", 1, count);
+    for (Map<String, Object> row : rowsToAdd)
+    {
+        TableSelector ts = new TableSelector(table, Collections.singleton("RowId"), new SimpleFilter(FieldKey.fromParts("Name"), row.get("name")), null);
+        int rowId;
+        try (var results = ts.getResults())
+        {
+            if (results.next())
+            {
+                rowId = results.getInt(FieldKey.fromParts("RowId"));
+                row.put("RowId", rowId); // intentional side-effect to help in retrieving update events as well
+
+                SimpleFilter filter = SimpleFilter.createContainerFilter(c);
+                filter.addCondition(FieldKey.fromParts("rowPk"), String.valueOf(rowId));
+                filter.addCondition(FieldKey.fromParts("queryName"), dataClassName);
+                List<AuditTypeEvent> events = AuditLogService.get().getAuditEvents(c, user, "QueryUpdateAuditEvent", filter, null);
+                assertEquals("Number of audit events not as expected", 1, events.size());
+            }
+        }
+    }
+
+    List<Map<String, Object>> rowsToUpdate = new ArrayList<>();
+    rowsToUpdate.add(CaseInsensitiveHashMap.of("name", "A-1", fieldName, "Updated"));
+    context.setInsertOption(QueryUpdateService.InsertOption.UPDATE);
+    count = qus.loadRows(user, c, MapDataIterator.of(rowsToUpdate), context, null);
+    assertFalse("Unexpected errors from update", context.getErrors().hasErrors());
+    assertEquals("Number of rows updated not as expected", 1, count);
+
+    for (Map<String, Object> row : rowsToAdd)
+    {
+        SimpleFilter filter = SimpleFilter.createContainerFilter(c);
+        filter.addCondition(FieldKey.fromParts("rowPk"), String.valueOf(row.get("rowId")));
+        filter.addCondition(FieldKey.fromParts("queryName"), dataClassName);
+        List<AuditTypeEvent> events = AuditLogService.get().getAuditEvents(c, user, "QueryUpdateAuditEvent", filter, new Sort("-RowId"));
+        assertEquals("Number of audit events not as expected", 2, events.size()); // should have one for insert and one for update
+        String oldRecordMap = ((DetailedAuditTypeEvent) events.get(0)).getOldRecordMap();
+        assertTrue("Old record map (" + oldRecordMap + ") does not contain expected field", oldRecordMap.contains(encodeURIComponent(fieldName.toLowerCase()) + "=Initial"));
+    }
+
 }
 
 %>


### PR DESCRIPTION
#### Rationale
Issue [52886](https://www.labkey.org/home/Developer/issues/issues-update.view?issueId=52886)

#### Changes
- Update `getRow` method for data classes to return a map with stringified field keys as keys instead of database column names
- Add JSP unit test
- Add `FieldKeyRowMap.toStringMap` static utility method