### PR TITLE
remove ColumnInfo.getLegalName()

### DIFF
--- a/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
@@ -214,12 +214,6 @@ public abstract class AbstractWrappedColumnInfo implements ColumnInfo
     }
 
     @Override
-    public String getLegalName()
-    {
-        return delegate.getLegalName();
-    }
-
-    @Override
     public String getPropertyName()
     {
         return delegate.getPropertyName();

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -905,12 +905,6 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     }
 
     @Override
-    public String getLegalName()
-    {
-        return legalNameFromName(getName());
-    }
-
-    @Override
     public String getPropertyName()
     {
         // this is surprisingly expensive, cache it!

--- a/api/src/org/labkey/api/data/ColumnInfo.java
+++ b/api/src/org/labkey/api/data/ColumnInfo.java
@@ -217,8 +217,6 @@ public interface ColumnInfo extends ColumnRenderProperties
 
     boolean isShouldLog();
 
-    String getLegalName();
-
     String getPropertyName();
 
     /**

--- a/assay/src/org/labkey/assay/TSVProtocolSchema.java
+++ b/assay/src/org/labkey/assay/TSVProtocolSchema.java
@@ -371,8 +371,9 @@ public class TSVProtocolSchema extends AssayProtocolSchema
             url.addParameter("rowId", protocol.getRowId());
             url.addParameter("columnName", col.getName());
             this.endpoint = url.getLocalURIString();
+            // I think the column name here does not really matter, see AssayController.getRowList()).
             this.jsConvertPKToLSID = "function(pk){return " +
-                    PageFlowUtil.jsString("protocol" + protocol.getRowId() + "." + getBoundColumn().getLegalName() + ":") + " + pk}";
+                    PageFlowUtil.jsString("protocol" + protocol.getRowId() + "." + getBoundColumn().getName() + ":") + " + pk}";
         }
 
         @Override
@@ -381,7 +382,8 @@ public class TSVProtocolSchema extends AssayProtocolSchema
             renderFlagScript(ctx, out);
             Integer id = ctx.get(rowId, Integer.class);
             Object comment = getValue(ctx);
-            String lsid = null==id ? null : "protocol" + protocol.getRowId() + "." + getBoundColumn().getLegalName() +  ":" + id;
+            // I think the column name here does not really matter, see AssayController.getRowList()).
+            String lsid = null==id ? null : "protocol" + protocol.getRowId() + "." + getBoundColumn().getName() +  ":" + id;
             _renderFlag(ctx, out, lsid, null == comment ? null : String.valueOf(comment));
         }
 


### PR DESCRIPTION
#### Rationale
It is not clear why there are two usages of this.  And we have too many ColumnInfo.get***Name() methods.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
