### PR TITLE
Support container permission inheritance in search SecurityQuery

### DIFF
--- a/search/src/org/labkey/search/model/SecurityQuery.java
+++ b/search/src/org/labkey/search/model/SecurityQuery.java
@@ -33,6 +33,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.module.Module;
 import org.labkey.api.search.SearchScope;
 import org.labkey.api.search.SearchService;
@@ -168,7 +169,12 @@ class SecurityQuery extends Query
 
         if (null == canRead)
         {
-            SecurableResource sr = new _SecurableResource(resourceId, _containerIds.get(containerId));
+            // If resourceId represents a Container, then check permissions on it; this is important to ensure that
+            // permission inheritance is respected. If it's not a Container, then just fake up a SecurableResource.
+            // This is likely specific to Data Finder, which wants search to check permissions on both the cube
+            // container and the study container, not a resource that lives within a container. Issue 53420.
+            Container container = ContainerManager.getForId(resourceId);
+            SecurableResource sr = null != container ? container : new _SecurableResource(resourceId, _containerIds.get(containerId));
             canRead = sr.hasPermission(_user, ReadPermission.class);
             _securableResourceIds.put(resourceId, canRead);
         }


### PR DESCRIPTION
#### Rationale
Data Finder study search wasn't working (i.e., no hits for readers) for study folders that inherit their permissions. The associated search documents were intended to permission check two containers: the "cube" container (where lists reside) and each individual study container. The study container ID was therefore stored in the indexed document as resourceId. However, resourceId was designed to represent a resource within a container, not a completely separate container. `SecurityQuery` has no provision for container policy inheritance, so inherited policies resulted in no permissions.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53420

#### Tasks 📍
- [x] Manual Testing / Verify Fix @labkey-matthewb 
- [x] Needs Automation - Yes, create at least one study folder that inherits permissions and search for it as a public user.
  - https://github.com/LabKey/premiumModules/pull/304