### PR TITLE
Fix SAML test IDP redirect 

### DIFF
--- a/api/src/org/labkey/api/util/URLHelper.java
+++ b/api/src/org/labkey/api/util/URLHelper.java
@@ -182,9 +182,10 @@ public class URLHelper implements Cloneable, Serializable, JSONString
     public boolean isLocalUri(ViewContext currentContext)
     {
         return getHost() == null
-                || currentContext == null
-                || currentContext.getActionURL() == null
-                || getHost().equalsIgnoreCase(currentContext.getActionURL().getHost());
+            || currentContext == null
+            || currentContext.getActionURL() == null
+                // Scheme check is here for test SAML redirect, which is to the same host ("localhost") but a different scheme
+            || getHost().equalsIgnoreCase(currentContext.getActionURL().getHost()) && getScheme().equalsIgnoreCase(currentContext.getActionURL().getScheme());
     }
 
     public String getURIString()

--- a/api/src/org/labkey/api/util/URLHelper.java
+++ b/api/src/org/labkey/api/util/URLHelper.java
@@ -185,7 +185,7 @@ public class URLHelper implements Cloneable, Serializable, JSONString
             || currentContext == null
             || currentContext.getActionURL() == null
                 // Scheme check is here for test SAML redirect, which is to the same host ("localhost") but a different scheme
-            || getHost().equalsIgnoreCase(currentContext.getActionURL().getHost()) && getScheme().equalsIgnoreCase(currentContext.getActionURL().getScheme());
+            || (getHost().equalsIgnoreCase(currentContext.getActionURL().getHost()) && getScheme().equalsIgnoreCase(currentContext.getActionURL().getScheme()));
     }
 
     public String getURIString()

--- a/api/src/org/labkey/api/view/HttpView.java
+++ b/api/src/org/labkey/api/view/HttpView.java
@@ -22,6 +22,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.HasViewContext;
@@ -32,6 +33,7 @@ import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.UnexpectedException;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.view.template.PageConfig;
 import org.springframework.beans.PropertyValues;
@@ -592,9 +594,12 @@ public abstract class HttpView<ModelBean> extends DefaultModelAndView<ModelBean>
         }
     }
 
+    private static final Logger LOG = LogHelper.getLogger(HttpView.class, "Info to help debug redirect problems");
+
     public static HttpView<?> redirect(URLHelper url, boolean allowAbsoluteUrl)
     {
         String redirectUrl = (!allowAbsoluteUrl || url.isLocalUri(getRootContext())) ? url.getLocalURIString() : url.getURIString();
+        LOG.info("Redirecting to '{}' allowAbsoluteUrl='{}' isLocalUri()={} local='{}' URI='{}'", redirectUrl, allowAbsoluteUrl, url.isLocalUri(getRootContext()), url.getLocalURIString(), url.getURIString());
         return redirect(redirectUrl);
     }
 

--- a/api/src/org/labkey/api/view/HttpView.java
+++ b/api/src/org/labkey/api/view/HttpView.java
@@ -22,7 +22,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.HasViewContext;
@@ -33,7 +32,6 @@ import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.MemTracker;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.util.UnexpectedException;
-import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.view.template.PageConfig;
 import org.springframework.beans.PropertyValues;
@@ -594,12 +592,9 @@ public abstract class HttpView<ModelBean> extends DefaultModelAndView<ModelBean>
         }
     }
 
-    private static final Logger LOG = LogHelper.getLogger(HttpView.class, "Info to help debug redirect problems");
-
     public static HttpView<?> redirect(URLHelper url, boolean allowAbsoluteUrl)
     {
         String redirectUrl = (!allowAbsoluteUrl || url.isLocalUri(getRootContext())) ? url.getLocalURIString() : url.getURIString();
-        LOG.info("Redirecting to '{}' allowAbsoluteUrl='{}' isLocalUri()={} local='{}' URI='{}'", redirectUrl, allowAbsoluteUrl, url.isLocalUri(getRootContext()), url.getLocalURIString(), url.getURIString());
         return redirect(redirectUrl);
     }
 


### PR DESCRIPTION
#### Rationale
Slightly stricter `isLocalUri()` check allows redirect to SAML test IDP (same host, but different servlet) as an "external" URI.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6867