### PR TITLE
Migrate Factory usages to Supplier

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -20,7 +20,6 @@ import jakarta.servlet.FilterRegistration;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletRegistration;
 import org.apache.catalina.filters.CorsFilter;
-import org.apache.commons.collections4.Factory;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.labkey.api.action.ApiXmlWriter;
@@ -201,6 +200,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static java.util.EnumSet.allOf;
 import static org.labkey.api.settings.LookAndFeelProperties.Properties.applicationMenuDisplayMode;
@@ -455,9 +455,9 @@ public class ApiModule extends CodeOnlyModule
     }
 
     @Override
-    public @NotNull Collection<Factory<Class<?>>> getIntegrationTestFactories()
+    public @NotNull Collection<Supplier<Class<?>>> getIntegrationTestFactories()
     {
-        List<Factory<Class<?>>> list = new ArrayList<>(super.getIntegrationTestFactories());
+        List<Supplier<Class<?>>> list = new ArrayList<>(super.getIntegrationTestFactories());
         list.add(new JspTestCase("/org/labkey/api/module/testSimpleModule.jsp"));
         list.add(new JspTestCase("/org/labkey/api/module/actionAndFormTest.jsp"));
         list.add(new JspTestCase("/org/labkey/vfs/vfsTestCase.jsp"));

--- a/api/src/org/labkey/api/data/FieldKeyRowMap.java
+++ b/api/src/org/labkey/api/data/FieldKeyRowMap.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class FieldKeyRowMap implements Map<FieldKey, Object>
+class FieldKeyRowMap implements Map<FieldKey, Object>
 {
     private final Results _results;
 
@@ -65,6 +65,8 @@ public class FieldKeyRowMap implements Map<FieldKey, Object>
     {
         try
         {
+            // Avoid ClassCastException if non-FieldKey is passed in. For example, StringExpressionFactory will
+            // convert FieldKeys to Strings if the field doesn't exist in the map (due to PHI column or bad expression)
             return key instanceof FieldKey fk ? _results.getObject(fk) : null;
         }
         catch (SQLException e)

--- a/api/src/org/labkey/api/module/Module.java
+++ b/api/src/org/labkey/api/module/Module.java
@@ -21,7 +21,6 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.commons.collections4.Factory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
@@ -245,12 +244,13 @@ public interface Module
      * Modules can provide JUnit tests that must be run inside the server
      * VM. These tests will be executed as part of the DRT. These are not true unit tests, and may rely on external
      * resources such as a database connection or services provided by other modules.
+     *
      * @return the integration tests that this module provides
      */
     @JsonIgnore
-    default @NotNull Collection<Factory<Class<?>>> getIntegrationTestFactories()
+    default @NotNull Collection<Supplier<Class<?>>> getIntegrationTestFactories()
     {
-        return getIntegrationTests().stream().map(c -> (Factory<Class<?>>)() -> c).collect(Collectors.toList());
+        return getIntegrationTests().stream().map(c -> (Supplier<Class<?>>)() -> c).collect(Collectors.toList());
     }
 
     /**

--- a/api/src/org/labkey/api/qc/view/manageQCStates.jsp
+++ b/api/src/org/labkey/api/qc/view/manageQCStates.jsp
@@ -134,7 +134,7 @@
     %>
 
     <%= button("Save").submit(true).onClick("document.manageQCStates.reshowPage.value='false'; return true;") %>
-    <%= button("Cancel").href(cancelUrl.getLocalURIString()) %>
+    <%= button("Cancel").href(cancelUrl) %>
 </labkey:form>
 <script type="text/javascript" nonce="<%=getScriptNonce()%>">
     function addRow() {

--- a/api/src/org/labkey/api/util/JspTestCase.java
+++ b/api/src/org/labkey/api/util/JspTestCase.java
@@ -1,13 +1,14 @@
 package org.labkey.api.util;
 
-import org.apache.commons.collections4.Factory;
 import org.labkey.api.jsp.JspLoader;
+
+import java.util.function.Supplier;
 
 /*
  * NOTE: we could call JspLoader.loadClass() directly in getIntegrationTests(), however,
  * that would cause all test jsp's to be compiled at startup.
  */
-public class JspTestCase implements Factory<Class<?>>
+public class JspTestCase implements Supplier<Class<?>>
 {
     private final String jspPath;
 
@@ -17,7 +18,7 @@ public class JspTestCase implements Factory<Class<?>>
     }
 
     @Override
-    public Class<?> create()
+    public Class<?> get()
     {
         return JspLoader.loadClass(jspPath);
     }

--- a/api/src/org/labkey/api/view/Portal.java
+++ b/api/src/org/labkey/api/view/Portal.java
@@ -17,7 +17,6 @@
 package org.labkey.api.view;
 
 import jakarta.servlet.http.HttpServletResponse;
-import org.apache.commons.collections4.Factory;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
@@ -66,13 +65,13 @@ import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.usageMetrics.UsageMetricsProvider;
 import org.labkey.api.util.ButtonBuilder;
+import org.labkey.api.util.CsrfInput;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.ModuleChangeListener;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
-import org.labkey.api.util.CsrfInput;
 import org.labkey.api.util.logging.LogHelper;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.PropertyValues;
@@ -95,6 +94,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.labkey.api.util.DOM.Attribute.action;
@@ -217,7 +217,7 @@ public class Portal implements ModuleChangeListener
     /** Bean object for persisting web part configurations in the core.portalwebparts table
      * NOTE: implements Factory<> so this can be used as a builder for immutable object
      */
-    public static class WebPart implements Serializable, Factory<WebPart>
+    public static class WebPart implements Serializable, Supplier<WebPart>
     {
         Container container;
         String pageId;
@@ -468,12 +468,12 @@ public class Portal implements ModuleChangeListener
         // return an immutable webpart
 
         @Override
-        public WebPart create()
+        public WebPart get()
         {
             return new WebPart(this, true)
             {
                 @Override
-                public WebPart create()
+                public WebPart get()
                 {
                     return this;
                 }
@@ -1897,7 +1897,7 @@ public class Portal implements ModuleChangeListener
         }
     }
 
-    public static class PortalPage implements Cloneable, Factory<PortalPage>
+    public static class PortalPage implements Cloneable, Supplier<PortalPage>
     {
         private GUID entityId;
         private GUID containerId;
@@ -1942,7 +1942,7 @@ public class Portal implements ModuleChangeListener
                 this.propertyMap = Collections.unmodifiableMap(propertyMap);
             // deep copy, note that .create() creates readonly copy
             for (WebPart wp : copyFrom.webparts.values())
-                webparts.put(wp.index, (readonly ? wp.create() : new WebPart(wp)));
+                webparts.put(wp.index, (readonly ? wp.get() : new WebPart(wp)));
             if (readonly)
                 this.webparts = Collections.unmodifiableMap(webparts);
         }
@@ -2110,12 +2110,12 @@ public class Portal implements ModuleChangeListener
 
         /** create a read only copy of this PortalPage suitable for caching */
         @Override
-        public PortalPage create()
+        public PortalPage get()
         {
             return new PortalPage(this, true)
             {
                 @Override
-                public PortalPage create()
+                public PortalPage get()
                 {
                     return this;
                 }

--- a/api/src/org/labkey/api/view/WebPartCache.java
+++ b/api/src/org/labkey/api/view/WebPartCache.java
@@ -45,8 +45,6 @@ import java.util.Map;
 
 /**
  * In-memory cache of the {@link WebPart}s configured for specific {@link Container}s.
- * User: adam
- * Date: 10/21/11
  */
 public class WebPartCache
 {
@@ -93,53 +91,50 @@ public class WebPartCache
     }
 
 
-    static CacheLoader<String, Map<String, Portal.PortalPage>> _webpartLoader = (containerId, o) ->
+    private static final CacheLoader<String, Map<String, Portal.PortalPage>> _webpartLoader = (containerId, o) ->
     {
+        DbSchema schema = CoreSchema.getInstance().getSchema();
+        final CaseInsensitiveHashMap<Portal.PortalPage> pages = new CaseInsensitiveHashMap<>();
+        Container container = ContainerManager.getForId(containerId);
+
+        SQLFragment selectPages = new SQLFragment("SELECT * FROM ").append(Portal.getTableInfoPortalPages()).append(" WHERE Container = ? ORDER BY \"index\"").add(container);
+        Collection<Portal.PortalPage> pagesSelect = new SqlSelector(schema, selectPages).getCollection(Portal.PortalPage.class);
+
+        Map<Integer, Portal.PortalPage> pagesByRowId = new HashMap<>();       // For webparts to lookup
+        for (Portal.PortalPage p : pagesSelect)
         {
-            DbSchema schema = CoreSchema.getInstance().getSchema();
-            final CaseInsensitiveHashMap<Portal.PortalPage> pages = new CaseInsensitiveHashMap<>();
-            Container container = ContainerManager.getForId(containerId);
-
-            SQLFragment selectPages = new SQLFragment("SELECT * FROM ").append(Portal.getTableInfoPortalPages()).append(" WHERE Container = ? ORDER BY \"index\"").add(container);
-            Collection<Portal.PortalPage> pagesSelect = new SqlSelector(schema, selectPages).getCollection(Portal.PortalPage.class);
-
-            Map<Integer, Portal.PortalPage> pagesByRowId = new HashMap<>();       // For webparts to lookup
-            for (Portal.PortalPage p : pagesSelect)
+            if (null == p.getEntityId())
             {
-                if (null == p.getEntityId())
-                {
-                    GUID g = new GUID();
-                    SQLFragment updateEntityId = new SQLFragment("UPDATE ").append(Portal.getTableInfoPortalPages()).append(" SET EntityId = ? WHERE Container = ? AND RowId = ? AND EntityId IS NULL")
-                        .addAll(g, containerId, p.getRowId());
-                    new SqlExecutor(schema).execute(updateEntityId);
-                    p.setEntityId(g);
-                }
-                if (pages.containsKey(p.getPageId()) && null != container)
-                    LOG.warn("Page '" + p.getPageId() + "' in container '" + container.getPath() +
-                            "' is duplicated, meaning some expected web parts may be missing. Recommended to remove the page (tab), which should remove one of them, and set web parts as desired.");
-                pages.put(p.getPageId(), p);
-                pagesByRowId.put(p.getRowId(), p);
+                GUID g = new GUID();
+                SQLFragment updateEntityId = new SQLFragment("UPDATE ").append(Portal.getTableInfoPortalPages()).append(" SET EntityId = ? WHERE Container = ? AND RowId = ? AND EntityId IS NULL")
+                    .addAll(g, containerId, p.getRowId());
+                new SqlExecutor(schema).execute(updateEntityId);
+                p.setEntityId(g);
             }
-
-            SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("Container"), containerId);
-
-            new TableSelector(Portal.getTableInfoPortalWebParts(), filter, new Sort("Index")).forEach(WebPart.class, wp -> {
-                Portal.PortalPage p = pagesByRowId.get(wp.getPortalPageId());
-                if (null != p)
-                {
-                    p.addWebPart(wp);
-                    wp.setPageId(p.getPageId());
-                }
-            });
-
-            // create immutable PortalPage objects for caching
-            CaseInsensitiveHashMap<Portal.PortalPage> ret = new CaseInsensitiveHashMap<>();
-            for (var entry : pages.entrySet())
-                ret.put(entry.getKey(), entry.getValue().create());
-            return Collections.unmodifiableMap(ret);
+            if (pages.containsKey(p.getPageId()) && null != container)
+                LOG.warn("Page '" + p.getPageId() + "' in container '" + container.getPath() +
+                        "' is duplicated, meaning some expected web parts may be missing. Recommended to remove the page (tab), which should remove one of them, and set web parts as desired.");
+            pages.put(p.getPageId(), p);
+            pagesByRowId.put(p.getRowId(), p);
         }
-    };
 
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("Container"), containerId);
+
+        new TableSelector(Portal.getTableInfoPortalWebParts(), filter, new Sort("Index")).forEach(WebPart.class, wp -> {
+            Portal.PortalPage p = pagesByRowId.get(wp.getPortalPageId());
+            if (null != p)
+            {
+                p.addWebPart(wp);
+                wp.setPageId(p.getPageId());
+            }
+        });
+
+        // create immutable PortalPage objects for caching
+        CaseInsensitiveHashMap<Portal.PortalPage> ret = new CaseInsensitiveHashMap<>();
+        for (var entry : pages.entrySet())
+            ret.put(entry.getKey(), entry.getValue().get());
+        return Collections.unmodifiableMap(ret);
+    };
 
     private static Map<String, Portal.PortalPage> get(@NotNull final Container c)
     {
@@ -149,8 +144,9 @@ public class WebPartCache
     public static void remove(Container c)
     {
         CoreSchema.getInstance().getSchema().getScope().addCommitTask(
-                () -> CACHE.remove(c.getId()),
-                DbScope.CommitTaskOption.IMMEDIATE,
-                DbScope.CommitTaskOption.POSTCOMMIT);
+            () -> CACHE.remove(c.getId()),
+            DbScope.CommitTaskOption.IMMEDIATE,
+            DbScope.CommitTaskOption.POSTCOMMIT
+        );
     }
 }

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -17,7 +17,6 @@
 package org.labkey.assay;
 
 import jakarta.servlet.ServletContext;
-import org.apache.commons.collections4.Factory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AbstractTsvAssayProvider;
@@ -101,6 +100,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.labkey.api.assay.transform.DataTransformService.LEGACY_SESSION_COOKIE_NAME_REPLACEMENT;
 import static org.labkey.api.assay.transform.DataTransformService.LEGACY_SESSION_ID_REPLACEMENT;
@@ -323,9 +323,9 @@ public class AssayModule extends SpringModule
     }
 
     @Override
-    public @NotNull Collection<Factory<Class<?>>> getIntegrationTestFactories()
+    public @NotNull Collection<Supplier<Class<?>>> getIntegrationTestFactories()
     {
-        ArrayList<Factory<Class<?>>> list = new ArrayList<>(super.getIntegrationTestFactories());
+        List<Supplier<Class<?>>> list = new ArrayList<>(super.getIntegrationTestFactories());
         list.add(new JspTestCase("/org/labkey/assay/AssayIntegrationTestCase.jsp"));
         return list;
     }

--- a/core/src/org/labkey/core/junit/JunitManager.java
+++ b/core/src/org/labkey/core/junit/JunitManager.java
@@ -43,7 +43,7 @@ public class JunitManager
         {
             Set<Class> moduleClazzes = new HashSet<>();
 
-            module.getIntegrationTestFactories().forEach(f -> moduleClazzes.add(f.create()));
+            module.getIntegrationTestFactories().forEach(f -> moduleClazzes.add(f.get()));
             moduleClazzes.addAll(module.getUnitTests());
 
             if (!moduleClazzes.isEmpty())

--- a/devtools/src/org/labkey/devtools/DevtoolsModule.java
+++ b/devtools/src/org/labkey/devtools/DevtoolsModule.java
@@ -16,7 +16,6 @@
 
 package org.labkey.devtools;
 
-import org.apache.commons.collections4.Factory;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.exp.property.Domain;
@@ -34,7 +33,7 @@ import org.labkey.devtools.authentication.TestSsoProvider;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.function.Supplier;
 
 public class DevtoolsModule extends CodeOnlyModule
 {
@@ -78,7 +77,7 @@ public class DevtoolsModule extends CodeOnlyModule
     }
 
     @Override
-    public @NotNull List<Factory<Class<?>>> getIntegrationTestFactories()
+    public @NotNull Collection<Supplier<Class<?>>> getIntegrationTestFactories()
     {
         return Collections.singletonList(new JspTestCase("/org/labkey/devtools/test/JspTestCaseTest.jsp"));
     }

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.experiment;
 
-import org.apache.commons.collections4.Factory;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -46,6 +45,7 @@ import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.DefaultExperimentDataHandler;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpDataClass;
+import org.labkey.api.exp.api.ExpLineageService;
 import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpProtocolAttachmentType;
@@ -54,7 +54,6 @@ import org.labkey.api.exp.api.ExpSampleType;
 import org.labkey.api.exp.api.ExperimentJSONConverter;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.api.FilterProtocolInputCriteria;
-import org.labkey.api.exp.api.ExpLineageService;
 import org.labkey.api.exp.api.SampleTypeDomainKind;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.api.StorageProvisioner;
@@ -112,9 +111,6 @@ import org.labkey.experiment.api.ExpSampleTypeTableImpl;
 import org.labkey.experiment.api.ExperimentServiceImpl;
 import org.labkey.experiment.api.ExperimentStressTest;
 import org.labkey.experiment.api.GraphAlgorithms;
-import org.labkey.experiment.api.property.DomainImpl;
-import org.labkey.experiment.api.property.StorageNameGenerator;
-import org.labkey.experiment.lineage.LineagePerfTest;
 import org.labkey.experiment.api.LineageTest;
 import org.labkey.experiment.api.LogDataType;
 import org.labkey.experiment.api.Protocol;
@@ -126,18 +122,21 @@ import org.labkey.experiment.api.data.ChildOfMethod;
 import org.labkey.experiment.api.data.LineageCompareType;
 import org.labkey.experiment.api.data.ParentOfCompareType;
 import org.labkey.experiment.api.data.ParentOfMethod;
+import org.labkey.experiment.api.property.DomainImpl;
 import org.labkey.experiment.api.property.DomainPropertyImpl;
 import org.labkey.experiment.api.property.LengthValidator;
 import org.labkey.experiment.api.property.LookupValidator;
 import org.labkey.experiment.api.property.PropertyServiceImpl;
 import org.labkey.experiment.api.property.RangeValidator;
 import org.labkey.experiment.api.property.RegExValidator;
+import org.labkey.experiment.api.property.StorageNameGenerator;
 import org.labkey.experiment.api.property.StorageProvisionerImpl;
 import org.labkey.experiment.api.property.TextChoiceValidator;
 import org.labkey.experiment.controllers.exp.ExperimentController;
 import org.labkey.experiment.controllers.property.PropertyController;
 import org.labkey.experiment.defaults.DefaultValueServiceImpl;
 import org.labkey.experiment.lineage.ExpLineageServiceImpl;
+import org.labkey.experiment.lineage.LineagePerfTest;
 import org.labkey.experiment.pipeline.ExperimentPipelineProvider;
 import org.labkey.experiment.samples.DataClassFolderImporter;
 import org.labkey.experiment.samples.DataClassFolderWriter;
@@ -161,6 +160,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.labkey.api.data.ColumnRenderPropertiesImpl.STORAGE_UNIQUE_ID_CONCEPT_URI;
@@ -966,9 +966,9 @@ public class ExperimentModule extends SpringModule
     }
 
     @Override
-    public @NotNull List<Factory<Class<?>>> getIntegrationTestFactories()
+    public @NotNull Collection<Supplier<Class<?>>> getIntegrationTestFactories()
     {
-        ArrayList<Factory<Class<?>>> list = new ArrayList<>(super.getIntegrationTestFactories());
+        List<Supplier<Class<?>>> list = new ArrayList<>(super.getIntegrationTestFactories());
         list.add(new JspTestCase("/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp"));
         list.add(new JspTestCase("/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp"));
         return list;

--- a/list/src/org/labkey/list/model/ListDef.java
+++ b/list/src/org/labkey/list/model/ListDef.java
@@ -382,6 +382,7 @@ public class ListDef extends Entity implements Cloneable, ListIndexingSettings
             _lastIndexed = lastIndexed;
         }
         public void setCategory(Category category) { _category = category; }
+        @SuppressWarnings("unused") // Invoked by reflection, e.g., ObjectFactory that retrieves ListDefs via TableSelector
         public void setDiscussionSetting(int value)
         {
             _discussionSetting = DiscussionSetting.getForValue(value);
@@ -406,6 +407,7 @@ public class ListDef extends Entity implements Cloneable, ListIndexingSettings
         {
             _entireListIndex = entireListIndex;
         }
+        @SuppressWarnings("unused") // Invoked by reflection, e.g., ObjectFactory that retrieves ListDefs via TableSelector
         public void setEntireListIndexSetting(int settingInt)
         {
             _entireListIndexSetting = IndexSetting.getForValue(settingInt);
@@ -418,6 +420,7 @@ public class ListDef extends Entity implements Cloneable, ListIndexingSettings
         {
             _entireListTitleTemplate = template;
         }
+        @SuppressWarnings("unused") // Invoked by reflection, e.g., ObjectFactory that retrieves ListDefs via TableSelector
         public void setEntireListBodySetting(int settingInt)
         {
             _entireListBodySetting = BodySetting.getForValue(settingInt);
@@ -438,6 +441,7 @@ public class ListDef extends Entity implements Cloneable, ListIndexingSettings
         {
             _eachItemTitleTemplate = template;
         }
+        @SuppressWarnings("unused") // Invoked by reflection, e.g., ObjectFactory that retrieves ListDefs via TableSelector
         public void setEachItemBodySetting(int settingInt)
         {
             _eachItemBodySetting = BodySetting.getForValue(settingInt);

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -16,7 +16,6 @@
 
 package org.labkey.query;
 
-import org.apache.commons.collections4.Factory;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.labkey.api.admin.FolderSerializationRegistry;
@@ -133,6 +132,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static org.labkey.api.query.QueryService.USE_ROW_BY_ROW_UPDATE;
 
@@ -361,9 +361,9 @@ public class QueryModule extends DefaultModule
     }
 
     @Override
-    public @NotNull List<Factory<Class<?>>> getIntegrationTestFactories()
+    public @NotNull Collection<Supplier<Class<?>>> getIntegrationTestFactories()
     {
-        List<Factory<Class<?>>> ret = new ArrayList<>(super.getIntegrationTestFactories());
+        List<Supplier<Class<?>>> ret = new ArrayList<>(super.getIntegrationTestFactories());
         ret.add(new JspTestCase("/org/labkey/query/MultiValueTest.jsp"));
         ret.add(new JspTestCase("/org/labkey/query/olap/OlapTestCase.jsp"));
         ret.add(new JspTestCase("/org/labkey/query/QueryServiceImplTestCase.jsp"));

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -16,7 +16,6 @@
 
 package org.labkey.study;
 
-import org.apache.commons.collections4.Factory;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
@@ -191,6 +190,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class StudyModule extends SpringModule implements SearchService.DocumentProvider
@@ -709,9 +709,9 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     }
 
     @Override
-    public @NotNull List<Factory<Class<?>>> getIntegrationTestFactories()
+    public @NotNull Collection<Supplier<Class<?>>> getIntegrationTestFactories()
     {
-        ArrayList<Factory<Class<?>>> list = new ArrayList<>(super.getIntegrationTestFactories());
+        List<Supplier<Class<?>>> list = new ArrayList<>(super.getIntegrationTestFactories());
         list.add(new JspTestCase("/org/labkey/study/model/DatasetImportTestCase.jsp"));
         return list;
     }


### PR DESCRIPTION
#### Rationale
Commons Collections `Factory` class is deprecated, superceded by the standard `java.util.function.Supplier` class (which is functionally equivalent)

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/280