### PR TITLE
Adjust alias size for suffix

### DIFF
--- a/api/src/org/labkey/api/query/AliasManager.java
+++ b/api/src/org/labkey/api/query/AliasManager.java
@@ -67,7 +67,7 @@ public class AliasManager
         return makeLegalName(str, dialect, truncate, 0);
     }
 
-    private static String makeLegalName(String str, @NotNull  SqlDialect dialect, boolean truncate, int reserveCount)
+    public static String makeLegalName(String str, @NotNull  SqlDialect dialect, boolean truncate, int reserveCount)
     {
         return dialect.makeLegalName(str, truncate, reserveCount);
     }

--- a/query/src/org/labkey/query/sql/QueryTable.java
+++ b/query/src/org/labkey/query/sql/QueryTable.java
@@ -304,8 +304,9 @@ public class QueryTable extends AbstractQueryRelation implements QueryRelation.C
             if (name.startsWith(gttp) && 10 < name.indexOf('$'))
                 name = name.substring(gttp.length(), name.indexOf("$"));
         }
-        String r = AliasManager.makeLegalName(name, getSchema().getDbSchema().getSqlDialect());
-        r += "_" + _uniqueAliasCounter;
+        String suffix = "_" + _uniqueAliasCounter;
+        String r = AliasManager.makeLegalName(name, getSchema().getDbSchema().getSqlDialect(), true, suffix.length());
+        r += suffix;
         return r;
     }
 


### PR DESCRIPTION
#### Rationale
This showed up in an Oracle dialect query but would show up anywhere there are long enough column names. The creation of the alias in QueryTable.makeRelationName is not accounting for the size of the suffix. Will create invalid sql queries.

#### Changes
- Account for suffix length in makeRelationName

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->