### PR TITLE
Ensure a valid file link path for file field types

### DIFF
--- a/api/src/org/labkey/api/assay/AssayFileWriter.java
+++ b/api/src/org/labkey/api/assay/AssayFileWriter.java
@@ -92,6 +92,7 @@ public class AssayFileWriter<ContextType extends AssayRunUploadContext<? extends
         }
     }
 
+    @NotNull
     public static FileLike getUploadDirectoryPath(Container container, String dirName)
     {
         if (dirName == null)

--- a/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
@@ -20,7 +20,6 @@ import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.attachments.AttachmentFile;
 import org.labkey.api.collections.ArrayListMap;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
@@ -780,8 +779,7 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
 
     final protected void convertTypes(User user, Container c, Map<String,Object> row) throws ValidationException
     {
-        Path path = AssayFileWriter.getUploadDirectoryPath(c, "datasetdata").toNioPathForWrite();
-        convertTypes(user, c, row,  getDbTable(), path);
+        convertTypes(user, c, row,  getDbTable(), null);
     }
 
     // TODO Path->FileObject

--- a/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
@@ -20,6 +20,7 @@ import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.attachments.AttachmentFile;
 import org.labkey.api.collections.ArrayListMap;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
@@ -779,7 +780,8 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
 
     final protected void convertTypes(User user, Container c, Map<String,Object> row) throws ValidationException
     {
-        convertTypes(user, c, row,  getDbTable(), null);
+        Path path = AssayFileWriter.getUploadDirectoryPath(c, "datasetdata").toNioPathForWrite();
+        convertTypes(user, c, row,  getDbTable(), path);
     }
 
     // TODO Path->FileObject

--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -23,6 +23,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.ResultSetRowMapFactory;
@@ -84,6 +85,7 @@ import org.labkey.study.model.StudyImpl;
 import org.labkey.study.model.StudyManager;
 import org.labkey.study.visitmanager.PurgeParticipantsJob.ParticipantPurger;
 
+import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -561,6 +563,16 @@ public class DatasetUpdateService extends DefaultQueryUpdateService
 
         if (errors.hasErrors())
             throw errors;
+    }
+
+    @Override
+    protected void convertTypes(User user, Container c, Map<String, Object> row, TableInfo t, @Nullable Path fileLinkDirPath) throws ValidationException
+    {
+        // Issue 53320 : ensure a valid file link path
+        if (fileLinkDirPath == null)
+            fileLinkDirPath = AssayFileWriter.getUploadDirectoryPath(c, "datasetdata").toNioPathForWrite();
+
+        super.convertTypes(user, c, row, t, fileLinkDirPath);
     }
 
     @Override

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
@@ -151,6 +151,13 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
         // assert correct reshow with error
         assertTextPresent("Could not convert value:");
         checker().verifyTrue("File is not present ",  isElementPresent(Locator.linkContainingText("remove")));
+
+        // Issue : 53320. Update a file field with a different file
+        click(Locator.linkContainingText("remove"));
+        File updateFile = TestFileUtils.getSampleData("fileTypes/pdf_sample.pdf");
+        setFormElement(Locator.name("quf_intField"), "2");
+        setFormElement(Locator.name("quf_fileField"), updateFile.toString());
+        clickButton("Submit");
     }
 
     protected void createDataset(String name)


### PR DESCRIPTION
#### Rationale
[53320: NPE updating a dataset file field](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53320)

This seems related to the recent changes to `DatasetUpdateService.updateRow`.

- Need to ensure that there is a valid path provided for file field types, this is already handled in the `DataIterator` for inserts.
- Added a test to validate this path. We were so close to probably catching it when we wired up support for files in the reshow case.