### PR TITLE
Issue 53253: forego indexing data class in a container being deleted

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassImpl.java
@@ -242,6 +242,8 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
     {
         if (_domain == null || (forUpdate && !_domain.isMutable()))
         {
+            assert getContainer() != null : "Container cannot be null when attempting to fetch data class domain.";
+
             _domain = PropertyService.get().getDomain(getContainer(), getLSID(), forUpdate);
             if (_domain == null)
             {
@@ -328,12 +330,9 @@ public class ExpDataClassImpl extends ExpIdentifiableEntityImpl<DataClass> imple
         }
     }
 
-    public TableInfo getTinfo()
+    public @NotNull TableInfo getTinfo()
     {
-        Domain d = getDomain();
-        if (null == d)
-            throw new NullPointerException("domain is null");
-        return StorageProvisioner.createTableInfo(d);
+        return StorageProvisioner.createTableInfo(getDomain());
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1219,13 +1219,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         SearchService.IndexTask task = ss.defaultTask();
 
         Runnable r = () -> {
-            Domain d = dataClass.getDomain();
-            if (d == null)
-                return; // Domain may be null if the DataClass has been deleted
-
-            TableInfo table = dataClass.getTinfo();
-            if (table == null)
-                return;
+            if (dataClass.getContainer() == null)
+                return; // Issue 53253: container may be deleted
 
             indexDataClass(dataClass, task);
             indexDataClassData(dataClass, task);
@@ -1830,13 +1825,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public List<? extends ExpData> getExpDatas(ExpDataClass dataClass)
     {
-        Domain d = dataClass.getDomain();
-        if (d == null)
-            throw new IllegalStateException("No domain for DataClass '" + dataClass.getName() + "' in container '" + dataClass.getContainer().getPath() + "'");
-
         TableInfo table = ((ExpDataClassImpl) dataClass).getTinfo();
-        if (table == null)
-            throw new IllegalStateException("No table for DataClass '" + dataClass.getName() + "' in container '" + dataClass.getContainer().getPath() + "'");
 
         SQLFragment sql = new SQLFragment()
                 .append("SELECT * FROM ").append(getTinfoData(), "d")
@@ -1848,7 +1837,6 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         return datas.stream().map(ExpDataImpl::new).collect(toList());
     }
-
 
     public List<ExpDataImpl> getExpDatasByObjectId(ContainerFilter containerFilter, Collection<Integer> objectIds)
     {
@@ -1862,13 +1850,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Nullable
     public ExpDataImpl getExpData(ExpDataClass dataClass, String name)
     {
-        Domain d = dataClass.getDomain();
-        if (d == null)
-            throw new IllegalStateException("No domain for DataClass '" + dataClass.getName() + "' in container '" + dataClass.getContainer().getPath() + "'");
-
         TableInfo table = ((ExpDataClassImpl) dataClass).getTinfo();
-        if (table == null)
-            throw new IllegalStateException("No table for DataClass '" + dataClass.getName() + "' in container '" + dataClass.getContainer().getPath() + "'");
 
         SQLFragment sql = new SQLFragment()
                 .append("SELECT * FROM ").append(getTinfoData(), "d")
@@ -1886,13 +1868,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Nullable
     public ExpDataImpl getExpData(ExpDataClass dataClass, int rowId)
     {
-        Domain d = dataClass.getDomain();
-        if (d == null)
-            throw new IllegalStateException("No domain for DataClass '" + dataClass.getName() + "' in container '" + dataClass.getContainer().getPath() + "'");
-
         TableInfo table = ((ExpDataClassImpl) dataClass).getTinfo();
-        if (table == null)
-            throw new IllegalStateException("No table for DataClass '" + dataClass.getName() + "' in container '" + dataClass.getContainer().getPath() + "'");
 
         SQLFragment sql = new SQLFragment()
                 .append("SELECT * FROM ").append(getTinfoData(), "d")
@@ -10226,6 +10202,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
     }
 
+    @SuppressWarnings("JUnitMalformedDeclaration")
     public static class TestCase extends Assert
     {
         final Logger log = LogManager.getLogger(ExperimentServiceImpl.class);
@@ -10389,6 +10366,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
     }
 
+    @SuppressWarnings("JUnitMalformedDeclaration")
     public static class LineageQueryTestCase extends Assert
     {
         TempTableTracker tt;
@@ -10587,6 +10565,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
     }
 
+    @SuppressWarnings("JUnitMalformedDeclaration")
     public static class ParseInputOutputAliasTestCase extends Assert
     {
         @Test


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53253](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53253) by checking that the `dataClass` instance that is about to be indexed has a container.

#### Changes
- Check for data class container prior to indexing
- Annotate `ExpDataClassImpl.getTinfo()` as `@NotNull` and update usages
- Add assertion check for container in `ExpDataClassImpl.getDomain()`