### PR TITLE
More specific rule to identify signed date/time duration

### DIFF
--- a/api/src/org/labkey/api/data/ConvertHelper.java
+++ b/api/src/org/labkey/api/data/ConvertHelper.java
@@ -1029,6 +1029,20 @@ public class ConvertHelper implements PropertyEditorRegistrar
             convertedDate = new LenientTimestampConverter().convert(Timestamp.class, "Thu Jun 10 00:00:00 PDT 1999");
             cal.set(1999, Calendar.JUNE,10,0,0,0);
             assertEquals("Wrong date", DateUtil.getDateOnly(cal.getTime()), DateUtil.getDateOnly((Timestamp)convertedDate));
+
+            try
+            {
+                new LenientDateConverter().convert(Date.class, "+212F");
+                fail("Should have failed to parse temperature");
+            }
+            catch (ConversionException ignored) {}
+
+            try
+            {
+                new LenientDateConverter().convert(Date.class, "-");
+                fail("Should have failed to parse just a sign");
+            }
+            catch (ConversionException ignored) {}
         }
 
         @Test
@@ -1050,6 +1064,21 @@ public class ConvertHelper implements PropertyEditorRegistrar
             convertedDate = new LenientDateConverter().convert(Date.class, "Thu Jun 10 08:00:00 PDT 1999");
             cal.set(1999, Calendar.JUNE,10,8,0,0);
             assertEquals("Wrong date", DateUtil.getDateOnly(cal.getTime()), DateUtil.getDateOnly((Date)convertedDate));
+
+            try
+            {
+                new LenientDateConverter().convert(Date.class, "-80C");
+                fail("Should have failed to parse temperature");
+            }
+            catch (ConversionException ignored) {}
+
+            try
+            {
+                new LenientDateConverter().convert(Date.class, "+");
+                fail("Should have failed to parse just a sign");
+            }
+            catch (ConversionException ignored) {}
+
         }
 
         @Test

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -1148,7 +1148,7 @@ public class DateUtil
     {
         try
         {
-            if (!durationCandidate.matches("^[+-]\\d+[a-zA-Z].*"))
+            if (!durationCandidate.matches("^[+-]\\d+[pymdhtsPMDHTS].*"))
             {
                 return false;
             }

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -62,6 +62,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 import static java.util.Calendar.AM_PM;
 import static java.util.Calendar.DAY_OF_MONTH;
@@ -120,6 +121,9 @@ public class DateUtil
         ISO_LONG_TIME_FORMAT_STRING,
         "hh:mm a"
     );
+
+    private static final Pattern SIGNED_TIME_DURATION_PATTERN =
+            Pattern.compile("^[+-]\\d+[pymdhtsPMDHTS].*");
 
     public static boolean isStandardDateDisplayFormat(String dateFormat)
     {
@@ -1148,7 +1152,9 @@ public class DateUtil
     {
         try
         {
-            if (!durationCandidate.matches("^[+-]\\d+[pymdhtsPMDHTS].*"))
+            // This should match values starting with [sign][number][date/time duration units] (ex. +1d, -300d).
+            // This should not match other signed values like just "+" or "-" or temps "-80C"
+            if (!SIGNED_TIME_DURATION_PATTERN.matcher(durationCandidate).matches())
             {
                 return false;
             }

--- a/api/src/org/labkey/api/util/DateUtil.java
+++ b/api/src/org/labkey/api/util/DateUtil.java
@@ -36,8 +36,6 @@ import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.util.time.CalendarParts;
 import org.labkey.api.util.time.ParseDateTimeEN;
-import org.labkey.api.view.HttpView;
-import org.labkey.api.view.ViewContext;
 
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
@@ -1150,7 +1148,7 @@ public class DateUtil
     {
         try
         {
-            if (!(durationCandidate.startsWith("+") || durationCandidate.startsWith("-")))
+            if (!durationCandidate.matches("^[+-]\\d+[a-zA-Z].*"))
             {
                 return false;
             }


### PR DESCRIPTION
#### Rationale
When checking potential date and timestamp conversions, only attempt signed duration conversion if the value matches a specific pattern. (sign)(number)(duration unit).

Needs to not match + or -, or temperatures like -80C.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6695

#### Changes
- Use regex in isSignedDuration
