### PR TITLE
Add external dependency on opencsv jar 

### DIFF
--- a/experiment/build.gradle
+++ b/experiment/build.gradle
@@ -20,7 +20,7 @@ dependencies{
    BuildUtils.addExternalDependency(
            project,
            new ExternalDependency(
-                   "com.opencsv:opencsv:${opencsvVersion}",
+                   "net.sf.opencsv:opencsv:${opencsvVersion}",
                    'Open CSV',
                    'Open CSV',
                    'http://opencsv.sf.net',

--- a/experiment/build.gradle
+++ b/experiment/build.gradle
@@ -17,7 +17,18 @@ sourceSets {
 
 
 dependencies{
-   implementation "com.opencsv:opencsv:${opencsvVersion}"
+   BuildUtils.addExternalDependency(
+           project,
+           new ExternalDependency(
+                   "com.opencsv:opencsv:${opencsvVersion}",
+                   'Open CSV',
+                   'Open CSV',
+                   'http://opencsv.sf.net',
+                   ExternalDependency.APACHE_2_LICENSE_NAME,
+                   ExternalDependency.APACHE_2_LICENSE_URL,
+                   'A simple library for reading and writing CSV in Java'
+           )
+   )
    BuildUtils.addExternalDependency(
            project,
            new ExternalDependency(


### PR DESCRIPTION
#### Rationale
The latest version of labkey-client-api no longer includes a dependency on `opencsv`. Several modules have declared `implementation` dependencies on this, but really need it included in the external jars. 

#### Changes
- Change from `implementation` dependency to an external dependency
- Update coordinates to be consistent with other dependency declarations
