### PR TITLE
Improve detection of an idle indexer

### DIFF
--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -212,9 +212,6 @@ public interface SearchService extends SearchMXBean
 
         void addResource(@NotNull WebdavResource r, SearchService.PRIORITY pri);
 
-        /* This adds do nothing item to the queue, this is only useful for tracking progress of the queue. see TaskListener. */
-        void addNoop(SearchService.PRIORITY pri);
-
         default <T> void addResourceList(List<T> list, int batchSize, Function<T,WebdavResource> mapper)
         {
             ListUtils.partition(list, batchSize).forEach(sublist ->
@@ -432,7 +429,7 @@ public interface SearchService extends SearchMXBean
     // helper to call when not found exception is detected
     void notFound(URLHelper url);
 
-    List<IndexTask> getTasks();
+    List<? extends IndexTask> getTasks();
 
     void addPathToCrawl(Path path, @Nullable Date nextCrawl);
 

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -120,6 +120,7 @@ public interface SearchService extends SearchMXBean
      */
     boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit) throws InterruptedException;
 
+    /** From lowest to highest priority */
     enum PRIORITY
     {
         commit,

--- a/core/src/org/labkey/core/search/NoopSearchService.java
+++ b/core/src/org/labkey/core/search/NoopSearchService.java
@@ -58,11 +58,6 @@ public class NoopSearchService implements SearchService
         }
 
         @Override
-        public void addNoop(PRIORITY pri)
-        {
-        }
-
-        @Override
         public void setReady()
         {
         }
@@ -169,7 +164,7 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
-    public WebPartView getSearchView(boolean includeSubfolders, int textBoxWidth, boolean includeHelpLink, boolean isWebpart)
+    public WebPartView<?> getSearchView(boolean includeSubfolders, int textBoxWidth, boolean includeHelpLink, boolean isWebpart)
     {
         return null;
     }
@@ -235,7 +230,7 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
-    public HttpView getCustomSearchResult(User user, @NotNull String resourceIdentifier)
+    public HttpView<?> getCustomSearchResult(User user, @NotNull String resourceIdentifier)
     {
         return null;
     }

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -20,6 +20,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.HttpStatus;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
@@ -58,6 +59,7 @@ import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.ResponseHelper;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.FolderManagement.FolderManagementViewPostAction;
 import org.labkey.api.view.HtmlView;
@@ -92,6 +94,8 @@ import java.util.concurrent.TimeUnit;
 public class SearchController extends SpringActionController
 {
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(SearchController.class);
+
+    private static final Logger LOG = LogHelper.getLogger(SearchController.class, "Search UI and admin");
 
     public SearchController()
     {
@@ -858,7 +862,10 @@ public class SearchController extends SpringActionController
         public void export(PriorityForm form, HttpServletResponse response, BindException errors) throws Exception
         {
             SearchService ss = SearchService.get();
+            long startTime = System.currentTimeMillis();
             boolean success = ss.drainQueue(form.getPriority(), 5, TimeUnit.MINUTES);
+
+            LOG.info("Spent {}ms draining the search indexer queue. Success: {}", System.currentTimeMillis() - startTime, success);
 
             // Return an error if we time out
             if (!success)

--- a/search/src/org/labkey/search/model/AbstractIndexTask.java
+++ b/search/src/org/labkey/search/model/AbstractIndexTask.java
@@ -25,6 +25,7 @@ import java.io.StringWriter;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/search/src/org/labkey/search/model/AbstractIndexTask.java
+++ b/search/src/org/labkey/search/model/AbstractIndexTask.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.search.model;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.search.SearchService;
 
@@ -25,7 +26,6 @@ import java.io.StringWriter;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -220,7 +220,7 @@ public abstract class AbstractIndexTask implements SearchService.IndexTask
 
 
     @Override
-    public SearchService.IndexTask get(long timeout, TimeUnit unit) throws InterruptedException
+    public SearchService.IndexTask get(long timeout, @NotNull TimeUnit unit) throws InterruptedException
     {
         synchronized (_completeEvent)
         {

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -256,6 +256,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         WebdavResource _res;
         Runnable _run;
         PRIORITY _pri;
+        // Used to ensure FIFO ordering in the queue
         final long seqNum = seq.incrementAndGet();
 
         int _preprocessAttempts = 0;

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -606,23 +606,21 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     {
         final CountDownLatch latch = new CountDownLatch(1);
 
-        SearchService.IndexTask task = createTask("WaitForIndexerRunnable");
-        task.addRunnable(priority, () ->
-                {
-                    // The indexer uses multiple threads for different types of work. Queue a Runnable first, and when it executes,
-                    // queue the Item
-                    SearchService.IndexTask itemTask = createTask("WaitForIndexer", new SearchService.TaskListener()
-                    {
-                        @Override public void success()
-                        {
-                            latch.countDown();
-                        }
-                        @Override public void indexError(Resource r, Throwable t) { }
-                    });
-                    itemTask.addNoop(priority);
-                    itemTask.setReady();
-                });
-
+        SearchService.IndexTask task = createTask("WaitForIndexerRunnable", new SearchService.TaskListener()
+        {
+            @Override public void success()
+            {
+                latch.countDown();
+            }
+            @Override public void indexError(Resource r, Throwable t)
+            {
+                latch.countDown();
+            }
+        });
+        // The indexer uses multiple threads for different types of work. Queue a Runnable first, and when it executes,
+        // queue the Item
+        task.addRunnable(priority, () -> task.addNoop(priority));
+        task.setReady();
         boolean success = latch.await(timeout, unit);
         refreshNow();
         return success;

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -34,6 +34,7 @@ import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.dialect.SqlDialect;
+import org.labkey.api.resource.Resource;
 import org.labkey.api.search.SearchResultTemplate;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
@@ -73,9 +74,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class AbstractSearchService implements SearchService, ShutdownListener
@@ -120,7 +121,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
 
     @Override
-    public IndexTask createTask(String description)
+    public _IndexTask createTask(String description)
     {
         _IndexTask task = new _IndexTask(description);
         addTask(task);
@@ -128,7 +129,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     }
 
     @Override
-    public IndexTask createTask(String description, TaskListener l)
+    public _IndexTask createTask(String description, TaskListener l)
     {
         _IndexTask task = new _IndexTask(description, l);
         addTask(task);
@@ -156,7 +157,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     }
 
 
-    class _IndexTask extends AbstractIndexTask
+    public class _IndexTask extends AbstractIndexTask
     {
         _IndexTask(String description)
         {
@@ -197,16 +198,15 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             queueItem(i);
         }
 
-        public void addNoop(PRIORITY pri, CustomCountLatch latch)
+        public void addNoop(PRIORITY pri)
         {
-            latch.increment();
             final Item i = new Item( this, OPERATION.noop, "noop://noop", null, pri)
             {
                 @Override
                 void complete(boolean success)
                 {
+                    logQueueStatus("addNoop() complete");
                     super.complete(success);
-                    latch.decrement();
                 }
             };
             addItem(i);
@@ -246,7 +246,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
     // Consider: remove _op/OPERATION (not used), subclasses for resource vs. runnable (would clarify invariants and make
     // hashCode() & equals() more straightforward), formalize _id (using Runnable.toString() seems weak).
-    class Item implements Comparable<Item>
+    public class Item implements Comparable<Item>
     {
         static final AtomicLong seq = new AtomicLong();
 
@@ -477,7 +477,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             return;
         }
 
-        _log.debug("_submitQueue.put(" + i._id + ")");
+        logQueueStatus("_submitQueue.put(" + i._id + ")");
 
         if (null != i._run)
         {
@@ -619,20 +619,40 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     @Override
     public boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit) throws InterruptedException
     {
-        final CustomCountLatch latch = new CustomCountLatch(1);
-        SearchService.IndexTask task = createTask("WaitForIndexer");
-        // The indexer uses multiple threads for different types of work. Queue a Runnable first, and when it executes,
-        // queue an Item on every task
-        task.addRunnable(priority, () -> {
-            _tasks.forEach(t -> t.addNoop(priority, latch));
-            _defaultTask.addNoop(priority, latch);
+        final CountDownLatch latch = new CountDownLatch(1);
+        long start = System.currentTimeMillis();
+        _IndexTask task = createTask("WaitForIndexer", new TaskListener()
+        {
+            @Override
+            public void success()
+            {
+               logQueueStatus("drainQueue's TaskListener.success()");
+               latch.countDown();
+            }
 
-            latch.decrement();  // Decrement one for the runnable itself
+            @Override
+            public void indexError(Resource r, Throwable t)
+            {
+                logQueueStatus("drainQueue's TaskListener.indexError()");
+                latch.countDown();
+            }
+        });
+        // The indexer uses multiple threads for different types of work. Queue a Runnable first, and when it executes,
+        // queue an Item to ensure all queues are cleared
+        task.addRunnable(priority, () -> {
+            logQueueStatus("drainQueue's Runnable.run()");
+            task.addNoop(priority);
         });
         task.setReady();
         boolean success = latch.await(timeout, unit);
         refreshNow();
+        logQueueStatus("drainQueue() complete after " + (System.currentTimeMillis() - start) + " ms");
         return success;
+    }
+
+    private void logQueueStatus(String message)
+    {
+        _log.debug("{}; _runQueue.size() = {}, _itemQueue.size() = {}", message, _runQueue.size(), _itemQueue.size());
     }
 
     @Override
@@ -1521,43 +1541,5 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     public long getFileSizeLimit()
     {
         return SearchPropertyManager.getFileSizeLimitMB() * (1024*1024);
-    }
-
-    public static class CustomCountLatch
-    {
-        private final AtomicInteger count;
-
-        public CustomCountLatch(int initialCount)
-        {
-            this.count = new AtomicInteger(initialCount);
-        }
-
-        public boolean await(long timeout, TimeUnit unit) throws InterruptedException
-        {
-            synchronized (this)
-            {
-                while (count.get() > 0)
-                {
-                    wait(unit.toMillis(timeout));
-                }
-            }
-            return count.get() == 0;
-        }
-
-        public void increment()
-        {
-            count.incrementAndGet();
-        }
-
-        public void decrement()
-        {
-            if (count.decrementAndGet() == 0)
-            {
-                synchronized (this)
-                {
-                    notifyAll();
-                }
-            }
-        }
     }
 }

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -34,7 +34,6 @@ import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.dialect.SqlDialect;
-import org.labkey.api.resource.Resource;
 import org.labkey.api.search.SearchResultTemplate;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
@@ -65,7 +64,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -75,9 +73,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class AbstractSearchService implements SearchService, ShutdownListener
 {
@@ -98,12 +97,12 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     }
 
     // Runnables go here, and get pulled off in a single-threaded manner (assumption is that Runnables can create work very quickly)
-    final PriorityBlockingQueue<Item> _runQueue = new PriorityBlockingQueue<>(1000, itemCompare);
+    final PriorityBlockingQueue<Item> _runQueue = new PriorityBlockingQueue<>(1000);
 
     // Resources go here for preprocessing (this can be multi-threaded)
-    final PriorityBlockingQueue<Item> _itemQueue = new PriorityBlockingQueue<>(1000, itemCompare);
+    final PriorityBlockingQueue<Item> _itemQueue = new PriorityBlockingQueue<>(1000);
 
-    private final List<IndexTask> _tasks = new CopyOnWriteArrayList<>();
+    private final List<_IndexTask> _tasks = new CopyOnWriteArrayList<>();
     private final _IndexTask _defaultTask = new _IndexTask("default");
 
     private Throwable _configurationError = null;
@@ -112,9 +111,6 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     {
         add, delete, noop
     }
-
-    static final Comparator<Item> itemCompare = Comparator.comparing(o -> o._pri);
-
 
     public AbstractSearchService()
     {
@@ -140,7 +136,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     }
 
     @Override
-    public IndexTask defaultTask()
+    public _IndexTask defaultTask()
     {
         return _defaultTask;
     }
@@ -201,16 +197,22 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             queueItem(i);
         }
 
-
-        @Override
-        public void addNoop(PRIORITY pri)
+        public void addNoop(PRIORITY pri, CustomCountLatch latch)
         {
-            final Item i = new Item( this, OPERATION.noop, "noop://noop", null, pri);
+            latch.increment();
+            final Item i = new Item( this, OPERATION.noop, "noop://noop", null, pri)
+            {
+                @Override
+                void complete(boolean success)
+                {
+                    super.complete(success);
+                    latch.decrement();
+                }
+            };
             addItem(i);
             final Item r = new Item(this, () -> queueItem(i), pri);
             queueItem(r);
         }
-
 
         @Override
         public void completeItem(Item item, boolean success)
@@ -241,17 +243,20 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         }
     }
 
-    
+
     // Consider: remove _op/OPERATION (not used), subclasses for resource vs. runnable (would clarify invariants and make
     // hashCode() & equals() more straightforward), formalize _id (using Runnable.toString() seems weak).
-    class Item
+    class Item implements Comparable<Item>
     {
+        static final AtomicLong seq = new AtomicLong();
+
         OPERATION _op;
         String _id;
-        IndexTask _task;
+        _IndexTask _task;
         WebdavResource _res;
         Runnable _run;
         PRIORITY _pri;
+        final long seqNum = seq.incrementAndGet();
 
         int _preprocessAttempts = 0;
 
@@ -259,7 +264,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         long _start = 0;    // used by setLastIndexed
         long _complete = 0; // really just for debugging
 
-        Item(IndexTask task, OPERATION op, String id, WebdavResource r, PRIORITY pri)
+        Item(_IndexTask task, OPERATION op, String id, WebdavResource r, PRIORITY pri)
         {
             if (null != r)
                 _start = HeartBeat.currentTimeMillis();
@@ -270,7 +275,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             _task = task;
         }
 
-        Item(IndexTask task, Runnable r, PRIORITY pri)
+        Item(_IndexTask task, Runnable r, PRIORITY pri)
         {
             _run = r;
             _pri = null == pri ? PRIORITY.bulk : pri;
@@ -297,7 +302,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         {
             if (null != _task)
             {
-                ((_IndexTask)_task).completeItem(this, success);
+                _task.completeItem(this, success);
             }
 
             if (!success)
@@ -336,6 +341,15 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         public String toString()
         {
             return "Item{" + (null != _res ? _res.toString() : null != _run ? _run.toString() : _op.name()) + '}';
+        }
+
+        @Override
+        public int compareTo(@NotNull AbstractSearchService.Item o)
+        {
+            int res = _pri.compareTo(o._pri) * -1;
+            if (res == 0 && o != this)
+                res = (seqNum < o.seqNum ? -1 : 1);
+            return res;
         }
     }
 
@@ -518,14 +532,14 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     }
 
 
-    public void addTask(IndexTask task)
+    private void addTask(_IndexTask task)
     {
         _tasks.add(task);
     }
 
 
     @Override
-    public List<IndexTask> getTasks()
+    public List<_IndexTask> getTasks()
     {
         return new LinkedList<>(_tasks);
     }
@@ -604,22 +618,16 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     @Override
     public boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit) throws InterruptedException
     {
-        final CountDownLatch latch = new CountDownLatch(1);
-
-        SearchService.IndexTask task = createTask("WaitForIndexerRunnable", new SearchService.TaskListener()
-        {
-            @Override public void success()
-            {
-                latch.countDown();
-            }
-            @Override public void indexError(Resource r, Throwable t)
-            {
-                latch.countDown();
-            }
-        });
+        final CustomCountLatch latch = new CustomCountLatch(1);
+        SearchService.IndexTask task = createTask("WaitForIndexer");
         // The indexer uses multiple threads for different types of work. Queue a Runnable first, and when it executes,
-        // queue the Item
-        task.addRunnable(priority, () -> task.addNoop(priority));
+        // queue an Item on every task
+        task.addRunnable(priority, () -> {
+            _tasks.forEach(t -> t.addNoop(priority, latch));
+            _defaultTask.addNoop(priority, latch);
+
+            latch.decrement();  // Decrement one for the runnable itself
+        });
         task.setReady();
         boolean success = latch.await(timeout, unit);
         refreshNow();
@@ -869,10 +877,10 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     public void purgeQueues()
     {
         _defaultTask._subtasks.clear();
-        for (IndexTask t : getTasks())
+        for (AbstractIndexTask t : getTasks())
         {
             t.cancel(true);
-            ((AbstractIndexTask)t)._subtasks.clear();
+            t._subtasks.clear();
         }
         _runQueue.clear();
         _itemQueue.clear();
@@ -1142,7 +1150,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
             if (null != out[0])
             {
-                _IndexTask t = (_IndexTask)i._task;
+                _IndexTask t = i._task;
                 if (null != t && null != t._listener)
                     t._listener.indexError(r,out[0]);
             }
@@ -1512,5 +1520,43 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     public long getFileSizeLimit()
     {
         return SearchPropertyManager.getFileSizeLimitMB() * (1024*1024);
+    }
+
+    public static class CustomCountLatch
+    {
+        private final AtomicInteger count;
+
+        public CustomCountLatch(int initialCount)
+        {
+            this.count = new AtomicInteger(initialCount);
+        }
+
+        public boolean await(long timeout, TimeUnit unit) throws InterruptedException
+        {
+            synchronized (this)
+            {
+                while (count.get() > 0)
+                {
+                    wait(unit.toMillis(timeout));
+                }
+            }
+            return count.get() == 0;
+        }
+
+        public void increment()
+        {
+            count.incrementAndGet();
+        }
+
+        public void decrement()
+        {
+            if (count.decrementAndGet() == 0)
+            {
+                synchronized (this)
+                {
+                    notifyAll();
+                }
+            }
+        }
     }
 }

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -604,22 +604,24 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     @Override
     public boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit) throws InterruptedException
     {
-        final CountDownLatch latch = new CountDownLatch(2);
+        final CountDownLatch latch = new CountDownLatch(1);
 
-        // The indexer uses multiple threads for different types of work. Queue an item and a Runnable to be sure
-        // both get drained
-        SearchService.IndexTask task = createTask("WaitForIndexer", new SearchService.TaskListener()
-        {
-            @Override public void success()
-            {
-                latch.countDown();
-            }
-            @Override public void indexError(Resource r, Throwable t) { }
-        });
-        task.addNoop(priority);
-        task.setReady();
-
-        task.addRunnable(latch::countDown, priority);
+        SearchService.IndexTask task = createTask("WaitForIndexerRunnable");
+        task.addRunnable(priority, () ->
+                {
+                    // The indexer uses multiple threads for different types of work. Queue a Runnable first, and when it executes,
+                    // queue the Item
+                    SearchService.IndexTask itemTask = createTask("WaitForIndexer", new SearchService.TaskListener()
+                    {
+                        @Override public void success()
+                        {
+                            latch.countDown();
+                        }
+                        @Override public void indexError(Resource r, Throwable t) { }
+                    });
+                    itemTask.addNoop(priority);
+                    itemTask.setReady();
+                });
 
         boolean success = latch.await(timeout, unit);
         refreshNow();

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -604,7 +604,10 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     @Override
     public boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit) throws InterruptedException
     {
-        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch = new CountDownLatch(2);
+
+        // The indexer uses multiple threads for different types of work. Queue an item and a Runnable to be sure
+        // both get drained
         SearchService.IndexTask task = createTask("WaitForIndexer", new SearchService.TaskListener()
         {
             @Override public void success()
@@ -615,6 +618,8 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         });
         task.addNoop(priority);
         task.setReady();
+
+        task.addRunnable(latch::countDown, priority);
 
         boolean success = latch.await(timeout, unit);
         refreshNow();


### PR DESCRIPTION
#### Rationale
We see intermittent failures when automated tests delete containers while indexing is still running. We need to check both `Item` and `Runnable` queues. An example is [Issue 53417](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53417).

#### Changes
- Queue a `Runnable` and when it completes, queue the `Item`