### PR TITLE
Issue 53408: Encode field names in attachment download links

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -537,7 +537,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
     {
         ActionURL url = new ActionURL(ExperimentController.DataClassAttachmentDownloadAction.class, getUserSchema().getContainer())
                 .addParameter("lsid", "${LSID}")
-                .addParameter("name", "${" + col.getName() + "}");
+                .addParameter("name", "${" + PageFlowUtil.encode(col.getName()) + "}");
         if (FileLinkDisplayColumn.AS_ATTACHMENT_FORMAT.equalsIgnoreCase(col.getFormat()))
         {
             url.addParameter("inline", "false");
@@ -622,7 +622,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                     columnInfo.setURL(StringExpressionFactory.createURL(
                             new ActionURL(ExperimentController.DataClassAttachmentDownloadAction.class, getContainer())
                                     .addParameter("lsid", "${LSID}")
-                                    .addParameter("name", "${" + columnInfo.getFieldKey() + "}")));
+                                    .addParameter("name", "${" + PageFlowUtil.encode(columnInfo.getName()) + "}")));
 
                 }
 

--- a/list/src/org/labkey/list/model/ListTable.java
+++ b/list/src/org/labkey/list/model/ListTable.java
@@ -70,6 +70,7 @@ import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.study.assay.FileLinkDisplayColumn;
 import org.labkey.api.util.ContainerContext;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.view.ActionURL;
 import org.labkey.data.xml.TableType;
@@ -366,7 +367,7 @@ public class ListTable extends FilteredTable<ListQuerySchema> implements Updatea
 
     private void configureAttachmentURL(MutableColumnInfo col)
     {
-        ActionURL url = ListController.getDownloadURL(_list, "${EntityId}", "${" + col.getName() + "}");
+        ActionURL url = ListController.getDownloadURL(_list, "${EntityId}", "${" + PageFlowUtil.encode(col.getName()) + "}");
         if (FileLinkDisplayColumn.AS_ATTACHMENT_FORMAT.equalsIgnoreCase(col.getFormat()))
         {
             url.addParameter("inline", "false");


### PR DESCRIPTION
#### Rationale
Issue [53408](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53408): When a field name for an Attachment field contains a character that should be URL encoded, we need to be sure to do that encoding for download links.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2543
- https://github.com/LabKey/limsModules/pull/1512


#### Changes
- Encode name of column in URL download template for Data Class attachments
- Encode name of column in URL download link for List attachments
