### PR TITLE
Fix link reports

### DIFF
--- a/api/src/org/labkey/api/view/HttpView.java
+++ b/api/src/org/labkey/api/view/HttpView.java
@@ -603,6 +603,7 @@ public abstract class HttpView<ModelBean> extends DefaultModelAndView<ModelBean>
         return redirect(url.getLocalURIString());
     }
 
+    @Deprecated(forRemoval = true) // Use ActionURL or URLHelper variant instead. TODO: Remove
     public static HttpView<?> redirect(String url)
     {
         throw new RedirectException(url);

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -149,6 +149,7 @@ import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.Portal;
+import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.VBox;
 import org.labkey.api.view.ViewBackgroundInfo;
@@ -1017,9 +1018,15 @@ public class ReportsController extends SpringActionController
             {
                 reportView = _report.getRunReportView(getViewContext());
             }
+            catch (RedirectException re)
+            {
+                // Link reports throw RedirectException... pass it on
+                throw re;
+            }
             catch (RuntimeException e)
             {
-                return new HtmlView(SPAN(cl("labkey-error"), e.getMessage(), ". Unable to create report."));
+                String message = e.getMessage();
+                return new HtmlView(SPAN(cl("labkey-error"), Objects.requireNonNullElse(message, e.getClass().getSimpleName()), ". Unable to create report."));
             }
 
             if (!isPrint() && DiscussionService.get() != null)

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -200,7 +200,6 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.labkey.api.reports.model.ViewCategoryManager.UNCATEGORIZED_ROWID;
 import static org.labkey.api.util.DOM.DIV;
-import static org.labkey.api.util.DOM.SPAN;
 import static org.labkey.api.util.DOM.cl;
 
 public class ReportsController extends SpringActionController
@@ -1025,8 +1024,8 @@ public class ReportsController extends SpringActionController
             }
             catch (RuntimeException e)
             {
-                String message = e.getMessage();
-                return new HtmlView(SPAN(cl("labkey-error"), Objects.requireNonNullElse(message, e.getClass().getSimpleName()), ". Unable to create report."));
+                String message = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName()) + ". Unable to create report.";
+                return HtmlView.err(message);
             }
 
             if (!isPrint() && DiscussionService.get() != null)


### PR DESCRIPTION
#### Rationale
Related PR changed `redirect()` to throw `RedirectException` instead of returning an `HttpRedirectView`. `ReportsController.getRunReportView()` was catching all exceptions and rendering them as errors. Just need to change that action to pass RedirectException on.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6862

#### Tasks 📍
- [x] Needs Automation - No: plenty of existing automated tests caught