### PR TITLE
Issue 53476: Improve queries dominating the execution time

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -2665,7 +2665,7 @@ public class ContainerManager
     {
         // We store the path as lower-case, so we don't need to also LOWER() on the value in core.ContainerAliases, letting the DB use the index
         Container[] ret = new SqlSelector(CORE.getSchema(),
-                "SELECT * FROM " + CORE.getTableInfoContainers() + " c, " + CORE.getTableInfoContainerAliases() + " ca WHERE ca.ContainerRowId = c.EntityRowId AND ca.path = LOWER(?)",
+                "SELECT * FROM " + CORE.getTableInfoContainers() + " c, " + CORE.getTableInfoContainerAliases() + " ca WHERE ca.ContainerRowId = c.RowId AND ca.path = LOWER(?)",
                 path).getArray(Container.class);
 
         return ret.length == 0 ? null : ret[0];

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1275,14 +1275,16 @@ public class ContainerManager
 
         try (DbScope.Transaction transaction = ensureTransaction())
         {
+            // Delete all of the aliases for the current container, plus any of the aliases that might be associated
+            // with another container right now
             SQLFragment deleteSQL = new SQLFragment();
             deleteSQL.append("DELETE FROM ");
             deleteSQL.append(CORE.getTableInfoContainerAliases());
-            deleteSQL.append(" WHERE ContainerId = ? ");
-            deleteSQL.add(container.getId());
+            deleteSQL.append(" WHERE ContainerRowId = ? ");
+            deleteSQL.add(container.getRowId());
             if (!aliases.isEmpty())
             {
-                deleteSQL.append(" OR LOWER(Path) IN (");
+                deleteSQL.append(" OR Path IN (");
                 String separator = "";
                 for (String alias : aliases)
                 {
@@ -1295,14 +1297,15 @@ public class ContainerManager
             }
             new SqlExecutor(CORE.getSchema()).execute(deleteSQL);
 
+            // Store the alias as LOWER() so that we can query against it using the index
             for (String alias : newAliases)
             {
                 SQLFragment insertSQL = new SQLFragment();
                 insertSQL.append("INSERT INTO ");
                 insertSQL.append(CORE.getTableInfoContainerAliases());
-                insertSQL.append(" (Path, ContainerId) VALUES (?, ?)");
+                insertSQL.append(" (Path, ContainerRowId) VALUES (LOWER(?), ?)");
                 insertSQL.add(alias);
-                insertSQL.add(container.getId());
+                insertSQL.add(container.getRowId());
                 new SqlExecutor(CORE.getSchema()).execute(insertSQL);
             }
 
@@ -1928,7 +1931,7 @@ public class ContainerManager
             fireDeleteContainer(c, user);
 
             SqlExecutor sqlExecutor = new SqlExecutor(CORE.getSchema());
-            sqlExecutor.execute("DELETE FROM " + CORE.getTableInfoContainerAliases() + " WHERE ContainerId=?", c.getId());
+            sqlExecutor.execute("DELETE FROM " + CORE.getTableInfoContainerAliases() + " WHERE ContainerRowId=?", c.getRowId());
             sqlExecutor.execute("DELETE FROM " + CORE.getTableInfoContainers() + " WHERE EntityId=?", c.getId());
             // now that the container is actually gone, delete all ACLs (better to have an ACL w/o object than object w/o ACL)
             SecurityPolicyManager.removeAll(c);
@@ -2607,8 +2610,8 @@ public class ContainerManager
     public static List<String> getAliasesForContainer(Container c)
     {
         return Collections.unmodifiableList(new SqlSelector(CORE.getSchema(),
-                new SQLFragment("SELECT Path FROM " + CORE.getTableInfoContainerAliases() + " WHERE ContainerId = ? ORDER BY LOWER(Path)",
-                        c.getId())).getArrayList(String.class));
+                new SQLFragment("SELECT Path FROM " + CORE.getTableInfoContainerAliases() + " WHERE ContainerRowId = ? ORDER BY Path",
+                        c.getRowId())).getArrayList(String.class));
     }
 
     @Nullable
@@ -2660,8 +2663,9 @@ public class ContainerManager
     @Nullable
     private static Container getForPathAlias(String path)
     {
+        // We store the path as lower-case, so we don't need to also LOWER() on the value in core.ContainerAliases, letting the DB use the index
         Container[] ret = new SqlSelector(CORE.getSchema(),
-                "SELECT * FROM " + CORE.getTableInfoContainers() + " c, " + CORE.getTableInfoContainerAliases() + " ca WHERE ca.ContainerId = c.EntityId AND LOWER(ca.path) = LOWER(?)",
+                "SELECT * FROM " + CORE.getTableInfoContainers() + " c, " + CORE.getTableInfoContainerAliases() + " ca WHERE ca.ContainerRowId = c.EntityRowId AND ca.path = LOWER(?)",
                 path).getArray(Container.class);
 
         return ret.length == 0 ? null : ret[0];

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 25.003
+SchemaVersion: 25.004
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/core.xml
+++ b/core/resources/schemas/core.xml
@@ -545,7 +545,7 @@
   <table tableName="ContainerAliases" tableDbType="TABLE">
     <columns>
       <column columnName="Path"/>
-      <column columnName="ContainerId"/>
+      <column columnName="ContainerRowId"/>
     </columns>
   </table>
 

--- a/core/resources/schemas/dbscripts/postgresql/core-25.003-25.004.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-25.003-25.004.sql
@@ -1,0 +1,26 @@
+-- Switch to always store the lower case version of the path. First, ensure we only have one row per path, regardless
+-- of its casing
+DELETE FROM core.ContainerAliases
+WHERE Path NOT IN (SELECT MIN(Path)
+                    FROM core.ContainerAliases
+                    GROUP BY LOWER(Path));
+
+UPDATE core.ContainerAliases SET Path = LOWER(Path);
+
+-- Switch to using RowId as the FK to core.containers
+ALTER TABLE core.ContainerAliases
+    ADD COLUMN ContainerRowId INT;
+
+UPDATE core.ContainerAliases
+SET ContainerRowId = (SELECT RowId
+                      FROM core.containers
+                      WHERE core.containers.EntityId = core.ContainerAliases.ContainerId);
+
+ALTER TABLE core.ContainerAliases
+    DROP COLUMN ContainerId;
+
+ALTER TABLE core.ContainerAliases
+    ADD CONSTRAINT FK_ContainerRowId FOREIGN KEY (ContainerRowId)
+        REFERENCES core.containers (RowId);
+
+CREATE INDEX idx_ContainerAliases_ContainerRowId ON core.ContainerAliases (ContainerRowId);

--- a/core/resources/schemas/dbscripts/sqlserver/core-25.003-25.004.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-25.003-25.004.sql
@@ -1,0 +1,31 @@
+-- Switch to always store the lower case version of the path. First, ensure we only have one row per path, regardless
+-- of its casing
+DELETE FROM core.ContainerAliases
+WHERE Path NOT IN (SELECT MIN(Path)
+                    FROM core.ContainerAliases
+                    GROUP BY LOWER(Path));
+
+UPDATE core.ContainerAliases SET Path = LOWER(Path);
+
+-- Switch to using RowId as the FK to core.containers
+ALTER TABLE core.ContainerAliases
+    ADD ContainerRowId INT;
+GO
+
+UPDATE core.ContainerAliases
+SET ContainerRowId = (SELECT RowId
+                      FROM core.containers
+                      WHERE core.containers.EntityId = core.ContainerAliases.ContainerId);
+
+ALTER TABLE core.ContainerAliases
+    DROP CONSTRAINT FK_ContainerAliases_Containers;
+GO
+
+ALTER TABLE core.ContainerAliases
+    DROP COLUMN ContainerId;
+
+ALTER TABLE core.ContainerAliases
+    ADD CONSTRAINT FK_ContainerRowId FOREIGN KEY (ContainerRowId)
+        REFERENCES core.containers (RowId);
+
+CREATE INDEX idx_ContainerAliases_ContainerRowId ON core.ContainerAliases (ContainerRowId);

--- a/core/resources/schemas/test.xml
+++ b/core/resources/schemas/test.xml
@@ -137,14 +137,14 @@
         <description>This is used to test synonyms on SQL Server</description>
         <columns>
             <column columnName="Path"/>
-            <column columnName="ContainerId"/>
+            <column columnName="ContainerRowId"/>
         </columns>
     </table>
     <table tableName="a%b" tableDbType="VIEW">
         <description>This is used to test LIKE wild card characters in table/view names</description>
         <columns>
             <column columnName="Path"/>
-            <column columnName="ContainerId"/>
+            <column columnName="ContainerRowId"/>
         </columns>
     </table>
     <table tableName="Users2" tableDbType="UNKNOWN">

--- a/core/src/org/labkey/core/admin/folderAliases.jsp
+++ b/core/src/org/labkey/core/admin/folderAliases.jsp
@@ -37,7 +37,7 @@
     </tr>
     <tr>
         <td><label for="aliasesTextArea">Enter one alias per line. Each alias should start with a '/'. Aliases that are
-            paths to real folders in the system will be ignored.</label></td>
+            paths to real folders in the system will be ignored. Aliases are case-insensitive.</label></td>
     </tr>
     <tr>
         <td>

--- a/search/resources/schemas/dbscripts/postgresql/search-25.000-25.001.sql
+++ b/search/resources/schemas/dbscripts/postgresql/search-25.000-25.001.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_crawlcollections_path
+    ON search.crawlcollections (path);

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -80,7 +80,7 @@ public class SearchModule extends DefaultModule
     @Override
     public Double getSchemaVersion()
     {
-        return 25.000;
+        return 25.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Four queries dominate the DB execution time on some deployments. They can be optimized to use indices.

#### Changes
- Add missing indices
- Store container aliases as lower case so the DB can use the index
- Join on container RowId instead of EntityId
