### PR TITLE
Don't turn Jupyter JSON outputs into HTML

### DIFF
--- a/api/src/org/labkey/api/reports/report/r/view/HtmlOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/HtmlOutput.java
@@ -90,6 +90,9 @@ public class HtmlOutput extends AbstractParamReplacement
             setLabel(label);
         }
 
+        /**
+         * Loads an HTML file and adds nonces to any embedded &lt;script> tags. Don't call this with files that aren't HTML.
+         */
         @Override
         protected String renderInternalAsString(File file) throws Exception
         {

--- a/api/src/org/labkey/api/reports/report/r/view/IpynbOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/IpynbOutput.java
@@ -93,7 +93,7 @@ public class IpynbOutput extends HtmlOutput
             {
                 String html = view.renderInternalAsString(file);
                 URI baseURI = new URI(AppProps.getInstance().getBaseServerUrl());
-                if (html != null && baseURI != null)
+                if (html != null)
                     thumb = ImageUtil.webThumbnail(context, html, baseURI);
             }
             catch(Exception ignore){}// if we can't get a thumbnail then that is okay; LabKey should use a default

--- a/api/src/org/labkey/api/reports/report/r/view/IpynbOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/IpynbOutput.java
@@ -31,6 +31,7 @@ import org.labkey.api.thumbnail.Thumbnail;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.ImageUtil;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
 
@@ -149,7 +150,8 @@ public class IpynbOutput extends HtmlOutput
         @Override
         protected String renderInternalAsString(File file) throws Exception
         {
-            String result = StringUtils.trimToEmpty(super.renderInternalAsString(file));
+            // Don't call super.renderInternalAsString(file) since we expect JSON
+            String result = file.exists() ? StringUtils.trimToEmpty(PageFlowUtil.getFileContentsAsString(file)) : "";
             try
             {
                 final JSONObject obj = new JSONObject(result);

--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -3166,14 +3166,21 @@ public class PageFlowUtil
         String ret = "";
         if (doc != null)
         {
-            addScriptNonces(doc);
-            try
+            if (addScriptNonces(doc) > 0)
             {
-                ret = convertNodeToHtml(doc);
+                try
+                {
+                    ret = convertNodeToHtml(doc);
+                }
+                catch (TransformerException | IOException e)
+                {
+                    throw new RuntimeException(e);
+                }
             }
-            catch (TransformerException | IOException e)
+            else
             {
-                throw new RuntimeException(e);
+                // If there are no script tags, just return the passed in HTML
+                ret = html;
             }
         }
 


### PR DESCRIPTION
#### Rationale
Jupyter tests started failing after my PR to inject nonces into HTML outputs. Tricky little `IpynbOutputView` extended `HtmlOutputView`, but expects JSON not HTML.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6809

#### Tasks 📍
- [x] Manual Testing / Verify Fix - some manual testing of Jupyter notebooks would be worthwhile (e.g., other output types)
- [x] Does not need automation: existing tests caught this (unless manual testing points out another problem that existing tests didn't catch)