### PR TITLE
Postgres specific implementation of ROUND()

### DIFF
--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -358,7 +358,7 @@ public abstract class Method
         labkeyMethod.put("repeat", new JdbcMethod("repeat", JdbcType.VARCHAR, 2, 2));
         labkeyMethod.put("round", new Method("round", JdbcType.DOUBLE, 1, 2)
 			{
-				@Override
+                @Override
 				public MethodInfo getMethodInfo()
 				{
 					return new RoundInfo();
@@ -840,28 +840,42 @@ public abstract class Method
                     return super.getSQL(dialect, new SQLFragment[] {arguments[0]});
             }
 
-            int i = Integer.MIN_VALUE;
-            try
+            if (supportsRoundDouble)
             {
-                i = Integer.parseInt(arguments[1].getSQL());
-            }
-            catch (NumberFormatException x)
-            {
-                /* fall through */
-            }
-
-            if (supportsRoundDouble || i == Integer.MIN_VALUE)
                 return super.getSQL(dialect, arguments);
-
-            // fall back, only supports simple integer
-            SQLFragment scaled = new SQLFragment();
-            scaled.append("(");
-            scaled.append(arguments[0]);
-            scaled.append(")*").appendValue(Math.pow(10,i));
-            SQLFragment ret = super.getSQL(dialect, new SQLFragment[] {scaled});
-            ret.append("/");
-            ret.appendValue(Math.pow(10,i));
-            return ret;
+            }
+            else if (dialect.isPostgreSQL())
+            {
+                // Postgres ROUND() requires NUMERIC argument and will error with DOUBLE
+                // This CAST works because in postgres NUMERIC(unspecified) => up to 131072 digits before the decimal point; up to 16383 digits after the decimal point
+                // This is not SQL standard behavior
+                SQLFragment numeric = new SQLFragment();
+                numeric.append("CAST((").append(arguments[0]).append(") AS NUMERIC)");
+                return super.getSQL(dialect, new SQLFragment[] {numeric, arguments[1]});
+            }
+            else
+            {
+                SQLFragment scaled = new SQLFragment();
+                int n = Integer.MIN_VALUE;
+                try
+                {
+                    n = Integer.parseInt(arguments[1].getSQL());
+                }
+                catch (NumberFormatException x)
+                {
+                    /* fall through */
+                }
+                // If 2nd argument isn't a constant, just do the default thing.  This may work or it may cause a server parse error.
+                if (n == Integer.MIN_VALUE)
+                    return super.getSQL(dialect, arguments);
+                scaled.append("(");
+                scaled.append(arguments[0]);
+                scaled.append(")*").appendValue(Math.pow(10, n));
+                SQLFragment ret = super.getSQL(dialect, new SQLFragment[]{scaled});
+                ret.append("/");
+                ret.appendValue(Math.pow(10, n));
+                return ret;
+            }
 		}
 	}
 

--- a/query/src/org/labkey/query/sql/QuerySelect.java
+++ b/query/src/org/labkey/query/sql/QuerySelect.java
@@ -2382,6 +2382,12 @@ public class QuerySelect extends AbstractQueryRelation implements Cloneable
                 to.setPrincipalConceptCode(null==c ? null : StringUtils.trimToNull(c.toString()));
             }
 
+            if (_annotations.containsKey("format"))
+            {
+                var format = _annotations.get("format");
+                to.setFormat(null==format ? null : StringUtils.trimToNull(format.toString()));
+            }
+
             boolean hidden = _annotations.containsKey("hidden");
             if (hidden)
                 to.setHidden(hidden);


### PR DESCRIPTION
#### Rationale
Postgres does not support ROUND(DOUBLE, precision).  This is an alternate Postgres specific implementation of ROUND().

This does not change the behavior of other databases that do support ROUND(DOUBLE,precision) that may use DOUBLE as a return type.  And not a general solution for formatting numbers.  Use CAST and LabKey formats.

Also, new SELECT annotation @format to make it easier to set a display format to make it easier to handle the general case for DOUBLE types.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
