### PR TITLE
Don't change host:port in redirect after successful login

### DIFF
--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -672,8 +672,8 @@ public class LoginController extends SpringActionController
                     response.put("approvedTermsOfUse", true);
                 }
 
-                // Use the full hostname in the URL if we have one, otherwise just go with a local URI
-                String redirectString = redirectUrl.getHost() != null && redirectUrl.getScheme() != null ? redirectUrl.getURIString() : redirectUrl.toString();
+                // Use relative path.  If the host in the URL changes then our session won't follow us, and we won't be logged in (that kinda defeats the purpose of this API)
+                String redirectString = redirectUrl.getLocalURIString();
 
                 if (null != user)
                 {


### PR DESCRIPTION
#### Rationale
Fixes confusion state where the user seems to be logged out immediately after successful login.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
