### PR TITLE
Generate better error views for webparts with bad user input

### DIFF
--- a/api/src/org/labkey/api/view/Portal.java
+++ b/api/src/org/labkey/api/view/Portal.java
@@ -1714,19 +1714,24 @@ public class Portal implements ModuleChangeListener
 
             return view;
         }
-        catch (BadRequestException x)
-        {
-            BindException errors = new BindException(new Object(), "form");
-            errors.reject(SpringActionController.ERROR_MSG, x.getMessage());
-            return new SimpleErrorView(errors,false);
-        }
         catch(Throwable t)
         {
-            int status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-            String message = "An unexpected error occurred";
-            WebPartView<?> errorView = ExceptionUtil.getErrorWebPartView(status, message, t, portalCtx.getRequest());
-            errorView.setTitle(webPart.getName());
+            WebPartView<?> errorView;
+            if (t instanceof HttpStatusException)
+            {
+                BindException errors = new BindException(new Object(), "form");
+                errors.reject(SpringActionController.ERROR_MSG, t.getMessage());
+                errorView = new SimpleErrorView(errors, false);
+            }
+            else
+            {
+                int status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+                String message = "An unexpected error occurred";
+                errorView = ExceptionUtil.getErrorWebPartView(status, message, t, portalCtx.getRequest());
+            }
+            errorView.setTitle(Objects.requireNonNullElseGet(webPart.getPropertyMap().get("title"), webPart::getName));
             errorView.setWebPart(webPart);
+            errorView.setFrame(WebPartView.FrameType.PORTAL);
             return errorView;
         }
     }

--- a/list/src/org/labkey/list/view/SingleListWebPartFactory.java
+++ b/list/src/org/labkey/list/view/SingleListWebPartFactory.java
@@ -86,14 +86,7 @@ public class SingleListWebPartFactory extends AlwaysAvailableWebPartFactory
             return new HtmlView(title, HtmlString.of("List does not exist"));
 
         form.setViewName(viewName);
-        try
-        {
-            return new SingleListWebPart(form, props);
-        }
-        catch (NotFoundException notFound)
-        {
-            return new HtmlView(title, HtmlString.of(notFound.getMessage()));
-        }
+        return new SingleListWebPart(form, props);
     }
 
     @Override

--- a/list/src/org/labkey/list/view/SingleListWebPartFactory.java
+++ b/list/src/org/labkey/list/view/SingleListWebPartFactory.java
@@ -27,6 +27,7 @@ import org.labkey.api.view.AlwaysAvailableWebPartFactory;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
+import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.Portal;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartView;
@@ -85,7 +86,14 @@ public class SingleListWebPartFactory extends AlwaysAvailableWebPartFactory
             return new HtmlView(title, HtmlString.of("List does not exist"));
 
         form.setViewName(viewName);
-        return new SingleListWebPart(form, props);
+        try
+        {
+            return new SingleListWebPart(form, props);
+        }
+        catch (NotFoundException notFound)
+        {
+            return new HtmlView(title, HtmlString.of(notFound.getMessage()));
+        }
     }
 
     @Override

--- a/list/src/org/labkey/list/view/SingleListWebPartFactory.java
+++ b/list/src/org/labkey/list/view/SingleListWebPartFactory.java
@@ -27,7 +27,6 @@ import org.labkey.api.view.AlwaysAvailableWebPartFactory;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
-import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.Portal;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartView;


### PR DESCRIPTION
#### Rationale
When we throw an exception during webpart creation, we display an ugly error.
The crawler triggered a `NotFoundException` in `SingleListWebPartFactory` with an invalid reportId. I was able to trigger a similar error with `QueryWebPartFactory`.
<details><summary>Stacktrace</summary>
<pre>
org.labkey.api.view.NotFoundException: Could not find report for the specified reportId
       at org.labkey.api.query.QuerySettings.init(QuerySettings.java:253)
       at org.labkey.api.query.UserSchema.getSettings(UserSchema.java:629)
       at org.labkey.api.query.UserSchema.getSettings(UserSchema.java:618)
       at org.labkey.api.query.QueryForm.createQuerySettings(QueryForm.java:266)
       at org.labkey.list.view.ListQueryForm.createQuerySettings(ListQueryForm.java:78)
       at org.labkey.api.query.QueryForm.init(QueryForm.java:332)
       at org.labkey.api.query.QueryForm.getSchema(QueryForm.java:316)
       at org.labkey.api.query.QueryView.<init>(QueryView.java:259)
       at org.labkey.list.view.ListQueryView.<init>(ListQueryView.java:45)
       at org.labkey.list.view.SingleListWebPartFactory$SingleListWebPart.<init>(SingleListWebPartFactory.java:101)
       at org.labkey.list.view.SingleListWebPartFactory.getWebPartView(SingleListWebPartFactory.java:88)
       at org.labkey.api.view.Portal.getWebPartViewSafe(Portal.java:1686)
</pre></details> 

Certain exceptions represent bad input and should have a more friendly representation. `BadRequestException` (representing a 400 response) already had special handling when populating the portal view. Other `HttpStatusException`s should be handled similarly.

<details><summary>Before</summary>

![image](https://github.com/user-attachments/assets/12c7ef20-689c-442c-acbf-ec82475010f6)
</details> 
<details><summary>After</summary>

![image](https://github.com/user-attachments/assets/d4833eed-73c6-4d3a-96d4-07ec9248970e)
</details> 

#### Related Pull Requests
- #1493 

#### Changes
- Generate better error views for webparts with bad user input
