### PR TITLE
Add includeSubdomains to Strict-Transport-Security HTTP header

### DIFF
--- a/api/src/org/labkey/api/security/AuthFilter.java
+++ b/api/src/org/labkey/api/security/AuthFilter.java
@@ -168,7 +168,7 @@ public class AuthFilter implements Filter
             {
                 // Issue 51904: Strict-Transport-Security header when HTTPS is required
                 // Avoid setting when in dev mode to make it easier to toggle HTTPS on and off again for local deployments
-                resp.setHeader("Strict-Transport-Security", "max-age=31536000");
+                resp.setHeader("Strict-Transport-Security", "max-age=31536000;includeSubdomains");
             }
         }
 


### PR DESCRIPTION
#### Rationale
Security scanners like to opine on optimal HTTP headers. Although neither we nor our customers tend to use subdomains of any LabKey's domain name, we can reduce a little bit of scanner noise.

This, of course, means that if the LabKey instance is running over HTTPS, if there happens to be a legitimate server running as a subdomain that only responds to HTTP, it won't be accessible. I think that's OK.

#### Changes
- Add  `includeSubdomains` to the `Strict-Transport-Security` header when we're sending it