### PR TITLE
Issue 52777: use field key if it already exists

### DIFF
--- a/api/src/org/labkey/api/assay/transform/DataTransformService.java
+++ b/api/src/org/labkey/api/assay/transform/DataTransformService.java
@@ -188,7 +188,7 @@ public class DataTransformService
 
                         context.setTransformResult(result);
                     }
-                    catch (ValidationException e)
+                    catch (ValidationException | RuntimeException e)
                     {
                         throw e;
                     }

--- a/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
@@ -34,7 +34,7 @@ public abstract class AbstractWrappedColumnInfo implements ColumnInfo
         this.delegate = delegate_;
     }
 
-    @Override
+    @Override @NotNull
     public String getName()
     {
         FieldKey fieldKey = getFieldKey();
@@ -55,7 +55,7 @@ public abstract class AbstractWrappedColumnInfo implements ColumnInfo
         return null;
     }
 
-    @Override
+    @Override @NotNull
     public FieldKey getFieldKey()
     {
         return delegate.getFieldKey();
@@ -124,8 +124,10 @@ public abstract class AbstractWrappedColumnInfo implements ColumnInfo
     @Override
     public String getLabel()
     {
-        if (null == getLabelValue() && getFieldKey() != null)
+        if (null == getLabelValue())
+        {
             return ColumnInfo.labelFromName(getFieldKey().getName());
+        }
         return getLabelValue();
     }
 

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -84,6 +84,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     private static final Logger LOG = LogHelper.getLogger(ColumnInfo.class, "BaseColumnInfo logger");
     private static final Set<String> NON_EDITABLE_COL_NAMES = new CaseInsensitiveHashSet("created", "createdBy", "modified", "modifiedBy", "_ts", "entityId", "container");
 
+    @NotNull
     private FieldKey _fieldKey;
     private String _name;
     // _propertyName is computed from getName();
@@ -131,9 +132,9 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     private ColumnLogging _columnLogging;
 
     // Always call this constructor
-    public BaseColumnInfo(FieldKey key, TableInfo parentTable)
+    public BaseColumnInfo(@NotNull FieldKey key, TableInfo parentTable)
     {
-        _fieldKey = key;
+        _fieldKey = Objects.requireNonNull(key);
         _parentTable = parentTable;
 
         // I'd kind of prefer using null here.  But this is currently used to column matching in the column logging code using ColumnLogging.equals()
@@ -142,9 +143,9 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
             _columnLogging = ColumnLogging.defaultLogging(this);
     }
 
-    public BaseColumnInfo(String name, TableInfo parentTable, JdbcType type)
+    public BaseColumnInfo(@NotNull String name, TableInfo parentTable, JdbcType type)
     {
-        this(FieldKey.fromParts(name), parentTable, type);
+        this(FieldKey.fromParts(Objects.requireNonNull(name)), parentTable, type);
     }
 
     public BaseColumnInfo(FieldKey key, TableInfo parentTable, JdbcType type)
@@ -178,25 +179,17 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     @Deprecated // Pass in a type!
     public BaseColumnInfo(String name)
     {
-        this(null != name ? new FieldKey(null, name) : null, (TableInfo)null);
-//        assert -1 == name.indexOf('/');
+        this(name, null, null);
     }
 
     public BaseColumnInfo(String name, JdbcType t)
     {
-        this(null != name ? new FieldKey(null, name) : null, (TableInfo)null);
-        if (null == name)
-            return;
-//        assert -1 == name.indexOf('/');
-        _jdbcType = t;
+        this(name, null, t);
     }
 
     public BaseColumnInfo(String name, JdbcType t, int scale, boolean nullable)
     {
-        this(null != name ? new FieldKey(null, name) : null, t);
-        if (null == name)
-            return;
-//        assert -1 == name.indexOf('/');
+        this(name, null, t);
         setScale(scale);
         setNullable(nullable);
     }
@@ -254,7 +247,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
 
 
     /** use setFieldKey() avoid ambiguity when columns have "/" */
-    public void setName(String name)
+    public void setName(@NotNull String name)
     {
         checkLocked();
         // Disallow changing the name completely -- fixing up the casing is allowed;
@@ -267,10 +260,10 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     }
 
 
-    @Override
+    @Override @NotNull
     public String getName()
     {
-        if (_name == null && _fieldKey != null)
+        if (_name == null)
         {
             if (_fieldKey.getParent() == null)
                 _name = _fieldKey.getName();
@@ -282,16 +275,16 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
 
 
     @Override
-    public void setFieldKey(FieldKey key)
+    public void setFieldKey(@NotNull FieldKey key)
     {
         checkLocked();
-        _fieldKey = key;
+        _fieldKey = Objects.requireNonNull(key);
         _name = null;
         _propertyName = null;
     }
 
 
-    @Override
+    @Override @NotNull
     public FieldKey getFieldKey()
     {
         return _fieldKey;
@@ -727,7 +720,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     @Override
     public String getLabel()
     {
-        if (null == _label && getFieldKey() != null)
+        if (null == _label)
             return labelFromName(getFieldKey().getName());
         return _label;
     }

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -86,7 +86,6 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
 
     @NotNull
     private FieldKey _fieldKey;
-    private String _name;
     // _propertyName is computed from getName();
     private String _propertyName = null;
     private DatabaseIdentifier _alias;
@@ -172,7 +171,6 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     public BaseColumnInfo(FieldKey key, JdbcType t)
     {
         this(key, (TableInfo)null);
-        _name = null;
         _jdbcType = t;
     }
 
@@ -255,7 +253,6 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
         FieldKey newFieldKey = new FieldKey(null, name);
         assert !_lockName || 0 == _fieldKey.compareTo(newFieldKey);
         _fieldKey = newFieldKey;
-        _name = null;
         _propertyName = null;
     }
 
@@ -263,14 +260,10 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     @Override @NotNull
     public String getName()
     {
-        if (_name == null)
-        {
-            if (_fieldKey.getParent() == null)
-                _name = _fieldKey.getName();
-            else
-                _name = _fieldKey.toString();
-        }
-        return _name;
+        if (_fieldKey.getParent() == null)
+            return _fieldKey.getName();
+        else
+            return _fieldKey.toString();
     }
 
 
@@ -279,7 +272,6 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     {
         checkLocked();
         _fieldKey = Objects.requireNonNull(key);
-        _name = null;
         _propertyName = null;
     }
 

--- a/api/src/org/labkey/api/data/ColumnInfo.java
+++ b/api/src/org/labkey/api/data/ColumnInfo.java
@@ -119,9 +119,10 @@ public interface ColumnInfo extends ColumnRenderProperties
         }
     }
 
-    @Override
+    @Override @NotNull
     String getName();
 
+    @NotNull
     FieldKey getFieldKey();
 
     // use only for debugging, will change after call to getAlias()
@@ -393,7 +394,7 @@ public interface ColumnInfo extends ColumnRenderProperties
         return BaseColumnInfo.legalNameFromName(name);
     }
 
-    static String getFriendlyTypeName(Class javaClass)
+    static String getFriendlyTypeName(Class<?> javaClass)
     {
         return ColumnRenderProperties.getFriendlyTypeName(javaClass);
     }

--- a/api/src/org/labkey/api/data/MutableColumnInfo.java
+++ b/api/src/org/labkey/api/data/MutableColumnInfo.java
@@ -16,7 +16,7 @@ import java.util.Set;
 
 public interface MutableColumnInfo extends MutableColumnRenderProperties, ColumnInfo
 {
-    void setFieldKey(FieldKey key);
+    void setFieldKey(@NotNull FieldKey key);
 
     void setAlias(DatabaseIdentifier alias);
 

--- a/api/src/org/labkey/api/data/WrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/WrappedColumnInfo.java
@@ -582,12 +582,12 @@ public class WrappedColumnInfo
         }
 
         @Override
-        public void setFieldKey(FieldKey fieldKey)
+        public void setFieldKey(@NotNull FieldKey fieldKey)
         {
             checkLocked();
             delegate = new AbstractWrappedColumnInfo(delegate)
             {
-                @Override
+                @Override @NotNull
                 public FieldKey getFieldKey()
                 {
                     return fieldKey;

--- a/api/src/org/labkey/api/dataiterator/AbstractMapDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/AbstractMapDataIterator.java
@@ -135,10 +135,20 @@ public abstract class AbstractMapDataIterator extends AbstractDataIterator imple
                     set.addAll(row.keySet());
                 colNames = set;
             }
+            boolean loggedNullWarning = false;
             for (String name : colNames)
             {
                 if (ROWNUMBER_COLUMNNAME.equals(name))
                     continue;
+                if (name == null)
+                {
+                    if (!loggedNullWarning)
+                    {
+                        loggedNullWarning = true;
+                        LOGGER.error("Null column name in data map. Full list of columns: {}", colNames, new NullPointerException());
+                    }
+                    continue;
+                }
                 _cols.add(new BaseColumnInfo(name, JdbcType.OTHER));
             }
             _rows = initRows(rows);

--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -217,8 +217,8 @@ public class DataIteratorUtil
         {
             // Issue 21015: Dataset snapshot over flow assay dataset doesn't pick up stat column values
             // TSVColumnWriter.ColumnHeaderType.queryColumnName format is a FieldKey display value from the column name. Blech.
-            // Issue 52777: If the column already has a fieldKey, use that one instead otherwise we convert $$Date to $$ate using fromString() and toDisplayString()
-            String tsvQueryColumnName = col.getFieldKey() != null ? col.getFieldKey().toDisplayString() : FieldKey.fromString(col.getName()).toDisplayString();
+            // Issue 52777: Use the column's FieldKey - otherwise we convert $$Date to $$ate using fromString() and toDisplayString()
+            String tsvQueryColumnName = col.getFieldKey().toDisplayString();
             targetAliasesMap.put(tsvQueryColumnName, new Pair<>(col, MatchType.tsvColumn));
         }
 
@@ -230,8 +230,8 @@ public class DataIteratorUtil
                     targetAliasesMap.put(alias, new Pair<>(col, MatchType.alias));
 
                 // Be sure we have an alias the column name we generate for TSV exports. See issue 21774
-                // Issue 52777: If the column already has a fieldKey, use that one instead otherwise we convert $$Date to $$ate using fromString() and toDisplayString()
-                String translatedFieldKey = col.getFieldKey() != null ? col.getFieldKey().toDisplayString() : FieldKey.fromString(col.getName()).toDisplayString();
+                // Issue 52777: Use the column's FieldKey - otherwise we convert $$Date to $$ate using fromString() and toDisplayString()
+                String translatedFieldKey = col.getFieldKey().toDisplayString();
                 targetAliasesMap.put(translatedFieldKey, new Pair<>(col, MatchType.alias));
             }
         }

--- a/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorUtil.java
@@ -217,7 +217,8 @@ public class DataIteratorUtil
         {
             // Issue 21015: Dataset snapshot over flow assay dataset doesn't pick up stat column values
             // TSVColumnWriter.ColumnHeaderType.queryColumnName format is a FieldKey display value from the column name. Blech.
-            String tsvQueryColumnName = FieldKey.fromString(col.getName()).toDisplayString();
+            // Issue 52777: If the column already has a fieldKey, use that one instead otherwise we convert $$Date to $$ate using fromString() and toDisplayString()
+            String tsvQueryColumnName = col.getFieldKey() != null ? col.getFieldKey().toDisplayString() : FieldKey.fromString(col.getName()).toDisplayString();
             targetAliasesMap.put(tsvQueryColumnName, new Pair<>(col, MatchType.tsvColumn));
         }
 
@@ -229,7 +230,8 @@ public class DataIteratorUtil
                     targetAliasesMap.put(alias, new Pair<>(col, MatchType.alias));
 
                 // Be sure we have an alias the column name we generate for TSV exports. See issue 21774
-                String translatedFieldKey = FieldKey.fromString(col.getName()).toDisplayString();
+                // Issue 52777: If the column already has a fieldKey, use that one instead otherwise we convert $$Date to $$ate using fromString() and toDisplayString()
+                String translatedFieldKey = col.getFieldKey() != null ? col.getFieldKey().toDisplayString() : FieldKey.fromString(col.getName()).toDisplayString();
                 targetAliasesMap.put(translatedFieldKey, new Pair<>(col, MatchType.alias));
             }
         }

--- a/assay/api-src/org/labkey/api/assay/plate/PlateBasedDataExchangeHandler.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PlateBasedDataExchangeHandler.java
@@ -68,7 +68,12 @@ public class PlateBasedDataExchangeHandler extends TsvDataExchangeHandler
 
                         for (Map.Entry<DomainProperty, String> colEntry : entry.entrySet())
                         {
-                            row.put(colEntry.getKey().getLabel(), colEntry.getValue());
+                            String name = colEntry.getKey().getLabel();
+                            if (name == null)
+                            {
+                                name = colEntry.getKey().getName();
+                            }
+                            row.put(name, colEntry.getValue());
                         }
                         rows.add(row);
                     }

--- a/query/src/org/labkey/query/MetadataTableJSON.java
+++ b/query/src/org/labkey/query/MetadataTableJSON.java
@@ -227,7 +227,7 @@ public class MetadataTableJSON extends GWTDomain<MetadataColumnJSON>
             if (rawColumnInfo == null)
             {
                 isNewColumn = true;
-                rawColumnInfo = new BaseColumnInfo((FieldKey)null, (TableInfo)null);
+                rawColumnInfo = new BaseColumnInfo(FieldKey.fromParts("DummyRawColumn"), (TableInfo)null);
                 // Establish the type of the column
                 if (metadataColumnJSON.getWrappedColumnName() != null)
                 {


### PR DESCRIPTION
#### Rationale
Issue [52777](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52777) - Previous PRs related to this issue addressed the export column name but we are still left with logic that can map a field that should be unrecognizable to a field name with dollar signs.  See the issue for more details.

#### Related Pull Requests
- #6663 
- https://github.com/LabKey/limsModules/pull/1483

#### Changes
- Update `_createTableMap` to use a column's fieldKey to discern the displayString
