### PR TITLE
Make 'QueryKey.ILLEGAL' private

### DIFF
--- a/api/src/org/labkey/api/query/QueryKey.java
+++ b/api/src/org/labkey/api/query/QueryKey.java
@@ -154,7 +154,7 @@ import java.util.Objects;
         return StringUtils.replaceEach(str, REPLACEMENT, ILLEGAL);
     }
 
-    public static final String[] ILLEGAL = {"$", "/", "&", "}", "~", ",", "."};
+    private static final String[] ILLEGAL = {"$", "/", "&", "}", "~", ",", "."};
     private static final String[] REPLACEMENT = {"$D", "$S", "$A", "$B", "$T", "$C", "$P"};
 
     /**


### PR DESCRIPTION
#### Rationale
`QueryKey.ILLEGAL` was made `public` to allow tests to access it. It is more appropriate for tests to reference the copy in `org.labkey.test.params.FieldKey`. Also, arrays are inherently mutable, so this isn't a great thing to make `public`.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6246

#### Changes
- Make 'QueryKey.ILLEGAL' private
