### PR TITLE
Initialize PageFlowUtil url matchers only when needed

### DIFF
--- a/api/src/org/labkey/api/util/PageFlowUtil.java
+++ b/api/src/org/labkey/api/util/PageFlowUtil.java
@@ -221,7 +221,7 @@ public class PageFlowUtil
         StringBuilder sb = new StringBuilder(2 * len);
         boolean newline = false;
 
-        Matcher urlMatcher = urlPatternStart.matcher(s);
+        CachingSupplier<Matcher> urlMatcher = new CachingSupplier<>(() -> urlPatternStart.matcher(s));
 
         for (int i = 0; i < len; ++i)
         {
@@ -281,10 +281,10 @@ public class PageFlowUtil
                     {
                         if (StringUtilsLabKey.startsWithURL(s.subSequence(i, Math.min(s.length(),i+10))))
                         {
-                            urlMatcher.region(i, s.length());
-                            if (urlMatcher.lookingAt())
+                            urlMatcher.get().region(i, s.length());
+                            if (urlMatcher.get().lookingAt())
                             {
-                                String href = urlMatcher.group(1);
+                                String href = urlMatcher.get().group(1);
                                 if (href.endsWith("."))
                                     href = href.substring(0, href.length() - 1);
                                 // for html/xml careful of " and "> and "/>


### PR DESCRIPTION
#### Rationale
[Issue 53385: Selecting millions of data region rows can cause OutOfMemoryError](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53385)

Creating unnecessary regex matchers for each rowId in a data region probably didn't cause the OOM error but it certainly doesn't help.
```
java.lang.OutOfMemoryError: Java heap space
    at java.base/java.util.regex.Pattern.matcher(Pattern.java:1134) ~[?:?]
    at org.labkey.api.util.PageFlowUtil.filter(PageFlowUtil.java:224) ~[api-25.3.11.jar:?]
    at org.labkey.api.util.PageFlowUtil.filter(PageFlowUtil.java:212) ~[api-25.3.11.jar:?]
    at org.labkey.api.util.PageFlowUtil.filter(PageFlowUtil.java:330) ~[api-25.3.11.jar:?]
    at org.labkey.api.data.DataRegion.getRecordSelectorValue(DataRegion.java:1832) ~[api-25.3.11.jar:?]
    at org.labkey.api.data.DataRegionSelection.createSelectionList(DataRegionSelection.java:512) ~[api-25.3.11.jar:?]
    at org.labkey.api.data.DataRegionSelection.setSelectionForAll(DataRegionSelection.java:444) ~[api-25.3.11.jar:?]
    at org.labkey.api.query.QueryView.selectAll(QueryView.java:3000) ~[api-25.3.11.jar:?]
```

#### Related Pull Requests
- #6349 

#### Changes
- Initialize url pattern matcher only when needed