### PR TITLE
Issue 53482: Folder import fails for a sample type / data class that has a field name that is long and has special characters

### DIFF
--- a/api/src/org/labkey/api/exp/Lsid.java
+++ b/api/src/org/labkey/api/exp/Lsid.java
@@ -34,6 +34,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.repeat;
@@ -328,10 +329,13 @@ public class Lsid
         catch (URISyntaxException e)
         {
             int hashIndex = uri.indexOf("#");
-            if (hashIndex > -1 && uri.substring(hashIndex).contains("%"))
-            {
+            String partToCheck = hashIndex > -1 ? uri.substring(hashIndex + 1) : uri;
+
+            // Issue 53482: Only call Lsid.encodePart if we find '%' not followed by exactly two hex digits
+            Pattern pattern = Pattern.compile("%(?![0-9A-Fa-f]{2})");
+            boolean hasUnencodedPercent = pattern.matcher(partToCheck).find();
+            if (hasUnencodedPercent)
                 return uri.substring(0, hashIndex + 1) + Lsid.encodePart(uri.substring(hashIndex + 1));
-            }
         }
         return uri;
     }

--- a/api/src/org/labkey/api/exp/Lsid.java
+++ b/api/src/org/labkey/api/exp/Lsid.java
@@ -330,7 +330,9 @@ public class Lsid
         {
             int hashIndex = uri.indexOf("#");
             if (hashIndex > -1 && uri.substring(hashIndex).contains("%"))
+            {
                 return uri.substring(0, hashIndex + 1) + Lsid.encodePart(uri.substring(hashIndex + 1));
+            }
         }
         return uri;
     }

--- a/api/src/org/labkey/api/exp/Lsid.java
+++ b/api/src/org/labkey/api/exp/Lsid.java
@@ -329,12 +329,7 @@ public class Lsid
         catch (URISyntaxException e)
         {
             int hashIndex = uri.indexOf("#");
-            String partToCheck = hashIndex > -1 ? uri.substring(hashIndex + 1) : uri;
-
-            // Issue 53482: Only call Lsid.encodePart if we find '%' not followed by exactly two hex digits
-            Pattern pattern = Pattern.compile("%(?![0-9A-Fa-f]{2})");
-            boolean hasUnencodedPercent = pattern.matcher(partToCheck).find();
-            if (hasUnencodedPercent)
+            if (hashIndex > -1 && uri.substring(hashIndex).contains("%"))
                 return uri.substring(0, hashIndex + 1) + Lsid.encodePart(uri.substring(hashIndex + 1));
         }
         return uri;

--- a/api/src/org/labkey/api/exp/Lsid.java
+++ b/api/src/org/labkey/api/exp/Lsid.java
@@ -34,7 +34,6 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.repeat;

--- a/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/PropertyServiceImpl.java
@@ -473,12 +473,13 @@ public class PropertyServiceImpl implements PropertyService, UsageMetricsProvide
         prop.setRangeURI(xProp.getRangeURI());
 
         String propertyURI = xProp.getPropertyURI();
-        // Deal with legacy property URIs that don't have % in the name part properly encoded
-        propertyURI = Lsid.fixupPropertyURI(propertyURI);
         if (context != null  && propertyURI != null && propertyURI.contains("${"))
         {
             propertyURI = LsidUtils.resolveLsidFromTemplate(propertyURI, context);
         }
+        // Deal with legacy property URIs that don't have % in the name part properly encoded
+        // Issue 53482: move call to Lsid.fixupPropertyURI after we resolve substitutions
+        propertyURI = Lsid.fixupPropertyURI(propertyURI);
         prop.setPropertyURI(propertyURI);
         if (xProp.isSetRequired())
         {


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53482

#### Changes
- Move call to Lsid.fixupPropertyURI after we replace substitutions in propertyURI

#### Tasks 📍
- [x] Manual Testing/Verify Fix (@cnathe opened the issue) @XingY 
- [x] Needs Automation