### PR TITLE
Improve bad input handling in resolveLSID

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -350,6 +350,7 @@ import static org.labkey.api.util.DOM.Attribute.href;
 import static org.labkey.api.util.DOM.Attribute.id;
 import static org.labkey.api.util.DOM.Attribute.method;
 import static org.labkey.api.util.DOM.Attribute.name;
+import static org.labkey.api.util.DOM.Attribute.size;
 import static org.labkey.api.util.DOM.Attribute.src;
 import static org.labkey.api.util.DOM.Attribute.target;
 import static org.labkey.api.util.DOM.Attribute.type;
@@ -409,7 +410,7 @@ public class ExperimentController extends SpringActionController
 
     @ActionNames("begin,gridView")
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public class BeginAction extends SimpleViewAction<Object>
     {
         @Override
         public VBox getView(Object o, BindException errors)
@@ -439,13 +440,12 @@ public class ExperimentController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class ShowRunsAction extends SimpleViewAction
+    public class ShowRunsAction extends SimpleViewAction<Object>
     {
         @Override
         public VBox getView(Object o, BindException errors)
         {
-            VBox result = createRunListView(100);
-            return result;
+            return createRunListView(100);
         }
 
         @Override
@@ -479,7 +479,7 @@ public class ExperimentController extends SpringActionController
 
     @RequiresPermission(ReadPermission.class)
     @ActionNames("showRunGroups, showExperiments")
-    public class ShowRunGroupsAction extends SimpleViewAction
+    public class ShowRunGroupsAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -752,7 +752,7 @@ public class ExperimentController extends SpringActionController
                 throw new NotFoundException();
             }
 
-            ExpExperiment group = ExperimentService.get().createHiddenRunGroup(getContainer(), getUser(), runs.toArray(new ExpRun[runs.size()]));
+            ExpExperiment group = ExperimentService.get().createHiddenRunGroup(getContainer(), getUser(), runs.toArray(new ExpRun[0]));
             if (selectionKey != null)
                 DataRegionSelection.clearAll(getViewContext(), selectionKey);
 
@@ -773,7 +773,7 @@ public class ExperimentController extends SpringActionController
             super(ExpObjectForm.class);
         }
 
-        private Pair<ExperimentRunListView, JspView> createViews(ExpObjectForm form, BindException errors)
+        private Pair<ExperimentRunListView, JspView<?>> createViews(ExpObjectForm form, BindException errors)
         {
             _experiment = ExperimentServiceImpl.get().getExpExperiment(form.getRowId());
             if (_experiment == null)
@@ -807,7 +807,7 @@ public class ExperimentController extends SpringActionController
         @Override
         protected ModelAndView getHtmlView(ExpObjectForm form, BindException errors) throws Exception
         {
-            Pair<ExperimentRunListView, JspView> views = createViews(form, errors);
+            Pair<ExperimentRunListView, JspView<?>> views = createViews(form, errors);
 
             CustomPropertiesView customPropertiesView = new CustomPropertiesView(_experiment.getLSID(), getContainer());
 
@@ -859,7 +859,7 @@ public class ExperimentController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class ListSampleTypesAction extends SimpleViewAction
+    public class ListSampleTypesAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -1002,7 +1002,7 @@ public class ExperimentController extends SpringActionController
             }
 
             // Not all sample types can be edited
-            DomainKind domainKind = _sampleType.getDomain().getDomainKind();
+            DomainKind<?> domainKind = _sampleType.getDomain().getDomainKind();
             if (domainKind != null && domainKind.canEditDefinition(getUser(), _sampleType.getDomain()))
             {
                 if (domainKind instanceof SampleTypeDomainKind)
@@ -1089,7 +1089,7 @@ public class ExperimentController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class ShowAllMaterialsAction extends SimpleViewAction
+    public class ShowAllMaterialsAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -1537,7 +1537,7 @@ public class ExperimentController extends SpringActionController
 
         private List<? extends ExpRun> getRuns(List<ExpDataClass> dataClasses)
         {
-            if (dataClasses.size() > 0)
+            if (!dataClasses.isEmpty())
             {
                 List<? extends ExpRun> runArray = ExperimentService.get().getRunsUsingDataClasses(dataClasses);
                 return ExperimentService.get().runsDeletedWithInput(runArray);
@@ -1570,7 +1570,7 @@ public class ExperimentController extends SpringActionController
         private ExpDataClassImpl _dataClass;
 
         @Override
-        public ModelAndView getView(DataClassForm form, BindException errors) throws Exception
+        public ModelAndView getView(DataClassForm form, BindException errors)
         {
             boolean create = form.getLSID() == null && form.getRowId() == 0 && form.getName() == null;
             if (!create)
@@ -1911,7 +1911,7 @@ public class ExperimentController extends SpringActionController
 
             VBox vbox = new VBox();
 
-            JspView<ExpRun> detailsView = new JspView<ExpRun>("/org/labkey/experiment/ExperimentRunDetails.jsp", _experimentRun);
+            JspView<ExpRun> detailsView = new JspView<>("/org/labkey/experiment/ExperimentRunDetails.jsp", _experimentRun);
             detailsView.setTitle("Standard Properties");
 
             var attachmentParent = new ExpRunAttachmentParent(_experimentRun);
@@ -2211,7 +2211,7 @@ public class ExperimentController extends SpringActionController
         protected TableInfo createTable()
         {
             String tableName = getSettings().getQueryName();
-            ExpInputTable tableInfo = (ExpInputTable) getSchema().getTable(tableName, new ContainerFilter.AllFolders(getUser()), true, true);
+            ExpInputTable<?> tableInfo = (ExpInputTable<?>) getSchema().getTable(tableName, new ContainerFilter.AllFolders(getUser()), true, true);
             tableInfo.setRun(_run, _type);
             tableInfo.setLocked(true);
             return tableInfo;
@@ -2291,7 +2291,7 @@ public class ExperimentController extends SpringActionController
             else
             {
                 table = schema.getSchema(ExpSchema.NestedSchemas.data).getTable(dataClass.getName());
-                pk = new TableSelector(table, Collections.singleton("rowId"), new SimpleFilter("lsid", _data.getLSID()), null).getObject(Integer.class);
+                pk = new TableSelector(table, Collections.singleton("rowId"), new SimpleFilter(FieldKey.fromParts("lsid"), _data.getLSID()), null).getObject(Integer.class);
             }
 
             DataRegion dr = new DataRegion();
@@ -2352,7 +2352,7 @@ public class ExperimentController extends SpringActionController
             // add links to any other exp.data that share the same dataFileUrl path
             var altDataList = ExperimentService.get().getAllExpDataByURL(_data.getDataFileUrl(), getContainer());
             altDataList.removeIf(_data::equals);
-            if (altDataList.size() > 0)
+            if (!altDataList.isEmpty())
             {
                 MenuButton menu = new MenuButton("Alternate Data");
                 for (ExpData altData : altDataList)
@@ -2405,7 +2405,7 @@ public class ExperimentController extends SpringActionController
             _data = form.lookupData();
             if (_data == null)
             {
-                errors.reject("No ExpData found for id: " + form.getRowId());
+                errors.reject(ERROR_MSG, "No ExpData found for id: " + form.getRowId());
             }
         }
 
@@ -2761,7 +2761,7 @@ public class ExperimentController extends SpringActionController
             {
                 JSONObject rootObject;
                 JSONArray sheetsArray;
-                if (form.getJson() == null || form.getJson().trim().length() == 0)
+                if (form.getJson() == null || form.getJson().trim().isEmpty())
                 {
                     // Create JSON so that we return an empty file
                     rootObject = new JSONObject();
@@ -2822,7 +2822,7 @@ public class ExperimentController extends SpringActionController
             {
                 JSONObject rootObject;
                 JSONArray rowsArray;
-                if (form.getJson() == null || form.getJson().trim().length() == 0)
+                if (form.getJson() == null || form.getJson().trim().isEmpty())
                 {
                     // Create JSON so that we return an empty file
                     rootObject = new JSONObject();
@@ -3064,7 +3064,7 @@ public class ExperimentController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class ShowProtocolGridAction extends SimpleViewAction
+    public class ShowProtocolGridAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -3215,7 +3215,7 @@ public class ExperimentController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public class ProtocolPredecessorsAction extends SimpleViewAction
+    public class ProtocolPredecessorsAction extends SimpleViewAction<Object>
     {
         private ExpProtocol _parentProtocol;
         private ProtocolActionStepDetail _actionStep;
@@ -3435,9 +3435,7 @@ public class ExperimentController extends SpringActionController
                                                 key.toString(),
                                                 "Runs"
                                         );
-                                        referenced.forEach(id -> {
-                                            referencedItems.put(id, idToRunMap.get(id));
-                                        });
+                                        referenced.forEach(id -> referencedItems.put(id, idToRunMap.get(id)));
                                         referenceDescriptions.add(referencer.getObjectReferenceDescription(ExpRun.class));
                                     }
                             );
@@ -3524,7 +3522,7 @@ public class ExperimentController extends SpringActionController
 
 
     @RequiresAnyOf({DeletePermission.class, SampleWorkflowDeletePermission.class})
-    public class DeleteRunsAction extends AbstractDeleteAPIAction
+    public static class DeleteRunsAction extends AbstractDeleteAPIAction
     {
         @Override
         protected ApiSimpleResponse deleteObjects(CascadeDeleteForm form)
@@ -3541,7 +3539,7 @@ public class ExperimentController extends SpringActionController
                         addReplacesRuns(run, runIdsCascadeDeleted);
                 }
 
-                if (runIdsCascadeDeleted.size() > 0)
+                if (!runIdsCascadeDeleted.isEmpty())
                     runIdsToDelete.addAll(runIdsCascadeDeleted);
             }
 
@@ -3549,7 +3547,7 @@ public class ExperimentController extends SpringActionController
 
             ApiSimpleResponse response = new ApiSimpleResponse("success", true);
             response.put("runIdsDeleted", runIdsToDelete);
-            if (runIdsCascadeDeleted.size() > 0)
+            if (!runIdsCascadeDeleted.isEmpty())
                 response.put("runIdsCascadeDeleted", runIdsCascadeDeleted);
             return response;
         }
@@ -3658,7 +3656,7 @@ public class ExperimentController extends SpringActionController
     }
 
     @RequiresPermission(DesignAssayPermission.class)
-    public class DeleteProtocolByRowIdsAPIAction extends AbstractDeleteAPIAction
+    public static class DeleteProtocolByRowIdsAPIAction extends AbstractDeleteAPIAction
     {
         @Override
         protected ApiSimpleResponse deleteObjects(CascadeDeleteForm form)
@@ -4572,7 +4570,7 @@ public class ExperimentController extends SpringActionController
             return new CaseInsensitiveHashSet(dataClass.getImportAliases().keySet());
         }
 
-        protected void initContext(DataLoader dl, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, @Nullable String auditUserComment) throws IOException
+        protected void initContext(DataLoader dl, BatchValidationException errors, @Nullable AuditBehaviorType auditBehaviorType, @Nullable String auditUserComment)
         {
             _context = createDataIteratorContext(_insertOption, getOptionParamsMap(), getLookupResolutionType(), auditBehaviorType, auditUserComment, errors, null, getContainer());
 
@@ -5346,35 +5344,38 @@ public class ExperimentController extends SpringActionController
             String message = "";
             if (!PageFlowUtil.empty(form.getLsid()))
             {
-                String lsid = Lsid.canonical(form.getLsid());
-                ActionURL url = LsidManager.get().getDisplayURL(lsid);
-                if (url == null && form.getType() != null)
+                try
                 {
-                    switch (form.getType().toLowerCase())
+                    String lsid = Lsid.canonical(form.getLsid().trim());
+                    ActionURL url = LsidManager.get().getDisplayURL(lsid);
+                    if (url == null && form.getType() != null)
                     {
-                        case "data":
-                            url = LsidType.Data.getDisplayURL(new Lsid(lsid));
-                            break;
-                        case "material":
-                            url = LsidType.Material.getDisplayURL(new Lsid(lsid));
-                            break;
+                        url = switch (form.getType().toLowerCase())
+                        {
+                            case "data" -> LsidType.Data.getDisplayURL(new Lsid(lsid));
+                            case "material" -> LsidType.Material.getDisplayURL(new Lsid(lsid));
+                            default -> url;
+                        };
                     }
+                    if (null != url)
+                    {
+                        throw new RedirectException(url);
+                    }
+                    message = "Could not map LSID to URL";
                 }
-                if (null != url)
+                catch (IllegalArgumentException e)
                 {
-                    throw new RedirectException(url);
+                    message = "Invalid LSID";
                 }
-
-                message = "Could not map lsid to URL";
             }
 
-            HtmlStringBuilder html = HtmlStringBuilder.of();
-            html.append(message).unsafeAppend("<form action=\"").append(getViewContext().cloneActionURL().setAction(ResolveLSIDAction.class).toString()).unsafeAppend("\">")
-                    .unsafeAppend(" Lsid <input type=text name=lsid size=\"80\" value=\"")
-                    .append(form.getLsid() == null ? "" : form.getLsid()).unsafeAppend("\">")
-                    .append(PageFlowUtil.button("Go").submit(true)).unsafeAppend("</form>");
-
-            return new HtmlView("Enter LSID", html);
+            return new HtmlView("Enter LSID",
+                    DOM.createHtmlFragment(
+                            message,
+                            DOM.FORM(at(action, getViewContext().cloneActionURL().setAction(ResolveLSIDAction.class)),
+                                "LSID: ",
+                                DOM.INPUT(at(type, "text", name, "lsid", size, "80", value, form.getLsid())),
+                                PageFlowUtil.button("Go").submit(true))));
         }
 
         @Override
@@ -5485,7 +5486,7 @@ public class ExperimentController extends SpringActionController
             setHelpTopic("sampleSets");
             addRootNavTrail(root);
             root.addChild("Sample Types", ExperimentUrlsImpl.get().getShowSampleTypeListURL(getContainer()));
-            ExpSampleType sampleType = _materials != null && _materials.size() > 0 ? _materials.get(0).getSampleType() : null;
+            ExpSampleType sampleType = _materials != null && !_materials.isEmpty() ? _materials.get(0).getSampleType() : null;
             if (sampleType != null)
             {
                 root.addChild(sampleType.getName(), ExperimentUrlsImpl.get().getShowSampleTypeURL(sampleType));
@@ -5706,7 +5707,7 @@ public class ExperimentController extends SpringActionController
                     lockedSamples.add(m);
                 }
                 String inputRole = form.determineLabel(i);
-                if (inputRole == null || "".equals(inputRole))
+                if (inputRole == null || inputRole.isEmpty())
                 {
                     ExpSampleType st = m.getSampleType();
                     inputRole = st != null ? st.getName() : ExpMaterialRunInput.DEFAULT_ROLE;
@@ -5721,7 +5722,7 @@ public class ExperimentController extends SpringActionController
         }
 
         @Override
-        public boolean handlePost(DeriveMaterialForm form, BindException errors) throws Exception
+        public boolean handlePost(DeriveMaterialForm form, BindException errors)
         {
             ExpSampleTypeImpl sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), getUser(), form.getTargetSampleTypeId());
 
@@ -6030,7 +6031,7 @@ public class ExperimentController extends SpringActionController
                     }
 
                     String role = in.role;
-                    if (role == null || "".equals(role))
+                    if (role == null || role.isEmpty())
                     {
                         role = st.getName();
                     }
@@ -6072,7 +6073,7 @@ public class ExperimentController extends SpringActionController
                     }
 
                     String role = in.role;
-                    if (role == null || "".equals(role))
+                    if (role == null || role.isEmpty())
                     {
                         role = dc.getName();
                     }
@@ -6152,11 +6153,10 @@ public class ExperimentController extends SpringActionController
                         }
 
                         @Override
-                        protected List<ExpMaterial> getExpObject(List<Map<String, Object>> insertedRows)
+                        protected List<? extends ExpMaterial> getExpObject(List<Map<String, Object>> insertedRows)
                         {
                             List<Integer> rowIds = insertedRows.stream().map(r -> (Integer) r.get("rowid")).collect(toList());
-                            List<? extends ExpMaterial> output = ExperimentService.get().getExpMaterials(rowIds);
-                            return (List<ExpMaterial>) output;
+                            return ExperimentService.get().getExpMaterials(rowIds);
                         }
                     };
 
@@ -6181,11 +6181,10 @@ public class ExperimentController extends SpringActionController
                         }
 
                         @Override
-                        protected List<ExpData> getExpObject(List<Map<String, Object>> insertedRows)
+                        protected List<? extends ExpData> getExpObject(List<Map<String, Object>> insertedRows)
                         {
                             List<String> lsids = insertedRows.stream().map(r -> (String) r.get("lsid")).collect(toList());
-                            List<? extends ExpData> output = ExperimentService.get().getExpDatasByLSID(lsids);
-                            return (List<ExpData>) output;
+                            return ExperimentService.get().getExpDatasByLSID(lsids);
                         }
                     };
 
@@ -6285,7 +6284,7 @@ public class ExperimentController extends SpringActionController
 
             protected abstract TableInfo createTable();
 
-            protected abstract List<T> getExpObject(List<Map<String, Object>> insertedRows);
+            protected abstract List<? extends T> getExpObject(List<Map<String, Object>> insertedRows);
 
             public Map<T, String> createOutputs() throws BatchValidationException, DuplicateKeyException, SQLException, QueryUpdateServiceException
             {
@@ -6310,7 +6309,7 @@ public class ExperimentController extends SpringActionController
                 if (insertedRows.size() != roles.size())
                     throw new IllegalStateException("Expected to create " + roles.size() + " new exp objects for derivation");
 
-                List<T> outputs = getExpObject(insertedRows);
+                List<? extends T> outputs = getExpObject(insertedRows);
                 if (outputs.size() != roles.size())
                     throw new IllegalStateException("Expected to create " + roles.size() + " new exp objects for derivation");
 
@@ -6411,7 +6410,7 @@ public class ExperimentController extends SpringActionController
                 form.setDataRegionSelectionKey(getViewContext().getRequest().getParameter(DataRegionSelection.DATA_REGION_SELECTION_KEY));
 
                 Experiment exp = form.getBean();
-                if (exp.getName() == null || exp.getName().trim().length() == 0)
+                if (exp.getName() == null || exp.getName().trim().isEmpty())
                 {
                     errors.reject(ERROR_MSG, "You must specify a name for the experiment");
                 }
@@ -6746,7 +6745,7 @@ public class ExperimentController extends SpringActionController
                 return false;
             }
             String userDirName = getUser().getEmail();
-            if (userDirName == null || userDirName.length() == 0)
+            if (userDirName == null || userDirName.isEmpty())
             {
                 userDirName = GUEST_DIRECTORY_NAME;
             }
@@ -6761,10 +6760,8 @@ public class ExperimentController extends SpringActionController
             Path xarFile = userDir.resolve(formFile.getOriginalFilename());
 
             // As this is multi-part will need to use finally to close, to prevent a stream closure exception
-            OutputStream out = null;
-            try
+            try (OutputStream out = new BufferedOutputStream(Files.newOutputStream(xarFile)))
             {
-                out = new BufferedOutputStream(Files.newOutputStream(xarFile));
                 out.write(bytes);
             }
             catch (IOException e)
@@ -6772,19 +6769,7 @@ public class ExperimentController extends SpringActionController
                 errors.reject(ERROR_MSG, "Unable to write uploaded XAR file to " + xarFile);
                 return false;
             }
-            finally
-            {
-                if (out != null)
-                { //noinspection EmptyCatchBlock
-                    try
-                    {
-                        out.close();
-                    }
-                    catch (IOException e)
-                    {
-                    }
-                }
-            }
+            //noinspection EmptyCatchBlock
 
             ExperimentPipelineJob job = new ExperimentPipelineJob(getViewBackgroundInfo(), xarFile,
                     "Uploaded file", true, pipeRoot);
@@ -7426,7 +7411,7 @@ public class ExperimentController extends SpringActionController
 
     @Marshal(Marshaller.Jackson)
     @RequiresPermission(AdminPermission.class)
-    public static class CheckDataClassesIndexedAction extends ReadOnlyApiAction
+    public static class CheckDataClassesIndexedAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public Object execute(Object o, BindException errors) throws Exception
@@ -7462,7 +7447,7 @@ public class ExperimentController extends SpringActionController
 
     @Marshal(Marshaller.Jackson)
     @RequiresPermission(AdminPermission.class)
-    public static class CheckEdgesAction extends ReadOnlyApiAction
+    public static class CheckEdgesAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public Object execute(Object o, BindException errors) throws Exception
@@ -7653,7 +7638,7 @@ public class ExperimentController extends SpringActionController
                     // deduplicate from existing ids
                     if (existingIds != null && form.getSessionKey() != null)
                     {
-                        existingIds.addAll(form.getIds().stream().filter(id -> !existingIds.contains(id)).collect(Collectors.toList()));
+                        existingIds.addAll(form.getIds().stream().filter(id -> !existingIds.contains(id)).toList());
                         session.setAttribute(key, existingIds);
                     }
                     else
@@ -7710,23 +7695,24 @@ public class ExperimentController extends SpringActionController
             // need to set the key field so selections are possible
             // need the SampleTypeUnits so we will display using that unit
             String metadata =
-                    "<tables xmlns=\"http://labkey.org/data/xml\">\n" +
-                    "   <table tableName=\"tempQuery\" tableDbType=\"NOT_IN_DB\">\n" +
-                    "       <columns>\n" +
-                    "           <column columnName=\"RowId\">\n" +
-                    "               <isKeyField>true</isKeyField>\n" +
-                    "               <isHidden>true</isHidden>\n" +
-                    "           </column>\n" +
-                    "           <column columnName=\"SampleTypeUnits\">\n" +
-                    "               <isHidden>true</isHidden>\n" +
-                    "           </column>\n" +
-                    "           <column columnName=\"Ordinal\">\n" +
-                    "               <isHidden>true</isHidden>\n" +
-                    "           </column>\n" +
-                    "       </columns>\n" +
-                    "   </table>\n" +
-                    "</tables>";
-            QueryDefinition def = QueryService.get().saveSessionQuery(getViewContext(), getContainer(), ExperimentServiceImpl.get().getExpSchema().getName(), select.getSQL(), metadata);
+                    """
+                            <tables xmlns="http://labkey.org/data/xml">
+                               <table tableName="tempQuery" tableDbType="NOT_IN_DB">
+                                   <columns>
+                                       <column columnName="RowId">
+                                           <isKeyField>true</isKeyField>
+                                           <isHidden>true</isHidden>
+                                       </column>
+                                       <column columnName="SampleTypeUnits">
+                                           <isHidden>true</isHidden>
+                                       </column>
+                                       <column columnName="Ordinal">
+                                           <isHidden>true</isHidden>
+                                       </column>
+                                   </columns>
+                               </table>
+                            </tables>""";
+            QueryDefinition def = QueryService.get().saveSessionQuery(getViewContext(), getContainer(), ExperimentServiceImpl.getExpSchema().getName(), select.getSQL(), metadata);
             return success("Session query created", Map.of("queryName", def.getName(), "ids", _ids));
         }
 
@@ -8262,7 +8248,7 @@ public class ExperimentController extends SpringActionController
         }
 
         @Override
-        public ModelAndView getView(Object o, boolean reshow, BindException errors) throws Exception
+        public ModelAndView getView(Object o, boolean reshow, BindException errors)
         {
             if (!reshow)
             {
@@ -8305,7 +8291,7 @@ public class ExperimentController extends SpringActionController
         }
 
         @Override
-        public boolean handlePost(Object o, BindException errors) throws Exception
+        public boolean handlePost(Object o, BindException errors)
         {
             var edges = new SqlSelector(ExperimentService.get().getSchema(), "SELECT fromObjectId, toObjectId FROM exp.Edge")
                     .resultSetStream()


### PR DESCRIPTION
#### Rationale
```
java.lang.IllegalArgumentException: URLDecoder: Illegal hex characters in escape (%) pattern - Error at index 0 in: "" "
	at java.base/java.net.URLDecoder.decode(URLDecoder.java:237) ~[?:?]
	at org.labkey.api.exp.Lsid.decodePart(Lsid.java:290) ~[api-25.7-SNAPSHOT.jar:?]
	at org.labkey.api.exp.Lsid$LsidBuilder.<init>(Lsid.java:372) ~[api-25.7-SNAPSHOT.jar:?]
	at org.labkey.api.exp.Lsid.canonical(Lsid.java:300) ~[api-25.7-SNAPSHOT.jar:?]
	at org.labkey.experiment.controllers.exp.ExperimentController$ResolveLSIDAction.getView(ExperimentController.java:5349) ~[experiment-25.7-SNAPSHOT.jar:?]
	at org.labkey.experiment.controllers.exp.ExperimentController$ResolveLSIDAction.getView(ExperimentController.java:5340) ~[experiment-25.7-SNAPSHOT.jar:?]
	at 
```

Repro: https://localhost/home/experiment-resolveLSID.view?lsid=urn%3Alsid%3Alabkey.com%3Atest%3Atest%25%22bad%3A2

#### Changes
- Catch the exception and show useful error
- Use DOM builder for trivial UI
- Minor auto-refactor code cleanup