### PR TITLE
Issue 53313: Fields with non alpha/numeric chars not shown in Custom Props

### DIFF
--- a/api/src/org/labkey/api/data/SimpleDisplayColumn.java
+++ b/api/src/org/labkey/api/data/SimpleDisplayColumn.java
@@ -107,7 +107,7 @@ public class SimpleDisplayColumn extends DisplayColumn
     {
         Object value = getValue(ctx);
         if (value != null)
-            out.write(value.toString());
+            out.write(value);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/CustomPropertiesView.java
+++ b/experiment/src/org/labkey/experiment/CustomPropertiesView.java
@@ -27,6 +27,7 @@ import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.SamplesSchema;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
@@ -37,8 +38,10 @@ import org.labkey.experiment.api.ExpMaterialImpl;
 import org.labkey.experiment.api.ExpSampleTypeImpl;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import static java.util.Collections.emptyList;
@@ -147,18 +150,19 @@ public class CustomPropertiesView extends JspView<CustomPropertiesView.CustomPro
 
             if (null != queryTable)
             {
-                SimpleFilter filter = new SimpleFilter("lsid", parentLSID);
-                Map<String,Object> tableProps = new TableSelector(queryTable, filter, null).getMap();
-                for (DomainProperty dp : d.getProperties())
+                Set<String> propertyUris = new HashSet<>();
+
+                for (DomainProperty property : d.getProperties())
                 {
-                    Object value = tableProps.get(dp.getName());
-                    if (null != value)
-                        map.put(dp.getName(), new ObjectProperty(parentLSID, c, dp.getPropertyURI(), value));
+                    propertyUris.add(property.getPropertyURI());
                 }
+
+                SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("lsid"), parentLSID);
+                Map<String,Object> tableProps = new TableSelector(queryTable, filter, null).getMap();
                 // include calculated fields from the domain / query as well
                 List<ColumnInfo> cols = queryTable.getColumns().stream()
                         .filter(ColumnInfo::isShownInDetailsView)
-                        .filter(ColumnInfo::isValueExpressionColumn)
+                        .filter(col -> propertyUris.contains(col.getPropertyURI()) || col.isValueExpressionColumn())
                         .toList();
                 for (ColumnInfo column : cols)
                 {

--- a/experiment/src/org/labkey/experiment/CustomPropertiesView.java
+++ b/experiment/src/org/labkey/experiment/CustomPropertiesView.java
@@ -24,6 +24,7 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
+import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.SamplesSchema;
@@ -41,6 +42,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -59,11 +61,7 @@ public class CustomPropertiesView extends JspView<CustomPropertiesView.CustomPro
         public CustomPropertyRenderer get(Object key)
         {
             CustomPropertyRenderer result = super.get(key);
-            if (result == null)
-            {
-                return DEFAULT_RENDERER;
-            }
-            return result;
+            return Objects.requireNonNullElse(result, DEFAULT_RENDERER);
         }
     };
 
@@ -167,8 +165,20 @@ public class CustomPropertiesView extends JspView<CustomPropertiesView.CustomPro
                 for (ColumnInfo column : cols)
                 {
                     Object value = column.getValue(tableProps);
-                    if (null != value)
-                        map.put(column.getName(), new ObjectProperty(parentLSID, c, column.getName(), value, column.getLabel()));
+                    PropertyType type = column.getPropertyType();
+                    // Calculated fields don't store an explicit property type
+                    if (type == null)
+                    {
+                        if (value == null)
+                        {
+                            type = PropertyType.STRING;
+                        }
+                        else
+                        {
+                            type = PropertyType.getFromClass(value.getClass());
+                        }
+                    }
+                    map.put(column.getName(), new ObjectProperty(parentLSID, c, column.getName(), value, type, column.getLabel()));
                 }
             }
         }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -957,7 +957,7 @@ public class ExperimentController extends SpringActionController
             if (_sampleType.hasIdColumns())
             {
                 SimpleDisplayColumn idCols = new SimpleDisplayColumn();
-                idCols.setCaption("Id Column(s)");
+                idCols.setCaption("Id Column(s):");
                 String names = _sampleType.getIdCols().stream()
                     .filter(Objects::nonNull)
                     .map(DomainProperty::getName)
@@ -972,7 +972,7 @@ public class ExperimentController extends SpringActionController
             if (_sampleType.getParentCol() != null)
             {
                 SimpleDisplayColumn parentCol = new SimpleDisplayColumn(PageFlowUtil.filter(_sampleType.getParentCol().getName()));
-                parentCol.setCaption("Parent Column");
+                parentCol.setCaption("Parent Column:");
                 detailsView.getDataRegion().addDisplayColumn(parentCol);
             }
 
@@ -997,7 +997,7 @@ public class ExperimentController extends SpringActionController
                         "\">" +
                         PageFlowUtil.filter(_sampleType.getContainer().getPath()) +
                         "</a>");
-                definedInCol.setCaption("Defined In");
+                definedInCol.setCaption("Defined In:");
                 detailsView.getDataRegion().addDisplayColumn(definedInCol);
             }
 
@@ -1405,7 +1405,7 @@ public class ExperimentController extends SpringActionController
                 ActionURL definitionURL = urlProvider(ExperimentUrls.class).getShowDataClassURL(_dataClass.getContainer(), _dataClass.getRowId());
                 LinkBuilder link = LinkBuilder.simpleLink(_dataClass.getContainer().getPath(), definitionURL);
                 SimpleDisplayColumn definedInCol = new SimpleDisplayColumn(link.toString());
-                definedInCol.setCaption("Defined In");
+                definedInCol.setCaption("Defined In:");
                 detailsView.getDataRegion().addDisplayColumn(definedInCol);
             }
 


### PR DESCRIPTION
#### Rationale
We're intending to show all of the admin-defined sample fields on its LKS details page but aren't looking them up in the map correctly.

#### Changes
- Consolidate handling for calculated and non-calculated fields
- Look up values correctly