### PR TITLE
Issue 53202: throw JsonParseException when initializing JSONDataLoader

### DIFF
--- a/api/src/org/labkey/api/reader/JSONDataLoader.java
+++ b/api/src/org/labkey/api/reader/JSONDataLoader.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.labkey.api.util.JsonUtil.checkObjectStart;
 import static org.labkey.api.util.JsonUtil.expectArrayEnd;
 import static org.labkey.api.util.JsonUtil.expectArrayStart;
 import static org.labkey.api.util.JsonUtil.expectObjectEnd;
@@ -94,9 +95,6 @@ import static org.labkey.api.util.JsonUtil.skipValue;
  *   }]
  * }
  * </pre>
- *
- * User: kevink
- * Date: 10/1/12
  */
 public class JSONDataLoader extends DataLoader
 {
@@ -192,14 +190,14 @@ public class JSONDataLoader extends DataLoader
         @Override
         public DataLoader createLoader(InputStream is, boolean hasColumnHeaders, Container mvIndicatorContainer) throws IOException
         {
-            return new JSONDataLoader(is, hasColumnHeaders, mvIndicatorContainer);
+            return new JSONDataLoader(is, mvIndicatorContainer);
         }
 
         @NotNull
         @Override
         public DataLoader createLoader(File file, boolean hasColumnHeaders, Container mvIndicatorContainer) throws IOException
         {
-            return new JSONDataLoader(file, hasColumnHeaders, mvIndicatorContainer);
+            return new JSONDataLoader(file, mvIndicatorContainer);
         }
 
         @NotNull
@@ -210,16 +208,14 @@ public class JSONDataLoader extends DataLoader
         }
     }
 
-    private ObjectMapper _mapper;
     private JsonParser _parser;
     private List<Map<String, Map<ColMapEntry, Object>>> _firstRows;
 
-    public JSONDataLoader(File inputFile, boolean hasColumnHeaders, Container mvIndicatorContainer) throws IOException
+    public JSONDataLoader(File inputFile, Container mvIndicatorContainer) throws IOException
     {
         super(mvIndicatorContainer);
         setSource(inputFile);
         setScrollable(true);
-        //setHasColumnHeaders(hasColumnHeaders);
         setHasColumnHeaders(false);
         setInferTypes(false);
         setScanAheadLineCount(1);
@@ -227,11 +223,10 @@ public class JSONDataLoader extends DataLoader
         init(new FileInputStream(inputFile));
     }
 
-    public JSONDataLoader(InputStream is, boolean hasColumnHeaders, Container mvIndicatorContainer) throws IOException
+    public JSONDataLoader(InputStream is, Container mvIndicatorContainer) throws IOException
     {
         super(mvIndicatorContainer);
         setScrollable(false);
-        //setHasColumnHeaders(hasColumnHeaders);
         setHasColumnHeaders(false);
         setInferTypes(false);
         setScanAheadLineCount(1);
@@ -251,27 +246,26 @@ public class JSONDataLoader extends DataLoader
 
     protected void init(InputStream is) throws IOException
     {
-        _mapper = JsonUtil.createDefaultMapper();
-        _parser = _mapper.getFactory().createParser(is);
-        enterTopLevel();
-    }
+        _parser = JsonUtil.createDefaultMapper().getFactory().createParser(is);
 
-    protected void enterTopLevel() throws IOException
-    {
         if (_parser == null)
             throw new IllegalStateException("Parser not initialized");
 
         if (!_parser.getParsingContext().inRoot())
             throw new IllegalStateException("Parser should be at top-level");
 
-        JsonToken tok = _parser.nextToken();
-        if (tok != JsonToken.START_OBJECT)
-            throw new IllegalStateException("Expected start object");
+        enterTopLevel();
+    }
+
+    protected void enterTopLevel() throws IOException
+    {
+        _parser.nextToken();
+        checkObjectStart(_parser);
     }
 
     /**
      * PRECONDITION: Parser is at START_OBJECT at top-level.
-     * POSTCONDITION: Parser is positioned at START_ARRAY token of 'rows', or throws an exception if 'rows' wasn't found.
+     * POST-CONDITION: Parser is positioned at START_ARRAY token of 'rows', or throws an exception if 'rows' wasn't found.
      *
      * We will skip forward until we find a 'metaData' field and parse the contents.
      * The parser will continue forward until the 'rows' field is found.
@@ -306,7 +300,7 @@ public class JSONDataLoader extends DataLoader
 
     /**
      * PRECONDITION: Parser is on START_OBJECT of metaData
-     * POSTCONDITION: Parser is on END_OBJECT of the metaData value
+     * POST-CONDITION: Parser is on END_OBJECT of the metaData value
      *
      * Parse the metaData fields and construct the ColumnDescriptor array.
      */
@@ -335,7 +329,7 @@ public class JSONDataLoader extends DataLoader
 
     /**
      * PRECONDITION: At start of 'fields' array
-     * POSTCONDITION: At end of 'fields' array.
+     * POST-CONDITION: At end of 'fields' array.
      *
      * Creates the list of ColumnDescriptors for this DataIterator.
      *
@@ -370,7 +364,7 @@ public class JSONDataLoader extends DataLoader
 
     /**
      * PRECONDITION: At start object for item in 'fields' array.
-     * POSTCONDITION: At end object.
+     * POST-CONDITION: At end object.
      *
      * Reads enough of a single metadata field to create a {@link ColumnDescriptor} for loading purposes.
      * The 'fieldKey' property is a JSON array in 13.2 format and is a string in earlier formats
@@ -427,7 +421,7 @@ public class JSONDataLoader extends DataLoader
                 String value = parser.getValueAsString();
 
                 if (value == null)
-                    throw new JsonParseException("Failed to find jdbc type property", loc);
+                    throw new JsonParseException(parser, "Failed to find jdbc type property", loc);
 
                 JdbcType jdbcType = JdbcType.valueOf(value);
 
@@ -477,7 +471,7 @@ public class JSONDataLoader extends DataLoader
 
     /**
      * PRECONDITION: At start object for item in 'rows' array.
-     * POSTCONDITION: At end object.
+     * POST-CONDITION: At end object.
      *
      * Reads a single row and returns the raw values (not display values) for the row as strings.
      * If not null, the values will be ordered according to the <code>cols</code> ColumnDescriptor array
@@ -519,7 +513,7 @@ public class JSONDataLoader extends DataLoader
 
     /**
      * PRECONDITION: At start object for item in 'rows' array.
-     * POSTCONDITION: At end object.
+     * POST-CONDITION: At end object.
      *
      * Reads a single row and returns a map of columns (ColMap).
      *
@@ -654,19 +648,6 @@ public class JSONDataLoader extends DataLoader
 
     protected static Map<String, Map<ColMapEntry, Object>> parseRow91(JsonParser parser, JsonNode dataNode) throws IOException
     {
-//        Map<String, Map<ColMapEntry, Object>> row = new HashMap<>();
-//
-//        Iterator<String> iter = dataNode.fieldNames();
-//        while (iter.hasNext())
-//        {
-//            String fieldName = iter.next();
-//            Map<ColMapEntry, Object> rowField = parseColumn(parser, dataNode.get(fieldName));
-//
-//            row.put(fieldName, rowField);
-//        }
-//
-//        return row;
-
         ObjectCodec codec = parser.getCodec();
         JsonParser subParser = dataNode.traverse(codec);
         Map<String, Map<ColMapEntry, Object>> row = subParser.readValueAs(rowType);
@@ -679,7 +660,6 @@ public class JSONDataLoader extends DataLoader
         Map<ColMapEntry, Object> col = codec.treeToValue(rowFieldNode, ExtendedApiQueryResponse.ColMap.class);
         return col;
     }
-
 
     /**
      * I hate this function.  We must implement it because of how inferColumns() behaves.

--- a/api/src/org/labkey/api/util/JsonUtil.java
+++ b/api/src/org/labkey/api/util/JsonUtil.java
@@ -71,11 +71,15 @@ public class JsonUtil
                 .enable(JsonWriteFeature.ESCAPE_FORWARD_SLASHES);
     }
 
-    public static JsonLocation expectObjectStart(JsonParser p) throws IOException
+    public static void checkObjectStart(JsonParser p) throws JsonParseException
     {
         if (p.currentToken() != JsonToken.START_OBJECT)
             throw new JsonParseException(p, "Expected object start '{', got '" + p.currentToken() + "'", p.currentTokenLocation());
+    }
 
+    public static JsonLocation expectObjectStart(JsonParser p) throws IOException
+    {
+        checkObjectStart(p);
         JsonLocation loc = p.currentTokenLocation();
         p.nextToken();
         return loc;

--- a/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -61,7 +61,7 @@ public class SelectRowsStreamHack
                 try
                 {
                     final InputStream is = response.getInputStream();
-                    final JSONDataLoader loader = new JSONDataLoader(is, false, targetContainer);
+                    final JSONDataLoader loader = new JSONDataLoader(is, targetContainer);
                     WrapperDataIterator wrapper = new WrapperDataIterator(loader.getDataIterator(context))
                     {
                         @Override


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53202](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53202) by altering the `JSONDataLoader` to throw a more appropriate exception type when initializing data loading.

#### Changes
- Move parser initialization into `JSONDataLoader.init()` and change error handling for parsing the "top level" object.
- Consolidate parsing check in `JsonUtil.checkObjectStart()`