### PR TITLE
Drop legacy audit table if exists

### DIFF
--- a/audit/resources/schemas/dbscripts/postgresql/audit-25.000-25.001.sql
+++ b/audit/resources/schemas/dbscripts/postgresql/audit-25.000-25.001.sql
@@ -1,2 +1,2 @@
 -- This old table hasn't been used since we migrated the audit log to provisioned tables (in 2013!)
-DROP TABLE audit.AuditLog;
+DROP TABLE IF EXISTS audit.AuditLog;

--- a/audit/resources/schemas/dbscripts/sqlserver/audit-25.000-25.001.sql
+++ b/audit/resources/schemas/dbscripts/sqlserver/audit-25.000-25.001.sql
@@ -1,2 +1,2 @@
 -- This old table hasn't been used since we migrated the audit log to provisioned tables (in 2013!)
-DROP TABLE audit.AuditLog;
+DROP TABLE IF EXISTS audit.AuditLog;


### PR DESCRIPTION
#### Rationale
Related PR dropped the unused `audit.AuditLog` table. For some unknown reason, our Nightly server lacks this table, which caused an upgrade failure.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53556

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6886