### PR TITLE
Fix Duo external redirect after SSO auth

### DIFF
--- a/api/src/org/labkey/api/security/AuthenticationManager.java
+++ b/api/src/org/labkey/api/security/AuthenticationManager.java
@@ -468,7 +468,7 @@ public class AuthenticationManager
                     AuthenticationManager.setPrimaryAuthenticationResult(request, primaryResult);
                     AuthenticationResult result = AuthenticationManager.handleAuthentication(request, getContainer());
 
-                    return HttpView.redirect(result.getRedirectURL());
+                    return HttpView.redirect(result.getRedirectURL(), true);
                 }
 
                 primaryResult.getStatus().addUserErrorMessage(errors, primaryResult, null, null);


### PR DESCRIPTION
#### Rationale
Duo 2FA redirects after SSO primary authentication (SAML, CAS) were incorrectly resolving to the local server. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53395

Although it didn't cause the problem, the "Universal Prompt" migration exposed an issue with the redirect method called by `BaseSsoValidateAction`, since this changed from a local redirect to an external redirect. Using database or LDAP primary authentication with Duo was not affected since those code paths redirect in a different manner.

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/130

#### Tasks 📍
- [x] Manual Testing & Verify Fix @labkey-bpatel
- [x] Needs Automation - No, we can't automate Duo interactions