### PR TITLE
Misc assay issues fixes for 25.7

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-25.002-25.003.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-25.002-25.003.sql
@@ -1,0 +1,2 @@
+--GH Issue 778: materialinput Role can be a field name, which has a max length of 200 characters
+ALTER TABLE exp.MaterialInput ALTER COLUMN Role TYPE VARCHAR(200);

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-25.002-25.003.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-25.002-25.003.sql
@@ -1,0 +1,4 @@
+--GH Issue 778: materialinput Role can be a field name, which has a max length of 200 characters
+EXECUTE core.fn_dropifexists 'MaterialInput', 'exp', 'INDEX', 'IDX_MaterialInput_Role';
+ALTER TABLE exp.MaterialInput ALTER COLUMN Role NVARCHAR(200) NOT NULL;
+CREATE INDEX IDX_MaterialInput_Role ON exp.MaterialInput(Role);

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -183,7 +183,7 @@ public class ExperimentModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 25.002;
+        return 25.003;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -862,7 +862,7 @@ public class DomainPropertyImpl implements DomainProperty
                     if (_pdOld.getJdbcType() == JdbcType.BOOLEAN && _pd.getJdbcType().isText())
                     {
                         updateBooleanValue(_domain.getDomainKind().getStorageSchemaName() + "." + _domain.getStorageTableName(),
-                                _pd.getLegalSelectName(dialect), _pdOld.getFormat(), null);
+                                _pd.getLegalSelectName(dialect), _pdOld.getFormat(), null); // GH Issue 755
                     }
                 }
                 else if (propResized)

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -26,6 +26,7 @@ import org.labkey.api.data.ColumnRenderPropertiesImpl;
 import org.labkey.api.data.ConditionalFormat;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.DatabaseIdentifier;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.SQLFragment;
@@ -839,6 +840,7 @@ public class DomainPropertyImpl implements DomainProperty
             OntologyManager.ensurePropertyDomain(_pd, dd, sortOrder);
 
             boolean hasProvisioner = null != getDomain().getDomainKind() && null != getDomain().getDomainKind().getStorageSchemaName() && dd.getStorageTableName() != null;
+            SqlDialect dialect = OntologyManager.getExpSchema().getSqlDialect();
 
             if (hasProvisioner)
             {
@@ -860,7 +862,7 @@ public class DomainPropertyImpl implements DomainProperty
                     if (_pdOld.getJdbcType() == JdbcType.BOOLEAN && _pd.getJdbcType().isText())
                     {
                         updateBooleanValue(_domain.getDomainKind().getStorageSchemaName() + "." + _domain.getStorageTableName(),
-                                _pd.getStorageColumnName(), _pdOld.getFormat(), null);
+                                _pd.getLegalSelectName(dialect), _pdOld.getFormat(), null);
                     }
                 }
                 else if (propResized)
@@ -889,7 +891,6 @@ public class DomainPropertyImpl implements DomainProperty
                 }
                 else if (oldType.getJdbcType().isDateOrTime() && newType.getJdbcType().isDateOrTime())
                 {
-                    SqlDialect dialect = OntologyManager.getExpSchema().getSqlDialect();
                     String sqlTypeName = dialect.getSqlTypeName(newType.getJdbcType());
                     String update = String.format("CAST(DateTimeValue AS %s)", sqlTypeName);
                     if (newType.getJdbcType() == JdbcType.TIME)
@@ -915,7 +916,7 @@ public class DomainPropertyImpl implements DomainProperty
 
             if (changedType && _pdOld.getJdbcType() == JdbcType.BOOLEAN && _pd.getJdbcType().isText())
             {
-                updateBooleanValue(OntologyManager.getTinfoObjectProperty().getSelectName(), "StringValue", _pdOld.getFormat(), new SQLFragment("PropertyId = ?", _pdOld.getPropertyId()));
+                updateBooleanValue(OntologyManager.getTinfoObjectProperty().getSelectName(), dialect.makeDatabaseIdentifier("StringValue"), _pdOld.getFormat(), new SQLFragment("PropertyId = ?", _pdOld.getPropertyId()));
             }
         }
         else
@@ -943,17 +944,16 @@ public class DomainPropertyImpl implements DomainProperty
      * Postgres will now have 'true' and 'false', and SQLServer will have '0' and '1'. Use the format string to use the
      * preferred format, and standardize on 'true' and 'false' in the absence of an explicitly configured format.
      */
-    private void updateBooleanValue(String schemaTable, String column, String formatString, @Nullable SQLFragment whereClause)
+    private void updateBooleanValue(String schemaTable, DatabaseIdentifier column, String formatString, @Nullable SQLFragment whereClause)
     {
-        column = OntologyManager.getExpSchema().getSqlDialect().makeLegalIdentifier(column);
         BooleanFormat f = BooleanFormat.getInstance(formatString);
         String trueValue = StringUtils.trimToNull(f.format(true));
         String falseValue = StringUtils.trimToNull(f.format(false));
         String nullValue = StringUtils.trimToNull(f.format(null));
         SQLFragment sql = new SQLFragment("UPDATE ").append(schemaTable).append(" SET ").
-                append(column).append(" = CASE WHEN ").
-                append(column).append(" IN ('1', 'true') THEN ? WHEN ").
-                append(column).append(" IN ('0', 'false') THEN ? ELSE ? END");
+                appendIdentifier(column).append(" = CASE WHEN ").
+                appendIdentifier(column).append(" IN ('1', 'true') THEN ? WHEN ").
+                appendIdentifier(column).append(" IN ('0', 'false') THEN ? ELSE ? END");
         sql.add(trueValue);
         sql.add(falseValue);
         sql.add(nullValue);


### PR DESCRIPTION
#### Rationale
#[755](https://github.com/LabKey/internal-issues/issues/647): Assay field type conversion from Boolean to String fails if the name contains uppercase characters
#[778](https://github.com/LabKey/internal-issues/issues/652): Unable to edit assay run when a run-level sample field's name is > 50 characters
#[779](https://github.com/LabKey/internal-issues/issues/653): Unable to import assay when result-level Sample field has name > 50 characters

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1810
- https://github.com/LabKey/labkey-ui-premium/pull/774
- https://github.com/LabKey/limsModules/pull/1470
- https://github.com/LabKey/platform/pull/6760
- https://github.com/LabKey/testAutomation/pull/2497

#### Changes
- exp SQL upgrade script for MaterialInputs "Role" field length
- DomainPropertyImpl to use getLegalSelectName for updateBooleanValue()
