### PR TITLE
Fix data region column name references

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/AssayTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AssayTest.java
@@ -440,9 +440,9 @@ public class AssayTest extends AbstractAssayTest
                 ALIASED_DATA);
 
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("SpecimenID/GlobalUniqueId", "Specimen Global Unique Id");
-        _customizeViewsHelper.addColumn("SpecimenID/Specimen/PrimaryType", "Specimen Specimen Primary Type");
-        _customizeViewsHelper.addColumn("SpecimenID/AssayMatch", "Specimen Assay Match");
+        _customizeViewsHelper.addColumn("SpecimenID/GlobalUniqueId");
+        _customizeViewsHelper.addColumn("SpecimenID/Specimen/PrimaryType");
+        _customizeViewsHelper.addColumn("SpecimenID/AssayMatch");
         _customizeViewsHelper.removeColumn("Run/testAssayRunProp1");
         _customizeViewsHelper.removeColumn("Run/Batch/testAssaySetProp2");
         _customizeViewsHelper.removeColumn("testAssayDataProp4");
@@ -542,7 +542,7 @@ public class AssayTest extends AbstractAssayTest
 
         log("Verifying that the data was published");
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn("QCState", "QC State");
+        _customizeViewsHelper.addColumn("QCState");
         _customizeViewsHelper.applyCustomView();
         assertTextPresent(
                 "Pending Review",

--- a/study/test/src/org/labkey/test/tests/study/LinkAssayToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/LinkAssayToStudyTest.java
@@ -267,9 +267,9 @@ public class LinkAssayToStudyTest extends AbstractAssayTest
                     ALIASED_DATA);
 
             _customizeViewsHelper.openCustomizeViewPanel();
-            _customizeViewsHelper.addColumn("SpecimenID/GlobalUniqueId", "Specimen Global Unique Id");
-            _customizeViewsHelper.addColumn("SpecimenID/Specimen/PrimaryType", "Specimen Specimen Primary Type");
-            _customizeViewsHelper.addColumn("SpecimenID/AssayMatch", "Specimen Assay Match");
+            _customizeViewsHelper.addColumn("SpecimenID/GlobalUniqueId");
+            _customizeViewsHelper.addColumn("SpecimenID/Specimen/PrimaryType");
+            _customizeViewsHelper.addColumn("SpecimenID/AssayMatch");
             _customizeViewsHelper.removeColumn("Run/testAssayRunProp1");
             _customizeViewsHelper.removeColumn("Run/Batch/testAssaySetProp2");
             _customizeViewsHelper.removeColumn("testAssayDataProp4");

--- a/study/test/src/org/labkey/test/tests/study/QuerySnapshotTest.java
+++ b/study/test/src/org/labkey/test/tests/study/QuerySnapshotTest.java
@@ -194,7 +194,7 @@ public class QuerySnapshotTest extends StudyBaseTest
         clickAndWait(Locator.linkWithText("APX-1: Abbreviated Physical Exam"));
         _customizeViewsHelper.openCustomizeViewPanel();
 
-        _customizeViewsHelper.addColumn("DataSets/DEM-1/DEMraco", "DEM-1: Demographics Screening 4f.Other specify");
+        _customizeViewsHelper.addColumn("DataSets/DEM-1/DEMraco");
         _customizeViewsHelper.saveCustomView("APX Joined View");
 
         createQuerySnapshot(APX_SNAPSHOT, true, false);

--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -34,6 +34,7 @@ import org.labkey.test.components.ParticipantListWebPart;
 import org.labkey.test.pages.DatasetInsertPage;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.pages.study.ManageVisitPage;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.util.Crawler;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
@@ -168,7 +169,7 @@ public class SharedStudyTest extends BaseWebDriverTest
         beginAt("/" + getProjectName() + "/" + STUDY1 + "/query-executeQuery.view?schemaName=study&query.queryName=PVString_Two");
         _customizeViewsHelper.openCustomizeViewPanel();
         _customizeViewsHelper.showHiddenItems();
-        _customizeViewsHelper.addColumn(new String[]{"PandaVisit", "Visit", "Folder"});
+        _customizeViewsHelper.addColumn(FieldKey.fromParts("PandaVisit", "Visit", "Folder"));
         _customizeViewsHelper.saveCustomView("withfolder");
 
         log("Verify visit folder is project");

--- a/study/test/src/org/labkey/test/tests/study/StudyDateAndContinuousTimepointTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDateAndContinuousTimepointTest.java
@@ -11,6 +11,7 @@ import org.labkey.test.components.CustomizeView;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PortalHelper;
@@ -100,7 +101,7 @@ public class StudyDateAndContinuousTimepointTest extends BaseWebDriverTest
         CustomizeView tableCustomizeView = table.getCustomizeView();
         tableCustomizeView.openCustomizeViewPanel();
         waitForText("Available Fields");
-        tableCustomizeView.addColumn(new String[]{"ParticipantVisit", "Visit"});
+        tableCustomizeView.addColumn(FieldKey.fromParts("ParticipantVisit", "Visit"));
         tableCustomizeView.saveDefaultView();
         checker().verifyEquals("Visit field is not blank when study is changed to date", Arrays.asList("Day 0"),
                 table.getColumnDataAsText("ParticipantVisit/Visit"));
@@ -180,7 +181,7 @@ public class StudyDateAndContinuousTimepointTest extends BaseWebDriverTest
         CustomizeView tableCustomizeView = table.getCustomizeView();
         tableCustomizeView.openCustomizeViewPanel();
         waitForText("Available Fields");
-        tableCustomizeView.addColumn(new String[]{"ParticipantVisit", "Visit"});
+        tableCustomizeView.addColumn(FieldKey.fromParts("ParticipantVisit", "Visit"));
         tableCustomizeView.saveDefaultView();
         checker().verifyEquals("Visit field is not Day 0 when study is changed to date", Arrays.asList("Day 0"),
                 table.getColumnDataAsText("ParticipantVisit/Visit")); //Needs to be updated when related bug is fixed.

--- a/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
@@ -1065,7 +1065,7 @@ public class StudyPublishTest extends StudyPHIExportTest
 
         clickAndWait(Locator.linkWithText(dataset));
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addFilter("MouseId", "Mouse Id", "Equals One Of", ptidFilter);
+        _customizeViewsHelper.addFilter("MouseId", "Equals One Of", ptidFilter);
         _customizeViewsHelper.saveCustomView(name, shared);
     }
 

--- a/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
@@ -39,6 +39,7 @@ import org.labkey.test.pages.study.ManageStudyPage;
 import org.labkey.test.pages.study.ManageVisitPage;
 import org.labkey.test.pages.study.QCStateTableRow;
 import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldKey;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
@@ -522,7 +523,7 @@ public class StudySimpleExportTest extends StudyBaseTest
         clickTab("Clinical and Assay Data");
         waitAndClickAndWait(Locator.linkWithText(TEST_DATASET_NAME));
         _customizeViewsHelper.openCustomizeViewPanel();
-        _customizeViewsHelper.addColumn(new String[]{"ParticipantVisit", "Visit"});
+        _customizeViewsHelper.addColumn(FieldKey.fromParts("ParticipantVisit", "Visit"));
         _customizeViewsHelper.saveDefaultView();
         mouseOver(Locator.tagWithText("td", visitLabel));
         waitForElement(Locator.xpath("id('helpDivBody')").containing(visitDescription));

--- a/study/test/src/org/labkey/test/tests/study/StudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyTest.java
@@ -777,7 +777,7 @@ public class StudyTest extends StudyBaseTest
                 clickAndWait(Locator.linkWithText("verifyAssay"));
                 BootstrapMenu.find(getDriver(),"QC State").clickSubMenu(true, "All data");
                 _customizeViewsHelper.openCustomizeViewPanel();
-                _customizeViewsHelper.addColumn("QCState", "QC State");
+                _customizeViewsHelper.addColumn("QCState");
                 _customizeViewsHelper.addSort("SampleId", SortDirection.ASC);
                 _customizeViewsHelper.applyCustomView();
                 DataRegionTable table = new DataRegionTable("Dataset", this);
@@ -810,7 +810,7 @@ public class StudyTest extends StudyBaseTest
             new DatasetPropertiesPage(getDriver())
                 .clickViewData();
             _customizeViewsHelper.openCustomizeViewPanel();
-            _customizeViewsHelper.addColumn("Bad Name", "Bad Name");
+            _customizeViewsHelper.addColumn("Bad Name");
             _customizeViewsHelper.applyCustomView();
             BootstrapMenu.find(getDriver(),"QC State").clickSubMenu(true, "All data");
             clickAndWait(Locator.tagWithAttribute("a", "data-original-title","edit").index(0));


### PR DESCRIPTION
#### Rationale
My previous DataRegionTable refactor attempted to recreate the previous behavior that would remove spaces when matching field labels. I covered the case where the test passed in an unnecessary space but not when they omitted a space. Rather that duplicating that particular behavior, this updates the handful of tests that are passing incorrect field labels.

I've also updated the `CustomizeView` helper to accept `FieldKey` objects instead of String arrays.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2526

#### Changes
- Remove unnecessary logging parameters from the CustomizeView helper
- Update CustomizeViewHelper to use FieldKey
- Fix problematic data region column name references