### PR TITLE
Issue 52485: App admins can't edit shorturls

### DIFF
--- a/api/src/org/labkey/api/security/permissions/AdminOperationsPermission.java
+++ b/api/src/org/labkey/api/security/permissions/AdminOperationsPermission.java
@@ -16,7 +16,9 @@
 package org.labkey.api.security.permissions;
 
 /**
- * Describes the ability to manage operational site administration settings.
+ * Describes the ability to manage operational site administration settings, such as arbitrary paths on the server's
+ * underlying file system. Use {@see org.labkey.api.security.permissions.ApplicationAdminPermission} for gating
+ * access to server-wide settings that don't have the potential to access these underlying server resources.
  */
 public class AdminOperationsPermission extends AdminPermission
 {

--- a/api/src/org/labkey/api/security/permissions/ApplicationAdminPermission.java
+++ b/api/src/org/labkey/api/security/permissions/ApplicationAdminPermission.java
@@ -15,6 +15,11 @@
  */
 package org.labkey.api.security.permissions;
 
+/**
+ * Used for places that impact server-wide behavior but don't grant access to arbitrary resources on the underlying
+ * server. Use {@see org.labkey.api.security.permissions.AdminOperationsPermission} for those checks,
+ * including pointing at arbitrary file paths.
+ */
 public class ApplicationAdminPermission extends AbstractSitePermission
 {
     public ApplicationAdminPermission()

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10402,7 +10402,11 @@ public class AdminController extends SpringActionController
 
             QuerySettings qSettings = new QuerySettings(getViewContext(), "ShortURL", CoreQuerySchema.SHORT_URL_TABLE_NAME);
             qSettings.setBaseSort(new Sort("-Created"));
-            QueryView existingView = new QueryView(new CoreQuerySchema(getUser(), getContainer()), qSettings, errors);
+            QueryView existingView = new QueryView(new CoreQuerySchema(getUser(), getContainer()), qSettings, null);
+            if (!getUser().hasRootPermission(ApplicationAdminPermission.class))
+            {
+                existingView.setButtonBarPosition(DataRegion.ButtonBarPosition.NONE);
+            }
             existingView.setTitle("Existing Short URLs");
             existingView.setFrame(WebPartView.FrameType.PORTAL);
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10308,7 +10308,6 @@ public class AdminController extends SpringActionController
         }
     }
 
-    @RequiresPermission(AdminPermission.class)
     public abstract static class AbstractShortURLAdminAction extends FormViewAction<ShortURLForm>
     {
         @Override

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -347,7 +347,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ClassLoadingMXBean;
@@ -1143,8 +1142,7 @@ public class AdminController extends SpringActionController
 
             if (null != wikiSource)
             {
-                String component = "the " + module.getName() + " Module";
-                String title = fileType + " Files Distributed with " + component;
+                String title = fileType + " Files Distributed with the " + module.getName() + " Module";
                 CreditsView credits = new CreditsView(wikiSource, title);
                 views.addView(credits);
             }
@@ -10311,7 +10309,7 @@ public class AdminController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public abstract class AbstractShortURLAdminAction extends FormViewAction<ShortURLForm>
+    public abstract static class AbstractShortURLAdminAction extends FormViewAction<ShortURLForm>
     {
         @Override
         public void validateCommand(ShortURLForm target, Errors errors) {}
@@ -10427,7 +10425,7 @@ public class AdminController extends SpringActionController
         }
     }
 
-    @RequiresPermission(AdminOperationsPermission.class)
+    @RequiresPermission(ApplicationAdminPermission.class)
     public class UpdateShortURLAction extends AbstractShortURLAdminAction
     {
         @Override
@@ -10598,7 +10596,7 @@ public class AdminController extends SpringActionController
     /** generate URLS to seed web-site scanner */
     @SuppressWarnings("UnusedDeclaration")
     @RequiresSiteAdmin
-    public static class SpiderAction extends SimpleViewAction
+    public static class SpiderAction extends SimpleViewAction<Object>
     {
         @Override
         public void addNavTrail(NavTree root)
@@ -11683,7 +11681,7 @@ public class AdminController extends SpringActionController
     public static class FilesAction extends ProjectSettingsViewPostAction<FilesForm>
     {
         @Override
-        protected HttpView getTabView(FilesForm form, boolean reshow, BindException errors)
+        protected HttpView<?> getTabView(FilesForm form, boolean reshow, BindException errors)
         {
             Container c = getContainer();
 
@@ -11722,7 +11720,7 @@ public class AdminController extends SpringActionController
                     for (String errorMessage : pipeRoot.validate())
                         errors.addError(new LabKeyError(errorMessage));
                 }
-                JspView pipelineView = (JspView) PipelineService.get().getSetupView(setupForm);
+                JspView<?> pipelineView = (JspView<?>) PipelineService.get().getSetupView(setupForm);
                 pipelineView.setTitle("Configure Data Processing Pipeline");
                 box.addView(pipelineView);
             }

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -464,7 +464,7 @@ public class AdminController extends SpringActionController
         AdminConsole.addLink(Configuration, "look and feel settings", new ActionURL(LookAndFeelSettingsAction.class, root));
         AdminConsole.addLink(Configuration, "missing value indicators", new AdminUrlsImpl().getMissingValuesURL(root), AdminPermission.class);
         AdminConsole.addLink(Configuration, "project display order", new ActionURL(ReorderFoldersAction.class, root), AdminPermission.class);
-        AdminConsole.addLink(Configuration, "short urls", new ActionURL(ShortURLAdminAction.class, root), AdminPermission.class);
+        AdminConsole.addLink(Configuration, "short urls", new ActionURL(ShortURLAdminAction.class, root), TroubleshooterPermission.class);
         AdminConsole.addLink(Configuration, "site settings", new AdminUrlsImpl().getCustomizeSiteURL());
         AdminConsole.addLink(Configuration, "system maintenance", new ActionURL(ConfigureSystemMaintenanceAction.class, root));
         AdminConsole.addLink(Configuration, "allowed external redirect hosts", new ActionURL(AllowListAction.class, root).addParameter("type", AllowListType.Redirect.name()), TroubleshooterPermission.class);
@@ -10392,7 +10392,6 @@ public class AdminController extends SpringActionController
     }
 
     @AdminConsoleAction
-    @RequiresPermission(AdminPermission.class)
     public class ShortURLAdminAction extends AbstractShortURLAdminAction
     {
         @Override
@@ -10402,7 +10401,7 @@ public class AdminController extends SpringActionController
             newView.setTitle("Create New Short URL");
             newView.setFrame(WebPartView.FrameType.PORTAL);
 
-            QuerySettings qSettings = new QuerySettings(getViewContext(), "ShortURL", "ShortURL");
+            QuerySettings qSettings = new QuerySettings(getViewContext(), "ShortURL", CoreQuerySchema.SHORT_URL_TABLE_NAME);
             qSettings.setBaseSort(new Sort("-Created"));
             QueryView existingView = new QueryView(new CoreQuerySchema(getUser(), getContainer()), qSettings, errors);
             existingView.setTitle("Existing Short URLs");

--- a/core/src/org/labkey/core/admin/createNewShortURL.jsp
+++ b/core/src/org/labkey/core/admin/createNewShortURL.jsp
@@ -17,6 +17,7 @@
 %>
 <%@ page import="org.labkey.api.admin.AdminUrls" %>
 <%@ page import="org.labkey.api.view.ShortURLRecord" %>
+<%@ page import="org.labkey.api.security.permissions.ApplicationAdminPermission" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <labkey:errors/>
@@ -47,7 +48,7 @@
         </tr>
         <tr>
             <td></td>
-            <td><%= button("Submit").submit(true) %></td>
+            <td><%= button("Submit").submit(true).enabled(getUser().hasRootPermission(ApplicationAdminPermission.class)) %></td>
         </tr>
     </table>
 </labkey:form>

--- a/core/src/org/labkey/core/query/ShortUrlTableInfo.java
+++ b/core/src/org/labkey/core/query/ShortUrlTableInfo.java
@@ -21,6 +21,8 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.permissions.TroubleshooterPermission;
 import org.labkey.api.util.DOM;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
@@ -185,11 +187,13 @@ public class ShortUrlTableInfo extends FilteredTable<CoreQuerySchema>
     @Override
     public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
     {
-        return canDisplayTable(user, getContainer()) && getContainer().hasPermission(user, perm);
+        return canDisplayTable(user, getContainer()) && (perm.equals(ReadPermission.class) || getContainer().hasPermission(user, perm));
     }
 
     public static boolean canDisplayTable(@NotNull UserPrincipal user, @NotNull Container container)
     {
-        return container.isRoot() && container.hasPermission(user, ApplicationAdminPermission.class);
+        return container.isRoot() &&
+                (container.hasPermission(user, ApplicationAdminPermission.class) ||
+                        container.hasPermission(user, TroubleshooterPermission.class));
     }
 }

--- a/core/src/org/labkey/core/query/ShortUrlTableInfo.java
+++ b/core/src/org/labkey/core/query/ShortUrlTableInfo.java
@@ -192,8 +192,6 @@ public class ShortUrlTableInfo extends FilteredTable<CoreQuerySchema>
 
     public static boolean canDisplayTable(@NotNull UserPrincipal user, @NotNull Container container)
     {
-        return container.isRoot() &&
-                (container.hasPermission(user, ApplicationAdminPermission.class) ||
-                        container.hasPermission(user, TroubleshooterPermission.class));
+        return container.isRoot() && container.hasPermission(user, TroubleshooterPermission.class);
     }
 }

--- a/core/src/org/labkey/core/view/ShortURLServiceImpl.java
+++ b/core/src/org/labkey/core/view/ShortURLServiceImpl.java
@@ -32,6 +32,7 @@ import org.labkey.api.security.MutableSecurityPolicy;
 import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.EditorRole;
@@ -85,7 +86,7 @@ public class ShortURLServiceImpl implements ShortURLService
     @Override
     public void deleteShortURL(@NotNull ShortURLRecord record, @NotNull User user) throws ValidationException
     {
-        if (!record.hasPermission(user, DeletePermission.class))
+        if (!record.hasPermission(user, DeletePermission.class) && !user.hasRootPermission(ApplicationAdminPermission.class))
         {
             throw new UnauthorizedException("You are not authorized to delete the short URL '" + record.getShortURL() + "'");
         }
@@ -148,7 +149,7 @@ public class ShortURLServiceImpl implements ShortURLService
         }
         else
         {
-            if (!existingRecord.hasPermission(user, UpdatePermission.class))
+            if (!existingRecord.hasPermission(user, UpdatePermission.class) && !user.hasRootPermission(ApplicationAdminPermission.class))
             {
                 throw new UnauthorizedException("You are not authorized to edit the short URL '" + shortURL + "'");
             }


### PR DESCRIPTION
#### Rationale
The Short URLs page in the Admin Console wasn't working as desired for app admins or troubleshooters

#### Changes
- Allow read-only access for troubleshooters
- Consistently check for ApplicationAdminPermission
- Comments to clarify difference between ApplicationAdminPermission and AdminOperationsPermission