### PR TITLE
PlateMapExcelWriter: case-insensitive column exclusion

### DIFF
--- a/api/src/org/labkey/api/data/ArrayExcelWriter.java
+++ b/api/src/org/labkey/api/data/ArrayExcelWriter.java
@@ -17,19 +17,19 @@ public class ArrayExcelWriter extends ExcelWriter
      * @param data The data rows, in which index position of a value corresponds to the desired respective column index
      * @param cols The columns, in which ordering determines the left-to-right column ordering in the generated Excel
      */
-    public ArrayExcelWriter(List<Object[]> data, ColumnDescriptor[] cols)
+    public ArrayExcelWriter(List<Object[]> data, List<ColumnDescriptor> cols)
     {
         super(ExcelDocumentType.xlsx);
         this.data = data;
-        List<DisplayColumn> xlcols = new ArrayList<>();
+        List<DisplayColumn> displayColumns = new ArrayList<>();
 
-        for (int i = 0; i < cols.length; i++)
+        for (int i = 0; i < cols.size(); i++)
         {
-            ColumnDescriptor col = cols[i];
-            xlcols.add(new ArrayDisplayColumn(col.name, col.clazz, i));
+            ColumnDescriptor col = cols.get(i);
+            displayColumns.add(new ArrayDisplayColumn(col.name, col.clazz, i));
         }
 
-        setDisplayColumns(xlcols);
+        setDisplayColumns(displayColumns);
     }
 
     @Override

--- a/api/src/org/labkey/api/data/TSVArrayWriter.java
+++ b/api/src/org/labkey/api/data/TSVArrayWriter.java
@@ -5,7 +5,6 @@ import org.labkey.api.util.FileUtil;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 // This class supports generating files with duplicate column names. Consider using TSVMapWriter if
 // multiple identical column names is not an implementation concern.
@@ -15,17 +14,17 @@ public class TSVArrayWriter extends TSVWriter
     private final List<List<String>> _rows;
     private final String _fileName;
 
-    public TSVArrayWriter(String fileName, ColumnDescriptor[] columns, List<Object[]> rows)
+    public TSVArrayWriter(String fileName, List<ColumnDescriptor> columns, List<Object[]> rows)
     {
         _fileName = fileName;
-        _columns = Arrays.stream(columns)
+        _columns = columns.stream()
                 .map(ColumnDescriptor::getColumnName)
-                .collect(Collectors.toList());
+                .toList();
         _rows = rows.stream()
                 .map(array -> Arrays.stream(array)
                         .map(obj -> (obj == null) ? "" : String.valueOf(obj))
-                        .collect(Collectors.toList()))
-                .collect(Collectors.toList());
+                        .toList())
+                .toList();
     }
 
     @Override

--- a/api/src/org/labkey/api/data/TSVColumnWriter.java
+++ b/api/src/org/labkey/api/data/TSVColumnWriter.java
@@ -26,9 +26,6 @@ import java.util.Map;
  * Extracted DisplayColumn handling out of TSVGridWriter so rendering DisplayColumns
  * may be used without a ResultSet.  You will still need to set up a RenderContext
  * for DisplayColumn to render values.
- *
- * User: kevink
- * Date: 9/9/11
  */
 public abstract class TSVColumnWriter extends TSVWriter
 {
@@ -72,11 +69,11 @@ public abstract class TSVColumnWriter extends TSVWriter
                 String header = _columnHeaderType.getText(dc);
                 if (renameColumn.containsKey(colName))
                     header = renameColumn.get(colName);
-                else if (dc instanceof DataColumn)
+                else if (dc instanceof DataColumn dataColumn)
                 {
-                    if (((DataColumn) dc).getBoundColumn() != null)
+                    if (dataColumn.getBoundColumn() != null)
                     {
-                        String fieldKey = ((DataColumn) dc).getBoundColumn().getFieldKey().toString();
+                        String fieldKey = dataColumn.getBoundColumn().getFieldKey().toString();
                         if (renameColumn.containsKey(fieldKey))
                             header = renameColumn.get(fieldKey);
 
@@ -88,7 +85,6 @@ public abstract class TSVColumnWriter extends TSVWriter
 
         return headers;
     }
-
 
     /** Get the unquoted column values. */
     protected Iterable<String> getValues(RenderContext ctx, Iterable<DisplayColumn> displayColumns)

--- a/api/src/org/labkey/api/data/TSVMapWriter.java
+++ b/api/src/org/labkey/api/data/TSVMapWriter.java
@@ -31,10 +31,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * User: kevink
- * Date: 9/11/11
- */
 public class TSVMapWriter extends TSVWriter
 {
     private final Collection<String> _columns;

--- a/api/src/org/labkey/api/data/TSVWriter.java
+++ b/api/src/org/labkey/api/data/TSVWriter.java
@@ -96,7 +96,6 @@ public abstract class TSVWriter extends TextWriter
     {
     }
 
-
     public String getFilenamePrefix()
     {
         return _filenamePrefix;
@@ -210,7 +209,6 @@ public abstract class TSVWriter extends TextWriter
             _escapedCharsString = "\r\n" + _rowSeparator + _chDelimiter + _chQuote;
         }
 
-
         int len = value.length();
         if (len == 0)
             return _preserveEmptyString;
@@ -278,7 +276,6 @@ public abstract class TSVWriter extends TextWriter
     {
         return _headerRowVisible;
     }
-
 
     public void setHeaderRowVisible(boolean headerRowVisible)
     {

--- a/api/src/org/labkey/api/data/TSVWriter.java
+++ b/api/src/org/labkey/api/data/TSVWriter.java
@@ -40,6 +40,7 @@ public abstract class TSVWriter extends TextWriter
     protected char _chQuote = '"';
     protected String _rowSeparator = "\n";
     public static final String BACKSLASH_CHAR_STRING = "\\";
+    private static final char COMMENT_CHAR = '#';
 
     protected List<String> _fileHeader = null;
     protected boolean _headerRowVisible = true;
@@ -216,6 +217,8 @@ public abstract class TSVWriter extends TextWriter
         char lastCh = value.charAt(len-1);
         if (Character.isSpaceChar(firstCh) || Character.isSpaceChar(lastCh))
             return true;
+        if (firstCh == COMMENT_CHAR) // Issue 50719, Issue 53302
+            return true;
         if (StringUtils.containsAny(value, _additionalQuotedChars))
             return true;
         return StringUtils.containsAny(value,_escapedCharsString);
@@ -234,7 +237,7 @@ public abstract class TSVWriter extends TextWriter
                 return delim.contentType;
         }
 
-        return "text/tab-separated-values";
+        return DELIM.TAB.contentType;
     }
 
     /**

--- a/api/src/org/labkey/api/reader/TabLoader.java
+++ b/api/src/org/labkey/api/reader/TabLoader.java
@@ -56,7 +56,6 @@ import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-
 /**
  * Parses rows of tab-delimited text, returning a CloseableIterator of Map<String, Object>. The iterator must be closed
  * (typically via try-with-resources or a finally block) to close the underlying input source. The iterator can be wrapped
@@ -91,7 +90,10 @@ public class TabLoader extends DataLoader
         }
 
         @NotNull @Override
-        public FileType getFileType() { return TSV_FILE_TYPE; }
+        public FileType getFileType()
+        {
+            return TSV_FILE_TYPE;
+        }
     }
 
     public static class CsvFactory extends AbstractDataLoaderFactory
@@ -114,7 +116,10 @@ public class TabLoader extends DataLoader
         }
 
         @NotNull @Override
-        public FileType getFileType() { return CSV_FILE_TYPE; }
+        public FileType getFileType()
+        {
+            return CSV_FILE_TYPE;
+        }
     }
 
     public static class CsvFactoryNoConversions extends CsvFactory
@@ -141,9 +146,6 @@ public class TabLoader extends DataLoader
             TabLoader loader = super.createLoader(is, hasColumnHeaders, mvIndicatorContainer);
             return configParsing(loader);
         }
-
-        @NotNull @Override
-        public FileType getFileType() { return CSV_FILE_TYPE; }
     }
 
     public static class MysqlFactory extends AbstractDataLoaderFactory
@@ -172,7 +174,10 @@ public class TabLoader extends DataLoader
         }
 
         @NotNull @Override
-        public FileType getFileType() { return CSV_FILE_TYPE; }
+        public FileType getFileType()
+        {
+            return CSV_FILE_TYPE;
+        }
     }
 
     protected static char COMMENT_CHAR = '#';

--- a/assay/src/org/labkey/assay/PlateController.java
+++ b/assay/src/org/labkey/assay/PlateController.java
@@ -1309,18 +1309,17 @@ public class PlateController extends SpringActionController
                 List<FieldKey> sourceIncludedMetadataCols = PlateManager.get().getMetadataColumns(plateSetSource, getContainer(), getUser(), cf);
                 List<FieldKey> destinationIncludedMetadataCols = PlateManager.get().getMetadataColumns(plateSetDestination, getContainer(), getUser(), cf);
 
-                ColumnDescriptor[] sourceXlCols = PlateSetExport.getColumnDescriptors(PlateSetExport.SOURCE, sourceIncludedMetadataCols);
-                ColumnDescriptor[] destinationXlCols = PlateSetExport.getColumnDescriptors(PlateSetExport.DESTINATION, destinationIncludedMetadataCols);
-                ColumnDescriptor[] xlCols = ArrayUtils.addAll(sourceXlCols, destinationXlCols);
+                List<ColumnDescriptor> sourceColumns = PlateSetExport.getColumnDescriptors(PlateSetExport.SOURCE, sourceIncludedMetadataCols);
+                List<ColumnDescriptor> destinationColumns = PlateSetExport.getColumnDescriptors(PlateSetExport.DESTINATION, destinationIncludedMetadataCols);
+                List<ColumnDescriptor> exportColumns = new ArrayList<>(sourceColumns);
+                exportColumns.addAll(destinationColumns);
 
                 List<Object[]> plateDataRows = PlateManager.get().getWorklist(form.getSourcePlateSetId(), form.getDestinationPlateSetId(), sourceIncludedMetadataCols, destinationIncludedMetadataCols, getContainer(), getUser());
 
                 String fullFileName = plateSetSource.getName() + " - " + plateSetDestination.getName();
 
-                PlateManager.get().getPlateSetExportFile(fullFileName, xlCols, plateDataRows, form.getFileType(), getViewContext().getResponse());
+                PlateManager.get().getPlateSetExportFile(fullFileName, exportColumns, plateDataRows, form.getFileType(), getViewContext().getResponse());
                 SimpleMetricsService.get().increment(AssayModule.NAME, "plateSet", "exportWorklist");
-
-                return null; // Returning anything here will cause error as excel writer will close the response stream
             }
             catch (Exception e)
             {
@@ -1387,12 +1386,10 @@ public class PlateController extends SpringActionController
                     cf = form.getContainerFilter().create(getViewContext());
 
                 List<FieldKey> includedMetadataCols = PlateManager.get().getMetadataColumns(plateSet, getContainer(), getUser(), cf);
-                ColumnDescriptor[] xlCols = PlateSetExport.getColumnDescriptors("", includedMetadataCols);
+                List<ColumnDescriptor> exportColumns = PlateSetExport.getColumnDescriptors("", includedMetadataCols);
                 List<Object[]> plateDataRows = PlateManager.get().getInstrumentInstructions(form.getPlateSetId(), includedMetadataCols, getContainer(), getUser());
 
-                PlateManager.get().getPlateSetExportFile(plateSet.getName() + "-instructions", xlCols, plateDataRows, form.getFileType(), getViewContext().getResponse());
-
-                return null; // Returning anything here will cause error as excel writer will close the response stream
+                PlateManager.get().getPlateSetExportFile(plateSet.getName() + "-instructions", exportColumns, plateDataRows, form.getFileType(), getViewContext().getResponse());
             }
             catch (Exception e)
             {

--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -279,7 +279,6 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
 
                 try (TSVMapWriter tsvWriter = saveMatchingColumnDataOnly ? new TSVMapWriter(columns, rawData) : new TSVMapWriter(columns, rawData, true))
                 {
-                    tsvWriter.setAdditionalQuotedChars("#"); //Issue 50719: If the first column name starts with a #, the data loader will treat the header row as a comment
                     tsvWriter.write(fileObject.toNioPathForWrite().toFile());
                     factory.setRawData(null);
                     factory.setUploadedData(Collections.singletonMap(PRIMARY_FILE, fileObject));

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3654,10 +3654,10 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         return counter;
     }
 
-    public void getPlateSetExportFile(String fileName, ColumnDescriptor[] cols, List<Object[]> rows, PlateController.FileType fileType, HttpServletResponse response) throws IOException
+    public void getPlateSetExportFile(String fileName, List<ColumnDescriptor> cols, List<Object[]> rows, PlateController.FileType fileType, HttpServletResponse response) throws IOException
     {
-        boolean isCSV = fileType.equals(PlateController.FileType.CSV);
-        boolean isTSV = fileType.equals(PlateController.FileType.TSV);
+        boolean isCSV = PlateController.FileType.CSV.equals(fileType);
+        boolean isTSV = PlateController.FileType.TSV.equals(fileType);
         if (isCSV || isTSV)
         {
             try (TSVArrayWriter writer = new TSVArrayWriter(fileName, cols, rows))

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3754,7 +3754,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         // Filter on isQueryColumn, so we don't get the details or update columns
         return dataRegion.getDisplayColumns().stream()
                 .filter(DisplayColumn::isQueryColumn)
-                .filter(col -> !col.getName().equals("sampleID"))
+                .filter(col -> !col.getName().equalsIgnoreCase(WellTable.Column.SampleID.name()))
                 .toList();
     }
 

--- a/assay/src/org/labkey/assay/plate/PlateSetExport.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetExport.java
@@ -67,7 +67,7 @@ public class PlateSetExport
             )
         );
 
-        if (!prefix.equals(PlateSetExport.DESTINATION))
+        if (!PlateSetExport.DESTINATION.equals(prefix))
             baseColumns.add(rs.getString(FKMap.get(SAMPLE_ID_COL)));
 
         for (FieldKey col : includedMetaDataCols)
@@ -103,7 +103,8 @@ public class PlateSetExport
     // Create sampleIdToRow of the following form:
     // {<sample id>: [{dataRow1}, {dataRow2}, ... ], ... }
     // Where the data rows contain the key's sample
-    private Map<String, List<Object[]>> getSampleIdToRows(TableInfo wellTable, List<FieldKey> includedMetadataCols, int plateSetId, String plateSetExport) {
+    private Map<String, List<Object[]>> getSampleIdToRows(TableInfo wellTable, List<FieldKey> includedMetadataCols, int plateSetId, String plateSetExport)
+    {
         Map<String, List<Object[]>> sampleIdToRow = new LinkedHashMap<>();
         try (Results rs = QueryService.get().select(wellTable, getWellColumns(wellTable, includedMetadataCols), new SimpleFilter(FKMap.get(PLATE_SET_ID_COL), plateSetId), new Sort(ROW_ID_COL)))
         {

--- a/assay/src/org/labkey/assay/plate/PlateSetExport.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetExport.java
@@ -77,9 +77,9 @@ public class PlateSetExport
     }
 
     // Returns array of ColumnDescriptors used as column layout once fed to an ArrayExcelWriter
-    public static ColumnDescriptor[] getColumnDescriptors(String prefix, List<FieldKey> includedMetadataCols)
+    public static List<ColumnDescriptor> getColumnDescriptors(String prefix, List<FieldKey> includedMetadataCols)
     {
-        List<ColumnDescriptor> baseColumns = new ArrayList<>(
+        List<ColumnDescriptor> columnDescriptors = new ArrayList<>(
             Arrays.asList(
                 new ColumnDescriptor(prefix + "Plate ID"),
                 new ColumnDescriptor(prefix + "Barcode"),
@@ -89,15 +89,15 @@ public class PlateSetExport
         );
 
         if (!PlateSetExport.DESTINATION.equals(prefix))
-            baseColumns.add(new ColumnDescriptor("Sample ID"));
+            columnDescriptors.add(new ColumnDescriptor("Sample ID"));
 
         List<ColumnDescriptor> metadataColumns = includedMetadataCols
                 .stream()
                 .map(fk -> new ColumnDescriptor(fk.getParts().size() > 1 ? fk.getParent().getCaption() : fk.getCaption()))
                 .toList();
 
-        baseColumns.addAll(metadataColumns);
-        return baseColumns.toArray(new ColumnDescriptor[0]);
+        columnDescriptors.addAll(metadataColumns);
+        return columnDescriptors;
     }
 
     // Create sampleIdToRow of the following form:

--- a/assay/src/org/labkey/assay/plate/data/PlateMapExcelWriter.java
+++ b/assay/src/org/labkey/assay/plate/data/PlateMapExcelWriter.java
@@ -10,6 +10,7 @@ import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateCustomField;
 import org.labkey.api.assay.plate.PositionImpl;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.ResultSetRowMapFactory;
 import org.labkey.api.collections.RowMap;
 import org.labkey.api.data.ColumnInfo;
@@ -22,7 +23,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.HttpView;
-import org.labkey.assay.plate.query.WellTable;
+import org.labkey.assay.plate.query.WellTable.Column;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -34,7 +35,7 @@ import java.util.Set;
 public class PlateMapExcelWriter extends ExcelWriter
 {
     private static final Logger logger = LogHelper.getLogger(PlateMapExcelWriter.class, "Plate map export");
-    private static final Set<String> excludedFields = Set.of("sampleid", "type", "wellgroup");
+    private static final Set<String> excludedFields = CaseInsensitiveHashSet.of(Column.SampleID.name(), Column.Type.name(), Column.WellGroup.name());
 
     private final Plate _plate;
     private final QueryView _queryView;
@@ -66,8 +67,8 @@ public class PlateMapExcelWriter extends ExcelWriter
             while (results.next())
             {
                 RowMap<Object> well = factory.getRowMap(results);
-                Integer row = (Integer) well.get(WellTable.Column.Row.name());
-                Integer col = (Integer) well.get(WellTable.Column.Col.name());
+                Integer row = (Integer) well.get(Column.Row.name());
+                Integer col = (Integer) well.get(Column.Col.name());
 
                 Map<Integer, RowMap<Object>> rowMap = _wellData.computeIfAbsent(row, k -> new HashMap<>());
 
@@ -190,7 +191,7 @@ public class PlateMapExcelWriter extends ExcelWriter
     // Removes fields explicitly excluded for Map export
     protected List<DisplayColumn> getDisplayColumns()
     {
-        return _displayColumns.stream().filter(col -> !excludedFields.contains(col.getName().toLowerCase())).toList();
+        return _displayColumns.stream().filter(col -> !excludedFields.contains(col.getName())).toList();
     }
 
     protected List<PlateCustomField> getCustomFields()
@@ -212,7 +213,10 @@ public class PlateMapExcelWriter extends ExcelWriter
             List<DisplayColumn> displayColumns;
 
             if (sheetNumber == 0) // Summary view, render all values in each cell
-                displayColumns = displayCols.stream().filter(dc -> !dc.getName().equals("row") && !dc.getName().equals("col")).toList();
+            {
+                Set<FieldKey> excludeFromSummary = Set.of(Column.Col.fieldKey(), Column.Row.fieldKey());
+                displayColumns = displayCols.stream().filter(dc -> !excludeFromSummary.contains(dc.getColumnInfo().getFieldKey())).toList();
+            }
             else if (sheetNumber == 1) // Sample ID view
                 displayColumns = List.of(displayCols.get(0));
             else // CustomField view


### PR DESCRIPTION
#### Rationale
Changes in #6804 exposed some case-sensitive comparisons being done in `PlateMapExcelWriter` which are resulting in undesired results in the exported plate map files.

#### Related Pull Requests
- #6804
- https://github.com/LabKey/limsModules/pull/1534

#### Changes
- Do case-insensitive column comparison when determining columns to exclude in plate map.
- Address [Issue 53302](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53302) by having `TSVWriter` quote values that start with `#`.