### PR TITLE
Add various metrics for sample types and data classes

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryImportAction.java
+++ b/api/src/org/labkey/api/query/AbstractQueryImportAction.java
@@ -604,6 +604,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
                             QueryImportPipelineJob job = new QueryImportPipelineJob(getQueryImportProviderName(), info, root, importContextBuilder);
                             PipelineService.get().queueJob(job, getQueryImportJobNotificationProviderName());
 
+                            SimpleMetricsService.get().increment("query", "fileBackgroundImports", getMetricPrefix(_target));
                             JSONObject response = new JSONObject();
                             response.put("success", true);
                             response.put("jobId", PipelineService.get().getJobId(user, getContainer(), job.getJobGUID()));
@@ -635,7 +636,10 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
             int rowCount = importData(loader, file, originalName, ve, behaviorType, auditEvent, _auditUserComment);
 
             if (ve.hasErrors())
+            {
+                addImportValidationErrorMetric(_insertOption, _target, (form instanceof QueryForm qf) ? qf.getQueryName() : null);
                 throw ve;
+            }
 
             JSONObject response = createSuccessResponse(rowCount);
             if (auditEvent != null)
@@ -879,9 +883,7 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
                 if (auditEvent != null)
                     auditEvent.addComment(auditAction, count);
 
-                String metricPrefix = target.getUserSchema() == null ? target.getSchema().getName() : target.getUserSchema().getSchemaName();
-                metricPrefix = metricPrefix.replace("exp.", "");
-                incrementRowCountMetric(count, context.getInsertOption(), metricPrefix);
+                incrementRowCountMetric(count, context.getInsertOption(), getMetricPrefix(target));
                 transaction.commit();
 
                 return count;
@@ -901,6 +903,24 @@ public abstract class AbstractQueryImportAction<FORM> extends FormApiAction<FORM
         }
 
         return 0;
+    }
+
+    public static void addImportValidationErrorMetric(QueryUpdateService.InsertOption insertOption, @Nullable TableInfo target, @Nullable String queryName)
+    {
+        String featureArea =  insertOption.toString().toLowerCase() + "FailWithValidationError";
+        String targetType = null;
+        if (target != null)
+            targetType = getMetricPrefix(target);
+        else if (queryName != null)
+            targetType = queryName.equalsIgnoreCase("materials") ? "samples" : queryName;
+        if (targetType != null)
+            SimpleMetricsService.get().increment("query", featureArea, targetType);
+    }
+
+    public static String getMetricPrefix(TableInfo target)
+    {
+        String metricPrefix = target.getUserSchema() == null ? target.getSchema().getName() : target.getUserSchema().getSchemaName();
+        return metricPrefix.replace("exp.", "");
     }
 
     public static void incrementRowCountMetric(int count, QueryUpdateService.InsertOption insertOption, String prefix)

--- a/api/src/org/labkey/api/query/QueryImportPipelineJob.java
+++ b/api/src/org/labkey/api/query/QueryImportPipelineJob.java
@@ -305,7 +305,10 @@ public class QueryImportPipelineJob extends PipelineJob
             int importedCount = AbstractQueryImportAction.importData(loader, target, updateService, diContext, auditEvent, getInfo().getUser(), getInfo().getContainer());
 
             if (ve.hasErrors())
+            {
+                AbstractQueryImportAction.addImportValidationErrorMetric(_importContextBuilder.getInsertOption(), target, null);
                 throw ve;
+            }
 
             if (auditEvent != null)
                 _transactionAuditId = auditEvent.getRowId();

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -720,7 +720,7 @@ public class ExperimentModule extends SpringModule
                 results.put("sampleNullAmountCount", new SqlSelector(schema, "SELECT COUNT(*) FROM exp.material WHERE storedamount IS NULL").getObject(Long.class));
                 results.put("sampleNegativeAmountCount", new SqlSelector(schema, "SELECT COUNT(*) FROM exp.material WHERE storedamount < 0").getObject(Long.class));
                 results.put("sampleUnitsDifferCount", new SqlSelector(schema, "SELECT COUNT(*) from exp.material m JOIN exp.materialSource s ON m.materialsourceid = s.rowid WHERE m.units != s.metricunit").getObject(Long.class));
-                results.put("noSampleUnitsCount", new SqlSelector(schema, "SELECT COUNT(*) from exp.materialSource WHERE category IS NULL AND metricunit IS NULL").getObject(Long.class));
+                results.put("sampleTypesWithoutUnitsCount", new SqlSelector(schema, "SELECT COUNT(*) from exp.materialSource WHERE category IS NULL AND metricunit IS NULL").getObject(Long.class));
 
                 results.put("duplicateSampleMaterialNameCount", new SqlSelector(schema, "SELECT COUNT(*) as duplicateCount FROM " +
                         "(SELECT name, cpastype FROM exp.material WHERE cpastype <> 'Material' GROUP BY name, cpastype HAVING COUNT(*) > 1) d").getObject(Long.class));

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -720,6 +720,7 @@ public class ExperimentModule extends SpringModule
                 results.put("sampleNullAmountCount", new SqlSelector(schema, "SELECT COUNT(*) FROM exp.material WHERE storedamount IS NULL").getObject(Long.class));
                 results.put("sampleNegativeAmountCount", new SqlSelector(schema, "SELECT COUNT(*) FROM exp.material WHERE storedamount < 0").getObject(Long.class));
                 results.put("sampleUnitsDifferCount", new SqlSelector(schema, "SELECT COUNT(*) from exp.material m JOIN exp.materialSource s ON m.materialsourceid = s.rowid WHERE m.units != s.metricunit").getObject(Long.class));
+                results.put("noSampleUnitsCount", new SqlSelector(schema, "SELECT COUNT(*) from exp.materialSource WHERE category IS NULL AND metricunit IS NULL").getObject(Long.class));
 
                 results.put("duplicateSampleMaterialNameCount", new SqlSelector(schema, "SELECT COUNT(*) as duplicateCount FROM " +
                         "(SELECT name, cpastype FROM exp.material WHERE cpastype <> 'Material' GROUP BY name, cpastype HAVING COUNT(*) > 1) d").getObject(Long.class));


### PR DESCRIPTION
#### Rationale
We want to track a few more metrics to inform future feature development:
- number of non-media sample types that do not have a metric unit defined 
- number of imports/updates/merges for sources and samples that use a pipeline job
- number of imports/updates/merges for sources and samples that fail because of a validation error

#### Changes
- Add metrics in `AbstactQueryImportAction`
- Add metric in `ExperimentModule`