### PR TITLE
Fix study crosstab save form; do better at closing ResultSet

### DIFF
--- a/api/src/org/labkey/api/data/AsyncQueryRequest.java
+++ b/api/src/org/labkey/api/data/AsyncQueryRequest.java
@@ -31,12 +31,10 @@ import org.labkey.api.util.AbortedRequestException;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.LogHelper;
-import org.labkey.api.view.HttpView;
 import org.labkey.api.view.MockHttpResponseWithRealPassthrough;
 
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
-import org.labkey.api.view.ViewContext;
 
 import java.io.IOException;
 import java.sql.SQLException;

--- a/api/src/org/labkey/api/study/reports/Crosstab.java
+++ b/api/src/org/labkey/api/study/reports/Crosstab.java
@@ -93,16 +93,14 @@ public class Crosstab
 
         try {
             // map the row, column and stat FieldKey names to result set aliases
-            Map<FieldKey, ColumnInfo> fieldMap = results.getFieldMap();
-
-            if (fieldMap.containsKey(rowFieldKey))
+            if (_fieldMap.containsKey(rowFieldKey))
                 rowFieldIndex = results.findColumn(_rowFieldKey);
-            if (fieldMap.containsKey(colFieldKey))
+            if (_fieldMap.containsKey(colFieldKey))
                 colFieldIndex = results.findColumn(_colFieldKey);
-            if (fieldMap.containsKey(statFieldKey))
+            if (_fieldMap.containsKey(statFieldKey))
             {
                 statFieldIndex = results.findColumn(_statFieldKey);
-                ColumnInfo col = fieldMap.get(statFieldKey);
+                ColumnInfo col = _fieldMap.get(statFieldKey);
                 if (Number.class.isAssignableFrom(col.getJavaClass()) || col.getJavaClass().isPrimitive())
                     _statType = StatType.numeric;
                 else if (String.class.isAssignableFrom(col.getJavaClass()))

--- a/api/src/org/labkey/api/study/reports/Crosstab.java
+++ b/api/src/org/labkey/api/study/reports/Crosstab.java
@@ -22,6 +22,7 @@ import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.VerticalAlignment;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DisplayColumn;
@@ -55,7 +56,7 @@ public class Crosstab
     public static final String TOTAL_ROW = "CROSSTAB_TOTAL_ROW";
 
     private final Set<StatDefinition> _statSet;
-    private final Results _results;
+    private final @NotNull Map<FieldKey, ColumnInfo> _fieldMap;
     private final FieldKey _rowFieldKey;
     private final FieldKey _colFieldKey;
     private final FieldKey _statFieldKey;
@@ -80,10 +81,10 @@ public class Crosstab
     public Crosstab(Results results, FieldKey rowFieldKey, FieldKey colFieldKey, FieldKey statFieldKey, Set<StatDefinition> statSet) throws SQLException
     {
         _statSet = statSet;
-        _results = results;
         _rowFieldKey = rowFieldKey;
         _colFieldKey = colFieldKey;
         _statFieldKey = statFieldKey;
+        _fieldMap = results.getFieldMap();
 
         int rowFieldIndex = 0;
         int colFieldIndex = 0;
@@ -95,12 +96,12 @@ public class Crosstab
             Map<FieldKey, ColumnInfo> fieldMap = results.getFieldMap();
 
             if (fieldMap.containsKey(rowFieldKey))
-                rowFieldIndex = _results.findColumn(_rowFieldKey);
+                rowFieldIndex = results.findColumn(_rowFieldKey);
             if (fieldMap.containsKey(colFieldKey))
-                colFieldIndex = _results.findColumn(_colFieldKey);
+                colFieldIndex = results.findColumn(_colFieldKey);
             if (fieldMap.containsKey(statFieldKey))
             {
-                statFieldIndex = _results.findColumn(_statFieldKey);
+                statFieldIndex = results.findColumn(_statFieldKey);
                 ColumnInfo col = fieldMap.get(statFieldKey);
                 if (Number.class.isAssignableFrom(col.getJavaClass()) || col.getJavaClass().isPrimitive())
                     _statType = StatType.numeric;
@@ -110,17 +111,15 @@ public class Crosstab
             else
                 throw new RuntimeException("The specified statistics column: " + _statFieldKey + " is not available in this view");
 
-//        ResultSet rs = _results.getResultSet();
-
             //TODO: Use DisplayField for display & value extraction. Support Grouping fields with custom groupings
-            while (_results.next())
+            while (results.next())
             {
                 Object rowVal = null;
                 List<Object> cellValues = null;
                 List<Object> colDataset = null;
                 if (0 != rowFieldIndex)
                 {
-                    rowVal = _results.getObject(rowFieldIndex);
+                    rowVal = results.getObject(rowFieldIndex);
                     Map<Object, List<Object>> rowMap = _crossTab.get(rowVal);
                     if (null == rowMap)
                     {
@@ -132,11 +131,9 @@ public class Crosstab
                         _rowDatasets.put(rowVal, new ArrayList<>());
                     }
 
-                    cellValues = null;
-                    colDataset = null;
                     if (0 != colFieldIndex)
                     {
-                        Object colVal = _results.getObject(colFieldIndex);
+                        Object colVal = results.getObject(colFieldIndex);
                         cellValues = rowMap.get(colVal);
                         if (null == cellValues)
                         {
@@ -154,7 +151,7 @@ public class Crosstab
                     }
                 }
 
-                Object statFieldVal = _results.getObject(statFieldIndex);
+                Object statFieldVal = results.getObject(statFieldIndex);
                 if (statFieldVal == null)
                 {
                     if (getStatType() == StatType.string)
@@ -176,7 +173,7 @@ public class Crosstab
         }
         finally
         {
-            ResultSetUtil.close(_results);
+            ResultSetUtil.close(results);
         }
     }
 
@@ -207,7 +204,7 @@ public class Crosstab
         if (null == fieldKey)
             return "";
 
-        ColumnInfo col = _results.getFieldMap().get(fieldKey);
+        ColumnInfo col = _fieldMap.get(fieldKey);
         if (null != col)
             return col.getLabel();
 
@@ -312,11 +309,6 @@ public class Crosstab
     public FieldKey getStatField()
     {
         return _statFieldKey;
-    }
-
-    public Results getResults()
-    {
-        return _results;
     }
 
     public ExcelWriter getExcelWriter()

--- a/api/src/org/labkey/api/study/reports/CrosstabReport.java
+++ b/api/src/org/labkey/api/study/reports/CrosstabReport.java
@@ -20,7 +20,6 @@ import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.ExcelWriter;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.Results;
-import org.labkey.api.data.ResultsImpl;
 import org.labkey.api.data.Table;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryParam;
@@ -93,7 +92,7 @@ public class CrosstabReport extends AbstractReport implements Report.ResultSetGe
     }
 
     @Override
-    public HttpView renderReport(ViewContext context)
+    public HttpView<?> renderReport(ViewContext context)
     {
         ReportDescriptor reportDescriptor = getDescriptor();
 
@@ -137,9 +136,7 @@ public class CrosstabReport extends AbstractReport implements Report.ResultSetGe
             rgn.setAllowAsync(allowAsyncQuery);
             RenderContext ctx = dataView.getRenderContext();
 
-            if (null == rgn.getResults(ctx))
-                return null;
-            return new ResultsImpl(ctx);
+            return rgn.getResults(ctx);
         }
         return null;
     }

--- a/api/src/org/labkey/api/study/reports/CrosstabView.java
+++ b/api/src/org/labkey/api/study/reports/CrosstabView.java
@@ -91,7 +91,7 @@ public class CrosstabView extends WebPartView<Object>
                 TR(
                     TH(_crosstab.getFieldLabel(_crosstab.getRowField())),
                     multipleStats ? TD(cl("xtab-col-header"), HtmlString.NBSP) : null,
-                    null != _crosstab.getColField() ? colHeaders.stream().map(colVal -> TD(cl("xtab-col-header"), colVal)) : null,
+                    null != _crosstab.getColField() ? colHeaders.stream().map(colVal -> TD(cl("xtab-col-header"), HtmlString.of(colVal))) : null,
                     TD(cl("xtab-col-header"), null == _crosstab.getColField() && null != stat ? stat.getName() : "Total")
                 ),
 

--- a/api/src/org/labkey/api/util/DOM.java
+++ b/api/src/org/labkey/api/util/DOM.java
@@ -876,6 +876,17 @@ public class DOM
                 throw new RuntimeException(e);
             }
         }
+        else if (body instanceof Boolean b)
+        {
+            try
+            {
+                builder.append(Boolean.toString(b));
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
         else if (body instanceof DOM.Renderable)
         {
             ((DOM.Renderable) body).appendTo(builder);
@@ -887,7 +898,7 @@ public class DOM
         }
         else if (body instanceof Iterable)
         {
-            for (var i : ((Iterable)body))
+            for (var i : ((Iterable<?>)body))
                 appendBody(builder, i);
         }
         else if (body instanceof Stream)

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -420,7 +420,7 @@ public class ReportsController extends BaseStudyController
         @Override
         public ModelAndView getView(CrosstabDesignBean form, boolean reshow, BindException errors) throws Exception
         {
-            form.setColumns(getColumns(form));
+            form.setColumns(getColumns(form, errors));
 
             JspView<CrosstabDesignBean> view = new JspView<>("/org/labkey/study/view/crosstabDesigner.jsp", form);
             view.setTitle("Design Crosstab Report");
@@ -462,7 +462,7 @@ public class ReportsController extends BaseStudyController
             return v;
         }
 
-        private Map<String, ColumnInfo> getColumns(CrosstabDesignBean form)
+        private Map<String, ColumnInfo> getColumns(CrosstabDesignBean form, BindException errors)
         {
             UserSchema schema = QueryService.get().getUserSchema(getUser(), getContainer(), form.getSchemaName());
             Map<String, ColumnInfo> colMap = new CaseInsensitiveHashMap<>();
@@ -471,7 +471,7 @@ public class ReportsController extends BaseStudyController
             {
                 QuerySettings settings = schema.getSettings(form.getViewContext(), "Dataset", form.getQueryName());
 
-                QueryView qv = schema.createView(getViewContext(), settings);
+                QueryView qv = schema.createView(getViewContext(), settings, errors);
                 List<DisplayColumn> cols = qv.getDisplayColumns();
                 for (DisplayColumn col : cols)
                 {
@@ -534,7 +534,7 @@ public class ReportsController extends BaseStudyController
     }
 
     @RequiresNoPermission
-    public class CreateCrosstabReportAction extends SimpleViewAction
+    public class CreateCrosstabReportAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -591,11 +591,11 @@ public class ReportsController extends BaseStudyController
 
     public static class CreateQueryReportBean
     {
-        private List<String> _tableAndQueryNames;
-        private Container _container;
-        private User _user;
-        private String _queryName;
-        private ActionURL _returnUrl;
+        private final List<String> _tableAndQueryNames;
+        private final Container _container;
+        private final User _user;
+        private final String _queryName;
+        private final ActionURL _returnUrl;
         private Map<String, DatasetDefinition> _datasetMap;
 
         public CreateQueryReportBean(ViewContext context, String queryName) throws IllegalStateException
@@ -685,14 +685,6 @@ public class ReportsController extends BaseStudyController
 
         public SaveReportForm()
         {
-        }
-
-        public SaveReportForm(Report report)
-        {
-            this.label = report.getDescriptor().getReportName();
-            this.params = report.getDescriptor().toQueryString();
-            this.reportType = report.getDescriptor().getReportType();
-            this.description = report.getDescriptor().getReportDescription();
         }
 
         public String getLabel()
@@ -862,7 +854,7 @@ public class ReportsController extends BaseStudyController
         }
     }
 
-    public static HttpView getParticipantNavTrail(ViewContext context, List<String> participantGroup)
+    public static HttpView<?> getParticipantNavTrail(ViewContext context, List<String> participantGroup)
     {
         String participantId = context.getActionURL().getParameter("participantId");
 
@@ -977,9 +969,7 @@ public class ReportsController extends BaseStudyController
             if (getContainer().hasPermission(getUser(), AdminPermission.class))
                 root.addChild("Manage Views", urlProvider(ReportUrls.class).urlManageViews(getContainer()));
         }
-        catch (Exception e)
-        {
-        }
+        catch (Exception ignored) {}
         root.addChild(name);
     }
 

--- a/study/src/org/labkey/study/view/saveReportView.jsp
+++ b/study/src/org/labkey/study/view/saveReportView.jsp
@@ -59,7 +59,7 @@
     {
         for (ObjectError e : bean.getErrors().getAllErrors())
         {
-            %><tr><td colspan=3><font class="labkey-error"><%=h(context.getMessage(e))%></font></td></tr><%
+            %><tr><td colspan=3><span class="labkey-error"><%=h(context.getMessage(e))%></span></td></tr><%
         }
     }
 %>
@@ -80,6 +80,7 @@
     if (confirm)
     {
 %>
+        <td></td>
         <td>There is already a report called: <i><%=h(report.getDescriptor().getReportName())%></i>.<br/>Overwrite the existing report?
         <input type=hidden name=confirmed value=1>
         <input type=hidden name=label value="<%=h(bean.getLabel())%>">
@@ -87,8 +88,8 @@
 <%
     } else {
 %>
-        <td><b>Save Report</b></td>
-        <td>Name:&nbsp;<input id="reportName" name="label" value="<%=h(bean.getLabel())%>">
+        <td><label for="reportName">Name:</label></td>
+        <td><input id="reportName" name="label" value="<%=h(bean.getLabel())%>">
         <%=generateReturnUrlFormField(getActionURL())%>
 <%
     }
@@ -100,8 +101,8 @@
     </tr>
     <% if (context.hasPermission(AdminPermission.class)) { %>
         <tr>
-            <td><input type="checkbox" value="true" name="shareReport"<%=checked(bean.getShareReport())%>>Make this report available to all users.</td>
-            <td colspan=2>description:<textarea name="description" style="width: 100%;" rows="2"><%=h(StringUtils.trimToEmpty(bean.getDescription()))%></textarea></td>
+            <td></td>
+            <td><input type="checkbox" value="true" id="shareReport" name="shareReport"<%=checked(bean.getShareReport())%>> <label for="shareReport">Make this report available to all users.</label></td>
         </tr>
     <% } %>
     <tr>


### PR DESCRIPTION
#### Rationale
The study cross tab report UI got mangled with a recent change. We are also failing to close ResultSets in some scenarios.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6736

#### Changes
- Fix form layout when saving cross tab reports
- Streamline use of Results/ResultSets
- Minor code cleanup

#### Tasks
- [x] Manual Testing @labkey-adam 
- [x] Needs Automation
- [x] Verify Fix
- [x] Teamcity Review