### PR TITLE
Issue 52339: Try to use shorter URIs for domains when possible

### DIFF
--- a/api/src/org/labkey/api/exp/LsidManager.java
+++ b/api/src/org/labkey/api/exp/LsidManager.java
@@ -23,6 +23,8 @@ import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.DbSequence;
+import org.labkey.api.data.DbSequenceManager;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableSelector;
@@ -70,6 +72,15 @@ public class LsidManager
     public static LsidManager get()
     {
         return INSTANCE;
+    }
+
+    public static DbSequence getLsidPrefixDbSeq(Container container, String lsidPrefix, int batchSize)
+    {
+        Container projectContainer = container; // use DBSeq at project level to avoid duplicate lsid for types in child folder
+        if (!container.isProject() && container.getProject() != null)
+            projectContainer = container.getProject();
+
+        return DbSequenceManager.getPreallocatingSequence(projectContainer, ExperimentService.LSID_COUNTER_DB_SEQUENCE_PREFIX + lsidPrefix, 0, batchSize);
     }
 
     public interface LsidHandler<I extends Identifiable>

--- a/api/src/org/labkey/api/exp/LsidManager.java
+++ b/api/src/org/labkey/api/exp/LsidManager.java
@@ -74,6 +74,11 @@ public class LsidManager
         return INSTANCE;
     }
 
+    public static DbSequence getLsidPrefixDbSeq(String lsidPrefix, int batchSize)
+    {
+        return getLsidPrefixDbSeq(ContainerManager.getRoot(), lsidPrefix, batchSize);
+    }
+
     public static DbSequence getLsidPrefixDbSeq(Container container, String lsidPrefix, int batchSize)
     {
         Container projectContainer = container; // use DBSeq at project level to avoid duplicate lsid for types in child folder

--- a/api/src/org/labkey/api/exp/property/Domain.java
+++ b/api/src/org/labkey/api/exp/property/Domain.java
@@ -46,7 +46,7 @@ public interface Domain extends IPropertyType
 
     Object get_Ts();
     Container getContainer();
-    DomainKind<?> getDomainKind();
+    @Nullable DomainKind<?> getDomainKind();
     String getName();
     String getTitle();
     String getDescription();

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -34,6 +34,7 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.exp.ChangePropertyDescriptorException;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.Lsid;
+import org.labkey.api.exp.LsidManager;
 import org.labkey.api.exp.PropertyColumn;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpMaterial;
@@ -964,7 +965,7 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
 
     public DbSequence getSampleLsidDbSeq(int batchSize, Container container)
     {
-        return ExperimentServiceImpl.getLsidPrefixDbSeq(container, "SampleType-" + getRowId(), batchSize);
+        return LsidManager.getLsidPrefixDbSeq(container, "SampleType-" + getRowId(), batchSize);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -71,7 +71,6 @@ import org.labkey.api.data.DatabaseCache;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
-import org.labkey.api.data.DbSequence;
 import org.labkey.api.data.DbSequenceManager;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.NameGenerator;
@@ -1633,18 +1632,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
     private Pair<String, String> generateLSIDWithDBSeq(Container container, String lsidPrefix)
     {
-        String dbSeqStr = String.valueOf(getLsidPrefixDbSeq(container, lsidPrefix, 1).next());
+        String dbSeqStr = String.valueOf(LsidManager.getLsidPrefixDbSeq(container, lsidPrefix, 1).next());
         String lsid = generateLSID(container, lsidPrefix, dbSeqStr);
         return new Pair<>(lsid, dbSeqStr);
-    }
-
-    public static DbSequence getLsidPrefixDbSeq(Container container, String lsidPrefix, int batchSize)
-    {
-        Container projectContainer = container; // use DBSeq at project level to avoid duplicate lsid for types in child folder
-        if (!container.isProject() && container.getProject() != null)
-            projectContainer = container.getProject();
-
-        return DbSequenceManager.getPreallocatingSequence(projectContainer, LSID_COUNTER_DB_SEQUENCE_PREFIX + lsidPrefix, 0, batchSize);
     }
 
     private String generateGuidLSID(Container container, String lsidPrefix)

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -177,7 +177,7 @@ public class DomainImpl implements Domain
         return _dd.getContainer();
     }
 
-    @Override
+    @Override @Nullable
     public DomainKind<?> getDomainKind()
     {
         return _dd.getDomainKind();

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -1808,7 +1808,7 @@ renaming a property AND toggling mvindicator on in the same change.
             {
                 d = new DomainImpl(c, uri, "test", true)
                 {
-                    @Override
+                    @Override @Nullable
                     public DomainKind<?> getDomainKind()
                     {
                         return k;

--- a/experiment/src/org/labkey/experiment/defaults/DefaultValueServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/defaults/DefaultValueServiceImpl.java
@@ -28,6 +28,7 @@ import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.query.ValidationException;
@@ -58,10 +59,13 @@ public class DefaultValueServiceImpl implements DefaultValueService
 
     private String getContainerDefaultsLSID(Container container, Domain domain)
     {
-        Lsid domainLsid = new Lsid(domain.getTypeURI());
         String suffix = "Folder-" + container.getRowId();
-        if (domain.getDomainKind().isUserCreatedType())
+        DomainKind<?> kind = domain.getDomainKind();
+        if (kind != null && kind.isUserCreatedType())
+        {
+            Lsid domainLsid = new Lsid(domain.getTypeURI());
             return (new Lsid(DOMAIN_DEFAULT_VALUE_LSID_PREFIX, suffix, Lsid.decodePart(domainLsid.getObjectId()))).toString();
+        }
         else
             return (new Lsid(DOMAIN_DEFAULT_VALUE_LSID_PREFIX, suffix, domain.getName())).toString();
 
@@ -69,10 +73,13 @@ public class DefaultValueServiceImpl implements DefaultValueService
 
     private String getUserDefaultsParentLSID(Container container, User user, Domain domain)
     {
-        Lsid domainLsid = new Lsid(domain.getTypeURI());
         String suffix = "Folder-" + container.getRowId() + ".User-" + user.getUserId();
-        if (domain.getDomainKind().isUserCreatedType())
+        DomainKind<?> kind = domain.getDomainKind();
+        if (kind != null && kind.isUserCreatedType())
+        {
+            Lsid domainLsid = new Lsid(domain.getTypeURI());
             return (new Lsid(USER_DEFAULT_VALUE_DOMAIN_PARENT, suffix, Lsid.decodePart(domainLsid.getObjectId()))).toString();
+        }
         else
             return (new Lsid(USER_DEFAULT_VALUE_DOMAIN_PARENT, suffix, domain.getName())).toString();
     }

--- a/experiment/src/org/labkey/experiment/defaults/DefaultValueServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/defaults/DefaultValueServiceImpl.java
@@ -58,14 +58,23 @@ public class DefaultValueServiceImpl implements DefaultValueService
 
     private String getContainerDefaultsLSID(Container container, Domain domain)
     {
+        Lsid domainLsid = new Lsid(domain.getTypeURI());
         String suffix = "Folder-" + container.getRowId();
-        return (new Lsid(DOMAIN_DEFAULT_VALUE_LSID_PREFIX, suffix, domain.getName())).toString();
+        if (domain.getDomainKind().isUserCreatedType())
+            return (new Lsid(DOMAIN_DEFAULT_VALUE_LSID_PREFIX, suffix, Lsid.decodePart(domainLsid.getObjectId()))).toString();
+        else
+            return (new Lsid(DOMAIN_DEFAULT_VALUE_LSID_PREFIX, suffix, domain.getName())).toString();
+
     }
 
     private String getUserDefaultsParentLSID(Container container, User user, Domain domain)
     {
+        Lsid domainLsid = new Lsid(domain.getTypeURI());
         String suffix = "Folder-" + container.getRowId() + ".User-" + user.getUserId();
-        return (new Lsid(USER_DEFAULT_VALUE_DOMAIN_PARENT, suffix, domain.getName())).toString();
+        if (domain.getDomainKind().isUserCreatedType())
+            return (new Lsid(USER_DEFAULT_VALUE_DOMAIN_PARENT, suffix, Lsid.decodePart(domainLsid.getObjectId()))).toString();
+        else
+            return (new Lsid(USER_DEFAULT_VALUE_DOMAIN_PARENT, suffix, domain.getName())).toString();
     }
 
     private static final String WILD_CARD_PLACEHOLDER = "WILDCARD";

--- a/experiment/src/org/labkey/experiment/defaults/DefaultValueServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/defaults/DefaultValueServiceImpl.java
@@ -66,7 +66,7 @@ public class DefaultValueServiceImpl implements DefaultValueService
             Lsid domainLsid = new Lsid(domain.getTypeURI());
             return (new Lsid(DOMAIN_DEFAULT_VALUE_LSID_PREFIX, suffix, Lsid.decodePart(domainLsid.getObjectId()))).toString();
         }
-        else
+        else // for internal domains (such as audit domains), the domain name and objectId are often not the same.
             return (new Lsid(DOMAIN_DEFAULT_VALUE_LSID_PREFIX, suffix, domain.getName())).toString();
 
     }
@@ -80,7 +80,7 @@ public class DefaultValueServiceImpl implements DefaultValueService
             Lsid domainLsid = new Lsid(domain.getTypeURI());
             return (new Lsid(USER_DEFAULT_VALUE_DOMAIN_PARENT, suffix, Lsid.decodePart(domainLsid.getObjectId()))).toString();
         }
-        else
+        else // for internal domains (such as audit domains), the domain name and objectId are often not the same.
             return (new Lsid(USER_DEFAULT_VALUE_DOMAIN_PARENT, suffix, domain.getName())).toString();
     }
 

--- a/list/src/org/labkey/list/model/ListDefinitionImpl.java
+++ b/list/src/org/labkey/list/model/ListDefinitionImpl.java
@@ -106,7 +106,7 @@ public class ListDefinitionImpl implements ListDefinition
         builder.setKeyType(keyType.toString());
         builder.setCategory(category);
         _def = builder;
-        Lsid lsid = ListDomainKind.generateDomainURI(name, container, keyType, category);
+        Lsid lsid = ListDomainKind.generateDomainURI(container, keyType, category);
         _domain = PropertyService.get().createDomain(container, lsid.toString(), name, templateInfo);
     }
 

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -39,6 +39,7 @@ import org.labkey.api.defaults.DefaultValueService;
 import org.labkey.api.di.DataIntegrationService;
 import org.labkey.api.exp.DomainNotFoundException;
 import org.labkey.api.exp.Lsid;
+import org.labkey.api.exp.LsidManager;
 import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
@@ -271,17 +272,15 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
     public static Lsid generateDomainURI(String name, Container c, KeyType keyType, @Nullable ListDefinition.Category category)
     {
         String type = getType(keyType, category);
-        StringBuilder typeURI = getBaseURI(name, type, c);
-
-        // Issue 13131: uniqueify the lsid for situations where a preexisting list was renamed
-        int i = 1;
-        String sTypeURI = typeURI.toString();
-        String uniqueURI = sTypeURI;
-        while (OntologyManager.getDomainDescriptor(uniqueURI, c) != null)
+        Lsid lsid;
+        // assure LSID does not collide with previous lsids that may have had number names
+        do
         {
-            uniqueURI = sTypeURI + '-' + (i++);
-        }
-        return new Lsid(uniqueURI);
+            String dbSeqStr = String.valueOf(LsidManager.getLsidPrefixDbSeq(c, type, 1).next());
+            lsid = new Lsid(type, "Folder-" + c.getRowId(), dbSeqStr);
+        } while (OntologyManager.getDomainDescriptor(lsid.toString(), c) != null);
+
+        return lsid;
     }
 
     public static Lsid createPropertyURI(String listName, String columnName, Container c, ListDefinition.KeyType keyType)

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -27,6 +27,7 @@ import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PropertyStorageSpec;
@@ -269,14 +270,14 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
         return Collections.emptySet(); // TODO: Allow this to return the Key Column
     }
 
-    public static Lsid generateDomainURI(String name, Container c, KeyType keyType, @Nullable ListDefinition.Category category)
+    public static Lsid generateDomainURI(Container c, KeyType keyType, @Nullable ListDefinition.Category category)
     {
         String type = getType(keyType, category);
         Lsid lsid;
         // assure LSID does not collide with previous lsids that may have had number names
         do
         {
-            String dbSeqStr = String.valueOf(LsidManager.getLsidPrefixDbSeq(c, type, 1).next());
+            String dbSeqStr = String.valueOf(LsidManager.getLsidPrefixDbSeq(type, 1).next());
             lsid = new Lsid(type, "Folder-" + c.getRowId(), dbSeqStr);
         } while (OntologyManager.getDomainDescriptor(lsid.toString(), c) != null);
 


### PR DESCRIPTION
#### Rationale
Issue [52339](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52339)

This doesn't address the creation of long domain URIs that might exist out there, but paves the way toward shorter URIs in other scenarios.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2522

#### Changes
- Move `getLsidPrefixDbSeq` to `LsidManager` for better accessibility
- Use `getLsidPrefixDbSeq` for creating domain URIs for lists
- Update `DefaultValueServiceImpl` to try to use these shorter URIs as appropriate as well.
