### PR TITLE
Restore override of handleConversionException in CoerceDataIterator (Issue 52098)

### DIFF
--- a/api/src/org/labkey/api/dataiterator/CoerceDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/CoerceDataIterator.java
@@ -17,6 +17,7 @@ package org.labkey.api.dataiterator;
 
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MultiValuedForeignKey;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.PropertyType;
@@ -86,5 +87,12 @@ public class CoerceDataIterator extends SimpleTranslator
                 addNullColumn(to.getName(), to.getJdbcType());
             }
         }
+    }
+
+    // Ignore conversion exceptions during coercion and just pass back the original value.
+    @Override
+    protected Object handleConversionException(String fieldName, Object value, JdbcType target, Exception x)
+    {
+        return value;
     }
 }

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -178,7 +178,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         return _missingValues.containsKey(mv);
     }
 
-    protected Object addConversionException(String fieldName, @Nullable Object value, @Nullable JdbcType target, Exception x)
+    protected Object handleConversionException(String fieldName, @Nullable Object value, @Nullable JdbcType target, Exception x)
     {
         String msg;
         if (x instanceof ConversionExceptionWithMessage)
@@ -651,7 +651,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             }
             catch (ConversionException x)
             {
-                return addConversionException(fieldName, value, type, x);
+                return handleConversionException(fieldName, value, type, x);
             }
         }
 
@@ -1913,7 +1913,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             catch (ConversionException x)
             {
                 // preferable to handle in call()
-                _row[i] = addConversionException(_outputColumns.get(i).getKey().getName(), null, null, x);
+                _row[i] = handleConversionException(_outputColumns.get(i).getKey().getName(), null, null, x);
             }
             catch (RuntimeException x)
             {


### PR DESCRIPTION
#### Rationale
When addressing Issue 52098, the override of `addConversionException` in `CoerceDataIterator` was removed since we were opting to fail earlier for lookup resolution and it seemed appropriate to fail earlier for other conversions as well. Turns out we want to not fail earlier except for lookup resolution where it would be more burdensome for trigger scripts to understand how to resolve in the face of number names.

#### Related Pull Requests
- #6642
- https://github.com/LabKey/testAutomation/pull/2487

#### Changes
- Restore override and add a comment
- Rename method for better clarity
