### PR TITLE
Fix intermittent test failure on stale password strength indicator

### DIFF
--- a/core/webapp/passwordGauge.js
+++ b/core/webapp/passwordGauge.js
@@ -10,6 +10,7 @@ LABKEY.PasswordGauge = new function() {
     let _emailId;               // the element ID for the email text box
     let _emailAddress;          // optional email address (for the AJAX request)
     let _renderBarFunction;
+    let _pendingScoreRequest;   // The most recent request made to score the proposed password
 
     // private methods
     function _drawOutline(canvas, ctx, ratio) {
@@ -68,7 +69,12 @@ LABKEY.PasswordGauge = new function() {
 
         _renderBarFunction = function() {
             const showPlaceholderText = !password.value;
-            LABKEY.Ajax.request({
+            if (_pendingScoreRequest) {
+                // We no longer care about any previous score requests as they're now stale relative to the current value
+                _pendingScoreRequest.abort();
+                _pendingScoreRequest = null;
+            }
+            _pendingScoreRequest = LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL("login", "getPasswordScore.api"),
                 method: 'POST',
                 params: {


### PR DESCRIPTION
#### Rationale
When users type in passwords, we make a request to score each of them for strength. The responses may come back out of order, which can lead to showing the wrong strength. This is bad for users and automated tests.

```
org.junit.ComparisonFailure: Strength guidance for password expected:<Very [Strong]> but was:<Very [Weak]>
  at org.junit.Assert.assertEquals(Assert.java:117)
  at org.labkey.test.components.core.login.SetPasswordForm.lambda$0(SetPasswordForm.java:117)
  at org.awaitility.core.AssertionCondition.lambda$new$0(AssertionCondition.java:53)
  at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:248)
```
Example: https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_Ehr_BvtEhrSqlserver/3534802?buildTab=overview&logFilter=debug&logView=flowAware

#### Changes
- Cancel any existing requests when we make a new one to check the latest password