### PR TITLE
Issue 53431: Data Class and Sample Type data doesn't round-trip via folder export/import for field names with special char

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3764,7 +3764,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 try (TSVGridWriter writer = new TSVGridWriter(plateQueryView::getResults, displayColumns, Collections.singletonMap(sampleIdNameFieldKey.toString(), "Sample ID")))
                 {
                     writer.setDelimiterCharacter(delim);
-                    writer.setColumnHeaderType(ColumnHeaderType.FieldKey);
+                    writer.setColumnHeaderType(ColumnHeaderType.ImportField); // Issue 53431
                     writer.write(plateFileBytes.bytes);
                 }
 

--- a/experiment/src/org/labkey/experiment/samples/AbstractExpFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/AbstractExpFolderWriter.java
@@ -96,7 +96,7 @@ public abstract class AbstractExpFolderWriter extends BaseFolderWriter implement
         try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
         {
             tsvWriter.setApplyFormats(false);
-            tsvWriter.setColumnHeaderType(ColumnHeaderType.FieldKey);
+            tsvWriter.setColumnHeaderType(ColumnHeaderType.ImportField); // Issue 53431
             PrintWriter out = dir.getPrintWriter(baseName + ".tsv");
             tsvWriter.write(out);
         }


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53431

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6838
- https://github.com/LabKey/limsModules/pull/1519
- https://github.com/LabKey/testAutomation/pull/2553

#### Changes
- use ColumnHeaderType.ImportField instead of FieldKey for writing folder archive tsv data column headers
- PlateManager.exportPlateData to use ColumnHeaderType.ImportField

#### Tasks 
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix