### PR TITLE
Issue 53243: add "includeEmptyPermGroups" to security-getGroupPerms.api

### DIFF
--- a/api/src/org/labkey/api/action/ApiJsonWriter.java
+++ b/api/src/org/labkey/api/action/ApiJsonWriter.java
@@ -295,11 +295,6 @@ public class ApiJsonWriter extends ApiResponseWriter
         jg.writeObjectFieldStart(name);
     }
 
-    public void startObject() throws IOException
-    {
-        jg.writeStartObject();
-    }
-
     public void endObject() throws IOException
     {
         jg.writeEndObject();

--- a/api/src/org/labkey/api/action/ApiJsonWriter.java
+++ b/api/src/org/labkey/api/action/ApiJsonWriter.java
@@ -295,6 +295,11 @@ public class ApiJsonWriter extends ApiResponseWriter
         jg.writeObjectFieldStart(name);
     }
 
+    public void startObject() throws IOException
+    {
+        jg.writeStartObject();
+    }
+
     public void endObject() throws IOException
     {
         jg.writeEndObject();

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.labkey.api.action.ApiJsonWriter;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.ApiVersion;
@@ -86,7 +85,6 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -180,6 +180,7 @@ public class SecurityApiActions
         protected List<Map<String, Object>> getGroupPerms(Container container, List<Group> groups, boolean includeEmptyPerms)
         {
             List<Map<String, Object>> groupsPerms = new ArrayList<>();
+            boolean isAdmin = container.hasPermission(getUser(), AdminPermission.class);
 
             for (Group group : groups)
             {
@@ -199,7 +200,7 @@ public class SecurityApiActions
                 groupPerms.put("roles", roles);
                 groupPerms.put("effectivePermissions", effectivePermissions);
 
-                if (container.hasPermission(getUser(), AdminPermission.class))
+                if (isAdmin)
                 {
                     List<Map<String, Object>> parentGroups = new ArrayList<>();
                     group.getGroups().stream().forEach(parentGroupId -> {

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -106,7 +106,18 @@ public class SecurityApiActions
 {
     public static class GetGroupPermsForm
     {
+        private boolean _includeEmptyPerms = true;
         private boolean _includeSubfolders = false;
+
+        public boolean isIncludeEmptyPerms()
+        {
+            return _includeEmptyPerms;
+        }
+
+        public void setIncludeEmptyPerms(boolean includeEmptyPerms)
+        {
+            _includeEmptyPerms = includeEmptyPerms;
+        }
 
         public boolean isIncludeSubfolders()
         {
@@ -132,7 +143,7 @@ public class SecurityApiActions
             writer.startResponse();
 
             writer.startObject("container");
-            writeContainer(writer, container, SecurityManager.getGroups(container.getProject(), true), form.isIncludeSubfolders());
+            writeContainer(writer, container, SecurityManager.getGroups(container.getProject(), true), form.isIncludeSubfolders(), form.isIncludeEmptyPerms());
             writer.endObject();
 
             writer.endResponse();
@@ -140,15 +151,13 @@ public class SecurityApiActions
             return null;
         }
 
-        private void writeContainer(ApiJsonWriter writer, Container container, List<Group> groups, boolean includeSubfolders) throws IOException
+        private void writeContainer(ApiJsonWriter writer, Container container, List<Group> groups, boolean includeSubfolders, boolean includeEmptyPerms) throws IOException
         {
             writer.writeProperty("path", container.getPath());
             writer.writeProperty("id", container.getId());
             writer.writeProperty("name", container.getName());
             writer.writeProperty("isInheritingPerms", container.isInheritedAcl());
-
-            if (groups != null && !groups.isEmpty())
-                writer.writeProperty("groups", getGroupPerms(container, groups));
+            writer.writeProperty("groups", getGroupPerms(container, groups, includeEmptyPerms));
 
             if (includeSubfolders && container.hasChildren())
             {
@@ -159,7 +168,7 @@ public class SecurityApiActions
                     if (child.hasPermission(getUser(), ReadPermission.class))
                     {
                         writer.startObject();
-                        writeContainer(writer, child, child.isProject() ? SecurityManager.getGroups(child, true) : groups, includeSubfolders);
+                        writeContainer(writer, child, child.isProject() ? SecurityManager.getGroups(child, true) : groups, includeSubfolders, includeEmptyPerms);
                         writer.endObject();
                     }
                 }
@@ -168,38 +177,40 @@ public class SecurityApiActions
             }
         }
 
-        protected List<Map<String, Object>> getGroupPerms(Container container, List<Group> groups)
+        protected List<Map<String, Object>> getGroupPerms(Container container, List<Group> groups, boolean includeEmptyPerms)
         {
             List<Map<String, Object>> groupsPerms = new ArrayList<>();
 
             for (Group group : groups)
             {
+                List<String> effectivePermissions = SecurityManager.getPermissionNames(container, group);
+                if (effectivePermissions.isEmpty() && !includeEmptyPerms)
+                    continue;
+
                 Map<String, Object> groupPerms = new HashMap<>();
                 groupPerms.put("id", group.getUserId());
                 groupPerms.put("name", SecurityManager.getDisambiguatedGroupName(group));
                 groupPerms.put("type", group.getPrincipalType().getTypeChar());
                 groupPerms.put("isSystemGroup", group.isSystemGroup());
                 groupPerms.put("isProjectGroup", group.isProjectGroup());
+                groupsPerms.add(groupPerms);
 
-                //add effective roles
-                List<String> effectiveRoleList = SecurityManager.getEffectiveRoles(container, group).map(Role::getUniqueName).toList();
-                groupPerms.put("roles", effectiveRoleList);
-                groupPerms.put("effectivePermissions", SecurityManager.getPermissionNames(container, group));
+                List<String> roles = SecurityManager.getEffectiveRoles(container, group).map(Role::getUniqueName).toList();
+                groupPerms.put("roles", roles);
+                groupPerms.put("effectivePermissions", effectivePermissions);
 
                 if (container.hasPermission(getUser(), AdminPermission.class))
                 {
-                    List<Map<String, Object>> parentGroupInfos = new ArrayList<>();
+                    List<Map<String, Object>> parentGroups = new ArrayList<>();
                     group.getGroups().stream().forEach(parentGroupId -> {
                         Group parentGroup = SecurityManager.getGroup(parentGroupId);
                         if (parentGroup != null && parentGroup.getUserId() != group.getUserId())
                         {
-                            parentGroupInfos.add(getGroupMap(parentGroup));
+                            parentGroups.add(getGroupMap(parentGroup));
                         }
                     });
-                    groupPerms.put("groups", parentGroupInfos);
+                    groupPerms.put("groups", parentGroups);
                 }
-
-                groupsPerms.add(groupPerms);
             }
 
             return groupsPerms;

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.labkey.api.action.ApiJsonWriter;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.ApiVersion;
@@ -85,6 +86,7 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -121,54 +123,53 @@ public class SecurityApiActions
     public static class GetGroupPermsAction extends ReadOnlyApiAction<GetGroupPermsForm>
     {
         @Override
-        public ApiResponse execute(GetGroupPermsForm form, BindException errors)
+        public ApiResponse execute(GetGroupPermsForm form, BindException errors) throws IOException
         {
+            // Issue 53243: stream response from security-getGroupPerms.api
             Container container = getContainer();
+            ApiJsonWriter writer = new ApiJsonWriter(getViewContext().getResponse());
 
-            ApiSimpleResponse response = new ApiSimpleResponse();
+            writer.startResponse();
 
-            //if the container is not the root container, get the set of groups
-            //from the container's project and pass that down the recursion stack
-            response.put("container", getContainerPerms(container,
-                    SecurityManager.getGroups(container.getProject(), true),
-                    form.isIncludeSubfolders()));
+            writer.startObject("container");
+            writeContainer(writer, container, SecurityManager.getGroups(container.getProject(), true), form.isIncludeSubfolders());
+            writer.endObject();
 
-            return response;
+            writer.endResponse();
+
+            return null;
         }
 
-        protected Map<String, Object> getContainerPerms(Container container, List<Group> groups, boolean recurse)
+        private void writeContainer(ApiJsonWriter writer, Container container, List<Group> groups, boolean includeSubfolders) throws IOException
         {
-            Map<String, Object> containerPerms = new HashMap<>();
-            containerPerms.put("path", container.getPath());
-            containerPerms.put("id", container.getId());
-            containerPerms.put("name", container.getName());
-            containerPerms.put("isInheritingPerms", container.isInheritedAcl());
-            containerPerms.put("groups", getGroupPerms(container, groups));
+            writer.writeProperty("path", container.getPath());
+            writer.writeProperty("id", container.getId());
+            writer.writeProperty("name", container.getName());
+            writer.writeProperty("isInheritingPerms", container.isInheritedAcl());
 
-            if (recurse && container.hasChildren())
+            if (groups != null && !groups.isEmpty())
+                writer.writeProperty("groups", getGroupPerms(container, groups));
+
+            if (includeSubfolders && container.hasChildren())
             {
-                List<Map<String, Object>> childPerms = new ArrayList<>();
+                writer.startList("children");
+
                 for (Container child : container.getChildren())
                 {
                     if (child.hasPermission(getUser(), ReadPermission.class))
                     {
-                        childPerms.add(getContainerPerms(child,
-                                child.isProject() ? SecurityManager.getGroups(child, true) : groups,
-                                recurse));
+                        writer.startObject();
+                        writeContainer(writer, child, child.isProject() ? SecurityManager.getGroups(child, true) : groups, includeSubfolders);
+                        writer.endObject();
                     }
                 }
 
-                containerPerms.put("children", childPerms);
+                writer.endList();
             }
-
-            return containerPerms;
         }
 
         protected List<Map<String, Object>> getGroupPerms(Container container, List<Group> groups)
         {
-            if (null == groups)
-                return null;
-
             List<Map<String, Object>> groupsPerms = new ArrayList<>();
 
             for (Group group : groups)

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -106,17 +106,17 @@ public class SecurityApiActions
 {
     public static class GetGroupPermsForm
     {
-        private boolean _includeEmptyPerms = true;
+        private boolean _includeEmptyPermGroups = true;
         private boolean _includeSubfolders = false;
 
-        public boolean isIncludeEmptyPerms()
+        public boolean isIncludeEmptyPermGroups()
         {
-            return _includeEmptyPerms;
+            return _includeEmptyPermGroups;
         }
 
-        public void setIncludeEmptyPerms(boolean includeEmptyPerms)
+        public void setIncludeEmptyPermGroups(boolean includeEmptyPermGroups)
         {
-            _includeEmptyPerms = includeEmptyPerms;
+            _includeEmptyPermGroups = includeEmptyPermGroups;
         }
 
         public boolean isIncludeSubfolders()
@@ -134,50 +134,50 @@ public class SecurityApiActions
     public static class GetGroupPermsAction extends ReadOnlyApiAction<GetGroupPermsForm>
     {
         @Override
-        public ApiResponse execute(GetGroupPermsForm form, BindException errors) throws IOException
+        public ApiResponse execute(GetGroupPermsForm form, BindException errors)
         {
-            // Issue 53243: stream response from security-getGroupPerms.api
             Container container = getContainer();
-            ApiJsonWriter writer = new ApiJsonWriter(getViewContext().getResponse());
 
-            writer.startResponse();
+            ApiSimpleResponse response = new ApiSimpleResponse();
 
-            writer.startObject("container");
-            writeContainer(writer, container, SecurityManager.getGroups(container.getProject(), true), form.isIncludeSubfolders(), form.isIncludeEmptyPerms());
-            writer.endObject();
+            //if the container is not the root container, get the set of groups
+            //from the container's project and pass that down the recursion stack
+            response.put("container", getContainerPerms(container,
+                    SecurityManager.getGroups(container.getProject(), true),
+                    form.isIncludeSubfolders(), form.isIncludeEmptyPermGroups()));
 
-            writer.endResponse();
-
-            return null;
+            return response;
         }
 
-        private void writeContainer(ApiJsonWriter writer, Container container, List<Group> groups, boolean includeSubfolders, boolean includeEmptyPerms) throws IOException
+        protected Map<String, Object> getContainerPerms(Container container, List<Group> groups, boolean includeSubfolders, boolean includeEmptyPermGroups)
         {
-            writer.writeProperty("path", container.getPath());
-            writer.writeProperty("id", container.getId());
-            writer.writeProperty("name", container.getName());
-            writer.writeProperty("isInheritingPerms", container.isInheritedAcl());
-            writer.writeProperty("groups", getGroupPerms(container, groups, includeEmptyPerms));
+            Map<String, Object> containerPerms = new HashMap<>();
+            containerPerms.put("path", container.getPath());
+            containerPerms.put("id", container.getId());
+            containerPerms.put("name", container.getName());
+            containerPerms.put("isInheritingPerms", container.isInheritedAcl());
+            containerPerms.put("groups", getGroupPerms(container, groups, includeEmptyPermGroups));
 
             if (includeSubfolders && container.hasChildren())
             {
-                writer.startList("children");
-
+                List<Map<String, Object>> childPerms = new ArrayList<>();
                 for (Container child : container.getChildren())
                 {
                     if (child.hasPermission(getUser(), ReadPermission.class))
                     {
-                        writer.startObject();
-                        writeContainer(writer, child, child.isProject() ? SecurityManager.getGroups(child, true) : groups, includeSubfolders, includeEmptyPerms);
-                        writer.endObject();
+                        childPerms.add(getContainerPerms(child,
+                                child.isProject() ? SecurityManager.getGroups(child, true) : groups,
+                                includeSubfolders, includeEmptyPermGroups));
                     }
                 }
 
-                writer.endList();
+                containerPerms.put("children", childPerms);
             }
+
+            return containerPerms;
         }
 
-        protected List<Map<String, Object>> getGroupPerms(Container container, List<Group> groups, boolean includeEmptyPerms)
+        protected List<Map<String, Object>> getGroupPerms(Container container, List<Group> groups, boolean includeEmptyPermGroups)
         {
             List<Map<String, Object>> groupsPerms = new ArrayList<>();
             boolean isAdmin = container.hasPermission(getUser(), AdminPermission.class);
@@ -185,7 +185,7 @@ public class SecurityApiActions
             for (Group group : groups)
             {
                 List<String> effectivePermissions = SecurityManager.getPermissionNames(container, group);
-                if (effectivePermissions.isEmpty() && !includeEmptyPerms)
+                if (effectivePermissions.isEmpty() && !includeEmptyPermGroups)
                     continue;
 
                 Map<String, Object> groupPerms = new HashMap<>();
@@ -194,24 +194,26 @@ public class SecurityApiActions
                 groupPerms.put("type", group.getPrincipalType().getTypeChar());
                 groupPerms.put("isSystemGroup", group.isSystemGroup());
                 groupPerms.put("isProjectGroup", group.isProjectGroup());
-                groupsPerms.add(groupPerms);
 
-                List<String> roles = SecurityManager.getEffectiveRoles(container, group).map(Role::getUniqueName).toList();
-                groupPerms.put("roles", roles);
+                //add effective roles
+                List<String> effectiveRoleList = SecurityManager.getEffectiveRoles(container, group).map(Role::getUniqueName).toList();
+                groupPerms.put("roles", effectiveRoleList);
                 groupPerms.put("effectivePermissions", effectivePermissions);
 
                 if (isAdmin)
                 {
-                    List<Map<String, Object>> parentGroups = new ArrayList<>();
+                    List<Map<String, Object>> parentGroupInfos = new ArrayList<>();
                     group.getGroups().stream().forEach(parentGroupId -> {
                         Group parentGroup = SecurityManager.getGroup(parentGroupId);
                         if (parentGroup != null && parentGroup.getUserId() != group.getUserId())
                         {
-                            parentGroups.add(getGroupMap(parentGroup));
+                            parentGroupInfos.add(getGroupMap(parentGroup));
                         }
                     });
-                    groupPerms.put("groups", parentGroups);
+                    groupPerms.put("groups", parentGroupInfos);
                 }
+
+                groupsPerms.add(groupPerms);
             }
 
             return groupsPerms;

--- a/core/src/org/labkey/core/security/SecurityApiActions.java
+++ b/core/src/org/labkey/core/security/SecurityApiActions.java
@@ -17,6 +17,7 @@ package org.labkey.core.security;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.labkey.api.action.ApiResponse;
@@ -147,7 +148,7 @@ public class SecurityApiActions
             return response;
         }
 
-        protected Map<String, Object> getContainerPerms(Container container, List<Group> groups, boolean includeSubfolders, boolean includeEmptyPermGroups)
+        protected Map<String, Object> getContainerPerms(Container container, @NotNull List<Group> groups, boolean includeSubfolders, boolean includeEmptyPermGroups)
         {
             Map<String, Object> containerPerms = new HashMap<>();
             containerPerms.put("path", container.getPath());
@@ -175,7 +176,7 @@ public class SecurityApiActions
             return containerPerms;
         }
 
-        protected List<Map<String, Object>> getGroupPerms(Container container, List<Group> groups, boolean includeEmptyPermGroups)
+        protected List<Map<String, Object>> getGroupPerms(Container container, @NotNull List<Group> groups, boolean includeEmptyPermGroups)
         {
             List<Map<String, Object>> groupsPerms = new ArrayList<>();
             boolean isAdmin = container.hasPermission(getUser(), AdminPermission.class);


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53243](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53243) by adding a new parameter `includeEmptyPermGroups` to the `security-getGroupPerms.api` which excludes groups that have no effective permissions.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2569

#### Changes
- new parameter `includeEmptyPermGroups` to the `security-getGroupPerms.api` and respect setting when computing groups. Defaults to true.
- Move security check out of groups iteration which can significantly improve performance when there are a large number of folders and/or groups. 

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing _(needs volunteer)_
- [x] Needs Automation
-->