### PR TITLE
give the mouse group checkboxes a moment to become interactive

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/StudyPHIExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPHIExportTest.java
@@ -80,6 +80,8 @@ public class StudyPHIExportTest extends StudyExportTest
         // not in any group only appears if there are participants not in any of the groups in a category
         assertTextPresent("Group 1", "Group 2");
         assertTextNotPresent("Not in any cohort");
+        sleep(1500);    // give grid-row checkboxes a moment to become interactable
+                            // it might be nice for ext4Helper to do this
 
         _ext4Helper.uncheckGridRowCheckbox("Group 1");
         _ext4Helper.uncheckGridRowCheckbox("Group 2");


### PR DESCRIPTION
#### Rationale
Recently, [StudyPHIExportTest.testSteps](https://teamcity.labkey.org/viewLog.html?buildId=3597644&buildTypeId=LabKey_257Release_Community_DailySqlServer&fromSakuraUI=true#testNameId-2177001183088745253) failed because the mouse-group selection checkboxes weren't ready for interaction when the ext4Helper tried to un-check them during the test. I was able to repro locally, adding a brief wait to give those checkboxes time seems to have helped.

#### Related Pull Requests
n/a

#### Changes
slow down the test a bit