### PR TITLE
Make delete protocol less prone to deadlock

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -439,9 +439,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             if (domain != null && domain.getStorageTableName() != null)
             {
                 SQLFragment deleteSQL = new SQLFragment("DELETE FROM ");
-                deleteSQL.append(domain.getDomainKind().getStorageSchemaName());
-                deleteSQL.append(".");
-                deleteSQL.append(domain.getStorageTableName());
+                deleteSQL.appendDottedIdentifiers(domain.getDomainKind().getStorageSchemaName(),domain.getStorageTableName());
                 deleteSQL.append(" WHERE DataId ").appendInClause(dataIds, ExperimentService.get().getSchema().getSqlDialect());
 
                 try

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -210,26 +210,22 @@ public class DbScope
     }
 
 
-    /* marker interface */
-    public interface ServerLock extends Lock
+    public static abstract class ServerLock implements Lock
     {
         @Override
-        void lock();
-
-        @Override
-        default void lockInterruptibly()
+        public void lockInterruptibly()
         {
             lock();
         }
 
         @Override
-        default boolean tryLock()
+        public boolean tryLock()
         {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        default boolean tryLock(long time, @NotNull TimeUnit unit)
+        public boolean tryLock(long time, @NotNull TimeUnit unit)
         {
             lock();
             return true;
@@ -237,21 +233,21 @@ public class DbScope
         }
 
         @Override
-        default void unlock()
+        final public void unlock()
         {
             /* noop, release with commit/rollback */
         }
 
         @NotNull
         @Override
-        default Condition newCondition()
+        public Condition newCondition()
         {
-            throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException("ServerRowLock does not support newCondition()");
         }
     }
 
 
-    public static class ServerNoopLock implements ServerLock
+    public static class ServerNoopLock extends ServerLock
     {
         @Override
         public void lock()
@@ -3468,7 +3464,14 @@ public class DbScope
         {
             // test ServerLock failures
 
-            Lock failServerLock = (ServerLock) () -> { throw new PessimisticLockingFailureException("test",null); };
+            Lock failServerLock = new ServerLock()
+            {
+                @Override
+                public void lock()
+                {
+                    throw new PessimisticLockingFailureException("test",null);
+                }
+            };
 
             try (Transaction txFg = CoreSchema.getInstance().getScope().ensureTransaction(failServerLock))
             {

--- a/api/src/org/labkey/api/data/ServerPrimaryKeyLock.java
+++ b/api/src/org/labkey/api/data/ServerPrimaryKeyLock.java
@@ -27,7 +27,7 @@ import java.util.concurrent.locks.Condition;
 /**
  * Created by matthew on 2/22/16.
  */
-public class ServerPrimaryKeyLock implements DbScope.ServerLock
+public class ServerPrimaryKeyLock extends DbScope.ServerLock
 {
     final DbScope scope;
     final SQLFragment forUpdate;
@@ -65,38 +65,5 @@ public class ServerPrimaryKeyLock implements DbScope.ServerLock
         Map[] maps = new SqlSelector(scope, forUpdate).getArray(Map.class);
         if (failIfRowNotFound && 0 == maps.length)
             throw OptimisticConflictException.create(Table.ERROR_DELETED);
-    }
-
-    @Override
-    public void lockInterruptibly()
-    {
-        lock();
-    }
-
-    @Override
-    public boolean tryLock()
-    {
-        throw new UnsupportedOperationException("ServerRowLock does not support tryLock()");
-    }
-
-    @Override
-    public boolean tryLock(long time, @NotNull TimeUnit unit)
-    {
-        // We don't really support the timeout but pretend we do to participate in DbScope.Transaction's deadlock prevention
-        lock();
-        return true;
-    }
-
-    @Override
-    public void unlock()
-    {
-        /* nope */
-    }
-
-    @NotNull
-    @Override
-    public Condition newCondition()
-    {
-        throw new UnsupportedOperationException("ServerRowLock does not support newCondition()");
     }
 }

--- a/api/src/org/labkey/api/exp/property/Domain.java
+++ b/api/src/org/labkey/api/exp/property/Domain.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.ChangePropertyDescriptorException;
@@ -84,6 +85,7 @@ public interface Domain extends IPropertyType
      * This pattern effectively forces all callers who are trying to manipulate this domain to queue up.
      */
     Lock getDatabaseLock();
+    void lockForDelete(DbSchema expSchema);
 
     void delete(@Nullable User user) throws DomainNotFoundException;
     default void delete(@Nullable User user, @Nullable String auditUserComment) throws DomainNotFoundException

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4532,6 +4532,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         try (DbScope.Transaction transaction = ensureTransaction())
         {
+            // To increase the chances of getting through this w/o a deadlock, lets lock tables now that we plan on deleting
+            // There are other tables/rows we could lock, but this is a start
+            // CONSIDER similar behavior for Domain.delete()
+            _lockProvisionedTables(assayService, expProtocols);
+
             for (ExperimentListener listener : _listeners)
             {
                 listener.beforeProtocolsDeleted(c, user, expProtocols);
@@ -4632,6 +4637,33 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (assayService != null)
             assayService.deindexAssays(Collections.unmodifiableCollection(expProtocols));
     }
+
+
+    private static void _lockProvisionedTables(AssayService assayService, List<ExpProtocolImpl> expProtocols)
+    {
+        if (null == assayService)
+            return;
+        DbSchema expSchema = ExperimentService.get().getSchema();
+        if (!expSchema.getSqlDialect().isPostgreSQL())
+            return;
+
+        SQLFragment lockSQL = new SQLFragment();
+        for (var expProtocol : expProtocols)
+        {
+            AssayProvider provider = assayService.getProvider(expProtocol);
+            if (provider != null)
+            {
+                for (var domain : provider.getDomains(expProtocol))
+                {
+                    if (null != domain.getStorageTableName())
+                        lockSQL.append("LOCK TABLE ").appendDottedIdentifiers(domain.getDomainKind().getStorageSchemaName(), domain.getStorageTableName()).append(" IN EXCLUSIVE MODE").appendEOS().append("\n");
+                }
+            }
+        }
+        if (!lockSQL.isEmpty())
+            new SqlExecutor(expSchema).execute(lockSQL);
+    }
+
 
     private void deleteAllProtocolInputs(Container c, String protocolIdsInClause)
     {
@@ -5431,10 +5463,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             // If we're a batch, delete all the runs too
             if (experiment.getDataObject().getBatchProtocolId() != null)
             {
-                for (ExpRunImpl expRun : experiment.getRuns())
-                {
-                    expRun.delete(user);
-                }
+                ExperimentServiceImpl.get().deleteExperimentRuns(c, user, null, experiment.getRuns());
             }
 
             SqlExecutor executor = new SqlExecutor(getExpSchema());

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4655,6 +4655,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             {
                 for (var domain : provider.getDomains(expProtocol))
                 {
+                    // CONSIDER verify table exists: SELECT 1 FROM pg_tables WHERE schemaname = ? AND tablename = ?
                     if (null != domain.getStorageTableName())
                         lockSQL.append("LOCK TABLE ").appendDottedIdentifiers(domain.getDomainKind().getStorageSchemaName(), domain.getStorageTableName()).append(" IN EXCLUSIVE MODE").appendEOS().append("\n");
                 }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4535,7 +4535,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             // To increase the chances of getting through this w/o a deadlock, lets lock tables now that we plan on deleting
             // There are other tables/rows we could lock, but this is a start
             // CONSIDER similar behavior for Domain.delete()
-            _lockProvisionedTables(assayService, expProtocols);
+            _lockDomainsAndProvisionedTables(assayService, expProtocols);
 
             for (ExperimentListener listener : _listeners)
             {
@@ -4638,16 +4638,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             assayService.deindexAssays(Collections.unmodifiableCollection(expProtocols));
     }
 
-
-    private static void _lockProvisionedTables(AssayService assayService, List<ExpProtocolImpl> expProtocols)
+    private static void _lockDomainsAndProvisionedTables(AssayService assayService, List<ExpProtocolImpl> expProtocols)
     {
         if (null == assayService)
             return;
         DbSchema expSchema = ExperimentService.get().getSchema();
-        if (!expSchema.getSqlDialect().isPostgreSQL())
-            return;
-
-        SQLFragment lockSQL = new SQLFragment();
         for (var expProtocol : expProtocols)
         {
             AssayProvider provider = assayService.getProvider(expProtocol);
@@ -4655,16 +4650,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             {
                 for (var domain : provider.getDomains(expProtocol))
                 {
-                    // CONSIDER verify table exists: SELECT 1 FROM pg_tables WHERE schemaname = ? AND tablename = ?
-                    if (null != domain.getStorageTableName())
-                        lockSQL.append("LOCK TABLE ").appendDottedIdentifiers(domain.getDomainKind().getStorageSchemaName(), domain.getStorageTableName()).append(" IN EXCLUSIVE MODE").appendEOS().append("\n");
+                    domain.lockForDelete(expSchema);
                 }
             }
         }
-        if (!lockSQL.isEmpty())
-            new SqlExecutor(expSchema).execute(lockSQL);
     }
-
 
     private void deleteAllProtocolInputs(Container c, String protocolIdsInClause)
     {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -5463,7 +5463,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             // If we're a batch, delete all the runs too
             if (experiment.getDataObject().getBatchProtocolId() != null)
             {
-                ExperimentServiceImpl.get().deleteExperimentRuns(c, user, null, experiment.getRuns());
+                for (ExpRunImpl expRun : experiment.getRuns())
+                {
+                    expRun.delete(user);
+                }
             }
 
             SqlExecutor executor = new SqlExecutor(getExpSchema());

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -415,6 +415,7 @@ public class DomainImpl implements Domain
         // NOTE code relies on the lock returned from Domain.getLock() does not require unlock().
         var lock = getDatabaseLock();
         assert lock instanceof DbScope.ServerLock;
+        assert ExperimentService.get().getSchema().getScope().isTransactionActive();
         lock.lock();
 
         // CONSIDER verify table exists: SELECT 1 FROM pg_tables WHERE schemaname = ? AND tablename = ?

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -374,13 +374,14 @@ public class DomainImpl implements Domain
     {
         delete(user, null);
     }
+
     @Override
     public void delete(@Nullable User user, @Nullable String auditUserComment) throws DomainNotFoundException
     {
         ExperimentService exp = ExperimentService.get();
-        Lock domainLock = getLock(_dd);
-        try (DbScope.Transaction transaction = exp.getSchema().getScope().ensureTransaction(domainLock))
+        try (DbScope.Transaction transaction = exp.getSchema().getScope().ensureTransaction())
         {
+            lockForDelete(exp.getSchema());
             DefaultValueService.get().clearDefaultValues(getContainer(), this);
             OntologyManager.deleteDomain(getTypeURI(), getContainer());
             StorageProvisioner.get().drop(this);
@@ -406,6 +407,22 @@ public class DomainImpl implements Domain
     public Lock getDatabaseLock()
     {
         return getLock(_dd);
+    }
+
+    @Override
+    public void lockForDelete(DbSchema expSchema)
+    {
+        // NOTE code relies on the lock returned from Domain.getLock() does not require unlock().
+        var lock = getDatabaseLock();
+        assert lock instanceof DbScope.ServerLock;
+        lock.lock();
+
+        // CONSIDER verify table exists: SELECT 1 FROM pg_tables WHERE schemaname = ? AND tablename = ?
+        if (null != getStorageTableName() && expSchema.getSqlDialect().isPostgreSQL())
+        {
+            SQLFragment lockSQL = new SQLFragment().append("LOCK TABLE ").appendDottedIdentifiers(getDomainKind().getStorageSchemaName(), getStorageTableName()).append(" IN EXCLUSIVE MODE").appendEOS().append("\n");
+            new SqlExecutor(expSchema).execute(lockSQL);
+        }
     }
 
     static Lock getLock(DomainDescriptor dd)


### PR DESCRIPTION
#### Rationale
I've seen deadlocks where runs are being deleted at the same time as the protocol/assay is being deleted.  One good approach is to grab locks as soon as possible in the transaction.  I think this will help.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
