### PR TITLE
Issue 53091: Don't include calculated aliquot rollup columns in audit details

### DIFF
--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -11,12 +11,15 @@ import org.labkey.api.query.QueryService;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
 {
     public static final String EVENT_TYPE = "SampleTimelineEvent";
 
     public static final String SAMPLE_TIMELINE_EVENT_TYPE = "SampleTimelineEventType";
+
+    public static final Set<String> EXCLUDED_DETAIL_FIELDS = Set.of("AvailableAliquotVolume", "AvailableAliquotCount", "AliquotCount", "AliquotVolume");
 
     public enum SampleTimelineEventType
     {
@@ -196,7 +199,8 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
 
     /**
      * If the sample state changed, explicitly add in the Status Label value to the map so that it will render in the
-     * audit log timeline event even if the DataState row is later deleted.
+     * audit log timeline event even if the DataState row is later deleted.  Also, remove the aliquot rollup calculated
+     * fields from the data.
      */
     @Override
     public void setOldRecordMap(String oldRecordMap, Container container)
@@ -204,6 +208,7 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
         if (oldRecordMap != null)
         {
             Map<String, String> row = new CaseInsensitiveHashMap<>(AbstractAuditTypeProvider.decodeFromDataMap(oldRecordMap));
+            EXCLUDED_DETAIL_FIELDS.forEach(row::remove);
             String label = getStatusLabel(row, container);
             if (label != null)
             {
@@ -216,7 +221,8 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
 
     /**
      * If the sample state changed, explicitly add in the Status Label value to the map so that it will render in the
-     * audit log timeline event even if the DataState row is later deleted.
+     * audit log timeline event even if the DataState row is later deleted. Also, remove the aliquot rollup calculated
+     * fields from the data.
      */
     @Override
     public void setNewRecordMap(String newRecordMap, Container container)
@@ -224,12 +230,11 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
         if (newRecordMap != null)
         {
             Map<String, String> row = new CaseInsensitiveHashMap<>(AbstractAuditTypeProvider.decodeFromDataMap(newRecordMap));
+            EXCLUDED_DETAIL_FIELDS.forEach(row::remove);
             String label = getStatusLabel(row, container);
             if (label != null)
-            {
                 row.put("samplestatelabel", label);
-                newRecordMap = AbstractAuditTypeProvider.encodeForDataMap(row);
-            }
+            newRecordMap = AbstractAuditTypeProvider.encodeForDataMap(row);
         }
         super.setNewRecordMap(newRecordMap, container);
     }

--- a/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
+++ b/api/src/org/labkey/api/audit/SampleTimelineAuditEvent.java
@@ -19,7 +19,7 @@ public class SampleTimelineAuditEvent extends DetailedAuditTypeEvent
 
     public static final String SAMPLE_TIMELINE_EVENT_TYPE = "SampleTimelineEventType";
 
-    public static final Set<String> EXCLUDED_DETAIL_FIELDS = Set.of("AvailableAliquotVolume", "AvailableAliquotCount", "AliquotCount", "AliquotVolume");
+    public static final Set<String> EXCLUDED_DETAIL_FIELDS = Set.of("AvailableAliquotVolume", "AvailableAliquotCount", "AliquotCount", "AliquotVolume", "AliquotUnit");
 
     public enum SampleTimelineEventType
     {

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
@@ -1022,8 +1022,11 @@ public void testDetailedAuditLog() throws Exception
     Map<String,String> newRecordMap = new CaseInsensitiveHashMap<>(PageFlowUtil.mapFromQueryString(events.get(0).getNewRecordMap()));
     assertEquals("Initial", newRecordMap.get("Measure"));
     assertEquals("1.0", newRecordMap.get("Value"));
-    assertEquals("0", newRecordMap.get("AliquotCount"));
-    assertEquals("0.0", newRecordMap.get("AliquotVolume"));
+    assertNull(newRecordMap.get("AliquotCount"));
+    assertNull(newRecordMap.get("AliquotVolume"));
+    assertNull(newRecordMap.get("AvailableAliquotVolume"));
+    assertNull(newRecordMap.get("AvailableAliquotCount"));
+    assertNull(newRecordMap.get("AliquotUnit"));
 
     // UPDATE
     rows.clear(); errors.clear();


### PR DESCRIPTION
#### Rationale
Issue [53091](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53091)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1502

#### Changes
- Update `SampleTimelineAuditEvent.setOldRecordMap` and `SampleTimelineAuditEvent.setNewRecordMap` to exclude the aliquot rollup calculated fields from the audit details.

#### Tasks 📍
- [ ] Manual Testing @XingY 
- [x] Needs Automation
- [ ] Verify Fix
