### PR TITLE
 Misc assay issues fixes for 25.7 - part 3

### DIFF
--- a/api/src/org/labkey/api/assay/AssayFileWriter.java
+++ b/api/src/org/labkey/api/assay/AssayFileWriter.java
@@ -138,33 +138,43 @@ public class AssayFileWriter<ContextType extends AssayRunUploadContext<? extends
         }
     }
 
+    public static String generateFileName(ExpProtocol protocol, boolean shouldEncode)
+    {
+        Date dateCreated = new Date();
+        String dateString = DateUtil.formatDateTime(dateCreated, "yyy-MM-dd-HHmmss");
+
+        String protocolName = protocol.getName();
+        if (shouldEncode)
+        {
+            char[] characters = protocolName.toCharArray();
+
+            for (int i = 0; i < characters.length; i++)
+            {
+                char character = characters[i];
+                boolean isAtoZchar = character >= 'A' && character <= 'z';
+                if (!Character.isDigit(character) && !isAtoZchar)
+                    characters[i] = '_';
+            }
+            protocolName = new String(characters);
+        }
+
+        return protocolName + "-" + dateString;
+    }
+
     /**
      * Create file name based upon the assay protocol's name and the current time.
      * e.g., <code>assayname-2020-04-14-1602345</code>
      */
     public static FileLike createFile(ExpProtocol protocol, FileLike dir, String extension)
     {
-        Date dateCreated = new Date();
-        String dateString = DateUtil.formatDateTime(dateCreated, "yyy-MM-dd-HHmmss-SSS");
+        String fileNamePrefix = generateFileName(protocol, true);
         int id = 0;
-
-        String protocolName = protocol.getName();
-        char[] characters = protocolName.toCharArray();
-
-        for (int i = 0; i < characters.length; i++)
-        {
-            char character = characters[i];
-            boolean isAtoZchar = character >= 'A' && character <= 'z';
-            if (!Character.isDigit(character) && !isAtoZchar)
-                characters[i] = '_';
-        }
-        protocolName = new String(characters);
 
         FileLike file;
         do
         {
             String extra = id++ == 0 ? "" : String.valueOf(id);
-            String fileName = protocolName + "-" + dateString + extra + "." + extension;
+            String fileName = fileNamePrefix + extra + "." + extension;
             fileName = fileName.replace('\\', '_').replace('/', '_').replace(':', '_');
             file = dir.resolveChild(fileName);
         }

--- a/api/src/org/labkey/api/assay/AssayFileWriter.java
+++ b/api/src/org/labkey/api/assay/AssayFileWriter.java
@@ -29,7 +29,6 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.AbstractQueryUpdateService;
-import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.view.ViewContext;
@@ -44,7 +43,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayDeque;
-import java.util.Date;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -140,25 +138,11 @@ public class AssayFileWriter<ContextType extends AssayRunUploadContext<? extends
 
     public static String generateFileName(ExpProtocol protocol, boolean shouldEncode)
     {
-        Date dateCreated = new Date();
-        String dateString = DateUtil.formatDateTime(dateCreated, "yyy-MM-dd-HHmmss");
-
         String protocolName = protocol.getName();
         if (shouldEncode)
-        {
-            char[] characters = protocolName.toCharArray();
+            return FileUtil.makeFileNameWithTimestamp(protocolName);
 
-            for (int i = 0; i < characters.length; i++)
-            {
-                char character = characters[i];
-                boolean isAtoZchar = character >= 'A' && character <= 'z';
-                if (!Character.isDigit(character) && !isAtoZchar)
-                    characters[i] = '_';
-            }
-            protocolName = new String(characters);
-        }
-
-        return protocolName + "-" + dateString;
+        return protocolName + "_" + FileUtil.getTimestamp(); // Issue 52075
     }
 
     /**

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -982,6 +982,14 @@ public class DomainUtil
         return validationException;
     }
 
+    // Issue 51321: check reserved domain name: First, All
+    public static @Nullable String validateReservedName(@NotNull String domainName, @NotNull String kindName)
+    {
+        if ("First".equalsIgnoreCase(domainName) || "All".equalsIgnoreCase(domainName))
+            return kindName + " name '" + domainName + "' is a reserved name.";
+        return null;
+    }
+
     public static @Nullable String validateDomainName(@NotNull String domainName, String kindName, boolean supportsNamingPattern)
     {
         String prefix = "Invalid " + kindName + " name '" + domainName + "'. ";

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1-cory257FixesV3.0"
+        "@labkey/components": "6.52.1-cory257FixesV3.2"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2224,9 +2224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1-cory257FixesV3.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.0.tgz",
-      "integrity": "sha512-6eioh5D005aqryyssXh/VIEI1qxO7Gd4Sf80GbVGd1IkTdqL2hQ7zpDqb6KzmTZ87o1B6Gc3UtqbMzToRyJ1Bg==",
+      "version": "6.52.1-cory257FixesV3.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.2.tgz",
+      "integrity": "sha512-1eKFWT61F80gLeG+NBTfh8/gy+SEE24FPkr6AUalULoCOdbMTLBqySLunrsyl3zdcf7N2LcEsG3UWiUkWWQyEg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1"
+        "@labkey/components": "6.52.1-cory257FixesV3.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2224,10 +2224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1.tgz",
-      "integrity": "sha512-w6Q/xza95hT8LvxF2IAnDzOsvg49p9YY6ap+TrWoXlP2DwlghvlQm5ncgFOhB45T0dozpZ9GDThpQsuCPVTpcQ==",
-      "license": "SEE LICENSE IN LICENSE.txt",
+      "version": "6.52.1-cory257FixesV3.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.0.tgz",
+      "integrity": "sha512-6eioh5D005aqryyssXh/VIEI1qxO7Gd4Sf80GbVGd1IkTdqL2hQ7zpDqb6KzmTZ87o1B6Gc3UtqbMzToRyJ1Bg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1-cory257FixesV3.2"
+        "@labkey/components": "6.52.3"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2224,9 +2224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1-cory257FixesV3.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.2.tgz",
-      "integrity": "sha512-1eKFWT61F80gLeG+NBTfh8/gy+SEE24FPkr6AUalULoCOdbMTLBqySLunrsyl3zdcf7N2LcEsG3UWiUkWWQyEg==",
+      "version": "6.52.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.3.tgz",
+      "integrity": "sha512-/exkGix4xfRq5OlHEiOvaVFPNmJDTzjx9KUWYkeo9LirFua3Cv/6rrvTe5RGgS5+nnScSQzWLFDWQ8qR/HJRlg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.0"
+        "@labkey/components": "6.52.0-cory257FixesV3.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2224,10 +2224,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.0.tgz",
-      "integrity": "sha512-gH9wQkmD/dQiPCfKYaY1+cNNDGaJ76XwrpR7Yl+n4rI01U3UJyR8vU4a3UpYEMEXn4P+R2tugCsbJoJA3fSMAw==",
-      "license": "SEE LICENSE IN LICENSE.txt",
+      "version": "6.52.0-cory257FixesV3.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.0-cory257FixesV3.0.tgz",
+      "integrity": "sha512-Azen/02FQT20szLxGd4PPV9be1BKMAy/UNMWTpyzoY0wlBbXQ4SOBpau8PVD8IplBq2n7CfCEQZk8FZse2PkSA==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.52.1"
+    "@labkey/components": "6.52.1-cory257FixesV3.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.52.1-cory257FixesV3.0"
+    "@labkey/components": "6.52.1-cory257FixesV3.2"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.52.1-cory257FixesV3.2"
+    "@labkey/components": "6.52.3"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.52.0"
+    "@labkey/components": "6.52.0-cory257FixesV3.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -426,15 +426,20 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                 boolean hasNameChange = false;
                 AssayProvider assayProvider = AssayService.get().getProvider(assay.getProviderName());
                 String oldAssayName = null;
+
+                // Issue 51321: check reserved domain name: First, All
+                if ("First".equalsIgnoreCase(assay.getName()) || "All".equalsIgnoreCase(assay.getName()))
+                    throw new ValidationException("Assay design name '" + assay.getName() + "' is reserved.");
+
+                String nameError = DomainUtil.validateDomainName(assay.getName(), "Assay Design", false);
+                if (nameError != null)
+                    throw new ValidationException(nameError);
+
                 if (isNew)
                 {
                     // check for existing assay protocol with the given name before creating
                     if (AssayManager.get().getAssayProtocolByName(getContainer(), assay.getName()) != null)
                         throw new ValidationException("Assay protocol already exists for this name.");
-
-                    String nameError = DomainUtil.validateDomainName(assay.getName(), "Assay Design", false);
-                    if (nameError != null)
-                        throw new ValidationException(nameError);
 
                     XarContext context = new XarContext("Domains", getContainer(), getUser());
                     context.addSubstitution("AssayName", PageFlowUtil.encode(assay.getName()));
@@ -478,14 +483,16 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                     if (!protocol.getContainer().equals(getContainer()))
                         throw new ValidationException("Assays can only be edited in the folder where they were created.  " +
                                 "This assay was created in folder " + protocol.getContainer().getPath());
+
                     oldAssayName = protocol.getName();
                     hasNameChange = !assay.getName().equals(oldAssayName);
                     if (hasNameChange)
                     {
+                        boolean casingOnlyChange = assay.getName().equalsIgnoreCase(oldAssayName);
+                        if (!casingOnlyChange && AssayManager.get().getAssayProtocolByName(getContainer(), assay.getName()) != null)
+                            throw new ValidationException("Another assay protocol already exists for this name.");
+
                         changeDetails.append("The name of the assay domain '" + oldAssayName + "' was changed to '" + assay.getName() + "'.");
-                        String nameError = DomainUtil.validateDomainName(assay.getName(), "Assay Design", false);
-                        if (nameError != null)
-                            throw new ValidationException(nameError);
                     }
                     protocol.setName(assay.getName());
                     protocol.setProtocolDescription(assay.getDescription());
@@ -513,16 +520,8 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                 }
                 protocol.setProtocolParameters(newParams.values());
 
-                // Issue 51321: check reserved sample type name: First
-                if ("First".equalsIgnoreCase(assay.getName()) || "All".equalsIgnoreCase(assay.getName()))
-                    throw new ValidationException("Assay design name '" + assay.getName() + "' is reserved.");
-
                 if (hasNameChange)
-                {
-                    if (AssayManager.get().getAssayProtocolByName(getContainer(), assay.getName()) != null)
-                        throw new ValidationException("Another assay protocol already exists for this name.");
                     ExperimentService.get().handleAssayNameChange(assay.getName(), oldAssayName, assayProvider,  protocol,getUser(), getContainer());
-                }
 
                 AssayProvider provider = AssayService.get().getProvider(protocol);
                 if (provider instanceof PlateBasedAssayProvider plateProvider && assay.getSelectedPlateTemplate() != null)

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -427,9 +427,9 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                 AssayProvider assayProvider = AssayService.get().getProvider(assay.getProviderName());
                 String oldAssayName = null;
 
-                // Issue 51321: check reserved domain name: First, All
-                if ("First".equalsIgnoreCase(assay.getName()) || "All".equalsIgnoreCase(assay.getName()))
-                    throw new ValidationException("Assay design name '" + assay.getName() + "' is reserved.");
+                String reservedError = DomainUtil.validateReservedName(assay.getName(), "Assay Design");
+                if (reservedError != null)
+                    throw new ValidationException(reservedError);
 
                 String nameError = DomainUtil.validateDomainName(assay.getName(), "Assay Design", false);
                 if (nameError != null)

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AbstractAssayProvider;
 import org.labkey.api.assay.AssayColumnInfoRenderer;
+import org.labkey.api.assay.AssayFileWriter;
 import org.labkey.api.assay.AssayFlagHandler;
 import org.labkey.api.assay.AssayHeaderLinkProvider;
 import org.labkey.api.assay.AssayListener;
@@ -839,15 +840,14 @@ public class AssayManager implements AssayService
     {
         if (name == null)
         {
+            boolean hasFile = file != null && file.isFile();
+            boolean isTmpFile = hasFile && file.getName().toLowerCase().endsWith(".tmp");
+
             // Check if we have a file to use
-            if (file == null || !file.isFile())
-            {
-                name = "[Untitled]";
-            }
-            else
-            {
+            if (hasFile && !isTmpFile)
                 name = file.getName();
-            }
+            else
+                name = AssayFileWriter.generateFileName(protocol, false);
         }
 
         String entityId = GUID.makeGUID();

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -414,7 +414,7 @@ public class AssayManager implements AssayService
             List<ExpProtocol> allProtocols = getAssayProtocols(container);
             for (ExpProtocol protocol : allProtocols)
             {
-                if (name.equals(protocol.getName()))
+                if (name.equalsIgnoreCase(protocol.getName())) // GitHub Issue 763: case-insensitive name check
                     return protocol;
             }
         }

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1-cory257FixesV3.0",
+        "@labkey/components": "6.52.1-cory257FixesV3.2",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3325,9 +3325,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1-cory257FixesV3.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.0.tgz",
-      "integrity": "sha512-6eioh5D005aqryyssXh/VIEI1qxO7Gd4Sf80GbVGd1IkTdqL2hQ7zpDqb6KzmTZ87o1B6Gc3UtqbMzToRyJ1Bg==",
+      "version": "6.52.1-cory257FixesV3.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.2.tgz",
+      "integrity": "sha512-1eKFWT61F80gLeG+NBTfh8/gy+SEE24FPkr6AUalULoCOdbMTLBqySLunrsyl3zdcf7N2LcEsG3UWiUkWWQyEg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1-cory257FixesV3.2",
+        "@labkey/components": "6.52.3",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3325,9 +3325,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1-cory257FixesV3.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.2.tgz",
-      "integrity": "sha512-1eKFWT61F80gLeG+NBTfh8/gy+SEE24FPkr6AUalULoCOdbMTLBqySLunrsyl3zdcf7N2LcEsG3UWiUkWWQyEg==",
+      "version": "6.52.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.3.tgz",
+      "integrity": "sha512-/exkGix4xfRq5OlHEiOvaVFPNmJDTzjx9KUWYkeo9LirFua3Cv/6rrvTe5RGgS5+nnScSQzWLFDWQ8qR/HJRlg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.0",
+        "@labkey/components": "6.52.0-cory257FixesV3.0",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3325,10 +3325,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.0.tgz",
-      "integrity": "sha512-gH9wQkmD/dQiPCfKYaY1+cNNDGaJ76XwrpR7Yl+n4rI01U3UJyR8vU4a3UpYEMEXn4P+R2tugCsbJoJA3fSMAw==",
-      "license": "SEE LICENSE IN LICENSE.txt",
+      "version": "6.52.0-cory257FixesV3.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.0-cory257FixesV3.0.tgz",
+      "integrity": "sha512-Azen/02FQT20szLxGd4PPV9be1BKMAy/UNMWTpyzoY0wlBbXQ4SOBpau8PVD8IplBq2n7CfCEQZk8FZse2PkSA==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1",
+        "@labkey/components": "6.52.1-cory257FixesV3.0",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3325,10 +3325,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1.tgz",
-      "integrity": "sha512-w6Q/xza95hT8LvxF2IAnDzOsvg49p9YY6ap+TrWoXlP2DwlghvlQm5ncgFOhB45T0dozpZ9GDThpQsuCPVTpcQ==",
-      "license": "SEE LICENSE IN LICENSE.txt",
+      "version": "6.52.1-cory257FixesV3.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.0.tgz",
+      "integrity": "sha512-6eioh5D005aqryyssXh/VIEI1qxO7Gd4Sf80GbVGd1IkTdqL2hQ7zpDqb6KzmTZ87o1B6Gc3UtqbMzToRyJ1Bg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.52.1-cory257FixesV3.0",
+    "@labkey/components": "6.52.1-cory257FixesV3.2",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.52.1-cory257FixesV3.2",
+    "@labkey/components": "6.52.3",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.52.1",
+    "@labkey/components": "6.52.1-cory257FixesV3.0",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.52.0",
+    "@labkey/components": "6.52.0-cory257FixesV3.0",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1-cory257FixesV3.0"
+        "@labkey/components": "6.52.1-cory257FixesV3.2"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2843,9 +2843,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1-cory257FixesV3.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.0.tgz",
-      "integrity": "sha512-6eioh5D005aqryyssXh/VIEI1qxO7Gd4Sf80GbVGd1IkTdqL2hQ7zpDqb6KzmTZ87o1B6Gc3UtqbMzToRyJ1Bg==",
+      "version": "6.52.1-cory257FixesV3.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.2.tgz",
+      "integrity": "sha512-1eKFWT61F80gLeG+NBTfh8/gy+SEE24FPkr6AUalULoCOdbMTLBqySLunrsyl3zdcf7N2LcEsG3UWiUkWWQyEg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1"
+        "@labkey/components": "6.52.1-cory257FixesV3.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2843,10 +2843,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1.tgz",
-      "integrity": "sha512-w6Q/xza95hT8LvxF2IAnDzOsvg49p9YY6ap+TrWoXlP2DwlghvlQm5ncgFOhB45T0dozpZ9GDThpQsuCPVTpcQ==",
-      "license": "SEE LICENSE IN LICENSE.txt",
+      "version": "6.52.1-cory257FixesV3.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.0.tgz",
+      "integrity": "sha512-6eioh5D005aqryyssXh/VIEI1qxO7Gd4Sf80GbVGd1IkTdqL2hQ7zpDqb6KzmTZ87o1B6Gc3UtqbMzToRyJ1Bg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.0"
+        "@labkey/components": "6.52.0-cory257FixesV3.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2843,10 +2843,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.0.tgz",
-      "integrity": "sha512-gH9wQkmD/dQiPCfKYaY1+cNNDGaJ76XwrpR7Yl+n4rI01U3UJyR8vU4a3UpYEMEXn4P+R2tugCsbJoJA3fSMAw==",
-      "license": "SEE LICENSE IN LICENSE.txt",
+      "version": "6.52.0-cory257FixesV3.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.0-cory257FixesV3.0.tgz",
+      "integrity": "sha512-Azen/02FQT20szLxGd4PPV9be1BKMAy/UNMWTpyzoY0wlBbXQ4SOBpau8PVD8IplBq2n7CfCEQZk8FZse2PkSA==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1-cory257FixesV3.2"
+        "@labkey/components": "6.52.3"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2843,9 +2843,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1-cory257FixesV3.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.2.tgz",
-      "integrity": "sha512-1eKFWT61F80gLeG+NBTfh8/gy+SEE24FPkr6AUalULoCOdbMTLBqySLunrsyl3zdcf7N2LcEsG3UWiUkWWQyEg==",
+      "version": "6.52.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.3.tgz",
+      "integrity": "sha512-/exkGix4xfRq5OlHEiOvaVFPNmJDTzjx9KUWYkeo9LirFua3Cv/6rrvTe5RGgS5+nnScSQzWLFDWQ8qR/HJRlg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.52.1-cory257FixesV3.0"
+    "@labkey/components": "6.52.1-cory257FixesV3.2"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.52.1-cory257FixesV3.2"
+    "@labkey/components": "6.52.3"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.52.0"
+    "@labkey/components": "6.52.0-cory257FixesV3.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.52.1"
+    "@labkey/components": "6.52.1-cory257FixesV3.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
@@ -165,7 +165,7 @@ public void reservedNameFirst() throws Exception
     }
     catch (ApiUsageException e)
     {
-        assertEquals("Invalid DataClass name 'First'. 'First' is a reserved name.", e.getMessage());
+        assertEquals("Data Class name 'First' is a reserved name.", e.getMessage());
     }
 }
 
@@ -183,7 +183,7 @@ public void reservedNameAll() throws Exception
     }
     catch (ApiUsageException e)
     {
-        assertEquals("Invalid DataClass name 'All'. 'All' is a reserved name.", e.getMessage());
+        assertEquals("Data Class name 'All' is a reserved name.", e.getMessage());
     }
 }
 

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
@@ -168,7 +168,7 @@ public void reservedNameFirst() throws Exception
     }
     catch (ApiUsageException ee)
     {
-        assertEquals("Invalid sample type name 'First'. 'First' is a reserved name.", ee.getMessage());
+        assertEquals("Sample Type name 'First' is a reserved name.", ee.getMessage());
     }
 }
 
@@ -188,7 +188,7 @@ public void reservedNameAll() throws Exception
     }
     catch (ApiUsageException ee)
     {
-        assertEquals("Invalid sample type name 'All'. 'All' is a reserved name.", ee.getMessage());
+        assertEquals("Sample Type name 'All' is a reserved name.", ee.getMessage());
     }
 }
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -8106,9 +8106,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 throw new ApiUsageException("DataClass '" + existing.getName() + "' already exists.");
         }
 
-        // Issue 51321: check reserved data class name: First, All
-        if ("First".equalsIgnoreCase(name) || "All".equalsIgnoreCase(name))
-            throw new ApiUsageException("Invalid DataClass name '" + name + "'. '" + name + "' is a reserved name.");
+        String reservedError = DomainUtil.validateReservedName(name, "Data Class");
+        if (reservedError != null)
+            throw new ApiUsageException(reservedError);
     }
 
     private void validateDataClassOptions(@NotNull Container c, @NotNull User u, @Nullable DataClassDomainKindProperties options)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -990,9 +990,9 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 throw new ApiUsageException("A Sample Type with name '" + name + "' already exists.");
         }
 
-        // Issue 51321: check reserved sample type name: First
-        if ("First".equalsIgnoreCase(name) || "All".equalsIgnoreCase(name))
-            throw new ApiUsageException("Invalid sample type name '" + name + "'. '" + name + "' is a reserved name.");
+        String reservedError = DomainUtil.validateReservedName(name, "Sample Type");
+        if (reservedError != null)
+            throw new ApiUsageException(reservedError);
     }
 
     @Override

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.0"
+        "@labkey/components": "6.52.0-cory257FixesV3.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2665,10 +2665,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.0.tgz",
-      "integrity": "sha512-gH9wQkmD/dQiPCfKYaY1+cNNDGaJ76XwrpR7Yl+n4rI01U3UJyR8vU4a3UpYEMEXn4P+R2tugCsbJoJA3fSMAw==",
-      "license": "SEE LICENSE IN LICENSE.txt",
+      "version": "6.52.0-cory257FixesV3.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.0-cory257FixesV3.0.tgz",
+      "integrity": "sha512-Azen/02FQT20szLxGd4PPV9be1BKMAy/UNMWTpyzoY0wlBbXQ4SOBpau8PVD8IplBq2n7CfCEQZk8FZse2PkSA==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1-cory257FixesV3.0"
+        "@labkey/components": "6.52.1-cory257FixesV3.2"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2665,9 +2665,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1-cory257FixesV3.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.0.tgz",
-      "integrity": "sha512-6eioh5D005aqryyssXh/VIEI1qxO7Gd4Sf80GbVGd1IkTdqL2hQ7zpDqb6KzmTZ87o1B6Gc3UtqbMzToRyJ1Bg==",
+      "version": "6.52.1-cory257FixesV3.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.2.tgz",
+      "integrity": "sha512-1eKFWT61F80gLeG+NBTfh8/gy+SEE24FPkr6AUalULoCOdbMTLBqySLunrsyl3zdcf7N2LcEsG3UWiUkWWQyEg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1-cory257FixesV3.2"
+        "@labkey/components": "6.52.3"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2665,9 +2665,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1-cory257FixesV3.2",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.2.tgz",
-      "integrity": "sha512-1eKFWT61F80gLeG+NBTfh8/gy+SEE24FPkr6AUalULoCOdbMTLBqySLunrsyl3zdcf7N2LcEsG3UWiUkWWQyEg==",
+      "version": "6.52.3",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.3.tgz",
+      "integrity": "sha512-/exkGix4xfRq5OlHEiOvaVFPNmJDTzjx9KUWYkeo9LirFua3Cv/6rrvTe5RGgS5+nnScSQzWLFDWQ8qR/HJRlg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.52.1"
+        "@labkey/components": "6.52.1-cory257FixesV3.0"
       },
       "devDependencies": {
         "@labkey/build": "8.5.0",
@@ -2665,10 +2665,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.52.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1.tgz",
-      "integrity": "sha512-w6Q/xza95hT8LvxF2IAnDzOsvg49p9YY6ap+TrWoXlP2DwlghvlQm5ncgFOhB45T0dozpZ9GDThpQsuCPVTpcQ==",
-      "license": "SEE LICENSE IN LICENSE.txt",
+      "version": "6.52.1-cory257FixesV3.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.52.1-cory257FixesV3.0.tgz",
+      "integrity": "sha512-6eioh5D005aqryyssXh/VIEI1qxO7Gd4Sf80GbVGd1IkTdqL2hQ7zpDqb6KzmTZ87o1B6Gc3UtqbMzToRyJ1Bg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
         "@labkey/api": "1.42.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.52.1-cory257FixesV3.2"
+    "@labkey/components": "6.52.3"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.52.1-cory257FixesV3.0"
+    "@labkey/components": "6.52.1-cory257FixesV3.2"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.52.0"
+    "@labkey/components": "6.52.0-cory257FixesV3.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.52.1"
+    "@labkey/components": "6.52.1-cory257FixesV3.0"
   },
   "devDependencies": {
     "@labkey/build": "8.5.0",

--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -40,6 +40,7 @@ import org.labkey.api.query.AbstractMethodInfo;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.QueryParseException;
 import org.labkey.api.query.QueryParseWarning;
+import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.Queryable;
 import org.labkey.api.query.UserIdQueryForeignKey;
@@ -1481,7 +1482,12 @@ public abstract class Method
     {
         Container cCompile = (Container)QueryServiceImpl.get().getEnvironment(QueryService.Environment.CONTAINER);
         if (null == cCompile && null != query)
-            cCompile = query.getSchema().getContainer();
+        {
+            // Issue 53355: A column may be erroneously constructed (e.g. invalid calculated column) which can result in the schema being null
+            QuerySchema querySchema = query.getSchema();
+            if (querySchema != null)
+                cCompile = querySchema.getContainer();
+        }
         return cCompile;
     }
 

--- a/query/webapp/query/browser/Browser.js
+++ b/query/webapp/query/browser/Browser.js
@@ -507,8 +507,9 @@ Ext4.define('LABKEY.query.browser.Browser', {
     },
 
     showChildSchemaDetails : function(schemaName, childSchemaName) {
-        this.selectSchema(schemaName + "." + childSchemaName, true);
-        this.showPanel(this.sspPrefix + schemaName + '.' + childSchemaName);
+        var encodedChildName = LABKEY.QueryKey.encodePart(childSchemaName); // GitHub Issue 795
+        this.selectSchema(schemaName + "." + encodedChildName, true);
+        this.showPanel(this.sspPrefix + schemaName + '.' + encodedChildName);
     }
 });
 

--- a/query/webapp/query/browser/Browser.js
+++ b/query/webapp/query/browser/Browser.js
@@ -275,7 +275,8 @@ Ext4.define('LABKEY.query.browser.Browser', {
             // Expand along the patch to fetch the schema data
             if (dataSourceRoot) {
                 var partIndex = 0;
-                var schemaPathStr = '/root/' + dataSourceRoot.data.name + '/' + parts[partIndex];
+                var separator = '__SEP__'; // GitHub Issue 795: use a separator that is unlikely to be in the schema name
+                var schemaPathStr = separator + 'root' + separator + dataSourceRoot.data.name + separator + parts[partIndex];
                 var onExpand = function (success, lastNode) {
                     if (!success) {
                         Ext4.Msg.alert("Missing Schema", "The schema '" + Ext4.htmlEncode(schemaName.toDisplayString()) + "' was not found. The data source for the schema may be unreachable, or the schema may have been deleted.");
@@ -293,11 +294,11 @@ Ext4.define('LABKEY.query.browser.Browser', {
                         });
                     }
                     else {
-                        schemaPathStr += '/' + parts[partIndex];
-                        tree.expandPath(schemaPathStr, 'name', '/', onExpand);
+                        schemaPathStr += separator + parts[partIndex];
+                        tree.expandPath(schemaPathStr, 'name', separator, onExpand);
                     }
                 };
-                tree.expandPath(schemaPathStr, 'name', '/', onExpand);
+                tree.expandPath(schemaPathStr, 'name', separator, onExpand);
             }
             else {
                 Ext4.Msg.alert('Missing Schema', "The schema '" + Ext4.htmlEncode(schemaName.toDisplayString()) + "' was not found. The data source for the schema may be unreachable, or the schema may have been deleted.");


### PR DESCRIPTION
#### Rationale
#[763](https://github.com/LabKey/internal-issues/issues/649): App assay creation allows for assay names that only differ by casing
#[795](https://github.com/LabKey/internal-issues/issues/661): LKS Schema Browser "missing schema" error when assay name has special characters
Issue [52075](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52075): labkey default assay run IDs replace all special characters in the assay name with underscores
Issue [53355](https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=53355): check for null schema

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1816
- https://github.com/LabKey/labkey-ui-premium/pull/781
- https://github.com/LabKey/limsModules/pull/1491
- https://github.com/LabKey/platform/pull/6795

#### Changes
- Assay create/save check name collision to be case-insensitive
- Schema browser click on sub-schema name with special characters
- Generated Assay ID for tmp file case to use original assay name instead of encoded name
- getCompileTimeContainer to check for null schema
