### PR TITLE
Fix assorted tests where users have access to subfolders but not parent

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1551,6 +1551,7 @@ public class ContainerManager
                             if (isNavAccessOpen)
                             {
                                 NavTree noLinkTree = new NavTree(missing.getName());
+                                noLinkTree.setId(missing.getId());
                                 m.put(missing.getId(), noLinkTree);
                             }
                             else


### PR DESCRIPTION
#### Rationale
Recent improvements to container caching changed the behavior for `ContainerManager.getForId("")`. It previously returned the root container, which it shouldn't have. That was a load-bearing bug for rendering folder trees where the user has access to a subfolder but no access to the parent.

Example failures in the external modules:

https://teamcity.labkey.org/buildConfiguration/bt310?branch=&buildTypeTab=overview

#### Changes
- Set the nav tree's ID even if it's not accessible so the container can be found