### PR TITLE
Issue 53120: respond with appropriate content-type and status in error response

### DIFF
--- a/api/src/org/labkey/api/action/ApiJsonWriter.java
+++ b/api/src/org/labkey/api/action/ApiJsonWriter.java
@@ -328,11 +328,20 @@ public class ApiJsonWriter extends ApiResponseWriter
     protected void resetOutput() throws IOException
     {
         var context = jg.getOutputContext();
+        var response = getResponse();
 
-        // If the entire response so far is buffered in memory, we get a do over.
-        if (!getResponse().isCommitted())
+        // If the entire response so far is buffered in memory, we get a do-over.
+        if (!response.isCommitted())
         {
-            getResponse().reset();
+            // Retain content-type and character encoding as reset() clears these
+            var contentType = response.getContentType();
+            var characterEncoding = response.getCharacterEncoding();
+
+            response.reset();
+
+            response.setContentType(contentType);
+            response.setCharacterEncoding(characterEncoding);
+
             jg = new JsonFactory().createGenerator(getWriter());
             initGenerator();
             if (state == WriterState.Started)

--- a/api/src/org/labkey/api/action/SpringActionController.java
+++ b/api/src/org/labkey/api/action/SpringActionController.java
@@ -346,6 +346,13 @@ public abstract class SpringActionController implements Controller, HasViewConte
 
        if (jsonResponse)
        {
+           if (!htmlWrappedJson)
+           {
+               // Issue 53120: Set content-type, status when responding with JSON content
+               response.setContentType(ApiJsonWriter.CONTENT_TYPE_JSON);
+               response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+           }
+
            Writer w = response.getWriter();
            JSONObject json = new JSONObject();
            json.put("success", false);

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1-fb-request-53120.0"
+        "@labkey/components": "6.52.1"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2224,9 +2224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1-fb-request-53120.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-fb-request-53120.0.tgz",
-      "integrity": "sha512-44dfPeOnGMICWBdntCcQkFeiUDWpKKS1aDSsPHmvXwQ7yPbekMFSwepGlfkh+04WA4Nurthh9za3XOVLaUV1uQ==",
+      "version": "6.52.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1.tgz",
+      "integrity": "sha512-w6Q/xza95hT8LvxF2IAnDzOsvg49p9YY6ap+TrWoXlP2DwlghvlQm5ncgFOhB45T0dozpZ9GDThpQsuCPVTpcQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.0"
+        "@labkey/components": "6.52.1-fb-request-53120.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2224,9 +2224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.0.tgz",
-      "integrity": "sha512-gH9wQkmD/dQiPCfKYaY1+cNNDGaJ76XwrpR7Yl+n4rI01U3UJyR8vU4a3UpYEMEXn4P+R2tugCsbJoJA3fSMAw==",
+      "version": "6.52.1-fb-request-53120.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-fb-request-53120.0.tgz",
+      "integrity": "sha512-44dfPeOnGMICWBdntCcQkFeiUDWpKKS1aDSsPHmvXwQ7yPbekMFSwepGlfkh+04WA4Nurthh9za3XOVLaUV1uQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.52.0"
+    "@labkey/components": "6.52.1-fb-request-53120.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.52.1-fb-request-53120.0"
+    "@labkey/components": "6.52.1"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.0",
+        "@labkey/components": "6.52.1-fb-request-53120.0",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3325,9 +3325,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.0.tgz",
-      "integrity": "sha512-gH9wQkmD/dQiPCfKYaY1+cNNDGaJ76XwrpR7Yl+n4rI01U3UJyR8vU4a3UpYEMEXn4P+R2tugCsbJoJA3fSMAw==",
+      "version": "6.52.1-fb-request-53120.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-fb-request-53120.0.tgz",
+      "integrity": "sha512-44dfPeOnGMICWBdntCcQkFeiUDWpKKS1aDSsPHmvXwQ7yPbekMFSwepGlfkh+04WA4Nurthh9za3XOVLaUV1uQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1-fb-request-53120.0",
+        "@labkey/components": "6.52.1",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3325,9 +3325,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1-fb-request-53120.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-fb-request-53120.0.tgz",
-      "integrity": "sha512-44dfPeOnGMICWBdntCcQkFeiUDWpKKS1aDSsPHmvXwQ7yPbekMFSwepGlfkh+04WA4Nurthh9za3XOVLaUV1uQ==",
+      "version": "6.52.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1.tgz",
+      "integrity": "sha512-w6Q/xza95hT8LvxF2IAnDzOsvg49p9YY6ap+TrWoXlP2DwlghvlQm5ncgFOhB45T0dozpZ9GDThpQsuCPVTpcQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.52.1-fb-request-53120.0",
+    "@labkey/components": "6.52.1",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.52.0",
+    "@labkey/components": "6.52.1-fb-request-53120.0",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.0"
+        "@labkey/components": "6.52.1-fb-request-53120.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2843,9 +2843,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.0.tgz",
-      "integrity": "sha512-gH9wQkmD/dQiPCfKYaY1+cNNDGaJ76XwrpR7Yl+n4rI01U3UJyR8vU4a3UpYEMEXn4P+R2tugCsbJoJA3fSMAw==",
+      "version": "6.52.1-fb-request-53120.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-fb-request-53120.0.tgz",
+      "integrity": "sha512-44dfPeOnGMICWBdntCcQkFeiUDWpKKS1aDSsPHmvXwQ7yPbekMFSwepGlfkh+04WA4Nurthh9za3XOVLaUV1uQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1-fb-request-53120.0"
+        "@labkey/components": "6.52.1"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2843,9 +2843,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1-fb-request-53120.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-fb-request-53120.0.tgz",
-      "integrity": "sha512-44dfPeOnGMICWBdntCcQkFeiUDWpKKS1aDSsPHmvXwQ7yPbekMFSwepGlfkh+04WA4Nurthh9za3XOVLaUV1uQ==",
+      "version": "6.52.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1.tgz",
+      "integrity": "sha512-w6Q/xza95hT8LvxF2IAnDzOsvg49p9YY6ap+TrWoXlP2DwlghvlQm5ncgFOhB45T0dozpZ9GDThpQsuCPVTpcQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.52.1-fb-request-53120.0"
+    "@labkey/components": "6.52.1"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.52.0"
+    "@labkey/components": "6.52.1-fb-request-53120.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1-fb-request-53120.0"
+        "@labkey/components": "6.52.1"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2665,9 +2665,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1-fb-request-53120.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-fb-request-53120.0.tgz",
-      "integrity": "sha512-44dfPeOnGMICWBdntCcQkFeiUDWpKKS1aDSsPHmvXwQ7yPbekMFSwepGlfkh+04WA4Nurthh9za3XOVLaUV1uQ==",
+      "version": "6.52.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1.tgz",
+      "integrity": "sha512-w6Q/xza95hT8LvxF2IAnDzOsvg49p9YY6ap+TrWoXlP2DwlghvlQm5ncgFOhB45T0dozpZ9GDThpQsuCPVTpcQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.0"
+        "@labkey/components": "6.52.1-fb-request-53120.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2665,9 +2665,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.0.tgz",
-      "integrity": "sha512-gH9wQkmD/dQiPCfKYaY1+cNNDGaJ76XwrpR7Yl+n4rI01U3UJyR8vU4a3UpYEMEXn4P+R2tugCsbJoJA3fSMAw==",
+      "version": "6.52.1-fb-request-53120.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-fb-request-53120.0.tgz",
+      "integrity": "sha512-44dfPeOnGMICWBdntCcQkFeiUDWpKKS1aDSsPHmvXwQ7yPbekMFSwepGlfkh+04WA4Nurthh9za3XOVLaUV1uQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.52.0"
+    "@labkey/components": "6.52.1-fb-request-53120.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.52.1-fb-request-53120.0"
+    "@labkey/components": "6.52.1"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53120](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53120) by setting the appropriate content-type and status code on the response when handling errors generically in `SpringActionController`.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1814
- https://github.com/LabKey/labkey-ui-premium/pull/778
- https://github.com/LabKey/limsModules/pull/1482
- https://github.com/LabKey/platform/pull/6780

#### Changes
- Set content-type and status code of response when responding with JSON in error responses.
