### PR TITLE
Ensure ResultSet get closed

### DIFF
--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -2079,9 +2079,9 @@ public class DataRegion extends DisplayElement
                 TableInfo tinfoMain = getTable();
                 var results = new TableSelector(tinfoMain, selectKeyMap.values(), new PkFilter(tinfoMain, viewForm.getPkVals()), null).getResults(true);
                 // NOTE MissingValueDisplayColumn does not work without Results, it relies on using .get(FieldKey) that it enables
+                ctx.setResults(results); // set unconditionally to ensure resultSet gets closed
                 if (results.next())
                 {
-                    ctx.setResults(results);
                     ctx.setRow(results.getRowMap());
                 }
             }


### PR DESCRIPTION
#### Rationale
Tests are hitting "CachedResultSet was not closed." errors during project deletion. It is happening inconsistently, and only on suites with the crawler enabled. Presumably, the crawler is hitting invalid update forms and the `renderUpdateForm` result set isn't getting closed because it finds no data.

#### Related Pull Requests
- #6741 

#### Changes
- Ensure ResultSet get closed