### PR TITLE
Deprecate the legacy name map along with the audit union table

### DIFF
--- a/api/src/org/labkey/api/audit/query/DefaultAuditTypeTable.java
+++ b/api/src/org/labkey/api/audit/query/DefaultAuditTypeTable.java
@@ -42,6 +42,7 @@ import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.roles.CanSeeAuditLogRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
+import org.labkey.api.settings.OptionalFeatureService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,6 +51,8 @@ import java.util.Set;
 
 public class DefaultAuditTypeTable extends FilteredTable<UserSchema>
 {
+    public static final String LEGACY_UNION_AUDIT_TABLE = "legacyUnionAuditTable";
+
     protected AuditTypeProvider _provider;
     protected Map<FieldKey, String> _legacyNameMap;
     protected Map<String, String> _dbSchemaToColumnMap;
@@ -64,7 +67,7 @@ public class DefaultAuditTypeTable extends FilteredTable<UserSchema>
         if (_provider.getDescription() != null)
             setDescription(_provider.getDescription());
 
-        _legacyNameMap = provider.legacyNameMap();
+        _legacyNameMap = OptionalFeatureService.get().isFeatureEnabled(LEGACY_UNION_AUDIT_TABLE) ? provider.legacyNameMap() : Map.of();
 
         // Create a mapping from the real dbTable names to the legacy query table names for QueryUpdateService.
         _dbSchemaToColumnMap = new CaseInsensitiveHashMap<>();

--- a/api/src/org/labkey/api/data/ContainerDisplayColumn.java
+++ b/api/src/org/labkey/api/data/ContainerDisplayColumn.java
@@ -186,8 +186,8 @@ public class ContainerDisplayColumn extends DataColumn
             fieldKeys.add(FieldKey.fromString("ProjectId"));
             fieldKeys.add(FieldKey.fromString("ProjectId/Name"));
             fieldKeys.add(FieldKey.fromString("ProjectId/Parent/Name"));
-            fieldKeys.add(FieldKey.fromString("ContainerId"));
-            fieldKeys.add(FieldKey.fromString("ContainerId/Name"));
+            fieldKeys.add(FieldKey.fromString("Container"));
+            fieldKeys.add(FieldKey.fromString("Container/Name"));
             fieldKeys.add(FieldKey.fromString("Comment"));
             mpv.addPropertyValue("query.columns", StringUtils.join(fieldKeys, ","));
 
@@ -243,14 +243,14 @@ public class ContainerDisplayColumn extends DataColumn
                             comment.contains(subFolder2.getName() + " was created"))
                 {
                     // These are all containers that have since been deleted, so we can't join to the container row for details
-                    assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ContainerId").optString("value", null));
-                    assertEquals("Incorrect json value for ContainerId column", "<deleted>", row.getJSONObject("ContainerId").getString("displayValue"));
+                    assertNull("Incorrect json value for Container column", row.getJSONObject("Container").optString("value", null));
+                    assertEquals("Incorrect json value for Container column", "<deleted>", row.getJSONObject("Container").getString("displayValue"));
 
-                    assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ContainerId/Name").optString("value", null));
-                    assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ContainerId/Name").optString("displayValue", null));
+                    assertNull("Incorrect json value for Container column", row.getJSONObject("Container/Name").optString("value", null));
+                    assertNull("Incorrect json value for Container column", row.getJSONObject("Container/Name").optString("displayValue", null));
 
-                    assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ProjectId/Parent/Name").optString("value", null));
-                    assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ProjectId/Parent/Name").optString("displayValue", null));
+                    assertNull("Incorrect json value for ProjectId column", row.getJSONObject("ProjectId/Parent/Name").optString("value", null));
+                    assertNull("Incorrect json value for ProjectId column", row.getJSONObject("ProjectId/Parent/Name").optString("displayValue", null));
                 }
                 else
                 {
@@ -262,13 +262,13 @@ public class ContainerDisplayColumn extends DataColumn
 
         private void validateContainerRow(Container project, JSONObject row)
         {
-            assertEquals("Incorrect json value for ContainerId column", project.getEntityId().toString(), row.getJSONObject("ContainerId").getString("value"));
-            assertEquals("Incorrect json value for ContainerId column", project.getName(), row.getJSONObject("ContainerId").getString("displayValue"));
+            assertEquals("Incorrect json value for Container column", project.getEntityId().toString(), row.getJSONObject("Container").getString("value"));
+            assertEquals("Incorrect json value for Container column", project.getName(), row.getJSONObject("Container").getString("displayValue"));
 
-            assertEquals("Incorrect json value for ContainerId column", project.getName(), row.getJSONObject("ContainerId/Name").getString("value"));
+            assertEquals("Incorrect json value for Container column", project.getName(), row.getJSONObject("Container/Name").getString("value"));
 
-            assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ProjectId/Parent/Name").optString("value", null));
-            assertNull("Incorrect json value for ContainerId column", row.getJSONObject("ProjectId/Parent/Name").optString("displayValue", null));
+            assertNull("Incorrect json value for ProjectId column", row.getJSONObject("ProjectId/Parent/Name").optString("value", null));
+            assertNull("Incorrect json value for ProjectId column", row.getJSONObject("ProjectId/Parent/Name").optString("displayValue", null));
         }
     }
 }

--- a/audit/src/org/labkey/audit/AuditModule.java
+++ b/audit/src/org/labkey/audit/AuditModule.java
@@ -19,6 +19,7 @@ package org.labkey.audit;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.provider.SiteSettingsAuditProvider;
+import org.labkey.api.audit.query.DefaultAuditTypeTable;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.settings.OptionalFeatureFlag;
@@ -32,8 +33,6 @@ import java.util.Set;
 
 public class AuditModule extends DefaultModule
 {
-    public static final String LEGACY_UNION_AUDIT_TABLE = "legacyUnionAuditTable";
-
     @Override
     @NotNull
     protected Collection<WebPartFactory> createWebPartFactories()
@@ -80,7 +79,7 @@ public class AuditModule extends DefaultModule
 
         AuditController.registerAdminConsoleLinks();
         OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(
-            LEGACY_UNION_AUDIT_TABLE,
+            DefaultAuditTypeTable.LEGACY_UNION_AUDIT_TABLE,
             "Restore legacy union audit table",
             "Restores a legacy query that unions all the event tables together into a single query. This option will be removed in LabKey Server v26.3.",
             false,

--- a/audit/src/org/labkey/audit/query/AuditQuerySchema.java
+++ b/audit/src/org/labkey/audit/query/AuditQuerySchema.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static org.labkey.audit.AuditModule.LEGACY_UNION_AUDIT_TABLE;
+import static org.labkey.api.audit.query.DefaultAuditTypeTable.LEGACY_UNION_AUDIT_TABLE;
 
 public class AuditQuerySchema extends UserSchema
 {


### PR DESCRIPTION
#### Rationale
The "legacy name map" offered by `AuditTypeProviders` is used to map provider-specific column names to generic names (int1, int2, string1, string2) in the union query (that's now deprecated). Turns out it's also used to map these generic column names to provider-specific names in the provisioned tables. We want to do away with this legacy map, so we need to blank out the map when the deprecated feature flag is off to test & eliminate code paths that depend on these legacy names.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6892