### PR TITLE
Issue 53536: LKSM/LKB: Moving assay runs with multiple file fields may populate file fields incorrectly

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayProvider.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayProvider.java
@@ -2169,10 +2169,11 @@ public abstract class AbstractAssayProvider implements AssayProvider
         Map<Integer, ExpRun> runMap = new HashMap<>();
         runs.forEach(run -> runMap.put(run.getRowId(), run));
 
-        Map<String, AssayFileMoveReference> fileMoveReferences = new HashMap<>();
-        Map<String, List<Integer>> fileMoveResultRowIds = new HashMap<>();
         for (String fileField : fileFields)
         {
+            Map<String, AssayFileMoveReference> fileMoveReferences = new HashMap<>();
+            Map<String, List<Integer>> fileMoveResultRowIds = new HashMap<>();
+
             var fileColumn = assayResultTable.getColumn(fileField);
             TableSelector ts = new TableSelector(assayResultTable, assayResultTable.getColumns("rowid", "run", fileField), filter, null);
             Map<String, Object>[] resultFiles = ts.getMapArray();


### PR DESCRIPTION
#### Rationale
Issue [53536](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53536): LKSM/LKB: Moving assay runs with multiple file fields may populate file fields incorrectly 

The related [PR](https://github.com/LabKey/platform/pull/6699) introduced a bug that sets a file field value even though there is no relevant file values found for that field. 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6881
- https://github.com/LabKey/limsModules/pull/1553
- https://github.com/LabKey/platform/pull/6699

#### Changes
- Correcting per field handling of result files during move.

#### Tasks 📍
- [x] Manual Testing @labkey-susanh 
- [x] Needs Automation
- [x] Verify Fix