### PR TITLE
NULL check on cohort filter

### DIFF
--- a/study/src/org/labkey/study/SingleCohortFilter.java
+++ b/study/src/org/labkey/study/SingleCohortFilter.java
@@ -43,7 +43,7 @@ public class SingleCohortFilter extends BaseCohortFilter
 
 
     @Deprecated  // Should use CohortFilterFactory instead
-    public SingleCohortFilter(Type type, Cohort cohort)
+    public SingleCohortFilter(Type type, @NotNull Cohort cohort)
     {
         super(type);
         _cohortId = -1;

--- a/study/src/org/labkey/study/view/overview.jsp
+++ b/study/src/org/labkey/study/view/overview.jsp
@@ -94,7 +94,8 @@
         {
             selectedCohort = bean.cohortFilter.getCohort(container, user);
             // Get a cohort filter that includes the label, so we use the label (not the rowId) in the filter clause
-            cohortFilter = new SingleCohortFilter(bean.cohortFilter.getType(), selectedCohort);
+            if (selectedCohort != null)
+                cohortFilter = new SingleCohortFilter(bean.cohortFilter.getType(), selectedCohort);
         }
         cohorts = manager.getCohorts(container, user);
     }


### PR DESCRIPTION
#### Rationale
The crawler recently exposed an [exception](https://teamcity.labkey.org/viewLog.html?buildId=3572671&buildTypeId=LabKey_257Release_Community_DailySqlServer&fromSakuraUI=true#testNameId-1581204562063725048) during the `CohortFilterTest`. 

The fix is to add a `null` check for that page.
