### PR TITLE
Another try to avoid showing stale password strength

### DIFF
--- a/core/webapp/passwordGauge.js
+++ b/core/webapp/passwordGauge.js
@@ -74,7 +74,7 @@ LABKEY.PasswordGauge = new function() {
                 _pendingScoreRequest.abort();
                 _pendingScoreRequest = null;
             }
-            let passwordAtTimeOfRequest = password.value;
+            const passwordAtTimeOfRequest = password.value;
             _pendingScoreRequest = LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL("login", "getPasswordScore.api"),
                 method: 'POST',

--- a/core/webapp/passwordGauge.js
+++ b/core/webapp/passwordGauge.js
@@ -74,14 +74,18 @@ LABKEY.PasswordGauge = new function() {
                 _pendingScoreRequest.abort();
                 _pendingScoreRequest = null;
             }
+            let passwordAtTimeOfRequest = password.value;
             _pendingScoreRequest = LABKEY.Ajax.request({
                 url: LABKEY.ActionURL.buildURL("login", "getPasswordScore.api"),
                 method: 'POST',
                 params: {
-                    password: password.value,
+                    password: passwordAtTimeOfRequest,
                     email: email || emailField?.value
                 },
                 success: LABKEY.Utils.getCallbackWrapper(function(responseText) {
+                    // Check that password input still matches what we had at the time of the request for the score
+                    if (password.value !== passwordAtTimeOfRequest)
+                        return;
                     // Clear everything inside the border. You might think I could clear using the same coordinates as
                     // I fill below (that's what I thought, anyway), but this tended to leave single-pixel trails of
                     // color behind. I clear a larger rectangle than what I filled to erase these trails.


### PR DESCRIPTION
#### Rationale
We've still seeing some test failures where the product seems to be showing stale password strength feedback.

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_InternalSuites_OldDependenciesSqlserver/3548355?buildTab=overview

#### Changes
- Check that the password in the input matches the one that initiated the request
