### PR TITLE
StudyDatasetsTest fix for importing tsv data with a field name that contains double quote

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetsTest.java
@@ -40,6 +40,7 @@ import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.TestDataGenerator;
+import org.labkey.test.util.data.TestDataUtils;
 import org.openqa.selenium.WebElement;
 
 import java.io.File;
@@ -226,7 +227,13 @@ public class StudyDatasetsTest extends BaseWebDriverTest
         DomainFormPanel panel = definitionPage.getFieldsPanel();
         panel.manuallyDefineFields(fieldInfo.getFieldDefinition());
         definitionPage.clickSave();
-        importDatasetData(datasetName, "mouseId\tsequenceNum\t\"" + fieldInfo.getName() + "\"\n", "a1\t1\ttest123", "All data");
+        importDatasetData(datasetName, "", TestDataUtils.tsvStringFromRowMaps(
+                List.of(Map.of(
+                        "mouseId", "a1",
+                        "sequenceNum", "1",
+                        fieldInfo.getName(), "test123"
+                )), List.of("mouseId", "sequenceNum", fieldInfo.getName()), true
+        ), "All data");
 
         File exportedFolder = exportFolderAsZip(null, false, false, false, false);
         deleteStudy();


### PR DESCRIPTION
#### Rationale
This is a backport of a test change so that we don't continue to get this failure randomly in 25.7. When the StudyDatasetsTest fuzz testing randomly generates a field name containing a double quote, it is failing the tsv import because the quote isn't encoded in the tsv import.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6859

#### Changes
- use the TestDataUtils.tsvStringFromRowMaps() helper instead of generating a tab sep string in the test case