### PR TITLE
Issue 53412: Don't return names or container paths if user doesn't have read permission

### DIFF
--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -1706,7 +1706,8 @@ public class AssayController extends SpringActionController
             for (ExpRun expRun : allRuns)
             {
                 Container c = expRun.getContainer();
-                containers.add(c);
+                if (c.hasPermission(getUser(), ReadPermission.class))
+                    containers.add(c);
                 if (permClass != null && !c.hasPermission(getUser(), permClass))
                     notPermittedIds.add(expRun.getRowId());
             }
@@ -1729,7 +1730,10 @@ public class AssayController extends SpringActionController
                 List<Map<String, Object>> notAllowedRows = new ArrayList<>();
 
                 allRuns.forEach((dataObject) -> {
-                    Map<String, Object> rowMap = Map.of("RowId", dataObject.getRowId(), "ContainerPath", dataObject.getContainer().getPath());
+                    Map<String, Object> rowMap = new HashMap<>();
+                    rowMap.put("RowId", dataObject.getRowId());
+                    if (dataObject.getContainer().hasPermission(getUser(), ReadPermission.class))
+                        rowMap.put("ContainerPath", dataObject.getContainer().getPath());
                     if (allowedIds.contains(dataObject.getRowId()))
                         allowedRows.add(rowMap);
                     else
@@ -1759,6 +1763,8 @@ public class AssayController extends SpringActionController
             ExperimentService service = ExperimentService.get();
             ExpProtocol protocol = service.getExpProtocol(form.getProtocolId());
             AssayProvider provider = AssayService.get().getProvider(protocol);
+            if (provider == null)
+                throw new NotFoundException("No provider found for protocol " + form.getProtocolId());
             AssaySchema schema = provider.createProtocolSchema(getUser(), getContainer(), protocol, null);
             TableInfo tableInfo = schema.getTableOrThrow(AssayProtocolSchema.DATA_TABLE_NAME, ContainerFilter.getUnsafeEverythingFilter());
 
@@ -1774,7 +1780,8 @@ public class AssayController extends SpringActionController
                 if (data == null || data.getRun() == null) continue;
 
                 Container c = data.getRun().getContainer();
-                uniqueContainers.add(c);
+                if (c.hasPermission(getUser(), ReadPermission.class))
+                    uniqueContainers.add(c);
                 if (c.hasPermission(getUser(), AssayRunOperations.Edit.getPermissionClass()))
                     permittedRowIds.add(rowId);
             }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2140,7 +2140,14 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         List<Map<String, Object>> allowedRows = new ArrayList<>();
         permittedIds.forEach(rowId -> {
             Plate plate = plates.get(rowId);
-            allowedRows.add(CaseInsensitiveHashMap.of("RowId", rowId, "Name", plate.getName(), "ContainerPath", plate.getContainer().getPath()));
+            Map<String, Object> allowedRow = new HashMap<>();
+            allowedRow.put("RowId", rowId);
+            if (plate.getContainer().hasPermission(user, ReadPermission.class))
+            {
+                allowedRow.put("Name", plate.getName());
+                allowedRow.put("ContainerPath", plate.getContainer().getPath());
+            }
+            allowedRows.add(allowedRow);
         });
 
         List<Map<String, Object>> notAllowedRows = new ArrayList<>();
@@ -2149,7 +2156,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             Map<String, Object> rowMap = new CaseInsensitiveHashMap<>();
             rowMap.put("RowId", rowId);
 
-            if (plate != null)
+            if (plate != null && plate.getContainer().hasPermission(user, ReadPermission.class))
             {
                 rowMap.put("Name", plate.getName());
                 rowMap.put("ContainerPath", plate.getContainer().getPath());

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2143,10 +2143,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             Map<String, Object> allowedRow = new HashMap<>();
             allowedRow.put("RowId", rowId);
             if (plate.getContainer().hasPermission(user, ReadPermission.class))
-            {
-                allowedRow.put("Name", plate.getName());
                 allowedRow.put("ContainerPath", plate.getContainer().getPath());
-            }
             allowedRows.add(allowedRow);
         });
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4686,10 +4686,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             Map<String, Object> rowMap = new HashMap<>();
             rowMap.put("RowId", dataObject.getRowId());
             if (dataObject.getContainer().hasPermission(user, ReadPermission.class))
-            {
                 rowMap.put("ContainerPath", dataObject.getContainer().getPath());
-                rowMap.put("Name", dataObject.getContainer().getName());
-            }
             if (allowedIds.contains(dataObject.getRowId()))
                 allowedRows.add(rowMap);
             else

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4676,14 +4676,20 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         new SqlExecutor(getSchema()).execute(deleteSql);
     }
 
-    public static Map<String, Collection<Map<String, Object>>> partitionRequestedOperationObjects(Collection<Integer> requestIds, Collection<Integer> notAllowedIds, List<? extends ExpRunItem> allData)
+    public static Map<String, Collection<Map<String, Object>>> partitionRequestedOperationObjects(User user, Collection<Integer> requestIds, Collection<Integer> notAllowedIds, List<? extends ExpRunItem> allData)
     {
         List<Integer> allowedIds = new ArrayList<>(requestIds);
         allowedIds.removeAll(notAllowedIds);
         List<Map<String, Object>> allowedRows = new ArrayList<>();
         List<Map<String, Object>> notAllowedRows = new ArrayList<>();
         allData.forEach((dataObject) -> {
-            Map<String, Object> rowMap = Map.of("RowId", dataObject.getRowId(), "Name", dataObject.getName(), "ContainerPath", dataObject.getContainer().getPath());
+            Map<String, Object> rowMap = new HashMap<>();
+            rowMap.put("RowId", dataObject.getRowId());
+            if (dataObject.getContainer().hasPermission(user, ReadPermission.class))
+            {
+                rowMap.put("ContainerPath", dataObject.getContainer().getPath());
+                rowMap.put("Name", dataObject.getContainer().getName());
+            }
             if (allowedIds.contains(dataObject.getRowId()))
                 allowedRows.add(rowMap);
             else
@@ -4709,6 +4715,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             ExpSampleType sampleType = allMaterials.get(0).getSampleType();
             UserSchema userSchema = QueryService.get().getUserSchema(user, container, SamplesSchema.SCHEMA_NAME);
             TableInfo tableInfo = userSchema.getTable(sampleType.getName());
+            if (tableInfo == null)
+                return associatedDatasets;
 
             // collect up columns of name 'dataset<N>'
             Set<String> linkedColumnNames = new LinkedHashSet<>();

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -3770,7 +3770,7 @@ public class ExperimentController extends SpringActionController
                 service.getObjectReferencers().forEach(referencer ->
                         notAllowedIds.addAll(referencer.getItemsWithReferences(requestIds, "exp.data")));
 
-            Map<String, Collection<Map<String, Object>>> response = ExperimentServiceImpl.partitionRequestedOperationObjects(requestIds, notAllowedIds, allData);
+            Map<String, Collection<Map<String, Object>>> response = ExperimentServiceImpl.partitionRequestedOperationObjects(getUser(), requestIds, notAllowedIds, allData);
 
             Collection<Container> containers = new HashSet<>();
             Collection<Integer> notPermittedIds = new ArrayList<>();
@@ -3778,7 +3778,8 @@ public class ExperimentController extends SpringActionController
             for (ExpDataImpl expData : allData)
             {
                 Container c = expData.getContainer();
-                containers.add(c);
+                if (c.hasPermission(getUser(), ReadPermission.class))
+                    containers.add(c);
                 if (permClass != null && !c.hasPermission(getUser(), permClass))
                     notPermittedIds.add(expData.getRowId());
             }
@@ -3843,7 +3844,7 @@ public class ExperimentController extends SpringActionController
             if (SampleStatusService.get().supportsSampleStatus())
                 notAllowedIds.addAll(service.findIdsNotPermittedForOperation(allMaterials, form.getSampleOperation()));
 
-            Map<String, Collection<Map<String, Object>>> response = ExperimentServiceImpl.partitionRequestedOperationObjects(requestIds, notAllowedIds, allMaterials);
+            Map<String, Collection<Map<String, Object>>> response = ExperimentServiceImpl.partitionRequestedOperationObjects(getUser(), requestIds, notAllowedIds, allMaterials);
 
             Collection<Container> containers = new HashSet<>();
             Collection<Integer> notPermittedIds = new ArrayList<>();
@@ -3851,7 +3852,8 @@ public class ExperimentController extends SpringActionController
             for (ExpMaterial material : allMaterials)
             {
                 Container c = material.getContainer();
-                containers.add(c);
+                if (c.hasPermission(getUser(), ReadPermission.class))
+                    containers.add(c);
                 if (permClass != null && !c.hasPermission(getUser(), permClass))
                     notPermittedIds.add(material.getRowId());
             }


### PR DESCRIPTION
#### Rationale
Issue [53412](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53412): Guest Users can figure out Sample/Source Names and their Container Paths if they have access to any folder on a LabKey server


#### Changes
- Check for read permission to containers before adding them or the names of objects in them to the response

#### Tasks
- [x] Manual Testing @labkey-alan 
- [x] ~Needs Automation~ - See [Issue 53415](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53415) 
- [x] Verify Fix @labkey-alan 
