### PR TITLE
Parse NUMERIC/DECIMAL with (precision,scale)

### DIFF
--- a/query/src/org/labkey/query/QueryTestCase.jsp
+++ b/query/src/org/labkey/query/QueryTestCase.jsp
@@ -330,7 +330,7 @@ d,seven,twelve,day,month,date,duration,guid
             }
         }
 
-        protected void validateResults(ResultSet rs) throws Exception
+        protected void validateResults(Results rs) throws Exception
         {
         }
     }
@@ -368,7 +368,7 @@ d,seven,twelve,day,month,date,duration,guid
         }
 
         @Override
-        protected void validateResults(ResultSet rs) throws Exception
+        protected void validateResults(Results rs) throws Exception
         {
             assertTrue("Expected one row: " + _sql, rs.next());
             Object o = rs.getObject(1);
@@ -838,7 +838,40 @@ d,seven,twelve,day,month,date,duration,guid
         new SqlTest("WITH v AS (SELECT column1, column2 FROM (VALUES (CAST('1' as VARCHAR), CAST('1' as INTEGER)), ('two', 2)) as v_) SELECT column1 as txt, column2 as i FROM v WHERE column1 = 'two'", 2, 1),
 
         // regression test: field reference in sub-select (https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43580)
-        new SqlTest("SELECT (SELECT a.title), a.parent.rowid FROM core.containers a", 2, 1)
+        new SqlTest("SELECT (SELECT a.title), a.parent.rowid FROM core.containers a", 2, 1),
+
+        // Column annotations
+        new SqlTest("SELECT 1 AS name @title='New Label'")
+        {
+            @Override
+            protected void validateResults(Results rs) throws Exception
+            {
+                assertEquals("New Label", rs.getColumn(1).getLabel());
+                assertFalse(rs.getColumn(1).isHidden());
+                assertNull(rs.getColumn(1).getFormat());
+            }
+        },
+        new SqlTest("SELECT 1 AS name @hidden'")
+        {
+            @Override
+            protected void validateResults(Results rs) throws Exception
+            {
+                assertEquals("Name", rs.getColumn(1).getLabel());
+                assertTrue(rs.getColumn(1).isHidden());
+                assertNull(rs.getColumn(1).getFormat());
+            }
+        },
+        new SqlTest("SELECT 1 AS name @format='0.00'")
+        {
+            @Override
+            protected void validateResults(Results rs) throws Exception
+            {
+                assertEquals("Name", rs.getColumn(1).getLabel());
+                assertFalse(rs.getColumn(1).isHidden());
+                assertEquals("0.00", rs.getColumn(1).getFormat());
+            }
+        }
+
     );
 
     List<SqlTest> postgres = List.of(

--- a/query/src/org/labkey/query/QueryTestCase.jsp
+++ b/query/src/org/labkey/query/QueryTestCase.jsp
@@ -667,8 +667,8 @@ d,seven,twelve,day,month,date,duration,guid
 
             private void verifyType(ColumnInfo column, JdbcType expectedType, @Nullable String expectedFormat)
             {
-                assertEquals("Type discrepancy for " + column.getName(), column.getJdbcType(), expectedType);
-                assertEquals("Format discrepancy for " + column.getName(), column.getFormat(), expectedFormat);
+                assertEquals("Type discrepancy for " + column.getName(), expectedType, column.getJdbcType());
+                assertEquals("Format discrepancy for " + column.getName(), expectedFormat, column.getFormat());
             }
         },
 

--- a/query/src/org/labkey/query/QueryTestCase.jsp
+++ b/query/src/org/labkey/query/QueryTestCase.jsp
@@ -702,6 +702,9 @@ d,seven,twelve,day,month,date,duration,guid
         new MethodSqlTest("SELECT concat('concat', concat('in', concat('the', 'hat'))) FROM R WHERE rowid=1", JdbcType.VARCHAR, "concatinthehat"),
         new MethodSqlTest("SELECT contextPath()", JdbcType.VARCHAR, () -> new ActionURL().getContextPath()),
         new MethodSqlTest("SELECT CONVERT(123, VARCHAR) FROM R WHERE rowid=1", JdbcType.VARCHAR, "123"),
+        new MethodSqlTest("SELECT CONVERT('+infinity', DOUBLE)", JdbcType.DOUBLE, Double.POSITIVE_INFINITY),
+        new MethodSqlTest("SELECT CONVERT('-infinity', DOUBLE)", JdbcType.DOUBLE, Double.NEGATIVE_INFINITY),
+        new MethodSqlTest("SELECT CONVERT('nan', DOUBLE)", JdbcType.DOUBLE, Double.NaN),
         new MethodSqlTest("SELECT COUNT(R.twelve) as cnt FROM R", JdbcType.INTEGER),
         // TODO: cos
         // TODO: cot

--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -685,30 +685,21 @@ public abstract class Method
         @Override
         public SQLFragment getSQL(SqlDialect dialect, SQLFragment[] fragments)
         {
-            JdbcType jdbcType;
-            SQLFragment length = null;
             if (fragments.length >= 2)
             {
-                String sqlEscapeTypeName = getTypeArgument(fragments[1]);
                 try
                 {
-                    jdbcType = ConvertType.valueOf(sqlEscapeTypeName).jdbcType;
-                    String typeName = dialect.getSqlTypeName(jdbcType);
-                    if (null == typeName)
-                        throw new NullPointerException("No sql type name found for '" + jdbcType.name() + "' in " + dialect.getProductName() + " database");
-                    if (fragments.length > 2)
-                        length = fragments[2];
-                    fragments = new SQLFragment[] {fragments[0], new SQLFragment(typeName)};
-
+                    String dialectTypeName = getTypeArgument(fragments[1]);
+                    JdbcType jdbcType = dialect.getJdbcType(dialect.sqlTypeIntFromSqlTypeName(dialectTypeName),dialectTypeName);
                     if (jdbcType == JdbcType.DOUBLE || jdbcType == JdbcType.REAL)
                     {
                         String s = fragments[0].getRawSQL().toLowerCase();
                         if ("'infinity'".equals(s) || "'+infinity'".equals(s))
-                            return new SQLFragment("?", jdbcType==JdbcType.DOUBLE ? Double.POSITIVE_INFINITY : Float.POSITIVE_INFINITY);
-                        if ("'-infinity'".equals(s))
-                            return new SQLFragment("?", jdbcType==JdbcType.DOUBLE ? Double.NEGATIVE_INFINITY : Float.NEGATIVE_INFINITY);
-                        if ("'nan'".equals(s))
-                            return new SQLFragment("?", jdbcType==JdbcType.DOUBLE ? Double.NaN : Float.NaN);
+                            fragments[0] = new SQLFragment("?", jdbcType==JdbcType.DOUBLE ? Double.POSITIVE_INFINITY : Float.POSITIVE_INFINITY);
+                        else if ("'-infinity'".equals(s))
+                            fragments[0] = new SQLFragment("?", jdbcType==JdbcType.DOUBLE ? Double.NEGATIVE_INFINITY : Float.NEGATIVE_INFINITY);
+                        else if ("'nan'".equals(s))
+                            fragments[0] = new SQLFragment("?", jdbcType==JdbcType.DOUBLE ? Double.NaN : Float.NaN);
                     }
                 }
                 catch (IllegalArgumentException x)
@@ -725,10 +716,6 @@ public abstract class Method
             {
                 ret.append(" AS ");
                 ret.append(fragments[1]);
-                if (null != length)
-                {
-                    ret.append("(").append(length).append(")");
-                }
             }
             ret.append(")");                            
             return ret;
@@ -737,9 +724,11 @@ public abstract class Method
         /** This code could be avoided by making our parser a little smarter to handle the valid convert constants */
         String getTypeArgument(SQLFragment typeSqlFragment) throws IllegalArgumentException
         {
-            String typeName = toSimpleString(typeSqlFragment);
+            String typeName = typeSqlFragment.getRawSQL();
             if (typeName.startsWith("SQL_"))
                 typeName = typeName.substring(4);
+            if (typeName.contains("("))
+                typeName = typeName.substring(0, typeName.indexOf("("));
             return typeName;
         }
 
@@ -755,13 +744,8 @@ public abstract class Method
             if (children.size() < 2)
                 return JdbcType.VARCHAR;
 
-            String sqlEscapeTypeName = ((QString)children.get(1)).getValue();
-            if (sqlEscapeTypeName.startsWith("SQL_"))
-                sqlEscapeTypeName = sqlEscapeTypeName.substring(4);
-
-            JdbcType jdbcType = JdbcType.OTHER;
-            try { jdbcType = ConvertType.valueOf(sqlEscapeTypeName).jdbcType; }catch (IllegalArgumentException x) {/* */}
-            return jdbcType;
+            QType type = (QType)children.get(1);
+            return type.getJdbcType();
         }
     }
 

--- a/query/src/org/labkey/query/sql/Method.java
+++ b/query/src/org/labkey/query/sql/Method.java
@@ -357,13 +357,13 @@ public abstract class Method
         labkeyMethod.put("rand", new JdbcMethod("rand", JdbcType.DOUBLE, 0, 1));
         labkeyMethod.put("repeat", new JdbcMethod("repeat", JdbcType.VARCHAR, 2, 2));
         labkeyMethod.put("round", new Method("round", JdbcType.DOUBLE, 1, 2)
-			{
-				@Override
-				public MethodInfo getMethodInfo()
-				{
-					return new RoundInfo();
-				}
-			});
+            {
+                @Override
+                public MethodInfo getMethodInfo()
+                {
+                    return new RoundInfo();
+                }
+            });
         labkeyMethod.put("rtrim", new JdbcMethod("rtrim", JdbcType.VARCHAR, 1, 1));
         labkeyMethod.put("second", new JdbcMethod("second", JdbcType.INTEGER, 1, 1));
         labkeyMethod.put("sign", new JdbcMethod("sign", JdbcType.DOUBLE, 1, 1));
@@ -513,7 +513,7 @@ public abstract class Method
     final String _name;
     final int _minArgs;
     final int _maxArgs;
-    
+
     Method(JdbcType jdbcType, int min, int max)
     {
         this("#UNDEF#", jdbcType, min, max);
@@ -657,21 +657,9 @@ public abstract class Method
         @Override
         public BaseColumnInfo createColumnInfo(TableInfo parentTable, ColumnInfo[] arguments, String alias)
         {
-            JdbcType jdbcType = _jdbcType;
-            if (arguments.length >= 2)
-            {
-                try
-                {
-                    SQLFragment[] frags = getSQLFragments(new ColumnInfo[] {arguments[1]}); // only convert the type arg
-                    String sqlEscapeTypeName = getTypeArgument(frags[0]);
-                    jdbcType = ConvertType.valueOf(sqlEscapeTypeName).jdbcType;
-                }
-                catch (IllegalArgumentException x)
-                {
-                    /* */
-                }
-            }
-
+            JdbcType jdbcType = JdbcType.OTHER;
+            for (ColumnInfo argument : arguments)
+                jdbcType = argument.getJdbcType();
             return new ExprColumn(parentTable, alias, null, jdbcType)
             {
                 @Override
@@ -691,14 +679,14 @@ public abstract class Method
                 {
                     String dialectTypeName = getTypeArgument(fragments[1]);
                     JdbcType jdbcType = dialect.getJdbcType(dialect.sqlTypeIntFromSqlTypeName(dialectTypeName),dialectTypeName);
-                    if (jdbcType == JdbcType.DOUBLE || jdbcType == JdbcType.REAL)
+                    if ((jdbcType == JdbcType.DOUBLE || jdbcType == JdbcType.REAL) && isSimpleString(fragments[0]))
                     {
-                        String s = fragments[0].getRawSQL().toLowerCase();
-                        if ("'infinity'".equals(s) || "'+infinity'".equals(s))
+                        String s = toSimpleString(fragments[0]).toLowerCase();
+                        if ("infinity".equals(s) || "+infinity".equals(s))
                             fragments[0] = new SQLFragment("?", jdbcType==JdbcType.DOUBLE ? Double.POSITIVE_INFINITY : Float.POSITIVE_INFINITY);
-                        else if ("'-infinity'".equals(s))
+                        else if ("-infinity".equals(s))
                             fragments[0] = new SQLFragment("?", jdbcType==JdbcType.DOUBLE ? Double.NEGATIVE_INFINITY : Float.NEGATIVE_INFINITY);
-                        else if ("'nan'".equals(s))
+                        else if ("nan".equals(s))
                             fragments[0] = new SQLFragment("?", jdbcType==JdbcType.DOUBLE ? Double.NaN : Float.NaN);
                     }
                 }
@@ -717,7 +705,7 @@ public abstract class Method
                 ret.append(" AS ");
                 ret.append(fragments[1]);
             }
-            ret.append(")");                            
+            ret.append(")");
             return ret;
         }
 
@@ -728,7 +716,7 @@ public abstract class Method
             if (typeName.startsWith("SQL_"))
                 typeName = typeName.substring(4);
             if (typeName.contains("("))
-                typeName = typeName.substring(0, typeName.indexOf("("));
+                typeName = typeName.substring(0, typeName.indexOf('('));
             return typeName;
         }
 
@@ -801,19 +789,19 @@ public abstract class Method
         }
     }
 
-	static class RoundInfo extends JdbcMethodInfoImpl
-	{
-		RoundInfo()
-		{
-			super("round", JdbcType.DOUBLE);
-		}
+    static class RoundInfo extends JdbcMethodInfoImpl
+    {
+        RoundInfo()
+        {
+            super("round", JdbcType.DOUBLE);
+        }
 
-		// https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=7078
+        // https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=7078
         // Even though we are generating {fn ROUND()}, SQL Server requires 2 arguments
         // while Postgres requires 1 argument (for doubles)
-		@Override
+        @Override
         public SQLFragment getSQL(SqlDialect dialect, SQLFragment[] arguments)
-		{
+        {
             boolean supportsRoundDouble = dialect.supportsRoundDouble();
             boolean unitRound = arguments.length == 1 || (arguments.length==2 && arguments[1].getSQL().equals("0"));
             if (unitRound)
@@ -846,11 +834,11 @@ public abstract class Method
             ret.append("/");
             ret.appendValue(Math.pow(10,i));
             return ret;
-		}
-	}
+        }
+    }
 
 
-    class AgeMethodInfo extends AbstractMethodInfo
+    static class AgeMethodInfo extends AbstractMethodInfo
     {
         AgeMethodInfo()
         {
@@ -1069,7 +1057,7 @@ public abstract class Method
         public SQLFragment getSQL(SqlDialect dialect, SQLFragment[] arguments)
         {
             SQLFragment ret = new SQLFragment("?");
-            ret.add((Callable) () -> {
+            ret.add((Callable<String>) () -> {
                 User user = (User)QueryServiceImpl.get().getEnvironment(QueryService.Environment.USER);
                 if (null == user)
                     return null;
@@ -1306,7 +1294,7 @@ public abstract class Method
     {
         return resolve(null, name);
     }
-    
+
     public static Method resolve(SqlDialect d, String name)
     {
         Method m = null;
@@ -1336,7 +1324,7 @@ public abstract class Method
         {
             super(JdbcType.BOOLEAN);
         }
-        
+
         @Override
         public SQLFragment getSQL(SqlDialect dialect, SQLFragment[] arguments)
         {

--- a/query/src/org/labkey/query/sql/ParameterType.java
+++ b/query/src/org/labkey/query/sql/ParameterType.java
@@ -44,7 +44,7 @@ public enum ParameterType
     VARCHAR(JdbcType.VARCHAR)
     ;
 
-    final JdbcType type;
+    final public JdbcType type;
 
     ParameterType(JdbcType type)
     {

--- a/query/src/org/labkey/query/sql/QParameter.java
+++ b/query/src/org/labkey/query/sql/QParameter.java
@@ -28,12 +28,12 @@ public class QParameter extends QExpr implements QueryService.ParameterDecl
 {
     private final QNode _decl;
     private final String _name;
-    private final ParameterType _type;
+    private final QType _type;
     private final boolean _required;
     private final Object _defaultValue;
 
 
-    QParameter(QNode decl, String name, ParameterType type, boolean required, Object def)
+    QParameter(QNode decl, String name, QType type, boolean required, Object def)
     {
         super();
         setLineAndColumn(decl);
@@ -61,7 +61,7 @@ public class QParameter extends QExpr implements QueryService.ParameterDecl
     @Override
     public JdbcType getJdbcType()
     {
-        return _type.type;
+        return _type.getJdbcType();
     }
 
     @Override
@@ -84,8 +84,7 @@ public class QParameter extends QExpr implements QueryService.ParameterDecl
             _decl.childList().get(0).appendSource(builder);
         if (count > 1)
         {
-            builder.append(" ");
-            _decl.childList().get(1).appendSource(builder);
+            _type.appendSource(builder);
         }
         if (count > 2)
         {
@@ -97,10 +96,9 @@ public class QParameter extends QExpr implements QueryService.ParameterDecl
     @Override
     public void appendSql(SqlBuilder builder, Query query)
     {
-        String sqlTypeName = builder.getDialect().getSqlTypeName(_type.type);
-        if ("NVARCHAR".equalsIgnoreCase(sqlTypeName))
-            sqlTypeName += "(4000)";
-        builder.append("CAST(? AS ").append(sqlTypeName).append(")");
+        builder.append("CAST(? AS ");
+        _type.appendSql(builder, query);
+        builder.append(")");
         builder.add(this);
     }
 

--- a/query/src/org/labkey/query/sql/QType.java
+++ b/query/src/org/labkey/query/sql/QType.java
@@ -1,0 +1,73 @@
+package org.labkey.query.sql;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.JdbcType;
+
+public class QType extends QExpr
+{
+    final JdbcType jdbcType;
+    final @Nullable Integer length;
+    final @Nullable Integer scale;
+
+    QType(@NotNull JdbcType jdbcType, @Nullable Integer length /* precision */, @Nullable Integer scale)
+    {
+        this.jdbcType = jdbcType;
+        this.length = length;
+        this.scale = scale;
+        if (scale != null && length == null)
+            throw new IllegalArgumentException("Length cannot be null");
+    }
+
+    QType(@NotNull ConvertType type, @Nullable Integer length /* precision */, @Nullable Integer scale)
+    {
+        this(type.jdbcType, length, scale);
+    }
+
+    QType(@NotNull ParameterType type, @Nullable Integer length /* precision */, @Nullable Integer scale)
+    {
+        this(type.type, length, scale);
+    }
+
+    @Override
+    public @NotNull JdbcType getJdbcType()
+    {
+        return jdbcType;
+    }
+
+    @Override
+    public void appendSql(SqlBuilder builder, Query query)
+    {
+        String typeName = builder.getDialect().getSqlTypeName(jdbcType);
+        builder.append(typeName);
+        Integer len = length;
+        if ("NVARCHAR".equalsIgnoreCase(typeName) && null == length)
+            len = 4000;
+        if (null != length)
+        {
+            builder.append("(").appendValue(length);
+            if (scale != null)
+                builder.append(",").appendValue(scale);
+            builder.append(")");
+        }
+    }
+
+    @Override
+    public boolean isConstant()
+    {
+        return true;
+    }
+
+    @Override
+    public void appendSource(SourceBuilder builder)
+    {
+        builder.append(jdbcType.name());
+        if (null != length)
+        {
+            builder.append("(").appendValue(length);
+            if (scale != null)
+                builder.append(",").appendValue(scale);
+            builder.append(")");
+        }
+    }
+}

--- a/query/src/org/labkey/query/sql/QuerySelect.java
+++ b/query/src/org/labkey/query/sql/QuerySelect.java
@@ -2382,6 +2382,12 @@ public class QuerySelect extends AbstractQueryRelation implements Cloneable
                 to.setPrincipalConceptCode(null==c ? null : StringUtils.trimToNull(c.toString()));
             }
 
+            if (_annotations.containsKey("format"))
+            {
+                var format = _annotations.get("format");
+                to.setFormat(null==format ? null : StringUtils.trimToNull(format.toString()));
+            }
+
             boolean hidden = _annotations.containsKey("hidden");
             if (hidden)
                 to.setHidden(hidden);

--- a/query/src/org/labkey/query/sql/SqlBase.g
+++ b/query/src/org/labkey/query/sql/SqlBase.g
@@ -276,7 +276,7 @@ declaration
 
 
 sqltype
-    : type=identifier (OPEN! NUM_INT CLOSE!)?
+    : type=identifier^ (OPEN! NUM_INT (COMMA! NUM_INT)? CLOSE!)?
     {
         if (!isSqlType($type.text))
             reportError(new MismatchedTokenException(DATATYPE, input));

--- a/query/src/org/labkey/query/sql/SqlParser.java
+++ b/query/src/org/labkey/query/sql/SqlParser.java
@@ -426,7 +426,9 @@ public class SqlParser
     private static void _prefix(Tree tree, StringBuilder sb)
     {
         if (tree.getChildCount() == 0)
+        {
             sb.append(tree.getText());
+        }
         else
         {
             sb.append("(");
@@ -451,7 +453,9 @@ public class SqlParser
     private static void _prefix(QNode tree, StringBuilder sb)
     {
         if (tree.getFirstChild() == null)
+        {
             sb.append(_text(tree));
+        }
         else
         {
             sb.append("(");
@@ -469,6 +473,8 @@ public class SqlParser
     {
         if (q.getTokenType() == METHOD_CALL)
             return "METHOD_CALL";
+        if (q instanceof QType qtype)
+            return qtype.getSourceText();
         return q.getTokenText();
     }
 
@@ -790,15 +796,20 @@ public class SqlParser
 
         QExpr exprDefault = (QExpr)nodeDefault;
         boolean required = exprDefault == null;
-        ParameterType type = ParameterType.resolve(identType.getIdentifier());
-        if (null == type)
+        // parameter types are a subset of convert types
+        ParameterType parameterType = ParameterType.resolve(identType.getIdentifier());
+        if (null == parameterType)
         {
             _parseErrors.add(new QueryParseException("Parameter type is not supported: " + identType.getIdentifier(), null, identType.getLine(), identType.getColumn()));
             return null;
         }
-        Object value = null==exprDefault ? null : type.convert(((IConstant)exprDefault).getValue());
+        Object value = null==exprDefault ? null : parameterType.convert(((IConstant)exprDefault).getValue());
 
-        return new QParameter(parameter, identName.getIdentifier(), type, required, value);
+        // reuse convert helper (we already validated parameter type above)
+        QType convertType = createType(nodeType);
+        if (null == convertType)
+            return null;
+        return new QParameter(parameter, identName.getIdentifier(), convertType, required, value);
     }
 
     private QNode convertParseTree(CommonTree node)
@@ -907,22 +918,19 @@ public class SqlParser
 
                 if (name.equals("convert") || name.equals("cast"))
                 {
-                    if (!(exprList instanceof QExprList) || (exprList.childList().size() != 2 && exprList.childList().size() != 3))
+                    if (!(exprList instanceof QExprList) || exprList.childList().size() != 2)
                     {
                         _parseErrors.add(new QueryParseException(name.toUpperCase() + " function expects 2 arguments", null, node.getLine(), node.getCharPositionInLine()));
                         break;
                     }
-                    LinkedList<QNode> args = new LinkedList<>();
-                    args.add(exprList.childList().get(0));
-                    args.add(constantToStringNode(exprList.childList().get(1)));
-                    QNode qNodeLength = null;
-                    if (exprList.childList().size() > 2)
+                    var valueExpression = exprList.childList().get(0);
+                    QNode type = createType(exprList.childList().get(1));
+                    if (null == type)
                     {
-                        args.add(exprList.childList().get(2));
-                        qNodeLength = exprList.childList().get(2);
+                        assert !_parseErrors.isEmpty();
+                        return null;
                     }
-                    exprList._replaceChildren(args);
-                    validateConvertConstant(args.get(1), qNodeLength);
+                    exprList._replaceChildren(new LinkedList<>(List.of(valueExpression, type)));
                 }
                 else if (name.equals("timestampadd") || name.equals("timestampdiff"))
                 {
@@ -1395,32 +1403,81 @@ public class SqlParser
     }
 
 
-    private boolean validateConvertConstant(QNode n, QNode length)
+    private QType createType(QNode qType)
     {
-        if (!(n instanceof QString))
+        String typeString;
+        if (qType instanceof QString qString)
         {
-            _parseErrors.add(new QueryParseException("constant expected", null, n.getLine(), n.getColumn()));
-            return false;
+            typeString = qString.getValue();
         }
-        String s = ((QString)n).getValue();
-        if (s.startsWith("SQL_"))
-            s = s.substring(4);
+        else if (qType instanceof QIdentifier qIdentifier)
+        {
+            typeString = qIdentifier.getIdentifier();
+        }
+        else
+        {
+            _parseErrors.add(new QueryParseException("Unexpected token", null, qType.getLine(), qType.getColumn()));
+            return null;
+        }
+        if (typeString.startsWith("SQL_"))
+            typeString = typeString.substring(4);
+
+        QNumber qLength = null;
+        QNumber qScale = null;
+        if (!qType.childList().isEmpty())
+        {
+            qLength = (QNumber)qType.childList().get(0);
+            if (qType.childList().size() > 1)
+                qScale = (QNumber)qType.childList().get(1);
+        }
+
         try
         {
-            ConvertType type = ConvertType.valueOf(s);
-            if (length != null)
+
+            ConvertType type = ConvertType.valueOf(typeString.toUpperCase());
+            switch (type)
             {
-                if (type != ConvertType.VARCHAR)
+                case VARCHAR ->
                 {
-                    _parseErrors.add(new QueryParseException("Unexpected length modifier for '" + s + "'", null, length.getLine(), length.getColumn()));
+                    if (null != qScale)
+                    {
+                        _parseErrors.add(new QueryParseException("Unexpected scale modifier for '" + typeString + "'", null, qType.getLine(), qType.getColumn()));
+                        return null;
+                    }
+                }
+                case NUMERIC, DECIMAL ->
+                {
+                    if (null != qLength && null != qScale)
+                    {
+                        int length = qLength._value.intValue();
+                        int scale = qScale._value.intValue();
+                        if (scale > length)
+                        {
+                            _parseErrors.add(new QueryParseException("NUMERIC scale must be between 0 and precision=" + length, null, qScale.getLine(), qScale.getColumn()));
+                            return null;
+                        }
+                    }
+                }
+                default ->
+                {
+                    if (null != qLength)
+                    {
+                        _parseErrors.add(new QueryParseException("Unexpected length modifier for '" + typeString + "'", null, qType.getLine(), qType.getColumn()));
+                        return null;
+                    }
                 }
             }
-            return true;
+
+            return new QType(
+                    type,
+                    null==qLength?null:qLength._value.intValue(),
+                    null==qScale?null:qScale._value.intValue()
+            );
         }
         catch (IllegalArgumentException x)
         {
-            _parseErrors.add(new QueryParseException("Unrecognized constant '" + ((QString)n).getValue() + "'", null, n.getLine(), n.getColumn()));
-            return false;
+            _parseErrors.add(new QueryParseException("Unrecognized constant '" + typeString + "'", null, qType.getLine(), qType.getColumn()));
+            return null;
         }
     }
 
@@ -1970,7 +2027,11 @@ public class SqlParser
             new Pair<>("LCASE('a')","(METHOD_CALL LCASE (EXPR_LIST 'a'))"),
             new Pair<>("AGE(a,b)", "(METHOD_CALL AGE (EXPR_LIST a b))"),
             new Pair<>("SUM(a+b)","(SUM (+ a b))"),
-            new Pair<>("CAST(a AS VARCHAR)", "(METHOD_CALL CAST (EXPR_LIST a 'VARCHAR'))")
+            new Pair<>("CAST(a AS VARCHAR)", "(METHOD_CALL CAST (EXPR_LIST a VARCHAR))"),
+
+            new Pair<>("CAST(1.23 AS NUMERIC)", "(METHOD_CALL CAST (EXPR_LIST 1.23 DECIMAL))"),
+            new Pair<>("CAST(1.23 AS NUMERIC(10))", "(METHOD_CALL CAST (EXPR_LIST 1.23 DECIMAL(10)))"),
+            new Pair<>("CAST(1.23 AS NUMERIC(10,2))", "(METHOD_CALL CAST (EXPR_LIST 1.23 DECIMAL(10,2)))")
         );
 
 
@@ -2047,7 +2108,7 @@ public class SqlParser
                 assertTrue(test.first + " has parse errors", errors.isEmpty());
                 assertNotNull(test.first + " did not parse", e);
                 String prefix = toPrefixString(e);
-                assertEquals("error parsing sql: " + test.first + "\nexpected  <<" + test.second + ">>\nfound     <<" + prefix + ">>",
+                assertEquals("error parsing expression: " + test.first + "\nexpected  <<" + test.second + ">>\nfound     <<" + prefix + ">>",
                         test.second, prefix);
             }
         }


### PR DESCRIPTION
#### Rationale
For control for formatting it is useful to to be able to explicitly cast to NUMERIC(prec,scale).
Also, add SELECT annotation support `@format="#.00"` (needs doc)

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
