### PR TITLE
Always reselect on reshow

### DIFF
--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -28,6 +28,7 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.collections.BoundMap;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.ResultSetRowMapFactory;
 import org.labkey.api.collections.RowMap;
 import org.labkey.api.collections.Sets;
@@ -1978,6 +1979,16 @@ public class DataRegion extends DisplayElement
         ctx.setResults(new ResultsImpl(null, selectKeyMap));
         if (null == valueMap)
         {
+            if (!hasPermission(ctx, ReadPermission.class))
+                throw new UnauthorizedException();
+
+            valueMap = new CaseInsensitiveHashMap<>();
+
+            TableInfo tinfoMain = getTable();
+            Collection<Map<String, Object>> maps = new TableSelector(tinfoMain, selectKeyMap.values(), new PkFilter(tinfoMain, viewForm.getPkVals()), null).getMapCollection();
+            if (!maps.isEmpty())
+                valueMap.putAll(maps.iterator().next());
+
             //For updates, the valueMap is the OLD version of the data.
             //If there is no old data, we reselect to get it
             if (null != viewForm.getOldValues())
@@ -1985,19 +1996,9 @@ public class DataRegion extends DisplayElement
                 //UNDONE: getOldValues() sometimes returns a map and sometimes a bean, this seems broken to me (MAB)
                 Object old = viewForm.getOldValues();
                 if (old instanceof Map m)
-                    valueMap = m;
+                    valueMap.putAll(m);
                 else
-                    valueMap = new BoundMap(old);
-            }
-            else
-            {
-                if (!hasPermission(ctx, ReadPermission.class))
-                    throw new UnauthorizedException();
-
-                TableInfo tinfoMain = getTable();
-                Collection<Map<String, Object>> maps = new TableSelector(tinfoMain, selectKeyMap.values(), new PkFilter(tinfoMain, viewForm.getPkVals()), null).getMapCollection();
-                if (!maps.isEmpty())
-                    valueMap = maps.iterator().next();
+                    valueMap.putAll(new BoundMap(old));
             }
             ctx.setRow(valueMap);
         }

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
@@ -137,6 +137,20 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
         downloadedFile = doAndWaitForDownload(() -> waitAndClick(WAIT_FOR_JAVASCRIPT, Locator.tagWithAttribute("a", "title", "Download attached file"), 0));
         checker().verifyTrue("Incorrect file content ", FileUtils.contentEquals(downloadedFile, inputFile));
 
+        log("Update with validation error, reshow test.");
+         _studyHelper.goToManageDatasets()
+                .selectDatasetByName(datasetName)
+                .clickViewData();
+
+        table = new DataRegionTable("Dataset", getDriver());
+        table.clickEditRow(0);
+        checker().verifyTrue("File is not present ",  isElementPresent(Locator.linkContainingText("remove")));
+        setFormElement(Locator.name("quf_intField"), "NOT A NUMBER");
+        clickButton("Submit");
+
+        // assert correct reshow with error
+        assertTextPresent("Could not convert value:");
+        checker().verifyTrue("File is not present ",  isElementPresent(Locator.linkContainingText("remove")));
     }
 
     protected void createDataset(String name)


### PR DESCRIPTION
#### Rationale
Always reselect on reshow.  This ensures that any data needed to properly render the form is available even if it is not POSTed by the rendered update form.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52764

#### Related Pull Requests
https://github.com/LabKey/platform/pull/4622

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
