### PR TITLE
Adjust short URL admin UI to match other similar admin pages

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -10397,13 +10397,14 @@ public class AdminController extends SpringActionController
         public ModelAndView getView(ShortURLForm form, boolean reshow, BindException errors)
         {
             JspView<ShortURLForm> newView = new JspView<>("/org/labkey/core/admin/createNewShortURL.jsp", form, errors);
-            newView.setTitle("Create New Short URL");
+            boolean isAppAdmin = getUser().hasRootPermission(ApplicationAdminPermission.class);
+            newView.setTitle(isAppAdmin ? "Create New Short URL" : "Short URLs");
             newView.setFrame(WebPartView.FrameType.PORTAL);
 
             QuerySettings qSettings = new QuerySettings(getViewContext(), "ShortURL", CoreQuerySchema.SHORT_URL_TABLE_NAME);
             qSettings.setBaseSort(new Sort("-Created"));
             QueryView existingView = new QueryView(new CoreQuerySchema(getUser(), getContainer()), qSettings, null);
-            if (!getUser().hasRootPermission(ApplicationAdminPermission.class))
+            if (!isAppAdmin)
             {
                 existingView.setButtonBarPosition(DataRegion.ButtonBarPosition.NONE);
             }

--- a/core/src/org/labkey/core/admin/createNewShortURL.jsp
+++ b/core/src/org/labkey/core/admin/createNewShortURL.jsp
@@ -25,19 +25,38 @@
     ShortURLRecord exampleRecord = new ShortURLRecord();
     exampleRecord.setShortURL("SHORT_URL");
     String exampleURL = exampleRecord.renderShortURL();
+    boolean isAppAdmin = getUser().hasRootPermission(ApplicationAdminPermission.class);
 %>
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    let _form;
+
+    LABKEY.Utils.onReady(function() {
+        _form = new LABKEY.Form({formElement: 'form-shortUrls'});
+    });
+</script>
 <div style="width: 700px">
     <p>
         Short URLs allow you to create convenient, memorable links to specific content on your server.
         They are similar to TinyURL or bit.ly links. Users can access a short URL using a link like <%= h(exampleURL) %>
     </p>
+<%
+    if (isAppAdmin)
+    {
+%>
     <p>
         If the server or port number are incorrect, you can correct the Base Server URL in <a href="<%= h(urlProvider(AdminUrls.class).getCustomizeSiteURL()) %>">Site Settings</a>
     </p>
+<%
+    }
+%>
 </div>
 
-<labkey:form method="post">
+<labkey:form id="form-shortUrls" method="post">
     <table>
+<%
+    if (isAppAdmin)
+    {
+%>
         <tr>
             <td class="labkey-form-label"><label for="shortURLTextField">Short URL</label><%= helpPopup("Short URL", "The unique name for this short URL")%></td>
             <td><input name="shortURL" id="shortURLTextField" size="40" /></td>
@@ -46,9 +65,16 @@
             <td class="labkey-form-label"><label for="targetURLTextField">Target URL</label><%= helpPopup("Target URL", "The URL on this server that will be the redirect target. The server portion of the URL will be stripped off - only the path portion will be retained")%></td>
             <td><input name="fullURL" id="targetURLTextField" size="40" /></td>
         </tr>
+        <tr><td>&nbsp;</td></tr>
+<%
+    }
+%>
         <tr>
-            <td></td>
-            <td><%= button("Submit").submit(true).enabled(getUser().hasRootPermission(ApplicationAdminPermission.class)) %></td>
+            <td colspan="2"><%=isAppAdmin ?
+                button("Submit").submit(true).onClick("_form.setClean();") :
+                button("Done").href(urlProvider(AdminUrls.class).getAdminConsoleURL())
+            %>
+            </td>
         </tr>
     </table>
 </labkey:form>

--- a/core/src/org/labkey/core/admin/existingListValues.jsp
+++ b/core/src/org/labkey/core/admin/existingListValues.jsp
@@ -19,7 +19,6 @@
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.security.permissions.ApplicationAdminPermission" %>
 <%@ page import="org.labkey.api.util.HtmlString" %>
-<%@ page import="org.labkey.api.util.SortHelpers" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.core.admin.AdminController.AllowListForm" %>
 <%@ page import="org.labkey.core.admin.AdminController.DeleteAllValuesAction" %>


### PR DESCRIPTION
#### Rationale
Adjust design so it's closer to "Allowed File Extensions" and "Allow External Redirect Hosts" pages

#### Changes
- Dirty handling
- For Troubleshooters: hide inputs and non-applicable instructions, switch "Submit" button to "Done," adjust title

#### Tasks 📍
- [x] Manual Testing @labkey-danield 
- [x] Needs Automation - No
- [x] Verify Fix @labkey-danield 