### PR TITLE
Issue 53478: Error deriving sample from a source where the source type has a name > 50 characters

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-25.003-25.004.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-25.003-25.004.sql
@@ -1,0 +1,2 @@
+--Issue 53478: DataInput Role can be a DataClass name, which has a max length of 200 characters
+ALTER TABLE exp.DataInput ALTER COLUMN Role TYPE VARCHAR(200);

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-25.003-25.004.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-25.003-25.004.sql
@@ -1,0 +1,4 @@
+--Issue 53478: DataInput Role can be a DataClass name, which has a max length of 200 characters
+EXECUTE core.fn_dropifexists 'DataInput', 'exp', 'INDEX', 'IDX_DataInput_Role';
+ALTER TABLE exp.DataInput ALTER COLUMN Role NVARCHAR(200) NOT NULL;
+CREATE INDEX IDX_DataInput_Role ON exp.DataInput(Role);

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -183,7 +183,7 @@ public class ExperimentModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 25.003;
+        return 25.004;
     }
 
     @Nullable


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53478

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6760

#### Changes
- update exp.DataInput from varchar 50 to 200

#### Tasks 📍
- [x] Manual Testing
- [x] Needs Automation
- [x] Verify Fix