### PR TITLE
Put legacy union audit table behind a deprecated feature flag

### DIFF
--- a/audit/src/org/labkey/audit/AuditModule.java
+++ b/audit/src/org/labkey/audit/AuditModule.java
@@ -21,6 +21,8 @@ import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.provider.SiteSettingsAuditProvider;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
+import org.labkey.api.settings.OptionalFeatureFlag;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.audit.query.AuditQuerySchema;
 
@@ -30,6 +32,8 @@ import java.util.Set;
 
 public class AuditModule extends DefaultModule
 {
+    public static final String LEGACY_UNION_AUDIT_TABLE = "legacyUnionAuditTable";
+
     @Override
     @NotNull
     protected Collection<WebPartFactory> createWebPartFactories()
@@ -75,6 +79,14 @@ public class AuditModule extends DefaultModule
         AuditLogService.get().registerAuditType(new SiteSettingsAuditProvider());
 
         AuditController.registerAdminConsoleLinks();
+        OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(
+            LEGACY_UNION_AUDIT_TABLE,
+            "Restore legacy union audit table",
+            "Restores a legacy query that unions all the event tables together into a single query. This option will be removed in LabKey Server v26.3.",
+            false,
+            false,
+            OptionalFeatureService.FeatureType.Deprecated
+        ));
     }
 
     @Override

--- a/audit/src/org/labkey/audit/query/AuditQuerySchema.java
+++ b/audit/src/org/labkey/audit/query/AuditQuerySchema.java
@@ -29,6 +29,7 @@ import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
+import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.view.ViewContext;
 import org.labkey.audit.AuditSchema;
 import org.springframework.validation.BindException;
@@ -37,10 +38,8 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-/**
- * User: Karl Lum
- * Date: Oct 5, 2007
- */
+import static org.labkey.audit.AuditModule.LEGACY_UNION_AUDIT_TABLE;
+
 public class AuditQuerySchema extends UserSchema
 {
     public static final String SCHEMA_NAME = "auditLog";
@@ -86,12 +85,12 @@ public class AuditQuerySchema extends UserSchema
     @Override
     public TableInfo createTable(String name, ContainerFilter cf)
     {
-        // event specific audit views are implemented as queries on the audit schema
+        // event-specific audit views are implemented as queries on the audit schema
         AuditTypeProvider provider = AuditLogService.get().getAuditProvider(name);
         if (provider != null)
             return provider.createTableInfo(this, cf);
 
-        if (AUDIT_TABLE_NAME.equalsIgnoreCase(name))
+        if (OptionalFeatureService.get().isFeatureEnabled(LEGACY_UNION_AUDIT_TABLE) && AUDIT_TABLE_NAME.equalsIgnoreCase(name))
             return new AuditLogUnionTable(this, cf);
 
         return null;


### PR DESCRIPTION
#### Rationale
This table is likely never used. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53551

#### Tasks 📍
- [x] Code review @labkey-klum 
- [x] Verify Fix
- [x] Adjust `RhinoService$TestCase` / simpleQueryTest.js - https://github.com/LabKey/testAutomation/pull/2595
- [x] Fix LDK usage queries - https://github.com/LabKey/LabDevKitModules/pull/255
- [x] Fix WNPRC backup query - https://github.com/LabKey/wnprc-modules/pull/858