### PR TITLE
Fix NumberFormatException on bad image URL

### DIFF
--- a/api/src/org/labkey/api/attachments/ImageServlet.java
+++ b/api/src/org/labkey/api/attachments/ImageServlet.java
@@ -86,7 +86,7 @@ public class ImageServlet extends HttpServlet
                     throw new NotFoundException("Auth logo request is missing configuration parameter - " + url);
 
                 int rowId = Integer.valueOf(configuration);
-                SSOAuthenticationConfiguration ssoConfiguration = AuthenticationManager.getSSOConfiguration(rowId);
+                SSOAuthenticationConfiguration<?> ssoConfiguration = AuthenticationManager.getSSOConfiguration(rowId);
 
                 if (null == ssoConfiguration)
                     throw new NotFoundException("Auth logo request specifies an unknown configuration - " + url);
@@ -98,6 +98,10 @@ public class ImageServlet extends HttpServlet
                 throw new NotFoundException("Unknown image requested - " + imageName);
             }
         }
+        catch (NumberFormatException e)
+        {
+            throw new NotFoundException("Invalid auth configuration value");
+        }
         catch (Throwable e)
         {
             ExceptionUtil.handleException(request, response, e, null, false);
@@ -105,7 +109,7 @@ public class ImageServlet extends HttpServlet
     }
 
 
-    protected void sendAuthLogo(String name, SSOAuthenticationConfiguration configuration, HttpServletResponse response) throws IOException, ServletException
+    protected void sendAuthLogo(String name, SSOAuthenticationConfiguration<?> configuration, HttpServletResponse response) throws IOException, ServletException
     {
         String cacheKey = name + "_" + configuration;
         CacheableWriter writer = AttachmentCache.getAuthLogo(cacheKey);

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -449,7 +449,7 @@ public class LoginController extends SpringActionController
             String expectedKatpcha = (String)getViewContext().getRequest().getSession(true).getAttribute(LabKeyKaptchaServlet.SESSION_KEY_VALUE);
             if (expectedKatpcha == null)
             {
-                logger.error("Captcha not initialized for self-registration attempt");
+                logger.info("Captcha not initialized for self-registration attempt");
                 errors.reject(ERROR_MSG,"Captcha not initialized, please retry.");
             }
             else


### PR DESCRIPTION
#### Rationale
http://localhost:8080/auth_x.image?configuration=542a gives a 500 error when it fails to parse `configuration` as an integer

#### Changes
- Transform to a more helpful 404
- Demote logging when submitting to self-registration without previously hitting the CAPTCHA form 