### PR TITLE
Fix not-equals check for SecurityQuery

### DIFF
--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -783,7 +783,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
             String resourceId = (String)props.get(PROPERTY.securableResourceId.toString());
             String securityContext = r.getContainerId()
                     + "|" + props.get(PROPERTY.categories.toString()) // multiple categories are separated by spaces, but we shouldn't need to distinguish here
-                    + (null != resourceId && !resourceId.equals(r.getContainerId()) ? "|" + resourceId : "");
+                    + (null != resourceId && !resourceId.equals(r.getContainerId().toString()) ? "|" + resourceId : "");
             doc.add(new BinaryDocValuesField(FIELD_NAME.securityContext.toString(), new BytesRef(securityContext)));
 
             // === Custom properties: Index and analyze, but don't store

--- a/search/src/org/labkey/search/model/SecurityQuery.java
+++ b/search/src/org/labkey/search/model/SecurityQuery.java
@@ -159,7 +159,7 @@ class SecurityQuery extends Query
 
     private boolean canReadResource(String resourceId, String containerId)
     {
-        if (!resourceId.equalsIgnoreCase(containerId))
+        if (resourceId.equalsIgnoreCase(containerId))
             throw new IllegalStateException("ResourceId was specified when it equals ContainerId: " + resourceId);
 
         if (_containerIds.containsKey(resourceId))

--- a/search/src/org/labkey/search/model/SecurityQuery.java
+++ b/search/src/org/labkey/search/model/SecurityQuery.java
@@ -159,7 +159,8 @@ class SecurityQuery extends Query
 
     private boolean canReadResource(String resourceId, String containerId)
     {
-        assert !resourceId.equals(containerId);
+        if (!resourceId.equalsIgnoreCase(containerId))
+            throw new IllegalStateException("ResourceId was specified when it equals ContainerId: " + resourceId);
 
         if (_containerIds.containsKey(resourceId))
             return true;


### PR DESCRIPTION
#### Rationale
Search tests started failing with an assert in SecurityQuery after related PR was merged. Assert was hit because an inequality check started to always fail due to `r.containerId()` changing its return type to GUID.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6782