### PR TITLE
Issue 53472: OutOfMemoryError during giant deletes from lists

### DIFF
--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -87,7 +87,8 @@ public interface AssayService
     AssaySchema createSchema(User user, Container container, @Nullable Container targetStudy);
 
     /**
-     * @return all the assay protocols that are in scope in the given container
+     * @return all the assay protocols that are in scope in the given container, which may include those
+     * defined in other containers
      */
     @NotNull List<ExpProtocol> getAssayProtocols(Container container);
 

--- a/api/src/org/labkey/api/exp/api/ExpObject.java
+++ b/api/src/org/labkey/api/exp/api/ExpObject.java
@@ -37,7 +37,7 @@ public interface ExpObject extends Identifiable, Comparable<ExpObject>
     String DEFAULT_CPAS_TYPE = "Object";
 
     /** Prevent edits to this object. Subsequent calls to setters will throw an IllegalStateException */
-    void lock();
+    ExpObject lock();
 
     int getRowId();
     /** Get the exp.object objectId */

--- a/api/src/org/labkey/api/security/SecurityPolicyManager.java
+++ b/api/src/org/labkey/api/security/SecurityPolicyManager.java
@@ -85,7 +85,7 @@ public class SecurityPolicyManager
                 Selector selector = new TableSelector(core.getTableInfoRoleAssignments(), filter, new Sort("UserId"));
                 Collection<RoleAssignment> assignments = selector.getCollection(RoleAssignment.class);
 
-                return new SecurityPolicy(policyBean.getResourceId(), policyBean.getResourceClass(), policyBean.getContainer().getId(), assignments, policyBean.getModified());
+                return new SecurityPolicy(policyBean.getResourceId(), policyBean.getResourceClass(), policyBean.getContainer().getId(), assignments.isEmpty() ? Collections.emptyList() : assignments, policyBean.getModified());
             }
 
             return null;

--- a/api/src/org/labkey/api/util/JsonUtil.java
+++ b/api/src/org/labkey/api/util/JsonUtil.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.*;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -31,6 +32,7 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.action.ApiUsageException;
+import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.AppProps;
@@ -202,15 +204,20 @@ public class JsonUtil
         return result;
     }
 
-    // The new JSONObject.toMap() translates all JSONObjects into Maps and JSONArrays into Lists. In many cases, this is
-    // fine, but some existing code paths want to maintain the contained JSONObjects and JSONArrays. This method does
-    // that, acting more like the old JSONObject.toMap().
-    public static void fillMapShallow(JSONObject json, Map<String, Object> map)
+    /**
+     * The new JSONObject.toMap() translates all JSONObjects into Maps and JSONArrays into Lists. In many cases, this is
+     * fine, but some existing code paths want to maintain the contained JSONObjects and JSONArrays. This method does
+     * that, acting more like the old JSONObject.toMap().
+     * @return whether there were duplicate values in the map (useful when filling a case-insensitive map)
+      */
+    public static boolean fillMapShallow(JSONObject json, Map<String, Object> map)
     {
+        MutableBoolean hadDuplicates = new MutableBoolean(false);
         json.keySet().forEach(key -> {
             Object value = json.get(key);
-            map.put(key, JSONObject.NULL == value ? null : value);
+            hadDuplicates.setValue(map.put(key, JSONObject.NULL == value ? null : value) != null || hadDuplicates.booleanValue());
         });
+        return hadDuplicates.booleanValue();
     }
 
     // New JSONObject discards all properties with null values. This returns a JSONObject containing all Map values,
@@ -459,6 +466,20 @@ public class JsonUtil
             assertEquals(url.toString(), roundTripJson.get("actionUrl"));
             assertEquals(html.toString(), roundTripJson.get("htmlString"));
             assertEquals(u.getUserId(), roundTripJson.get("user"));
+        }
+
+        @Test
+        public void testConflictingCase()
+        {
+            JSONObject json = new JSONObject();
+            json.put("foo", "bar");
+            json.put("x", "y");
+            assertFalse(fillMapShallow(json, new HashMap<>()));
+            assertFalse(fillMapShallow(json, new CaseInsensitiveHashMap<>()));
+
+            json.put("FOO", "BAR");
+            assertFalse(fillMapShallow(json, new HashMap<>()));
+            assertTrue(fillMapShallow(json, new CaseInsensitiveHashMap<>()));
         }
 
         @Test

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -380,7 +380,7 @@ public class AssayManager implements AssayService
                         result.add(protocol);
                     }
                 }
-                return Collections.unmodifiableList(result);
+                return result.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(result);
             });
             allProtocols.addAll(ids);
         }

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -55,6 +55,7 @@ import org.labkey.api.exp.LsidManager.LsidHandlerFinder;
 import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.api.ExpExperiment;
+import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
@@ -110,9 +111,11 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class AssayManager implements AssayService
 {
@@ -138,7 +141,8 @@ public class AssayManager implements AssayService
         }
     };
 
-    private static final Cache<Container, List<ExpProtocol>> PROTOCOL_CACHE = CacheManager.getCache(CacheManager.UNLIMITED, TimeUnit.HOURS.toMillis(1), "Assay protocols");
+    /** Cache the RowIds for the protocols, which we can quickly resolve to ExpProtocol objects via a separate cache */
+    private static final Cache<Container, List<Integer>> PROTOCOL_CACHE = CacheManager.getCache(CacheManager.UNLIMITED, TimeUnit.HOURS.toMillis(1), "Assay protocols");
 
     private static final List<AssayListener> _listeners = new CopyOnWriteArrayList<>();
     private final List<AssayProvider> _providers = new CopyOnWriteArrayList<>();
@@ -287,7 +291,7 @@ public class AssayManager implements AssayService
 
         @Nullable
         @Override
-        public LsidHandler findHandler(String authority, String namespacePrefix)
+        public LsidHandler<?> findHandler(String authority, String namespacePrefix)
         {
             if (AppProps.getInstance().getDefaultLsidAuthority().equals(authority))
             {
@@ -360,7 +364,7 @@ public class AssayManager implements AssayService
     @Override
     public @NotNull List<ExpProtocol> getAssayProtocols(Container container)
     {
-        return PROTOCOL_CACHE.get(container, null, (c, argument) ->
+        List<Integer> ids = PROTOCOL_CACHE.get(container, null, (c, argument) ->
         {
             // Build up a set of containers so that we can query them all at once
             Set<Container> containers = c.getContainersFor(ContainerType.DataType.protocol);
@@ -381,8 +385,9 @@ public class AssayManager implements AssayService
             }
             // Sort them, just to be nice
             Collections.sort(result);
-            return Collections.unmodifiableList(result);
+            return result.stream().map(ExpObject::getRowId).toList();
         });
+        return ids.stream().map(id -> ExperimentService.get().getExpProtocol(id)).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -375,6 +375,8 @@ public class AssayManager implements AssayService
                     AssayProvider p = getProvider(protocol);
                     if (p != null)
                     {
+                        // We don't want anyone editing our cached object
+                        protocol.lock();
                         result.add(protocol);
                     }
                 }

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -55,7 +55,6 @@ import org.labkey.api.exp.LsidManager.LsidHandlerFinder;
 import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.XarContext;
 import org.labkey.api.exp.api.ExpExperiment;
-import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
@@ -111,11 +110,9 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public class AssayManager implements AssayService
 {
@@ -141,8 +138,8 @@ public class AssayManager implements AssayService
         }
     };
 
-    /** Cache the RowIds for the protocols, which we can quickly resolve to ExpProtocol objects via a separate cache */
-    private static final Cache<Container, List<Integer>> PROTOCOL_CACHE = CacheManager.getCache(CacheManager.UNLIMITED, TimeUnit.HOURS.toMillis(1), "Assay protocols");
+    /** Cache the protocols defined in a given container, which we can quickly compose to get the protocols in scope */
+    private static final Cache<Container, List<ExpProtocol>> PROTOCOL_CACHE = CacheManager.getCache(CacheManager.UNLIMITED, TimeUnit.HOURS.toMillis(1), "Assay protocols");
 
     private static final List<AssayListener> _listeners = new CopyOnWriteArrayList<>();
     private final List<AssayProvider> _providers = new CopyOnWriteArrayList<>();
@@ -364,30 +361,30 @@ public class AssayManager implements AssayService
     @Override
     public @NotNull List<ExpProtocol> getAssayProtocols(Container container)
     {
-        List<Integer> ids = PROTOCOL_CACHE.get(container, null, (c, argument) ->
+        List<ExpProtocol> allProtocols = new ArrayList<>();
+
+        for (Container containerInScope : container.getContainersFor(ContainerType.DataType.protocol))
         {
-            // Build up a set of containers so that we can query them all at once
-            Set<Container> containers = c.getContainersFor(ContainerType.DataType.protocol);
-
-            List<? extends ExpProtocol> protocols = ExperimentService.get().getExpProtocols(containers.toArray(new Container[0]));
-            List<ExpProtocol> result = new ArrayList<>();
-
-            // Filter to just the ones that have an AssayProvider associated with them
-            for (ExpProtocol protocol : protocols)
+            List<ExpProtocol> ids = PROTOCOL_CACHE.get(containerInScope, null, (c, argument) ->
             {
-                AssayProvider p = getProvider(protocol);
-                if (p != null)
+                List<ExpProtocol> result = new ArrayList<>();
+
+                // Filter to just the ones that have an AssayProvider associated with them
+                for (ExpProtocol protocol : ExperimentService.get().getExpProtocols(c))
                 {
-                    // We don't want anyone editing our cached object
-                    protocol.lock();
-                    result.add(protocol);
+                    AssayProvider p = getProvider(protocol);
+                    if (p != null)
+                    {
+                        result.add(protocol);
+                    }
                 }
-            }
-            // Sort them, just to be nice
-            Collections.sort(result);
-            return result.stream().map(ExpObject::getRowId).toList();
-        });
-        return ids.stream().map(id -> ExperimentService.get().getExpProtocol(id)).filter(Objects::nonNull).collect(Collectors.toList());
+                return Collections.unmodifiableList(result);
+            });
+            allProtocols.addAll(ids);
+        }
+
+        Collections.sort(allProtocols);
+        return Collections.unmodifiableList(allProtocols);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpObjectImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpObjectImpl.java
@@ -43,9 +43,10 @@ abstract public class ExpObjectImpl implements ExpObject, Serializable
     protected ExpObjectImpl() {}
 
     @Override
-    public void lock()
+    public ExpObjectImpl lock()
     {
         _locked = true;
+        return this;
     }
 
     protected void ensureUnlocked()

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -318,10 +318,12 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     private static final Logger LOG = LogHelper.getLogger(ExperimentServiceImpl.class, "Experiment infrastructure including maintaining runs and lineage");
 
     private final Cache<Integer, ExpProtocolImpl> PROTOCOL_ROW_ID_CACHE = DatabaseCache.get(getExpSchema().getScope(), CacheManager.UNLIMITED, CacheManager.HOUR, "Protocol by RowId",
-        (key, argument) -> getExpProtocol(new SimpleFilter(FieldKey.fromParts("RowId"), key)));
+        (key, argument) ->
+                (ExpProtocolImpl) getExpProtocol(new SimpleFilter(FieldKey.fromParts("RowId"), key)).lock());
 
     private final Cache<String, ExpProtocolImpl> PROTOCOL_LSID_CACHE = DatabaseCache.get(getExpSchema().getScope(), CacheManager.UNLIMITED, CacheManager.HOUR, "Protocol by LSID",
-        (key, argument) -> getExpProtocol(new SimpleFilter(FieldKey.fromParts("LSID"), key)));
+        (key, argument) ->
+                (ExpProtocolImpl) getExpProtocol(new SimpleFilter(FieldKey.fromParts("LSID"), key)).lock());
     private final Cache<String, ExperimentRun> EXPERIMENT_RUN_CACHE = DatabaseCache.get(getExpSchema().getScope(), getTinfoExperimentRun().getCacheSize(), "Experiment Run by LSID", new ExperimentRunCacheLoader());
 
     private final Cache<String, SortedSet<DataClass>> dataClassCache = CacheManager.getBlockingStringKeyCache(CacheManager.UNLIMITED, CacheManager.DAY, "Data classes", (containerId, argument) ->

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -318,12 +318,24 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     private static final Logger LOG = LogHelper.getLogger(ExperimentServiceImpl.class, "Experiment infrastructure including maintaining runs and lineage");
 
     private final Cache<Integer, ExpProtocolImpl> PROTOCOL_ROW_ID_CACHE = DatabaseCache.get(getExpSchema().getScope(), CacheManager.UNLIMITED, CacheManager.HOUR, "Protocol by RowId",
-        (key, argument) ->
-                (ExpProtocolImpl) getExpProtocol(new SimpleFilter(FieldKey.fromParts("RowId"), key)).lock());
+        (key, argument) -> {
+            var result = getExpProtocol(new SimpleFilter(FieldKey.fromParts("RowId"), key));
+            if (result != null)
+            {
+                result.lock();
+            }
+            return result;
+        });
 
     private final Cache<String, ExpProtocolImpl> PROTOCOL_LSID_CACHE = DatabaseCache.get(getExpSchema().getScope(), CacheManager.UNLIMITED, CacheManager.HOUR, "Protocol by LSID",
-        (key, argument) ->
-                (ExpProtocolImpl) getExpProtocol(new SimpleFilter(FieldKey.fromParts("LSID"), key)).lock());
+        (key, argument) -> {
+            var result = getExpProtocol(new SimpleFilter(FieldKey.fromParts("LSID"), key));
+            if (result != null)
+            {
+                result.lock();
+            }
+            return result;
+        });
     private final Cache<String, ExperimentRun> EXPERIMENT_RUN_CACHE = DatabaseCache.get(getExpSchema().getScope(), getTinfoExperimentRun().getCacheSize(), "Experiment Run by LSID", new ExperimentRunCacheLoader());
 
     private final Cache<String, SortedSet<DataClass>> dataClassCache = CacheManager.getBlockingStringKeyCache(CacheManager.UNLIMITED, CacheManager.DAY, "Data classes", (containerId, argument) ->

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -318,24 +318,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     private static final Logger LOG = LogHelper.getLogger(ExperimentServiceImpl.class, "Experiment infrastructure including maintaining runs and lineage");
 
     private final Cache<Integer, ExpProtocolImpl> PROTOCOL_ROW_ID_CACHE = DatabaseCache.get(getExpSchema().getScope(), CacheManager.UNLIMITED, CacheManager.HOUR, "Protocol by RowId",
-        (key, argument) -> {
-            var result = getExpProtocol(new SimpleFilter(FieldKey.fromParts("RowId"), key));
-            if (result != null)
-            {
-                result.lock();
-            }
-            return result;
-        });
+        (key, argument) -> getExpProtocol(new SimpleFilter(FieldKey.fromParts("RowId"), key)));
 
     private final Cache<String, ExpProtocolImpl> PROTOCOL_LSID_CACHE = DatabaseCache.get(getExpSchema().getScope(), CacheManager.UNLIMITED, CacheManager.HOUR, "Protocol by LSID",
-        (key, argument) -> {
-            var result = getExpProtocol(new SimpleFilter(FieldKey.fromParts("LSID"), key));
-            if (result != null)
-            {
-                result.lock();
-            }
-            return result;
-        });
+        (key, argument) -> getExpProtocol(new SimpleFilter(FieldKey.fromParts("LSID"), key)));
+
     private final Cache<String, ExperimentRun> EXPERIMENT_RUN_CACHE = DatabaseCache.get(getExpSchema().getScope(), getTinfoExperimentRun().getCacheSize(), "Experiment Run by LSID", new ExperimentRunCacheLoader());
 
     private final Cache<String, SortedSet<DataClass>> dataClassCache = CacheManager.getBlockingStringKeyCache(CacheManager.UNLIMITED, CacheManager.DAY, "Data classes", (containerId, argument) ->

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -108,7 +108,7 @@ public class ListManager implements SearchService.DocumentProvider
         {
             SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("Container"), entityId);
             ArrayList<ListDef> ownLists = new TableSelector(getListMetadataTable(), filter, null).getArrayList(ListDef.class);
-            return Collections.unmodifiableList(ownLists);
+            return ownLists.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(ownLists);
         }
     }
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4580,8 +4580,9 @@ public class QueryController extends SpringActionController
             // NOTE RowMapFactory is faster, but for update it's important to preserve missing v explicit NULL values
             // Do we need to support some sort of UNDEFINED and NULL instance of MvFieldWrapper?
             RowMapFactory<Object> f = null;
-            if (commandType == CommandType.insert || commandType == CommandType.insertWithKeys)
+            if (commandType == CommandType.insert || commandType == CommandType.insertWithKeys || commandType == CommandType.delete)
                 f = new RowMapFactory<>();
+            CaseInsensitiveHashMap<Object> referenceCasing = new CaseInsensitiveHashMap<>();
 
             for (int idx = 0; idx < rows.length(); ++idx)
             {
@@ -4596,10 +4597,14 @@ public class QueryController extends SpringActionController
                 }
                 if (null != jsonObj)
                 {
-                    // TODO: validate duplicate keys with different cases don't exist in data ('Name' vs 'name') (Issue 52616)
-                    Map<String, Object> rowMap = null == f ? new CaseInsensitiveHashMap<>() : f.getRowMap();
+                    Map<String, Object> rowMap = null == f ? new CaseInsensitiveHashMap<>(new HashMap<>(), referenceCasing) : f.getRowMap();
                     // Use shallow copy since jsonObj.toMap() will translate contained JSONObjects into Maps, which we don't want
-                    JsonUtil.fillMapShallow(jsonObj, rowMap);
+                    boolean conflictingCasing = JsonUtil.fillMapShallow(jsonObj, rowMap);
+                    if (conflictingCasing)
+                    {
+                        // Issue 52616
+                        LOG.error("Row contained conflicting casing for key names in the incoming row: {}", jsonObj);
+                    }
                     if (allowRowAttachments())
                         addRowAttachments(table, rowMap, idx, commandIndex);
 

--- a/query/src/org/labkey/query/persist/ExternalSchemaDefCache.java
+++ b/query/src/org/labkey/query/persist/ExternalSchemaDefCache.java
@@ -25,14 +25,12 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableSelector;
 import org.labkey.query.persist.AbstractExternalSchemaDef.SchemaType;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 /**
  * Created by adam on 11/14/2015.
@@ -83,50 +81,52 @@ public class ExternalSchemaDefCache
             Map<Class<? extends AbstractExternalSchemaDef>, Map<String, AbstractExternalSchemaDef>> byName = new HashMap<>();
             Map<Class<? extends AbstractExternalSchemaDef>, Map<Integer, AbstractExternalSchemaDef>> byRowId = new HashMap<>();
 
-            // Initialize maps for all the schema types as well as AbstractExternalSchemaDef
-            Stream.concat(Arrays.stream(SchemaType.values()).map(SchemaType::getSchemaDefClass), Stream.of(AbstractExternalSchemaDef.class))
-                .forEach(clazz->{
-                    byName.put(clazz, new CaseInsensitiveHashMap<>());
-                    byRowId.put(clazz, new HashMap<>());
-                });
-
             SimpleFilter filter = null != c ? SimpleFilter.createContainerFilter(c) : new SimpleFilter();
 
             new TableSelector(QueryManager.get().getTableInfoExternalSchema(), filter, null).forEach(rs -> {
                 String schemaTypeName = rs.getString("SchemaType");
                 SchemaType type = SchemaType.valueOf(schemaTypeName);
                 AbstractExternalSchemaDef def = type.handle(rs);
-                byRowId.get(type.getSchemaDefClass()).put(def.getExternalSchemaId(), def);
-                byRowId.get(AbstractExternalSchemaDef.class).put(def.getExternalSchemaId(), def);
+                byRowId.computeIfAbsent(type.getSchemaDefClass(), x -> new HashMap<>()).put(def.getExternalSchemaId(), def);
+                byRowId.computeIfAbsent(AbstractExternalSchemaDef.class, x -> new HashMap<>()).put(def.getExternalSchemaId(), def);
 
                 // Don't bother in the null case (site-wide list)... we only need one map and by-name is likely not unique
                 if (null != c)
                 {
-                    byName.get(type.getSchemaDefClass()).put(def.getUserSchemaName(), def);
-                    byName.get(AbstractExternalSchemaDef.class).put(def.getUserSchemaName(), def);
+                    byName.computeIfAbsent(type.getSchemaDefClass(), x -> new CaseInsensitiveHashMap<>()).put(def.getUserSchemaName(), def);
+                    byName.computeIfAbsent(AbstractExternalSchemaDef.class, x -> new CaseInsensitiveHashMap<>()).put(def.getUserSchemaName(), def);
                 }
             });
 
-            _byName = Collections.unmodifiableMap(byName);
-            _byRowId = Collections.unmodifiableMap(byRowId);
+            // Issue 53472 - when there are tens of thousands of containers, it takes a lot of memory
+            // to cache with unique empty collections. Use emptyMap() when we didn't find anything.
+            _byName = byName.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(byName);
+            _byRowId = byRowId.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(byRowId);
         }
 
         @Nullable
         private <T extends AbstractExternalSchemaDef> T getSchemaDef(String userSchemaName, Class<T> clazz)
         {
-            return (T) _byName.get(clazz).get(userSchemaName);
+            Map<String, AbstractExternalSchemaDef> map = _byName.get(clazz);
+            return map == null ? null : (T) map.get(userSchemaName);
         }
 
         @Nullable
         private <T extends AbstractExternalSchemaDef> T getSchemaDef(int rowId, Class<T> clazz)
         {
-            return (T) _byRowId.get(clazz).get(rowId);
+            Map<Integer, AbstractExternalSchemaDef> map = _byRowId.get(clazz);
+            return map == null ? null : (T) map.get(rowId);
         }
 
         @NotNull
         private <T extends AbstractExternalSchemaDef> List<T> getSchemaDefs(Class<T> clazz)
         {
-            Collection<T> collection = (Collection<T>) _byRowId.get(clazz).values();
+            Map<Integer, AbstractExternalSchemaDef> map = _byRowId.get(clazz);
+            if (map == null)
+            {
+                return Collections.emptyList();
+            }
+            Collection<T> collection = (Collection<T>) map.values();
             return new LinkedList<>(collection);
         }
     }

--- a/query/src/org/labkey/query/persist/ExternalSchemaDefCache.java
+++ b/query/src/org/labkey/query/persist/ExternalSchemaDefCache.java
@@ -37,7 +37,7 @@ import java.util.Map;
  */
 public class ExternalSchemaDefCache
 {
-    private static final Cache<Container, ExternalSchemaCollections> EXTERNAL_SCHEMA_DEF_CACHE = CacheManager.getBlockingCache(CacheManager.UNLIMITED, CacheManager.DAY, "External/linked schema definitions", (c, argument) -> new ExternalSchemaCollections(c));
+    private static final Cache<Container, ExternalSchemaCollections> EXTERNAL_SCHEMA_DEF_CACHE = CacheManager.getBlockingCache(CacheManager.UNLIMITED, CacheManager.DAY, "External/linked schema definitions", (c, argument) -> getCollectionsToCache(c));
 
     @Nullable
     public static <T extends AbstractExternalSchemaDef> T getSchemaDef(Container c, @Nullable String userSchemaName, Class<T> clazz)
@@ -71,37 +71,49 @@ public class ExternalSchemaDefCache
         EXTERNAL_SCHEMA_DEF_CACHE.remove(null);  // Clear out the full list
     }
 
+    private static final ExternalSchemaCollections EMPTY_COLLECTION = new ExternalSchemaCollections(Collections.emptyMap(), Collections.emptyMap());
+
+    /** @param c the container to use, or null for data for ALL containers */
+    private static ExternalSchemaCollections getCollectionsToCache(@Nullable Container c)
+    {
+        Map<Class<? extends AbstractExternalSchemaDef>, Map<String, AbstractExternalSchemaDef>> byName = new HashMap<>();
+        Map<Class<? extends AbstractExternalSchemaDef>, Map<Integer, AbstractExternalSchemaDef>> byRowId = new HashMap<>();
+
+        SimpleFilter filter = null != c ? SimpleFilter.createContainerFilter(c) : new SimpleFilter();
+
+        new TableSelector(QueryManager.get().getTableInfoExternalSchema(), filter, null).forEach(rs -> {
+            String schemaTypeName = rs.getString("SchemaType");
+            SchemaType type = SchemaType.valueOf(schemaTypeName);
+            AbstractExternalSchemaDef def = type.handle(rs);
+            byRowId.computeIfAbsent(type.getSchemaDefClass(), x -> new HashMap<>()).put(def.getExternalSchemaId(), def);
+            byRowId.computeIfAbsent(AbstractExternalSchemaDef.class, x -> new HashMap<>()).put(def.getExternalSchemaId(), def);
+
+            // Don't bother in the null case (site-wide list)... we only need one map and by-name is likely not unique
+            if (null != c)
+            {
+                byName.computeIfAbsent(type.getSchemaDefClass(), x -> new CaseInsensitiveHashMap<>()).put(def.getUserSchemaName(), def);
+                byName.computeIfAbsent(AbstractExternalSchemaDef.class, x -> new CaseInsensitiveHashMap<>()).put(def.getUserSchemaName(), def);
+            }
+        });
+
+        // Issue 53472 - when there are tens of thousands of containers, it takes a lot of memory
+        // to cache with unique empty collections. Use a shared empty collection
+        if (byName.isEmpty() && byRowId.isEmpty())
+        {
+            return EMPTY_COLLECTION;
+        }
+        return new ExternalSchemaCollections(Collections.unmodifiableMap(byName), Collections.unmodifiableMap(byRowId));
+    }
+
     private static class ExternalSchemaCollections
     {
         private final Map<Class<? extends AbstractExternalSchemaDef>, Map<String, AbstractExternalSchemaDef>> _byName;
         private final Map<Class<? extends AbstractExternalSchemaDef>, Map<Integer, AbstractExternalSchemaDef>> _byRowId;
 
-        private ExternalSchemaCollections(@Nullable Container c)
+        private ExternalSchemaCollections(Map<Class<? extends AbstractExternalSchemaDef>, Map<String, AbstractExternalSchemaDef>> byName, Map<Class<? extends AbstractExternalSchemaDef>, Map<Integer, AbstractExternalSchemaDef>> byRowId)
         {
-            Map<Class<? extends AbstractExternalSchemaDef>, Map<String, AbstractExternalSchemaDef>> byName = new HashMap<>();
-            Map<Class<? extends AbstractExternalSchemaDef>, Map<Integer, AbstractExternalSchemaDef>> byRowId = new HashMap<>();
-
-            SimpleFilter filter = null != c ? SimpleFilter.createContainerFilter(c) : new SimpleFilter();
-
-            new TableSelector(QueryManager.get().getTableInfoExternalSchema(), filter, null).forEach(rs -> {
-                String schemaTypeName = rs.getString("SchemaType");
-                SchemaType type = SchemaType.valueOf(schemaTypeName);
-                AbstractExternalSchemaDef def = type.handle(rs);
-                byRowId.computeIfAbsent(type.getSchemaDefClass(), x -> new HashMap<>()).put(def.getExternalSchemaId(), def);
-                byRowId.computeIfAbsent(AbstractExternalSchemaDef.class, x -> new HashMap<>()).put(def.getExternalSchemaId(), def);
-
-                // Don't bother in the null case (site-wide list)... we only need one map and by-name is likely not unique
-                if (null != c)
-                {
-                    byName.computeIfAbsent(type.getSchemaDefClass(), x -> new CaseInsensitiveHashMap<>()).put(def.getUserSchemaName(), def);
-                    byName.computeIfAbsent(AbstractExternalSchemaDef.class, x -> new CaseInsensitiveHashMap<>()).put(def.getUserSchemaName(), def);
-                }
-            });
-
-            // Issue 53472 - when there are tens of thousands of containers, it takes a lot of memory
-            // to cache with unique empty collections. Use emptyMap() when we didn't find anything.
-            _byName = byName.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(byName);
-            _byRowId = byRowId.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(byRowId);
+            _byName = byName;
+            _byRowId = byRowId;
         }
 
         @Nullable

--- a/query/src/org/labkey/query/reports/DatabaseReportCache.java
+++ b/query/src/org/labkey/query/reports/DatabaseReportCache.java
@@ -74,10 +74,10 @@ public class DatabaseReportCache
                 }
             });
 
-            _rowIdMap = Collections.unmodifiableMap(rowIdMap);
-            _entityIdMap = Collections.unmodifiableMap(entityIdMap);
-            _reportKeyMap = MultiMapUtils.unmodifiableMultiValuedMap(reportKeyMap);
-            _inheritableReports = Collections.unmodifiableList(inheritableReports);
+            _rowIdMap = rowIdMap.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(rowIdMap);
+            _entityIdMap = entityIdMap.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(entityIdMap);
+            _reportKeyMap = reportKeyMap.isEmpty() ? MultiMapUtils.emptyMultiValuedMap() : MultiMapUtils.unmodifiableMultiValuedMap(reportKeyMap);
+            _inheritableReports = inheritableReports.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(inheritableReports);
         }
 
         private @Nullable Report getForRowId(int rowId)


### PR DESCRIPTION
#### Rationale
We can do better at baseline memory use and what's required for big query API operations.

#### Changes
- Use RowMap and reused canonical case maps for key query APIs
- Cache protocols by RowId instead of ExpProtocolImpl objects
- Log errors when we have conflicting data with different casing for keys
- Use empty maps when possible for caching external schemas

#### Tasks 📍
- [x] Manual Testing @labkey-tchad 📍 
  - Add and remove external schemas via the Schema Administration page. Ensure they appear and disappear as expected  in the admin UI and in the schema browser
  - Add and remove assay designs in the current folder, in the project, and in /Shared. Ensure they appear and disappear as expected as child schemas in the schema browser's assay schema.
