### PR TITLE
Well table contextual role support

### DIFF
--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -19,13 +19,17 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.qc.DataLoaderSettings;
+import org.labkey.api.query.QuerySchema;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.vfs.FileLike;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface AssayPlateMetadataService
 {
@@ -178,4 +182,13 @@ public interface AssayPlateMetadataService
         TableInfo resultsTable,
         List<Integer> runIds
     ) throws ValidationException;
+
+    /**
+     * Should only be used to get a local instance of a plate schema where a contextual role might be involved. Schemas created this way are not cached,
+     * and all other usages should retrieve schemas from the QueryService.
+     * <p>
+     * This method would be better placed in the PlateService interface, but it would have required moving that (and other) classes into API.
+     */
+    @NotNull
+    UserSchema getPlateSchema(QuerySchema schema, Set<Role> contextualRoles);
 }

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -32,6 +32,8 @@ import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.lists.permissions.ManagePicklistsPermission;
 import org.labkey.api.qc.DataState;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QuerySchema;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
@@ -40,6 +42,7 @@ import org.labkey.api.security.permissions.MoveEntitiesPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.SampleWorkflowJobPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.util.Pair;
 
@@ -254,4 +257,10 @@ public interface SampleTypeService
     long getCurrentCount(NameGenerator.EntityCounter counterType, Container container);
 
     void ensureMinSampleCount(long newSeqValue, NameGenerator.EntityCounter counterType, Container container) throws ExperimentException;
+
+    /**
+     * Should only be used to get a local instance of a schema and isn't cached. All other usages should get
+     * it from the QueryService.
+     */
+    UserSchema getUserSchema(QuerySchema schema, Set<Role> contextualRoles);
 }

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -32,8 +32,6 @@ import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.lists.permissions.ManagePicklistsPermission;
 import org.labkey.api.qc.DataState;
 import org.labkey.api.query.BatchValidationException;
-import org.labkey.api.query.QuerySchema;
-import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
@@ -42,7 +40,6 @@ import org.labkey.api.security.permissions.MoveEntitiesPermission;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.SampleWorkflowJobPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.security.roles.Role;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.util.Pair;
 
@@ -257,10 +254,4 @@ public interface SampleTypeService
     long getCurrentCount(NameGenerator.EntityCounter counterType, Container container);
 
     void ensureMinSampleCount(long newSeqValue, NameGenerator.EntityCounter counterType, Container container) throws ExperimentException;
-
-    /**
-     * Should only be used to get a local instance of a schema and isn't cached. All other usages should get
-     * it from the QueryService.
-     */
-    UserSchema getUserSchema(QuerySchema schema, Set<Role> contextualRoles);
 }

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -38,6 +38,7 @@ import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.SchemaKey;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.roles.ReaderRole;
@@ -56,7 +57,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Set;
 
-public class SamplesSchema extends AbstractExpSchema
+public class SamplesSchema extends AbstractExpSchema implements UserSchema.HasContextualRoles
 {
     public static final String SCHEMA_NAME = "samples";
     public static final String STUDY_LINKED_SCHEMA_NAME = "~~STUDY.LINKED.SAMPLE~~";
@@ -107,7 +108,7 @@ public class SamplesSchema extends AbstractExpSchema
         setDefaultSchema(schema.getDefaultSchema());
     }
 
-    public SamplesSchema(QuerySchema schema, boolean studyLinkedSamples)
+    private SamplesSchema(QuerySchema schema, boolean studyLinkedSamples)
     {
         this(schema.getUser(), schema.getContainer());
         setDefaultSchema(schema.getDefaultSchema());
@@ -124,6 +125,19 @@ public class SamplesSchema extends AbstractExpSchema
     public SamplesSchema(User user, Container container)
     {
         this(SchemaKey.fromParts(SCHEMA_NAME), user, container);
+    }
+
+    public SamplesSchema(QuerySchema schema, Set<Role> contextualRoles)
+    {
+        this(schema.getUser(), schema.getContainer());
+        setDefaultSchema(schema.getDefaultSchema());
+        this.contextualRoles = contextualRoles;
+    }
+
+    @Override
+    public @NotNull Set<Role> getContextualRoles()
+    {
+        return contextualRoles;
     }
 
     @Override

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -127,13 +127,6 @@ public class SamplesSchema extends AbstractExpSchema implements UserSchema.HasCo
         this(SchemaKey.fromParts(SCHEMA_NAME), user, container);
     }
 
-    public SamplesSchema(QuerySchema schema, Set<Role> contextualRoles)
-    {
-        this(schema.getUser(), schema.getContainer());
-        setDefaultSchema(schema.getDefaultSchema());
-        this.contextualRoles = contextualRoles;
-    }
-
     @Override
     public @NotNull Set<Role> getContextualRoles()
     {

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -78,12 +78,15 @@ import org.labkey.api.qc.DataLoaderSettings;
 import org.labkey.api.qc.DataState;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.RuntimeValidationException;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.DataLoader;
 import org.labkey.api.security.User;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.Pair;
@@ -93,6 +96,7 @@ import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.assay.TSVProtocolSchema;
 import org.labkey.assay.plate.model.WellBean;
+import org.labkey.assay.plate.query.PlateSchema;
 import org.labkey.assay.plate.query.PlateTable;
 import org.labkey.assay.plate.query.WellTable;
 import org.labkey.assay.query.AssayDbSchema;
@@ -1483,6 +1487,12 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         }
 
         return StringUtils.join(parts, " and ");
+    }
+
+    @Override
+    public UserSchema getPlateSchema(QuerySchema querySchema, Set<Role> contextualRoles)
+    {
+        return new PlateSchema(querySchema, contextualRoles);
     }
 
     private static class PlateMetadataImportHelper extends SimpleAssayDataImportHelper

--- a/assay/src/org/labkey/assay/plate/query/PlateSchema.java
+++ b/assay/src/org/labkey/assay/plate/query/PlateSchema.java
@@ -16,6 +16,7 @@
 
 package org.labkey.assay.plate.query;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
 import org.labkey.api.data.Container;
@@ -25,13 +26,16 @@ import org.labkey.api.module.Module;
 import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.SimpleUserSchema;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.assay.query.AssayDbSchema;
 
 import java.util.List;
 import java.util.Set;
 
-public class PlateSchema extends SimpleUserSchema
+public class PlateSchema extends SimpleUserSchema implements UserSchema.HasContextualRoles
 {
     public static final String SCHEMA_NAME = "plate";
     private static final String DESCRIPTION = "Contains data about defined plates";
@@ -48,10 +52,19 @@ public class PlateSchema extends SimpleUserSchema
         AmountUnitsTable.NAME
     ));
 
+    Set<Role> contextualRoles = Set.of();
+
     public PlateSchema(User user, Container container)
     {
         super(SCHEMA_NAME, DESCRIPTION, user, container, AssayDbSchema.getInstance().getSchema(),
                 null, AVAILABLE_TABLES, null);
+    }
+
+    public PlateSchema(QuerySchema schema, Set<Role> contextualRoles)
+    {
+        this(schema.getUser(), schema.getContainer());
+        setDefaultSchema(schema.getDefaultSchema());
+        this.contextualRoles = contextualRoles;
     }
 
     @Override
@@ -83,6 +96,18 @@ public class PlateSchema extends SimpleUserSchema
             return new AmountUnitsTable(this);
 
         return null;
+    }
+
+    @Override
+    public @NotNull Set<Role> getContextualRoles()
+    {
+        return contextualRoles;
+    }
+
+    @Override
+    public boolean canReadSchema()
+    {
+        return super.canReadSchema() || getContainer().hasPermission(getUser(), ReadPermission.class, contextualRoles) ;
     }
 
     public static TableInfo getPlateSetTable(Container container, User user, @Nullable ContainerFilter cf)

--- a/assay/src/org/labkey/assay/plate/query/WellTable.java
+++ b/assay/src/org/labkey/assay/plate/query/WellTable.java
@@ -48,6 +48,7 @@ import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.assay.plate.PlateManager;
 import org.labkey.assay.plate.TsvPlateLayoutHandler;
@@ -374,6 +375,10 @@ public class WellTable extends SimpleUserSchema.SimpleTable<PlateSchema>
     {
         if (!_allowInsertDelete && (InsertPermission.class.equals(perm) || DeletePermission.class.equals(perm)))
             return false;
+
+        if (perm.equals(ReadPermission.class))
+            return _userSchema.getContainer().hasPermission(user, perm, _userSchema.getContextualRoles());
+
         return super.hasPermission(user, perm);
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -804,7 +804,9 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
         SQLFragment sql;
         UserSchema plateUserSchema;
-        // Issue 53194 : this would be the case for linked to study samples
+        // Issue 53194 : this would be the case for linked to study samples. The contextual role is set up from the study dataset
+        // for the source sample, we want to allow the plate schema to inherit any contextual roles to allow querying
+        // against tables in that schema.
         if (_userSchema instanceof UserSchema.HasContextualRoles samplesSchema && !samplesSchema.getContextualRoles().isEmpty())
             plateUserSchema = AssayPlateMetadataService.get().getPlateSchema(_userSchema, samplesSchema.getContextualRoles());
         else

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -20,6 +20,7 @@ import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.audit.AuditHandler;
 import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.CacheManager;
@@ -27,7 +28,28 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.compliance.TableRules;
 import org.labkey.api.compliance.TableRulesManager;
-import org.labkey.api.data.*;
+import org.labkey.api.data.ColumnHeaderType;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DataRegion;
+import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.ImportAliasable;
+import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.MaterializedQueryHelper;
+import org.labkey.api.data.MutableColumnInfo;
+import org.labkey.api.data.PHI;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.Sort;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.UnionContainerFilter;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.LoggingDataIterator;
@@ -120,7 +142,7 @@ import static org.labkey.api.exp.query.ExpMaterialTable.Column.AliquotVolume;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.AvailableAliquotCount;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.AvailableAliquotVolume;
 import static org.labkey.api.util.StringExpressionFactory.AbstractStringExpression.NullValueBehavior.NullResult;
-import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.*;
+import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.schema;
 
 public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.Column> implements ExpMaterialTable
 {
@@ -780,8 +802,14 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         if (InventoryService.get() != null && (st == null || !st.isMedia()))
             defaultCols.addAll(InventoryService.get().addInventoryStatusColumns(st == null ? null : st.getMetricUnit(), this, getContainer(), _userSchema.getUser()));
 
-        UserSchema plateUserSchema = QueryService.get().getUserSchema(_userSchema.getUser(), getContainer(), "plate");
         SQLFragment sql;
+        UserSchema plateUserSchema;
+        // Issue 53194 : this would be the case for linked to study samples
+        if (_userSchema instanceof UserSchema.HasContextualRoles samplesSchema && !samplesSchema.getContextualRoles().isEmpty())
+            plateUserSchema = AssayPlateMetadataService.get().getPlateSchema(_userSchema, samplesSchema.getContextualRoles());
+        else
+            plateUserSchema = QueryService.get().getUserSchema(_userSchema.getUser(), _userSchema.getContainer(), "plate");
+
         if (plateUserSchema != null && plateUserSchema.getTable("Well") != null)
         {
             String rowIdField = ExprColumn.STR_TABLE_ALIAS + "." + Column.RowId.name();

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -77,13 +77,16 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.MetadataUnavailableException;
 import org.labkey.api.query.QueryChangeListener;
+import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.SimpleValidationError;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.roles.Role;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.publish.StudyPublishService;
@@ -2270,5 +2273,11 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     public void refreshSampleTypeMaterializedView(@NotNull ExpSampleType st, SampleChangeType reason)
     {
         ExpMaterialTableImpl.refreshMaterializedView(st.getLSID(), reason);
+    }
+
+    @Override
+    public UserSchema getUserSchema(QuerySchema schema, Set<Role> contextualRoles)
+    {
+        return new SamplesSchema(schema, contextualRoles);
     }
 }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -32,7 +32,25 @@ import org.labkey.api.audit.SampleTimelineAuditEvent;
 import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
-import org.labkey.api.data.*;
+import org.labkey.api.data.AuditConfigurable;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.data.DbSequence;
+import org.labkey.api.data.DbSequenceManager;
+import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.NameGenerator;
+import org.labkey.api.data.Parameter;
+import org.labkey.api.data.ParameterMapStatement;
+import org.labkey.api.data.RuntimeSQLException;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.measurement.Measurement;
 import org.labkey.api.defaults.DefaultValueService;
@@ -77,16 +95,13 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.MetadataUnavailableException;
 import org.labkey.api.query.QueryChangeListener;
-import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.SimpleValidationError;
-import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.security.roles.Role;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.publish.StudyPublishService;
@@ -2273,11 +2288,5 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     public void refreshSampleTypeMaterializedView(@NotNull ExpSampleType st, SampleChangeType reason)
     {
         ExpMaterialTableImpl.refreshMaterializedView(st.getLSID(), reason);
-    }
-
-    @Override
-    public UserSchema getUserSchema(QuerySchema schema, Set<Role> contextualRoles)
-    {
-        return new SamplesSchema(schema, contextualRoles);
     }
 }

--- a/study/src/org/labkey/study/query/SampleDatasetTable.java
+++ b/study/src/org/labkey/study/query/SampleDatasetTable.java
@@ -10,22 +10,18 @@ import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpSampleType;
-import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.security.roles.ReaderRole;
-import org.labkey.api.security.roles.RoleManager;
 import org.labkey.study.model.DatasetDefinition;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 public class SampleDatasetTable extends LinkedDatasetTable
 {
@@ -116,9 +112,7 @@ public class SampleDatasetTable extends LinkedDatasetTable
                 return null;
             _sampleType = sampleType;
 
-            UserSchema userSchema = SampleTypeService.get().getUserSchema(_userSchema, Set.of(RoleManager.getRole(ReaderRole.class)));
-                    //QueryService.get().getUserSchema(_userSchema.getUser(), sampleType.getContainer(), SamplesSchema.SCHEMA_NAME);
-
+            UserSchema userSchema = QueryService.get().getUserSchema(_userSchema.getUser(), sampleType.getContainer(), SamplesSchema.SCHEMA_NAME);
             // Hide 'linked' column for Sample Type Datasets
             if (userSchema instanceof SamplesSchema samplesSchema)
             {

--- a/study/src/org/labkey/study/query/SampleDatasetTable.java
+++ b/study/src/org/labkey/study/query/SampleDatasetTable.java
@@ -10,18 +10,22 @@ import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpSampleType;
+import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.SamplesSchema;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.roles.ReaderRole;
+import org.labkey.api.security.roles.RoleManager;
 import org.labkey.study.model.DatasetDefinition;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public class SampleDatasetTable extends LinkedDatasetTable
 {
@@ -112,7 +116,8 @@ public class SampleDatasetTable extends LinkedDatasetTable
                 return null;
             _sampleType = sampleType;
 
-            UserSchema userSchema = QueryService.get().getUserSchema(_userSchema.getUser(), sampleType.getContainer(), SamplesSchema.SCHEMA_NAME);
+            UserSchema userSchema = SampleTypeService.get().getUserSchema(_userSchema, Set.of(RoleManager.getRole(ReaderRole.class)));
+                    //QueryService.get().getUserSchema(_userSchema.getUser(), sampleType.getContainer(), SamplesSchema.SCHEMA_NAME);
 
             // Hide 'linked' column for Sample Type Datasets
             if (userSchema instanceof SamplesSchema samplesSchema)


### PR DESCRIPTION
#### Rationale
[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53194)

We patched around the related issue to avoid the NPE, but the fix was more of a stopgap since it avoided the join to the `Well` table if the user didn't have read access. The appropriate fix is to support and push a `ContextualRole` through the `SampleSchema` and into the `PlateSchema` so it can be used in the `Well` table.
