### PR TITLE
Restore getter used by reflection

### DIFF
--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -488,7 +488,7 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
             throw new IllegalStateException();
     }
 
-    @SuppressWarnings("unused") // Used via reflection
+    @SuppressWarnings("unused") // Used via DB persistence reflection
     public String getDataSharing()
     {
         return getDataSharingEnum().name();

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -488,6 +488,12 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
             throw new IllegalStateException();
     }
 
+    @SuppressWarnings("unused") // Used via reflection
+    public String getDataSharing()
+    {
+        return getDataSharingEnum().name();
+    }
+
     @Override
     public DataSharing getDataSharingEnum()
     {


### PR DESCRIPTION
#### Rationale
`SharedStudyTest.testDuplicateParticipantInsertDisallowed()` started failing after merging the related PR; I suspect the removal of this method is the reason.

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySuites_DailyEPostgres/3563168?buildTab=overview

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6782