### PR TITLE
53194 : The user may not have access to the Well table

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -780,7 +780,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
         UserSchema plateUserSchema = QueryService.get().getUserSchema(_userSchema.getUser(), getContainer(), "plate");
         SQLFragment sql;
-        if (plateUserSchema != null)
+        if (plateUserSchema != null && plateUserSchema.getTable("Well") != null)
         {
             String rowIdField = ExprColumn.STR_TABLE_ALIAS + "." + Column.RowId.name();
             SQLFragment existsSubquery = new SQLFragment()


### PR DESCRIPTION
#### Rationale
[issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53194)

When samples are linked to a study, the study user may not have read access to the source sample folder. This is just an initial targeted fix. The desired behavior should be that the study user should have access to the `Well` table through a `ContextualRole`. The role does exist on the sample schema but isn't passed into the plate schema. This will require a larger change as there is not a standard API way to push a contextual role into a user schema.

I plan to try to fix this more properly in `develop`.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/6719
https://github.com/LabKey/testAutomation/pull/2472