### PR TITLE
Preliminary support for PostgreSQL 18

### DIFF
--- a/api/src/org/labkey/api/data/dialect/sqlKeywords.txt
+++ b/api/src/org/labkey/api/data/dialect/sqlKeywords.txt
@@ -307,6 +307,7 @@ end
 end-exec
 ends
 endtran
+enforced
 engine
 engines
 enum
@@ -697,6 +698,7 @@ numeric
 numeric_truncation
 nvarchar
 object
+objects
 occurrences_regex
 octet_length
 octets
@@ -772,6 +774,7 @@ percent
 percent_rank
 percentile_cont
 percentile_disc
+period
 perm
 permanent
 permission

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -160,7 +160,8 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
             good("PostgreSQL", 15.0, 16.0, "", connectionUrl, null, PostgreSql_15_Dialect.class);
             good("PostgreSQL", 16.0, 17.0, "", connectionUrl, null, PostgreSql_16_Dialect.class);
             good("PostgreSQL", 17.0, 18.0, "", connectionUrl, null, PostgreSql_17_Dialect.class);
-            good("PostgreSQL", 18.0, 19.0, "", connectionUrl, null, PostgreSql_17_Dialect.class);
+            good("PostgreSQL", 18.0, 19.0, "", connectionUrl, null, PostgreSql_18_Dialect.class);
+            good("PostgreSQL", 19.0, 20.0, "", connectionUrl, null, PostgreSql_18_Dialect.class);
         }
     }
 

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -21,7 +21,8 @@ public enum PostgreSqlVersion
     POSTGRESQL_15(150, false, true, PostgreSql_15_Dialect::new),
     POSTGRESQL_16(160, false, true, PostgreSql_16_Dialect::new),
     POSTGRESQL_17(170, false, true, PostgreSql_17_Dialect::new),
-    POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_17_Dialect::new);
+    POSTGRESQL_18(180, false, false, PostgreSql_18_Dialect::new),
+    POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_18_Dialect::new);
 
     private final int _version;
     private final boolean _deprecated;
@@ -87,11 +88,12 @@ public enum PostgreSqlVersion
             test(150, POSTGRESQL_15);
             test(160, POSTGRESQL_16);
             test(170, POSTGRESQL_17);
+            test(180, POSTGRESQL_18);
 
             // Future
-            test(180, POSTGRESQL_FUTURE);
             test(190, POSTGRESQL_FUTURE);
             test(200, POSTGRESQL_FUTURE);
+            test(210, POSTGRESQL_FUTURE);
 
             // Bad
             test(83, POSTGRESQL_UNSUPPORTED);

--- a/core/src/org/labkey/core/dialect/PostgreSql_18_Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql_18_Dialect.java
@@ -1,0 +1,5 @@
+package org.labkey.core.dialect;
+
+public class PostgreSql_18_Dialect extends PostgreSql_17_Dialect
+{
+}


### PR DESCRIPTION
#### Rationale
PostgreSQL 18 Beta 1 was released in May

