### PR TITLE
Issue list default values shouldn't render in the detail views.

### DIFF
--- a/issues/src/org/labkey/issue/model/IssuePage.java
+++ b/issues/src/org/labkey/issue/model/IssuePage.java
@@ -400,11 +400,6 @@ public class IssuePage implements DataRegionSelection.DataSelectionKeyForm
         return _tableInfo;
     }
 
-    public HtmlString renderColumn(DomainProperty prop, ViewContext context) throws IOException
-    {
-        return renderColumn(prop, context, true, false);
-    }
-
     public HtmlString renderColumn(DomainProperty prop, ViewContext context, boolean visible, boolean readOnly) throws IOException
     {
         if (prop != null && shouldDisplay(prop, context.getContainer(), context.getUser()))

--- a/issues/src/org/labkey/issue/view/detailView.jsp
+++ b/issues/src/org/labkey/issue/view/detailView.jsp
@@ -244,7 +244,7 @@
             <tr><%=bean.renderLabel(bean.getLabel("Status", false))%><td><%=h(issue.getStatus())%></td></tr><%
             for (DomainProperty prop : extraColumns)
             {%>
-                <%=bean.renderColumn(prop, getViewContext())%><%
+                <%=bean.renderColumn(prop, getViewContext(), true, true)%><%
             }%>
 
             <%=unsafe(bean.renderAdditionalDetailInfo())%>
@@ -277,7 +277,7 @@
             }
             for (DomainProperty prop : column1Props)
             {%>
-            <%=bean.renderColumn(prop, getViewContext())%><%
+                <%=bean.renderColumn(prop, getViewContext(), true, true)%><%
             }%>
         </table></td>
         <td valign="top" width="33%"><table class="lk-fields-table">
@@ -290,7 +290,7 @@
 
             for (DomainProperty prop : column2Props)
             {%>
-            <%=bean.renderColumn(prop, getViewContext())%><%
+                <%=bean.renderColumn(prop, getViewContext(), true, true)%><%
             }%>
         </table></td>
     </tr>

--- a/issues/src/org/labkey/issue/view/updateView.jsp
+++ b/issues/src/org/labkey/issue/view/updateView.jsp
@@ -351,7 +351,7 @@
 
                     for (DomainProperty prop : column1Props)
                     {%>
-                                <%=bean.renderColumn(prop, getViewContext())%><%
+                        <%=bean.renderColumn(prop, getViewContext(), true, false)%><%
                     }%>
                 </table>
             </td>
@@ -385,7 +385,7 @@
             }
             for (DomainProperty prop : column2Props)
             {%>
-                <%=bean.renderColumn(prop, getViewContext())%><%
+                <%=bean.renderColumn(prop, getViewContext(), true, false)%><%
             }%>
             </table></td>
         </tr>
@@ -393,8 +393,8 @@
         <%
             for (DomainProperty prop : extraColumns)
             {%>
-        <%=bean.renderColumn(prop, getViewContext())%><%
-        }%>
+                <%=bean.renderColumn(prop, getViewContext(), true, false)%><%
+            }%>
         <tr>
             <%=bean.renderLabel(bean.getLabel("Comment", bean.isInsert()))%>
             <td colspan="3">


### PR DESCRIPTION
#### Rationale
related issue: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53343
 
This was caused by a helper function which automatically set the visible state to `true` and readonly to `false`. It was used as a convenience for the update view and unfortunately got propagated to the detail view. I've deleted that variant so users have to be explicit when setting those states.

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/2525

#### Tasks
- [x] Manual Testing
- [x] Needs Automation
- [x] Verify Fix
