### PR TITLE
Fix intermittent DatasetUpdateService$TestCase failure

### DIFF
--- a/study/src/org/labkey/study/query/DatasetUpdateService.java
+++ b/study/src/org/labkey/study/query/DatasetUpdateService.java
@@ -875,7 +875,7 @@ public class DatasetUpdateService extends DefaultQueryUpdateService
 
         private String getLatestAuditMessage()
         {
-            return new TableSelector(QueryService.get().getUserSchema(_user, _container, AbstractAuditTypeProvider.QUERY_SCHEMA_NAME).getTable(DatasetAuditProvider.DATASET_AUDIT_EVENT), PageFlowUtil.set("Comment"), null, new Sort("-created")).setMaxRows(1).getObject(String.class);
+            return new TableSelector(QueryService.get().getUserSchema(_user, _container, AbstractAuditTypeProvider.QUERY_SCHEMA_NAME).getTable(DatasetAuditProvider.DATASET_AUDIT_EVENT), PageFlowUtil.set("Comment"), null, new Sort("-rowId")).setMaxRows(1).getObject(String.class);
         }
 
         @Test


### PR DESCRIPTION
#### Rationale
[query](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_GitSqlserver2014/3603416?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests.JUnitTest%24RemoteTest.org.labkey.study&class=query).[DatasetUpdateService$TestCase](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_GitSqlserver2014/3603416?buildTab=tests&status=failed)

This test occasionally fails by querying the previous audit log instead of the last audit log. One theory is that sorting by "created" is not a reliable way to return the last record since SQL Server stores time as number of 1/300 second it's possible that 2 audit event have the same time stamp.  This PR changes the sort to use RowId instead. 

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Sort by rowId instead of Created

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->