### PR TITLE
Rename SaveRowsResponse to RowsResponse

### DIFF
--- a/study/test/src/org/labkey/test/tests/search/DataClassSearchTest.java
+++ b/study/test/src/org/labkey/test/tests/search/DataClassSearchTest.java
@@ -26,7 +26,7 @@ import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.query.DeleteRowsCommand;
 import org.labkey.remoteapi.query.InsertRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsResponse;
+import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.remoteapi.query.UpdateRowsCommand;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
@@ -217,7 +217,7 @@ public class DataClassSearchTest extends BaseWebDriverTest
         row2.put("foodColor", "white");
         row2.put("sequence", "ichi\nni\nsan");
         insertRowsCommand.setRows(new ArrayList<>(Arrays.asList(row1, row2)));
-        SaveRowsResponse insertResponse = insertRowsCommand.execute(connection, getCurrentContainerPath());
+        RowsResponse insertResponse = insertRowsCommand.execute(connection, getCurrentContainerPath());
 
         List<Map<String, Object>> responseRows = insertResponse.getRows();
         dataClassRowIds[0] = (int)responseRows.get(0).get("rowid");
@@ -272,7 +272,7 @@ public class DataClassSearchTest extends BaseWebDriverTest
         row1.put("name", DATA_CLASS_3_NAME);
         row1.put("iceCreamFlavor", "raspberry");
         insertRowsCommand.addRow(row1);
-        SaveRowsResponse insertResponse = insertRowsCommand.execute(connection, getCurrentContainerPath());
+        RowsResponse insertResponse = insertRowsCommand.execute(connection, getCurrentContainerPath());
         List<Map<String, Object>> responseRows = insertResponse.getRows();
         dataClassRowIds[2] = (int)responseRows.get(0).get("rowid");
 

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetLsidTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetLsidTest.java
@@ -9,7 +9,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.InsertRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsResponse;
+import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.remoteapi.query.UpdateRowsCommand;
@@ -202,7 +202,7 @@ public class StudyDatasetLsidTest extends MissingValueIndicatorsTest
                 .create(conn, containerPath);
 
         log("Validate inserting into the MV indicator dataset");
-        SaveRowsResponse response = expectSuccess(conn, MV_INDICATOR_DATASET, containerPath,
+        RowsResponse response = expectSuccess(conn, MV_INDICATOR_DATASET, containerPath,
                 List.of(
                         Map.of("Ptid", "111", "Visit", 1, "IntField", "N", "StringField", "Q"),
                         Map.of("Ptid", "222", "Visit", 2, "IntField", 1, "StringField", "StringValue"),
@@ -224,7 +224,7 @@ public class StudyDatasetLsidTest extends MissingValueIndicatorsTest
         cmd.setRows(updated);
         try
         {
-            SaveRowsResponse resp = cmd.execute(conn, containerPath);
+            RowsResponse resp = cmd.execute(conn, containerPath);
             List<Map<String, Object>> updatedRows = resp.getRows();
             validateValuesPresent(updatedRows.get(0), Map.of("IntFieldMvIndicator", "Z", "StringFieldMvIndicator", "Q"));
             validateValuesPresent(updatedRows.get(1), Map.of("IntField", 1, "StringFieldMvIndicator", "Q"));
@@ -365,19 +365,19 @@ public class StudyDatasetLsidTest extends MissingValueIndicatorsTest
         validateUpdateOfGeneratedColumns(conn, containerPath, TIME_PORTION_OF_DATE);
     }
 
-    private SaveRowsResponse expectSuccess(Connection conn, String datasetName, String containerPath, List<Map<String, Object>> rows) throws Exception
+    private RowsResponse expectSuccess(Connection conn, String datasetName, String containerPath, List<Map<String, Object>> rows) throws Exception
     {
         return validateInsertRows(conn, datasetName, containerPath, rows, false);
     }
 
-    private SaveRowsResponse expectFail(Connection conn, String datasetName, String containerPath, List<Map<String, Object>> rows) throws Exception
+    private RowsResponse expectFail(Connection conn, String datasetName, String containerPath, List<Map<String, Object>> rows) throws Exception
     {
         return validateInsertRows(conn, datasetName, containerPath, rows, true);
     }
 
-    private SaveRowsResponse validateInsertRows(Connection conn, String datasetName, String containerPath, List<Map<String, Object>> rows, boolean fail) throws Exception
+    private RowsResponse validateInsertRows(Connection conn, String datasetName, String containerPath, List<Map<String, Object>> rows, boolean fail) throws Exception
     {
-        SaveRowsResponse resp = null;
+        RowsResponse resp = null;
         InsertRowsCommand cmd = new InsertRowsCommand("Study", datasetName);
         cmd.setRows(rows);
         try

--- a/study/test/src/org/labkey/test/tests/study/StudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyTest.java
@@ -22,7 +22,7 @@ import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.ContainerFilter;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.InsertRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsResponse;
+import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.remoteapi.query.Sort;
@@ -151,7 +151,7 @@ public class StudyTest extends StudyBaseTest
 
         try
         {
-            SaveRowsResponse saveResp = insertCmd.execute(cn, getProjectName() + "/" + getFolderName());
+            RowsResponse saveResp = insertCmd.execute(cn, getProjectName() + "/" + getFolderName());
 
             // Spot check return values for inserted values and user defined and built-in columns in response
             assertEquals("Save rows return has incorrect value for: MouseId", "92104", saveResp.getRows().get(0).get("MouseId"));
@@ -192,7 +192,7 @@ public class StudyTest extends StudyBaseTest
 
         try
         {
-            SaveRowsResponse updateResp = updateCmd.execute(cn, getProjectName() + "/" + getFolderName());
+            RowsResponse updateResp = updateCmd.execute(cn, getProjectName() + "/" + getFolderName());
 
             // Spot check response values for updated values and user defined and built-in columns
             assertEquals("Save rows return has incorrect value for: MouseId", "92104", updateResp.getRows().get(0).get("MouseId"));


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-api-java/pull/83 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-java/pull/83

#### Changes
- Rename `SaveRowsResponse` to `RowsResponse`
