### PR TITLE
Move server usage methods out of MothershipHelper

### DIFF
--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipReportTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.OrderWith;
 import org.junit.runner.manipulation.Alphanumeric;
+import org.labkey.serverapi.util.UsageReportingLevel;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
@@ -94,7 +95,7 @@ public class MothershipReportTest extends BaseWebDriverTest implements PostgresO
     @Test
     public void testTopLevelItems() throws Exception
     {
-        _mothershipHelper.createUsageReport(MothershipHelper.ReportLevel.ON, true, null);
+        _mothershipHelper.createUsageReport(UsageReportingLevel.ON, true, null);
         ShowInstallationDetailPage installDetail = ShowInstallationDetailPage.beginAt(this, TEST_HOST_NAME);
         String distributionName = getDeployedDistributionName();
         Assert.assertEquals("Distribution name.", distributionName, installDetail.getDistributionName());
@@ -129,7 +130,7 @@ public class MothershipReportTest extends BaseWebDriverTest implements PostgresO
     @Test
     public void testJsonMetrics() throws Exception
     {
-        _mothershipHelper.createUsageReport(MothershipHelper.ReportLevel.ON, false, null);
+        _mothershipHelper.createUsageReport(UsageReportingLevel.ON, false, null);
         assertTextPresent("jsonMetrics",
                 "modules",
                 "controllerHits", // Should have multiple sections for this across different modules
@@ -193,7 +194,7 @@ public class MothershipReportTest extends BaseWebDriverTest implements PostgresO
     {
         log("Simulate receiving a report behind a load balancer");
         String forwardedFor = "172.217.5.68"; // The IP address for www.google.com, so unlikely to ever be the real test server IP address
-        _mothershipHelper.createUsageReport(MothershipHelper.ReportLevel.ON, true, forwardedFor);
+        _mothershipHelper.createUsageReport(UsageReportingLevel.ON, true, forwardedFor);
         ShowInstallationDetailPage installDetail = ShowInstallationDetailPage.beginAt(this, TEST_HOST_NAME);
         Assert.assertEquals("Forwarded for", forwardedFor, installDetail.getServerIP());
     }
@@ -213,7 +214,7 @@ public class MothershipReportTest extends BaseWebDriverTest implements PostgresO
     public void testServerHostName() throws Exception
     {
         log("Send test server host name from base server url");
-        _mothershipHelper.createUsageReport(MothershipHelper.ReportLevel.ON, true, null);
+        _mothershipHelper.createUsageReport(UsageReportingLevel.ON, true, null);
 
         String hostName = new URI(CustomizeSitePage.beginAt(this).getBaseServerUrl()).getHost();
         String hostName2 = "TEST_" + hostName;

--- a/mothership/test/src/org/labkey/test/util/mothership/MothershipHelper.java
+++ b/mothership/test/src/org/labkey/test/util/mothership/MothershipHelper.java
@@ -28,15 +28,14 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.remoteapi.CommandException;
-import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.remoteapi.query.Sort;
 import org.labkey.remoteapi.query.UpdateRowsCommand;
+import org.labkey.serverapi.util.UsageReportingLevel;
 import org.labkey.test.LabKeySiteWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.core.admin.CustomizeSitePage;
@@ -49,6 +48,7 @@ import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.Maps;
 import org.labkey.test.util.TestLogger;
+import org.labkey.test.util.core.admin.ServerUsageUtils;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WrapsDriver;
@@ -59,6 +59,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 
@@ -85,7 +86,7 @@ public class MothershipHelper extends LabKeySiteWrapper
     }
 
     @Override
-    public WebDriver getWrappedDriver()
+    public @NotNull WebDriver getWrappedDriver()
     {
         return _driver.getWrappedDriver();
     }
@@ -192,7 +193,7 @@ public class MothershipHelper extends LabKeySiteWrapper
             params.put("comments", comments);
         if (assignedToEmail != null)
         {
-            String assignedToId = assignedToEmail.isEmpty() ? "" : new APIUserHelper(this).getUserId(assignedToEmail).toString();
+            String assignedToId = assignedToEmail.isEmpty() ? "" : Objects.requireNonNull(new APIUserHelper(this).getUserId(assignedToEmail), () -> "User not found: " + assignedToEmail).toString();
             params.put("assignedTo", assignedToId);
         }
         command.setParameters(params);
@@ -222,43 +223,29 @@ public class MothershipHelper extends LabKeySiteWrapper
         }
     }
 
-    public enum ReportLevel
-    {
-        NONE,
-        ON
-    }
-
-    public void createUsageReport(ReportLevel level, boolean submit, String forwardedFor)
+    public void createUsageReport(UsageReportingLevel level, boolean submit, String forwardedFor)
     {
         createMothershipReport("CheckForUpdates", level, submit, forwardedFor);
     }
 
-    public void createExceptionReport(ReportLevel level, boolean submit)
+    public void createExceptionReport(UsageReportingLevel level, boolean submit)
     {
         createMothershipReport("ReportException", level, submit, null);
     }
 
-    private void createMothershipReport(String type, ReportLevel level, boolean submit, @Nullable String forwardedFor)
+    private void createMothershipReport(String type, UsageReportingLevel level, boolean submit, @Nullable String forwardedFor)
     {
-        String relativeUrl = getTestMothershipReportUrl(type, level, submit, forwardedFor);
+        String relativeUrl = ServerUsageUtils.getTestMothershipReportUrl(type, level, submit, forwardedFor);
         beginAt(relativeUrl);
     }
 
     public void submitMockUsageReport(String hostName, String serverGUID, String sessionGUID) throws IOException, CommandException
     {
-        Map<String, Object> usageReportJson = getUsageReportJson();
+        Map<String, Object> usageReportJson = ServerUsageUtils.getUsageReportJson(createDefaultConnection());
         usageReportJson.put("serverHostName", hostName);
         usageReportJson.put("serverGUID", serverGUID);
         usageReportJson.put("serverSessionGUID", sessionGUID);
         submitUsageReport(usageReportJson);
-    }
-
-    public Map<String, Object> getUsageReportJson() throws IOException, CommandException
-    {
-        SimpleGetCommand command = new SimpleGetCommand("admin", "testMothershipReport");
-        command.setParameters(getMothershipReportParams("CheckForUpdates", ReportLevel.ON, false, null));
-        CommandResponse response = command.execute(createDefaultConnection(), "/");
-        return response.getParsedData();
     }
 
     private void submitUsageReport(Map<String, Object> report) throws IOException
@@ -286,26 +273,6 @@ public class MothershipHelper extends LabKeySiteWrapper
                 EntityUtils.consumeQuietly(response.getEntity());
             }
         }
-    }
-
-    @NotNull
-    public static String getTestMothershipReportUrl(String type, ReportLevel level, boolean submit, @Nullable String forwardedFor)
-    {
-        Map<String, Object> params = getMothershipReportParams(type, level, submit, forwardedFor);
-        return WebTestHelper.buildURL("admin", "testMothershipReport", params);
-    }
-
-    @NotNull
-    private static Map<String, Object> getMothershipReportParams(String type, ReportLevel level, boolean submit, @Nullable String forwardedFor)
-    {
-        Map<String, Object> params = new HashMap<>();
-        params.put("type", type);
-        params.put("level", level.toString());
-        params.put("submit", submit);
-        params.put("testMode", true);
-        if (null != forwardedFor)
-            params.put("forwardedFor", forwardedFor);
-        return params;
     }
 
     @LogMethod


### PR DESCRIPTION
#### Rationale
MothershipHelper contains functionality that is useful more broadly. `testMothershipReport` returns server metrics, which we should probably be testing more broadly.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2579

#### Changes
- Move server usage methods to `testAutomation` repository