### PR TITLE
Issue 53254: Multi-value lookups should reselect values in form

### DIFF
--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -600,12 +600,22 @@ public class DataColumn extends DisplayColumn
 
     protected boolean isSelectInputSelected(String entryName, Object value, String valueStr)
     {
-        if (value instanceof Collection)
+        if (entryName == null)
+            return false;
+
+        if (value instanceof Collection<?> collection)
         {
-            // CONSIDER: stringify values in collection?
-            return ((Collection)value).contains(entryName);
+            // Issue 53254: Multi-value lookups should reselect values in form
+            for (var item : collection)
+            {
+                if (item != null && entryName.equals(item.toString()))
+                    return true;
+            }
+
+            return false;
         }
-        return null != entryName && entryName.equals(valueStr);
+
+        return entryName.equals(valueStr);
     }
 
     protected String getSelectInputDisplayValue(NamedObject entry)


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53254](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53254) by comparing against a collection of values that may contain non-string values.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6776
- https://github.com/LabKey/limsModules/pull/1479
- https://github.com/LabKey/testAutomation/pull/2505

#### Changes
- Compare values as strings when determining selected values for a multi-value select `DataColumn`.
