### PR TITLE
Issue 52746: SM Import: Newlines in field names on import

### DIFF
--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -1409,6 +1409,13 @@ public class DomainUtil
                 continue;
             }
 
+            // Issue 52746: SM Import: Newlines in field names on import
+            if (StringUtils.containsAny(name, "\t\n\r"))
+            {
+                exception.addFieldError(name, getDomainErrorMessage(updates, "Field name may not contain 'tab', 'new line', or 'return' characters."));
+                continue;
+            }
+
             if (!reservedPrefixes.isEmpty())
             {
                 String lcName = name.toLowerCase();

--- a/experiment/src/client/test/integration/DataClassCrud.ispec.ts
+++ b/experiment/src/client/test/integration/DataClassCrud.ispec.ts
@@ -74,7 +74,7 @@ describe('Data Class Designer', () => {
         await checkLackDesignerOrReaderPerm(server, 'DataClass', topFolderOptions, readerUserOptions, editorUserOptions, designerOptions);
     });
 
-    it('Data class name validation', async () => {
+    it('Data class name and field name validation', async () => {
         await checkDomainName(server, 'DataClass', true, topFolderOptions, designerReaderOptions);
     });
 

--- a/experiment/src/client/test/integration/SampleTypeCrud.ispec.ts
+++ b/experiment/src/client/test/integration/SampleTypeCrud.ispec.ts
@@ -143,7 +143,7 @@ describe('Sample Type Designer', () => {
     });
 
     describe('Create/update/delete designs', () => {
-        it('Sample type name validation', async () => {
+        it('Sample type name and field name validation', async () => {
             await checkDomainName(server, 'SampleSet', true, topFolderOptions, designerReaderOptions);
         });
 

--- a/experiment/src/client/test/integration/utils.ts
+++ b/experiment/src/client/test/integration/utils.ts
@@ -305,11 +305,14 @@ export async function initProject(server: IntegrationTestServer, projectName: st
     }
 }
 
-async function verifyDomainCreateFailure(server: IntegrationTestServer, domainType: string, badDomainName: string, error: string, folderOptions: RequestOptions, userOptions: RequestOptions) {
-    const field = domainType === 'SampleSet' ? { name: 'Name' } : { name: 'Prop' };
+async function verifyDomainCreateFailure(server: IntegrationTestServer, domainType: string, badDomainName: string, error: string, folderOptions: RequestOptions, userOptions: RequestOptions, domainFields?: any[]) {
+    const field : Record<string, string> = domainType === 'SampleSet' ? { name: 'Name' } : { name: 'Prop' };
+    const fields = [field];
+    if (domainFields)
+        fields.push(...domainFields);
     const badDomainNameResp = await server.post('property', 'createDomain', {
         kind: domainType,
-        domainDesign: { name: badDomainName, fields: [field] },
+        domainDesign: { name: badDomainName, fields },
         options: {
             name: badDomainName,
         }
@@ -319,15 +322,22 @@ async function verifyDomainCreateFailure(server: IntegrationTestServer, domainTy
     expect(badDomainNameResp['body']['exception']).toBe(error.replace('REPLACE', badDomainName));
 }
 
-async function verifyDomainUpdateFailure(server: IntegrationTestServer, domainId: number, domainURI: string, dataTypeRowId/*needed for updating dataclass*/: number, badDomainName: string, error: string, folderOptions: RequestOptions, userOptions: RequestOptions) {
+async function verifyDomainUpdateFailure(server: IntegrationTestServer, domainId: number, domainURI: string, dataTypeRowId/*needed for updating dataclass*/: number, badDomainName: string, error: string, folderOptions: RequestOptions, userOptions: RequestOptions, domainFields?: any[]) {
     const options = {
         name: badDomainName
     }
     if (dataTypeRowId)
         options['rowId'] = dataTypeRowId;
+    const domainDesign = {
+        name: badDomainName,
+        domainId,
+        domainURI
+    }
+    if (domainFields)
+        domainDesign['fields'] = domainFields;
     const updatedDomainPayload = {
         domainId,
-        domainDesign: {name: badDomainName, domainId, domainURI},
+        domainDesign,
         options
     };
 
@@ -378,6 +388,12 @@ export async function checkDomainName(server: IntegrationTestServer, domainType:
     for (let i = 0; i < badNameKeys.length; i++)
         await verifyDomainCreateFailure(server, domainType, badNameKeys[i], badNames[badNameKeys[i]], folderOptions, userOptions);
 
+    const domainNameWithBadField = 'FieldNameNewLineInvalid';
+    const fieldNameError = " -- Field name may not contain 'tab', 'new line', or 'return' characters.";
+    await verifyDomainCreateFailure(server, domainType, domainNameWithBadField, domainNameWithBadField + fieldNameError, folderOptions, userOptions, [{'Name': 'a\nb'}]);
+    await verifyDomainCreateFailure(server, domainType, domainNameWithBadField, domainNameWithBadField + fieldNameError, folderOptions, userOptions, [{'Name': 'a\rb'}]);
+    await verifyDomainCreateFailure(server, domainType, domainNameWithBadField, domainNameWithBadField + fieldNameError, folderOptions, userOptions, [{'Name': 'a\tb'}]);
+
     if (!supportNameExpression)
     {
         await verifyDomainCreateSuccess(server, domainType, 'withCounter', folderOptions, userOptions);
@@ -399,6 +415,7 @@ export async function checkDomainName(server: IntegrationTestServer, domainType:
         await verifyDomainUpdateFailure(server, domainId, domainURI, dataTypeRowId, badNameKeys[i], badNames[badNameKeys[i]], folderOptions, userOptions);
     }
 
+    await verifyDomainUpdateFailure(server, domainId, domainURI, dataTypeRowId, domainName, domainName + fieldNameError, folderOptions, userOptions, [{'Name': 'a\nb'}]);
 }
 
 export async function checkLackDesignerOrReaderPerm(server: IntegrationTestServer, domainType: string, topFolderOptions: RequestOptions, readerUserOptions: RequestOptions, editorUserOptions: RequestOptions, designerOptions: RequestOptions) {


### PR DESCRIPTION
#### Rationale
<!-- Rationale describing why this pull request is needed, what behavior it's adding/changing/removing, etc. (replace this comment) -->

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- disallow newline,  carriage returns and tab characters in field names
- jest api tests
