### PR TITLE
Don't cache objects that hold Containers

### DIFF
--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -109,11 +109,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-/**
- * User: mbellew
- * Date: Mar 11, 2005
- * Time: 10:08:26 AM
- */
 public class AnnouncementManager
 {
     private static final Logger LOG = LogHelper.getLogger(AnnouncementManager.class, "Announcement handling");
@@ -917,7 +912,7 @@ public class AnnouncementManager
                     SimpleDocumentResource sdr = new SimpleDocumentResource(
                             new Path(docid),
                             docid,
-                            containerId,
+                            c.getEntityId(),
                             "text/html",
                             html.toString(),
                             url,

--- a/api/src/org/labkey/api/attachments/AttachmentService.java
+++ b/api/src/org/labkey/api/attachments/AttachmentService.java
@@ -44,11 +44,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-/**
- * User: adam
- * Date: Jan 3, 2007
- * Time: 7:03:21 PM
- */
 public interface AttachmentService
 {
     String ATTACHMENT_AUDIT_EVENT = "AttachmentAuditEvent";

--- a/api/src/org/labkey/api/cache/CacheManager.java
+++ b/api/src/org/labkey/api/cache/CacheManager.java
@@ -236,7 +236,9 @@ public class CacheManager
 
                     if (Container.class.isAssignableFrom(type) || User.class.isAssignableFrom(type) || Project.class.isAssignableFrom(type))
                     {
-                        LOG.debug("{}: {} field {} ({})", cacheName, clazz.getName(), newFieldPath, field.getType().getName());
+                        String message = cacheName + ": " + clazz.getName() + " field " + newFieldPath + " (" + field.getType().getName() + ")";
+                        throw new IllegalStateException(message);
+//                        LOG.debug("{}: {} field {} ({})", cacheName, clazz.getName(), newFieldPath, field.getType().getName());
                     }
                     else
                     {

--- a/api/src/org/labkey/api/cache/CacheManager.java
+++ b/api/src/org/labkey/api/cache/CacheManager.java
@@ -17,6 +17,7 @@ package org.labkey.api.cache;
 
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.ehcache.EhCacheProvider;
 import org.labkey.api.collections.CollectionUtils;
@@ -197,7 +198,7 @@ public class CacheManager
 
     private static final int MAX_DEPTH = 4;
 
-    private static void analyzeValue(@Nullable Object value, String cacheName, @Nullable String fields, int depth)
+    private static void analyzeValue(@Nullable Object value, String cacheName, @Nullable String fieldPath, int depth)
     {
         if (value != null && depth < MAX_DEPTH)
         {
@@ -208,34 +209,34 @@ public class CacheManager
                 m.entrySet().stream()
                     .findFirst()
                     .ifPresent(entry -> {
-                        analyzeValue(entry.getKey(), cacheName, fields, depth + 1);
-                        analyzeValue(entry.getValue(), cacheName, fields, depth + 1);
+                        analyzeValue(entry.getKey(), cacheName, safeAppend(fieldPath, "Map", "_key"), depth + 1);
+                        analyzeValue(entry.getValue(), cacheName, safeAppend(fieldPath, "Map", "_value"), depth + 1);
                     });
             }
             else if (value instanceof Collection<?> coll)
             {
                 coll.stream()
                     .findFirst()
-                    .ifPresent(element -> analyzeValue(element, cacheName, fields, depth + 1));
+                    .ifPresent(element -> analyzeValue(element, cacheName, safeAppend(fieldPath, coll.getClass().getSimpleName(), "get(0)"), depth + 1));
             }
             else if (clazz.isArray() && Array.getLength(value) > 0)
             {
-                analyzeValue(Array.get(value, 0), cacheName, fields, depth + 1);
+                analyzeValue(Array.get(value, 0), cacheName, safeAppend(fieldPath, "Array", "[0]"), depth + 1);
             }
             else if (value instanceof Reference<?> ref)
             {
-                analyzeValue(ref, cacheName, fields, depth + 1);
+                analyzeValue(ref, cacheName, fieldPath, depth + 1);
             }
             else if (CLASSES.add(clazz))
             {
                 for (Field field : getAllInstanceFields(clazz))
                 {
-                    String fieldPath = (fields != null ? fields + "." : "") + field.getName();
+                    String newFieldPath = safeAppend(fieldPath, clazz.getSimpleName(), field.getName());
                     Class<?> type = field.getType();
 
                     if (Container.class.isAssignableFrom(type) || User.class.isAssignableFrom(type) || Project.class.isAssignableFrom(type))
                     {
-                        LOG.debug("{}: {} field {} ({})", cacheName, clazz.getName(), fieldPath, field.getType().getName());
+                        LOG.debug("{}: {} field {} ({})", cacheName, clazz.getName(), newFieldPath, field.getType().getName());
                     }
                     else
                     {
@@ -243,20 +244,25 @@ public class CacheManager
                         {
                             field.setAccessible(true);
                             Object val = field.get(value);
-                            analyzeValue(val, cacheName, fieldPath, depth + 1);
+                            analyzeValue(val, cacheName, newFieldPath, depth + 1);
                         }
                         catch (InaccessibleObjectException e)
                         {
-                            LOG.debug("{}: {} field {} ({}): inaccessible member", cacheName, clazz.getName(), fieldPath, field.getType().getName());
+                            LOG.debug("{}: {} field {} ({}): inaccessible member", cacheName, clazz.getName(), newFieldPath, field.getType().getName());
                         }
                         catch (IllegalAccessException e)
                         {
-                            LOG.debug("{}: {} field {} ({}): exception attempting to access", cacheName, clazz.getName(), fieldPath, field.getType().getName(), e);
+                            LOG.debug("{}: {} field {} ({}): exception attempting to access", cacheName, clazz.getName(), newFieldPath, field.getType().getName(), e);
                         }
                     }
                 }
             }
         }
+    }
+
+    private static String safeAppend(@Nullable String fieldPath, @NotNull String currentClass, @NotNull String fieldName)
+    {
+        return (fieldPath == null ? currentClass : fieldPath) + "." + fieldName;
     }
 
     // Recurse up the class hierarchy

--- a/api/src/org/labkey/api/cache/CacheManager.java
+++ b/api/src/org/labkey/api/cache/CacheManager.java
@@ -236,9 +236,9 @@ public class CacheManager
 
                     if (Container.class.isAssignableFrom(type) || User.class.isAssignableFrom(type) || Project.class.isAssignableFrom(type))
                     {
-                        String message = cacheName + ": " + clazz.getName() + " field " + newFieldPath + " (" + field.getType().getName() + ")";
-                        throw new IllegalStateException(message);
-//                        LOG.debug("{}: {} field {} ({})", cacheName, clazz.getName(), newFieldPath, field.getType().getName());
+//                        String message = cacheName + ": " + clazz.getName() + " field " + newFieldPath + " (" + field.getType().getName() + ")";
+//                        throw new IllegalStateException(message);
+                        LOG.debug("{}: {} field {} ({})", cacheName, clazz.getName(), newFieldPath, field.getType().getName());
                     }
                     else
                     {

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -87,6 +87,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -780,7 +781,7 @@ public class Container implements Serializable, Comparable<Container>, Securable
 
         final Container container = (Container) o;
 
-        return _id == null ? container._id == null : _id.equals(container._id);
+        return Objects.equals(_id, container._id);
     }
 
 

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1116,12 +1116,12 @@ public class ContainerManager
         return selector.getObject(Container.class);
     }
 
-    public static Container getForId(@NotNull GUID id)
+    public static @Nullable Container getForId(@NotNull GUID guid)
     {
-        return getForId(id.toString());
+        return guid != null ? getForId(guid.toString()) : null;
     }
 
-    public static Container getForId(String id)
+    public static @Nullable Container getForId(String id)
     {
         Container d = getFromCacheId(id);
         if (null != d)

--- a/api/src/org/labkey/api/data/Entity.java
+++ b/api/src/org/labkey/api/data/Entity.java
@@ -24,19 +24,14 @@ import org.labkey.api.util.MemTracker;
 import java.util.Date;
 
 
-/**
- * User: mbellew
- * Date: Feb 16, 2005
- * Time: 11:34:34 AM
- */
 public class Entity implements java.io.Serializable, Ownable
 {
     protected GUID entityId;
+    protected GUID containerId;
     private int createdBy;
     private long created = 0;
     private int modifiedBy;
     private long modified;
-    private GUID containerId;
 
     protected void copyTo(Entity to)
     {

--- a/api/src/org/labkey/api/data/Entity.java
+++ b/api/src/org/labkey/api/data/Entity.java
@@ -136,15 +136,13 @@ public class Entity implements java.io.Serializable, Ownable
     @Override
     public String getContainerId()
     {
-        return null==containerId?null:containerId.toString();
+        return null == containerId ? null : containerId.toString();
     }
-
 
     public void setContainerId(String containerId)
     {
         this.containerId = containerId == null ? null : new GUID(containerId);
     }
-
 
     // for Table layer
     public void setContainer(String containerId)

--- a/api/src/org/labkey/api/data/queryprofiler/QueryTracker.java
+++ b/api/src/org/labkey/api/data/queryprofiler/QueryTracker.java
@@ -172,7 +172,7 @@ class QueryTracker
 
     public long getAverage()
     {
-        return _count == 0 ? 0 : _cumulative / _count;
+        return _count == 0 ? 0 : Math.round((double)_cumulative / _count);
     }
 
     public int getStackTraceCount()

--- a/api/src/org/labkey/api/exp/Identifiable.java
+++ b/api/src/org/labkey/api/exp/Identifiable.java
@@ -24,8 +24,6 @@ import org.labkey.api.view.ActionURL;
 
 /**
  * Base functionality for objects that have an LSID.
- * User: migra
- * Date: Jun 14, 2005
  */
 public interface Identifiable
 {

--- a/api/src/org/labkey/api/exp/ObjectProperty.java
+++ b/api/src/org/labkey/api/exp/ObjectProperty.java
@@ -18,7 +18,9 @@ package org.labkey.api.exp;
 
 import org.labkey.api.data.BeanObjectFactory;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.MvUtil;
+import org.labkey.api.util.GUID;
 
 import java.io.File;
 import java.util.Collections;
@@ -27,15 +29,13 @@ import java.util.Map;
 
 /**
  * A single object-property-value triple.
- * User: migra
- * Date: Oct 25, 2005
  */
 public class ObjectProperty extends OntologyManager.PropertyRow
 {
     private int hashCode = 0;
 
     // Object fields
-    private Container container;
+    private GUID containerId;
     private String objectURI;
     private Integer objectOwnerId;
 
@@ -122,7 +122,7 @@ public class ObjectProperty extends OntologyManager.PropertyRow
     private void init(String objectURI, Container container, String propertyURI, PropertyType propertyType)
     {
         this.objectURI = objectURI;
-        this.container = container;
+        this.containerId = container.getEntityId();
         this.propertyURI = propertyURI;
         this.typeTag = propertyType.getStorageType();
         //TODO: For resource, need to override with known type
@@ -134,7 +134,7 @@ public class ObjectProperty extends OntologyManager.PropertyRow
     private void init(String objectURI, Container container, String propertyURI, PropertyType propertyType, Object value)
     {
         this.objectURI = objectURI;
-        this.container = container;
+        this.containerId = container.getEntityId();
         this.propertyURI = propertyURI;
         this.typeTag = propertyType.getStorageType();
         //TODO: For resource, need to override with known type
@@ -153,7 +153,7 @@ public class ObjectProperty extends OntologyManager.PropertyRow
         Object value = value();
         if (mvIndicator == null)
             return value;
-        return new MvFieldWrapper(MvUtil.getMvIndicators(container), value, mvIndicator);
+        return new MvFieldWrapper(MvUtil.getMvIndicators(getContainer()), value, mvIndicator);
     }
 
     public Object value()
@@ -168,12 +168,12 @@ public class ObjectProperty extends OntologyManager.PropertyRow
 
     public Container getContainer()
     {
-        return container;
+        return ContainerManager.getForId(containerId);
     }
 
     public void setContainer(Container container)
     {
-        this.container = container;
+        this.containerId = container.getEntityId();
     }
 
     public String getObjectURI()

--- a/api/src/org/labkey/api/qc/DataState.java
+++ b/api/src/org/labkey/api/qc/DataState.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.qc;
 
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.util.GUID;
@@ -56,9 +57,9 @@ public class DataState
         return ContainerManager.getForId(_containerId);
     }
 
-    public void setContainer(Container container)
+    public void setContainer(@Nullable Container container)
     {
-        _containerId = container.getEntityId();
+        _containerId = container != null ? container.getEntityId() : null;
     }
 
     public String getDescription()

--- a/api/src/org/labkey/api/qc/DataState.java
+++ b/api/src/org/labkey/api/qc/DataState.java
@@ -16,17 +16,16 @@
 package org.labkey.api.qc;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.util.GUID;
 
-/*
- * User: brittp
- * Date: Jul 15, 2008
- * Time: 2:48:55 PM
- */
+import java.util.Objects;
+
 public class DataState
 {
     private int _rowId;
     private String _label;
-    private Container _container;
+    private GUID _containerId;
     private String _description;
     private boolean _publicData;
     private String _stateType;
@@ -54,12 +53,12 @@ public class DataState
 
     public Container getContainer()
     {
-        return _container;
+        return ContainerManager.getForId(_containerId);
     }
 
     public void setContainer(Container container)
     {
-        _container = container;
+        _containerId = container.getEntityId();
     }
 
     public String getDescription()
@@ -116,13 +115,12 @@ public class DataState
 
         if (_publicData != qcState._publicData) return false;
         if (_rowId != qcState._rowId) return false;
-        if (_container != null ? !_container.equals(qcState._container) : qcState._container != null) return false;
-        if (_description != null ? !_description.equals(qcState._description) : qcState._description != null)
+        if (!Objects.equals(_containerId, qcState._containerId)) return false;
+        if (!Objects.equals(_description, qcState._description))
             return false;
-        if (_label != null ? !_label.equals(qcState._label) : qcState._label != null) return false;
-        if (_stateType != null ? !_stateType.equals(qcState._stateType) : qcState._stateType != null) return false;
+        if (!Objects.equals(_label, qcState._label)) return false;
 
-        return true;
+        return Objects.equals(_stateType, qcState._stateType);
     }
 
     public int hashCode()
@@ -130,7 +128,7 @@ public class DataState
         int result;
         result = _rowId;
         result = 31 * result + (_label != null ? _label.hashCode() : 0);
-        result = 31 * result + (_container != null ? _container.hashCode() : 0);
+        result = 31 * result + (_containerId != null ? _containerId.hashCode() : 0);
         result = 31 * result + (_description != null ? _description.hashCode() : 0);
         result = 31 * result + (_publicData ? 1 : 0);
         result = 31 * result + (_stateType != null ? _stateType.hashCode() : 0);

--- a/api/src/org/labkey/api/study/StudyEntity.java
+++ b/api/src/org/labkey/api/study/StudyEntity.java
@@ -22,11 +22,6 @@ import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.User;
 
-/**
- * User: Matthew
- * Date: Jun 6, 2006
- * Time: 2:57:59 PM
- */
 public interface StudyEntity extends SecurableResource
 {
     Container getContainer();
@@ -54,5 +49,4 @@ public interface StudyEntity extends SecurableResource
     SecurityPolicy getPolicy();
 
     void savePolicy(MutableSecurityPolicy policy, User user);
-
 }

--- a/api/src/org/labkey/api/util/GUID.java
+++ b/api/src/org/labkey/api/util/GUID.java
@@ -247,7 +247,7 @@ public class GUID implements Serializable, Parameter.JdbcParameterValue, SafeToR
         return makeHash("");
     }
 
-   public static String makeHash(String addl)
+    public static String makeHash(String addl)
     {
         return makeLongHash(addl).substring(0, 32);
     }

--- a/api/src/org/labkey/api/webdav/AbstractWebdavResolver.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResolver.java
@@ -94,24 +94,6 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
         }
 
         @Override
-        public boolean exists()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isCollection()
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isFile()
-        {
-            return false;
-        }
-
-        @Override
         public Set<Class<? extends Permission>> getPermissions(User user)
         {
             return Collections.emptySet();
@@ -124,12 +106,6 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
         }
 
         @Override
-        public Collection<String> listNames()
-        {
-            return Collections.emptyList();
-        }
-
-        @Override
         public Collection<WebdavResource> list()
         {
             return Collections.emptyList();
@@ -137,12 +113,6 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
 
         @Override
         public long getCreated()
-        {
-            return Long.MIN_VALUE;
-        }
-
-        @Override
-        public long getLastModified()
         {
             return Long.MIN_VALUE;
         }
@@ -164,40 +134,32 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
         {
             return 0;
         }
-
-        @Override
-        @NotNull
-        public Collection<History> getHistory()
-        {
-            return Collections.emptyList();
-        }
     }
 
     public abstract static class AbstractWebFolderResource extends AbstractWebdavResourceCollection implements WebdavResolver.WebFolder
     {
         protected WebdavResolver _resolver;
-        final Container _c;
         protected ArrayList<String> _children = null;
 
         protected AbstractWebFolderResource(WebdavResolver resolver, Container c)
         {
             super(resolver.getRootPath().append(c.getParsedPath()), resolver);
             _resolver = resolver;
-            _c = c;
-            _containerId = c.getId();
+            _containerId = c.getEntityId();
             setSecurableResource(c);
         }
 
         @Override
         public long getCreated()
         {
-            return null != _c && null != _c.getCreated() ? _c.getCreated().getTime() : Long.MIN_VALUE;
+            Container c = getContainer();
+            return null != c && null != c.getCreated() ? c.getCreated().getTime() : Long.MIN_VALUE;
         }
 
         @Override
         public User getCreatedBy()
         {
-            return UserManager.getUser(_c.getCreatedBy());
+            return UserManager.getUser(getContainer().getCreatedBy());
         }
 
         @Override
@@ -218,14 +180,14 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
             // context
             Path contextPath = null==context ? AppProps.getInstance().getParsedContextPath() : Path.parse(context.getContextPath());
             // _webdav
-            Path path = contextPath.append(getPath().get(0)).append(getContainerId());
+            Path path = contextPath.append(getPath().get(0)).append(getContainerId().toString());
             return path.encode("/", "/");
         }
 
         @Override
         public Container getContainer()
         {
-            return _c;
+            return ContainerManager.getForId(_containerId);
         }
 
         @Override
@@ -244,7 +206,7 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
         {
             if (null == _children)
             {
-                List<Container> list = ContainerManager.getChildren(_c);
+                List<Container> list = ContainerManager.getChildren(getContainer());
                 ArrayList<String> children = new ArrayList<>(list.size() + 2);
                 for (Container aList : list)
                     children.add(aList.getName());

--- a/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
@@ -47,6 +47,7 @@ import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.FileStream;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.view.ActionURL;
@@ -75,7 +76,7 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
     private SecurableResource _resource;
     private List<ExpData> _data = null;
 
-    protected String _containerId;
+    protected GUID _containerId;
     protected String _etag = null;
     protected Map<String, Object> _properties = null;
 
@@ -577,7 +578,7 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
     }
 
     @Override
-    public String getContainerId()
+    public GUID getContainerId()
     {
         return _containerId;
     }
@@ -712,7 +713,7 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
 
     Container getContainer()
     {
-        String id = getContainerId();
+        GUID id = getContainerId();
         if (null == id)
             return null;
         return ContainerManager.getForId(id);

--- a/api/src/org/labkey/api/webdav/FileSystemResource.java
+++ b/api/src/org/labkey/api/webdav/FileSystemResource.java
@@ -53,6 +53,7 @@ import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.FileStream;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.NavTree;
@@ -146,11 +147,11 @@ public class FileSystemResource extends AbstractWebdavResource
     }
 
     @Override
-    public String getContainerId()
+    public GUID getContainerId()
     {
         if (null != _containerId)
             return _containerId;
-        return null==_folder ? null : _folder.getContainerId();
+        return null == _folder ? null : _folder.getContainerId();
     }
 
     @Override

--- a/api/src/org/labkey/api/webdav/SimpleDocumentResource.java
+++ b/api/src/org/labkey/api/webdav/SimpleDocumentResource.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileStream;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.URLHelper;
@@ -32,11 +33,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * User: matthewb
- * Date: Nov 25, 2009
- * Time: 5:31:23 PM
- */
 public class SimpleDocumentResource extends AbstractDocumentResource
 {
     private final String _documentId;
@@ -48,12 +44,12 @@ public class SimpleDocumentResource extends AbstractDocumentResource
     private final long _created;
     private final long _modified;
 
-    public SimpleDocumentResource(Path path, String documentId, String containerId, String contentType, @Nullable String body, URLHelper executeUrl, @Nullable Map<String, Object> properties)
+    public SimpleDocumentResource(Path path, String documentId, GUID containerId, String contentType, @Nullable String body, URLHelper executeUrl, @Nullable Map<String, Object> properties)
     {
         this(path, documentId, containerId, contentType, body, executeUrl, null, null, null, null, properties);
     }
 
-    public SimpleDocumentResource(Path path, String documentId, String containerId, String contentType, @Nullable String body, URLHelper executeUrl,
+    public SimpleDocumentResource(Path path, String documentId, GUID containerId, String contentType, @Nullable String body, URLHelper executeUrl,
                                   @Nullable User createdBy, @Nullable Date created,
                                   @Nullable User modifiedBy, @Nullable Date modified,
                                   @Nullable Map<String, Object> properties)
@@ -72,7 +68,7 @@ public class SimpleDocumentResource extends AbstractDocumentResource
         if (_executeUrl instanceof ActionURL actionURL)
         {
             String extraPath = StringUtils.strip(actionURL.getExtraPath(),"/");
-            assert extraPath.equals(_containerId) || (null != properties && extraPath.equals(properties.get(SearchService.PROPERTY.securableResourceId.toString())));
+            assert extraPath.equals(_containerId.toString()) || (null != properties && extraPath.equals(properties.get(SearchService.PROPERTY.securableResourceId.toString())));
         }
         if (null != properties)
             _properties = new HashMap<>(properties);
@@ -80,7 +76,7 @@ public class SimpleDocumentResource extends AbstractDocumentResource
 
     public SimpleDocumentResource(Path path, String documentId, String contentType, @Nullable String body, ActionURL executeUrl, @Nullable Map<String, Object> properties)
     {
-        this(path, documentId, executeUrl.getParsedExtraPath().toString("",""), contentType, body, executeUrl, properties);
+        this(path, documentId, new GUID(executeUrl.getParsedExtraPath().toString("","")), contentType, body, executeUrl, properties);
     }
 
     private static long toTime(String fieldName, @Nullable Date d, @Nullable Map<String, Object> properties)

--- a/api/src/org/labkey/api/webdav/WebdavResolver.java
+++ b/api/src/org/labkey/api/webdav/WebdavResolver.java
@@ -23,11 +23,6 @@ import org.labkey.api.util.Path;
 
 import java.util.Date;
 
-/**
- * User: matthewb
- * Date: Apr 28, 2008
- * Time: 2:02:25 PM
- */
 public interface WebdavResolver extends Resolver
 {
     Path.Part INDEX_HTML = Path.toPathPart("index.html");
@@ -44,6 +39,7 @@ public interface WebdavResolver extends Resolver
     }
 
     boolean requiresLogin();
+
     @Override
     Path getRootPath();
 

--- a/api/src/org/labkey/api/webdav/WebdavResolverImpl.java
+++ b/api/src/org/labkey/api/webdav/WebdavResolverImpl.java
@@ -41,12 +41,6 @@ import org.labkey.api.util.TestContext;
 
 import java.util.Collection;
 
-
-/**
- * User: matthewb
- * Date: Apr 28, 2008
- * Time: 2:07:13 PM
- */
 public class WebdavResolverImpl extends AbstractWebdavResolver
 {
     static WebdavResolverImpl _instance = new WebdavResolverImpl(WebdavService.getPath());
@@ -151,7 +145,7 @@ public class WebdavResolverImpl extends AbstractWebdavResolver
         WebFolderResource(WebdavResolver resolver, Container c)
         {
             super(resolver, c);
-            documentId =  "dav:" + _resolver.getRootPath().append(_c.getId()).toString("/","/");
+            documentId =  "dav:" + _resolver.getRootPath().append(_containerId.toString()).toString("/","/");
         }
 
         @Override
@@ -197,7 +191,7 @@ public class WebdavResolverImpl extends AbstractWebdavResolver
             TestContext context = TestContext.get();
             User guest = UserManager.getGuestUser();
             User user = context.getUser();
-            assertTrue("login before running this test", null != user);
+            assertNotNull("login before running this test", user);
             assertFalse("login before running this test", user.isGuest());
             
             Container junitContainer = JunitUtil.getTestContainer();

--- a/api/src/org/labkey/api/webdav/WebdavResource.java
+++ b/api/src/org/labkey/api/webdav/WebdavResource.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileStream;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.Path;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
@@ -43,6 +44,7 @@ public interface WebdavResource extends Resource
 
     // TODO move more functionality into interface and remove this method
     @Nullable File getFile();
+
     default @Nullable java.nio.file.Path getNioPath()
     {
         File file = getFile();
@@ -214,7 +216,7 @@ public interface WebdavResource extends Resource
     /**
      * required for fast permission filtering by SearchService, only non-indexable resources may return null
      */
-    String getContainerId();
+    GUID getContainerId();
 
     /**
      * For a collection, this indicates whether this resource should be scanned for children to index

--- a/api/src/org/labkey/api/webdav/WebdavResourceReadOnly.java
+++ b/api/src/org/labkey/api/webdav/WebdavResourceReadOnly.java
@@ -21,6 +21,7 @@ import org.labkey.api.resource.Resolver;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileStream;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.Path;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
@@ -34,9 +35,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Created by matthew on 10/23/15.
- */
 public class WebdavResourceReadOnly implements WebdavResource
 {
     final private WebdavResource _delegate;
@@ -318,7 +316,7 @@ public class WebdavResourceReadOnly implements WebdavResource
     }
 
     @Override
-    public String getContainerId()
+    public GUID getContainerId()
     {
         return getDelegate().getContainerId();
     }

--- a/assay/api-src/org/labkey/api/assay/plate/PositionImpl.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PositionImpl.java
@@ -37,6 +37,7 @@ public class PositionImpl implements Position
     private String _lsid;
     private Integer _plateId;
 
+    @SuppressWarnings("unused")
     public PositionImpl()
     {
         // no-arg constructor for reflection    

--- a/assay/api-src/org/labkey/api/assay/plate/PositionImpl.java
+++ b/assay/api-src/org/labkey/api/assay/plate/PositionImpl.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.util.GUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -32,7 +33,7 @@ public class PositionImpl implements Position
 
     protected int _row;
     protected int _column;
-    private Container _container;
+    private GUID _containerId;
     private Integer _rowId;
     private String _lsid;
     private Integer _plateId;
@@ -55,7 +56,7 @@ public class PositionImpl implements Position
     public PositionImpl(Container container, @NotNull String description)
     {
         description = description.toUpperCase();
-        _container = container;
+        setContainer(container);
 
         String rowStr = description.substring(0, 1);
         if (description.length() >= 3)
@@ -85,7 +86,7 @@ public class PositionImpl implements Position
 
     public PositionImpl(Container container, int row, int column)
     {
-        _container = container;
+        setContainer(container);
         _row = row;
         _column = column;
     }
@@ -179,12 +180,12 @@ public class PositionImpl implements Position
 
     public Container getContainer()
     {
-        return _container;
+        return ContainerManager.getForId(_containerId);
     }
 
     public void setContainer(Container container)
     {
-        _container = container;
+        _containerId = container != null ? container.getEntityId() : null;
     }
 
     @Override
@@ -192,7 +193,7 @@ public class PositionImpl implements Position
     {
         if (getRow() > ALPHABET.length)
             return "Row " + (getRow() + 1) + ", Column " + (getColumn() + 1);
-        return "" + ALPHABET[getRow()] + (getColumn() + 1);
+        return ALPHABET[getRow()] + (getColumn() + 1);
     }
 
     public static final class TestCase

--- a/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
@@ -74,7 +74,7 @@ public class AssayBatchDocumentProvider implements SearchService.DocumentProvide
         return new SimpleDocumentResource(
             new Path(documentId),
             documentId,
-            batch.getContainer().getId(),
+            batch.getContainer().getEntityId(),
             "text/plain",
             body.toString(),
             url,

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -675,7 +675,7 @@ public class AssayManager implements AssayService
             });
 
         String docId = protocol.getDocumentId();
-        WebdavResource r = new SimpleDocumentResource(new Path(docId), docId, c.getId(), "text/plain", body.toString(), assayBeginURL, createdBy, created, modifiedBy, modified, m);
+        WebdavResource r = new SimpleDocumentResource(new Path(docId), docId, c.getEntityId(), "text/plain", body.toString(), assayBeginURL, createdBy, created, modifiedBy, modified, m);
         task.addResource(r, SearchService.PRIORITY.item);
     }
 

--- a/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
@@ -73,7 +73,7 @@ public class AssayRunDocumentProvider implements SearchService.DocumentProvider
         return new SimpleDocumentResource(
             new Path(documentId),
             documentId,
-            expRun.getContainer().getId(),
+            expRun.getContainer().getEntityId(),
             "text/plain",
             body.toString(),
             url,

--- a/assay/src/org/labkey/assay/plate/PlateDocumentProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateDocumentProvider.java
@@ -84,7 +84,7 @@ public class PlateDocumentProvider implements SearchService.DocumentProvider
         return new SimpleDocumentResource(
             new Path(documentId),
             documentId,
-            plate.getContainer().getId(),
+            plate.getContainer().getEntityId(),
             "text/plain",
             body.toString(),
             url,

--- a/assay/src/org/labkey/assay/plate/PlateImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateImpl.java
@@ -213,7 +213,7 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
         for (int col = upperLeft.getColumn(); col <= lowerRight.getColumn(); col++)
         {
             for (int row = upperLeft.getRow(); row <= lowerRight.getRow(); row++)
-                allPositions.add(new PositionImpl(_container, row, col));
+                allPositions.add(new PositionImpl(getContainer(), row, col));
         }
         return addWellGroup(name, type, allPositions);
     }
@@ -387,7 +387,7 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     @Override
     public @NotNull PositionImpl getPosition(int row, int col)
     {
-        return new PositionImpl(_container, row, col);
+        return new PositionImpl(getContainer(), row, col);
     }
 
     @Override
@@ -480,9 +480,9 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
         _dataFileId = dataFileId;
     }
 
-    public String getContainerId()
+    public GUID getContainerId()
     {
-        return _container.getId();
+        return _containerId;
     }
 
     @JsonIgnore

--- a/assay/src/org/labkey/assay/plate/PlateImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateImpl.java
@@ -68,14 +68,14 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     private String _assayType = TsvPlateLayoutHandler.TYPE;
     private String _barcode;
     private long _created;
-    private User _createdBy;
+    private int _createdBy;
     private List<PlateCustomField> _customFields = Collections.emptyList();
     private String _dataFileId;
     private List<WellGroupImpl> _deletedGroups;
     private String _description;
     private Map<WellGroup.Type, Map<String, WellGroupImpl>> _groups;
     private long _modified;
-    private User _modifiedBy;
+    private int _modifiedBy;
     private String _name;
     private String _plateId;
     private int _plateNumber = 1;
@@ -432,14 +432,13 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     @JsonProperty("createdBy")
     public JSONObject getCreatedBy()
     {
-        if (_createdBy == null)
-            return null;
-        return _createdBy.getUserProps();
+        User user = UserManager.getUser(_createdBy);
+        return user != null ? user.getUserProps() : null;
     }
 
     public void setCreatedBy(User createdBy)
     {
-        _createdBy = createdBy;
+        _createdBy = createdBy.getUserId();
     }
 
     public Date getModified()
@@ -455,14 +454,13 @@ public class PlateImpl extends PropertySetImpl implements Plate, Cloneable
     @JsonProperty("modifiedBy")
     public JSONObject getModifiedBy()
     {
-        if (_modifiedBy == null)
-            return null;
-        return _modifiedBy.getUserProps();
+        User user = UserManager.getUser(_modifiedBy);
+        return user != null ? user.getUserProps() : null;
     }
 
     public void setModifiedBy(User modifiedBy)
     {
-        _modifiedBy = modifiedBy;
+        _modifiedBy = modifiedBy.getUserId();
     }
 
     public String getDataFileId()

--- a/assay/src/org/labkey/assay/plate/PlateSetDocumentProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetDocumentProvider.java
@@ -89,7 +89,7 @@ public class PlateSetDocumentProvider implements SearchService.DocumentProvider
         return new SimpleDocumentResource(
             new Path(documentId),
             documentId,
-            plateSet.getContainer().getId(),
+            plateSet.getContainer().getEntityId(),
             "text/plain",
             body.toString(),
             url,

--- a/assay/src/org/labkey/assay/plate/PlateSetImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetImpl.java
@@ -8,6 +8,7 @@ import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateSet;
 import org.labkey.api.assay.plate.PlateSetType;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.Entity;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlSelector;
@@ -26,7 +27,6 @@ import java.util.List;
 public class PlateSetImpl extends Entity implements PlateSet
 {
     private boolean _archived;
-    private Container _container;
     private String _description;
     private String _name;
     private String _plateSetId;
@@ -50,14 +50,14 @@ public class PlateSetImpl extends Entity implements PlateSet
 
     public void setContainer(Container container)
     {
-        _container = container;
+        containerId = container.getEntityId();
     }
 
     @JsonIgnore
     @Override
     public Container getContainer()
     {
-        return _container;
+        return ContainerManager.getForId(containerId);
     }
 
     @JsonIgnore
@@ -71,23 +71,6 @@ public class PlateSetImpl extends Entity implements PlateSet
     public void setFolder(Container container)
     {
         setContainer(container);
-    }
-
-    @Override
-    public String getContainerId()
-    {
-        return _container == null ? null : _container.getId();
-    }
-
-    @Override
-    public String getContainerPath()
-    {
-        return _container == null ? null : _container.getPath();
-    }
-
-    public String getContainerName()
-    {
-        return _container == null ? null : _container.getName();
     }
 
     public void setLsid(String lsid)

--- a/assay/src/org/labkey/assay/plate/PlateSetImpl.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetImpl.java
@@ -73,6 +73,13 @@ public class PlateSetImpl extends Entity implements PlateSet
         setContainer(container);
     }
 
+    @SuppressWarnings("unused") // Serialized to the client
+    public String getContainerName()
+    {
+        Container container = getContainer();
+        return container == null ? null : container.getName();
+    }
+
     public void setLsid(String lsid)
     {
         _lsid = lsid;

--- a/assay/src/org/labkey/assay/plate/PropertySetImpl.java
+++ b/assay/src/org/labkey/assay/plate/PropertySetImpl.java
@@ -19,7 +19,9 @@ package org.labkey.assay.plate;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.study.PropertySet;
+import org.labkey.api.util.GUID;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,7 +33,7 @@ public abstract class PropertySetImpl implements PropertySet
 {
     private Map<String, Object> _properties = new HashMap<>();
     private String _lsid;
-    protected Container _container;
+    protected GUID _containerId;
 
     public PropertySetImpl()
     {
@@ -39,7 +41,7 @@ public abstract class PropertySetImpl implements PropertySet
 
     public PropertySetImpl(Container container)
     {
-        _container = container;
+        _containerId = container.getEntityId();
     }
 
     @JsonIgnore
@@ -89,11 +91,11 @@ public abstract class PropertySetImpl implements PropertySet
     @Override
     public Container getContainer()
     {
-        return _container;
+        return ContainerManager.getForId(_containerId);
     }
 
     public void setContainer(Container container)
     {
-        _container = container;
+        _containerId = container.getEntityId();
     }
 }

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1574,7 +1574,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             startURL.setExtraPath(c.getId());
             WebdavResource doc = new SimpleDocumentResource(c.getParsedPath(),
                     "link:" + c.getId(),
-                    c.getId(),
+                    c.getEntityId(),
                     "text/plain",
                     body,
                     startURL,

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -78,6 +78,7 @@ import org.labkey.api.test.TestWhen;
 import org.labkey.api.util.ContainerUtil;
 import org.labkey.api.util.FileStream;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.MimeMap;
@@ -1388,7 +1389,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
             super(path);
 
             Container c = ContainerManager.getForId(parent.getContainerId());
-            _containerId = parent.getContainerId();
+            _containerId = new GUID(parent.getContainerId());
             if (null != c)
                 setSecurableResource(c);
             _downloadUrl = downloadURL;
@@ -1430,7 +1431,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
         AttachmentResource(@NotNull WebdavResource folder, @NotNull AttachmentParent parent, @NotNull String name)
         {
             super(folder.getPath(), name);
-            _containerId = parent.getContainerId();
+            _containerId = new GUID(parent.getContainerId());
             _folder = folder;
             Container c = ContainerManager.getForId(parent.getContainerId());
             if (c != null)

--- a/core/src/org/labkey/core/webdav/WebFilesResolverImpl.java
+++ b/core/src/org/labkey/core/webdav/WebFilesResolverImpl.java
@@ -56,8 +56,8 @@ import java.util.stream.Stream;
 
 public class WebFilesResolverImpl extends AbstractWebdavResolver implements FileListener
 {
-    final private static Path PATH = Path.parse("/_webfiles/");
-    static WebFilesResolverImpl _instance = new WebFilesResolverImpl(PATH);
+    private static final Path PATH = Path.parse("/_webfiles/");
+    private static final WebFilesResolverImpl _instance = new WebFilesResolverImpl(PATH);
 
     final Path _rootPath;
 
@@ -469,5 +469,4 @@ public class WebFilesResolverImpl extends AbstractWebdavResolver implements File
             return false; // resources in _webdav are already indexed, prevent _webfiles from double indexing
         }
     }
-
 }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
@@ -424,7 +424,7 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
         String body = StringUtils.isNotBlank(getDescription()) ? getDescription() : "";
 
         return new SimpleDocumentResource(new Path(getDocumentId()), getDocumentId(),
-                container.getId(), "text/plain",
+                container.getEntityId(), "text/plain",
                 body, url,
                 getCreatedBy(), getCreated(),
                 getModifiedBy(), getModified(),

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -61,6 +61,7 @@ import org.labkey.api.security.permissions.MoveEntitiesPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.MimeMap;
@@ -773,7 +774,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
             getRowId(),
             new Path(docId),
             docId,
-            container.getId(),
+            container.getEntityId(),
             "text/plain",
             body.toString(),
             view,
@@ -797,7 +798,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
     {
         final int _rowId;
 
-        public ExpDataResource(int rowId, Path path, String documentId, String containerId, String contentType, String body, URLHelper executeUrl, Map<String, Object> properties, User createdBy, Date created, User modifiedBy, Date modified)
+        public ExpDataResource(int rowId, Path path, String documentId, GUID containerId, String contentType, String body, URLHelper executeUrl, Map<String, Object> properties, User createdBy, Date created, User modifiedBy, Date modified)
         {
             super(path, documentId, containerId, contentType, body, executeUrl, createdBy, created, modifiedBy, modified, properties);
             _rowId = rowId;

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -425,7 +425,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
         }
 
         return new SimpleDocumentResource(new Path(getDocumentId()), getDocumentId(),
-                container.getId(), "text/plain",
+                container.getEntityId(), "text/plain",
                 body.toString(), url,
                 getCreatedBy(), getCreated(),
                 getModifiedBy(), getModified(),

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -1013,7 +1013,7 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         String body = StringUtils.isNotBlank(getDescription()) ? getDescription() : "";
 
         return new SimpleDocumentResource(new Path(getDocumentId()), getDocumentId(),
-                container.getId(), "text/plain",
+                container.getEntityId(), "text/plain",
                 body, url,
                 getCreatedBy(), getCreated(),
                 getModifiedBy(), getModified(),

--- a/experiment/src/org/labkey/experiment/api/MaterialSource.java
+++ b/experiment/src/org/labkey/experiment/api/MaterialSource.java
@@ -28,8 +28,6 @@ import org.labkey.experiment.controllers.exp.ExperimentController;
 
 /**
  * Bean class for the exp.materialsource table. Referred to as sample types within the UI.
- * User: migra
- * Date: Aug 15, 2005
  */
 public class MaterialSource extends IdentifiableEntity implements Comparable<MaterialSource>
 {

--- a/experiment/src/org/labkey/experiment/api/MaterialSource.java
+++ b/experiment/src/org/labkey/experiment/api/MaterialSource.java
@@ -23,6 +23,7 @@ import org.labkey.api.exp.query.ExpSampleTypeTable;
 import org.labkey.api.exp.query.ExpSchema;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryRowReference;
+import org.labkey.api.util.GUID;
 import org.labkey.api.view.ActionURL;
 import org.labkey.experiment.controllers.exp.ExperimentController;
 
@@ -46,7 +47,7 @@ public class MaterialSource extends IdentifiableEntity implements Comparable<Mat
     private String _aliquotNameExpression;
     private String _labelColor;
     private String _metricUnit;
-    private Container _autoLinkTargetContainer;
+    private GUID _autoLinkTargetContainerId;
     private String _autoLinkCategory;
 
     private String _materialParentImportAliasMap;
@@ -163,14 +164,12 @@ public class MaterialSource extends IdentifiableEntity implements Comparable<Mat
 
     public Container getAutoLinkTargetContainer()
     {
-        if (_autoLinkTargetContainer == null)
-            return null;
-        return ContainerManager.getForId(_autoLinkTargetContainer.getId());
+        return ContainerManager.getForId(_autoLinkTargetContainerId);
     }
     
     public void setAutoLinkTargetContainer(Container autoLinkTargetContainer)
     {
-        _autoLinkTargetContainer = autoLinkTargetContainer;
+        _autoLinkTargetContainerId = autoLinkTargetContainer != null ? autoLinkTargetContainer.getEntityId() : null;
     }
 
     public String getAutoLinkCategory()

--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -78,6 +78,7 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.util.ContainerUtil;
 import org.labkey.api.util.FileStream;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.PageFlowUtil;
@@ -1341,7 +1342,7 @@ public class IssueManager
             // UNDONE: custom field names
             // UNDONE: user names
             m.remove("comments");
-            _containerId = issue.getContainerId();
+            _containerId = new GUID(issue.getContainerId());
             _properties = m;
             _comments = issue.getCommentObjects();
             _properties.put(categories.toString(), searchCategory.getName());
@@ -1352,7 +1353,7 @@ public class IssueManager
         {
             super(new Path("issue:"+ issueId));
             _issueId = issueId;
-            _containerId = (String)m.get("folder");
+            _containerId = new GUID((String)m.get("folder"));
             _properties = m;
             _comments = comments;
             _properties.put(categories.toString(), searchCategory.getName());
@@ -1397,7 +1398,7 @@ public class IssueManager
         @Override
         public void setLastIndexed(long ms, long modified)
         {
-            IssueManager.setLastIndexed(_containerId, _issueId, ms);
+            IssueManager.setLastIndexed(_containerId.toString(), _issueId, ms);
         }
 
         @Override
@@ -1417,7 +1418,7 @@ public class IssueManager
         public String getExecuteHref(ViewContext context)
         {
             ActionURL url = new ActionURL(IssuesController.DetailsAction.class, null).addParameter("issueId", String.valueOf(_properties.get("issueid")));
-            url.setExtraPath(_containerId);
+            url.setExtraPath(_containerId.toString());
             return url.getLocalURIString();
         }
 

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -684,7 +684,7 @@ public class ListManager implements SearchService.DocumentProvider
                 SimpleDocumentResource r = new SimpleDocumentResource(
                     new Path(documentId),
                     documentId,
-                    list.getContainer().getId(),
+                    list.getContainer().getEntityId(),
                     "text/plain",
                     body,
                     itemURL,
@@ -870,7 +870,7 @@ public class ListManager implements SearchService.DocumentProvider
                 SimpleDocumentResource r = new SimpleDocumentResource(
                     new Path(documentId),
                     documentId,
-                    list.getContainer().getId(),
+                    list.getContainer().getEntityId(),
                     "text/plain",
                     body.toString(),
                     url,

--- a/pipeline/src/org/labkey/pipeline/PipelineWebdavProvider.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineWebdavProvider.java
@@ -93,7 +93,7 @@ public class PipelineWebdavProvider implements WebdavService.Provider
             super(parent.getPath(), Path.toPathPart(FileContentService.PIPELINE_LINK));
 
             this.c = c;
-            _containerId = c.getId();
+            _containerId = c.getEntityId();
             _shouldIndex = root.isSearchable();
             setSecurableResource(root);
             _files = new ArrayList<>(root.getRootFileLikePaths(true));

--- a/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
+++ b/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
@@ -39,11 +39,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * User: adam
- * Date: Apr 29, 2010
- * Time: 9:25:48 AM
- */
 public class ExternalSchemaDocumentProvider implements SearchService.DocumentProvider
 {
     private static final Logger LOG = LogManager.getLogger(ExternalSchemaDocumentProvider.class);
@@ -152,7 +147,7 @@ public class ExternalSchemaDocumentProvider implements SearchService.DocumentPro
                     SimpleDocumentResource r1 = new SimpleDocumentResource(
                             new Path(documentId),
                             documentId,
-                            c.getId(),
+                            c.getEntityId(),
                             "text/plain",
                             body.toString(),
                             url,

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -1159,7 +1159,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                     Logger categoryLogger = getLoggerForCategory(category);
                     if (categoryLogger.isDebugEnabled())
                     {
-                        String containerId = i._res.getContainerId();
+                        GUID containerId = i._res.getContainerId();
                         Container c = ContainerManager.getForId(containerId);
                         String containerPath = c != null ? c.getPath() : "UNKNOWN PATH: Container not found!";
                         categoryLogger.debug(category + " " + i._res.getDocumentId() + " " + containerPath + " " + containerId);

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -736,11 +736,11 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
             // === Index without analyzing, store ===
 
             doc.add(new Field(FIELD_NAME.uniqueId.toString(), r.getDocumentId(), StringField.TYPE_STORED));
-            doc.add(new Field(FIELD_NAME.container.toString(), r.getContainerId(), StringField.TYPE_STORED));
+            doc.add(new Field(FIELD_NAME.container.toString(), r.getContainerId().toString(), StringField.TYPE_STORED));
 
             // See: https://stackoverflow.com/questions/29695307/sortiing-string-field-alphabetically-in-lucene-5-0
             // But note that Lucene 9.0.0 changed to require BinaryDocValuesField instead
-            doc.add(new BinaryDocValuesField(FIELD_NAME.container.toString(), new BytesRef(r.getContainerId())));
+            doc.add(new BinaryDocValuesField(FIELD_NAME.container.toString(), new BytesRef(r.getContainerId().toString())));
 
             // === Index and analyze, don't store ===
 
@@ -2219,7 +2219,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
             props.put(PROPERTY.categories.toString(), _category.getName());
             props.put(PROPERTY.title.toString(), title);
 
-            SimpleDocumentResource resource1 = new SimpleDocumentResource(new Path(docId), docId, _c.getId(), "text/plain", body, _url, props) {
+            SimpleDocumentResource resource1 = new SimpleDocumentResource(new Path(docId), docId, _c.getEntityId(), "text/plain", body, _url, props) {
                 @Override
                 public void setLastIndexed(long ms, long modified)
                 {

--- a/study/api-src/org/labkey/api/specimen/location/LocationImpl.java
+++ b/study/api-src/org/labkey/api/specimen/location/LocationImpl.java
@@ -17,15 +17,17 @@
 package org.labkey.api.specimen.location;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.study.AbstractStudyCachable;
 import org.labkey.api.study.Location;
+import org.labkey.api.util.GUID;
 
 import java.util.Map;
 
 public class LocationImpl extends AbstractStudyCachable<Integer, LocationImpl> implements Location
 {
     private int _rowId; // INT IDENTITY(1,1),
-    private Container _container;
+    private GUID _containerId;
     private String _entityId;
 
     private Integer _externalId; // INT,
@@ -60,34 +62,34 @@ public class LocationImpl extends AbstractStudyCachable<Integer, LocationImpl> i
         setContainer(container);
         setEntityId((String)map.get("EntityId"));
         _rowId = (int)map.get("RowId");
-        _label  = (String)map.get("Label");
-        _externalId  = (Integer)map.get("ExternalId");
-        _ldmsLabCode  = (Integer)map.get("LdmsLabCode");
-        _labwareLabCode  = (String)map.get("LabwareLabCode");
-        _labUploadCode  = (String)map.get("LabUploadCode");
-        _repository  = (Boolean)map.get("Repository");
-        _clinic  = (Boolean)map.get("Clinic");
-        _sal  = (Boolean)map.get("SAL");
-        _endpoint  = (Boolean)map.get("Endpoint");
-        _description  = (String)map.get("Description");
-        _streetAddress  = (String)map.get("StreetAddress");
-        _city  = (String)map.get("City");
-        _governingDistrict  = (String)map.get("GoverningDistrict");
-        _country  = (String)map.get("Country");
+        _label = (String)map.get("Label");
+        _externalId = (Integer)map.get("ExternalId");
+        _ldmsLabCode = (Integer)map.get("LdmsLabCode");
+        _labwareLabCode = (String)map.get("LabwareLabCode");
+        _labUploadCode = (String)map.get("LabUploadCode");
+        _repository = (Boolean)map.get("Repository");
+        _clinic = (Boolean)map.get("Clinic");
+        _sal = (Boolean)map.get("SAL");
+        _endpoint = (Boolean)map.get("Endpoint");
+        _description = (String)map.get("Description");
+        _streetAddress = (String)map.get("StreetAddress");
+        _city = (String)map.get("City");
+        _governingDistrict = (String)map.get("GoverningDistrict");
+        _country = (String)map.get("Country");
         _postalArea = (String)map.get("PostalArea");
     }
 
     @Override
     public Container getContainer()
     {
-        return _container;
+        return ContainerManager.getForId(_containerId);
     }
 
     @Override
     public void setContainer(Container container)
     {
         verifyMutability();
-        _container = container;
+        _containerId = container.getEntityId();
     }
 
     @Override

--- a/study/src/org/labkey/study/model/AbstractStudyEntity.java
+++ b/study/src/org/labkey/study/model/AbstractStudyEntity.java
@@ -32,6 +32,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.study.AbstractStudyCachable;
 import org.labkey.api.study.StudyEntity;
+import org.labkey.api.util.GUID;
 import org.labkey.study.StudyModule;
 
 import java.io.Serializable;
@@ -42,39 +43,37 @@ import java.util.List;
 
 public abstract class AbstractStudyEntity<K, T> extends AbstractStudyCachable<K, T> implements StudyEntity, Serializable
 {
-    transient private Container _container;
-    private String _containerId;
+    private GUID _containerId;
     protected String _entityId;
     protected String _label;
     protected boolean _showByDefault = true;
     protected int _displayOrder;
 
-
     public AbstractStudyEntity()
     {
-        super();
     }
     
     public AbstractStudyEntity(Container c)
     {
-        super();
         setContainer(c);
+    }
+
+    public GUID getContainerId()
+    {
+        return _containerId;
     }
 
     @Override
     public Container getContainer()
     {
-        if (_container == null && _containerId != null)
-            _container = ContainerManager.getForId(_containerId);
-        return _container;
+        return ContainerManager.getForId(_containerId);
     }
 
     @Override
     public void setContainer(Container container)
     {
         verifyMutability();
-        _container = container;
-        _containerId = container == null ? null : container.getId();
+        _containerId = container == null ? null : container.getEntityId();
     }
 
     @Override

--- a/study/src/org/labkey/study/model/AbstractStudyEntity.java
+++ b/study/src/org/labkey/study/model/AbstractStudyEntity.java
@@ -66,7 +66,7 @@ public abstract class AbstractStudyEntity<K, T> extends AbstractStudyCachable<K,
     @Override
     public Container getContainer()
     {
-        return ContainerManager.getForId(_containerId);
+        return _containerId != null ? ContainerManager.getForId(_containerId) : null;
     }
 
     @Override

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -144,15 +144,11 @@ import static org.labkey.api.query.QueryService.AuditAction.TRUNCATE;
 
 public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefinition> implements Cloneable, Dataset, InitializingBean
 {
-    // DatasetQueryUpdateService
-
-
-    //    static final Object MANAGED_KEY_LOCK = new Object();
     private static final Logger _log = LogManager.getLogger(DatasetDefinition.class);
 
     private final ReentrantLock _lock = new ReentrantLockWithName(DatasetDefinition.class, "_lock");
 
-    private Container _definitionContainer;
+    private GUID _definitionContainerId;
     private Boolean _isShared = null;
     private StudyImpl _study;
     private int _datasetId;
@@ -176,8 +172,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
     private boolean _useTimeKeyField = false;
     private String _sourceQueryName;
     private String _sourceQuerySchema;
-    private Container _sourceQueryContainer;
-
+    private GUID _sourceQueryContainerId;
 
     private static final String[] BASE_DEFAULT_FIELD_NAMES_ARRAY = new String[]
     {
@@ -259,7 +254,6 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
     {
     }
 
-
     public DatasetDefinition(StudyImpl study, int datasetId)
     {
         _study = study;
@@ -271,7 +265,6 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
         _showByDefault = true;
         _isShared = study.getShareDatasetDefinitions();
     }
-
 
     public DatasetDefinition(StudyImpl study, int datasetId, String name, String label, String category, String entityId, @Nullable String typeURI)
     {
@@ -297,7 +290,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
         assert isShared();
         DatasetDefinition sub = createMutable();
         assert sub != this;
-        sub._definitionContainer = sub.getContainer();
+        sub._definitionContainerId = sub.getContainer().getEntityId();
         sub.setContainer(substudy.getContainer());
         sub._study = substudy;
 
@@ -332,9 +325,11 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
         SecurityPolicy existingPolicy = SecurityPolicyManager.getPolicy(this);
         if (!existingPolicy.getAssignments().equals(policy.getAssignments()))
         {
-            DatasetAuditProvider.DatasetAuditEvent event = new DatasetAuditProvider.DatasetAuditEvent(getContainer(),
-                    getPolicyChangeSummary(policy, existingPolicy, baseDescription, removalDescription, additionDescription),
-                    getDatasetId());
+            DatasetAuditProvider.DatasetAuditEvent event = new DatasetAuditProvider.DatasetAuditEvent(
+                getContainer(),
+                getPolicyChangeSummary(policy, existingPolicy, baseDescription, removalDescription, additionDescription),
+                getDatasetId()
+            );
             AuditLogService.get().addEvent(user, event);
         }
         super.savePolicy(policy, user);
@@ -349,7 +344,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
 
     public boolean isInherited()
     {
-        return isShared() && null != _definitionContainer && !_definitionContainer.equals(getContainer());
+        return isShared() && null != _definitionContainerId && !_definitionContainerId.equals(getContainerId());
     }
 
     /**
@@ -359,7 +354,6 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
     {
         return StudyManager.getInstance().getShadowedDatasets(getStudy(), Arrays.asList(this));
     }
-
 
     //TODO this should probably be driven off the DomainKind to avoid code duplication
     public static boolean isDefaultFieldName(String fieldName, Study study)
@@ -372,19 +366,17 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
             return true;
 
         return switch (study.getTimepointType())
-                {
-                    case VISIT -> DEFAULT_VISIT_FIELDS.contains(fieldName);
-                    case CONTINUOUS -> DEFAULT_ABSOLUTE_DATE_FIELDS.contains(fieldName);
-                    default -> DEFAULT_RELATIVE_DATE_FIELDS.contains(fieldName);
-                };
+        {
+            case VISIT -> DEFAULT_VISIT_FIELDS.contains(fieldName);
+            case CONTINUOUS -> DEFAULT_ABSOLUTE_DATE_FIELDS.contains(fieldName);
+            default -> DEFAULT_RELATIVE_DATE_FIELDS.contains(fieldName);
+        };
     }
-
 
     public static boolean showOnManageView(String fieldName, Study study)
     {
         return !HIDDEN_DEFAULT_FIELDS.contains(fieldName);
     }
-
 
     @Override
     public Set<String> getDefaultFieldNames()
@@ -397,7 +389,6 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
 
         return Collections.unmodifiableSet(fieldNames);
     }
-
 
     @Override
     public String getName()
@@ -484,11 +475,6 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
         _datasetId = datasetId;
     }
 
-    public String getDataSharing()
-    {
-        return getDataSharingEnum().name();
-    }
-
     public void setDataSharing(@NotNull String datasharing)
     {
         // datasharing can == null during server upgrade
@@ -509,7 +495,6 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
             return DataSharing.NONE;
         return _datasharing;
     }
-
 
     /**
      * We do not want to invalidate caches every time someone updates a dataset row
@@ -917,14 +902,14 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
     public StudyImpl getDefinitionStudy()
     {
         if (isInherited())
-            return StudyManager.getInstance().getStudy(_definitionContainer);
+            return StudyManager.getInstance().getStudy(getDefinitionContainer());
         return getStudy();
     }
 
 
     public Container getDefinitionContainer()
     {
-        return null!=_definitionContainer ? _definitionContainer : getContainer();
+        return null != _definitionContainerId ? ContainerManager.getForId(_definitionContainerId) : getContainer();
     }
 
 
@@ -1227,7 +1212,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
     @Override
     public boolean isQueryDataset()
     {
-        return _sourceQueryName != null && _sourceQuerySchema != null && _sourceQueryContainer != null;
+        return _sourceQueryName != null && _sourceQuerySchema != null && _sourceQueryContainerId != null;
     }
 
     public boolean isQuerySnapshot()
@@ -1257,12 +1242,12 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
 
     public Container getSourceQueryContainer()
     {
-        return _sourceQueryContainer;
+        return _sourceQueryContainerId != null ? ContainerManager.getForId(_sourceQueryContainerId) : null;
     }
 
     public void setSourceQueryContainer(Container sourceQueryContainer)
     {
-        _sourceQueryContainer = sourceQueryContainer;
+        _sourceQueryContainerId = null != sourceQueryContainer ? sourceQueryContainer.getEntityId() : null;
     }
 
     @Override

--- a/study/src/org/labkey/study/model/Participant.java
+++ b/study/src/org/labkey/study/model/Participant.java
@@ -16,13 +16,15 @@
 package org.labkey.study.model;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.util.GUID;
 
 import java.util.Date;
 import java.util.Objects;
 
 public class Participant
 {
-    private Container _container;
+    private GUID _containerId;
     private String _participantId;
     private Integer _enrollmentSiteId;      // This is a locationId, but still needs to match the column in the table
     private Integer _currentSiteId;         // This is a locationId, but still needs to match the column in the table
@@ -32,12 +34,12 @@ public class Participant
 
     public Container getContainer()
     {
-        return _container;
+        return ContainerManager.getForId(_containerId);
     }
 
     public void setContainer(Container container)
     {
-        _container = container;
+        _containerId = container.getEntityId();
     }
 
     public String getParticipantId()
@@ -106,12 +108,12 @@ public class Participant
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Participant that = (Participant) o;
-        return Objects.equals(_container, that._container) && Objects.equals(_participantId, that._participantId) && Objects.equals(_enrollmentSiteId, that._enrollmentSiteId) && Objects.equals(_currentSiteId, that._currentSiteId) && Objects.equals(_startDate, that._startDate) && Objects.equals(_initialCohortId, that._initialCohortId) && Objects.equals(_currentCohortId, that._currentCohortId);
+        return Objects.equals(_containerId, that._containerId) && Objects.equals(_participantId, that._participantId) && Objects.equals(_enrollmentSiteId, that._enrollmentSiteId) && Objects.equals(_currentSiteId, that._currentSiteId) && Objects.equals(_startDate, that._startDate) && Objects.equals(_initialCohortId, that._initialCohortId) && Objects.equals(_currentCohortId, that._currentCohortId);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(_container, _participantId, _enrollmentSiteId, _currentSiteId, _startDate, _initialCohortId, _currentCohortId);
+        return Objects.hash(_containerId, _participantId, _enrollmentSiteId, _currentSiteId, _startDate, _initialCohortId, _currentCohortId);
     }
 }

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -1707,8 +1707,9 @@ public class StudyManager
 
     public void updateParticipant(User user, Participant participant)
     {
-        Table.update(user, SCHEMA.getTableInfoParticipant(), participant, new Object[]{participant.getContainer().getId(), participant.getParticipantId()});
-        _participantCache.remove(participant.getContainer());
+        Container c = participant.getContainer();
+        Table.update(user, SCHEMA.getTableInfoParticipant(), participant, new Object[]{c.getId(), participant.getParticipantId()});
+        _participantCache.remove(c);
     }
 
     public void createVisitDatasetMapping(User user, Container container, int visitId, int datasetId, boolean isRequired)
@@ -4388,7 +4389,7 @@ public class StudyManager
                     // SimpleDocument
                     SimpleDocumentResource r = new SimpleDocumentResource(
                         p, docid,
-                        c.getId(),
+                        c.getEntityId(),
                         "text/plain",
                         displayTitle,
                         execute, props

--- a/wiki/src/org/labkey/wiki/WikiWebdavProvider.java
+++ b/wiki/src/org/labkey/wiki/WikiWebdavProvider.java
@@ -121,7 +121,7 @@ public class WikiWebdavProvider implements WebdavService.Provider
         {
             super(parent.getPath(), WIKI_NAME);
             _c = c;
-            _containerId = _c.getId();
+            _containerId = _c.getEntityId();
             setSecurableResource(c);
         }
 
@@ -318,7 +318,7 @@ public class WikiWebdavProvider implements WebdavService.Provider
         {
             super(folder.getPath(), name);
             _c = folder._c;
-            _containerId = _c.getId();
+            _containerId = _c.getEntityId();
             setSecurableResource(_c);
             _wiki = WikiSelectManager.getWiki(_c, name);
             if (null != _wiki)
@@ -465,7 +465,7 @@ public class WikiWebdavProvider implements WebdavService.Provider
         private void init(Container c, String name, String entityId, WikiFolder folder, Map<String, Object> properties)
         {
             _c = c;
-            _containerId = _c.getId();
+            _containerId = _c.getEntityId();
             _name = name;
             _entityId = entityId;
             _folder = folder;


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53058

#### Changes
- Stop holding onto `Container` objects in:
  - `AbstractStudyEntity`
  - `AbstractWebdavResolver`
  - `DatasetDefinition`
  - `DataState`
  - `LocationImpl`
  - `ObjectProperty`
  - `Participant`
  - `PlateImpl`
  - `PositionImpl`
  - `PropertySetImpl`
- Prefer holding and passing container IDs as `GUID` not `String`