### PR TITLE
Issue 53431: Data Class and Sample Type data doesn't round-trip via folder export/import for field names with special char

### DIFF
--- a/api/src/org/labkey/api/data/ColumnHeaderType.java
+++ b/api/src/org/labkey/api/data/ColumnHeaderType.java
@@ -109,7 +109,7 @@ public enum ColumnHeaderType
         }
     },
 
-    // Use the ColumnInfo's FieldKey with FieldKey escaping. Useful for import/export round-tripping, but can lead to ugly names.
+    // Use the ColumnInfo's FieldKey with FieldKey escaping.
     FieldKey("Field Key", "The column name rendered with FieldKey encoding; unambiguous and canonical, useful for exporting and re-importing.") {
         @Override
         public String getText(DisplayColumn dc)

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3768,7 +3768,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                 try (TSVGridWriter writer = new TSVGridWriter(plateQueryView::getResults, displayColumns, Collections.singletonMap(sampleIdNameFieldKey.toString(), "Sample ID")))
                 {
                     writer.setDelimiterCharacter(delim);
-                    writer.setColumnHeaderType(ColumnHeaderType.FieldKey);
+                    writer.setColumnHeaderType(ColumnHeaderType.ImportField); // Issue 53431
                     writer.write(plateFileBytes.bytes);
                 }
 

--- a/experiment/src/org/labkey/experiment/samples/AbstractExpFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/AbstractExpFolderWriter.java
@@ -96,7 +96,7 @@ public abstract class AbstractExpFolderWriter extends BaseFolderWriter implement
         try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
         {
             tsvWriter.setApplyFormats(false);
-            tsvWriter.setColumnHeaderType(ColumnHeaderType.FieldKey);
+            tsvWriter.setColumnHeaderType(ColumnHeaderType.ImportField); // Issue 53431
             PrintWriter out = dir.getPrintWriter(baseName + ".tsv");
             tsvWriter.write(out);
         }

--- a/list/src/org/labkey/list/model/ListWriter.java
+++ b/list/src/org/labkey/list/model/ListWriter.java
@@ -189,7 +189,7 @@ public class ListWriter
                     try (TSVGridWriter tsvWriter = new TSVGridWriter(()->QueryService.get().getSelectBuilder(ti).columns(columns).sort(sort).select(null, false), displayColumns))
                     {
                         tsvWriter.setApplyFormats(false);
-                        tsvWriter.setColumnHeaderType(ColumnHeaderType.ImportField);
+                        tsvWriter.setColumnHeaderType(ColumnHeaderType.ImportField); // Issue 53431
                         PrintWriter out = listsDir.getPrintWriter( def.getName() + ".tsv");
                         tsvWriter.write(out);
                     }

--- a/list/src/org/labkey/list/model/ListWriter.java
+++ b/list/src/org/labkey/list/model/ListWriter.java
@@ -189,7 +189,7 @@ public class ListWriter
                     try (TSVGridWriter tsvWriter = new TSVGridWriter(()->QueryService.get().getSelectBuilder(ti).columns(columns).sort(sort).select(null, false), displayColumns))
                     {
                         tsvWriter.setApplyFormats(false);
-                        tsvWriter.setColumnHeaderType(ColumnHeaderType.DisplayFieldKey); // CONSIDER: Use FieldKey instead
+                        tsvWriter.setColumnHeaderType(ColumnHeaderType.ImportField);
                         PrintWriter out = listsDir.getPrintWriter( def.getName() + ".tsv");
                         tsvWriter.write(out);
                     }

--- a/study/src/org/labkey/study/writer/DatasetDataWriter.java
+++ b/study/src/org/labkey/study/writer/DatasetDataWriter.java
@@ -179,7 +179,7 @@ public class DatasetDataWriter implements InternalStudyWriter
         try (TSVGridWriter tsvWriter = new TSVGridWriter(factory))
         {
             tsvWriter.setApplyFormats(false);
-            tsvWriter.setColumnHeaderType(ColumnHeaderType.DisplayFieldKey); // CONSIDER: Use FieldKey instead
+            tsvWriter.setColumnHeaderType(ColumnHeaderType.ImportField); // Issue 53431
             PrintWriter out = vf.getPrintWriter(fileName);
             tsvWriter.write(out);
         }

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -33,6 +33,7 @@ import org.labkey.test.components.study.DatasetFacetPanel;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.TimeChartWizard;
 import org.labkey.test.pages.study.DatasetDesignerPage;
+import org.labkey.test.params.FieldInfo;
 import org.labkey.test.util.AuditLogHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
@@ -41,6 +42,7 @@ import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TestDataGenerator;
 import org.openqa.selenium.WebElement;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -211,6 +213,40 @@ public class StudyDatasetsTest extends BaseWebDriverTest
         clickButton("Cancel");
         clickTab("Overview");
     }
+
+    @Test
+    public void testDatasetRoundTripWithSpecialChars() // Issue 53431
+    {
+        goToManageStudy();
+        String datasetName = "Issue 53431";
+        FieldInfo fieldInfo = FieldInfo.random("test,./field");
+        DatasetDesignerPage definitionPage = _studyHelper.goToManageDatasets()
+                .clickCreateNewDataset()
+                .setName(datasetName);
+        DomainFormPanel panel = definitionPage.getFieldsPanel();
+        panel.manuallyDefineFields(fieldInfo.getFieldDefinition());
+        definitionPage.clickSave();
+        importDatasetData(datasetName, "mouseId\tsequenceNum\t\"" + fieldInfo.getName() + "\"\n", "a1\t1\ttest123", "All data");
+
+        File exportedFolder = exportFolderAsZip(null, false, false, false, false);
+        deleteStudy();
+        importFolderFromZip(exportedFolder, false, 2, false);
+        _studyHelper.goToManageDatasets()
+                .selectDatasetByName(datasetName)
+                .clickViewData();
+        DataRegionTable drt = new DataRegionTable("Dataset", getDriver());
+        checker().verifyEquals("Field data didn't import as expected", "test123",
+                drt.getDataAsText(0, fieldInfo));
+    }
+
+    private void deleteStudy()
+    {
+        clickTab("Manage");
+        clickButton("Delete Study");
+        checkCheckbox(Locator.checkboxByName("confirm"));
+        clickButton("Delete", WAIT_FOR_PAGE * 2);
+    }
+
 
     @LogMethod
     protected void createDataset(@LoggedParam String name, @Nullable String error)


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53431

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6840
- https://github.com/LabKey/limsModules/pull/1520
- https://github.com/LabKey/testAutomation/pull/2556

#### Changes
- use ColumnHeaderType.ImportField instead of FieldKey for writing folder archive tsv data column headers
- PlateManager.exportPlateData to use ColumnHeaderType.ImportField

#### Tasks 
- [x] Manual Testing @labkey-danield 
- [x] Needs Automation
- [x] Verify Fix