### PR TITLE
Update error messages to include folder or sample type when appropriate

### DIFF
--- a/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
+++ b/api/src/org/labkey/api/dataiterator/DataIteratorContext.java
@@ -55,6 +55,8 @@ public class DataIteratorContext
     QueryImportPipelineJob _backgroundJob = null;
     boolean _crossTypeImport = false;
     boolean _crossFolderImport = false;
+    boolean _isCrossTypePartition = false;
+    boolean _isCrossFolderPartition = false;
     boolean _allowCreateStorage = false;
     boolean _useTransactionAuditCache = false;
     private final Set<String> _passThroughBuiltInColumnNames = new CaseInsensitiveHashSet();
@@ -210,6 +212,26 @@ public class DataIteratorContext
     public void setCrossFolderImport(boolean crossFolderImport)
     {
         _crossFolderImport = crossFolderImport;
+    }
+
+    public boolean isCrossTypePartition()
+    {
+        return _isCrossTypePartition;
+    }
+
+    public void setCrossTypePartition(boolean crossTypePartition)
+    {
+        _isCrossTypePartition = crossTypePartition;
+    }
+
+    public boolean isCrossFolderPartition()
+    {
+        return _isCrossFolderPartition;
+    }
+
+    public void setCrossFolderPartition(boolean crossFolderPartition)
+    {
+        _isCrossFolderPartition = crossFolderPartition;
     }
 
     public boolean isAllowCreateStorage()

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -90,7 +90,6 @@ import org.labkey.api.query.FileColumnValueMapper;
 import org.labkey.api.query.QueryDefinition;
 import org.labkey.api.query.QueryException;
 import org.labkey.api.query.QueryKey;
-import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.UserSchema;
@@ -2534,6 +2533,8 @@ public class ExpDataIterators
                 Collection<String> importOrderKeys = getImportOrderTypeKeys();
                 if (!_context.getErrors().hasErrors())
                 {
+                    _context.setCrossTypePartition(_context.isCrossTypeImport());
+                    _context.setCrossFolderPartition(_context.isCrossFolderImport());
                     _context.setCrossTypeImport(false);
                     _context.setCrossFolderImport(false);
 


### PR DESCRIPTION
#### Rationale
For better error messaging when we split files up for cross-type or cross-folder import, it is helpful to know if the split has happened. This is done via properties on the `DataIteratorContext`. I opted for new Boolean properties instead of changing the existing `isCrossType` and `isCrossFolder` properties to enum properties but could be convinced otherwise.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1567

#### Changes
- Add new properties to `DataIteratorContext` and set them appropriately in the MultiPart data iterator

