### PR TITLE
Add URL to AsyncQueryRequest thread to troubleshoot unclosed ResultSet

### DIFF
--- a/api/src/org/labkey/api/data/AsyncQueryRequest.java
+++ b/api/src/org/labkey/api/data/AsyncQueryRequest.java
@@ -31,10 +31,13 @@ import org.labkey.api.util.AbortedRequestException;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.LogHelper;
+import org.labkey.api.view.HttpView;
 import org.labkey.api.view.MockHttpResponseWithRealPassthrough;
 
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
+import org.labkey.api.view.ViewContext;
+
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -140,7 +143,13 @@ public class AsyncQueryRequest<T>
             }
         };
 
-        Thread thread = new Thread(runnable, "AsyncQueryRequest: " + Thread.currentThread().getName());
+        String threadName = "AsyncQueryRequest: " + Thread.currentThread().getName();
+        TransactionFilter.RequestTracker requestTracker = TransactionFilter.getRequestSummary(Thread.currentThread());
+        if (requestTracker != null)
+        {
+            threadName += " for " + requestTracker.getUrl();
+        }
+        Thread thread = new Thread(runnable, threadName);
         // We want the async thread to use the same database connection, in case we have a transaction open, and
         // so that when the original thread finishes processing the results it ends up closing the right connection
         try (DbScope.ConnectionSharingCloseable ignored = DbScope.shareConnections(Thread.currentThread(), thread);

--- a/api/src/org/labkey/api/data/TransactionFilter.java
+++ b/api/src/org/labkey/api/data/TransactionFilter.java
@@ -25,6 +25,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.ContextListener;
@@ -63,9 +64,14 @@ public class TransactionFilter implements Filter
         @Override
         public String toString()
         {
-            String url = request.getRequestURI() + "?" + trimToEmpty(request.getQueryString());
+            String url = getUrl();
             Principal user = request.getUserPrincipal();
             return url + " running for " + (System.currentTimeMillis() - startTime) + "ms by " + (user == null ? "guest" : user.getName());
+        }
+
+        public @NotNull String getUrl()
+        {
+            return request.getRequestURI() + "?" + trimToEmpty(request.getQueryString());
         }
     }
 


### PR DESCRIPTION
#### Rationale
Logging on nightly during a security scan shows that we're failing to close a ResultSet. It's hard to correlate that with the source request though.

#### Changes
- Push request URL into the AsyncQueryRequest thread's name to capture in the logging