### PR TITLE
Track search work by container; purge on delete

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -242,10 +242,9 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
 
 
     @Override
-    public void enumerateDocuments(final SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, final Date modifiedSince)
     {
-        Runnable r = () -> AnnouncementManager.indexMessages(task, c, modifiedSince);
-        task.addRunnable(c, SearchService.PRIORITY.crawl, r);
+        queue.addRunnable((q) -> AnnouncementManager.indexMessages(q, modifiedSince));
     }
 
     @Override

--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -245,7 +245,7 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
     public void enumerateDocuments(final SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
     {
         Runnable r = () -> AnnouncementManager.indexMessages(task, c, modifiedSince);
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, r);
+        task.addRunnable(c, SearchService.PRIORITY.crawl, r);
     }
 
     @Override

--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -245,7 +245,7 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
     public void enumerateDocuments(final SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
     {
         Runnable r = () -> AnnouncementManager.indexMessages(task, c, modifiedSince);
-        task.addRunnable(c, SearchService.PRIORITY.bulk, r);
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, r);
     }
 
     @Override

--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -245,7 +245,7 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
     public void enumerateDocuments(final SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
     {
         Runnable r = () -> AnnouncementManager.indexMessages(task, c, modifiedSince);
-        task.addRunnable(r, SearchService.PRIORITY.bulk);
+        task.addRunnable(c, SearchService.PRIORITY.bulk, r);
     }
 
     @Override

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -356,7 +356,7 @@ public class AnnouncementManager
                 sendNotificationEmails(ann, currentRendererType, c, user);
             }
 
-            indexThread(ann);
+            indexThread(ann, c);
         }
     }
 
@@ -688,7 +688,7 @@ public class AnnouncementManager
         }
         finally
         {
-            indexThread(update);
+            indexThread(update, c);
         }
 
         return result;
@@ -851,26 +851,25 @@ public class AnnouncementManager
         ContainerUtil.purgeTable(_comm.getTableInfoAnnouncements(), c, null);
     }
 
-    public static void indexMessages(SearchService.IndexTask task, @NotNull Container c, Date modifiedSince)
+    public static void indexMessages(SearchService.TaskIndexingQueue queue, Date modifiedSince)
     {
-        indexMessages(task, c.getId(), modifiedSince, null, SearchService.PRIORITY.modified);
+        indexMessages(queue, modifiedSince, null);
     }
 
 
     // TODO: Fix inconsistency -- cid is @NotNull and we check c != null, yet some code below allows for c == null
-    public static void indexMessages(final SearchService.IndexTask task, final @NotNull String containerId, Date modifiedSince, @Nullable String threadId, SearchService.PRIORITY priority)
+    public static void indexMessages(SearchService.TaskIndexingQueue queue, Date modifiedSince, @Nullable String threadId)
     {
-        assert null != containerId;
-        if (null == containerId || (null != modifiedSince && null != threadId))
+        if ((null != modifiedSince && null != threadId))
             throw new IllegalArgumentException();
         // make sure container still exists
-        Container c = ContainerManager.getForId(containerId);
+        Container c = queue.getContainer();
         if (null == c || isSecure(c))
             return;
 
         SQLFragment sql = new SQLFragment("SELECT EntityId FROM " + _comm.getTableInfoThreads() + " _t_ ");
         sql.append(" WHERE Container = ?");
-        sql.add(containerId);
+        sql.add(c);
         String and = " AND ";
 
         if (null != threadId)
@@ -897,7 +896,7 @@ public class AnnouncementManager
                 {
                     String docid = "thread:" + entityId;
                     ActionURL url = new ActionURL(AnnouncementsController.ThreadAction.class, null);
-                    url.setExtraPath(containerId);
+                    url.setExtraPath(c.getId());
                     url.addParameter("entityId", entityId);
 
                     Map<String, Object> props = new HashMap<>();
@@ -927,7 +926,7 @@ public class AnnouncementManager
                         }
                     };
 
-                    task.addResource(sdr, priority);
+                    queue.addResource(sdr);
                 }
             });
         }
@@ -937,7 +936,7 @@ public class AnnouncementManager
         // find all messages that have attachments
         sql = new SQLFragment("SELECT a.EntityId, MIN(CAST(a.Parent AS VARCHAR(36))) as parent, MIN(a.Title) AS title FROM " + _comm.getTableInfoAnnouncements() + " a INNER JOIN core.Documents d ON a.entityid = d.parent");
         sql.append("\nWHERE a.container = ?");
-        sql.add(containerId);
+        sql.add(c);
         and = " AND ";
         if (null != threadId)
         {
@@ -966,7 +965,7 @@ public class AnnouncementManager
             AnnouncementModel ann = new AnnouncementModel();
             ann.setEntityId(entityId);
             ann.setParent(parent);
-            ann.setContainer(containerId);
+            ann.setContainer(c.getId());
             ann.setTitle(title);
             map.put(entityId, ann);
         });
@@ -975,7 +974,7 @@ public class AnnouncementManager
         {
             List<Pair<String, String>> list = AttachmentService.get().listAttachmentsForIndexing(annIds, modifiedSince);
             ActionURL urlThread = new ActionURL(AnnouncementsController.ThreadAction.class, null);
-            urlThread.setExtraPath(containerId);
+            urlThread.setExtraPath(c.getId());
 
             for (Pair<String, String> pair : list)
             {
@@ -996,7 +995,7 @@ public class AnnouncementManager
                         ann.getAttachmentParent(),
                         documentName, searchCategory);
                 attachmentRes.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
-                task.addResource(attachmentRes, SearchService.PRIORITY.modified);
+                queue.addResource(attachmentRes);
             }
         }
     }
@@ -1019,26 +1018,16 @@ public class AnnouncementManager
     private static void unindexThread(@NotNull AnnouncementModel ann)
     {
         String docid = "thread:" + ann.getEntityId();
-        SearchService ss = SearchService.get();
-        if (null != ss)
-        {
-            ss.deleteResource(docid);
-        }
+        SearchService.get().deleteResource(docid);
         // Note: Attachments are unindexed by attachment service
     }
 
 
-    static void indexThread(AnnouncementModel ann)
+    static void indexThread(AnnouncementModel ann, Container c)
     {
         String parent = null == ann.getParent() ? ann.getEntityId() : ann.getParent();
-        String container = ann.getContainerId();
-        SearchService svc = SearchService.get();
-        if (svc != null)
-        {
-            SearchService.IndexTask task = svc.defaultTask();
-            // indexMessages is overkill, but I don't want to duplicate the code
-            indexMessages(task, container, null, parent, SearchService.PRIORITY.modified);
-        }
+        // indexMessages is overkill, but I don't want to duplicate the code
+        indexMessages(SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified), null, parent);
     }
 
     public static HtmlString getUserDetailsLink(Container container, User currentUser, int formattedUserId, boolean includeGroups, boolean forEmail)

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -853,12 +853,12 @@ public class AnnouncementManager
 
     public static void indexMessages(SearchService.IndexTask task, @NotNull Container c, Date modifiedSince)
     {
-        indexMessages(task, c.getId(), modifiedSince, null);
+        indexMessages(task, c.getId(), modifiedSince, null, SearchService.PRIORITY.modifiedLow);
     }
 
 
     // TODO: Fix inconsistency -- cid is @NotNull and we check c != null, yet some code below allows for c == null
-    public static void indexMessages(final SearchService.IndexTask task, final @NotNull String containerId, Date modifiedSince, @Nullable String threadId)
+    public static void indexMessages(final SearchService.IndexTask task, final @NotNull String containerId, Date modifiedSince, @Nullable String threadId, SearchService.PRIORITY priority)
     {
         assert null != containerId;
         if (null == containerId || (null != modifiedSince && null != threadId))
@@ -927,7 +927,7 @@ public class AnnouncementManager
                         }
                     };
 
-                    task.addResource(sdr, SearchService.PRIORITY.item);
+                    task.addResource(sdr, priority);
                 }
             });
         }
@@ -996,7 +996,7 @@ public class AnnouncementManager
                         ann.getAttachmentParent(),
                         documentName, searchCategory);
                 attachmentRes.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
-                task.addResource(attachmentRes, SearchService.PRIORITY.item);
+                task.addResource(attachmentRes, SearchService.PRIORITY.modifiedHigh);
             }
         }
     }
@@ -1037,7 +1037,7 @@ public class AnnouncementManager
         {
             SearchService.IndexTask task = svc.defaultTask();
             // indexMessages is overkill, but I don't want to duplicate the code
-            indexMessages(task, container, null, parent);
+            indexMessages(task, container, null, parent, SearchService.PRIORITY.modifiedLow);
         }
     }
 

--- a/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
+++ b/announcements/src/org/labkey/announcements/model/AnnouncementManager.java
@@ -853,7 +853,7 @@ public class AnnouncementManager
 
     public static void indexMessages(SearchService.IndexTask task, @NotNull Container c, Date modifiedSince)
     {
-        indexMessages(task, c.getId(), modifiedSince, null, SearchService.PRIORITY.modifiedLow);
+        indexMessages(task, c.getId(), modifiedSince, null, SearchService.PRIORITY.modified);
     }
 
 
@@ -996,7 +996,7 @@ public class AnnouncementManager
                         ann.getAttachmentParent(),
                         documentName, searchCategory);
                 attachmentRes.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
-                task.addResource(attachmentRes, SearchService.PRIORITY.modifiedHigh);
+                task.addResource(attachmentRes, SearchService.PRIORITY.modified);
             }
         }
     }
@@ -1037,7 +1037,7 @@ public class AnnouncementManager
         {
             SearchService.IndexTask task = svc.defaultTask();
             // indexMessages is overkill, but I don't want to duplicate the code
-            indexMessages(task, container, null, parent, SearchService.PRIORITY.modifiedLow);
+            indexMessages(task, container, null, parent, SearchService.PRIORITY.modified);
         }
     }
 

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -131,10 +131,10 @@ public interface AssayService
     @Nullable
     ExpExperiment findBatch(ExpRun run);
 
-    void indexAssay(SearchService.IndexTask task, Container c, ExpProtocol protocol, SearchService.PRIORITY priority);
-    void indexAssays(SearchService.IndexTask task, Container c, SearchService.PRIORITY priority);
+    void indexAssay(SearchService.TaskIndexingQueue queue, ExpProtocol protocol);
+    void indexAssays(SearchService.TaskIndexingQueue queue);
 
-    void indexAssayRun(int expRunRowId, SearchService.PRIORITY priority);
+    void indexAssayRun(SearchService.TaskIndexingQueue queue, int expRunRowId);
 
     void deindexAssays(@NotNull Collection<? extends ExpProtocol> expProtocols);
 

--- a/api/src/org/labkey/api/assay/AssayService.java
+++ b/api/src/org/labkey/api/assay/AssayService.java
@@ -131,10 +131,10 @@ public interface AssayService
     @Nullable
     ExpExperiment findBatch(ExpRun run);
 
-    void indexAssay(SearchService.IndexTask task, Container c, ExpProtocol protocol);
-    void indexAssays(SearchService.IndexTask task, Container c);
+    void indexAssay(SearchService.IndexTask task, Container c, ExpProtocol protocol, SearchService.PRIORITY priority);
+    void indexAssays(SearchService.IndexTask task, Container c, SearchService.PRIORITY priority);
 
-    void indexAssayRun(int expRunRowId);
+    void indexAssayRun(int expRunRowId, SearchService.PRIORITY priority);
 
     void deindexAssays(@NotNull Collection<? extends ExpProtocol> expProtocols);
 

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -62,6 +62,7 @@ import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.SimpleValidationError;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.search.SearchService;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.MutableSecurityPolicy;
 import org.labkey.api.security.SecurityLogger;
@@ -1902,6 +1903,13 @@ public class ContainerManager
         }
 
         LOG.debug("Starting container delete for " + c.getContainerNoun(true) + " " + c.getPath());
+
+        SearchService ss = SearchService.get();
+        if (ss != null)
+        {
+            // Tell the search indexer to drop work for the container that's about to be deleted
+            ss.purgeForContainer(c);
+        }
 
         DbScope.RetryFn<Boolean> tryDeleteContainer = (tx) ->
         {

--- a/api/src/org/labkey/api/exp/api/ExpSearchable.java
+++ b/api/src/org/labkey/api/exp/api/ExpSearchable.java
@@ -1,5 +1,6 @@
 package org.labkey.api.exp.api;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
@@ -11,22 +12,17 @@ public interface ExpSearchable
 {
     @Nullable WebdavResource createIndexDocument(@Nullable TableInfo table);
 
-    default void index()
+    default void index(@NotNull SearchService.PRIORITY priority)
     {
-        index(null);
+        index(priority, null);
     }
 
-    default void index(@Nullable SearchService.IndexTask task)
+    default void index(@NotNull SearchService.PRIORITY priority, @Nullable SearchService.IndexTask task)
     {
-        index(task, null);
+        index(priority, task, null);
     }
 
-    default void index(@Nullable SearchService.IndexTask task, @Nullable SearchService.PRIORITY priority)
-    {
-        index(task, priority, null);
-    }
-
-    default void index(@Nullable SearchService.IndexTask task, @Nullable SearchService.PRIORITY priority, @Nullable TableInfo table)
+    default void index(@NotNull SearchService.PRIORITY priority, @Nullable SearchService.IndexTask task, @Nullable TableInfo table)
     {
         if (task == null)
         {
@@ -40,6 +36,6 @@ public interface ExpSearchable
         var expScope = DbSchema.get("exp", DbSchemaType.Module).getScope();
         var doc = expScope.executeWithRetryReadOnly((tx) -> createIndexDocument(table));
         if (doc != null)
-            task.addResource(doc, priority == null ? SearchService.PRIORITY.item : priority);
+            task.addResource(doc, priority);
     }
 }

--- a/api/src/org/labkey/api/exp/api/ExpSearchable.java
+++ b/api/src/org/labkey/api/exp/api/ExpSearchable.java
@@ -12,30 +12,11 @@ public interface ExpSearchable
 {
     @Nullable WebdavResource createIndexDocument(@Nullable TableInfo table);
 
-    default void index(@NotNull SearchService.PRIORITY priority)
+    default void index(@NotNull SearchService.TaskIndexingQueue queue, @Nullable TableInfo table)
     {
-        index(priority, null);
-    }
-
-    default void index(@NotNull SearchService.PRIORITY priority, @Nullable SearchService.IndexTask task)
-    {
-        index(priority, task, null);
-    }
-
-    default void index(@NotNull SearchService.PRIORITY priority, @Nullable SearchService.IndexTask task, @Nullable TableInfo table)
-    {
-        if (task == null)
-        {
-            SearchService ss = SearchService.get();
-            if (null == ss)
-                return;
-
-            task = ss.defaultTask();
-        }
-
         var expScope = DbSchema.get("exp", DbSchemaType.Module).getScope();
         var doc = expScope.executeWithRetryReadOnly((tx) -> createIndexDocument(table));
         if (doc != null)
-            task.addResource(doc, priority);
+            queue.addResource(doc);
     }
 }

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -223,7 +223,7 @@ public interface SampleTypeService
     void deleteSampleType(int rowId, Container c, User user, @Nullable String auditUserComment) throws ExperimentException;
 
     // used by DomainKind.invalidate()
-    void indexSampleType(ExpSampleType sampleType, SearchService.PRIORITY priority);
+    void indexSampleType(ExpSampleType sampleType, SearchService.TaskIndexingQueue queue);
 
     @Nullable DbSequence getSampleCountSequence(Container container, boolean isRootSampleOnly);
 

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -33,6 +33,7 @@ import org.labkey.api.lists.permissions.ManagePicklistsPermission;
 import org.labkey.api.qc.DataState;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
@@ -222,7 +223,7 @@ public interface SampleTypeService
     void deleteSampleType(int rowId, Container c, User user, @Nullable String auditUserComment) throws ExperimentException;
 
     // used by DomainKind.invalidate()
-    void indexSampleType(ExpSampleType sampleType);
+    void indexSampleType(ExpSampleType sampleType, SearchService.PRIORITY priority);
 
     @Nullable DbSequence getSampleCountSequence(Container container, boolean isRootSampleOnly);
 

--- a/api/src/org/labkey/api/search/NoopSearchService.java
+++ b/api/src/org/labkey/api/search/NoopSearchService.java
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.labkey.core.search;
+package org.labkey.api.search;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
-import org.labkey.api.search.SearchResultTemplate;
-import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
@@ -37,20 +35,36 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 public class NoopSearchService implements SearchService
 {
     IndexTask _dummyTask = new IndexTask()
     {
-        @Override
-        public void addRunnable(Container container, @NotNull PRIORITY pri, @NotNull Runnable r)
-        {
-        }
-
 
         @Override
-        public void addResource(@NotNull WebdavResource r, @NotNull PRIORITY pri)
+        public TaskIndexingQueue getQueue(@Nullable Container container, @NotNull PRIORITY pri)
         {
+            return new TaskIndexingQueue()
+            {
+                @Override
+                public void addRunnable(@NotNull Consumer<TaskIndexingQueue> r)
+                {
+
+                }
+
+                @Override
+                public void addResource(@NotNull WebdavResource r)
+                {
+
+                }
+
+                @Override
+                public Container getContainer()
+                {
+                    return container;
+                }
+            };
         }
 
         @Override
@@ -178,7 +192,7 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
-    public void purgeForContainer(Container container)
+    public void purgeForContainer(@NotNull Container container)
     {
     }
 
@@ -370,12 +384,6 @@ public class NoopSearchService implements SearchService
 
     @Override
     public IndexTask indexContainer(@Nullable IndexTask task, Container c, Date since)
-    {
-        return null==task?_dummyTask:task;
-    }
-
-    @Override
-    public IndexTask indexProject(@Nullable IndexTask task, Container project)
     {
         return null==task?_dummyTask:task;
     }

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -65,6 +65,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 public interface SearchService extends SearchMXBean
 {
@@ -96,9 +97,12 @@ public interface SearchService extends SearchMXBean
     // marker value for documents with indexing errors
     Date failDate = new Timestamp(DateUtil.parseISODateTime("1899-12-30"));
 
-    static @Nullable SearchService get()
+    static final SearchService NO_OP = new NoopSearchService();
+
+    static @NotNull SearchService get()
     {
-        return ServiceRegistry.get().getService(SearchService.class);
+        SearchService service = ServiceRegistry.get().getService(SearchService.class);
+        return service == null ? NO_OP : service;
     }
 
     static void setInstance(SearchService impl)
@@ -111,7 +115,10 @@ public interface SearchService extends SearchMXBean
      */
     void reindexContainerFiles(Container c);
 
-    void purgeForContainer(Container container);
+    /**
+     * Removes all non-delete work from the queue associated with the target container
+     */
+    void purgeForContainer(@NotNull Container container);
 
     /**
      * Puts work in the indexer queue at the specified priority and waits up to the timeout for it to complete
@@ -199,18 +206,23 @@ public interface SearchService extends SearchMXBean
          */
         void setReady();
 
+        TaskIndexingQueue getQueue(@Nullable Container container, @NotNull SearchService.PRIORITY pri);
+    }
+
+    interface TaskIndexingQueue
+    {
         /**
          * Runnables are used to queue up search work that will often involve adding many individual resources.
          * This lets us avoid holding lots of to-be-index resources in memory all at once.
-         * @param container optionally, the container associated with the indexer work. Used to purge work from the queue when a container is about to be deleted */
-        void addRunnable(@Nullable Container container, @NotNull SearchService.PRIORITY pri, @NotNull Runnable r);
+         */
+        void addRunnable(@NotNull Consumer<TaskIndexingQueue> r);
 
         /**
-         * Resources are individual documents that should be added to the index
-         * @param r
-         * @param pri
+         * Resources represent individual documents that should be added to the index
          */
-        void addResource(@NotNull WebdavResource r, @NotNull SearchService.PRIORITY pri);
+        void addResource(@NotNull WebdavResource r);
+
+        Container getContainer();
     }
 
 
@@ -421,8 +433,6 @@ public interface SearchService extends SearchMXBean
     void addPathToCrawl(Path path, @Nullable Date nextCrawl);
 
     IndexTask indexContainer(@Nullable IndexTask task, Container c, Date since);
-    // TODO: Remove? This is never called
-    IndexTask indexProject(@Nullable IndexTask task, Container project /*boolean incremental*/);
     void indexFull(boolean force, String reason);
 
     void waitForIdle() throws InterruptedException;
@@ -463,7 +473,7 @@ public interface SearchService extends SearchMXBean
          *
          * @param modifiedSince when null, do a full reindex; otherwise incremental (either modified > modifiedSince, or modified > lastIndexed)
          */
-        void enumerateDocuments(IndexTask task, @NotNull Container c, @Nullable Date modifiedSince);
+        void enumerateDocuments(TaskIndexingQueue adder, @Nullable Date modifiedSince);
 
         /**
          * if the full-text search index is deleted, providers may need to clear stored lastIndexed values.

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -114,11 +114,13 @@ public interface SearchService extends SearchMXBean
      */
     void reindexContainerFiles(Container c);
 
+    void purgeForContainer(Container container);
+
     /**
      * Puts work in the indexer queue at the specified priority and waits up to the timeout for it to complete
      * @return true if the task in the queue completed before the timeout
      */
-    boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit) throws InterruptedException;
+    boolean drainQueue(@NotNull PRIORITY priority, long timeout, @NotNull TimeUnit unit) throws InterruptedException;
 
     /** From lowest to highest priority */
     enum PRIORITY
@@ -201,29 +203,9 @@ public interface SearchService extends SearchMXBean
          */
         void setReady();
 
-        default void addRunnable(@NotNull SearchService.PRIORITY pri, @NotNull Runnable r)
-        {
-            addRunnable(r, pri);
-        }
-
-        void addRunnable(@NotNull Runnable r, @NotNull SearchService.PRIORITY pri);
-
-        void addResource(@NotNull String identifier, SearchService.PRIORITY pri);
+        void addRunnable(Container container, @NotNull SearchService.PRIORITY pri, @NotNull Runnable r);
 
         void addResource(@NotNull WebdavResource r, SearchService.PRIORITY pri);
-
-        default <T> void addResourceList(List<T> list, int batchSize, Function<T,WebdavResource> mapper)
-        {
-            ListUtils.partition(list, batchSize).forEach(sublist ->
-            {
-                addRunnable(() ->
-                    sublist.stream()
-                        .map(mapper)
-                        .filter(Objects::nonNull)
-                        .forEach(doc -> addResource(doc, PRIORITY.item))
-                    , PRIORITY.group);
-            });
-        }
     }
 
 

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -129,23 +129,12 @@ public interface SearchService extends SearchMXBean
         /** Only used by the no-op task to detect when there is no other work in the queue */
         idle,
 
-        /** Lowest priority used for real indexing work. Intended for Runnables placed in the queue as part of a call to DocumentProvider.enumerateDocuments() */
-        crawlLow,
-        /** Intended for individual resources found during a crawl, such as a wiki or sample */
-        crawlHigh,
-
-        /** Intended for parent items that were touched by a server action. For example, a sample type that may in turn trigger indexing of its child samples */
-        modifiedLow,
-        /** Intended for individual items that were touched by a server action */
-        modifiedHigh,
-
+        /** Lower priority indexing work. Intended for work placed in the queue as part of a call to DocumentProvider.enumerateDocuments() */
+        crawl,
+        /** Intended for content that needed indexing or reindexing because it was modified or created */
+        modified,
         /** Highest priority. Used for removing documents from the index, which is generally faster than adding */
         delete;
-
-        public PRIORITY getOneHigher()
-        {
-            return ordinal() == values().length - 1 ? delete : values()[ordinal() - 1];
-        }
     }
 
 
@@ -467,10 +456,12 @@ public interface SearchService extends SearchMXBean
     interface DocumentProvider
     {
         /**
-         * enumerate documents for full text search
+         * Enumerate documents for full-text search. Unless it's known there will be a small number of documents
+         * added to the queue, add Runnable to the IndexTask that adds the Resources from the container to the queue.
+         * If there are potentially many documents for a container, add resources in batches of 1,000 or so to avoid
+         * a huge memory footprint.
          *
-         * modifiedSince == null -> full reindex
-         * else incremental (either modified > modifiedSince, or modified > lastIndexed)
+         * @param modifiedSince when null, do a full reindex; otherwise incremental (either modified > modifiedSince, or modified > lastIndexed)
          */
         void enumerateDocuments(IndexTask task, @NotNull Container c, @Nullable Date modifiedSince);
 

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.api.search;
 
-import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -63,11 +62,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 public interface SearchService extends SearchMXBean
 {
@@ -122,19 +119,33 @@ public interface SearchService extends SearchMXBean
      */
     boolean drainQueue(@NotNull PRIORITY priority, long timeout, @NotNull TimeUnit unit) throws InterruptedException;
 
-    /** From lowest to highest priority */
+    /**
+     * From lowest to highest priority
+     */
     enum PRIORITY
     {
+        /** Lowest priority. Used for internal bookkeeping to commit the search index to disk and other upkeep */
         commit,
-        
-        idle,       // only used to detect when there is no other work to do
-        crawl,      // lowest work priority
-        background, // crawler item
+        /** Only used by the no-op task to detect when there is no other work in the queue */
+        idle,
 
-        bulk,       // all wikis
-        group,      // one container
-        item,       // one page/attachment
-        delete
+        /** Lowest priority used for real indexing work. Intended for Runnables placed in the queue as part of a call to DocumentProvider.enumerateDocuments() */
+        crawlLow,
+        /** Intended for individual resources found during a crawl, such as a wiki or sample */
+        crawlHigh,
+
+        /** Intended for parent items that were touched by a server action. For example, a sample type that may in turn trigger indexing of its child samples */
+        modifiedLow,
+        /** Intended for individual items that were touched by a server action */
+        modifiedHigh,
+
+        /** Highest priority. Used for removing documents from the index, which is generally faster than adding */
+        delete;
+
+        public PRIORITY getOneHigher()
+        {
+            return ordinal() == values().length - 1 ? delete : values()[ordinal() - 1];
+        }
     }
 
 
@@ -181,8 +192,6 @@ public interface SearchService extends SearchMXBean
     {
         String getDescription();
 
-        int getDocumentCountEstimate();
-
         int getIndexedCount();
 
         int getFailedCount();
@@ -195,17 +204,24 @@ public interface SearchService extends SearchMXBean
 
         Reader getLog();
 
-        void addToEstimate(int i);// indicates that caller is done adding Resources to this task
-
         /**
          * indicates that we're done adding the initial set of resources/runnables to this task
          * the task be considered done after calling setReady() and there is no more work to do.
          */
         void setReady();
 
-        void addRunnable(Container container, @NotNull SearchService.PRIORITY pri, @NotNull Runnable r);
+        /**
+         * Runnables are used to queue up search work that will often involve adding many individual resources.
+         * This lets us avoid holding lots of to-be-index resources in memory all at once.
+         * @param container optionally, the container associated with the indexer work. Used to purge work from the queue when a container is about to be deleted */
+        void addRunnable(@Nullable Container container, @NotNull SearchService.PRIORITY pri, @NotNull Runnable r);
 
-        void addResource(@NotNull WebdavResource r, SearchService.PRIORITY pri);
+        /**
+         * Resources are individual documents that should be added to the index
+         * @param r
+         * @param pri
+         */
+        void addResource(@NotNull WebdavResource r, @NotNull SearchService.PRIORITY pri);
     }
 
 

--- a/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
@@ -28,8 +28,8 @@ public class AssayBatchDocumentProvider implements SearchService.DocumentProvide
     @Override
     public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
-        Runnable runEnumerate = () -> AssayManager.get().indexAssayBatches(task, c, modifiedSince, SearchService.PRIORITY.crawlHigh);
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, runEnumerate);
+        Runnable runEnumerate = () -> AssayManager.get().indexAssayBatches(task, c, modifiedSince, SearchService.PRIORITY.crawl);
+        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
     }
 
     private static SearchService.SearchCategory getSearchCategory()

--- a/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
@@ -29,7 +29,7 @@ public class AssayBatchDocumentProvider implements SearchService.DocumentProvide
     public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
         Runnable runEnumerate = () -> AssayManager.get().indexAssayBatches(task, c, modifiedSince);
-        task.addRunnable(runEnumerate, SearchService.PRIORITY.group);
+        task.addRunnable(c, SearchService.PRIORITY.group, runEnumerate);
     }
 
     private static SearchService.SearchCategory getSearchCategory()

--- a/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
@@ -3,7 +3,6 @@ package org.labkey.assay;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExperimentJSONConverter;
 import org.labkey.api.exp.api.ExperimentService;
@@ -26,10 +25,9 @@ import static org.labkey.api.util.StringUtilsLabKey.append;
 public class AssayBatchDocumentProvider implements SearchService.DocumentProvider
 {
     @Override
-    public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince)
     {
-        Runnable runEnumerate = () -> AssayManager.get().indexAssayBatches(task, c, modifiedSince, SearchService.PRIORITY.crawl);
-        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
+        queue.addRunnable((q) -> AssayManager.get().indexAssayBatches(q, modifiedSince));
     }
 
     private static SearchService.SearchCategory getSearchCategory()

--- a/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayBatchDocumentProvider.java
@@ -28,8 +28,8 @@ public class AssayBatchDocumentProvider implements SearchService.DocumentProvide
     @Override
     public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
-        Runnable runEnumerate = () -> AssayManager.get().indexAssayBatches(task, c, modifiedSince);
-        task.addRunnable(c, SearchService.PRIORITY.group, runEnumerate);
+        Runnable runEnumerate = () -> AssayManager.get().indexAssayBatches(task, c, modifiedSince, SearchService.PRIORITY.crawlHigh);
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, runEnumerate);
     }
 
     private static SearchService.SearchCategory getSearchCategory()

--- a/assay/src/org/labkey/assay/AssayDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayDocumentProvider.java
@@ -21,8 +21,8 @@ public class AssayDocumentProvider implements DocumentProvider
     @Override
     public void enumerateDocuments(IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
-        Runnable runEnumerate = () -> AssayService.get().indexAssays(task, c, SearchService.PRIORITY.crawlHigh);
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, runEnumerate);
+        Runnable runEnumerate = () -> AssayService.get().indexAssays(task, c, SearchService.PRIORITY.crawl);
+        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
     }
 
     public static SearchService.ResourceResolver getSearchResolver()

--- a/assay/src/org/labkey/assay/AssayDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayDocumentProvider.java
@@ -22,7 +22,7 @@ public class AssayDocumentProvider implements DocumentProvider
     public void enumerateDocuments(IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
         Runnable runEnumerate = () -> AssayService.get().indexAssays(task, c);
-        task.addRunnable(runEnumerate, SearchService.PRIORITY.group);
+        task.addRunnable(c, SearchService.PRIORITY.group, runEnumerate);
     }
 
     public static SearchService.ResourceResolver getSearchResolver()

--- a/assay/src/org/labkey/assay/AssayDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayDocumentProvider.java
@@ -5,12 +5,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.assay.AssayService;
-import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.search.SearchService.DocumentProvider;
-import org.labkey.api.search.SearchService.IndexTask;
 import org.labkey.api.security.User;
 
 import java.util.Date;
@@ -19,10 +17,9 @@ import java.util.Map;
 public class AssayDocumentProvider implements DocumentProvider
 {
     @Override
-    public void enumerateDocuments(IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince)
     {
-        Runnable runEnumerate = () -> AssayService.get().indexAssays(task, c, SearchService.PRIORITY.crawl);
-        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
+        queue.addRunnable((q) -> AssayService.get().indexAssays(q));
     }
 
     public static SearchService.ResourceResolver getSearchResolver()

--- a/assay/src/org/labkey/assay/AssayDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayDocumentProvider.java
@@ -21,8 +21,8 @@ public class AssayDocumentProvider implements DocumentProvider
     @Override
     public void enumerateDocuments(IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
-        Runnable runEnumerate = () -> AssayService.get().indexAssays(task, c);
-        task.addRunnable(c, SearchService.PRIORITY.group, runEnumerate);
+        Runnable runEnumerate = () -> AssayService.get().indexAssays(task, c, SearchService.PRIORITY.crawlHigh);
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, runEnumerate);
     }
 
     public static SearchService.ResourceResolver getSearchResolver()

--- a/assay/src/org/labkey/assay/AssayExperimentListener.java
+++ b/assay/src/org/labkey/assay/AssayExperimentListener.java
@@ -26,7 +26,7 @@ public class AssayExperimentListener implements ExperimentListener
     @Override
     public void afterExperimentSaved(Container c, User user, ExpExperiment experiment)
     {
-        AssayManager.get().indexAssayBatch(experiment.getRowId(), SearchService.PRIORITY.modified);
+        AssayManager.get().indexAssayBatch(SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified), experiment);
     }
 
     @Override
@@ -41,6 +41,6 @@ public class AssayExperimentListener implements ExperimentListener
     @Override
     public void afterRunSaved(Container container, User user, ExpProtocol protocol, ExpRun run)
     {
-        AssayManager.get().indexAssayRun(run.getRowId(), SearchService.PRIORITY.modified);
+        AssayManager.get().indexAssayRun(SearchService.get().defaultTask().getQueue(container, SearchService.PRIORITY.modified), run.getRowId());
     }
 }

--- a/assay/src/org/labkey/assay/AssayExperimentListener.java
+++ b/assay/src/org/labkey/assay/AssayExperimentListener.java
@@ -7,6 +7,7 @@ import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentListener;
+import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 
 import java.util.List;
@@ -25,7 +26,7 @@ public class AssayExperimentListener implements ExperimentListener
     @Override
     public void afterExperimentSaved(Container c, User user, ExpExperiment experiment)
     {
-        AssayManager.get().indexAssayBatch(experiment.getRowId());
+        AssayManager.get().indexAssayBatch(experiment.getRowId(), SearchService.PRIORITY.modifiedHigh);
     }
 
     @Override
@@ -40,6 +41,6 @@ public class AssayExperimentListener implements ExperimentListener
     @Override
     public void afterRunSaved(Container container, User user, ExpProtocol protocol, ExpRun run)
     {
-        AssayManager.get().indexAssayRun(run.getRowId());
+        AssayManager.get().indexAssayRun(run.getRowId(), SearchService.PRIORITY.modifiedHigh);
     }
 }

--- a/assay/src/org/labkey/assay/AssayExperimentListener.java
+++ b/assay/src/org/labkey/assay/AssayExperimentListener.java
@@ -26,7 +26,7 @@ public class AssayExperimentListener implements ExperimentListener
     @Override
     public void afterExperimentSaved(Container c, User user, ExpExperiment experiment)
     {
-        AssayManager.get().indexAssayBatch(experiment.getRowId(), SearchService.PRIORITY.modifiedHigh);
+        AssayManager.get().indexAssayBatch(experiment.getRowId(), SearchService.PRIORITY.modified);
     }
 
     @Override
@@ -41,6 +41,6 @@ public class AssayExperimentListener implements ExperimentListener
     @Override
     public void afterRunSaved(Container container, User user, ExpProtocol protocol, ExpRun run)
     {
-        AssayManager.get().indexAssayRun(run.getRowId(), SearchService.PRIORITY.modifiedHigh);
+        AssayManager.get().indexAssayRun(run.getRowId(), SearchService.PRIORITY.modified);
     }
 }

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -620,22 +620,18 @@ public class AssayManager implements AssayService
      * the names and comments from all the runs.
      */
     @Override
-    public void indexAssays(SearchService.IndexTask task, Container c, SearchService.PRIORITY priority)
+    public void indexAssays(SearchService.TaskIndexingQueue queue)
     {
-        SearchService ss = SearchService.get();
-
-        if (null == ss)
-            return;
-
-        List<ExpProtocol> protocols = getAssayProtocols(c);
+        List<ExpProtocol> protocols = getAssayProtocols(queue.getContainer());
 
         for (ExpProtocol protocol : protocols)
-            indexAssay(task, c, protocol, priority);
+            indexAssay(queue, protocol);
     }
 
     @Override
-    public void indexAssay(SearchService.IndexTask task, Container c, ExpProtocol protocol, SearchService.PRIORITY priority)
+    public void indexAssay(SearchService.TaskIndexingQueue queue, ExpProtocol protocol)
     {
+        Container c = queue.getContainer();
         AssayProvider provider = getProvider(protocol);
 
         if (null == provider || null == c)
@@ -677,7 +673,7 @@ public class AssayManager implements AssayService
 
         String docId = protocol.getDocumentId();
         WebdavResource r = new SimpleDocumentResource(new Path(docId), docId, c.getEntityId(), "text/plain", body.toString(), assayBeginURL, createdBy, created, modifiedBy, modified, m);
-        task.addResource(r, SearchService.PRIORITY.modified);
+        queue.addResource(r);
     }
 
     private boolean shouldIndexBatch(ExpExperiment batch)
@@ -712,94 +708,71 @@ public class AssayManager implements AssayService
         return expRun != null && getProvider(expRun) != null && expRun.getReplacedByRun() == null;
     }
 
-    public void indexAssayBatch(int expRunRowId, SearchService.PRIORITY priority)
-    {
-        ExpRun run = ExperimentService.get().getExpRun(expRunRowId);
-        if (run == null)
-            return;
-
-        SearchService ss = SearchService.get();
-        if (ss == null)
-            return;
-
-        ExpExperiment batch = run.getBatch();
-        if (shouldIndexBatch(batch))
-            indexAssayBatch(ss.defaultTask(), batch, priority);
-    }
-
-    private void indexAssayBatch(@NotNull SearchService.IndexTask task, ExpExperiment batch, SearchService.PRIORITY priority)
+    public void indexAssayBatch(@NotNull SearchService.TaskIndexingQueue queue, ExpExperiment batch)
     {
         WebdavResource resource = AssayBatchDocumentProvider.createDocument(batch);
-        task.addResource(resource, priority);
+        queue.addResource(resource);
     }
 
-    public void indexAssayBatches(SearchService.IndexTask task, Container c, @Nullable Date modifiedSince, SearchService.PRIORITY priority)
+    public void indexAssayBatches(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince)
     {
-        for (ExpProtocol protocol : getAssayProtocols(c))
+        for (ExpProtocol protocol : getAssayProtocols(queue.getContainer()))
         {
             if (shouldIndexProtocolBatches(protocol))
-                indexAssayBatches(task, protocol, modifiedSince, priority);
+                indexAssayBatches(queue, protocol, modifiedSince);
         }
     }
 
-    private void indexAssayBatches(SearchService.IndexTask task, ExpProtocol protocol, @Nullable Date modifiedSince, SearchService.PRIORITY priority)
+    private void indexAssayBatches(SearchService.TaskIndexingQueue queue, ExpProtocol protocol, @Nullable Date modifiedSince)
     {
         if (shouldIndexProtocolBatches(protocol))
         {
             for (ExpExperiment batch : protocol.getBatches())
             {
                 if (modifiedSince == null || modifiedSince.before(batch.getModified()))
-                    indexAssayBatch(task, batch, priority);
+                    indexAssayBatch(queue, batch);
             }
         }
     }
 
-    public void indexAssayRuns(SearchService.IndexTask task, Container c, @Nullable Date modifiedSince, SearchService.PRIORITY priority)
+    public void indexAssayRuns(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince)
     {
-        for (ExpProtocol protocol : getAssayProtocols(c))
-            indexAssayRuns(task, c, protocol, modifiedSince, priority);
+        for (ExpProtocol protocol : getAssayProtocols(queue.getContainer()))
+            indexAssayRuns(queue, protocol, modifiedSince);
     }
 
-    private void indexAssayRuns(SearchService.IndexTask task, Container c, ExpProtocol protocol, @Nullable Date modifiedSince, SearchService.PRIORITY priority)
+    private void indexAssayRuns(SearchService.TaskIndexingQueue queue, ExpProtocol protocol, @Nullable Date modifiedSince)
     {
-        ExperimentService.get().getExpRuns(c, protocol, null, run ->
+        ExperimentService.get().getExpRuns(queue.getContainer(), protocol, null, run ->
                 modifiedSince == null || modifiedSince.before(run.getModified())
-        ).forEach(r -> indexAssayRun(task, r, priority));
+        ).forEach(r -> indexAssayRun(queue, r));
     }
 
     @Override
-    public void indexAssayRun(int expRunRowId, SearchService.PRIORITY priority)
+    public void indexAssayRun(SearchService.TaskIndexingQueue queue, int expRunRowId)
     {
-        SearchService ss = SearchService.get();
-        if (ss == null)
-            return;
-
         ExpRun expRun = ExperimentService.get().getExpRun(expRunRowId);
         if (expRun == null)
             return;
         
         if (shouldIndexRun(expRun))
-            indexAssayRun(ss.defaultTask(), ExperimentService.get().getExpRun(expRunRowId), priority);
+            indexAssayRun(queue, ExperimentService.get().getExpRun(expRunRowId));
     }
 
-    private void indexAssayRun(SearchService.IndexTask task, ExpRun run, SearchService.PRIORITY priority)
+    private void indexAssayRun(SearchService.TaskIndexingQueue queue, ExpRun run)
     {
         if (run == null)
             return;
 
         WebdavResource resource = AssayRunDocumentProvider.createDocument(run);
-        task.addResource(resource, priority);
+        queue.addResource(resource);
     }
 
     @Override
     public void deindexAssays(@NotNull Collection<? extends ExpProtocol> expProtocols)
     {
-        SearchService ss = SearchService.get();
-        if (null == ss)
-            return;
-
         for (ExpProtocol protocol : expProtocols)
-            ss.deleteResource(protocol.getDocumentId());
+            SearchService.get().deleteResource(protocol.getDocumentId());
     }
 
     @Override
@@ -808,15 +781,11 @@ public class AssayManager implements AssayService
         if (expRuns == null || expRuns.isEmpty())
             return;
 
-        SearchService ss = SearchService.get();
-        if (null == ss)
-            return;
-
         Set<String> documentIds = new HashSet<>();
         for (ExpRun expRun : expRuns)
             documentIds.add(AssayRunDocumentProvider.getDocumentId(expRun));
 
-        ss.deleteResources(documentIds);
+        SearchService.get().deleteResources(documentIds);
     }
 
     public void deindexAssayBatches(Collection<? extends ExpExperiment> batches)
@@ -824,15 +793,11 @@ public class AssayManager implements AssayService
         if (batches == null || batches.isEmpty())
             return;
 
-        SearchService ss = SearchService.get();
-        if (null == ss)
-            return;
-
         Set<String> documentIds = new HashSet<>();
         for (ExpExperiment batch : batches)
             documentIds.add(AssayBatchDocumentProvider.getDocumentId(batch));
 
-        ss.deleteResources(documentIds);
+        SearchService.get().deleteResources(documentIds);
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -677,7 +677,7 @@ public class AssayManager implements AssayService
 
         String docId = protocol.getDocumentId();
         WebdavResource r = new SimpleDocumentResource(new Path(docId), docId, c.getEntityId(), "text/plain", body.toString(), assayBeginURL, createdBy, created, modifiedBy, modified, m);
-        task.addResource(r, SearchService.PRIORITY.modifiedHigh);
+        task.addResource(r, SearchService.PRIORITY.modified);
     }
 
     private boolean shouldIndexBatch(ExpExperiment batch)

--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -620,7 +620,7 @@ public class AssayManager implements AssayService
      * the names and comments from all the runs.
      */
     @Override
-    public void indexAssays(SearchService.IndexTask task, Container c)
+    public void indexAssays(SearchService.IndexTask task, Container c, SearchService.PRIORITY priority)
     {
         SearchService ss = SearchService.get();
 
@@ -630,11 +630,11 @@ public class AssayManager implements AssayService
         List<ExpProtocol> protocols = getAssayProtocols(c);
 
         for (ExpProtocol protocol : protocols)
-            indexAssay(task, c, protocol);
+            indexAssay(task, c, protocol, priority);
     }
 
     @Override
-    public void indexAssay(SearchService.IndexTask task, Container c, ExpProtocol protocol)
+    public void indexAssay(SearchService.IndexTask task, Container c, ExpProtocol protocol, SearchService.PRIORITY priority)
     {
         AssayProvider provider = getProvider(protocol);
 
@@ -677,7 +677,7 @@ public class AssayManager implements AssayService
 
         String docId = protocol.getDocumentId();
         WebdavResource r = new SimpleDocumentResource(new Path(docId), docId, c.getEntityId(), "text/plain", body.toString(), assayBeginURL, createdBy, created, modifiedBy, modified, m);
-        task.addResource(r, SearchService.PRIORITY.item);
+        task.addResource(r, SearchService.PRIORITY.modifiedHigh);
     }
 
     private boolean shouldIndexBatch(ExpExperiment batch)
@@ -712,7 +712,7 @@ public class AssayManager implements AssayService
         return expRun != null && getProvider(expRun) != null && expRun.getReplacedByRun() == null;
     }
 
-    public void indexAssayBatch(int expRunRowId)
+    public void indexAssayBatch(int expRunRowId, SearchService.PRIORITY priority)
     {
         ExpRun run = ExperimentService.get().getExpRun(expRunRowId);
         if (run == null)
@@ -724,51 +724,51 @@ public class AssayManager implements AssayService
 
         ExpExperiment batch = run.getBatch();
         if (shouldIndexBatch(batch))
-            indexAssayBatch(ss.defaultTask(), batch);
+            indexAssayBatch(ss.defaultTask(), batch, priority);
     }
 
-    private void indexAssayBatch(@NotNull SearchService.IndexTask task, ExpExperiment batch)
+    private void indexAssayBatch(@NotNull SearchService.IndexTask task, ExpExperiment batch, SearchService.PRIORITY priority)
     {
         WebdavResource resource = AssayBatchDocumentProvider.createDocument(batch);
-        task.addResource(resource, SearchService.PRIORITY.item);
+        task.addResource(resource, priority);
     }
 
-    public void indexAssayBatches(SearchService.IndexTask task, Container c, @Nullable Date modifiedSince)
+    public void indexAssayBatches(SearchService.IndexTask task, Container c, @Nullable Date modifiedSince, SearchService.PRIORITY priority)
     {
         for (ExpProtocol protocol : getAssayProtocols(c))
         {
             if (shouldIndexProtocolBatches(protocol))
-                indexAssayBatches(task, protocol, modifiedSince);
+                indexAssayBatches(task, protocol, modifiedSince, priority);
         }
     }
 
-    private void indexAssayBatches(SearchService.IndexTask task, ExpProtocol protocol, @Nullable Date modifiedSince)
+    private void indexAssayBatches(SearchService.IndexTask task, ExpProtocol protocol, @Nullable Date modifiedSince, SearchService.PRIORITY priority)
     {
         if (shouldIndexProtocolBatches(protocol))
         {
             for (ExpExperiment batch : protocol.getBatches())
             {
                 if (modifiedSince == null || modifiedSince.before(batch.getModified()))
-                    indexAssayBatch(task, batch);
+                    indexAssayBatch(task, batch, priority);
             }
         }
     }
 
-    public void indexAssayRuns(SearchService.IndexTask task, Container c, @Nullable Date modifiedSince)
+    public void indexAssayRuns(SearchService.IndexTask task, Container c, @Nullable Date modifiedSince, SearchService.PRIORITY priority)
     {
         for (ExpProtocol protocol : getAssayProtocols(c))
-            indexAssayRuns(task, c, protocol, modifiedSince);
+            indexAssayRuns(task, c, protocol, modifiedSince, priority);
     }
 
-    private void indexAssayRuns(SearchService.IndexTask task, Container c, ExpProtocol protocol, @Nullable Date modifiedSince)
+    private void indexAssayRuns(SearchService.IndexTask task, Container c, ExpProtocol protocol, @Nullable Date modifiedSince, SearchService.PRIORITY priority)
     {
         ExperimentService.get().getExpRuns(c, protocol, null, run ->
-                        modifiedSince == null || modifiedSince.before(run.getModified())
-                ).forEach(r -> indexAssayRun(task, r));
+                modifiedSince == null || modifiedSince.before(run.getModified())
+        ).forEach(r -> indexAssayRun(task, r, priority));
     }
 
     @Override
-    public void indexAssayRun(int expRunRowId)
+    public void indexAssayRun(int expRunRowId, SearchService.PRIORITY priority)
     {
         SearchService ss = SearchService.get();
         if (ss == null)
@@ -779,16 +779,16 @@ public class AssayManager implements AssayService
             return;
         
         if (shouldIndexRun(expRun))
-            indexAssayRun(ss.defaultTask(), ExperimentService.get().getExpRun(expRunRowId));
+            indexAssayRun(ss.defaultTask(), ExperimentService.get().getExpRun(expRunRowId), priority);
     }
 
-    private void indexAssayRun(SearchService.IndexTask task, ExpRun run)
+    private void indexAssayRun(SearchService.IndexTask task, ExpRun run, SearchService.PRIORITY priority)
     {
         if (run == null)
             return;
 
         WebdavResource resource = AssayRunDocumentProvider.createDocument(run);
-        task.addResource(resource, SearchService.PRIORITY.item);
+        task.addResource(resource, priority);
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
@@ -28,8 +28,8 @@ public class AssayRunDocumentProvider implements SearchService.DocumentProvider
     @Override
     public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
-        Runnable runEnumerate = () -> AssayManager.get().indexAssayRuns(task, c, modifiedSince, SearchService.PRIORITY.crawlHigh);
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, runEnumerate);
+        Runnable runEnumerate = () -> AssayManager.get().indexAssayRuns(task, c, modifiedSince, SearchService.PRIORITY.crawl);
+        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
     }
 
     private static SearchService.SearchCategory getSearchCategory()

--- a/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
@@ -3,7 +3,6 @@ package org.labkey.assay;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.data.Container;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentJSONConverter;
 import org.labkey.api.exp.api.ExperimentService;
@@ -26,10 +25,9 @@ import static org.labkey.api.util.StringUtilsLabKey.append;
 public class AssayRunDocumentProvider implements SearchService.DocumentProvider
 {
     @Override
-    public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince)
     {
-        Runnable runEnumerate = () -> AssayManager.get().indexAssayRuns(task, c, modifiedSince, SearchService.PRIORITY.crawl);
-        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
+        queue.addRunnable((q) -> AssayManager.get().indexAssayRuns(q, modifiedSince));
     }
 
     private static SearchService.SearchCategory getSearchCategory()

--- a/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
@@ -28,8 +28,8 @@ public class AssayRunDocumentProvider implements SearchService.DocumentProvider
     @Override
     public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
-        Runnable runEnumerate = () -> AssayManager.get().indexAssayRuns(task, c, modifiedSince);
-        task.addRunnable(c, SearchService.PRIORITY.group, runEnumerate);
+        Runnable runEnumerate = () -> AssayManager.get().indexAssayRuns(task, c, modifiedSince, SearchService.PRIORITY.crawlHigh);
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, runEnumerate);
     }
 
     private static SearchService.SearchCategory getSearchCategory()

--- a/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
+++ b/assay/src/org/labkey/assay/AssayRunDocumentProvider.java
@@ -29,7 +29,7 @@ public class AssayRunDocumentProvider implements SearchService.DocumentProvider
     public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
         Runnable runEnumerate = () -> AssayManager.get().indexAssayRuns(task, c, modifiedSince);
-        task.addRunnable(runEnumerate, SearchService.PRIORITY.group);
+        task.addRunnable(c, SearchService.PRIORITY.group, runEnumerate);
     }
 
     private static SearchService.SearchCategory getSearchCategory()

--- a/assay/src/org/labkey/assay/plate/PlateDocumentProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateDocumentProvider.java
@@ -32,7 +32,7 @@ public class PlateDocumentProvider implements SearchService.DocumentProvider
     public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
         Runnable runEnumerate = () -> PlateManager.get().indexPlates(task, c, modifiedSince);
-        task.addRunnable(c, SearchService.PRIORITY.group, runEnumerate);
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, runEnumerate);
     }
 
     private static SearchService.SearchCategory getSearchCategory()

--- a/assay/src/org/labkey/assay/plate/PlateDocumentProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateDocumentProvider.java
@@ -32,7 +32,7 @@ public class PlateDocumentProvider implements SearchService.DocumentProvider
     public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
         Runnable runEnumerate = () -> PlateManager.get().indexPlates(task, c, modifiedSince);
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, runEnumerate);
+        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
     }
 
     private static SearchService.SearchCategory getSearchCategory()

--- a/assay/src/org/labkey/assay/plate/PlateDocumentProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateDocumentProvider.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.assay.plate.Plate;
 import org.labkey.api.assay.plate.PlateType;
-import org.labkey.api.data.Container;
 import org.labkey.api.exp.Lsid;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
@@ -29,10 +28,9 @@ import static org.labkey.api.util.StringUtilsLabKey.append;
 public class PlateDocumentProvider implements SearchService.DocumentProvider
 {
     @Override
-    public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince)
     {
-        Runnable runEnumerate = () -> PlateManager.get().indexPlates(task, c, modifiedSince);
-        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
+        queue.addRunnable((q) -> PlateManager.get().indexPlates(q, modifiedSince));
     }
 
     private static SearchService.SearchCategory getSearchCategory()

--- a/assay/src/org/labkey/assay/plate/PlateDocumentProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateDocumentProvider.java
@@ -32,7 +32,7 @@ public class PlateDocumentProvider implements SearchService.DocumentProvider
     public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
         Runnable runEnumerate = () -> PlateManager.get().indexPlates(task, c, modifiedSince);
-        task.addRunnable(runEnumerate, SearchService.PRIORITY.group);
+        task.addRunnable(c, SearchService.PRIORITY.group, runEnumerate);
     }
 
     private static SearchService.SearchCategory getSearchCategory()

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2218,7 +2218,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     private void indexPlate(SearchService.IndexTask task, @NotNull Plate plate)
     {
         WebdavResource resource = PlateDocumentProvider.createDocument(plate);
-        task.addResource(resource, SearchService.PRIORITY.modifiedHigh);
+        task.addResource(resource, SearchService.PRIORITY.modified);
     }
 
     public void indexPlates(SearchService.IndexTask task, Container c, @Nullable Date modifiedSince)
@@ -2244,7 +2244,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     private void indexPlateSet(SearchService.IndexTask task, @NotNull PlateSet plateSet)
     {
         WebdavResource resource = PlateSetDocumentProvider.createDocument(plateSet);
-        task.addResource(resource, SearchService.PRIORITY.modifiedHigh);
+        task.addResource(resource, SearchService.PRIORITY.modified);
     }
 
     public void indexPlateSets(SearchService.IndexTask task, Container c, @Nullable Date modifiedSince)

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -1271,8 +1271,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             transaction.addCommitTask(() -> {
                 clearCache(container, plate);
                 indexPlate(container, plateRowId, false);
-                if (plate.getPlateSet() != null && SearchService.get() != null)
-                    indexPlateSet(SearchService.get().defaultTask(), plate.getPlateSet());
+                if (plate.getPlateSet() != null)
+                    indexPlateSet(SearchService.get().defaultTask().getQueue(container, SearchService.PRIORITY.modified), plate.getPlateSet());
             }, DbScope.CommitTaskOption.POSTCOMMIT);
             transaction.commit();
 
@@ -2167,14 +2167,10 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
     private void deindexPlates(Collection<Lsid> plateLsids)
     {
-        SearchService ss = SearchService.get();
-        if (ss == null)
-            return;
-
         Set<String> documentIds = new HashSet<>();
         for (Lsid lsid : plateLsids)
             documentIds.add(PlateDocumentProvider.getDocumentId(lsid));
-        ss.deleteResources(documentIds);
+        SearchService.get().deleteResources(documentIds);
     }
 
     private void pausePlateIndexing()
@@ -2206,63 +2202,61 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         else
         {
             Plate plate = getPlate(c, plateRowId);
-            SearchService ss = SearchService.get();
 
-            if (ss == null || plate == null)
+            if (plate == null)
                 return;
 
-            indexPlate(ss.defaultTask(), plate);
+            indexPlate(SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified), plate);
         }
     }
 
-    private void indexPlate(SearchService.IndexTask task, @NotNull Plate plate)
+    private void indexPlate(SearchService.TaskIndexingQueue queue, @NotNull Plate plate)
     {
         WebdavResource resource = PlateDocumentProvider.createDocument(plate);
-        task.addResource(resource, SearchService.PRIORITY.modified);
+        queue.addResource(resource);
     }
 
-    public void indexPlates(SearchService.IndexTask task, Container c, @Nullable Date modifiedSince)
+    public void indexPlates(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince)
     {
+        Container c = queue.getContainer();
         for (Plate plate : getPlates(c))
         {
             if (modifiedSince == null || modifiedSince.before(((PlateImpl) plate).getModified()))
-                indexPlate(task, plate);
+                indexPlate(queue, plate);
         }
     }
 
     public void indexPlateSet(Container container, Integer plateSetRowId)
     {
         PlateSet plateSet = getPlateSet(container, plateSetRowId);
-        SearchService ss = SearchService.get();
 
-        if (ss == null || plateSet == null)
+        if (plateSet == null)
             return;
 
-        indexPlateSet(ss.defaultTask(), plateSet);
+        indexPlateSet(SearchService.get().defaultTask().getQueue(container, SearchService.PRIORITY.modified), plateSet);
     }
 
-    private void indexPlateSet(SearchService.IndexTask task, @NotNull PlateSet plateSet)
+    private void indexPlateSet(SearchService.TaskIndexingQueue queue, @NotNull PlateSet plateSet)
     {
         WebdavResource resource = PlateSetDocumentProvider.createDocument(plateSet);
-        task.addResource(resource, SearchService.PRIORITY.modified);
+        queue.addResource(resource);
     }
 
-    public void indexPlateSets(SearchService.IndexTask task, Container c, @Nullable Date modifiedSince)
+    public void indexPlateSets(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince)
     {
-        for (PlateSet plateset : getPlateSets(c))
+        for (PlateSet plateset : getPlateSets(queue.getContainer()))
         {
             if (modifiedSince == null || modifiedSince.before(((PlateSetImpl) plateset).getModified()))
-                indexPlateSet(task, plateset);
+                indexPlateSet(queue, plateset);
         }
     }
 
     public static void deindexPlateSet(Container container, Integer plateSetRowId)
     {
-        SearchService ss = SearchService.get();
-        if (ss == null || plateSetRowId == null)
+        if (plateSetRowId == null)
             return;
 
-        ss.deleteResources(Set.of(PlateSetDocumentProvider.getDocumentId(container, plateSetRowId)));
+        SearchService.get().deleteResources(Set.of(PlateSetDocumentProvider.getDocumentId(container, plateSetRowId)));
     }
 
     /**
@@ -2830,8 +2824,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
             tx.commit();
         }
 
-        if (plateSet != null && SearchService.get() != null)
-            indexPlateSet(SearchService.get().defaultTask(), plateSet);
+        if (plateSet != null)
+            indexPlateSet(SearchService.get().defaultTask().getQueue(container, SearchService.PRIORITY.modified), plateSet);
 
         return plateSet;
     }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -2218,7 +2218,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     private void indexPlate(SearchService.IndexTask task, @NotNull Plate plate)
     {
         WebdavResource resource = PlateDocumentProvider.createDocument(plate);
-        task.addResource(resource, SearchService.PRIORITY.item);
+        task.addResource(resource, SearchService.PRIORITY.modifiedHigh);
     }
 
     public void indexPlates(SearchService.IndexTask task, Container c, @Nullable Date modifiedSince)
@@ -2244,7 +2244,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
     private void indexPlateSet(SearchService.IndexTask task, @NotNull PlateSet plateSet)
     {
         WebdavResource resource = PlateSetDocumentProvider.createDocument(plateSet);
-        task.addResource(resource, SearchService.PRIORITY.item);
+        task.addResource(resource, SearchService.PRIORITY.modifiedHigh);
     }
 
     public void indexPlateSets(SearchService.IndexTask task, Container c, @Nullable Date modifiedSince)

--- a/assay/src/org/labkey/assay/plate/PlateSetDocumentProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetDocumentProvider.java
@@ -32,7 +32,7 @@ public class PlateSetDocumentProvider implements SearchService.DocumentProvider
     public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
         Runnable runEnumerate = () -> PlateManager.get().indexPlateSets(task, c, modifiedSince);
-        task.addRunnable(runEnumerate, SearchService.PRIORITY.group);
+        task.addRunnable(c, SearchService.PRIORITY.group, runEnumerate);
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/PlateSetDocumentProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetDocumentProvider.java
@@ -32,7 +32,7 @@ public class PlateSetDocumentProvider implements SearchService.DocumentProvider
     public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
         Runnable runEnumerate = () -> PlateManager.get().indexPlateSets(task, c, modifiedSince);
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, runEnumerate);
+        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/PlateSetDocumentProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetDocumentProvider.java
@@ -29,10 +29,9 @@ import static org.labkey.api.util.StringUtilsLabKey.append;
 public class PlateSetDocumentProvider implements SearchService.DocumentProvider
 {
     @Override
-    public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince)
     {
-        Runnable runEnumerate = () -> PlateManager.get().indexPlateSets(task, c, modifiedSince);
-        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
+        queue.addRunnable((q) -> PlateManager.get().indexPlateSets(q, modifiedSince));
     }
 
     @Override

--- a/assay/src/org/labkey/assay/plate/PlateSetDocumentProvider.java
+++ b/assay/src/org/labkey/assay/plate/PlateSetDocumentProvider.java
@@ -32,7 +32,7 @@ public class PlateSetDocumentProvider implements SearchService.DocumentProvider
     public void enumerateDocuments(SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
         Runnable runEnumerate = () -> PlateManager.get().indexPlateSets(task, c, modifiedSince);
-        task.addRunnable(c, SearchService.PRIORITY.group, runEnumerate);
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, runEnumerate);
     }
 
     @Override

--- a/core/src/org/labkey/core/CoreContainerListener.java
+++ b/core/src/org/labkey/core/CoreContainerListener.java
@@ -31,6 +31,7 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TestSchema;
 import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.view.Portal;
 
@@ -53,7 +54,9 @@ public class CoreContainerListener implements ContainerManager.ContainerListener
     {
         String message = auditMsg == null ? c.getContainerNoun(true) + " " + c.getName() + " was created" : auditMsg;
         addAuditEvent(user, c, message);
-        ((CoreModule)ModuleLoader.getInstance().getCoreModule()).enumerateDocuments(null, c, null);
+        SearchService ss = SearchService.get();
+        if (ss != null)
+            ((CoreModule)ModuleLoader.getInstance().getCoreModule()).enumerateDocuments(ss.defaultTask().getQueue(c, SearchService.PRIORITY.modified), null);
     }
 
     @Override
@@ -105,7 +108,7 @@ public class CoreContainerListener implements ContainerManager.ContainerListener
     {
         ContainerManager.ContainerPropertyChangeEvent evt = (ContainerManager.ContainerPropertyChangeEvent)propertyChangeEvent;
         Container c = evt.container;
-        ((CoreModule)ModuleLoader.getInstance().getCoreModule()).enumerateDocuments(null, c, null);
+        ((CoreModule) ModuleLoader.getInstance().getCoreModule()).enumerateDocuments(SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified), null);
 
         switch (evt.property)
         {

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1581,7 +1581,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                     UserManager.getUser(c.getCreatedBy()), c.getCreated(),
                     null, null,
                     properties);
-            (null==task?ss.defaultTask():task).addResource(doc, SearchService.PRIORITY.item);
+            (null==task?ss.defaultTask():task).addResource(doc, SearchService.PRIORITY.crawlHigh);
         };
         // running this asynchronously seems to expose race conditions in domain checking/creation
         // (null==task?ss.defaultTask():task).addRunnable(r, SearchService.PRIORITY.item);

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1581,7 +1581,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                     UserManager.getUser(c.getCreatedBy()), c.getCreated(),
                     null, null,
                     properties);
-            (null==task?ss.defaultTask():task).addResource(doc, SearchService.PRIORITY.crawlHigh);
+            (null==task?ss.defaultTask():task).addResource(doc, SearchService.PRIORITY.crawl);
         };
         // running this asynchronously seems to expose race conditions in domain checking/creation
         // (null==task?ss.defaultTask():task).addRunnable(r, SearchService.PRIORITY.item);

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1519,12 +1519,9 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     }
 
     @Override
-    public void enumerateDocuments(final SearchService.IndexTask task, @NotNull final Container c, Date since)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, Date since)
     {
-        final SearchService ss = SearchService.get();
-        if (ss == null)
-            return;
-
+        Container c = queue.getContainer();
         if (c.isRoot())
             return;
 
@@ -1581,10 +1578,8 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
                     UserManager.getUser(c.getCreatedBy()), c.getCreated(),
                     null, null,
                     properties);
-            (null==task?ss.defaultTask():task).addResource(doc, SearchService.PRIORITY.crawl);
+            queue.addResource(doc);
         };
-        // running this asynchronously seems to expose race conditions in domain checking/creation
-        // (null==task?ss.defaultTask():task).addRunnable(r, SearchService.PRIORITY.item);
         r.run();
     }
 

--- a/core/src/org/labkey/core/search/NoopSearchService.java
+++ b/core/src/org/labkey/core/search/NoopSearchService.java
@@ -43,14 +43,10 @@ public class NoopSearchService implements SearchService
     IndexTask _dummyTask = new IndexTask()
     {
         @Override
-        public void addRunnable(@NotNull Runnable r, @NotNull PRIORITY pri)
+        public void addRunnable(Container container, @NotNull PRIORITY pri, @NotNull Runnable r)
         {
         }
 
-        @Override
-        public void addResource(@NotNull String identifier, PRIORITY pri)
-        {
-        }
 
         @Override
         public void addResource(@NotNull WebdavResource r, PRIORITY pri)
@@ -193,7 +189,12 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
-    public boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit)
+    public void purgeForContainer(Container container)
+    {
+    }
+
+    @Override
+    public boolean drainQueue(@NotNull PRIORITY priority, long timeout, @NotNull TimeUnit unit)
     {
         return true;
     }

--- a/core/src/org/labkey/core/search/NoopSearchService.java
+++ b/core/src/org/labkey/core/search/NoopSearchService.java
@@ -49,7 +49,7 @@ public class NoopSearchService implements SearchService
 
 
         @Override
-        public void addResource(@NotNull WebdavResource r, PRIORITY pri)
+        public void addResource(@NotNull WebdavResource r, @NotNull PRIORITY pri)
         {
         }
 
@@ -68,12 +68,6 @@ public class NoopSearchService implements SearchService
         public boolean isCancelled()
         {
             return false;
-        }
-
-        @Override
-        public int getDocumentCountEstimate()
-        {
-            return 0;
         }
 
         @Override
@@ -109,11 +103,6 @@ public class NoopSearchService implements SearchService
         public Reader getLog()
         {
             return null;
-        }
-
-        @Override
-        public void addToEstimate(int i)
-        {
         }
 
         @Override

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -6504,7 +6504,7 @@ public class DavController extends SpringActionController
         
         SearchService ss = SearchService.get();
         if (null != ss)
-            ss.defaultTask().addResource(r, SearchService.PRIORITY.item);
+            ss.defaultTask().addResource(r, SearchService.PRIORITY.modifiedHigh);
     }
 
 

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -6504,7 +6504,7 @@ public class DavController extends SpringActionController
         
         SearchService ss = SearchService.get();
         if (null != ss)
-            ss.defaultTask().addResource(r, SearchService.PRIORITY.modifiedHigh);
+            ss.defaultTask().addResource(r, SearchService.PRIORITY.modified);
     }
 
 

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -6502,9 +6502,7 @@ public class DavController extends SpringActionController
         if (isTempFile(r))
             return;
         
-        SearchService ss = SearchService.get();
-        if (null != ss)
-            ss.defaultTask().addResource(r, SearchService.PRIORITY.modified);
+        SearchService.get().defaultTask().getQueue(ContainerManager.getForId(r.getContainerId()), SearchService.PRIORITY.modified).addResource(r);
     }
 
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -934,20 +934,20 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                     List<Integer> orderedRowIds = searchIndexDataKeys.orderedRowIds();
                     // Issue 51263: order by RowId to reduce deadlock
                     ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.group, () ->
+                            searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.modifiedLow, () ->
                                     scope.executeWithRetryReadOnly(tx -> {
                                         for (ExpDataImpl expData : experimentServiceImpl.getExpDatas(sublist))
-                                            expData.index(searchService.defaultTask(), null, this);
+                                            expData.index(SearchService.PRIORITY.modifiedHigh, searchService.defaultTask(), this);
                                         return (Void) null;
                                     }))
                     );
 
                     List<String> lsids = searchIndexDataKeys.lsids();
                     ListUtils.partition(lsids, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.group, () ->
+                            searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.modifiedLow, () ->
                                     scope.executeWithRetryReadOnly(tx -> {
                                         for (ExpDataImpl expData : experimentServiceImpl.getExpDatasByLSID(sublist))
-                                            expData.index(searchService.defaultTask(), null, this);
+                                            expData.index(SearchService.PRIORITY.modifiedHigh, searchService.defaultTask(), this);
                                         return (Void) null;
                                     }))
                     );
@@ -1431,10 +1431,10 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
                         // Issue 51263: order by RowId to reduce deadlock
                         ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                                searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.group, () ->
+                                searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.modifiedLow, () ->
                                 {
                                     for (ExpDataImpl expData : ExperimentServiceImpl.get().getExpDatas(sublist))
-                                        expData.index(null, null, _expDataClassDataTableImpl);
+                                        expData.index(SearchService.PRIORITY.modifiedHigh, null, _expDataClassDataTableImpl);
                                 })
                         );
                     }, DbScope.CommitTaskOption.POSTCOMMIT);

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -924,36 +924,34 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
         try
         {
             PersistDataIteratorBuilder step0 = new ExpDataIterators.PersistDataIteratorBuilder(data, this, propertiesTable, _dataClass, getUserSchema().getContainer(), getUserSchema().getUser(), _dataClass.getImportAliases(), null);
-            SearchService searchService = SearchService.get();
             ExperimentServiceImpl experimentServiceImpl = ExperimentServiceImpl.get();
-            if (null != searchService)
+            final var scope = propertiesTable.getSchema().getScope();
+            SearchService.TaskIndexingQueue queue = SearchService.get().defaultTask().getQueue(getContainer(), SearchService.PRIORITY.modified);
+            step0.setIndexFunction(searchIndexDataKeys -> scope.addCommitTask(() ->
             {
-                final var scope = propertiesTable.getSchema().getScope();
-                step0.setIndexFunction(searchIndexDataKeys -> scope.addCommitTask(() ->
-                {
-                    List<Integer> orderedRowIds = searchIndexDataKeys.orderedRowIds();
-                    // Issue 51263: order by RowId to reduce deadlock
-                    ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.modified, () ->
-                                    scope.executeWithRetryReadOnly(tx -> {
-                                        for (ExpDataImpl expData : experimentServiceImpl.getExpDatas(sublist))
-                                            expData.index(SearchService.PRIORITY.modified, searchService.defaultTask(), this);
-                                        return (Void) null;
-                                    }))
-                    );
+                List<Integer> orderedRowIds = searchIndexDataKeys.orderedRowIds();
+                // Issue 51263: order by RowId to reduce deadlock
+                ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
+                        queue.addRunnable((q) ->
+                                scope.executeWithRetryReadOnly(tx -> {
+                                    for (ExpDataImpl expData : experimentServiceImpl.getExpDatas(sublist))
+                                        expData.index(q, this);
+                                    return (Void) null;
+                                }))
+                );
 
-                    List<String> lsids = searchIndexDataKeys.lsids();
-                    ListUtils.partition(lsids, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.modified, () ->
-                                    scope.executeWithRetryReadOnly(tx -> {
-                                        for (ExpDataImpl expData : experimentServiceImpl.getExpDatasByLSID(sublist))
-                                            expData.index(SearchService.PRIORITY.modified, searchService.defaultTask(), this);
-                                        return (Void) null;
-                                    }))
-                    );
+                List<String> lsids = searchIndexDataKeys.lsids();
+                ListUtils.partition(lsids, 100).forEach(sublist ->
+                        queue.addRunnable((q) ->
+                                scope.executeWithRetryReadOnly(tx -> {
+                                    for (ExpDataImpl expData : experimentServiceImpl.getExpDatasByLSID(sublist))
+                                        expData.index(q, this);
+                                    return (Void) null;
+                                }))
+                );
 
-                }, DbScope.CommitTaskOption.POSTCOMMIT));
-            }
+            }, DbScope.CommitTaskOption.POSTCOMMIT));
+
             DataIteratorBuilder builder = LoggingDataIterator.wrap(step0);
             return LoggingDataIterator.wrap(new AliasDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), ExperimentService.get().getTinfoDataAliasMap()));
         }
@@ -1414,31 +1412,27 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             {
                 results = super.updateRows(user, container, rows, oldKeys, errors, configParameters, extraScriptContext);
 
-                SearchService searchService = SearchService.get();
-                if (searchService != null)
+                DbScope scope = getUserSchema().getDbSchema().getScope();
+                scope.addCommitTask(() ->
                 {
-                    DbScope scope = getUserSchema().getDbSchema().getScope();
-                    scope.addCommitTask(() ->
+                    List<Integer> orderedRowIds = new ArrayList<>();
+                    for (Map<String, Object> result : results)
                     {
-                        List<Integer> orderedRowIds = new ArrayList<>();
-                        for (Map<String, Object> result : results)
-                        {
-                            Integer rowId = (Integer) result.get(RowId.name());
-                            if (rowId != null)
-                                orderedRowIds.add(rowId);
-                        }
-                        Collections.sort(orderedRowIds);
+                        Integer rowId = (Integer) result.get(RowId.name());
+                        if (rowId != null)
+                            orderedRowIds.add(rowId);
+                    }
+                    Collections.sort(orderedRowIds);
 
-                        // Issue 51263: order by RowId to reduce deadlock
-                        ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                                searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.modified, () ->
-                                {
-                                    for (ExpDataImpl expData : ExperimentServiceImpl.get().getExpDatas(sublist))
-                                        expData.index(SearchService.PRIORITY.modified, null, _expDataClassDataTableImpl);
-                                })
-                        );
-                    }, DbScope.CommitTaskOption.POSTCOMMIT);
-                }
+                    // Issue 51263: order by RowId to reduce deadlock
+                    ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
+                            SearchService.get().defaultTask().getQueue(_dataClass.getContainer(), SearchService.PRIORITY.modified).addRunnable((q) ->
+                            {
+                                for (ExpDataImpl expData : ExperimentServiceImpl.get().getExpDatas(sublist))
+                                    expData.index(q, null);
+                            })
+                    );
+                }, DbScope.CommitTaskOption.POSTCOMMIT);
 
                 /* setup mini dataiterator pipeline to process lineage */
                 DataIterator di = _toDataIteratorBuilder("updateRows.lineage", results).getDataIterator(new DataIteratorContext());

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -934,7 +934,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                     List<Integer> orderedRowIds = searchIndexDataKeys.orderedRowIds();
                     // Issue 51263: order by RowId to reduce deadlock
                     ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
+                            searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.group, () ->
                                     scope.executeWithRetryReadOnly(tx -> {
                                         for (ExpDataImpl expData : experimentServiceImpl.getExpDatas(sublist))
                                             expData.index(searchService.defaultTask(), null, this);
@@ -944,7 +944,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
                     List<String> lsids = searchIndexDataKeys.lsids();
                     ListUtils.partition(lsids, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
+                            searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.group, () ->
                                     scope.executeWithRetryReadOnly(tx -> {
                                         for (ExpDataImpl expData : experimentServiceImpl.getExpDatasByLSID(sublist))
                                             expData.index(searchService.defaultTask(), null, this);
@@ -1431,7 +1431,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
                         // Issue 51263: order by RowId to reduce deadlock
                         ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                                searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
+                                searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.group, () ->
                                 {
                                     for (ExpDataImpl expData : ExperimentServiceImpl.get().getExpDatas(sublist))
                                         expData.index(null, null, _expDataClassDataTableImpl);

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -934,20 +934,20 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                     List<Integer> orderedRowIds = searchIndexDataKeys.orderedRowIds();
                     // Issue 51263: order by RowId to reduce deadlock
                     ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.modifiedLow, () ->
+                            searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.modified, () ->
                                     scope.executeWithRetryReadOnly(tx -> {
                                         for (ExpDataImpl expData : experimentServiceImpl.getExpDatas(sublist))
-                                            expData.index(SearchService.PRIORITY.modifiedHigh, searchService.defaultTask(), this);
+                                            expData.index(SearchService.PRIORITY.modified, searchService.defaultTask(), this);
                                         return (Void) null;
                                     }))
                     );
 
                     List<String> lsids = searchIndexDataKeys.lsids();
                     ListUtils.partition(lsids, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.modifiedLow, () ->
+                            searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.modified, () ->
                                     scope.executeWithRetryReadOnly(tx -> {
                                         for (ExpDataImpl expData : experimentServiceImpl.getExpDatasByLSID(sublist))
-                                            expData.index(SearchService.PRIORITY.modifiedHigh, searchService.defaultTask(), this);
+                                            expData.index(SearchService.PRIORITY.modified, searchService.defaultTask(), this);
                                         return (Void) null;
                                     }))
                     );
@@ -1431,10 +1431,10 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
                         // Issue 51263: order by RowId to reduce deadlock
                         ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                                searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.modifiedLow, () ->
+                                searchService.defaultTask().addRunnable(_dataClass.getContainer(), SearchService.PRIORITY.modified, () ->
                                 {
                                     for (ExpDataImpl expData : ExperimentServiceImpl.get().getExpDatas(sublist))
-                                        expData.index(SearchService.PRIORITY.modifiedHigh, null, _expDataClassDataTableImpl);
+                                        expData.index(SearchService.PRIORITY.modified, null, _expDataClassDataTableImpl);
                                 })
                         );
                     }, DbScope.CommitTaskOption.POSTCOMMIT);

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
@@ -127,7 +127,7 @@ public void setUp()
 public void tearDown() throws InterruptedException
 {
     // Wait for the indexer to finish working on the data we just added to help avoid deadlocks
-    SearchService.get().drainQueue(SearchService.PRIORITY.crawl, 15, TimeUnit.SECONDS);
+    SearchService.get().drainQueue(SearchService.PRIORITY.crawlLow, 15, TimeUnit.SECONDS);
     ContainerManager.deleteAll(c, TestContext.get().getUser());
 }
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
@@ -127,7 +127,7 @@ public void setUp()
 public void tearDown() throws InterruptedException
 {
     // Wait for the indexer to finish working on the data we just added to help avoid deadlocks
-    SearchService.get().drainQueue(SearchService.PRIORITY.crawlLow, 15, TimeUnit.SECONDS);
+    SearchService.get().drainQueue(SearchService.PRIORITY.crawl, 15, TimeUnit.SECONDS);
     ContainerManager.deleteAll(c, TestContext.get().getUser());
 }
 

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
@@ -46,6 +46,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.DataClassReadPermission;
@@ -313,7 +314,7 @@ public class ExpDataClassTableImpl extends ExpTableImpl<ExpDataClassTable.Column
 
             ExperimentServiceImpl.get().clearDataClassCache(c);
             dc = ExperimentServiceImpl.get().getDataClass(c, rowId); // retrieve the new data class with updated domain
-            ExperimentServiceImpl.get().indexDataClass(dc);
+            ExperimentServiceImpl.get().indexDataClass(dc, SearchService.PRIORITY.modifiedHigh);
 
             return ret;
         }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
@@ -314,7 +314,7 @@ public class ExpDataClassTableImpl extends ExpTableImpl<ExpDataClassTable.Column
 
             ExperimentServiceImpl.get().clearDataClassCache(c);
             dc = ExperimentServiceImpl.get().getDataClass(c, rowId); // retrieve the new data class with updated domain
-            ExperimentServiceImpl.get().indexDataClass(dc, SearchService.PRIORITY.modified);
+            ExperimentServiceImpl.get().indexDataClass(dc, SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified));
 
             return ret;
         }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassTableImpl.java
@@ -314,7 +314,7 @@ public class ExpDataClassTableImpl extends ExpTableImpl<ExpDataClassTable.Column
 
             ExperimentServiceImpl.get().clearDataClassCache(c);
             dc = ExperimentServiceImpl.get().getDataClass(c, rowId); // retrieve the new data class with updated domain
-            ExperimentServiceImpl.get().indexDataClass(dc, SearchService.PRIORITY.modifiedHigh);
+            ExperimentServiceImpl.get().indexDataClass(dc, SearchService.PRIORITY.modified);
 
             return ret;
         }

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -179,7 +179,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         super.setComment(user, comment);
 
         if (index)
-            index(SearchService.PRIORITY.modified);
+            index(SearchService.get().defaultTask().getQueue(getContainer(), SearchService.PRIORITY.modified), null);
     }
 
     @Override
@@ -267,7 +267,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
                 Table.insert(user, dataClass.getTinfo(), map);
             }
         }
-        index(SearchService.PRIORITY.modified);
+        index(SearchService.get().defaultTask().getQueue(getContainer(), SearchService.PRIORITY.modified), null);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -179,7 +179,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         super.setComment(user, comment);
 
         if (index)
-            index();
+            index(SearchService.PRIORITY.modifiedHigh);
     }
 
     @Override
@@ -267,7 +267,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
                 Table.insert(user, dataClass.getTinfo(), map);
             }
         }
-        index();
+        index(SearchService.PRIORITY.modifiedHigh);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -179,7 +179,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
         super.setComment(user, comment);
 
         if (index)
-            index(SearchService.PRIORITY.modifiedHigh);
+            index(SearchService.PRIORITY.modified);
     }
 
     @Override
@@ -267,7 +267,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
                 Table.insert(user, dataClass.getTinfo(), map);
             }
         }
-        index(SearchService.PRIORITY.modifiedHigh);
+        index(SearchService.PRIORITY.modified);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -315,7 +315,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
             }
         }
 
-        index(SearchService.PRIORITY.modifiedHigh);
+        index(SearchService.PRIORITY.modified);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -315,7 +315,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
             }
         }
 
-        index(SearchService.PRIORITY.modified);
+        index(SearchService.get().defaultTask().getQueue(getContainer(), SearchService.PRIORITY.modified), null);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -315,7 +315,7 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
             }
         }
 
-        index();
+        index(SearchService.PRIORITY.modifiedHigh);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1608,7 +1608,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
                         // Issue 51263: order by RowId to reduce deadlock
                         ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
+                            searchService.defaultTask().addRunnable(_ss.getContainer(), SearchService.PRIORITY.group, () ->
                             {
                                 for (ExpMaterialImpl expMaterial : experimentServiceImpl.getExpMaterials(sublist))
                                     expMaterial.index(searchService.defaultTask(), null, this);
@@ -1616,7 +1616,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                         );
 
                         ListUtils.partition(lsids, 100).forEach(sublist ->
-                                searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
+                                searchService.defaultTask().addRunnable(_ss.getContainer(), SearchService.PRIORITY.group, () ->
                                 {
                                     for (ExpMaterialImpl expMaterial : experimentServiceImpl.getExpMaterialsByLsid(sublist))
                                         expMaterial.index(searchService.defaultTask(), null, this);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1608,18 +1608,18 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
                         // Issue 51263: order by RowId to reduce deadlock
                         ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(_ss.getContainer(), SearchService.PRIORITY.modifiedLow, () ->
+                            searchService.defaultTask().addRunnable(_ss.getContainer(), SearchService.PRIORITY.modified, () ->
                             {
                                 for (ExpMaterialImpl expMaterial : experimentServiceImpl.getExpMaterials(sublist))
-                                    expMaterial.index(SearchService.PRIORITY.modifiedHigh, searchService.defaultTask(), this);
+                                    expMaterial.index(SearchService.PRIORITY.modified, searchService.defaultTask(), this);
                             })
                         );
 
                         ListUtils.partition(lsids, 100).forEach(sublist ->
-                                searchService.defaultTask().addRunnable(_ss.getContainer(), SearchService.PRIORITY.modifiedLow, () ->
+                                searchService.defaultTask().addRunnable(_ss.getContainer(), SearchService.PRIORITY.modified, () ->
                                 {
                                     for (ExpMaterialImpl expMaterial : experimentServiceImpl.getExpMaterialsByLsid(sublist))
-                                        expMaterial.index(SearchService.PRIORITY.modifiedHigh, searchService.defaultTask(), this);
+                                        expMaterial.index(SearchService.PRIORITY.modified, searchService.defaultTask(), this);
                                 })
                         );
                     }, DbScope.CommitTaskOption.POSTCOMMIT)

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1608,18 +1608,18 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
                         // Issue 51263: order by RowId to reduce deadlock
                         ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(_ss.getContainer(), SearchService.PRIORITY.group, () ->
+                            searchService.defaultTask().addRunnable(_ss.getContainer(), SearchService.PRIORITY.modifiedLow, () ->
                             {
                                 for (ExpMaterialImpl expMaterial : experimentServiceImpl.getExpMaterials(sublist))
-                                    expMaterial.index(searchService.defaultTask(), null, this);
+                                    expMaterial.index(SearchService.PRIORITY.modifiedHigh, searchService.defaultTask(), this);
                             })
                         );
 
                         ListUtils.partition(lsids, 100).forEach(sublist ->
-                                searchService.defaultTask().addRunnable(_ss.getContainer(), SearchService.PRIORITY.group, () ->
+                                searchService.defaultTask().addRunnable(_ss.getContainer(), SearchService.PRIORITY.modifiedLow, () ->
                                 {
                                     for (ExpMaterialImpl expMaterial : experimentServiceImpl.getExpMaterialsByLsid(sublist))
-                                        expMaterial.index(searchService.defaultTask(), null, this);
+                                        expMaterial.index(SearchService.PRIORITY.modifiedHigh, searchService.defaultTask(), this);
                                 })
                         );
                     }, DbScope.CommitTaskOption.POSTCOMMIT)

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1596,35 +1596,32 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         {
             var persist = new ExpDataIterators.PersistDataIteratorBuilder(data, this, propertiesTable, _ss, getUserSchema().getContainer(), getUserSchema().getUser(), _ss.getImportAliases(), sampleTypeObjectId)
                     .setFileLinkDirectory(SAMPLETYPE_FILE_DIRECTORY);
-            SearchService searchService = SearchService.get();
             ExperimentServiceImpl experimentServiceImpl = ExperimentServiceImpl.get();
+            SearchService.TaskIndexingQueue queue = SearchService.get().defaultTask().getQueue(getContainer(), SearchService.PRIORITY.modified);
 
-            if (null != searchService)
-            {
-                persist.setIndexFunction(searchIndexDataKeys -> propertiesTable.getSchema().getScope().addCommitTask(() ->
-                    {
-                        List<String> lsids = searchIndexDataKeys.lsids();
-                        List<Integer> orderedRowIds = searchIndexDataKeys.orderedRowIds();
+            persist.setIndexFunction(searchIndexDataKeys -> propertiesTable.getSchema().getScope().addCommitTask(() ->
+                {
+                    List<String> lsids = searchIndexDataKeys.lsids();
+                    List<Integer> orderedRowIds = searchIndexDataKeys.orderedRowIds();
 
-                        // Issue 51263: order by RowId to reduce deadlock
-                        ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(_ss.getContainer(), SearchService.PRIORITY.modified, () ->
+                    // Issue 51263: order by RowId to reduce deadlock
+                    ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
+                        queue.addRunnable((q) ->
+                        {
+                            for (ExpMaterialImpl expMaterial : experimentServiceImpl.getExpMaterials(sublist))
+                                expMaterial.index(q, this);
+                        })
+                    );
+
+                    ListUtils.partition(lsids, 100).forEach(sublist ->
+                            queue.addRunnable((q) ->
                             {
-                                for (ExpMaterialImpl expMaterial : experimentServiceImpl.getExpMaterials(sublist))
-                                    expMaterial.index(SearchService.PRIORITY.modified, searchService.defaultTask(), this);
+                                for (ExpMaterialImpl expMaterial : experimentServiceImpl.getExpMaterialsByLsid(sublist))
+                                    expMaterial.index(q, this);
                             })
-                        );
-
-                        ListUtils.partition(lsids, 100).forEach(sublist ->
-                                searchService.defaultTask().addRunnable(_ss.getContainer(), SearchService.PRIORITY.modified, () ->
-                                {
-                                    for (ExpMaterialImpl expMaterial : experimentServiceImpl.getExpMaterialsByLsid(sublist))
-                                        expMaterial.index(SearchService.PRIORITY.modified, searchService.defaultTask(), this);
-                                })
-                        );
-                    }, DbScope.CommitTaskOption.POSTCOMMIT)
-                );
-            }
+                    );
+                }, DbScope.CommitTaskOption.POSTCOMMIT)
+            );
 
             DataIteratorBuilder builder = LoggingDataIterator.wrap(persist);
             return LoggingDataIterator.wrap(new AliasDataIteratorBuilder(builder, getUserSchema().getContainer(), getUserSchema().getUser(), ExperimentService.get().getTinfoMaterialAliasMap()));

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
@@ -120,7 +120,7 @@ public void setUp()
 public void tearDown() throws InterruptedException
 {
     // Wait for the indexer to finish working on the data we just added to help avoid deadlocks
-    SearchService.get().drainQueue(SearchService.PRIORITY.crawlLow, 15, TimeUnit.SECONDS);
+    SearchService.get().drainQueue(SearchService.PRIORITY.crawl, 15, TimeUnit.SECONDS);
     ContainerManager.deleteAll(c, TestContext.get().getUser());
 }
 

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
@@ -120,7 +120,7 @@ public void setUp()
 public void tearDown() throws InterruptedException
 {
     // Wait for the indexer to finish working on the data we just added to help avoid deadlocks
-    SearchService.get().drainQueue(SearchService.PRIORITY.crawl, 15, TimeUnit.SECONDS);
+    SearchService.get().drainQueue(SearchService.PRIORITY.crawlLow, 15, TimeUnit.SECONDS);
     ContainerManager.deleteAll(c, TestContext.get().getUser());
 }
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -979,25 +979,25 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     private static final int INDEXING_LIMIT = 1_000;
 
     @Override
-    public void enumerateDocuments(final @NotNull SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, final Date modifiedSince)
     {
-        task.addRunnable(c, SearchService.PRIORITY.crawl, () -> {
-            for (ExpSampleTypeImpl sampleType : getIndexableSampleTypes(c, modifiedSince))
+        queue.addRunnable((a) -> {
+            for (ExpSampleTypeImpl sampleType : getIndexableSampleTypes(queue.getContainer(), modifiedSince))
             {
-                sampleType.index(SearchService.PRIORITY.crawl, task);
+                sampleType.index(queue, null);
             }
         });
 
-        task.addRunnable(c, SearchService.PRIORITY.crawl, () -> indexMaterials(task, c, modifiedSince, 0, SearchService.PRIORITY.crawl));
+        queue.addRunnable((q) -> indexMaterials(q, modifiedSince, 0));
 
-        task.addRunnable(c, SearchService.PRIORITY.crawl, () -> {
-            for (ExpDataClassImpl dataClass : getIndexableDataClasses(c, modifiedSince))
+        queue.addRunnable((q) -> {
+            for (ExpDataClassImpl dataClass : getIndexableDataClasses(q.getContainer(), modifiedSince))
             {
-                dataClass.index(SearchService.PRIORITY.crawl, task);
+                dataClass.index(q, null);
             }
         });
 
-        task.addRunnable(c, SearchService.PRIORITY.crawl, () -> indexData(task, c, modifiedSince, 0, SearchService.PRIORITY.crawl));
+        queue.addRunnable((q) -> indexData(q, modifiedSince, 0));
     }
 
     @Override
@@ -1016,8 +1016,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
     }
 
-    private void indexMaterials(final @NotNull SearchService.IndexTask task, final @NotNull Container container, final Date modifiedSince, int minRowId, SearchService.PRIORITY priority)
+    private void indexMaterials(final @NotNull SearchService.TaskIndexingQueue queue, final Date modifiedSince, int minRowId)
     {
+        Container container = queue.getContainer();
         final String materialAlias = "_m_";
         final String materialIndexedAlias = "_mi_";
         // Big hack to prevent indexing study specimens and bogus samples created from some plate assays (Issue 46037). Also in ExpMaterialImpl.index()
@@ -1042,19 +1043,20 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         List<Material> materials = selector.getArrayList(Material.class);
         materials.forEach(m -> {
             ExpMaterialImpl expMaterial = new ExpMaterialImpl(m);
-            expMaterial.index(SearchService.PRIORITY.crawl, task);
+            expMaterial.index(queue, null);
             maxRowIdProcessed.setValue(Math.max(maxRowIdProcessed.getValue(), expMaterial.getRowId()));
         });
 
         if (materials.size() == INDEXING_LIMIT)
         {
             // Requeue for the next batch. This avoids overwhelming the indexer's queue with documents
-            task.addRunnable(container, priority, () -> indexMaterials(task, container, modifiedSince, maxRowIdProcessed.getValue(), priority));
+            queue.addRunnable((q) -> indexMaterials(q, modifiedSince, maxRowIdProcessed.getValue()));
         }
     }
 
-    public void indexData(final @NotNull SearchService.IndexTask task, final @NotNull Container container, final Date modifiedSince, int minRowId, @NotNull SearchService.PRIORITY priority)
+    public void indexData(final @NotNull SearchService.TaskIndexingQueue queue, final Date modifiedSince, int minRowId)
     {
+        Container container = queue.getContainer();
         final String dataAlias = "_d_";
         final String dataIndexedAlias = "_di_";
 
@@ -1079,14 +1081,14 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         List<Data> data = selector.getArrayList(Data.class);
         data.forEach(d -> {
             ExpDataImpl expData = new ExpDataImpl(d);
-            expData.index(priority, task);
+            expData.index(queue, null);
             maxRowIdProcessed.setValue(Math.max(maxRowIdProcessed.getValue(), expData.getRowId()));
         });
 
         if (data.size() == INDEXING_LIMIT)
         {
             // Requeue for the next batch. This avoids overwhelming the indexer's queue with documents
-            task.addRunnable(container, priority, () -> indexData(task, container, modifiedSince, maxRowIdProcessed.getValue(), priority));
+            queue.addRunnable((q) -> indexData(q, modifiedSince, maxRowIdProcessed.getValue()));
         }
     }
 
@@ -1207,18 +1209,12 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 new Timestamp(ms), rowId);
     }
 
-    public void indexDataClass(ExpDataClassImpl dataClass, SearchService.PRIORITY priority)
+    public void indexDataClass(ExpDataClassImpl dataClass, SearchService.TaskIndexingQueue queue)
     {
         if (dataClass == null)
             return;
 
-        SearchService ss = SearchService.get();
-        if (ss == null)
-            return;
-
-        SearchService.IndexTask task = ss.defaultTask();
-
-        Runnable r = () -> {
+        queue.addRunnable((q) -> {
             Domain d = dataClass.getDomain();
             if (d == null)
                 return; // Domain may be null if the DataClass has been deleted
@@ -1227,14 +1223,12 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (table == null)
                 return;
 
-            indexDataClass(dataClass, task, priority);
-            indexDataClassData(dataClass, task, priority);
-        };
-
-        task.addRunnable(dataClass.getContainer(), priority, r);
+            indexDataClass(dataClass, q);
+            indexDataClassData(dataClass, q);
+        });
     }
 
-    private void indexDataClassData(ExpDataClassImpl dataClass, SearchService.IndexTask task, SearchService.PRIORITY priority)
+    private void indexDataClassData(ExpDataClassImpl dataClass, SearchService.TaskIndexingQueue queue)
     {
         TableInfo table = dataClass.getTinfo();
         // Index all ExpData that have never been indexed OR where either the ExpDataClass definition or ExpData itself has changed since last indexed
@@ -1252,27 +1246,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         var scope = table.getSchema().getScope();
         scope.executeWithRetryReadOnly(tx ->
                 new SqlSelector(scope, sql).forEachBatch(Data.class, 1000, batch ->
-                        task.addRunnable(dataClass.getContainer(), priority, () -> batch.forEach(data ->
-                                new ExpDataImpl(data).index(priority, task))
+                        queue.addRunnable((q) -> batch.forEach(data ->
+                                new ExpDataImpl(data).index(q, null))
                         )
                 ));
-    }
-
-    private void indexDataClass(ExpDataClass expDataClass, SearchService.IndexTask task, SearchService.PRIORITY priority)
-    {
-        // Index the data class if it has never been indexed OR it has changed since it was last indexed
-        SQLFragment sql = new SQLFragment("SELECT * FROM ")
-            .append(getTinfoDataClass(), "dc")
-            .append(" WHERE dc.LSID = ?").add(expDataClass.getLSID())
-            .append(" AND (dc.lastIndexed IS NULL OR dc.lastIndexed < ?)")
-            .add(expDataClass.getModified());
-
-        DataClass dClass = new SqlSelector(getExpSchema().getScope(), sql).getObject(DataClass.class);
-        if (dClass != null)
-        {
-            ExpDataClassImpl impl = new ExpDataClassImpl(dClass);
-            impl.index(priority, task);
-        }
     }
 
     private @Nullable ExpExperimentImpl getExpExperiment(SimpleFilter filter)
@@ -4371,7 +4348,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                     List<ExpRunImpl> replacedRuns = run.getReplacesRuns();
                     transaction.addCommitTask(() ->
                         replacedRuns.forEach(replacedRun ->
-                                AssayService.get().indexAssayRun(replacedRun.getRowId(), SearchService.PRIORITY.modified)
+                                AssayService.get().indexAssayRun(SearchService.get().defaultTask().getQueue(container, SearchService.PRIORITY.modified), replacedRun.getRowId())
                         ),
                         DbScope.CommitTaskOption.POSTCOMMIT
                     );
@@ -5037,14 +5014,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                     SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(st, SampleTypeServiceImpl.SampleChangeType.delete);
 
             // On successful commit, start task to remove items from search index
-            final SearchService ss = SearchService.get();
-            if (null != ss)
-            {
-                transaction.addCommitTask(
-                    // Use null as container because we want deletes to run even if the container is deleted
-                    () -> ss.defaultTask().addRunnable(null, SearchService.PRIORITY.delete, () -> ss.deleteResources(docids)),
-                    POSTCOMMIT);
-            }
+            transaction.addCommitTask(
+                // Use null as container because we want deletes to run even if the container is deleted
+                () -> SearchService.get().deleteResources(docids),
+                POSTCOMMIT);
 
             transaction.commit();
             if (timing != null)
@@ -5407,17 +5380,13 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             afterDeleteData(user, container, expDatas);
 
             // Remove from search index
-            SearchService ss = SearchService.get();
-            if (null != ss)
+            Set<String> documentIds = new HashSet<>();
+            for (ExpDataImpl data : ExpDataImpl.fromDatas(datas))
             {
-                Set<String> documentIds = new HashSet<>();
-                for (ExpDataImpl data : ExpDataImpl.fromDatas(datas))
-                {
-                    documentIds.add(data.getDocumentId());
-                }
-
-                transaction.addCommitTask(() -> ss.deleteResources(documentIds), POSTCOMMIT);
+                documentIds.add(data.getDocumentId());
             }
+
+            transaction.addCommitTask(() -> SearchService.get().deleteResources(documentIds), POSTCOMMIT);
 
             transaction.commit();
         }
@@ -6581,13 +6550,11 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             return;
 
         AssayService assayService = AssayService.get();
-        SearchService ss = SearchService.get();
 
-        if (assayService != null && ss != null)
+        if (assayService != null)
         {
-            SearchService.IndexTask task = ss.defaultTask();
-            Runnable runEnumerate = () -> assayService.indexAssay(task, protocol.getContainer(), new ExpProtocolImpl(protocol), SearchService.PRIORITY.modified);
-            task.addRunnable(protocol.getContainer(), SearchService.PRIORITY.modified, runEnumerate);
+            SearchService.get().defaultTask().getQueue(protocol.getContainer(), SearchService.PRIORITY.modified).addRunnable((q) ->
+                    assayService.indexAssay(q, new ExpProtocolImpl(protocol)));
         }
     }
 
@@ -7971,7 +7938,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(DataTypeForExclusion.DataClass, impl.getRowId(), c, u);
 
             tx.addCommitTask(() -> clearDataClassCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
-            tx.addCommitTask(() -> indexDataClass(getDataClass(c, bean.getName()), SearchService.PRIORITY.modified), POSTCOMMIT);
+            tx.addCommitTask(() -> indexDataClass(getDataClass(c, bean.getName()), SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified)), POSTCOMMIT);
             tx.commit();
         }
         catch (MetadataUnavailableException e)
@@ -8072,7 +8039,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (!errors.hasErrors())
             {
                 transaction.addCommitTask(() -> clearDataClassCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
-                transaction.addCommitTask(() -> indexDataClass(getDataClass(c, dataClass.getName()), SearchService.PRIORITY.modified), POSTCOMMIT);
+                transaction.addCommitTask(() -> indexDataClass(getDataClass(c, dataClass.getName()), SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified)), POSTCOMMIT);
                 transaction.commit();
             }
         }
@@ -9621,7 +9588,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 // update search index for moved data class object via indexDataClass() helper. It filters for data objects
                 // to index based on the modified date
                 for (ExpDataClass dataClass : dataClassesMap.keySet())
-                    indexDataClass((ExpDataClassImpl) dataClass, SearchService.PRIORITY.modified);
+                    indexDataClass((ExpDataClassImpl) dataClass, SearchService.get().defaultTask().getQueue(dataClass.getContainer(), SearchService.PRIORITY.modified));
             }, DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
             transaction.commit();
         }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -981,23 +981,23 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public void enumerateDocuments(final @NotNull SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
     {
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, () -> {
+        task.addRunnable(c, SearchService.PRIORITY.crawl, () -> {
             for (ExpSampleTypeImpl sampleType : getIndexableSampleTypes(c, modifiedSince))
             {
-                sampleType.index(SearchService.PRIORITY.crawlHigh, task);
+                sampleType.index(SearchService.PRIORITY.crawl, task);
             }
         });
 
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, () -> indexMaterials(task, c, modifiedSince, 0, SearchService.PRIORITY.crawlHigh));
+        task.addRunnable(c, SearchService.PRIORITY.crawl, () -> indexMaterials(task, c, modifiedSince, 0, SearchService.PRIORITY.crawl));
 
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, () -> {
+        task.addRunnable(c, SearchService.PRIORITY.crawl, () -> {
             for (ExpDataClassImpl dataClass : getIndexableDataClasses(c, modifiedSince))
             {
-                dataClass.index(SearchService.PRIORITY.crawlHigh, task);
+                dataClass.index(SearchService.PRIORITY.crawl, task);
             }
         });
 
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, () -> indexData(task, c, modifiedSince, 0, SearchService.PRIORITY.crawlHigh));
+        task.addRunnable(c, SearchService.PRIORITY.crawl, () -> indexData(task, c, modifiedSince, 0, SearchService.PRIORITY.crawl));
     }
 
     @Override
@@ -1042,7 +1042,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         List<Material> materials = selector.getArrayList(Material.class);
         materials.forEach(m -> {
             ExpMaterialImpl expMaterial = new ExpMaterialImpl(m);
-            expMaterial.index(SearchService.PRIORITY.crawlHigh, task);
+            expMaterial.index(SearchService.PRIORITY.crawl, task);
             maxRowIdProcessed.setValue(Math.max(maxRowIdProcessed.getValue(), expMaterial.getRowId()));
         });
 
@@ -1253,7 +1253,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         scope.executeWithRetryReadOnly(tx ->
                 new SqlSelector(scope, sql).forEachBatch(Data.class, 1000, batch ->
                         task.addRunnable(dataClass.getContainer(), priority, () -> batch.forEach(data ->
-                                new ExpDataImpl(data).index(priority.getOneHigher(), task))
+                                new ExpDataImpl(data).index(priority, task))
                         )
                 ));
     }
@@ -4371,7 +4371,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                     List<ExpRunImpl> replacedRuns = run.getReplacesRuns();
                     transaction.addCommitTask(() ->
                         replacedRuns.forEach(replacedRun ->
-                                AssayService.get().indexAssayRun(replacedRun.getRowId(), SearchService.PRIORITY.modifiedHigh)
+                                AssayService.get().indexAssayRun(replacedRun.getRowId(), SearchService.PRIORITY.modified)
                         ),
                         DbScope.CommitTaskOption.POSTCOMMIT
                     );
@@ -6586,8 +6586,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (assayService != null && ss != null)
         {
             SearchService.IndexTask task = ss.defaultTask();
-            Runnable runEnumerate = () -> assayService.indexAssay(task, protocol.getContainer(), new ExpProtocolImpl(protocol), SearchService.PRIORITY.modifiedLow);
-            task.addRunnable(protocol.getContainer(), SearchService.PRIORITY.modifiedHigh, runEnumerate);
+            Runnable runEnumerate = () -> assayService.indexAssay(task, protocol.getContainer(), new ExpProtocolImpl(protocol), SearchService.PRIORITY.modified);
+            task.addRunnable(protocol.getContainer(), SearchService.PRIORITY.modified, runEnumerate);
         }
     }
 
@@ -7971,7 +7971,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(DataTypeForExclusion.DataClass, impl.getRowId(), c, u);
 
             tx.addCommitTask(() -> clearDataClassCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
-            tx.addCommitTask(() -> indexDataClass(getDataClass(c, bean.getName()), SearchService.PRIORITY.modifiedLow), POSTCOMMIT);
+            tx.addCommitTask(() -> indexDataClass(getDataClass(c, bean.getName()), SearchService.PRIORITY.modified), POSTCOMMIT);
             tx.commit();
         }
         catch (MetadataUnavailableException e)
@@ -8072,7 +8072,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (!errors.hasErrors())
             {
                 transaction.addCommitTask(() -> clearDataClassCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
-                transaction.addCommitTask(() -> indexDataClass(getDataClass(c, dataClass.getName()), SearchService.PRIORITY.modifiedLow), POSTCOMMIT);
+                transaction.addCommitTask(() -> indexDataClass(getDataClass(c, dataClass.getName()), SearchService.PRIORITY.modified), POSTCOMMIT);
                 transaction.commit();
             }
         }
@@ -9621,7 +9621,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 // update search index for moved data class object via indexDataClass() helper. It filters for data objects
                 // to index based on the modified date
                 for (ExpDataClass dataClass : dataClassesMap.keySet())
-                    indexDataClass((ExpDataClassImpl) dataClass, SearchService.PRIORITY.modifiedLow);
+                    indexDataClass((ExpDataClassImpl) dataClass, SearchService.PRIORITY.modified);
             }, DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
             transaction.commit();
         }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -981,23 +981,23 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public void enumerateDocuments(final @NotNull SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
     {
-        task.addRunnable(() -> {
+        task.addRunnable(c, SearchService.PRIORITY.bulk, () -> {
             for (ExpSampleTypeImpl sampleType : getIndexableSampleTypes(c, modifiedSince))
             {
                 sampleType.index(task, SearchService.PRIORITY.bulk);
             }
-        }, SearchService.PRIORITY.bulk);
+        });
 
-        task.addRunnable(() -> indexMaterials(task, c, modifiedSince, 0), SearchService.PRIORITY.bulk);
+        task.addRunnable(c, SearchService.PRIORITY.bulk, () -> indexMaterials(task, c, modifiedSince, 0));
 
-        task.addRunnable(() -> {
+        task.addRunnable(c, SearchService.PRIORITY.bulk, () -> {
             for (ExpDataClassImpl dataClass : getIndexableDataClasses(c, modifiedSince))
             {
                 dataClass.index(task, SearchService.PRIORITY.bulk);
             }
-        }, SearchService.PRIORITY.bulk);
+        });
 
-        task.addRunnable(() -> indexData(task, c, modifiedSince, 0), SearchService.PRIORITY.bulk);
+        task.addRunnable(c, SearchService.PRIORITY.bulk, () -> indexData(task, c, modifiedSince, 0));
     }
 
     @Override
@@ -1049,7 +1049,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (materials.size() == INDEXING_LIMIT)
         {
             // Requeue for the next batch. This avoids overwhelming the indexer's queue with documents
-            task.addRunnable(() -> indexMaterials(task, container, modifiedSince, maxRowIdProcessed.getValue()), SearchService.PRIORITY.bulk);
+            task.addRunnable(container, SearchService.PRIORITY.bulk, () -> indexMaterials(task, container, modifiedSince, maxRowIdProcessed.getValue()));
         }
     }
 
@@ -1086,7 +1086,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (data.size() == INDEXING_LIMIT)
         {
             // Requeue for the next batch. This avoids overwhelming the indexer's queue with documents
-            task.addRunnable(() -> indexData(task, container, modifiedSince, maxRowIdProcessed.getValue()), SearchService.PRIORITY.bulk);
+            task.addRunnable(container, SearchService.PRIORITY.bulk, () -> indexData(task, container, modifiedSince, maxRowIdProcessed.getValue()));
         }
     }
 
@@ -1231,7 +1231,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             indexDataClassData(dataClass, task);
         };
 
-        task.addRunnable(r, SearchService.PRIORITY.bulk);
+        task.addRunnable(dataClass.getContainer(), SearchService.PRIORITY.bulk, r);
     }
 
     private void indexDataClassData(ExpDataClassImpl dataClass, SearchService.IndexTask task)
@@ -1252,9 +1252,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         var scope = table.getSchema().getScope();
         scope.executeWithRetryReadOnly(tx ->
             new SqlSelector(scope, sql).forEachBatch(Data.class, 1000, batch ->
-                    task.addRunnable(() -> batch.forEach(data ->
-                        new ExpDataImpl(data).index(task)),
-                    SearchService.PRIORITY.bulk)
+                    task.addRunnable(dataClass.getContainer(), SearchService.PRIORITY.bulk, () -> batch.forEach(data ->
+                        new ExpDataImpl(data).index(task))
+                    )
         ));
     }
 
@@ -5041,7 +5041,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (null != ss)
             {
                 transaction.addCommitTask(
-                    () -> ss.defaultTask().addRunnable(() -> ss.deleteResources(docids), SearchService.PRIORITY.bulk),
+                    // Use null as container because we want deletes to run even if the container is deleted
+                    () -> ss.defaultTask().addRunnable(null, SearchService.PRIORITY.bulk, () -> ss.deleteResources(docids)),
                     POSTCOMMIT);
             }
 
@@ -6586,7 +6587,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         {
             SearchService.IndexTask task = ss.defaultTask();
             Runnable runEnumerate = () -> assayService.indexAssay(task, protocol.getContainer(), new ExpProtocolImpl(protocol));
-            task.addRunnable(runEnumerate, SearchService.PRIORITY.item);
+            task.addRunnable(protocol.getContainer(), SearchService.PRIORITY.item, runEnumerate);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -981,23 +981,23 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public void enumerateDocuments(final @NotNull SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
     {
-        task.addRunnable(c, SearchService.PRIORITY.bulk, () -> {
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, () -> {
             for (ExpSampleTypeImpl sampleType : getIndexableSampleTypes(c, modifiedSince))
             {
-                sampleType.index(task, SearchService.PRIORITY.bulk);
+                sampleType.index(SearchService.PRIORITY.crawlHigh, task);
             }
         });
 
-        task.addRunnable(c, SearchService.PRIORITY.bulk, () -> indexMaterials(task, c, modifiedSince, 0));
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, () -> indexMaterials(task, c, modifiedSince, 0, SearchService.PRIORITY.crawlHigh));
 
-        task.addRunnable(c, SearchService.PRIORITY.bulk, () -> {
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, () -> {
             for (ExpDataClassImpl dataClass : getIndexableDataClasses(c, modifiedSince))
             {
-                dataClass.index(task, SearchService.PRIORITY.bulk);
+                dataClass.index(SearchService.PRIORITY.crawlHigh, task);
             }
         });
 
-        task.addRunnable(c, SearchService.PRIORITY.bulk, () -> indexData(task, c, modifiedSince, 0));
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, () -> indexData(task, c, modifiedSince, 0, SearchService.PRIORITY.crawlHigh));
     }
 
     @Override
@@ -1016,7 +1016,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         }
     }
 
-    private void indexMaterials(final @NotNull SearchService.IndexTask task, final @NotNull Container container, final Date modifiedSince, int minRowId)
+    private void indexMaterials(final @NotNull SearchService.IndexTask task, final @NotNull Container container, final Date modifiedSince, int minRowId, SearchService.PRIORITY priority)
     {
         final String materialAlias = "_m_";
         final String materialIndexedAlias = "_mi_";
@@ -1042,18 +1042,18 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         List<Material> materials = selector.getArrayList(Material.class);
         materials.forEach(m -> {
             ExpMaterialImpl expMaterial = new ExpMaterialImpl(m);
-            expMaterial.index(task, SearchService.PRIORITY.bulk);
+            expMaterial.index(SearchService.PRIORITY.crawlHigh, task);
             maxRowIdProcessed.setValue(Math.max(maxRowIdProcessed.getValue(), expMaterial.getRowId()));
         });
 
         if (materials.size() == INDEXING_LIMIT)
         {
             // Requeue for the next batch. This avoids overwhelming the indexer's queue with documents
-            task.addRunnable(container, SearchService.PRIORITY.bulk, () -> indexMaterials(task, container, modifiedSince, maxRowIdProcessed.getValue()));
+            task.addRunnable(container, priority, () -> indexMaterials(task, container, modifiedSince, maxRowIdProcessed.getValue(), priority));
         }
     }
 
-    public void indexData(final @NotNull SearchService.IndexTask task, final @NotNull Container container, final Date modifiedSince, int minRowId)
+    public void indexData(final @NotNull SearchService.IndexTask task, final @NotNull Container container, final Date modifiedSince, int minRowId, @NotNull SearchService.PRIORITY priority)
     {
         final String dataAlias = "_d_";
         final String dataIndexedAlias = "_di_";
@@ -1079,14 +1079,14 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         List<Data> data = selector.getArrayList(Data.class);
         data.forEach(d -> {
             ExpDataImpl expData = new ExpDataImpl(d);
-            expData.index(task, SearchService.PRIORITY.bulk);
+            expData.index(priority, task);
             maxRowIdProcessed.setValue(Math.max(maxRowIdProcessed.getValue(), expData.getRowId()));
         });
 
         if (data.size() == INDEXING_LIMIT)
         {
             // Requeue for the next batch. This avoids overwhelming the indexer's queue with documents
-            task.addRunnable(container, SearchService.PRIORITY.bulk, () -> indexData(task, container, modifiedSince, maxRowIdProcessed.getValue()));
+            task.addRunnable(container, priority, () -> indexData(task, container, modifiedSince, maxRowIdProcessed.getValue(), priority));
         }
     }
 
@@ -1207,7 +1207,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 new Timestamp(ms), rowId);
     }
 
-    public void indexDataClass(ExpDataClassImpl dataClass)
+    public void indexDataClass(ExpDataClassImpl dataClass, SearchService.PRIORITY priority)
     {
         if (dataClass == null)
             return;
@@ -1227,38 +1227,38 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (table == null)
                 return;
 
-            indexDataClass(dataClass, task);
-            indexDataClassData(dataClass, task);
+            indexDataClass(dataClass, task, priority);
+            indexDataClassData(dataClass, task, priority);
         };
 
-        task.addRunnable(dataClass.getContainer(), SearchService.PRIORITY.bulk, r);
+        task.addRunnable(dataClass.getContainer(), priority, r);
     }
 
-    private void indexDataClassData(ExpDataClassImpl dataClass, SearchService.IndexTask task)
+    private void indexDataClassData(ExpDataClassImpl dataClass, SearchService.IndexTask task, SearchService.PRIORITY priority)
     {
         TableInfo table = dataClass.getTinfo();
         // Index all ExpData that have never been indexed OR where either the ExpDataClass definition or ExpData itself has changed since last indexed
         SQLFragment sql = new SQLFragment()
-            .append("SELECT * FROM ").append(getTinfoData(), "d")
-            .append(" INNER JOIN ").append(table, "t")
-            .append(" ON t.lsid = d.lsid")
-            .append(" LEFT OUTER JOIN ").append(getTinfoDataIndexed(), "di")
-            .append(" ON d.RowId = di.DataId")
-            .append(" WHERE d.classId = ?").add(dataClass.getRowId())
-            .append(" AND (di.lastIndexed IS NULL OR di.lastIndexed < ? OR (d.modified IS NOT NULL AND di.lastIndexed < d.modified))")
-            .append(" ORDER BY d.RowId") // Issue 51263: order by RowId to reduce deadlock
+                .append("SELECT * FROM ").append(getTinfoData(), "d")
+                .append(" INNER JOIN ").append(table, "t")
+                .append(" ON t.lsid = d.lsid")
+                .append(" LEFT OUTER JOIN ").append(getTinfoDataIndexed(), "di")
+                .append(" ON d.RowId = di.DataId")
+                .append(" WHERE d.classId = ?").add(dataClass.getRowId())
+                .append(" AND (di.lastIndexed IS NULL OR di.lastIndexed < ? OR (d.modified IS NOT NULL AND di.lastIndexed < d.modified))")
+                .append(" ORDER BY d.RowId") // Issue 51263: order by RowId to reduce deadlock
                 .add(dataClass.getModified());
 
         var scope = table.getSchema().getScope();
         scope.executeWithRetryReadOnly(tx ->
-            new SqlSelector(scope, sql).forEachBatch(Data.class, 1000, batch ->
-                    task.addRunnable(dataClass.getContainer(), SearchService.PRIORITY.bulk, () -> batch.forEach(data ->
-                        new ExpDataImpl(data).index(task))
-                    )
-        ));
+                new SqlSelector(scope, sql).forEachBatch(Data.class, 1000, batch ->
+                        task.addRunnable(dataClass.getContainer(), priority, () -> batch.forEach(data ->
+                                new ExpDataImpl(data).index(priority.getOneHigher(), task))
+                        )
+                ));
     }
 
-    private void indexDataClass(ExpDataClass expDataClass, SearchService.IndexTask task)
+    private void indexDataClass(ExpDataClass expDataClass, SearchService.IndexTask task, SearchService.PRIORITY priority)
     {
         // Index the data class if it has never been indexed OR it has changed since it was last indexed
         SQLFragment sql = new SQLFragment("SELECT * FROM ")
@@ -1271,7 +1271,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (dClass != null)
         {
             ExpDataClassImpl impl = new ExpDataClassImpl(dClass);
-            impl.index(task);
+            impl.index(priority, task);
         }
     }
 
@@ -4371,7 +4371,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                     List<ExpRunImpl> replacedRuns = run.getReplacesRuns();
                     transaction.addCommitTask(() ->
                         replacedRuns.forEach(replacedRun ->
-                                AssayService.get().indexAssayRun(replacedRun.getRowId())
+                                AssayService.get().indexAssayRun(replacedRun.getRowId(), SearchService.PRIORITY.modifiedHigh)
                         ),
                         DbScope.CommitTaskOption.POSTCOMMIT
                     );
@@ -5042,7 +5042,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             {
                 transaction.addCommitTask(
                     // Use null as container because we want deletes to run even if the container is deleted
-                    () -> ss.defaultTask().addRunnable(null, SearchService.PRIORITY.bulk, () -> ss.deleteResources(docids)),
+                    () -> ss.defaultTask().addRunnable(null, SearchService.PRIORITY.delete, () -> ss.deleteResources(docids)),
                     POSTCOMMIT);
             }
 
@@ -6586,8 +6586,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         if (assayService != null && ss != null)
         {
             SearchService.IndexTask task = ss.defaultTask();
-            Runnable runEnumerate = () -> assayService.indexAssay(task, protocol.getContainer(), new ExpProtocolImpl(protocol));
-            task.addRunnable(protocol.getContainer(), SearchService.PRIORITY.item, runEnumerate);
+            Runnable runEnumerate = () -> assayService.indexAssay(task, protocol.getContainer(), new ExpProtocolImpl(protocol), SearchService.PRIORITY.modifiedLow);
+            task.addRunnable(protocol.getContainer(), SearchService.PRIORITY.modifiedHigh, runEnumerate);
         }
     }
 
@@ -7971,7 +7971,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(DataTypeForExclusion.DataClass, impl.getRowId(), c, u);
 
             tx.addCommitTask(() -> clearDataClassCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
-            tx.addCommitTask(() -> indexDataClass(getDataClass(c, bean.getName())), POSTCOMMIT);
+            tx.addCommitTask(() -> indexDataClass(getDataClass(c, bean.getName()), SearchService.PRIORITY.modifiedLow), POSTCOMMIT);
             tx.commit();
         }
         catch (MetadataUnavailableException e)
@@ -8072,7 +8072,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (!errors.hasErrors())
             {
                 transaction.addCommitTask(() -> clearDataClassCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
-                transaction.addCommitTask(() -> indexDataClass(getDataClass(c, dataClass.getName())), POSTCOMMIT);
+                transaction.addCommitTask(() -> indexDataClass(getDataClass(c, dataClass.getName()), SearchService.PRIORITY.modifiedLow), POSTCOMMIT);
                 transaction.commit();
             }
         }
@@ -9621,7 +9621,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 // update search index for moved data class object via indexDataClass() helper. It filters for data objects
                 // to index based on the modified date
                 for (ExpDataClass dataClass : dataClassesMap.keySet())
-                    indexDataClass((ExpDataClassImpl) dataClass);
+                    indexDataClass((ExpDataClassImpl) dataClass, SearchService.PRIORITY.modifiedLow);
             }, DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
             transaction.commit();
         }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -251,7 +251,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
         Runnable r = () -> {
             indexSampleType(sampleType, task, priority);
-            indexSampleTypeMaterials(sampleType, task, priority.getOneHigher());
+            indexSampleTypeMaterials(sampleType, task, priority);
         };
 
         task.addRunnable(sampleType.getContainer(), priority, r);
@@ -891,7 +891,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                         ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(ExperimentService.DataTypeForExclusion.DashboardSampleType, st.getRowId(), c, u);
                     transaction.addCommitTask(() -> clearMaterialSourceCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
                     transaction.addCommitTask(() -> {
-                        indexSampleType(SampleTypeService.get().getSampleType(domain.getTypeURI()), SearchService.PRIORITY.modifiedLow);
+                        indexSampleType(SampleTypeService.get().getSampleType(domain.getTypeURI()), SearchService.PRIORITY.modified);
                     }, POSTCOMMIT);
 
                     return st;
@@ -1131,7 +1131,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                         }
                     }
                 }, DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
-                transaction.addCommitTask(() -> SampleTypeServiceImpl.get().indexSampleType(st, SearchService.PRIORITY.modifiedLow), POSTCOMMIT);
+                transaction.addCommitTask(() -> SampleTypeServiceImpl.get().indexSampleType(st, SearchService.PRIORITY.modified), POSTCOMMIT);
                 transaction.commit();
                 refreshSampleTypeMaterializedView(st, SampleChangeType.schema);
             }
@@ -1929,7 +1929,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                     SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(sampleType, SampleChangeType.update);
                     // update search index for moved samples via indexSampleType() helper, it filters for samples to index
                     // based on the modified date
-                    SampleTypeServiceImpl.get().indexSampleType(sampleType, SearchService.PRIORITY.modifiedLow);
+                    SampleTypeServiceImpl.get().indexSampleType(sampleType, SearchService.PRIORITY.modified);
                 }
             }, DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -238,7 +238,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     }
 
     @Override
-    public void indexSampleType(ExpSampleType sampleType)
+    public void indexSampleType(ExpSampleType sampleType, SearchService.PRIORITY priority)
     {
         if (sampleType == null)
             return;
@@ -250,14 +250,14 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         SearchService.IndexTask task = ss.defaultTask();
 
         Runnable r = () -> {
-            indexSampleType(sampleType, task);
-            indexSampleTypeMaterials(sampleType, task);
+            indexSampleType(sampleType, task, priority);
+            indexSampleTypeMaterials(sampleType, task, priority.getOneHigher());
         };
 
-        task.addRunnable(sampleType.getContainer(), SearchService.PRIORITY.bulk, r);
+        task.addRunnable(sampleType.getContainer(), priority, r);
     }
 
-    private void indexSampleType(ExpSampleType sampleType, SearchService.IndexTask task)
+    private void indexSampleType(ExpSampleType sampleType, SearchService.IndexTask task, SearchService.PRIORITY priority)
     {
         // Index all ExpMaterial that have never been indexed OR where either the ExpSampleType definition or ExpMaterial itself has changed since last indexed
         SQLFragment sql = new SQLFragment("SELECT * FROM ")
@@ -271,11 +271,11 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         if (materialSource != null)
         {
             ExpSampleTypeImpl impl = new ExpSampleTypeImpl(materialSource);
-            impl.index(task);
+            impl.index(priority, task);
         }
     }
 
-    private void indexSampleTypeMaterials(ExpSampleType sampleType, SearchService.IndexTask task)
+    private void indexSampleTypeMaterials(ExpSampleType sampleType, SearchService.IndexTask task, SearchService.PRIORITY priority)
     {
         // Index all ExpMaterial that have never been indexed OR where either the ExpSampleType definition or ExpMaterial itself has changed since last indexed
         SQLFragment sql = new SQLFragment("SELECT m.* FROM ")
@@ -292,7 +292,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             for (Material m : batch)
             {
                 ExpMaterialImpl impl = new ExpMaterialImpl(m);
-                impl.index(task, null, null /* null tableInfo since samples may belong to multiple containers*/);
+                impl.index(priority, task, null /* null tableInfo since samples may belong to multiple containers*/);
             }
         });
     }
@@ -891,7 +891,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                         ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(ExperimentService.DataTypeForExclusion.DashboardSampleType, st.getRowId(), c, u);
                     transaction.addCommitTask(() -> clearMaterialSourceCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
                     transaction.addCommitTask(() -> {
-                        indexSampleType(SampleTypeService.get().getSampleType(domain.getTypeURI()));
+                        indexSampleType(SampleTypeService.get().getSampleType(domain.getTypeURI()), SearchService.PRIORITY.modifiedLow);
                     }, POSTCOMMIT);
 
                     return st;
@@ -1131,7 +1131,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                         }
                     }
                 }, DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
-                transaction.addCommitTask(() -> SampleTypeServiceImpl.get().indexSampleType(st), POSTCOMMIT);
+                transaction.addCommitTask(() -> SampleTypeServiceImpl.get().indexSampleType(st, SearchService.PRIORITY.modifiedLow), POSTCOMMIT);
                 transaction.commit();
                 refreshSampleTypeMaterializedView(st, SampleChangeType.schema);
             }
@@ -1929,7 +1929,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                     SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(sampleType, SampleChangeType.update);
                     // update search index for moved samples via indexSampleType() helper, it filters for samples to index
                     // based on the modified date
-                    SampleTypeServiceImpl.get().indexSampleType(sampleType);
+                    SampleTypeServiceImpl.get().indexSampleType(sampleType, SearchService.PRIORITY.modifiedLow);
                 }
             }, DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -254,7 +254,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             indexSampleTypeMaterials(sampleType, task);
         };
 
-        task.addRunnable(r, SearchService.PRIORITY.bulk);
+        task.addRunnable(sampleType.getContainer(), SearchService.PRIORITY.bulk, r);
     }
 
     private void indexSampleType(ExpSampleType sampleType, SearchService.IndexTask task)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -238,44 +238,32 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     }
 
     @Override
-    public void indexSampleType(ExpSampleType sampleType, SearchService.PRIORITY priority)
+    public void indexSampleType(ExpSampleType sampleType, SearchService.TaskIndexingQueue queue)
     {
         if (sampleType == null)
             return;
 
-        SearchService ss = SearchService.get();
-        if (ss == null)
-            return;
+        queue.addRunnable((q) -> {
+            // Index all ExpMaterial that have never been indexed OR where either the ExpSampleType definition or ExpMaterial itself has changed since last indexed
+            SQLFragment sql = new SQLFragment("SELECT * FROM ")
+                    .append(getTinfoMaterialSource(), "ms")
+                    .append(" WHERE ms.LSID NOT LIKE ").appendValue("%:" + StudyService.SPECIMEN_NAMESPACE_PREFIX + "%", getExpSchema().getSqlDialect())
+                    .append(" AND ms.LSID = ?").add(sampleType.getLSID())
+                    .append(" AND (ms.lastIndexed IS NULL OR ms.lastIndexed < ? OR (ms.modified IS NOT NULL AND ms.lastIndexed < ms.modified))")
+                    .add(sampleType.getModified());
 
-        SearchService.IndexTask task = ss.defaultTask();
+            MaterialSource materialSource = new SqlSelector(getExpSchema().getScope(), sql).getObject(MaterialSource.class);
+            if (materialSource != null)
+            {
+                ExpSampleTypeImpl impl = new ExpSampleTypeImpl(materialSource);
+                impl.index(q, null);
+            }
 
-        Runnable r = () -> {
-            indexSampleType(sampleType, task, priority);
-            indexSampleTypeMaterials(sampleType, task, priority);
-        };
-
-        task.addRunnable(sampleType.getContainer(), priority, r);
+            indexSampleTypeMaterials(sampleType, q);
+        });
     }
 
-    private void indexSampleType(ExpSampleType sampleType, SearchService.IndexTask task, SearchService.PRIORITY priority)
-    {
-        // Index all ExpMaterial that have never been indexed OR where either the ExpSampleType definition or ExpMaterial itself has changed since last indexed
-        SQLFragment sql = new SQLFragment("SELECT * FROM ")
-                .append(getTinfoMaterialSource(), "ms")
-                .append(" WHERE ms.LSID NOT LIKE ").appendValue("%:" + StudyService.SPECIMEN_NAMESPACE_PREFIX + "%", getExpSchema().getSqlDialect())
-                .append(" AND ms.LSID = ?").add(sampleType.getLSID())
-                .append(" AND (ms.lastIndexed IS NULL OR ms.lastIndexed < ? OR (ms.modified IS NOT NULL AND ms.lastIndexed < ms.modified))")
-                .add(sampleType.getModified());
-
-        MaterialSource materialSource = new SqlSelector(getExpSchema().getScope(), sql).getObject(MaterialSource.class);
-        if (materialSource != null)
-        {
-            ExpSampleTypeImpl impl = new ExpSampleTypeImpl(materialSource);
-            impl.index(priority, task);
-        }
-    }
-
-    private void indexSampleTypeMaterials(ExpSampleType sampleType, SearchService.IndexTask task, SearchService.PRIORITY priority)
+    private void indexSampleTypeMaterials(ExpSampleType sampleType, SearchService.TaskIndexingQueue queue)
     {
         // Index all ExpMaterial that have never been indexed OR where either the ExpSampleType definition or ExpMaterial itself has changed since last indexed
         SQLFragment sql = new SQLFragment("SELECT m.* FROM ")
@@ -292,7 +280,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             for (Material m : batch)
             {
                 ExpMaterialImpl impl = new ExpMaterialImpl(m);
-                impl.index(priority, task, null /* null tableInfo since samples may belong to multiple containers*/);
+                impl.index(queue, null /* null tableInfo since samples may belong to multiple containers*/);
             }
         });
     }
@@ -630,13 +618,9 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         QueryService.get().fireQueryDeleted(user, c, null, expMaterialsSchema, singleton(source.getName()));
 
         // Remove SampleType from search index
-        SearchService ss = SearchService.get();
-        if (null != ss)
+        try (Timing ignored = MiniProfiler.step("search docs"))
         {
-            try (Timing ignored = MiniProfiler.step("search docs"))
-            {
-                ss.deleteResource(source.getDocumentId());
-            }
+            SearchService.get().deleteResource(source.getDocumentId());
         }
 
         timer.stop();
@@ -891,7 +875,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                         ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(ExperimentService.DataTypeForExclusion.DashboardSampleType, st.getRowId(), c, u);
                     transaction.addCommitTask(() -> clearMaterialSourceCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
                     transaction.addCommitTask(() -> {
-                        indexSampleType(SampleTypeService.get().getSampleType(domain.getTypeURI()), SearchService.PRIORITY.modified);
+                        indexSampleType(SampleTypeService.get().getSampleType(domain.getTypeURI()), SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified));
                     }, POSTCOMMIT);
 
                     return st;
@@ -1131,7 +1115,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                         }
                     }
                 }, DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
-                transaction.addCommitTask(() -> SampleTypeServiceImpl.get().indexSampleType(st, SearchService.PRIORITY.modified), POSTCOMMIT);
+                transaction.addCommitTask(() -> SampleTypeServiceImpl.get().indexSampleType(st, SearchService.get().defaultTask().getQueue(container, SearchService.PRIORITY.modified)), POSTCOMMIT);
                 transaction.commit();
                 refreshSampleTypeMaterializedView(st, SampleChangeType.schema);
             }
@@ -1929,7 +1913,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                     SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(sampleType, SampleChangeType.update);
                     // update search index for moved samples via indexSampleType() helper, it filters for samples to index
                     // based on the modified date
-                    SampleTypeServiceImpl.get().indexSampleType(sampleType, SearchService.PRIORITY.modified);
+                    SampleTypeServiceImpl.get().indexSampleType(sampleType, SearchService.get().defaultTask().getQueue(sampleType.getContainer(), SearchService.PRIORITY.modified));
                 }
             }, DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -529,7 +529,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
                     ExpMaterialTableImpl tableInfo = (ExpMaterialTableImpl) QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_SAMPLES).getTable(_sampleType.getName());
                     ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(SearchService.PRIORITY.group, () ->
+                            searchService.defaultTask().addRunnable(_sampleType.getContainer(), SearchService.PRIORITY.group, () ->
                             {
                                 for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterials(sublist))
                                     expMaterial.index(searchService.defaultTask(), null, tableInfo);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -529,10 +529,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
                     ExpMaterialTableImpl tableInfo = (ExpMaterialTableImpl) QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_SAMPLES).getTable(_sampleType.getName());
                     ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(_sampleType.getContainer(), SearchService.PRIORITY.group, () ->
+                            searchService.defaultTask().addRunnable(_sampleType.getContainer(), SearchService.PRIORITY.modifiedLow, () ->
                             {
                                 for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterials(sublist))
-                                    expMaterial.index(searchService.defaultTask(), null, tableInfo);
+                                    expMaterial.index(SearchService.PRIORITY.modifiedHigh, searchService.defaultTask(), tableInfo);
                             })
                     );
                 }, DbScope.CommitTaskOption.POSTCOMMIT);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -529,10 +529,10 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
                     ExpMaterialTableImpl tableInfo = (ExpMaterialTableImpl) QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_SAMPLES).getTable(_sampleType.getName());
                     ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(_sampleType.getContainer(), SearchService.PRIORITY.modifiedLow, () ->
+                            searchService.defaultTask().addRunnable(_sampleType.getContainer(), SearchService.PRIORITY.modified, () ->
                             {
                                 for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterials(sublist))
-                                    expMaterial.index(SearchService.PRIORITY.modifiedHigh, searchService.defaultTask(), tableInfo);
+                                    expMaterial.index(SearchService.PRIORITY.modified, searchService.defaultTask(), tableInfo);
                             })
                     );
                 }, DbScope.CommitTaskOption.POSTCOMMIT);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -512,31 +512,28 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         {
             results = super.updateRows(user, container, rows, oldKeys, errors, configParameters, extraScriptContext);
 
-            SearchService searchService = SearchService.get();
-            if (searchService != null)
+            SearchService.TaskIndexingQueue queue = SearchService.get().defaultTask().getQueue(container, SearchService.PRIORITY.modified);
+            scope.addCommitTask(() ->
             {
-                scope.addCommitTask(() ->
+                List<Integer> orderedRowIds = new ArrayList<>();
+                for (Map<String, Object> result : results)
                 {
-                    List<Integer> orderedRowIds = new ArrayList<>();
-                    for (Map<String, Object> result : results)
-                    {
-                        Integer rowId = (Integer) result.get(RowId.name());
-                        if (rowId != null)
-                            orderedRowIds.add(rowId);
-                    }
-                    // Issue 51263: order by RowId to reduce deadlock
-                    Collections.sort(orderedRowIds);
+                    Integer rowId = (Integer) result.get(RowId.name());
+                    if (rowId != null)
+                        orderedRowIds.add(rowId);
+                }
+                // Issue 51263: order by RowId to reduce deadlock
+                Collections.sort(orderedRowIds);
 
-                    ExpMaterialTableImpl tableInfo = (ExpMaterialTableImpl) QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_SAMPLES).getTable(_sampleType.getName());
-                    ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
-                            searchService.defaultTask().addRunnable(_sampleType.getContainer(), SearchService.PRIORITY.modified, () ->
-                            {
-                                for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterials(sublist))
-                                    expMaterial.index(SearchService.PRIORITY.modified, searchService.defaultTask(), tableInfo);
-                            })
-                    );
-                }, DbScope.CommitTaskOption.POSTCOMMIT);
-            }
+                ExpMaterialTableImpl tableInfo = (ExpMaterialTableImpl) QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_SAMPLES).getTable(_sampleType.getName());
+                ListUtils.partition(orderedRowIds, 100).forEach(sublist ->
+                        queue.addRunnable((q) ->
+                        {
+                            for (ExpMaterialImpl expMaterial : ExperimentServiceImpl.get().getExpMaterials(sublist))
+                                expMaterial.index(q, tableInfo);
+                        })
+                );
+            }, DbScope.CommitTaskOption.POSTCOMMIT);
 
             /* setup mini dataiterator pipeline to process lineage */
             DataIterator di = _toDataIteratorBuilder("updateRows.lineage", results).getDataIterator(new DataIteratorContext());

--- a/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
+++ b/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
@@ -449,7 +449,7 @@ public class FileQueryUpdateService extends AbstractQueryUpdateService
                 SearchService ss = SearchService.get();
 
                 if (null != ss)
-                    ss.defaultTask().addResource(resource, SearchService.PRIORITY.modifiedHigh);
+                    ss.defaultTask().addResource(resource, SearchService.PRIORITY.modified);
 
                 resource.notify(ContainerUser.create(container, user), sb.toString());
             }

--- a/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
+++ b/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
@@ -446,10 +446,7 @@ public class FileQueryUpdateService extends AbstractQueryUpdateService
                         delim = ",";
                     }
                 }
-                SearchService ss = SearchService.get();
-
-                if (null != ss)
-                    ss.defaultTask().addResource(resource, SearchService.PRIORITY.modified);
+                SearchService.get().defaultTask().getQueue(container, SearchService.PRIORITY.modified).addResource(resource);
 
                 resource.notify(ContainerUser.create(container, user), sb.toString());
             }

--- a/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
+++ b/filecontent/src/org/labkey/filecontent/FileQueryUpdateService.java
@@ -449,7 +449,7 @@ public class FileQueryUpdateService extends AbstractQueryUpdateService
                 SearchService ss = SearchService.get();
 
                 if (null != ss)
-                    ss.defaultTask().addResource(resource, SearchService.PRIORITY.item);
+                    ss.defaultTask().addResource(resource, SearchService.PRIORITY.modifiedHigh);
 
                 resource.notify(ContainerUser.create(container, user), sb.toString());
             }

--- a/issues/src/org/labkey/issue/IssuesModule.java
+++ b/issues/src/org/labkey/issue/IssuesModule.java
@@ -217,8 +217,8 @@ public class IssuesModule extends DefaultModule implements SearchService.Documen
     @Override
     public void enumerateDocuments(final SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
     {
-        Runnable r = () -> IssueManager.indexIssues(task, c, modifiedSince);
-        task.addRunnable(c, SearchService.PRIORITY.bulk, r);
+        Runnable r = () -> IssueManager.indexIssues(task, c, modifiedSince, SearchService.PRIORITY.crawlHigh);
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, r);
     }
 
     @Override

--- a/issues/src/org/labkey/issue/IssuesModule.java
+++ b/issues/src/org/labkey/issue/IssuesModule.java
@@ -217,8 +217,8 @@ public class IssuesModule extends DefaultModule implements SearchService.Documen
     @Override
     public void enumerateDocuments(final SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
     {
-        Runnable r = () -> IssueManager.indexIssues(task, c, modifiedSince, SearchService.PRIORITY.crawlHigh);
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, r);
+        Runnable r = () -> IssueManager.indexIssues(task, c, modifiedSince, SearchService.PRIORITY.crawl);
+        task.addRunnable(c, SearchService.PRIORITY.crawl, r);
     }
 
     @Override

--- a/issues/src/org/labkey/issue/IssuesModule.java
+++ b/issues/src/org/labkey/issue/IssuesModule.java
@@ -215,10 +215,10 @@ public class IssuesModule extends DefaultModule implements SearchService.Documen
     }
 
     @Override
-    public void enumerateDocuments(final SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, final Date modifiedSince)
     {
-        Runnable r = () -> IssueManager.indexIssues(task, c, modifiedSince, SearchService.PRIORITY.crawl);
-        task.addRunnable(c, SearchService.PRIORITY.crawl, r);
+        queue.addRunnable((q) ->
+                IssueManager.indexIssues(q, modifiedSince));
     }
 
     @Override

--- a/issues/src/org/labkey/issue/IssuesModule.java
+++ b/issues/src/org/labkey/issue/IssuesModule.java
@@ -218,7 +218,7 @@ public class IssuesModule extends DefaultModule implements SearchService.Documen
     public void enumerateDocuments(final SearchService.IndexTask task, final @NotNull Container c, final Date modifiedSince)
     {
         Runnable r = () -> IssueManager.indexIssues(task, c, modifiedSince);
-        task.addRunnable(r, SearchService.PRIORITY.bulk);
+        task.addRunnable(c, SearchService.PRIORITY.bulk, r);
     }
 
     @Override

--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -934,7 +934,7 @@ public class IssueManager
 
         // Index issues in batches of 100
         new TableSelector(_issuesSchema.getTableInfoIssues(), PageFlowUtil.set("issueid"), f, null)
-                .forEachBatch(Integer.class, 100, batch -> task.addRunnable(new IndexGroup(task, batch), SearchService.PRIORITY.group));
+                .forEachBatch(Integer.class, 100, batch -> task.addRunnable(c, SearchService.PRIORITY.group, new IndexGroup(task, batch)));
     }
 
     private static class IndexGroup implements Runnable

--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -919,7 +919,7 @@ public class IssueManager
     }
 
 
-    public static void indexIssues(IndexTask task, @NotNull Container c, Date modifiedSince)
+    public static void indexIssues(IndexTask task, @NotNull Container c, Date modifiedSince, SearchService.PRIORITY priority)
     {
         SearchService ss = SearchService.get();
         if (null == ss)
@@ -934,31 +934,33 @@ public class IssueManager
 
         // Index issues in batches of 100
         new TableSelector(_issuesSchema.getTableInfoIssues(), PageFlowUtil.set("issueid"), f, null)
-                .forEachBatch(Integer.class, 100, batch -> task.addRunnable(c, SearchService.PRIORITY.group, new IndexGroup(task, batch)));
+                .forEachBatch(Integer.class, 100, batch -> task.addRunnable(c, priority, new IndexGroup(task, batch, priority)));
     }
 
     private static class IndexGroup implements Runnable
     {
         private final List<Integer> _ids;
         private final IndexTask _task;
+        private final SearchService.PRIORITY _priority;
 
-        IndexGroup(IndexTask task, List<Integer> ids)
+        IndexGroup(IndexTask task, List<Integer> ids, SearchService.PRIORITY priority)
         {
             _ids = ids;
             _task = task;
+            _priority = priority;
         }
 
         @Override
         public void run()
         {
             User user = new LimitedUser(UserManager.getGuestUser(), ReaderRole.class);
-            indexIssues(null, user, _task, _ids);
+            indexIssues(null, user, _task, _ids, _priority);
         }
     }
 
 
     /* CONSIDER: some sort of generator interface instead */
-    public static void indexIssues(@Nullable Container container, User user, IndexTask task, Collection<Integer> ids)
+    public static void indexIssues(@Nullable Container container, User user, IndexTask task, Collection<Integer> ids, SearchService.PRIORITY priority)
     {
         if (ids.isEmpty())
             return;
@@ -975,7 +977,7 @@ public class IssueManager
             {
                 IssueObject issue = IssueManager.getIssue(container, user, id);
                 if (issue != null)
-                    queueIssue(task, id, issue.getProperties(), issue.getCommentObjects());
+                    queueIssue(task, id, issue.getProperties(), issue.getCommentObjects(), priority);
             }
             catch (UnauthorizedException e)
             {
@@ -999,11 +1001,11 @@ public class IssueManager
         // task.addResource(new IssueResource(issue), SearchService.PRIORITY.item);
 
         // try requery instead
-        indexIssues(container, user, task, Collections.singleton(issue.getIssueId()));
+        indexIssues(container, user, task, Collections.singleton(issue.getIssueId()), SearchService.PRIORITY.modifiedHigh);
     }
 
 
-    static void queueIssue(IndexTask task, int id, Map<String,Object> m, Collection<IssueObject.CommentObject> comments)
+    static void queueIssue(IndexTask task, int id, Map<String,Object> m, Collection<IssueObject.CommentObject> comments, SearchService.PRIORITY priority)
     {
         if (null == task || null == m)
             return;
@@ -1011,7 +1013,7 @@ public class IssueManager
         m.put(SearchService.PROPERTY.title.toString(), id + " : " + title);
         m.put("comment", null);
         m.put("_row", null);
-        task.addResource(new IssueResource(id, m, comments), SearchService.PRIORITY.item);
+        task.addResource(new IssueResource(id, m, comments), priority);
     }
 
 

--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -1001,7 +1001,7 @@ public class IssueManager
         // task.addResource(new IssueResource(issue), SearchService.PRIORITY.item);
 
         // try requery instead
-        indexIssues(container, user, task, Collections.singleton(issue.getIssueId()), SearchService.PRIORITY.modifiedHigh);
+        indexIssues(container, user, task, Collections.singleton(issue.getIssueId()), SearchService.PRIORITY.modified);
     }
 
 

--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -64,7 +64,6 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.search.SearchService;
-import org.labkey.api.search.SearchService.IndexTask;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.LimitedUser;
 import org.labkey.api.security.MemberType;
@@ -121,6 +120,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Consumer;
 
 import static org.labkey.api.search.SearchService.PROPERTY.categories;
 import static org.labkey.api.security.UserManager.USER_DISPLAY_NAME_COMPARATOR;
@@ -401,7 +401,7 @@ public class IssueManager
                 saveComments(user, issue);
                 saveRelatedIssues(user, issue);
 
-                indexIssue(container, user, null, issue);
+                indexIssue(container, user, issue);
 
                 transaction.commit();
             }
@@ -919,12 +919,9 @@ public class IssueManager
     }
 
 
-    public static void indexIssues(IndexTask task, @NotNull Container c, Date modifiedSince, SearchService.PRIORITY priority)
+    public static void indexIssues(SearchService.TaskIndexingQueue queue, Date modifiedSince)
     {
-        SearchService ss = SearchService.get();
-        if (null == ss)
-            return;
-
+        Container c = queue.getContainer();
         SimpleFilter f = SimpleFilter.createContainerFilter(c);
         SearchService.LastIndexedClause incremental = new SearchService.LastIndexedClause(_issuesSchema.getTableInfoIssues(), modifiedSince, null);
         if (!incremental.isEmpty())
@@ -934,37 +931,34 @@ public class IssueManager
 
         // Index issues in batches of 100
         new TableSelector(_issuesSchema.getTableInfoIssues(), PageFlowUtil.set("issueid"), f, null)
-                .forEachBatch(Integer.class, 100, batch -> task.addRunnable(c, priority, new IndexGroup(task, batch, priority)));
+                .forEachBatch(Integer.class, 100, batch -> queue.addRunnable(new IndexGroup(batch)));
     }
 
-    private static class IndexGroup implements Runnable
+    private static class IndexGroup implements Consumer<SearchService.TaskIndexingQueue>
     {
         private final List<Integer> _ids;
-        private final IndexTask _task;
-        private final SearchService.PRIORITY _priority;
 
-        IndexGroup(IndexTask task, List<Integer> ids, SearchService.PRIORITY priority)
+        IndexGroup(List<Integer> ids)
         {
             _ids = ids;
-            _task = task;
-            _priority = priority;
         }
 
         @Override
-        public void run()
+        public void accept(SearchService.TaskIndexingQueue a)
         {
             User user = new LimitedUser(UserManager.getGuestUser(), ReaderRole.class);
-            indexIssues(null, user, _task, _ids, _priority);
+            indexIssues(a, user, _ids);
         }
     }
 
 
     /* CONSIDER: some sort of generator interface instead */
-    public static void indexIssues(@Nullable Container container, User user, IndexTask task, Collection<Integer> ids, SearchService.PRIORITY priority)
+    public static void indexIssues(SearchService.TaskIndexingQueue queue, User user, Collection<Integer> ids)
     {
         if (ids.isEmpty())
             return;
 
+        Container container = queue.getContainer();
         SQLFragment f = new SQLFragment();
         f.append("SELECT I.issueId, I.container, I.entityid, I.duplicate, ")
                 .append("C.comment\n");
@@ -977,7 +971,7 @@ public class IssueManager
             {
                 IssueObject issue = IssueManager.getIssue(container, user, id);
                 if (issue != null)
-                    queueIssue(task, id, issue.getProperties(), issue.getCommentObjects(), priority);
+                    queueIssue(queue, id, issue.getProperties(), issue.getCommentObjects());
             }
             catch (UnauthorizedException e)
             {
@@ -987,33 +981,22 @@ public class IssueManager
     }
 
 
-    static void indexIssue(Container container, User user, @Nullable IndexTask task, IssueObject issue)
+    static void indexIssue(Container container, User user, IssueObject issue)
     {
-        if (task == null)
-        {
-            SearchService ss = SearchService.get();
-            if (null == ss)
-                return;
-            task = ss.defaultTask();
-        }
-
-        // UNDONE: broken ??
-        // task.addResource(new IssueResource(issue), SearchService.PRIORITY.item);
-
         // try requery instead
-        indexIssues(container, user, task, Collections.singleton(issue.getIssueId()), SearchService.PRIORITY.modified);
+        indexIssues(SearchService.get().defaultTask().getQueue(container, SearchService.PRIORITY.modified), user, Collections.singleton(issue.getIssueId()));
     }
 
 
-    static void queueIssue(IndexTask task, int id, Map<String,Object> m, Collection<IssueObject.CommentObject> comments, SearchService.PRIORITY priority)
+    static void queueIssue(SearchService.TaskIndexingQueue queue, int id, Map<String,Object> m, Collection<IssueObject.CommentObject> comments)
     {
-        if (null == task || null == m)
+        if (null == m)
             return;
         String title = String.valueOf(m.get("title"));
         m.put(SearchService.PROPERTY.title.toString(), id + " : " + title);
         m.put("comment", null);
         m.put("_row", null);
-        task.addResource(new IssueResource(id, m, comments), priority);
+        queue.addResource(new IssueResource(id, m, comments));
     }
 
 

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -54,7 +54,6 @@ import org.labkey.api.query.QueryChangeListener;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.search.SearchService;
-import org.labkey.api.search.SearchService.IndexTask;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.util.ExceptionUtil;
@@ -87,6 +86,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class ListManager implements SearchService.DocumentProvider
@@ -472,38 +472,25 @@ public class ListManager implements SearchService.DocumentProvider
 
     // Index all lists in this container
     @Override
-    public void enumerateDocuments(@Nullable IndexTask t, final @NotNull Container c, @Nullable Date since)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, @Nullable Date since)
     {
-        final IndexTask task;
-        if (null == t)
-        {
-            final SearchService ss = SearchService.get();
-            if (ss == null)
-                return;
-            task = ss.defaultTask();
-        }
-        else
-        {
-            task = t;
-        }
-
-        Runnable r = () -> {
-            Map<String, ListDefinition> lists = ListService.get().getLists(c, null, false);
+        Consumer<SearchService.TaskIndexingQueue> r = (q) -> {
+            Map<String, ListDefinition> lists = ListService.get().getLists(q.getContainer(), null, false);
 
             try
             {
                 QueryService.get().setEnvironment(QueryService.Environment.USER, User.getSearchUser());
-                QueryService.get().setEnvironment(QueryService.Environment.CONTAINER, c);
+                QueryService.get().setEnvironment(QueryService.Environment.CONTAINER, q.getContainer());
                 for (ListDefinition list : lists.values())
                 {
                     try
                     {
                         boolean reindex = since == null;
-                        indexList(task, list, reindex);
+                        indexList(q, list, reindex);
                     }
                     catch (Exception ex)
                     {
-                        LOG.error("Error indexing list '" + list.getName() + "' in container '" + c.getPath() + "'.", ex);
+                        LOG.error("Error indexing list '" + list.getName() + "' in container '" + q.getContainer().getPath() + "'.", ex);
                     }
                 }
             }
@@ -513,7 +500,7 @@ public class ListManager implements SearchService.DocumentProvider
             }
         };
 
-        task.addRunnable(c, SearchService.PRIORITY.crawl, r);
+        queue.addRunnable(r);
     }
 
     public void indexList(final ListDefinition def)
@@ -524,28 +511,9 @@ public class ListManager implements SearchService.DocumentProvider
     // Index a single list
     public void indexList(final ListDef def)
     {
-        SearchService ss = SearchService.get();
-
-        if (null != ss)
+        SearchService.TaskIndexingQueue queue = SearchService.get().defaultTask().getQueue(def.lookupContainer(), SearchService.PRIORITY.modified);
+        Consumer<SearchService.TaskIndexingQueue> r = (q) ->
         {
-            final IndexTask task = ss.defaultTask();
-
-            Runnable r = () ->
-            {
-                Container c = def.lookupContainer();
-                if (!ContainerManager.exists(c))
-                {
-                    LOG.info("List container has been deleted or is being deleted; not indexing list \"" + def.getName() + "\"");
-                }
-                else
-                {
-                    //Refresh list definition -- Issue #42207 - MSSQL server returns entityId as uppercase string
-                    ListDefinition list = ListService.get().getList(c, def.getListId());
-                    if (null != list) // Could have just been deleted
-                        indexList(task, list, false);
-                }
-            };
-
             Container c = def.lookupContainer();
             if (!ContainerManager.exists(c))
             {
@@ -553,13 +521,25 @@ public class ListManager implements SearchService.DocumentProvider
             }
             else
             {
-                task.addRunnable(c, SearchService.PRIORITY.modified, r);
+                //Refresh list definition -- Issue #42207 - MSSQL server returns entityId as uppercase string
+                ListDefinition list = ListService.get().getList(c, def.getListId());
+                if (null != list) // Could have just been deleted
+                    indexList(q, list, false);
             }
+        };
 
+        Container c = def.lookupContainer();
+        if (!ContainerManager.exists(c))
+        {
+            LOG.info("List container has been deleted or is being deleted; not indexing list \"" + def.getName() + "\"");
+        }
+        else
+        {
+            queue.addRunnable(r);
         }
     }
 
-    private void indexList(@NotNull IndexTask task, ListDefinition list, final boolean reindex)
+    private void indexList(SearchService.TaskIndexingQueue queue, ListDefinition list, final boolean reindex)
     {
         Domain domain = list.getDomain();
 
@@ -569,9 +549,9 @@ public class ListManager implements SearchService.DocumentProvider
             // indexing methods turn off JDBC driver caching and use a side connection, so we must not be in a transaction
             assert !DbScope.getLabKeyScope().isTransactionActive() : "Should not be in a transaction since this code path disables JDBC driver caching";
 
-            indexEntireList(task, list, reindex);
-            indexModifiedItems(task, list, reindex);
-            indexAttachments(task, list, reindex);
+            indexEntireList(queue, list, reindex);
+            indexModifiedItems(queue, list, reindex);
+            indexAttachments(queue, list, reindex);
         }
     }
 
@@ -582,23 +562,16 @@ public class ListManager implements SearchService.DocumentProvider
         // because it turns off JDBC caching, using a non-transacted connection (bad news if we call it mid-transaction).
         getListMetadataSchema().getScope().addCommitTask(() ->
         {
-            SearchService ss = SearchService.get();
-
-            if (null != ss)
+            SearchService.TaskIndexingQueue queue = SearchService.get().defaultTask().getQueue(list.getContainer(), SearchService.PRIORITY.modified);
+            if (list.getEachItemIndex())
             {
-                final IndexTask task = ss.defaultTask();
+                SearchService.get().deleteResource(getDocumentId(list, entityId));
+            }
 
-                if (list.getEachItemIndex())
-                {
-                    Runnable r = () -> ss.deleteResource(getDocumentId(list, entityId));
-                    task.addRunnable(list.getContainer(), SearchService.PRIORITY.delete, r);
-                }
-
-                // Reindex the entire list document iff data is being indexed
-                if (list.getEntireListIndex() && list.getEntireListIndexSetting().indexItemData())
-                {
-                    indexEntireList(task, list, true);
-                }
+            // Reindex the entire list document iff data is being indexed
+            if (list.getEntireListIndex() && list.getEntireListIndexSetting().indexItemData())
+            {
+                indexEntireList(queue, list, true);
             }
         }, DbScope.CommitTaskOption.POSTCOMMIT);
     }
@@ -621,7 +594,7 @@ public class ListManager implements SearchService.DocumentProvider
     }
 
     // Index all modified items in this list
-    private void indexModifiedItems(@NotNull final IndexTask task, final ListDefinition list, final boolean reindex)
+    private void indexModifiedItems(@NotNull SearchService.TaskIndexingQueue queue, final ListDefinition list, final boolean reindex)
     {
         if (list.getEachItemIndex())
         {
@@ -631,12 +604,12 @@ public class ListManager implements SearchService.DocumentProvider
             lastIndexClause += "LastIndexed IS NULL OR LastIndexed < ? OR (Modified IS NOT NULL AND LastIndexed < Modified)";
             SimpleFilter filter = new SimpleFilter(new SimpleFilter.SQLClause(lastIndexClause, new Object[]{list.getModified()}));
 
-            indexItems(task, list, filter);
+            indexItems(queue, list, filter);
         }
     }
 
     // Reindex items specified by filter
-    private void indexItems(@NotNull final IndexTask task, final ListDefinition list, SimpleFilter filter)
+    private void indexItems(@NotNull SearchService.TaskIndexingQueue queue, final ListDefinition list, SimpleFilter filter)
     {
         TableInfo listTable = list.getTable(User.getSearchUser());
 
@@ -727,7 +700,7 @@ public class ListManager implements SearchService.DocumentProvider
                 String nav = NavTree.toJS(Collections.singleton(t), null, false, true).toString();
                 r.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
 
-                task.addResource(r, SearchService.PRIORITY.modified);
+                queue.addResource(r);
                 LOG.debug("List \"" + list + "\": Queued indexing of item with PK = " + pk);
             });
         }
@@ -735,10 +708,9 @@ public class ListManager implements SearchService.DocumentProvider
 
     /**
      * Add searchable resources to Indexing task for file attachments
-     * @param task indexing task
      * @param list containing file attachments
      */
-    private void indexAttachments(@NotNull final IndexTask task, ListDefinition list, boolean reindex)
+    private void indexAttachments(@NotNull final SearchService.TaskIndexingQueue queue, ListDefinition list, boolean reindex)
     {
         TableInfo listTable = list.getTable(User.getSearchUser());
         if (listTable != null && list.getFileAttachmentIndex() && hasAttachmentColumns(listTable))
@@ -789,7 +761,7 @@ public class ListManager implements SearchService.DocumentProvider
                         );
 
                         attachmentRes.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
-                        task.addResource(attachmentRes, SearchService.PRIORITY.modified);
+                        queue.addResource(attachmentRes);
                         LOG.debug("List \"" + list + "\": Queued indexing of attachment \"" + documentName + "\" for item with PK = " + map.get(list.getKeyName()));
                     });
                 });
@@ -797,7 +769,7 @@ public class ListManager implements SearchService.DocumentProvider
         }
     }
 
-    private void indexEntireList(@NotNull IndexTask task, final ListDefinition list, boolean reindex)
+    private void indexEntireList(SearchService.TaskIndexingQueue queue, final ListDefinition list, boolean reindex)
     {
         if (list.getEntireListIndex())
         {
@@ -892,7 +864,7 @@ public class ListManager implements SearchService.DocumentProvider
                     }
                 };
 
-                task.addResource(r, SearchService.PRIORITY.modified);
+                queue.addResource(r);
                 LOG.debug("List \"" + list + "\": Queued indexing of entire list document");
             }
         }

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -513,7 +513,7 @@ public class ListManager implements SearchService.DocumentProvider
             }
         };
 
-        task.addRunnable(r, SearchService.PRIORITY.group);
+        task.addRunnable(c, SearchService.PRIORITY.group, r);
     }
 
     public void indexList(final ListDefinition def)
@@ -546,7 +546,16 @@ public class ListManager implements SearchService.DocumentProvider
                 }
             };
 
-            task.addRunnable(r, SearchService.PRIORITY.item);
+            Container c = def.lookupContainer();
+            if (!ContainerManager.exists(c))
+            {
+                LOG.info("List container has been deleted or is being deleted; not indexing list \"" + def.getName() + "\"");
+            }
+            else
+            {
+                task.addRunnable(c, SearchService.PRIORITY.item, r);
+            }
+
         }
     }
 
@@ -582,7 +591,7 @@ public class ListManager implements SearchService.DocumentProvider
                 if (list.getEachItemIndex())
                 {
                     Runnable r = () -> ss.deleteResource(getDocumentId(list, entityId));
-                    task.addRunnable(r, SearchService.PRIORITY.delete);
+                    task.addRunnable(list.getContainer(), SearchService.PRIORITY.delete, r);
                 }
 
                 // Reindex the entire list document iff data is being indexed

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -513,7 +513,7 @@ public class ListManager implements SearchService.DocumentProvider
             }
         };
 
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, r);
+        task.addRunnable(c, SearchService.PRIORITY.crawl, r);
     }
 
     public void indexList(final ListDefinition def)
@@ -553,7 +553,7 @@ public class ListManager implements SearchService.DocumentProvider
             }
             else
             {
-                task.addRunnable(c, SearchService.PRIORITY.modifiedHigh, r);
+                task.addRunnable(c, SearchService.PRIORITY.modified, r);
             }
 
         }
@@ -727,7 +727,7 @@ public class ListManager implements SearchService.DocumentProvider
                 String nav = NavTree.toJS(Collections.singleton(t), null, false, true).toString();
                 r.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
 
-                task.addResource(r, SearchService.PRIORITY.modifiedHigh);
+                task.addResource(r, SearchService.PRIORITY.modified);
                 LOG.debug("List \"" + list + "\": Queued indexing of item with PK = " + pk);
             });
         }
@@ -789,7 +789,7 @@ public class ListManager implements SearchService.DocumentProvider
                         );
 
                         attachmentRes.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
-                        task.addResource(attachmentRes, SearchService.PRIORITY.modifiedHigh);
+                        task.addResource(attachmentRes, SearchService.PRIORITY.modified);
                         LOG.debug("List \"" + list + "\": Queued indexing of attachment \"" + documentName + "\" for item with PK = " + map.get(list.getKeyName()));
                     });
                 });
@@ -892,7 +892,7 @@ public class ListManager implements SearchService.DocumentProvider
                     }
                 };
 
-                task.addResource(r, SearchService.PRIORITY.modifiedHigh);
+                task.addResource(r, SearchService.PRIORITY.modified);
                 LOG.debug("List \"" + list + "\": Queued indexing of entire list document");
             }
         }

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -513,7 +513,7 @@ public class ListManager implements SearchService.DocumentProvider
             }
         };
 
-        task.addRunnable(c, SearchService.PRIORITY.group, r);
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, r);
     }
 
     public void indexList(final ListDefinition def)
@@ -553,7 +553,7 @@ public class ListManager implements SearchService.DocumentProvider
             }
             else
             {
-                task.addRunnable(c, SearchService.PRIORITY.item, r);
+                task.addRunnable(c, SearchService.PRIORITY.modifiedHigh, r);
             }
 
         }
@@ -727,7 +727,7 @@ public class ListManager implements SearchService.DocumentProvider
                 String nav = NavTree.toJS(Collections.singleton(t), null, false, true).toString();
                 r.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
 
-                task.addResource(r, SearchService.PRIORITY.item);
+                task.addResource(r, SearchService.PRIORITY.modifiedHigh);
                 LOG.debug("List \"" + list + "\": Queued indexing of item with PK = " + pk);
             });
         }
@@ -789,7 +789,7 @@ public class ListManager implements SearchService.DocumentProvider
                         );
 
                         attachmentRes.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
-                        task.addResource(attachmentRes, SearchService.PRIORITY.item);
+                        task.addResource(attachmentRes, SearchService.PRIORITY.modifiedHigh);
                         LOG.debug("List \"" + list + "\": Queued indexing of attachment \"" + documentName + "\" for item with PK = " + map.get(list.getKeyName()));
                     });
                 });
@@ -892,7 +892,7 @@ public class ListManager implements SearchService.DocumentProvider
                     }
                 };
 
-                task.addResource(r, SearchService.PRIORITY.item);
+                task.addResource(r, SearchService.PRIORITY.modifiedHigh);
                 LOG.debug("List \"" + list + "\": Queued indexing of entire list document");
             }
         }

--- a/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
+++ b/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
@@ -18,7 +18,6 @@ package org.labkey.query;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.TableInfo;
@@ -38,6 +37,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 public class ExternalSchemaDocumentProvider implements SearchService.DocumentProvider
 {
@@ -56,26 +56,18 @@ public class ExternalSchemaDocumentProvider implements SearchService.DocumentPro
     }
 
     @Override
-    public void enumerateDocuments(SearchService.IndexTask t, final @NotNull Container c, Date since)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, Date since)
     {
-        SearchService ss = SearchService.get();
-        if (ss == null)
-            return;
-
-        final SearchService.IndexTask task = null==t ? ss.defaultTask() : t;
-
-        Runnable r = () ->
+        Consumer<SearchService.TaskIndexingQueue> r = (q) ->
         {
+            Container c = q.getContainer();
             User user = User.getSearchUser();
             QueryServiceImpl svc = (QueryServiceImpl)QueryService.get();
             Map<String, UserSchema> externalSchemas = svc.getExternalSchemas(user, c);
 
             // First, delete all external schema docs in this container.  This addresses schemas/tables that have
             // disappeared from the data source plus existing schemas that get changed to not index.
-            SearchService ss1 = SearchService.get();
-
-            if (null != ss1)
-                ss1.deleteResourcesForPrefix("externalTable:" + c.getId());
+            SearchService.get().deleteResourcesForPrefix("externalTable:" + c.getId());
 
             for (UserSchema schema : externalSchemas.values())
             {
@@ -152,11 +144,11 @@ public class ExternalSchemaDocumentProvider implements SearchService.DocumentPro
                             body.toString(),
                             url,
                             props);
-                    task.addResource(r1, SearchService.PRIORITY.modified);
+                    q.addResource(r1);
                 }
             }
         };
 
-        task.addRunnable(c, SearchService.PRIORITY.crawl, r);
+        queue.addRunnable(r);
     }
 }

--- a/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
+++ b/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
@@ -152,11 +152,11 @@ public class ExternalSchemaDocumentProvider implements SearchService.DocumentPro
                             body.toString(),
                             url,
                             props);
-                    task.addResource(r1, SearchService.PRIORITY.modifiedHigh);
+                    task.addResource(r1, SearchService.PRIORITY.modified);
                 }
             }
         };
 
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, r);
+        task.addRunnable(c, SearchService.PRIORITY.crawl, r);
     }
 }

--- a/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
+++ b/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
@@ -157,6 +157,6 @@ public class ExternalSchemaDocumentProvider implements SearchService.DocumentPro
             }
         };
 
-        task.addRunnable(r, SearchService.PRIORITY.group);
+        task.addRunnable(c, SearchService.PRIORITY.group, r);
     }
 }

--- a/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
+++ b/query/src/org/labkey/query/ExternalSchemaDocumentProvider.java
@@ -152,11 +152,11 @@ public class ExternalSchemaDocumentProvider implements SearchService.DocumentPro
                             body.toString(),
                             url,
                             props);
-                    task.addResource(r1, SearchService.PRIORITY.item);
+                    task.addResource(r1, SearchService.PRIORITY.modifiedHigh);
                 }
             }
         };
 
-        task.addRunnable(c, SearchService.PRIORITY.group, r);
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, r);
     }
 }

--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -59,6 +59,7 @@ import org.labkey.api.query.QueryParseWarning;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.usageMetrics.UsageMetricsService;
 import org.labkey.api.view.NotFoundException;
@@ -386,7 +387,7 @@ public class QueryManager
         if (null != c)
         {
             ExternalSchemaDefCache.uncache(c);
-            ExternalSchemaDocumentProvider.getInstance().enumerateDocuments(null, c, null);
+            ExternalSchemaDocumentProvider.getInstance().enumerateDocuments(SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified), null);
         }
     }
 

--- a/search/src/org/labkey/search/SearchContainerListener.java
+++ b/search/src/org/labkey/search/SearchContainerListener.java
@@ -40,28 +40,20 @@ public class SearchContainerListener extends ContainerManager.AbstractContainerL
     @Override
     public void containerDeleted(Container c, User user)
     {
-        SearchService ss = SearchService.get();
-        if (null != ss)
-        {
-            ss.deleteContainer(c.getId());
-        }
+        SearchService.get().deleteContainer(c.getId());
     }
 
     @Override
     public void propertyChange(PropertyChangeEvent propertyChangeEvent)
     {
-        SearchService ss = SearchService.get();
-        if (null != ss)
-        {
-            ContainerManager.ContainerPropertyChangeEvent evt = (ContainerManager.ContainerPropertyChangeEvent) propertyChangeEvent;
+        ContainerManager.ContainerPropertyChangeEvent evt = (ContainerManager.ContainerPropertyChangeEvent) propertyChangeEvent;
 
-            switch (evt.property)
-            {
-                case Name: // Rename
-                case Parent: // Move
-                    ss.reindexContainerFiles(evt.container);
-                    break;
-            }
+        switch (evt.property)
+        {
+            case Name: // Rename
+            case Parent: // Move
+                SearchService.get().reindexContainerFiles(evt.container);
+                break;
         }
     }
 }

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -837,7 +837,7 @@ public class SearchController extends SpringActionController
 
     public static class PriorityForm
     {
-        SearchService.PRIORITY priority = SearchService.PRIORITY.modifiedHigh;
+        SearchService.PRIORITY priority = SearchService.PRIORITY.modified;
 
         public SearchService.PRIORITY getPriority()
         {
@@ -846,7 +846,7 @@ public class SearchController extends SpringActionController
 
         public void setPriority(SearchService.PRIORITY priority)
         {
-            this.priority = Objects.requireNonNullElse(priority, SearchService.PRIORITY.modifiedLow);
+            this.priority = Objects.requireNonNullElse(priority, SearchService.PRIORITY.modified);
         }
     }
 

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -837,7 +837,7 @@ public class SearchController extends SpringActionController
 
     public static class PriorityForm
     {
-        SearchService.PRIORITY priority = SearchService.PRIORITY.item;
+        SearchService.PRIORITY priority = SearchService.PRIORITY.modifiedHigh;
 
         public SearchService.PRIORITY getPriority()
         {
@@ -846,7 +846,7 @@ public class SearchController extends SpringActionController
 
         public void setPriority(SearchService.PRIORITY priority)
         {
-            this.priority = Objects.requireNonNullElse(priority, SearchService.PRIORITY.item);
+            this.priority = Objects.requireNonNullElse(priority, SearchService.PRIORITY.modifiedLow);
         }
     }
 

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -294,26 +294,26 @@ public class SearchController extends SpringActionController
             {
                 HtmlStringBuilder builder = HtmlStringBuilder.of(HtmlString.unsafe("<span class=\"labkey-error\">Your search index is misconfigured. Search is disabled and documents are not being indexed, pending resolution of this issue. See below for details about the cause of the problem.</span></br></br>"));
                 builder.append(ExceptionUtil.renderException(t));
-                WebPartView configErrorView = new HtmlView(builder);
+                WebPartView<?> configErrorView = new HtmlView(builder);
                 configErrorView.setTitle("Search Configuration Error");
                 configErrorView.setFrame(WebPartView.FrameType.PORTAL);
                 vbox.addView(configErrorView);
             }
 
             // Spring errors get displayed in the "Index Configuration" pane
-            WebPartView indexerView = new JspView<>("/org/labkey/search/view/indexerAdmin.jsp", form, errors);
+            WebPartView<?> indexerView = new JspView<>("/org/labkey/search/view/indexerAdmin.jsp", form, errors);
             indexerView.setTitle("Index Configuration");
             vbox.addView(indexerView);
 
             // Won't be able to gather statistics if the search index is misconfigured
             if (null == t)
             {
-                WebPartView indexerStatsView = new JspView<>("/org/labkey/search/view/indexerStats.jsp", form);
+                WebPartView<?> indexerStatsView = new JspView<>("/org/labkey/search/view/indexerStats.jsp", form);
                 indexerStatsView.setTitle("Index Statistics");
                 vbox.addView(indexerStatsView);
             }
 
-            WebPartView searchStatsView = new JspView<>("/org/labkey/search/view/searchStats.jsp", form);
+            WebPartView<?> searchStatsView = new JspView<>("/org/labkey/search/view/searchStats.jsp", form);
             searchStatsView.setTitle("Search Statistics");
             vbox.addView(searchStatsView);
 
@@ -445,7 +445,7 @@ public class SearchController extends SpringActionController
         @Override
         public URLHelper getRedirectURL(Object o) throws Exception
         {
-            SearchService ss = SearchService.get();
+            SearchService ss = AbstractSearchService.get();
             ss.waitForIdle();
             return new ActionURL(AdminAction.class, getContainer());
         }
@@ -865,14 +865,13 @@ public class SearchController extends SpringActionController
             long startTime = System.currentTimeMillis();
             boolean success = ss.drainQueue(form.getPriority(), 5, TimeUnit.MINUTES);
 
-            LOG.info("Spent {}ms draining the search indexer queue. Success: {}", System.currentTimeMillis() - startTime, success);
+            LOG.info("Spent {}ms draining the search indexer queue at priority {}. Success: {}", System.currentTimeMillis() - startTime, form.getPriority(), success);
 
             // Return an error if we time out
             if (!success)
                 response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }
     }
-
 
     @RequiresPermission(ReadPermission.class)
     public class CommentAction extends FormHandlerAction<SearchForm>
@@ -1090,7 +1089,7 @@ public class SearchController extends SpringActionController
 
         public SearchResultTemplate getSearchResultTemplate()
         {
-            SearchService ss = SearchService.get();
+            SearchService ss = AbstractSearchService.get();
             return ss.getSearchResultTemplate(getTemplate());
         }
 

--- a/search/src/org/labkey/search/model/AbstractIndexTask.java
+++ b/search/src/org/labkey/search/model/AbstractIndexTask.java
@@ -37,7 +37,6 @@ public abstract class AbstractIndexTask implements SearchService.IndexTask
     protected long _complete = 0;
     protected boolean _cancelled = false;
     protected boolean _isReady = false;
-    final private AtomicInteger _estimate = new AtomicInteger();
     final private AtomicInteger _indexed = new AtomicInteger();
     final private AtomicInteger _failed = new AtomicInteger();
     final protected Map<Object,Object> _subtasks = Collections.synchronizedMap(new IdentityHashMap<>());
@@ -59,13 +58,6 @@ public abstract class AbstractIndexTask implements SearchService.IndexTask
     public String getDescription()
     {
         return _description;
-    }
-
-
-    @Override
-    public int getDocumentCountEstimate()
-    {
-        return _estimate.get();
     }
 
 
@@ -123,14 +115,7 @@ public abstract class AbstractIndexTask implements SearchService.IndexTask
     }
 
 
-    @Override
-    public void addToEstimate(int i)
-    {
-        _estimate.addAndGet(i);
-    }
-
-
-    // indicates that caller is done adding Resources to this task
+    /** indicates that the caller is done adding Resources to this task and it can start executing */
     @Override
     public void setReady()
     {

--- a/search/src/org/labkey/search/model/AbstractIndexTask.java
+++ b/search/src/org/labkey/search/model/AbstractIndexTask.java
@@ -39,7 +39,7 @@ public abstract class AbstractIndexTask implements SearchService.IndexTask
     protected boolean _isReady = false;
     final private AtomicInteger _indexed = new AtomicInteger();
     final private AtomicInteger _failed = new AtomicInteger();
-    final protected Map<Object,Object> _subtasks = Collections.synchronizedMap(new IdentityHashMap<>());
+    final protected Map<AbstractSearchService.Item,AbstractSearchService.Item> _subtasks = Collections.synchronizedMap(new IdentityHashMap<>());
     final StringWriter _sw = new StringWriter();
     final PrintWriter _out = new PrintWriter(_sw);
 
@@ -89,11 +89,10 @@ public abstract class AbstractIndexTask implements SearchService.IndexTask
     }
 
 
-    protected void addItem(Object item)
+    protected void addItem(AbstractSearchService.Item item)
     {
-        _subtasks.put(item,item);
+        _subtasks.put(item, item);
     }
-
 
     @Override
     public void log(String message)

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -18,7 +18,6 @@ package org.labkey.search.model;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multiset.Entry;
-import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.time.DateUtils;
@@ -69,7 +68,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -81,6 +79,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 
 public abstract class AbstractSearchService implements SearchService, ShutdownListener
 {
@@ -113,7 +112,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
     enum OPERATION
     {
-        add, delete, noop
+        add, noop
     }
 
     public AbstractSearchService()
@@ -172,16 +171,38 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             super(description, l);
         }
 
-
         @Override
-        public void addRunnable(Container container, @NotNull PRIORITY pri, @NotNull Runnable r)
+        public TaskIndexingQueue getQueue(@Nullable Container container, @NotNull PRIORITY pri)
+        {
+            return new TaskIndexingQueue()
+            {
+                @Override
+                public void addRunnable(@NotNull Consumer<TaskIndexingQueue> r)
+                {
+                    _IndexTask.this.addRunnable(container, pri, r);
+                }
+
+                @Override
+                public void addResource(@NotNull WebdavResource r)
+                {
+                    _IndexTask.this.addResource(r, pri);
+                }
+
+                @Override
+                public Container getContainer()
+                {
+                    return container;
+                }
+            };
+        }
+
+        public void addRunnable(Container container, @NotNull PRIORITY pri, @NotNull Consumer<TaskIndexingQueue> r)
         {
             Item i = new Item(this, r, pri, container);
-            this.addItem(i);
+            addItem(i);
             queueItem(i);
         }
 
-        @Override
         public void addResource(@NotNull WebdavResource r, @NotNull PRIORITY pri)
         {
             if (!r.shouldIndex())
@@ -203,7 +224,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 }
             };
             addItem(i);
-            final Item r = new Item(this, () -> queueItem(i), pri, null);
+            final Item r = new Item(this, (q) -> queueItem(i), pri, null);
             queueItem(r);
         }
 
@@ -247,10 +268,10 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         String _id;
         _IndexTask _task;
         WebdavResource _res;
-        Runnable _run;
+        Consumer<TaskIndexingQueue> _run;
         PRIORITY _pri;
         // Used to ensure FIFO ordering in the queue
-        final long _seqNum = seq.incrementAndGet();
+        final long _seqNum;
         final GUID _containerId;
 
         int _preprocessAttempts = 0;
@@ -269,15 +290,40 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             _pri = pri;
             _task = task;
             _containerId = r == null ? null : r.getContainerId();
+            _seqNum = seq.incrementAndGet();
         }
 
-        Item(_IndexTask task, Runnable r, @NotNull PRIORITY pri, Container container)
+        Item(_IndexTask task, Consumer<TaskIndexingQueue> r, @NotNull PRIORITY pri, Container container)
         {
             _run = r;
             _pri = pri;
             _task = task;
             _id = String.valueOf(r);
             _containerId = container == null ? null : container.getEntityId();
+            _seqNum = seq.incrementAndGet();
+        }
+
+        Item(Item parentItem, Consumer<TaskIndexingQueue> r, WebdavResource resource)
+        {
+            if (null != resource)
+            {
+                _start = HeartBeat.currentTimeMillis();
+                _op = OPERATION.add;
+                _res = resource;
+            }
+            else if (r != null)
+            {
+                _run = r;
+            }
+            else
+            {
+                throw new IllegalArgumentException("Both resource and runnable cannot be null");
+            }
+            _pri = parentItem._pri;
+            _task = parentItem._task;
+            _id = r == null ? resource.getDocumentId() : String.valueOf(r);
+            _containerId = parentItem._containerId;
+            _seqNum = parentItem._seqNum;
         }
 
         OPERATION getOperation()
@@ -363,7 +409,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     }
 
 
-    final Item _commitItem = new Item(null, () -> {}, PRIORITY.commit, null);
+    final Item _commitItem = new Item(null, (q) -> {}, PRIORITY.commit, null);
 
 
     @Override
@@ -420,15 +466,13 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     @Override
     public final void deleteContainer(final String id)
     {
-        Runnable r = () -> {
+        Consumer<TaskIndexingQueue> r = (q) -> {
             deleteIndexedContainer(id);
             synchronized (_commitLock)
             {
                 _countIndexedSinceCommit++;
             }
         };
-        // Don't try to pass in a container because we don't want to eject this from the queue as part of the container
-        // deletion process
         queueItem(new Item(defaultTask(), r, PRIORITY.delete, null));
     }
 
@@ -465,7 +509,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     public void reindexContainerFiles(Container c)
     {
         //Create new runnable instead of using existing methods so they can be run within the same job.
-        Runnable r = () -> {
+        Consumer<TaskIndexingQueue> r = (q) -> {
             //Remove old items
             clearIndexedFileSystemFiles(c);
 
@@ -473,8 +517,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             //Recrawl files as the container name may be used in paths & Urls. Issue #39696
             DavCrawler.getInstance().startFull(WebdavService.getPath().append(c.getParsedPath()), true);
         };
-        // Don't pass a container because we don't want to skip this when a container is deleted
-        queueItem(new Item(defaultTask(), r, PRIORITY.delete, null));
+        queueItem(new Item(defaultTask(), r, PRIORITY.delete, c));
     }
 
     private void queueItem(Item i)
@@ -633,10 +676,10 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     }
 
     @Override
-    public void purgeForContainer(Container container)
+    public void purgeForContainer(@NotNull Container container)
     {
-        _runQueue.removeIf(i -> container.getEntityId().equals(i._containerId));
-        _itemQueue.removeIf(i -> container.getEntityId().equals(i._containerId));
+        _runQueue.removeIf(i -> container.getEntityId().equals(i._containerId) && i._pri != PRIORITY.delete);
+        _itemQueue.removeIf(i -> container.getEntityId().equals(i._containerId) && i._pri != PRIORITY.delete);
     }
 
     @Override
@@ -663,7 +706,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         });
         // The indexer uses multiple threads for different types of work. Queue a Runnable first, and when it executes,
         // queue an Item to ensure all queues are cleared
-        task.addRunnable(null, priority, () -> {
+        task.addRunnable(null, priority, (q) -> {
             logQueueStatus("drainQueue's Runnable.run()");
             task.addNoop(priority);
         });
@@ -1031,11 +1074,35 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
                 if (null != i)
                 {
+                    final Item item = i;
                     while (!_shuttingDown && _itemQueue.size() > 1000)
                     {
                         try {Thread.sleep(100);}catch(InterruptedException ignored){}
                     }
-                    i._run.run();
+                    item._run.accept(new TaskIndexingQueue()
+                    {
+                        @Override
+                        public void addRunnable(@NotNull Consumer<TaskIndexingQueue> r)
+                        {
+                            Item childItem = new Item(item, r, null);
+                            item._task.addItem(childItem);
+                            queueItem(childItem);
+                        }
+
+                        @Override
+                        public void addResource(@NotNull WebdavResource r)
+                        {
+                            Item childItem = new Item(item, null, r);
+                            item._task.addItem(childItem);
+                            queueItem(childItem);
+                        }
+
+                        @Override
+                        public Container getContainer()
+                        {
+                            return ContainerManager.getForId(item._containerId);
+                        }
+                    });
                 }
             }
             catch (InterruptedException ignored) {}
@@ -1347,42 +1414,13 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     {
         _log.debug("Indexing container \"" + c + "\", since: " + since);
         final IndexTask task = null==in ? createTask("Index folder " + c.getPath()) : in;
-
-        Runnable r = () ->
+        task.getQueue(c, PRIORITY.crawl).addRunnable((q) ->
         {
             for (DocumentProvider p : _documentProviders)
             {
-                p.enumerateDocuments(task, c, since);
+                p.enumerateDocuments(q, since);
             }
-        };
-        task.addRunnable(c, PRIORITY.crawl, r);
-        if (null == in)
-            task.setReady();
-        return task;
-    }
-
-
-    // TODO: Remove? This is never called
-    // UNDONE: get last crawl time from Crawler? support incrementals
-    @Override
-    public IndexTask indexProject(IndexTask in, final Container c)
-    {
-        final IndexTask task = null==in ? createTask("Index project " + c.getName()) : in;
-
-        Runnable r = () -> {
-            MultiValuedMap<Container, Container> mmap = ContainerManager.getContainerTree(c);
-            Set<Container> set = new HashSet<>();
-            for (Container key : mmap.keySet())
-            {
-                set.add(key);
-                set.addAll(mmap.get(key));
-            }
-            for (Container i : set)
-            {
-                indexContainer(task, i, null);
-            }
-        };
-        task.addRunnable(c, PRIORITY.crawl, r);
+        });
         if (null == in)
             task.setReady();
         return task;

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Multiset;
 import com.google.common.collect.Multiset.Entry;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -181,7 +182,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         }
 
         @Override
-        public void addResource(@NotNull WebdavResource r, PRIORITY pri)
+        public void addResource(@NotNull WebdavResource r, @NotNull PRIORITY pri)
         {
             if (!r.shouldIndex())
                 return;
@@ -258,22 +259,22 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         long _start = 0;    // used by setLastIndexed
         long _complete = 0; // really just for debugging
 
-        Item(_IndexTask task, OPERATION op, String id, WebdavResource r, PRIORITY pri)
+        Item(_IndexTask task, OPERATION op, String id, WebdavResource r, @NotNull PRIORITY pri)
         {
             if (null != r)
                 _start = HeartBeat.currentTimeMillis();
             _op = op;
             _id = id;
             _res = r;
-            _pri = null == pri ? PRIORITY.bulk : pri;
+            _pri = pri;
             _task = task;
             _containerId = r == null ? null : r.getContainerId();
         }
 
-        Item(_IndexTask task, Runnable r, PRIORITY pri, Container container)
+        Item(_IndexTask task, Runnable r, @NotNull PRIORITY pri, Container container)
         {
             _run = r;
-            _pri = null == pri ? PRIORITY.bulk : pri;
+            _pri = pri;
             _task = task;
             _id = String.valueOf(r);
             _containerId = container == null ? null : container.getEntityId();
@@ -414,8 +415,9 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 _countIndexedSinceCommit++;
             }
         };
-        // Don't pass in a container because we don't want to eject this from the queue
-        queueItem(new Item(defaultTask(), r, PRIORITY.background, null));
+        // Don't try to pass in a container because we don't want to eject this from the queue as part of the container
+        // deletion process
+        queueItem(new Item(defaultTask(), r, PRIORITY.delete, null));
     }
 
     @Override
@@ -829,7 +831,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         if (null != name)
         {
             for (SearchResultTemplate template : _templates)
-                if (StringUtils.equalsIgnoreCase(name, template.getName()))
+                if (Strings.CI.equals(name, template.getName()))
                     return template;
         }
 
@@ -1341,7 +1343,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 p.enumerateDocuments(task, c, since);
             }
         };
-        task.addRunnable(c, PRIORITY.bulk, r); // breaks rule of always adding w/higher priority than parent task
+        task.addRunnable(c, PRIORITY.crawlLow, r);
         if (null == in)
             task.setReady();
         return task;
@@ -1368,7 +1370,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 indexContainer(task, i, null);
             }
         };
-        task.addRunnable(c, PRIORITY.bulk, r);
+        task.addRunnable(c, PRIORITY.crawlLow, r);
         if (null == in)
             task.setReady();
         return task;

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -38,6 +38,7 @@ import org.labkey.api.resource.Resource;
 import org.labkey.api.search.SearchResultTemplate;
 import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
+import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.Formats;
@@ -72,6 +73,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -171,22 +173,12 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
 
         @Override
-        public void addRunnable(@NotNull Runnable r, @NotNull PRIORITY pri)
+        public void addRunnable(Container container, @NotNull PRIORITY pri, @NotNull Runnable r)
         {
-            Item i = new Item(this, r, pri);
+            Item i = new Item(this, r, pri, container);
             this.addItem(i);
             queueItem(i);
         }
-
-
-        @Override
-        public void addResource(@NotNull String identifier, PRIORITY pri)
-        {
-            Item i = new Item(this, OPERATION.add, identifier, null, pri);
-            this.addItem(i);
-            queueItem(i);
-        }
-
 
         @Override
         public void addResource(@NotNull WebdavResource r, PRIORITY pri)
@@ -210,7 +202,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 }
             };
             addItem(i);
-            final Item r = new Item(this, () -> queueItem(i), pri);
+            final Item r = new Item(this, () -> queueItem(i), pri, null);
             queueItem(r);
         }
 
@@ -257,7 +249,8 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         Runnable _run;
         PRIORITY _pri;
         // Used to ensure FIFO ordering in the queue
-        final long seqNum = seq.incrementAndGet();
+        final long _seqNum = seq.incrementAndGet();
+        final GUID _containerId;
 
         int _preprocessAttempts = 0;
 
@@ -274,14 +267,16 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             _res = r;
             _pri = null == pri ? PRIORITY.bulk : pri;
             _task = task;
+            _containerId = r == null ? null : r.getContainerId();
         }
 
-        Item(_IndexTask task, Runnable r, PRIORITY pri)
+        Item(_IndexTask task, Runnable r, PRIORITY pri, Container container)
         {
             _run = r;
             _pri = null == pri ? PRIORITY.bulk : pri;
             _task = task;
             _id = String.valueOf(r);
+            _containerId = container == null ? null : container.getEntityId();
         }
 
         OPERATION getOperation()
@@ -349,13 +344,13 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         {
             int res = _pri.compareTo(o._pri) * -1;
             if (res == 0 && o != this)
-                res = (seqNum < o.seqNum ? -1 : 1);
+                res = (_seqNum < o._seqNum ? -1 : 1);
             return res;
         }
     }
 
 
-    final Item _commitItem = new Item(null, () -> {}, PRIORITY.commit);
+    final Item _commitItem = new Item(null, () -> {}, PRIORITY.commit, null);
 
 
     @Override
@@ -419,7 +414,8 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 _countIndexedSinceCommit++;
             }
         };
-        queueItem(new Item(defaultTask(), r, PRIORITY.background));
+        // Don't pass in a container because we don't want to eject this from the queue
+        queueItem(new Item(defaultTask(), r, PRIORITY.background, null));
     }
 
     @Override
@@ -463,7 +459,8 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             //Recrawl files as the container name may be used in paths & Urls. Issue #39696
             DavCrawler.getInstance().startFull(WebdavService.getPath().append(c.getParsedPath()), true);
         };
-        queueItem(new Item(defaultTask(), r, PRIORITY.delete));
+        // Don't pass a container because we don't want to skip this when a container is deleted
+        queueItem(new Item(defaultTask(), r, PRIORITY.delete, null));
     }
 
     private void queueItem(Item i)
@@ -616,11 +613,24 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         return URLHelper.queryEqual(a,b);
     }
 
+    public static @NotNull SearchService get()
+    {
+        return Objects.requireNonNull(ServiceRegistry.get().getService(SearchService.class));
+    }
+
     @Override
-    public boolean drainQueue(PRIORITY priority, long timeout, TimeUnit unit) throws InterruptedException
+    public void purgeForContainer(Container container)
+    {
+        _runQueue.removeIf(i -> container.getEntityId().equals(i._containerId));
+        _itemQueue.removeIf(i -> container.getEntityId().equals(i._containerId));
+    }
+
+    @Override
+    public boolean drainQueue(@NotNull PRIORITY priority, long timeout, @NotNull TimeUnit unit) throws InterruptedException
     {
         final CountDownLatch latch = new CountDownLatch(1);
         long start = System.currentTimeMillis();
+
         _IndexTask task = createTask("WaitForIndexer", new TaskListener()
         {
             @Override
@@ -639,7 +649,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         });
         // The indexer uses multiple threads for different types of work. Queue a Runnable first, and when it executes,
         // queue an Item to ensure all queues are cleared
-        task.addRunnable(priority, () -> {
+        task.addRunnable(null, priority, () -> {
             logQueueStatus("drainQueue's Runnable.run()");
             task.addNoop(priority);
         });
@@ -1331,7 +1341,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 p.enumerateDocuments(task, c, since);
             }
         };
-        task.addRunnable(r, PRIORITY.bulk); // breaks rule of always adding w/higher priority than parent task
+        task.addRunnable(c, PRIORITY.bulk, r); // breaks rule of always adding w/higher priority than parent task
         if (null == in)
             task.setReady();
         return task;
@@ -1358,7 +1368,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 indexContainer(task, i, null);
             }
         };
-        task.addRunnable(r, PRIORITY.bulk);
+        task.addRunnable(c, PRIORITY.bulk, r);
         if (null == in)
             task.setReady();
         return task;

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -239,7 +239,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
     // Consider: remove _op/OPERATION (not used), subclasses for resource vs. runnable (would clarify invariants and make
     // hashCode() & equals() more straightforward), formalize _id (using Runnable.toString() seems weak).
-    public class Item implements Comparable<Item>
+    public static class Item implements Comparable<Item>
     {
         static final AtomicLong seq = new AtomicLong();
 
@@ -290,7 +290,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             if (null == _res)
             {
                 _start = HeartBeat.currentTimeMillis();
-                _res = resolveResource(_id);
+                _res = get().resolveResource(_id);
             }
             return _res;
         }
@@ -344,6 +344,18 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         public int compareTo(@NotNull AbstractSearchService.Item o)
         {
             int res = _pri.compareTo(o._pri) * -1;
+            if (res == 0)
+            {
+                // Treat Runnables as a lower priority than Resources
+                if (this._run != null && o._run == null)
+                {
+                    return 1;
+                }
+                if (this._run == null && o._run != null)
+                {
+                    return -1;
+                }
+            }
             if (res == 0 && o != this)
                 res = (_seqNum < o._seqNum ? -1 : 1);
             return res;
@@ -1343,7 +1355,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 p.enumerateDocuments(task, c, since);
             }
         };
-        task.addRunnable(c, PRIORITY.crawlLow, r);
+        task.addRunnable(c, PRIORITY.crawl, r);
         if (null == in)
             task.setReady();
         return task;
@@ -1370,7 +1382,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 indexContainer(task, i, null);
             }
         };
-        task.addRunnable(c, PRIORITY.crawlLow, r);
+        task.addRunnable(c, PRIORITY.crawl, r);
         if (null == in)
             task.setReady();
         return task;

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -80,6 +80,7 @@ import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 public abstract class AbstractSearchService implements SearchService, ShutdownListener
 {
@@ -678,8 +679,16 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     @Override
     public void purgeForContainer(@NotNull Container container)
     {
-        _runQueue.removeIf(i -> container.getEntityId().equals(i._containerId) && i._pri != PRIORITY.delete);
-        _itemQueue.removeIf(i -> container.getEntityId().equals(i._containerId) && i._pri != PRIORITY.delete);
+        Predicate<Item> itemChecker = (i) -> container.getEntityId().equals(i._containerId) && i._pri != PRIORITY.delete;
+        _runQueue.removeIf(itemChecker);
+        _itemQueue.removeIf(itemChecker);
+
+        // Let the task know too, treating them as failures (since they were not successfully indexed)
+        for (_IndexTask task : _tasks)
+        {
+            List<Item> toRemove = task._subtasks.keySet().stream().filter(itemChecker).toList();
+            toRemove.forEach(i -> task.completeItem(i, false));
+        }
     }
 
     @Override
@@ -1591,10 +1600,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         @Override
         public void run(Logger log)
         {
-            SearchService ss = SearchService.get();
-
-            if (null != ss)
-                ss.maintenance();
+            SearchService.get().maintenance();
         }
     }
 

--- a/search/src/org/labkey/search/model/DavCrawler.java
+++ b/search/src/org/labkey/search/model/DavCrawler.java
@@ -417,7 +417,7 @@ public class DavCrawler implements ShutdownListener
                         _fileIORateLimiter.add(f.length(), isCrawlerThread);
                     }
 
-                    _task.addResource(child, SearchService.PRIORITY.background);
+                    _task.addResource(child, SearchService.PRIORITY.crawlLow);
                     addRecent(child);
                 }
                 else if (!child.shouldIndex())

--- a/search/src/org/labkey/search/model/DavCrawler.java
+++ b/search/src/org/labkey/search/model/DavCrawler.java
@@ -417,7 +417,7 @@ public class DavCrawler implements ShutdownListener
                         _fileIORateLimiter.add(f.length(), isCrawlerThread);
                     }
 
-                    _task.addResource(child, SearchService.PRIORITY.crawlLow);
+                    _task.addResource(child, SearchService.PRIORITY.crawl);
                     addRecent(child);
                 }
                 else if (!child.shouldIndex())

--- a/search/src/org/labkey/search/model/DavCrawler.java
+++ b/search/src/org/labkey/search/model/DavCrawler.java
@@ -417,7 +417,7 @@ public class DavCrawler implements ShutdownListener
                         _fileIORateLimiter.add(f.length(), isCrawlerThread);
                     }
 
-                    _task.addResource(child, SearchService.PRIORITY.crawl);
+                    _task.getQueue(null, SearchService.PRIORITY.crawl).addResource(child);
                     addRecent(child);
                 }
                 else if (!child.shouldIndex())

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -146,6 +146,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -2087,7 +2088,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         @Test
         public void testSort()
         {
-            Runnable r = () -> {};
+            Consumer<TaskIndexingQueue> r = (q) -> {};
 
             // Create crawl/Runnable items to ensure they get ordered based on creation order
             Item crawlRunnable1 = new Item(_ss.defaultTask(), r, PRIORITY.crawl, null);

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -2226,7 +2226,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
                     _latch.countDown();
                 }
             };
-            _ss.defaultTask().addResource(resource1, PRIORITY.item);
+            _ss.defaultTask().addResource(resource1, PRIORITY.modifiedHigh);
         }
 
         private List<SearchHit> search(String query) throws IOException

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -115,6 +115,7 @@ import org.labkey.api.view.WebPartView;
 import org.labkey.api.webdav.FileSystemResource;
 import org.labkey.api.webdav.SimpleDocumentResource;
 import org.labkey.api.webdav.WebdavResource;
+import org.labkey.api.webdav.WebdavService;
 import org.labkey.search.view.SearchWebPart;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
@@ -132,6 +133,7 @@ import java.lang.ref.SoftReference;
 import java.nio.ByteBuffer;
 import java.nio.file.FileSystemException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -2052,7 +2054,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         private final TestContext _context = TestContext.get();
         private final ActionURL _url = PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(_c).setExtraPath(_c.getId());
         private final SearchCategory _category = new SearchCategory("SearchTest", "Just a test");
-        private final SearchService _ss = SearchService.get();
+        private final AbstractSearchService _ss = (AbstractSearchService) SearchService.get();
         private final CountDownLatch _latch = new CountDownLatch(DOC_COUNT);
 
         /**
@@ -2080,6 +2082,25 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
             rootResource.list().stream()
                 .filter(Resource::isCollection)
                 .forEach(dir -> traverse(dir, fileFilter));
+        }
+
+        @Test
+        public void testSort()
+        {
+            Runnable r = () -> {};
+
+            // Create crawl/Runnable items to ensure they get ordered based on creation order
+            Item crawlRunnable1 = new Item(_ss.defaultTask(), r, PRIORITY.crawl, null);
+            Item crawlRunnable2 = new Item(_ss.defaultTask(), r, PRIORITY.crawl, null);
+            Item modifiedRunnable = new Item(_ss.defaultTask(), r, PRIORITY.modified, null);
+            Item deleteRunnable = new Item(_ss.defaultTask(), r, PRIORITY.delete, null);
+            Item crawlResource = new Item(_ss.defaultTask(), OPERATION.add, "fakeId1", WebdavService.get().lookup("/"), PRIORITY.crawl);
+            Item modifiedResource = new Item(_ss.defaultTask(), OPERATION.add, "fakeId2", WebdavService.get().lookup("/"), PRIORITY.modified);
+            Item deleteResource = new Item(_ss.defaultTask(), OPERATION.add, "fakeId3", WebdavService.get().lookup("/"), PRIORITY.delete);
+
+            List<Item> items = new ArrayList<>(Arrays.asList(crawlRunnable2, crawlRunnable1, modifiedRunnable, deleteRunnable, crawlResource, modifiedResource, deleteResource));
+            items.sort(null);
+            assertEquals(Arrays.asList(deleteResource, deleteRunnable, modifiedResource, modifiedRunnable, crawlResource, crawlRunnable1, crawlRunnable2), items);
         }
 
         @Test
@@ -2226,7 +2247,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
                     _latch.countDown();
                 }
             };
-            _ss.defaultTask().addResource(resource1, PRIORITY.modifiedHigh);
+            _ss.defaultTask().addResource(resource1, PRIORITY.modified);
         }
 
         private List<SearchHit> search(String query) throws IOException

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -366,14 +366,9 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
         ReportService.get().addUIProvider(new StudyReportUIProvider());
         ReportService.get().addGlobalItemFilterType(QueryReport.TYPE);
 
-        SearchService ss = SearchService.get();
-
-        if (null != ss)
-        {
-            ss.addSearchCategory(StudyManager.subjectCategory);
-            ss.addSearchCategory(StudyManager.datasetCategory);
-            ss.addDocumentProvider(this);
-        }
+        SearchService.get().addSearchCategory(StudyManager.subjectCategory);
+        SearchService.get().addSearchCategory(StudyManager.datasetCategory);
+        SearchService.get().addDocumentProvider(this);
 
         SystemMaintenance.addTask(new PurgeParticipantsMaintenanceTask());
         if (null != SpecimenService.get())
@@ -742,9 +737,9 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     }
 
     @Override
-    public void enumerateDocuments(@NotNull SearchService.IndexTask task, @NotNull Container c, Date modifiedSince)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, Date modifiedSince)
     {
-        StudyManager._enumerateDocuments(task, c, modifiedSince);
+        StudyManager._enumerateDocuments(queue, modifiedSince);
     }
     
     @Override

--- a/study/src/org/labkey/study/model/StudyImpl.java
+++ b/study/src/org/labkey/study/model/StudyImpl.java
@@ -672,9 +672,7 @@ public class StudyImpl extends ExtensibleStudyEntity<String, StudyImpl> implemen
     public void attachProtocolDocument(List<AttachmentFile> files, User user) throws IOException
     {
         AttachmentService.get().addAttachments(getProtocolDocumentAttachmentParent(), files, user);
-        SearchService ss = SearchService.get();
-        if (null != ss)
-            StudyManager._enumerateProtocolDocuments(ss.defaultTask(), this);
+        StudyManager._enumerateProtocolDocuments(SearchService.get().defaultTask().getQueue(getContainer(), SearchService.PRIORITY.modified), this);
     }
 
     @Override
@@ -766,9 +764,7 @@ public class StudyImpl extends ExtensibleStudyEntity<String, StudyImpl> implemen
     public void removeProtocolDocument(String name, User user)
     {
         AttachmentService.get().deleteAttachment(getProtocolDocumentAttachmentParent(), name, user);
-        SearchService ss = SearchService.get();
-        if (null != ss)
-            ss.deleteResource("attachment:/" + _protocolDocumentEntityId + "/" + PageFlowUtil.encode(name));
+        SearchService.get().deleteResource("attachment:/" + _protocolDocumentEntityId + "/" + PageFlowUtil.encode(name));
     }
 
     @Override

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4408,7 +4408,7 @@ public class StudyManager
                 });
             };
 
-            task.addRunnable(runnable, SearchService.PRIORITY.bulk);
+            task.addRunnable(c, SearchService.PRIORITY.bulk, runnable);
         });
     }
 
@@ -4467,7 +4467,7 @@ public class StudyManager
             }
         }
         
-        task.addRunnable(runEnumerate, SearchService.PRIORITY.crawl);
+        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
     }
 
 

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -129,7 +129,6 @@ import org.labkey.api.reports.model.ViewCategory;
 import org.labkey.api.reports.model.ViewCategoryListener;
 import org.labkey.api.reports.model.ViewCategoryManager;
 import org.labkey.api.search.SearchService;
-import org.labkey.api.search.SearchService.IndexTask;
 import org.labkey.api.search.SearchService.LastIndexedClause;
 import org.labkey.api.security.RoleAssignment;
 import org.labkey.api.security.SecurableResource;
@@ -219,6 +218,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.WeakHashMap;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.labkey.api.action.SpringActionController.ERROR_MSG;
@@ -4212,12 +4212,9 @@ public class StudyManager
             ss.deleteResource(docid);
     }
 
-    public static void indexDatasets(IndexTask task, Container c, Date modifiedSince)
+    public static void indexDatasets(SearchService.TaskIndexingQueue queue, Date modifiedSince)
     {
-        SearchService ss = SearchService.get();
-        if (null == ss)
-            return;
-
+        Container c = queue.getContainer();
         SimpleFilter filter = (null != c ? SimpleFilter.createContainerFilter(c) : new SimpleFilter());
         if (null != modifiedSince)
             filter.addCondition(FieldKey.fromParts("Modified"), modifiedSince, CompareType.DATE_GT);
@@ -4238,26 +4235,18 @@ public class StudyManager
                 {
                     DatasetDefinition dsd = StudyManager.getInstance().getDatasetDefinition(study, id);
                     if (null != dsd)
-                        indexDataset(task, dsd);
+                        indexDataset(queue, dsd);
                 }
             }
         });
     }
 
-    private static void indexDataset(@Nullable IndexTask task, DatasetDefinition dsd)
+    private static void indexDataset(SearchService.TaskIndexingQueue queue, DatasetDefinition dsd)
     {
         if (dsd.getType().equals(Dataset.TYPE_PLACEHOLDER))
             return;
         if (null == dsd.getTypeURI() || null == dsd.getDomain())
             return;
-        if (null == task)
-        {
-            // TODO: Workaround for 30614: Search module doesn't work on TeamCity
-            final SearchService ss = SearchService.get();
-            if (ss == null)
-                return;
-            task = ss.defaultTask();
-        }
         String docid = "dataset:" + new Path(dsd.getContainer().getId(), String.valueOf(dsd.getDatasetId()));
 
         StringBuilder body = new StringBuilder();
@@ -4295,14 +4284,15 @@ public class StudyManager
         SimpleDocumentResource r = new SimpleDocumentResource(new Path(docid), docid,
                 "text/plain", body.toString(),
                 view, props);
-        task.addResource(r, SearchService.PRIORITY.modified);
+        queue.addResource(r);
     }
 
-    public static void indexParticipants(final IndexTask task, @NotNull final Container c, @Nullable List<String> ptids, @Nullable Date modifiedSince)
+    public static void indexParticipants(SearchService.TaskIndexingQueue queue, @Nullable List<String> ptids, @Nullable Date modifiedSince)
     {
         if (null != ptids && ptids.isEmpty())
             return;
 
+        Container c = queue.getContainer();
         final StudyImpl study = StudyManager.getInstance().getStudy(c);
         if (null == study)
             return;
@@ -4345,7 +4335,7 @@ public class StudyManager
         List<List<String>> batches = ptids != null ? ListUtils.partition(ptids, BATCH_SIZE) : Collections.singletonList(null);
 
         batches.forEach(batch -> {
-            Runnable runnable = () -> {
+            Consumer<SearchService.TaskIndexingQueue> runnable = (q) -> {
                 SQLFragment sql;
 
                 if (null != batch)
@@ -4404,11 +4394,11 @@ public class StudyManager
                             new SqlExecutor(ss.getSchema()).execute(update);
                         }
                     };
-                    task.addResource(r, SearchService.PRIORITY.modified);
+                    queue.addResource(r);
                 });
             };
 
-            task.addRunnable(c, SearchService.PRIORITY.modified, runnable);
+            queue.addRunnable(runnable);
         });
     }
 
@@ -4418,60 +4408,45 @@ public class StudyManager
     // CONSIDER: add some facility like this to SearchService??
     // NOTE: this needs to be reviewed if we use modifiedSince
 
-    final static WeakHashMap<Container, Runnable> _lastEnumerate = new WeakHashMap<>();
+    final static WeakHashMap<Container, Consumer<SearchService.TaskIndexingQueue>> _lastEnumerate = new WeakHashMap<>();
 
-    public static void _enumerateDocuments(IndexTask t, final Container c, @Nullable Date modifiedSince)
+    public static void _enumerateDocuments(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince)
     {
-        if (null == c)
-            return;
-
-        final SearchService ss = SearchService.get();
-        if (ss == null)
-            return;
-        final IndexTask defaultTask = ss.defaultTask();
-        final IndexTask task = null==t ? defaultTask : t;
-
-        Runnable runEnumerate = new Runnable()
+        Container c = queue.getContainer();
+        Consumer<SearchService.TaskIndexingQueue> runEnumerate = new Consumer<>()
         {
-            @Override
-            public void run()
+            public void accept(SearchService.TaskIndexingQueue a)
             {
-                if (task == defaultTask)
+                synchronized (_lastEnumerate)
                 {
-                    synchronized (_lastEnumerate)
-                    {
-                        Runnable r = _lastEnumerate.get(c);
-                        if (this != r)
-                            return;
-                        _lastEnumerate.remove(c);
-                    }
+                    Consumer<SearchService.TaskIndexingQueue> r = _lastEnumerate.get(c);
+                    if (this != r)
+                        return;
+                    _lastEnumerate.remove(c);
                 }
 
                 Study study = StudyManager.getInstance().getStudy(c);
 
                 if (null != study)
                 {
-                    StudyManager.indexDatasets(task, c, modifiedSince);
-                    StudyManager.indexParticipants(task, c, null, modifiedSince);
+                    StudyManager.indexDatasets(a, modifiedSince);
+                    StudyManager.indexParticipants(a, null, modifiedSince);
                     // study protocol document
-                    _enumerateProtocolDocuments(task, study);
+                    _enumerateProtocolDocuments(queue, study);
                 }
             }
         };
 
-        if (task == defaultTask)
+        synchronized (_lastEnumerate)
         {
-            synchronized (_lastEnumerate)
-            {
-                _lastEnumerate.put(c, runEnumerate);
-            }
+            _lastEnumerate.put(c, runEnumerate);
         }
-        
-        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
+
+        queue.addRunnable(runEnumerate);
     }
 
 
-    public static void _enumerateProtocolDocuments(IndexTask task, @NotNull Study study)
+    public static void _enumerateProtocolDocuments(SearchService.TaskIndexingQueue queue, @NotNull Study study)
     {
         AttachmentParent parent = ((StudyImpl)study).getProtocolDocumentAttachmentParent();
         if (null == parent)
@@ -4494,7 +4469,7 @@ public class StudyManager
                 parent, att.getName(), SearchService.fileCategory
             );
             r.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
-            task.addResource(r, SearchService.PRIORITY.modified);
+            queue.addResource(r);
         }
     }
 

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4295,7 +4295,7 @@ public class StudyManager
         SimpleDocumentResource r = new SimpleDocumentResource(new Path(docid), docid,
                 "text/plain", body.toString(),
                 view, props);
-        task.addResource(r, SearchService.PRIORITY.item);
+        task.addResource(r, SearchService.PRIORITY.modifiedHigh);
     }
 
     public static void indexParticipants(final IndexTask task, @NotNull final Container c, @Nullable List<String> ptids, @Nullable Date modifiedSince)
@@ -4404,11 +4404,11 @@ public class StudyManager
                             new SqlExecutor(ss.getSchema()).execute(update);
                         }
                     };
-                    task.addResource(r, SearchService.PRIORITY.item);
+                    task.addResource(r, SearchService.PRIORITY.modifiedHigh);
                 });
             };
 
-            task.addRunnable(c, SearchService.PRIORITY.bulk, runnable);
+            task.addRunnable(c, SearchService.PRIORITY.modifiedLow, runnable);
         });
     }
 
@@ -4467,7 +4467,7 @@ public class StudyManager
             }
         }
         
-        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, runEnumerate);
     }
 
 
@@ -4494,7 +4494,7 @@ public class StudyManager
                 parent, att.getName(), SearchService.fileCategory
             );
             r.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
-            task.addResource(r, SearchService.PRIORITY.item);
+            task.addResource(r, SearchService.PRIORITY.modifiedHigh);
         }
     }
 

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4295,7 +4295,7 @@ public class StudyManager
         SimpleDocumentResource r = new SimpleDocumentResource(new Path(docid), docid,
                 "text/plain", body.toString(),
                 view, props);
-        task.addResource(r, SearchService.PRIORITY.modifiedHigh);
+        task.addResource(r, SearchService.PRIORITY.modified);
     }
 
     public static void indexParticipants(final IndexTask task, @NotNull final Container c, @Nullable List<String> ptids, @Nullable Date modifiedSince)
@@ -4404,11 +4404,11 @@ public class StudyManager
                             new SqlExecutor(ss.getSchema()).execute(update);
                         }
                     };
-                    task.addResource(r, SearchService.PRIORITY.modifiedHigh);
+                    task.addResource(r, SearchService.PRIORITY.modified);
                 });
             };
 
-            task.addRunnable(c, SearchService.PRIORITY.modifiedLow, runnable);
+            task.addRunnable(c, SearchService.PRIORITY.modified, runnable);
         });
     }
 
@@ -4467,7 +4467,7 @@ public class StudyManager
             }
         }
         
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, runEnumerate);
+        task.addRunnable(c, SearchService.PRIORITY.crawl, runEnumerate);
     }
 
 
@@ -4494,7 +4494,7 @@ public class StudyManager
                 parent, att.getName(), SearchService.fileCategory
             );
             r.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
-            task.addResource(r, SearchService.PRIORITY.modifiedHigh);
+            task.addResource(r, SearchService.PRIORITY.modified);
         }
     }
 

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -845,7 +845,7 @@ public class StudyManager
                     QueryService.get().fireQueryChanged(user, datasetDefinition.getContainer(), null, new SchemaKey(null, StudyQuerySchema.SCHEMA_NAME),
                             QueryChangeListener.QueryProperty.Name, Collections.singleton(change));
                 }
-                indexDataset(null, datasetDefinition);
+                indexDataset(SearchService.get().defaultTask().getQueue(datasetDefinition.getContainer(), SearchService.PRIORITY.modified), datasetDefinition);
             }, CommitTaskOption.POSTCOMMIT);
 
             // NOTE: not redundant with uncache() in commit task, there may be an active outer transaction

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -670,7 +670,7 @@ public class StudyManager
             QueryService.get().updateLastModified();
             transaction.commit();
         }
-        indexDataset(null, datasetDefinition);
+        indexDataset(SearchService.get().defaultTask().getQueue(datasetDefinition.getContainer(), SearchService.PRIORITY.modified), datasetDefinition);
     }
 
     /**

--- a/study/src/org/labkey/study/visitmanager/VisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/VisitManager.java
@@ -491,7 +491,7 @@ public abstract class VisitManager
             {
                 final ArrayList<String> ptids = new ArrayList<>(potentiallyInsertedParticipants);
                 Runnable r = () -> StudyManager.indexParticipants(ss.defaultTask(), c, ptids, null);
-                ss.defaultTask().addRunnable(r, SearchService.PRIORITY.group);
+                ss.defaultTask().addRunnable(c, SearchService.PRIORITY.group, r);
             }
             else
             {
@@ -502,7 +502,7 @@ public abstract class VisitManager
                     List<String> ptids = new TableSelector(StudySchema.getInstance().getTableInfoParticipant(), Collections.singleton("ParticipantId"), filter, null).getArrayList(String.class);
                     StudyManager.indexParticipants(ss.defaultTask(), c, ptids, null);
                 };
-                ss.defaultTask().addRunnable(r, SearchService.PRIORITY.group);
+                ss.defaultTask().addRunnable(c, SearchService.PRIORITY.group, r);
             }
         }
     }

--- a/study/src/org/labkey/study/visitmanager/VisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/VisitManager.java
@@ -484,26 +484,21 @@ public abstract class VisitManager
         //
         // tell the search service about potential new ptids
         //
-        final SearchService ss = SearchService.get();
-        if (null != ss)
+        SearchService.TaskIndexingQueue queue = SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified);
+        if (null != potentiallyInsertedParticipants)
         {
-            if (null != potentiallyInsertedParticipants)
+            final ArrayList<String> ptids = new ArrayList<>(potentiallyInsertedParticipants);
+            queue.addRunnable((q) -> StudyManager.indexParticipants(q, ptids, null));
+        }
+        else
+        {
+            queue.addRunnable((q) ->
             {
-                final ArrayList<String> ptids = new ArrayList<>(potentiallyInsertedParticipants);
-                Runnable r = () -> StudyManager.indexParticipants(ss.defaultTask(), c, ptids, null);
-                ss.defaultTask().addRunnable(c, SearchService.PRIORITY.modified, r);
-            }
-            else
-            {
-                Runnable r = () ->
-                {
-                    SimpleFilter filter = SimpleFilter.createContainerFilter(c);
-                    filter.addCondition(FieldKey.fromParts("LastIndexed"), null, CompareType.ISBLANK);
-                    List<String> ptids = new TableSelector(StudySchema.getInstance().getTableInfoParticipant(), Collections.singleton("ParticipantId"), filter, null).getArrayList(String.class);
-                    StudyManager.indexParticipants(ss.defaultTask(), c, ptids, null);
-                };
-                ss.defaultTask().addRunnable(c, SearchService.PRIORITY.modified, r);
-            }
+                SimpleFilter filter = SimpleFilter.createContainerFilter(c);
+                filter.addCondition(FieldKey.fromParts("LastIndexed"), null, CompareType.ISBLANK);
+                List<String> ptids = new TableSelector(StudySchema.getInstance().getTableInfoParticipant(), Collections.singleton("ParticipantId"), filter, null).getArrayList(String.class);
+                StudyManager.indexParticipants(q, ptids, null);
+            });
         }
     }
 

--- a/study/src/org/labkey/study/visitmanager/VisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/VisitManager.java
@@ -491,7 +491,7 @@ public abstract class VisitManager
             {
                 final ArrayList<String> ptids = new ArrayList<>(potentiallyInsertedParticipants);
                 Runnable r = () -> StudyManager.indexParticipants(ss.defaultTask(), c, ptids, null);
-                ss.defaultTask().addRunnable(c, SearchService.PRIORITY.modifiedLow, r);
+                ss.defaultTask().addRunnable(c, SearchService.PRIORITY.modified, r);
             }
             else
             {
@@ -502,7 +502,7 @@ public abstract class VisitManager
                     List<String> ptids = new TableSelector(StudySchema.getInstance().getTableInfoParticipant(), Collections.singleton("ParticipantId"), filter, null).getArrayList(String.class);
                     StudyManager.indexParticipants(ss.defaultTask(), c, ptids, null);
                 };
-                ss.defaultTask().addRunnable(c, SearchService.PRIORITY.modifiedLow, r);
+                ss.defaultTask().addRunnable(c, SearchService.PRIORITY.modified, r);
             }
         }
     }

--- a/study/src/org/labkey/study/visitmanager/VisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/VisitManager.java
@@ -491,7 +491,7 @@ public abstract class VisitManager
             {
                 final ArrayList<String> ptids = new ArrayList<>(potentiallyInsertedParticipants);
                 Runnable r = () -> StudyManager.indexParticipants(ss.defaultTask(), c, ptids, null);
-                ss.defaultTask().addRunnable(c, SearchService.PRIORITY.group, r);
+                ss.defaultTask().addRunnable(c, SearchService.PRIORITY.modifiedLow, r);
             }
             else
             {
@@ -502,7 +502,7 @@ public abstract class VisitManager
                     List<String> ptids = new TableSelector(StudySchema.getInstance().getTableInfoParticipant(), Collections.singleton("ParticipantId"), filter, null).getArrayList(String.class);
                     StudyManager.indexParticipants(ss.defaultTask(), c, ptids, null);
                 };
-                ss.defaultTask().addRunnable(c, SearchService.PRIORITY.group, r);
+                ss.defaultTask().addRunnable(c, SearchService.PRIORITY.modifiedLow, r);
             }
         }
     }

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -45,7 +45,6 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.search.SearchService;
-import org.labkey.api.search.SearchService.IndexTask;
 import org.labkey.api.security.User;
 import org.labkey.api.security.WikiTermsOfUseProvider;
 import org.labkey.api.util.ContainerUtil;
@@ -686,8 +685,11 @@ public class WikiManager implements WikiService
             return;
         }
         Container c = ContainerService.get().getForId(page.getContainerId());
-        if (null != c)
-            indexWikis(null, c, null, page.getName(), SearchService.PRIORITY.modified);
+        SearchService ss = getSearchService();
+        if (null != ss && c != null)
+        {
+            indexWikis(ss.defaultTask().getQueue(c, SearchService.PRIORITY.modified), null, page.getName());
+        }
     }
 
 
@@ -704,32 +706,23 @@ public class WikiManager implements WikiService
     }
 
 
-    public void indexWikis(@Nullable IndexTask task, @NotNull Container c, @Nullable Date modifiedSince, @Nullable String wikiName, SearchService.PRIORITY priority)
+    public void indexWikis(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince, @Nullable String wikiName)
     {
-        final SearchService ss = getSearchService();
-        if (null == ss)
-            return;
-
-        if (null == task)
-            task = ss.defaultTask();
-
-        final IndexTask fTask = task;
-
         // Use a Runnable to postpone construction of the MockViewContext; if we're bootstrapping then base server URL won't be ready.
-        fTask.addRunnable(c, priority, () -> {
+        queue.addRunnable((q) -> {
             // Push a ViewContext onto the stack before indexing; wikis may need this to render embedded webparts
-            try (StackResetter ignored = ViewContext.pushMockViewContext(User.getSearchUser(), c, new ActionURL()))
+            try (StackResetter ignored = ViewContext.pushMockViewContext(User.getSearchUser(), q.getContainer(), new ActionURL()))
             {
-                indexWikiContainerFast(fTask, c, modifiedSince, wikiName);
+                indexWikiContainerFast(q, modifiedSince, wikiName);
             }
         });
     }
 
 
-    private void indexWikiContainerFast(@NotNull IndexTask task, @NotNull Container c, @Nullable Date modifiedSince, @Nullable String wikiName)
+    private void indexWikiContainerFast(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince, @Nullable String wikiName)
     {
         LOG.debug("indexWikiContainerFast(" + wikiName + ")");
-
+        Container c = queue.getContainer();
         SQLFragment f = new SQLFragment();
         f.append("SELECT P.entityid, P.container, P.name, P.owner, P.createdby, P.created, P.modifiedby, P.modified, P.shouldindex,")
             .append("V.title, V.body, V.renderertype\n");
@@ -791,7 +784,7 @@ public class WikiManager implements WikiService
                 try
                 {
                     WikiWebdavProvider.WikiPageResource r = new RenderedWikiResource(c, wikiName, entityId, body, rendererType, props);
-                    task.addResource(r, SearchService.PRIORITY.modified);
+                    queue.addResource(r);
                 }
                 catch (Throwable t)
                 {
@@ -851,7 +844,7 @@ public class WikiManager implements WikiService
                 NavTree t = new NavTree("wiki page", wikiUrl);
                 String nav = NavTree.toJS(Collections.singleton(t), null, false, true).toString();
                 attachmentRes.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
-                task.addResource(attachmentRes, SearchService.PRIORITY.modified);
+                queue.addResource(attachmentRes);
             }
         }
     }

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -687,7 +687,7 @@ public class WikiManager implements WikiService
         }
         Container c = ContainerService.get().getForId(page.getContainerId());
         if (null != c)
-            indexWikis(null, c, null, page.getName());
+            indexWikis(null, c, null, page.getName(), SearchService.PRIORITY.modifiedHigh);
     }
 
 
@@ -703,8 +703,8 @@ public class WikiManager implements WikiService
         new SqlExecutor(comm.getSchema()).execute("UPDATE " + comm.getTableInfoPages() + " SET LastIndexed = ? WHERE Container = ? AND Name = ?", new Timestamp(ms), c, name);
     }
 
-    
-    public void indexWikis(@Nullable IndexTask task, @NotNull Container c, @Nullable Date modifiedSince, @Nullable String wikiName)
+
+    public void indexWikis(@Nullable IndexTask task, @NotNull Container c, @Nullable Date modifiedSince, @Nullable String wikiName, SearchService.PRIORITY priority)
     {
         final SearchService ss = getSearchService();
         if (null == ss)
@@ -716,7 +716,7 @@ public class WikiManager implements WikiService
         final IndexTask fTask = task;
 
         // Use a Runnable to postpone construction of the MockViewContext; if we're bootstrapping then base server URL won't be ready.
-        fTask.addRunnable(c, SearchService.PRIORITY.item, () -> {
+        fTask.addRunnable(c, priority, () -> {
             // Push a ViewContext onto the stack before indexing; wikis may need this to render embedded webparts
             try (StackResetter ignored = ViewContext.pushMockViewContext(User.getSearchUser(), c, new ActionURL()))
             {
@@ -791,7 +791,7 @@ public class WikiManager implements WikiService
                 try
                 {
                     WikiWebdavProvider.WikiPageResource r = new RenderedWikiResource(c, wikiName, entityId, body, rendererType, props);
-                    task.addResource(r, SearchService.PRIORITY.item);
+                    task.addResource(r, SearchService.PRIORITY.modifiedHigh);
                 }
                 catch (Throwable t)
                 {
@@ -851,7 +851,7 @@ public class WikiManager implements WikiService
                 NavTree t = new NavTree("wiki page", wikiUrl);
                 String nav = NavTree.toJS(Collections.singleton(t), null, false, true).toString();
                 attachmentRes.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
-                task.addResource(attachmentRes, SearchService.PRIORITY.item);
+                task.addResource(attachmentRes, SearchService.PRIORITY.modifiedHigh);
             }
         }
     }

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -716,13 +716,13 @@ public class WikiManager implements WikiService
         final IndexTask fTask = task;
 
         // Use a Runnable to postpone construction of the MockViewContext; if we're bootstrapping then base server URL won't be ready.
-        fTask.addRunnable(() -> {
+        fTask.addRunnable(c, SearchService.PRIORITY.item, () -> {
             // Push a ViewContext onto the stack before indexing; wikis may need this to render embedded webparts
             try (StackResetter ignored = ViewContext.pushMockViewContext(User.getSearchUser(), c, new ActionURL()))
             {
                 indexWikiContainerFast(fTask, c, modifiedSince, wikiName);
             }
-        }, SearchService.PRIORITY.item);
+        });
     }
 
 

--- a/wiki/src/org/labkey/wiki/WikiManager.java
+++ b/wiki/src/org/labkey/wiki/WikiManager.java
@@ -687,7 +687,7 @@ public class WikiManager implements WikiService
         }
         Container c = ContainerService.get().getForId(page.getContainerId());
         if (null != c)
-            indexWikis(null, c, null, page.getName(), SearchService.PRIORITY.modifiedHigh);
+            indexWikis(null, c, null, page.getName(), SearchService.PRIORITY.modified);
     }
 
 
@@ -791,7 +791,7 @@ public class WikiManager implements WikiService
                 try
                 {
                     WikiWebdavProvider.WikiPageResource r = new RenderedWikiResource(c, wikiName, entityId, body, rendererType, props);
-                    task.addResource(r, SearchService.PRIORITY.modifiedHigh);
+                    task.addResource(r, SearchService.PRIORITY.modified);
                 }
                 catch (Throwable t)
                 {
@@ -851,7 +851,7 @@ public class WikiManager implements WikiService
                 NavTree t = new NavTree("wiki page", wikiUrl);
                 String nav = NavTree.toJS(Collections.singleton(t), null, false, true).toString();
                 attachmentRes.getMutableProperties().put(SearchService.PROPERTY.navtrail.toString(), nav);
-                task.addResource(attachmentRes, SearchService.PRIORITY.modifiedHigh);
+                task.addResource(attachmentRes, SearchService.PRIORITY.modified);
             }
         }
     }

--- a/wiki/src/org/labkey/wiki/WikiModule.java
+++ b/wiki/src/org/labkey/wiki/WikiModule.java
@@ -207,8 +207,8 @@ public class WikiModule extends CodeOnlyModule implements SearchService.Document
     @Override
     public void enumerateDocuments(final SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
-        Runnable r = () -> getWikiManager().indexWikis(task, c, modifiedSince, null);
-        task.addRunnable(c, SearchService.PRIORITY.bulk, r);
+        Runnable r = () -> getWikiManager().indexWikis(task, c, modifiedSince, null, SearchService.PRIORITY.crawlHigh);
+        task.addRunnable(c, SearchService.PRIORITY.crawlLow, r);
     }
 
 

--- a/wiki/src/org/labkey/wiki/WikiModule.java
+++ b/wiki/src/org/labkey/wiki/WikiModule.java
@@ -207,8 +207,8 @@ public class WikiModule extends CodeOnlyModule implements SearchService.Document
     @Override
     public void enumerateDocuments(final SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
-        Runnable r = () -> getWikiManager().indexWikis(task, c, modifiedSince, null, SearchService.PRIORITY.crawlHigh);
-        task.addRunnable(c, SearchService.PRIORITY.crawlLow, r);
+        Runnable r = () -> getWikiManager().indexWikis(task, c, modifiedSince, null, SearchService.PRIORITY.crawl);
+        task.addRunnable(c, SearchService.PRIORITY.crawl, r);
     }
 
 

--- a/wiki/src/org/labkey/wiki/WikiModule.java
+++ b/wiki/src/org/labkey/wiki/WikiModule.java
@@ -208,7 +208,7 @@ public class WikiModule extends CodeOnlyModule implements SearchService.Document
     public void enumerateDocuments(final SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
     {
         Runnable r = () -> getWikiManager().indexWikis(task, c, modifiedSince, null);
-        task.addRunnable(r, SearchService.PRIORITY.bulk);
+        task.addRunnable(c, SearchService.PRIORITY.bulk, r);
     }
 
 

--- a/wiki/src/org/labkey/wiki/WikiModule.java
+++ b/wiki/src/org/labkey/wiki/WikiModule.java
@@ -205,10 +205,10 @@ public class WikiModule extends CodeOnlyModule implements SearchService.Document
 
 
     @Override
-    public void enumerateDocuments(final SearchService.IndexTask task, @NotNull Container c, @Nullable Date modifiedSince)
+    public void enumerateDocuments(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince)
     {
-        Runnable r = () -> getWikiManager().indexWikis(task, c, modifiedSince, null, SearchService.PRIORITY.crawl);
-        task.addRunnable(c, SearchService.PRIORITY.crawl, r);
+        queue.addRunnable((q) ->
+                getWikiManager().indexWikis(q, modifiedSince, null));
     }
 
 


### PR DESCRIPTION
#### Rationale
Instead of waiting for the indexer to drain its queue before deleting a container, we can purge that work from the queue.

#### Changes
- Track search work based on the container for the data
- Purge work for the container being deleted

#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix