### PR TITLE
Option to expose read-only specimen data without the module

### DIFF
--- a/specimen/src/org/labkey/specimen/SpecimenManager.java
+++ b/specimen/src/org/labkey/specimen/SpecimenManager.java
@@ -28,6 +28,7 @@ import org.labkey.api.specimen.Vial;
 import org.labkey.api.specimen.location.LocationImpl;
 import org.labkey.api.specimen.location.LocationManager;
 import org.labkey.api.specimen.model.SpecimenComment;
+import org.labkey.api.specimen.model.SpecimenTablesProvider;
 import org.labkey.specimen.model.SpecimenTypeSummary;
 import org.labkey.specimen.model.SpecimenTypeSummaryRow;
 import org.labkey.api.study.Cohort;
@@ -73,7 +74,7 @@ public class SpecimenManager
     {
         Study study = StudyService.get().getStudy(container);
         UserSchema schema = SpecimenQuerySchema.get(study, user);
-        TableInfo tinfo = schema.getTable(SpecimenQuerySchema.SIMPLE_SPECIMEN_TABLE_NAME);
+        TableInfo tinfo = schema.getTable(SpecimenTablesProvider.SIMPLE_SPECIMEN_TABLE_NAME);
 
         FieldKey visitKey = FieldKey.fromParts("Visit");
         Map<FieldKey, ColumnInfo> colMap = QueryService.get().getColumns(tinfo, Collections.singleton(visitKey));
@@ -114,7 +115,7 @@ public class SpecimenManager
     public Set<LocationImpl> getEnrollmentSitesWithRequests(Container container, User user)
     {
         UserSchema schema = SpecimenQuerySchema.get(StudyService.get().getStudy(container), user);
-        TableInfo tableInfoSpecimenDetail = schema.getTable(SpecimenQuerySchema.SPECIMEN_WRAP_TABLE_NAME);
+        TableInfo tableInfoSpecimenDetail = schema.getTable(SpecimenTablesProvider.SPECIMEN_WRAP_TABLE_NAME);
         if (null == tableInfoSpecimenDetail)
             throw new IllegalStateException("SpecimenDetail table not found.");
         String tableInfoAlias = "Specimen";
@@ -143,7 +144,7 @@ public class SpecimenManager
     public Set<LocationImpl> getEnrollmentSitesWithSpecimens(Container container, User user)
     {
         UserSchema schema = SpecimenQuerySchema.get(StudyService.get().getStudy(container), user);
-        TableInfo tableInfoSpecimenDetail = schema.getTable(SpecimenQuerySchema.SPECIMEN_WRAP_TABLE_NAME);
+        TableInfo tableInfoSpecimenDetail = schema.getTable(SpecimenTablesProvider.SPECIMEN_WRAP_TABLE_NAME);
         if (null == tableInfoSpecimenDetail)
             throw new IllegalStateException("SpecimenDetail table not found.");
         String tableInfoAlias = "Specimen";
@@ -517,7 +518,7 @@ public class SpecimenManager
             throw new NotFoundException("No study in container " + container.getPath());
         }
         UserSchema schema = SpecimenQuerySchema.get(study, user);
-        TableInfo specimenTable = schema.getTable(SpecimenQuerySchema.SPECIMEN_WRAP_TABLE_NAME);
+        TableInfo specimenTable = schema.getTable(SpecimenTablesProvider.SPECIMEN_WRAP_TABLE_NAME);
         return new TableSelector(specimenTable, filter, null);
     }
 
@@ -608,13 +609,13 @@ public class SpecimenManager
     public SpecimenTypeSummary getSpecimenTypeSummary(Container container, @NotNull User user)
     {
         UserSchema querySchema = SpecimenQuerySchema.get(StudyService.get().getStudy(container), user);
-        TableInfo tableInfoSpecimenWrap = querySchema.getTable(SpecimenQuerySchema.SPECIMEN_WRAP_TABLE_NAME);
+        TableInfo tableInfoSpecimenWrap = querySchema.getTable(SpecimenTablesProvider.SPECIMEN_WRAP_TABLE_NAME);
         if (null == tableInfoSpecimenWrap)
             throw new IllegalStateException("SpecimenDetail table not found.");
 
-        TableInfo additiveTableInfo = querySchema.getTable(SpecimenQuerySchema.SPECIMEN_ADDITIVE_TABLE_NAME);
-        TableInfo derivativeTableInfo = querySchema.getTable(SpecimenQuerySchema.SPECIMEN_DERIVATIVE_TABLE_NAME);
-        TableInfo primaryTypeTableInfo = querySchema.getTable(SpecimenQuerySchema.SPECIMEN_PRIMARY_TYPE_TABLE_NAME);
+        TableInfo additiveTableInfo = querySchema.getTable(SpecimenTablesProvider.ADDITIVE_TYPE_TABLE_NAME);
+        TableInfo derivativeTableInfo = querySchema.getTable(SpecimenTablesProvider.DERIVATIVE_TYPE_TABLE_NAME);
+        TableInfo primaryTypeTableInfo = querySchema.getTable(SpecimenTablesProvider.PRIMARY_TYPE_TABLE_NAME);
         String tableInfoSelectName = "SpecimenWrap";
 
         // TODO: consider caching

--- a/specimen/src/org/labkey/specimen/SpecimenModule.java
+++ b/specimen/src/org/labkey/specimen/SpecimenModule.java
@@ -48,6 +48,7 @@ import org.labkey.api.specimen.SpecimenMigrationService;
 import org.labkey.api.specimen.SpecimenQuerySchema;
 import org.labkey.api.specimen.SpecimenSchema;
 import org.labkey.api.specimen.SpecimensPage;
+import org.labkey.api.specimen.model.SpecimenTablesProvider;
 import org.labkey.api.study.SpecimenService;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyInternalService;
@@ -274,15 +275,15 @@ public class SpecimenModule extends SpringModule
                             if (settings.isSimple())
                             {
                                 specimenBag.add("simple");
-                                TableInfo simpleSpecimens = schema.getTable(SpecimenQuerySchema.SIMPLE_SPECIMEN_TABLE_NAME);
+                                TableInfo simpleSpecimens = schema.getTable(SpecimenTablesProvider.SIMPLE_SPECIMEN_TABLE_NAME);
                                 specimenBag.add("simpleSpecimens", (int) new TableSelector(simpleSpecimens).getRowCount());
                             }
                             else
                             {
                                 specimenBag.add("advanced");
-                                TableInfo events = schema.getTable(SpecimenQuerySchema.SPECIMEN_EVENT_TABLE_NAME);
-                                TableInfo vials = schema.getTable(SpecimenQuerySchema.SPECIMEN_DETAIL_TABLE_NAME);
-                                TableInfo specimens = schema.getTable(SpecimenQuerySchema.SPECIMEN_SUMMARY_TABLE_NAME);
+                                TableInfo events = schema.getTable(SpecimenTablesProvider.SPECIMEN_EVENT_TABLE_NAME);
+                                TableInfo vials = schema.getTable(SpecimenTablesProvider.SPECIMEN_DETAIL_TABLE_NAME);
+                                TableInfo specimens = schema.getTable(SpecimenTablesProvider.SPECIMEN_SUMMARY_TABLE_NAME);
                                 specimenBag.add("events", (int) new TableSelector(events).getRowCount());
                                 specimenBag.add("vials", (int) new TableSelector(vials).getRowCount());
                                 specimenBag.add("specimens", (int) new TableSelector(specimens).getRowCount());

--- a/specimen/src/org/labkey/specimen/SpecimenRequestManager.java
+++ b/specimen/src/org/labkey/specimen/SpecimenRequestManager.java
@@ -38,6 +38,7 @@ import org.labkey.api.specimen.Vial;
 import org.labkey.api.specimen.importer.RollupHelper;
 import org.labkey.api.specimen.importer.RollupInstance;
 import org.labkey.api.specimen.importer.VialSpecimenRollup;
+import org.labkey.api.specimen.model.SpecimenTablesProvider;
 import org.labkey.api.specimen.security.permissions.RequestSpecimensPermission;
 import org.labkey.api.study.QueryHelper;
 import org.labkey.api.study.QueryHelper.StudyCacheCollections;
@@ -941,7 +942,7 @@ public class SpecimenRequestManager
 
                     // Basic SQL with joins
                     UserSchema schema = SpecimenQuerySchema.get(study, user);
-                    TableInfo tableInfo = schema.getTable(SpecimenQuerySchema.SPECIMEN_WRAP_TABLE_NAME);
+                    TableInfo tableInfo = schema.getTable(SpecimenTablesProvider.SPECIMEN_WRAP_TABLE_NAME);
                     Map<FieldKey, ColumnInfo> columnMap = queryService.getColumns(tableInfo, fieldKeys);
 
                     SQLFragment inner = queryService.getSelectSQL(tableInfo, columnMap.values(), null, null, -1, 0, false);

--- a/specimen/src/org/labkey/specimen/actions/SpecimenController.java
+++ b/specimen/src/org/labkey/specimen/actions/SpecimenController.java
@@ -91,6 +91,7 @@ import org.labkey.api.specimen.Vial;
 import org.labkey.api.specimen.location.LocationImpl;
 import org.labkey.api.specimen.location.LocationManager;
 import org.labkey.api.specimen.model.SpecimenComment;
+import org.labkey.api.specimen.model.SpecimenTablesProvider;
 import org.labkey.api.specimen.security.permissions.EditSpecimenDataPermission;
 import org.labkey.api.specimen.security.permissions.ManageRequestSettingsPermission;
 import org.labkey.api.specimen.security.permissions.RequestSpecimensPermission;
@@ -746,8 +747,8 @@ public class SpecimenController extends SpringActionController
         DataRegion dr = new DataRegion();
         Container container = specimenRequest.getContainer();
         SpecimenQuerySchema querySchema = SpecimenQuerySchema.get(StudyService.get().getStudy(container), getViewContext().getUser());
-        TableInfo table = querySchema.getTable(SpecimenQuerySchema.LOCATION_SPECIMEN_LIST_TABLE_NAME, true);
-        QueryDefinition queryDef = querySchema.getQueryDefForTable(SpecimenQuerySchema.LOCATION_SPECIMEN_LIST_TABLE_NAME);
+        TableInfo table = querySchema.getTable(SpecimenTablesProvider.LOCATION_SPECIMEN_LIST_TABLE_NAME, true);
+        QueryDefinition queryDef = querySchema.getQueryDefForTable(SpecimenTablesProvider.LOCATION_SPECIMEN_LIST_TABLE_NAME);
         CustomView defaultView = QueryService.get().getCustomView(getViewContext().getUser(), container, getViewContext().getUser(), querySchema.getName(), queryDef.getName(), null);
         List<ColumnInfo> columns = queryDef.getColumns(defaultView, table);
         dr.setTable(table);

--- a/specimen/src/org/labkey/specimen/query/SpecimenQueryView.java
+++ b/specimen/src/org/labkey/specimen/query/SpecimenQueryView.java
@@ -50,6 +50,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.specimen.SpecimenQuerySchema;
 import org.labkey.api.specimen.SpecimenSchema;
 import org.labkey.api.specimen.Vial;
+import org.labkey.api.specimen.model.SpecimenTablesProvider;
 import org.labkey.api.specimen.security.permissions.EditSpecimenDataPermission;
 import org.labkey.api.specimen.security.permissions.RequestSpecimensPermission;
 import org.labkey.api.study.CohortFilter;
@@ -720,7 +721,7 @@ public class SpecimenQueryView extends BaseSpecimenQueryView
     public static SQLFragment getBaseRequestedEnrollmentSql(Container container, User user, boolean isCompleteRequestsOnly)
     {
         UserSchema schema = SpecimenQuerySchema.get(StudyService.get().getStudy(container), user);
-        TableInfo tableInfoSpecimenDetail = schema.getTable(SpecimenQuerySchema.SPECIMEN_WRAP_TABLE_NAME);
+        TableInfo tableInfoSpecimenDetail = schema.getTable(SpecimenTablesProvider.SPECIMEN_WRAP_TABLE_NAME);
         if (null == tableInfoSpecimenDetail)
             throw new IllegalStateException("SpecimenDetail table not found.");
         String tableInfoAlias = "Specimen";

--- a/specimen/src/org/labkey/specimen/report/SpecimenReportManager.java
+++ b/specimen/src/org/labkey/specimen/report/SpecimenReportManager.java
@@ -17,6 +17,7 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.specimen.SpecimenQuerySchema;
 import org.labkey.api.specimen.SpecimenSchema;
+import org.labkey.api.specimen.model.SpecimenTablesProvider;
 import org.labkey.api.study.CohortFilter;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.view.ActionURL;
@@ -50,7 +51,7 @@ public class SpecimenReportManager
                                                                    SpecimenTypeLevel level)
     {
         UserSchema schema = SpecimenQuerySchema.get(StudyService.get().getStudy(container), user);
-        TableInfo tinfo = schema.getTable(SpecimenQuerySchema.SPECIMEN_DETAIL_TABLE_NAME);
+        TableInfo tinfo = schema.getTable(SpecimenTablesProvider.SPECIMEN_DETAIL_TABLE_NAME);
 
         Map<String, SpecimenTypeBeanProperty> aliasToTypeProperty = new LinkedHashMap<>();
 

--- a/specimen/src/org/labkey/specimen/writer/SpecimenArchiveWriter.java
+++ b/specimen/src/org/labkey/specimen/writer/SpecimenArchiveWriter.java
@@ -87,17 +87,17 @@ public class SpecimenArchiveWriter extends AbstractSpecimenWriter
         TablesType tablesXml = tablesDoc.addNewTables();
         Map<String, TableInfo> specimenTables = new HashMap<>();
 
-        TableInfo eventTable = tablesProvider.getTableInfoIfExists(SpecimenTablesProvider.SPECIMENEVENT_TABLENAME);
+        TableInfo eventTable = tablesProvider.getTableInfoIfExists(SpecimenTablesProvider.SPECIMEN_EVENT_TABLE_NAME);
         if (eventTable != null)
-            specimenTables.put(SpecimenTablesProvider.SPECIMENEVENT_TABLENAME, eventTable);
+            specimenTables.put(SpecimenTablesProvider.SPECIMEN_EVENT_TABLE_NAME, eventTable);
 
-        TableInfo specimenTable = tablesProvider.getTableInfoIfExists(SpecimenTablesProvider.SPECIMEN_TABLENAME);
+        TableInfo specimenTable = tablesProvider.getTableInfoIfExists(SpecimenTablesProvider.SPECIMEN_TABLE_NAME);
         if (specimenTable != null)
-            specimenTables.put(SpecimenTablesProvider.SPECIMEN_TABLENAME, specimenTable);
+            specimenTables.put(SpecimenTablesProvider.SPECIMEN_TABLE_NAME, specimenTable);
 
-        TableInfo vialTable = tablesProvider.getTableInfoIfExists(SpecimenTablesProvider.VIAL_TABLENAME);
+        TableInfo vialTable = tablesProvider.getTableInfoIfExists(SpecimenTablesProvider.VIAL_TABLE_NAME);
         if (vialTable != null)
-            specimenTables.put(SpecimenTablesProvider.VIAL_TABLENAME, vialTable);
+            specimenTables.put(SpecimenTablesProvider.VIAL_TABLE_NAME, vialTable);
 
         for (Map.Entry<String, TableInfo> entry : specimenTables.entrySet())
         {

--- a/study/api-src/org/labkey/api/specimen/SpecimenManager.java
+++ b/study/api-src/org/labkey/api/specimen/SpecimenManager.java
@@ -30,6 +30,7 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.specimen.model.SpecimenComment;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
@@ -45,6 +46,8 @@ public class SpecimenManager
 {
     private final static SpecimenManager INSTANCE = new SpecimenManager();
 
+    public static final String VIEW_SPECIMEN_TABLES_FLAG = "viewSpecimenTables";
+
     private SpecimenManager()
     {
     }
@@ -58,6 +61,13 @@ public class SpecimenManager
     {
         Module specimenModule = ModuleLoader.getInstance().getModule("Specimen");
         return null != specimenModule && c.getActiveModules().contains(specimenModule);
+    }
+
+    // Include specimen queries in the study schema if the specimen module is active or an admin has chosen to expose
+    // them via an optional feature
+    public boolean areSpecimenTablesViewable(Container c)
+    {
+        return isSpecimenModuleActive(c) || OptionalFeatureService.get().isFeatureEnabled(VIEW_SPECIMEN_TABLES_FLAG);
     }
 
     public int getSpecimenCountForVisit(Visit visit)

--- a/study/api-src/org/labkey/api/specimen/SpecimenMigrationService.java
+++ b/study/api-src/org/labkey/api/specimen/SpecimenMigrationService.java
@@ -25,7 +25,7 @@ import java.util.Set;
 // These should all go away once the migration is complete
 public interface SpecimenMigrationService
 {
-    static SpecimenMigrationService get()
+    static @Nullable SpecimenMigrationService get()
     {
         return ServiceRegistry.get().getService(SpecimenMigrationService.class);
     }

--- a/study/api-src/org/labkey/api/specimen/SpecimenQuerySchema.java
+++ b/study/api-src/org/labkey/api/specimen/SpecimenQuerySchema.java
@@ -13,18 +13,7 @@ import java.util.Set;
 public class SpecimenQuerySchema extends UserSchema
 {
     public static final String SCHEMA_NAME = "Study";
-    public static final String SIMPLE_SPECIMEN_TABLE_NAME = "SimpleSpecimen";
-    public static final String SPECIMEN_DETAIL_TABLE_NAME = "SpecimenDetail";
-    public static final String SPECIMEN_WRAP_TABLE_NAME = "SpecimenWrap";
-    public static final String SPECIMEN_EVENT_TABLE_NAME = "SpecimenEvent";
-    public static final String SPECIMEN_SUMMARY_TABLE_NAME = "SpecimenSummary";
-    public static final String PARTICIPANT_GROUP_COHORT_UNION_TABLE_NAME = "ParticipantGroupCohortUnion";
-    public static final String LOCATION_SPECIMEN_LIST_TABLE_NAME = "LocationSpecimenList";
     public static final String LOCATION_TABLE_NAME = "Location";
-    public static final String SPECIMEN_PRIMARY_TYPE_TABLE_NAME = "SpecimenPrimaryType";
-    public static final String SPECIMEN_DERIVATIVE_TABLE_NAME = "SpecimenDerivative";
-    public static final String SPECIMEN_ADDITIVE_TABLE_NAME = "SpecimenAdditive";
-    public static final String VIAL_TABLE_NAME = "Vial";
 
     private final UserSchema _studySchema;
     private final Study _study;

--- a/study/api-src/org/labkey/api/specimen/SpecimenSchema.java
+++ b/study/api-src/org/labkey/api/specimen/SpecimenSchema.java
@@ -12,6 +12,8 @@ import org.labkey.api.specimen.model.SpecimenTablesProvider;
 import org.labkey.api.study.SpecimenTablesTemplate;
 import org.labkey.api.study.StudyService;
 
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMEN_COMMENTS_TABLE_NAME;
+
 public class SpecimenSchema
 {
     private static final SpecimenSchema INSTANCE = new SpecimenSchema();
@@ -80,7 +82,7 @@ public class SpecimenSchema
 
     public TableInfo getTableInfoSpecimenComment()
     {
-        return getSchema().getTable("SpecimenComment");
+        return getSchema().getTable(SPECIMEN_COMMENTS_TABLE_NAME);
     }
 
     public TableInfo getTableInfoLocation(Container container)
@@ -91,7 +93,7 @@ public class SpecimenSchema
     public TableInfo getTableInfoLocation(Container container, User user)
     {
         SpecimenTablesProvider specimenTablesProvider = new SpecimenTablesProvider(container, user, SPECIMEN_TABLES_TEMPLATE);
-        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.LOCATION_TABLENAME);
+        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.LOCATION_TABLE_NAME);
     }
 
     /*
@@ -122,14 +124,14 @@ public class SpecimenSchema
     public TableInfo getTableInfoVial(Container container, User user)
     {
         SpecimenTablesProvider specimenTablesProvider = new SpecimenTablesProvider(container, user, _specimenTablesTemplate);
-        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.VIAL_TABLENAME);
+        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.VIAL_TABLE_NAME);
     }
 
     @Nullable
     public TableInfo getTableInfoVialIfExists(Container container)
     {
         SpecimenTablesProvider specimenTablesProvider = new SpecimenTablesProvider(container, null, _specimenTablesTemplate);
-        return specimenTablesProvider.getTableInfoIfExists(SpecimenTablesProvider.VIAL_TABLENAME);
+        return specimenTablesProvider.getTableInfoIfExists(SpecimenTablesProvider.VIAL_TABLE_NAME);
     }
 
     @NotNull
@@ -142,14 +144,14 @@ public class SpecimenSchema
     public TableInfo getTableInfoSpecimen(Container container, User user)
     {
         SpecimenTablesProvider specimenTablesProvider = new SpecimenTablesProvider(container, user, _specimenTablesTemplate);
-        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.SPECIMEN_TABLENAME);
+        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.SPECIMEN_TABLE_NAME);
     }
 
     @Nullable
     public TableInfo getTableInfoSpecimenIfExists(Container container)
     {
         SpecimenTablesProvider specimenTablesProvider = new SpecimenTablesProvider(container, null, _specimenTablesTemplate);
-        return specimenTablesProvider.getTableInfoIfExists(SpecimenTablesProvider.SPECIMEN_TABLENAME);
+        return specimenTablesProvider.getTableInfoIfExists(SpecimenTablesProvider.SPECIMEN_TABLE_NAME);
     }
 
     @NotNull
@@ -162,14 +164,14 @@ public class SpecimenSchema
     public TableInfo getTableInfoSpecimenEvent(Container container, User user)
     {
         SpecimenTablesProvider specimenTablesProvider = new SpecimenTablesProvider(container, user, _specimenTablesTemplate);
-        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.SPECIMENEVENT_TABLENAME);
+        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.SPECIMEN_EVENT_TABLE_NAME);
     }
 
     @Nullable
     public TableInfo getTableInfoSpecimenEventIfExists(Container container)
     {
         SpecimenTablesProvider specimenTablesProvider = new SpecimenTablesProvider(container, null, _specimenTablesTemplate);
-        return specimenTablesProvider.getTableInfoIfExists(SpecimenTablesProvider.SPECIMENEVENT_TABLENAME);
+        return specimenTablesProvider.getTableInfoIfExists(SpecimenTablesProvider.SPECIMEN_EVENT_TABLE_NAME);
     }
 
     public TableInfo getTableInfoSpecimenDetail(Container container)
@@ -185,7 +187,7 @@ public class SpecimenSchema
     public TableInfo getTableInfoSpecimenPrimaryType(Container container, User user)
     {
         SpecimenTablesProvider specimenTablesProvider = new SpecimenTablesProvider(container, user, _specimenTablesTemplate);
-        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.PRIMARYTYPE_TABLENAME);
+        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.PRIMARY_TYPE_TABLE_NAME);
     }
 
     public TableInfo getTableInfoSpecimenAdditive(Container container)
@@ -196,7 +198,7 @@ public class SpecimenSchema
     public TableInfo getTableInfoSpecimenAdditive(Container container, User user)
     {
         SpecimenTablesProvider specimenTablesProvider = new SpecimenTablesProvider(container, user, _specimenTablesTemplate);
-        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.ADDITIVETYPE_TABLENAME);
+        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.ADDITIVE_TYPE_TABLE_NAME);
     }
 
     public TableInfo getTableInfoSpecimenDerivative(Container container)
@@ -207,7 +209,7 @@ public class SpecimenSchema
     public TableInfo getTableInfoSpecimenDerivative(Container container, User user)
     {
         SpecimenTablesProvider specimenTablesProvider = new SpecimenTablesProvider(container, user, _specimenTablesTemplate);
-        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.DERIVATIVETYPE_TABLENAME);
+        return specimenTablesProvider.createTableInfo(SpecimenTablesProvider.DERIVATIVE_TYPE_TABLE_NAME);
     }
 
     // The tables below are managed by study, not by specimen, but lots of specimen code interacts with them

--- a/study/api-src/org/labkey/api/specimen/model/SpecimenTablesProvider.java
+++ b/study/api-src/org/labkey/api/specimen/model/SpecimenTablesProvider.java
@@ -40,16 +40,23 @@ public class SpecimenTablesProvider
 {
     public static final String SCHEMA_NAME = "specimentables";
 
-    public static final String SPECIMEN_TABLENAME = "Specimen";
-    public static final String VIAL_TABLENAME = "Vial";
-    public static final String SPECIMENEVENT_TABLENAME = "SpecimenEvent";
-    public static final String LOCATION_TABLENAME = "Site";
-    public static final String PRIMARYTYPE_TABLENAME = "SpecimenPrimaryType";
-    public static final String DERIVATIVETYPE_TABLENAME = "SpecimenDerivative";
-    public static final String ADDITIVETYPE_TABLENAME = "SpecimenAdditive";
-    public static final String SPECIMENVIALCOUNT_TABLENAME = "SpecimenVialCount";
-    public static final String SPECIMENREQUEST_TABLENAME = "SpecimenRequest";
-    public static final String VIALREQUEST_TABLENAME = "VialRequest";
+    public static final String SPECIMEN_TABLE_NAME = "Specimen";
+    public static final String VIAL_TABLE_NAME = "Vial";
+    public static final String SPECIMEN_EVENT_TABLE_NAME = "SpecimenEvent";
+    public static final String SIMPLE_SPECIMEN_TABLE_NAME = "SimpleSpecimen";
+    public static final String SPECIMEN_DETAIL_TABLE_NAME = "SpecimenDetail";
+    public static final String LOCATION_TABLE_NAME = "Site";
+    public static final String PRIMARY_TYPE_TABLE_NAME = "SpecimenPrimaryType";
+    public static final String DERIVATIVE_TYPE_TABLE_NAME = "SpecimenDerivative";
+    public static final String ADDITIVE_TYPE_TABLE_NAME = "SpecimenAdditive";
+    public static final String SPECIMEN_COMMENTS_TABLE_NAME = "SpecimenComment";
+    public static final String SPECIMEN_VIAL_COUNT_TABLE_NAME = "SpecimenVialCount";
+    public static final String SPECIMEN_REQUEST_TABLE_NAME = "SpecimenRequest";
+    public static final String SPECIMEN_REQUEST_STATUSES_TABLE_NAME = "SpecimenRequestStatus";
+    public static final String VIAL_REQUEST_TABLE_NAME = "VialRequest";
+    public static final String SPECIMEN_SUMMARY_TABLE_NAME = "SpecimenSummary";
+    public static final String LOCATION_SPECIMEN_LIST_TABLE_NAME = "LocationSpecimenList";
+    public static final String SPECIMEN_WRAP_TABLE_NAME = "SpecimenWrap";
 
     private static final Cache<String, Domain> DOMAIN_CREATION_CACHE = CacheManager.getBlockingStringKeyCache(1000, CacheManager.HOUR, "Specimen domain creation", null);
 
@@ -71,11 +78,11 @@ public class SpecimenTablesProvider
         _template = template;
 
         // Vial depends on Specimen
-        String specimenDomainURI = getDomainKind(SPECIMEN_TABLENAME).generateDomainURI(SCHEMA_NAME, SPECIMEN_TABLENAME, _container, _user);
+        String specimenDomainURI = getDomainKind(SPECIMEN_TABLE_NAME).generateDomainURI(SCHEMA_NAME, SPECIMEN_TABLE_NAME, _container, _user);
         _vialDomainKind = new VialDomainKind(specimenDomainURI);
 
         // SpecimenEvent depends on Vial
-        String vialDomainURI = getDomainKind(VIAL_TABLENAME).generateDomainURI(SCHEMA_NAME, VIAL_TABLENAME, _container, _user);
+        String vialDomainURI = getDomainKind(VIAL_TABLE_NAME).generateDomainURI(SCHEMA_NAME, VIAL_TABLE_NAME, _container, _user);
         _specimenEventDomainKind =  new SpecimenEventDomainKind(vialDomainURI);
     }
 
@@ -151,8 +158,8 @@ public class SpecimenTablesProvider
 
     public void deleteTables()
     {
-        List<String> tableNames = Arrays.asList(SPECIMENEVENT_TABLENAME, VIAL_TABLENAME, SPECIMEN_TABLENAME, LOCATION_TABLENAME,
-                                                PRIMARYTYPE_TABLENAME, DERIVATIVETYPE_TABLENAME, ADDITIVETYPE_TABLENAME);
+        List<String> tableNames = Arrays.asList(SPECIMEN_EVENT_TABLE_NAME, VIAL_TABLE_NAME, SPECIMEN_TABLE_NAME, LOCATION_TABLE_NAME,
+                                                PRIMARY_TYPE_TABLE_NAME, DERIVATIVE_TYPE_TABLE_NAME, ADDITIVE_TYPE_TABLE_NAME);
         for (String tableName : tableNames)
         {
             try
@@ -173,25 +180,25 @@ public class SpecimenTablesProvider
 
     private AbstractSpecimenDomainKind getDomainKind(String tableName)
     {
-        if (SPECIMEN_TABLENAME.equalsIgnoreCase(tableName))
+        if (SPECIMEN_TABLE_NAME.equalsIgnoreCase(tableName))
             return _specimenDomainKind;
 
-        if (VIAL_TABLENAME.equalsIgnoreCase(tableName))
+        if (VIAL_TABLE_NAME.equalsIgnoreCase(tableName))
             return _vialDomainKind;
 
-        if (SPECIMENEVENT_TABLENAME.equalsIgnoreCase(tableName))
+        if (SPECIMEN_EVENT_TABLE_NAME.equalsIgnoreCase(tableName))
             return _specimenEventDomainKind;
 
-        if (LOCATION_TABLENAME.equalsIgnoreCase(tableName))
+        if (LOCATION_TABLE_NAME.equalsIgnoreCase(tableName))
             return _locationDomainKind;
 
-        if (PRIMARYTYPE_TABLENAME.equalsIgnoreCase(tableName))
+        if (PRIMARY_TYPE_TABLE_NAME.equalsIgnoreCase(tableName))
             return _primaryTypeDomainKind;
 
-        if (DERIVATIVETYPE_TABLENAME.equalsIgnoreCase(tableName))
+        if (DERIVATIVE_TYPE_TABLE_NAME.equalsIgnoreCase(tableName))
             return _derivativeTypeDomainKind;
 
-        if (ADDITIVETYPE_TABLENAME.equalsIgnoreCase(tableName))
+        if (ADDITIVE_TYPE_TABLE_NAME.equalsIgnoreCase(tableName))
             return _additiveTypeDomainKind;
 
         throw new IllegalStateException("Unknown domain kind: " + tableName);

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -66,6 +66,9 @@ import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.settings.AdminConsole;
+import org.labkey.api.settings.AdminConsole.OptionalFeatureFlag;
+import org.labkey.api.settings.OptionalFeatureService;
+import org.labkey.api.specimen.SpecimenManager;
 import org.labkey.api.specimen.SpecimenSampleTypeDomainKind;
 import org.labkey.api.specimen.model.AdditiveTypeDomainKind;
 import org.labkey.api.specimen.model.DerivativeTypeDomainKind;
@@ -405,6 +408,15 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
             "Allow query based dataset snapshots",
             "Allow unprovisioned, query-based dataset snapshots to be created.",
             false);
+
+        if (SpecimenService.get() == null)
+        {
+            AdminConsole.addOptionalFeatureFlag(new OptionalFeatureFlag(SpecimenManager.VIEW_SPECIMEN_TABLES_FLAG,
+                "Show read-only specimen tables in the study schema",
+                "Provides a read-only view of specimen data when the specimen module is not present.",
+                false, false, OptionalFeatureService.FeatureType.Optional
+            ));
+        }
 
         ReportAndDatasetChangeDigestProvider.get().addNotificationInfoProvider(new DatasetNotificationInfoProvider());
 

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -80,6 +80,7 @@ import org.labkey.api.security.permissions.RestrictedUpdatePermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.settings.OptionalFeatureService;
+import org.labkey.api.specimen.model.SpecimenTablesProvider;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.DatasetTable;
 import org.labkey.api.study.DataspaceContainerFilter;
@@ -367,7 +368,7 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
                         @Override
                         public TableInfo getLookupTableInfo()
                         {
-                            TableInfo table = _userSchema.getTable(StudyQuerySchema.SPECIMEN_DETAIL_TABLE_NAME, null, true, true);
+                            TableInfo table = _userSchema.getTable(SpecimenTablesProvider.SPECIMEN_DETAIL_TABLE_NAME, null, true, true);
                             if (table instanceof SpecimenDetailTable)       // Could be a UnionTable, which should already have right containers
                                 ((SpecimenDetailTable)table).addCondition(new SimpleFilter(FieldKey.fromParts("Container"), _userSchema.getContainer().getId()));
                             return table;

--- a/study/src/org/labkey/study/query/SpecimenDetailTable.java
+++ b/study/src/org/labkey/study/query/SpecimenDetailTable.java
@@ -94,7 +94,8 @@ public class SpecimenDetailTable extends AbstractSpecimenTable
 
         addSpecimenCommentColumns(_userSchema, true);
 
-        boolean enableSpecimenRequest = SpecimenMigrationService.get().isEnableRequests(getContainer());
+        SpecimenMigrationService sms = SpecimenMigrationService.get();
+        boolean enableSpecimenRequest = sms != null && sms.isEnableRequests(getContainer());
         addWrapColumn(_rootTable.getColumn("LockedInRequest")).setHidden(!enableSpecimenRequest);
         addWrapColumn(_rootTable.getColumn("Requestable")).setHidden(!enableSpecimenRequest);
 

--- a/study/src/org/labkey/study/query/SpecimenRequestStatusTable.java
+++ b/study/src/org/labkey/study/query/SpecimenRequestStatusTable.java
@@ -19,18 +19,14 @@ package org.labkey.study.query;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.specimen.SpecimenSchema;
+import org.labkey.api.specimen.model.SpecimenTablesProvider;
 
-/**
- * User: brittp
- * Date: Apr 20, 2007
- * Time: 3:18:58 PM
- */
 public class SpecimenRequestStatusTable extends BaseStudyTable
 {
     public SpecimenRequestStatusTable(StudyQuerySchema schema, ContainerFilter cf)
     {
         super(schema, SpecimenSchema.get().getTableInfoSampleRequestStatus(), cf);
-        setName("SpecimenRequestStatus");
+        setName(SpecimenTablesProvider.SPECIMEN_REQUEST_STATUSES_TABLE_NAME);
         for (ColumnInfo baseColumn : _rootTable.getColumns())
         {
             String name = baseColumn.getName();

--- a/study/src/org/labkey/study/query/SpecimenRequestTable.java
+++ b/study/src/org/labkey/study/query/SpecimenRequestTable.java
@@ -26,19 +26,14 @@ import org.labkey.api.specimen.SpecimenSchema;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMENREQUEST_TABLENAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMEN_REQUEST_TABLE_NAME;
 
-/**
- * User: brittp
- * Date: Apr 20, 2007
- * Time: 2:55:18 PM
- */
 public class SpecimenRequestTable extends BaseStudyTable
 {
     public SpecimenRequestTable(StudyQuerySchema schema, ContainerFilter cf)
     {
         super(schema, SpecimenSchema.get().getTableInfoSampleRequest(), cf);
-        setName(SPECIMENREQUEST_TABLENAME);
+        setName(SPECIMEN_REQUEST_TABLE_NAME);
 
         AliasedColumn rowIdColumn = new AliasedColumn(this, "RequestId", _rootTable.getColumn("RowId"));
         rowIdColumn.setKeyField(true);

--- a/study/src/org/labkey/study/query/SpecimenSchema.java
+++ b/study/src/org/labkey/study/query/SpecimenSchema.java
@@ -2,15 +2,11 @@ package org.labkey.study.query;
 
 import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.SchemaKey;
-import org.labkey.api.specimen.SpecimenMigrationService;
 import org.labkey.api.study.StudyService;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
-
-import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMENVIALCOUNT_TABLENAME;
-import static org.labkey.api.specimen.model.SpecimenTablesProvider.VIALREQUEST_TABLENAME;
 
 class SpecimenSchema extends StudyQuerySchema
 {
@@ -49,24 +45,7 @@ class SpecimenSchema extends StudyQuerySchema
                     throw new IllegalStateException("No StudyService!");
 
                 names.add(LOCATION_TABLE_NAME);
-                names.add(SPECIMEN_EVENT_TABLE_NAME);
-                names.add(SPECIMEN_DETAIL_TABLE_NAME);
-                names.add(SPECIMEN_SUMMARY_TABLE_NAME);
-                names.add(SPECIMENVIALCOUNT_TABLENAME);
-                names.add(SIMPLE_SPECIMEN_TABLE_NAME);
-                names.add("SpecimenRequest");
-                names.add("SpecimenRequestStatus");
-                names.add(VIALREQUEST_TABLENAME);
-                names.add(SPECIMEN_ADDITIVE_TABLE_NAME);
-                names.add(SPECIMEN_DERIVATIVE_TABLE_NAME);
-                names.add(SPECIMEN_PRIMARY_TYPE_TABLE_NAME);
-                names.add("SpecimenComment");
-
-                // CONSIDER: show under queries instead of tables?
-                // specimen report pivots
-                SpecimenMigrationService.get().addSpecimenPivotTableNames(names);
-
-                names.add(LOCATION_SPECIMEN_LIST_TABLE_NAME);
+                addSpecimenTables(names);
             }
             _tableNames = Collections.unmodifiableSet(names);
         }

--- a/study/src/org/labkey/study/query/SpecimenSummaryTable.java
+++ b/study/src/org/labkey/study/query/SpecimenSummaryTable.java
@@ -54,23 +54,23 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import static org.labkey.study.query.StudyQuerySchema.SPECIMEN_SUMMARY_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMEN_SUMMARY_TABLE_NAME;
 
 public class SpecimenSummaryTable extends BaseStudyTable
 {
-    final ColumnInfo _participantidColumn;
-    final ColumnInfo _sequencenumColumn;
-    final BaseColumnInfo _participantSequenceNumColumn;
+    private final ColumnInfo _participantIdColumn;
+    private final ColumnInfo _sequenceNumColumn;
+    private final BaseColumnInfo _participantSequenceNumColumn;
 
     public SpecimenSummaryTable(StudyQuerySchema schema, ContainerFilter cf)
     {
         super(schema, SpecimenSchema.get().getTableInfoSpecimen(schema.getContainer()), cf,true);
         setName(SPECIMEN_SUMMARY_TABLE_NAME);
 
-        _participantidColumn = addWrapParticipantColumn("PTID");
+        _participantIdColumn = addWrapParticipantColumn("PTID");
         addContainerColumn(true);
 
-        _sequencenumColumn = addSpecimenVisitColumn(_userSchema.getStudy().getTimepointType(), true);
+        _sequenceNumColumn = addSpecimenVisitColumn(_userSchema.getStudy().getTimepointType(), true);
 
         _participantSequenceNumColumn = new AliasedColumn(this, StudyService.get().getSubjectVisitColumnName(schema.getContainer()),
                 _rootTable.getColumn("ParticipantSequenceNum"));
@@ -85,7 +85,8 @@ public class SpecimenSummaryTable extends BaseStudyTable
         _participantSequenceNumColumn.setIsUnselectable(true);
         addColumn(_participantSequenceNumColumn);
 
-        boolean enableSpecimenRequest = SpecimenMigrationService.get().isEnableRequests(getContainer());
+        SpecimenMigrationService sms = SpecimenMigrationService.get();
+        boolean enableSpecimenRequest = sms != null && sms.isEnableRequests(getContainer());
         addWrapColumn(_rootTable.getColumn("TotalVolume"));
         addWrapColumn(_rootTable.getColumn("AvailableVolume")).setHidden(!enableSpecimenRequest);
         addWrapColumn(_rootTable.getColumn("VolumeUnits"));
@@ -112,9 +113,9 @@ public class SpecimenSummaryTable extends BaseStudyTable
         addWrapColumn(_rootTable.getColumn("ProtocolNumber"));
         addWrapColumn(_rootTable.getColumn("SpecimenHash")).setHidden(true);
 
-        // Create an ExprColumn to get the max *possible* comments for each specimen.  It's only the possible number
+        // Create an ExprColumn to get the max *possible* comments for each specimen. It's only the possible number
         // (rather than the actual number), because a specimennumber isn't sufficient to identify a row in the specimen
-        // summary table; derivative and additive types are required as well.  We use this number so we know if additional
+        // summary table; derivative and additive types are required as well. We use this number so we know if additional
         // (more expensive) queries are required to check for actual comments in the DB for each row.
         SQLFragment sqlFragComments = new SQLFragment("(SELECT CAST(COUNT(*) AS VARCHAR(5)) FROM " +
                 SpecimenSchema.get().getTableInfoSpecimenComment() +
@@ -162,10 +163,10 @@ public class SpecimenSummaryTable extends BaseStudyTable
     {
         name = name.toLowerCase();
         if (name.equals("participantid") || name.equals("ptid") || name.equals(StudyService.get().getSubjectColumnName(_userSchema.getContainer()).toLowerCase()))
-            return _participantidColumn;
+            return _participantIdColumn;
 
         if (name.equals("sequencenum") || name.equals(StudyService.get().getSubjectVisitColumnName(_userSchema.getContainer()).toLowerCase()))
-            return _sequencenumColumn;
+            return _sequenceNumColumn;
 
         // Resolve 'ParticipantSequenceKey' to 'ParticipantSequenceNum' for compatibility with versions <12.2.
         if (name.equals("participantvisit") || name.equals("participantsequencekey"))

--- a/study/src/org/labkey/study/query/SpecimenVialCountTable.java
+++ b/study/src/org/labkey/study/query/SpecimenVialCountTable.java
@@ -25,12 +25,8 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.specimen.SpecimenMigrationService;
 import org.labkey.api.specimen.SpecimenSchema;
 
-import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMENVIALCOUNT_TABLENAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMEN_VIAL_COUNT_TABLE_NAME;
 
-/**
- * User: klum
- * Date: Jun 2, 2009
- */
 public class SpecimenVialCountTable extends BaseStudyTable
 {
     public SpecimenVialCountTable(StudyQuerySchema schema, ContainerFilter cf)
@@ -50,7 +46,7 @@ public class SpecimenVialCountTable extends BaseStudyTable
         addColumn(new AliasedColumn(this, "ExpectedAvailable", _rootTable.getColumn("ExpectedAvailableCount"))).setHidden(!enableSpecimenRequest);
 */
         super(schema, SpecimenSchema.get().getTableInfoVial(schema.getContainer()), cf);
-        setName(SPECIMENVIALCOUNT_TABLENAME);
+        setName(SPECIMEN_VIAL_COUNT_TABLE_NAME);
         setTitle("VialCounts");
 
         addContainerColumn(true).setHidden(true);
@@ -58,7 +54,8 @@ public class SpecimenVialCountTable extends BaseStudyTable
 
         addColumn(new ExprColumn(this, "TotalCount", new SQLFragment(ExprColumn.STR_TABLE_ALIAS + "." + "VialCount"), JdbcType.INTEGER));
 
-        boolean enableSpecimenRequest = SpecimenMigrationService.get().isEnableRequests(getContainer());
+        SpecimenMigrationService sms = SpecimenMigrationService.get();
+        boolean enableSpecimenRequest = sms != null && sms.isEnableRequests(getContainer());
 
         addColumn(new ExprColumn(this, "LockedInRequest", new SQLFragment(ExprColumn.STR_TABLE_ALIAS + "." + "LockedInRequestCount"), JdbcType.INTEGER)).setHidden(!enableSpecimenRequest);
         addColumn(new ExprColumn(this, "AtRepository", new SQLFragment(ExprColumn.STR_TABLE_ALIAS + "." + "AtRepositoryCount"), JdbcType.INTEGER));

--- a/study/src/org/labkey/study/query/StudyQuerySchema.java
+++ b/study/src/org/labkey/study/query/StudyQuerySchema.java
@@ -48,7 +48,6 @@ import org.labkey.api.specimen.SpecimenManager;
 import org.labkey.api.specimen.SpecimenMigrationService;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.DatasetTable;
-import org.labkey.api.study.SpecimenService;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.TimepointType;
@@ -89,9 +88,21 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMENREQUEST_TABLENAME;
-import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMENVIALCOUNT_TABLENAME;
-import static org.labkey.api.specimen.model.SpecimenTablesProvider.VIALREQUEST_TABLENAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.ADDITIVE_TYPE_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.DERIVATIVE_TYPE_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.LOCATION_SPECIMEN_LIST_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.PRIMARY_TYPE_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SIMPLE_SPECIMEN_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMEN_COMMENTS_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMEN_DETAIL_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMEN_EVENT_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMEN_REQUEST_STATUSES_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMEN_REQUEST_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMEN_SUMMARY_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMEN_VIAL_COUNT_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.SPECIMEN_WRAP_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.VIAL_REQUEST_TABLE_NAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.VIAL_TABLE_NAME;
 
 public class StudyQuerySchema extends UserSchema implements UserSchema.HasContextualRoles
 {
@@ -103,18 +114,8 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
     public static final String SPECIMENS_SCHEMA_NAME = "Specimens";
 
     public static final String SCHEMA_DESCRIPTION = "Contains all data related to the study, including subjects, cohorts, visits, datasets, specimens, etc.";
-    public static final String SIMPLE_SPECIMEN_TABLE_NAME = "SimpleSpecimen";
-    public static final String SPECIMEN_DETAIL_TABLE_NAME = "SpecimenDetail";
-    public static final String SPECIMEN_WRAP_TABLE_NAME = "SpecimenWrap";
-    public static final String SPECIMEN_EVENT_TABLE_NAME = "SpecimenEvent";
-    public static final String SPECIMEN_SUMMARY_TABLE_NAME = "SpecimenSummary";
     public static final String PARTICIPANT_GROUP_COHORT_UNION_TABLE_NAME = "ParticipantGroupCohortUnion";
-    public static final String LOCATION_SPECIMEN_LIST_TABLE_NAME = "LocationSpecimenList";
     public static final String LOCATION_TABLE_NAME = "Location";
-    public static final String SPECIMEN_PRIMARY_TYPE_TABLE_NAME = "SpecimenPrimaryType";
-    public static final String SPECIMEN_DERIVATIVE_TABLE_NAME = "SpecimenDerivative";
-    public static final String SPECIMEN_ADDITIVE_TABLE_NAME = "SpecimenAdditive";
-    public static final String VIAL_TABLE_NAME = "Vial";
 
     public static final String STUDY_TABLE_NAME = "Study";
     public static final String PROPERTIES_TABLE_NAME = "StudyProperties";
@@ -215,7 +216,7 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
         if (!AppProps.getInstance().isOptionalFeatureEnabled(EXPERIMENTAL_STUDY_SUBSCHEMAS))
             return Set.of();
         var ret = new LinkedHashSet<>(Arrays.asList(DATASETS_SCHEMA_NAME, DESIGN_SCHEMA_NAME));
-        if (null != SpecimenService.get() && SpecimenManager.get().isSpecimenModuleActive(getContainer()))
+        if (SpecimenManager.get().areSpecimenTablesViewable(getContainer()))
             ret.add(SPECIMENS_SCHEMA_NAME);
         return ret;
     }
@@ -227,7 +228,7 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
             return new DatasetSchema(this);
         if (StringUtils.equalsIgnoreCase(DESIGN_SCHEMA_NAME, name))
             return new DesignSchema(this);
-        if (StringUtils.equalsIgnoreCase(SPECIMENS_SCHEMA_NAME,name) && SpecimenManager.get().isSpecimenModuleActive(getContainer()))
+        if (StringUtils.equalsIgnoreCase(SPECIMENS_SCHEMA_NAME, name) && SpecimenManager.get().areSpecimenTablesViewable(getContainer()))
             return new SpecimenSchema(this);
         return super.getSchema(name);
     }
@@ -290,26 +291,7 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
                     names.add(VISIT_ALIASES);
                 }
 
-                if (SpecimenManager.get().isSpecimenModuleActive(getContainer()))
-                {
-                    names.add(SPECIMEN_EVENT_TABLE_NAME);
-                    names.add(SPECIMEN_DETAIL_TABLE_NAME);
-                    names.add(SPECIMEN_SUMMARY_TABLE_NAME);
-                    names.add(SPECIMENVIALCOUNT_TABLENAME);
-                    names.add(SIMPLE_SPECIMEN_TABLE_NAME);
-                    names.add(SPECIMENREQUEST_TABLENAME);
-                    names.add("SpecimenRequestStatus");
-                    names.add(VIALREQUEST_TABLENAME);
-                    names.add(SPECIMEN_ADDITIVE_TABLE_NAME);
-                    names.add(SPECIMEN_DERIVATIVE_TABLE_NAME);
-                    names.add(SPECIMEN_PRIMARY_TYPE_TABLE_NAME);
-                    names.add("SpecimenComment");
-
-                    // specimen report pivots
-                    SpecimenMigrationService.get().addSpecimenPivotTableNames(names);
-
-                    names.add(LOCATION_SPECIMEN_LIST_TABLE_NAME);
-                }
+                addSpecimenTables(names);
 
                 names.add(VISIT_MAP_TABLE_NAME);
 
@@ -349,6 +331,32 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
         }
 
         return _tableNames;
+    }
+
+    protected void addSpecimenTables(Set<String> names)
+    {
+        if (SpecimenManager.get().areSpecimenTablesViewable(getContainer()))
+        {
+            names.add(SPECIMEN_EVENT_TABLE_NAME);
+            names.add(SPECIMEN_DETAIL_TABLE_NAME);
+            names.add(SPECIMEN_SUMMARY_TABLE_NAME);
+            names.add(SPECIMEN_VIAL_COUNT_TABLE_NAME);
+            names.add(SIMPLE_SPECIMEN_TABLE_NAME);
+            names.add(SPECIMEN_REQUEST_TABLE_NAME);
+            names.add(SPECIMEN_REQUEST_STATUSES_TABLE_NAME);
+            names.add(VIAL_REQUEST_TABLE_NAME);
+            names.add(ADDITIVE_TYPE_TABLE_NAME);
+            names.add(DERIVATIVE_TYPE_TABLE_NAME);
+            names.add(PRIMARY_TYPE_TABLE_NAME);
+            names.add(SPECIMEN_COMMENTS_TABLE_NAME);
+
+            // specimen report pivots
+            SpecimenMigrationService sms = SpecimenMigrationService.get();
+            if (sms != null)
+                sms.addSpecimenPivotTableNames(names);
+
+            names.add(LOCATION_SPECIMEN_LIST_TABLE_NAME);
+        }
     }
 
     public Map<String, DatasetDefinition> getDatasetDefinitions()
@@ -537,7 +545,7 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
 
             return new SpecimenWrapTable(this, cf);
         }
-        if (SPECIMENVIALCOUNT_TABLENAME.equalsIgnoreCase(name))
+        if (SPECIMEN_VIAL_COUNT_TABLE_NAME.equalsIgnoreCase(name))
         {
             return new SpecimenVialCountTable(this, cf);
         }
@@ -551,11 +559,11 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
         {
             return new ParticipantVisitTable(this, cf, false);
         }
-        if (SPECIMENREQUEST_TABLENAME.equalsIgnoreCase(name))
+        if (SPECIMEN_REQUEST_TABLE_NAME.equalsIgnoreCase(name))
         {
             return new SpecimenRequestTable(this, cf);
         }
-        if ("SpecimenRequestStatus".equalsIgnoreCase(name))
+        if (SPECIMEN_REQUEST_STATUSES_TABLE_NAME.equalsIgnoreCase(name))
         {
             return new SpecimenRequestStatusTable(this, cf);
         }
@@ -580,32 +588,32 @@ public class StudyQuerySchema extends UserSchema implements UserSchema.HasContex
             // Moved to core but kept here for backwards compatibility
             return new QCStateTable(this, cf);
         }
-        if (SPECIMEN_ADDITIVE_TABLE_NAME.equalsIgnoreCase(name))
+        if (ADDITIVE_TYPE_TABLE_NAME.equalsIgnoreCase(name))
         {
             if (getContainer().isRoot())
                 return null;
 
             return new AdditiveTypeTable(this, cf);
         }
-        if (SPECIMEN_DERIVATIVE_TABLE_NAME.equalsIgnoreCase(name))
+        if (DERIVATIVE_TYPE_TABLE_NAME.equalsIgnoreCase(name))
         {
             if (getContainer().isRoot())
                 return null;
 
             return new DerivativeTypeTable(this, cf);
         }
-        if (SPECIMEN_PRIMARY_TYPE_TABLE_NAME.equalsIgnoreCase(name))
+        if (PRIMARY_TYPE_TABLE_NAME.equalsIgnoreCase(name))
         {
             if (getContainer().isRoot())
                 return null;
 
             return new PrimaryTypeTable(this, cf);
         }
-        if ("SpecimenComment".equalsIgnoreCase(name))
+        if (SPECIMEN_COMMENTS_TABLE_NAME.equalsIgnoreCase(name))
         {
             return new SpecimenCommentTable(this, cf);
         }
-        if (VIALREQUEST_TABLENAME.equalsIgnoreCase(name))
+        if (VIAL_REQUEST_TABLE_NAME.equalsIgnoreCase(name))
         {
             return new VialRequestTable(this, cf);
         }

--- a/study/src/org/labkey/study/query/VialRequestTable.java
+++ b/study/src/org/labkey/study/query/VialRequestTable.java
@@ -26,18 +26,14 @@ import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.specimen.SpecimenSchema;
 
-import static org.labkey.api.specimen.model.SpecimenTablesProvider.VIALREQUEST_TABLENAME;
+import static org.labkey.api.specimen.model.SpecimenTablesProvider.VIAL_REQUEST_TABLE_NAME;
 
-/**
- * User: brittp
- * Created: July 15, 2008 11:13:43 AM
- */
 public class VialRequestTable extends FilteredTable<StudyQuerySchema>
 {
     public VialRequestTable(final StudyQuerySchema schema, ContainerFilter cf)
     {
         super(SpecimenSchema.get().getTableInfoSampleRequestSpecimen(), schema, cf);
-        setName(VIALREQUEST_TABLENAME);
+        setName(VIAL_REQUEST_TABLE_NAME);
 
         for (ColumnInfo baseColumn : _rootTable.getColumns())
         {

--- a/study/src/org/labkey/study/query/VialTable.java
+++ b/study/src/org/labkey/study/query/VialTable.java
@@ -24,11 +24,8 @@ import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.LookupForeignKey;
 import org.labkey.api.specimen.SpecimenSchema;
+import org.labkey.api.specimen.model.SpecimenTablesProvider;
 
-/**
- * User: jeckels
- * Date: Jun 22, 2009
- */
 public class VialTable extends BaseStudyTable
 {
     public VialTable(final StudyQuerySchema schema, ContainerFilter cf)
@@ -49,7 +46,7 @@ public class VialTable extends BaseStudyTable
             @Override
             public TableInfo getLookupTableInfo()
             {
-                TableInfo tableInfo = schema.getTable(StudyQuerySchema.SIMPLE_SPECIMEN_TABLE_NAME);
+                TableInfo tableInfo = schema.getTable(SpecimenTablesProvider.SIMPLE_SPECIMEN_TABLE_NAME);
                 if (tableInfo instanceof ContainerFilterable)
                 {
                     ((ContainerFilterable) tableInfo).setContainerFilter(ContainerFilter.getUnsafeEverythingFilter());    // TODO: what would this do without provisioned?


### PR DESCRIPTION
#### Rationale
Clients who are migrating from Specimen to Sample Manager would like a read-only view of their specimen data. This provides an optional feature that displays the specimen tables in the study schema in the absence of the specimen module.

Most of the changes simply consolidate the many redundant specimen table name constants to the ones defined in `SpecimenTablesProvider`.