### PR TITLE
Issue 53280: Assure non-admins will see user options, even when filtering for Active users

### DIFF
--- a/core/src/org/labkey/core/query/UsersTable.java
+++ b/core/src/org/labkey/core/query/UsersTable.java
@@ -106,7 +106,8 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
     private static final Set<FieldKey> ALWAYS_AVAILABLE_FIELDS = Set.of(
         FieldKey.fromParts("EntityId"),
         FieldKey.fromParts("UserId"),
-        FieldKey.fromParts("DisplayName")
+        FieldKey.fromParts("DisplayName"),
+        FieldKey.fromParts("Active") // Issue 53280
     );
 
     private final static Logger LOG = LogManager.getLogger(UsersTable.class);


### PR DESCRIPTION
#### Rationale
Issue [53280](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53280): In the related PR from Platform, we allowed non-admin users to see the `Active` column for the `UsersTable`, but it didn't go quite far enough so when the column is included in a filter, it resulted in the addition of a NullColumnInfo column, which then cause a query that filtered on the `Active` column, to fail because it was comparing the `true` filter value to `NULL`.  Here we add the Active column to the set of always available columns.

#### Related Pull Requests
- #6653
- https://github.com/LabKey/limsModules/pull/1465

#### Changes
- Make "Active" always available so it can be used for filters for non-admins.
