### PR TITLE
Always set Results

### DIFF
--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -29,7 +29,6 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.collections.BoundMap;
-import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.ResultSetRowMapFactory;
 import org.labkey.api.collections.RowMap;
 import org.labkey.api.collections.Sets;
@@ -2065,36 +2064,38 @@ public class DataRegion extends DisplayElement
 
     private void renderUpdateForm(RenderContext ctx, HtmlWriter out)
     {
-        TableViewForm viewForm = ctx.getForm();
-        Map<String, Object> valueMap = ctx.getRow();
-        LinkedHashMap<FieldKey, ColumnInfo> selectKeyMap = getSelectColumns();
-        if (null == valueMap)
+        try
         {
-            if (!hasPermission(ctx, ReadPermission.class))
-                throw new UnauthorizedException();
-
-            valueMap = new CaseInsensitiveHashMap<>();
-
-            TableInfo tinfoMain = getTable();
-            Collection<Map<String, Object>> maps = new TableSelector(tinfoMain, selectKeyMap.values(), new PkFilter(tinfoMain, viewForm.getPkVals()), null).getMapCollection();
-            if (!maps.isEmpty())
-                valueMap.putAll(maps.iterator().next());
-
-            //For updates, the valueMap is the OLD version of the data.
-            //If there is no old data, we reselect to get it
-            if (null != viewForm.getOldValues())
+            TableViewForm viewForm = ctx.getForm();
+            Map<String, Object> valueMap = ctx.getRow();
+            LinkedHashMap<FieldKey, ColumnInfo> selectKeyMap = getSelectColumns();
+            if (null == valueMap)
             {
-                //UNDONE: getOldValues() sometimes returns a map and sometimes a bean, this seems broken to me (MAB)
-                Object old = viewForm.getOldValues();
-                if (old instanceof Map m)
-                    valueMap.putAll(m);
-                else
-                    valueMap.putAll(new BoundMap(old));
-            }
-            ctx.setRow(valueMap);
-        }
+                if (!hasPermission(ctx, ReadPermission.class))
+                    throw new UnauthorizedException();
 
-        renderForm(ctx, out);
+                // For update the Results holds the current version of the data.
+                // The posted values (for reshow) are help by TableViewForm (RenderContext.getForm()). see DisplayColumn.getInputValue()
+                TableInfo tinfoMain = getTable();
+                var results = new TableSelector(tinfoMain, selectKeyMap.values(), new PkFilter(tinfoMain, viewForm.getPkVals()), null).getResults(true);
+                // NOTE MissingValueDisplayColumn does not work without Results, it relies on using .get(FieldKey) that it enables
+                if (results.next())
+                {
+                    ctx.setResults(results);
+                    ctx.setRow(results.getRowMap());
+                }
+            }
+
+            renderForm(ctx, out);
+        }
+        catch (SQLException e)
+        {
+            throw new RuntimeSQLException(e);
+        }
+        finally
+        {
+            ResultSetUtil.close(ctx.getResults());
+        }
     }
 
     /**


### PR DESCRIPTION
#### Rationale
MissingValueDisplayColumn requires FieldKey lookup to work so we have to set Results.  Internally it is hanging on to a ColumnInfo with the right FieldKey, but wrong Alias.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
