### PR TITLE
Assay: update instead of overwrite domain fields

### DIFF
--- a/api/gwtsrc/org/labkey/api/gwt/client/model/GWTPropertyDescriptor.java
+++ b/api/gwtsrc/org/labkey/api/gwt/client/model/GWTPropertyDescriptor.java
@@ -100,8 +100,17 @@ public class GWTPropertyDescriptor implements IsSerializable
 
     public GWTPropertyDescriptor(GWTPropertyDescriptor s)
     {
-        setPropertyId(s.getPropertyId());
-        setPropertyURI(s.getPropertyURI());
+        this(s, false);
+    }
+
+    public GWTPropertyDescriptor(GWTPropertyDescriptor s, boolean isNew)
+    {
+        if (!isNew)
+        {
+            setPropertyId(s.getPropertyId());
+            setPropertyURI(s.getPropertyURI());
+        }
+
         setContainer(s.getContainer());
         setName(s.getName());
         setDescription(s.getDescription());
@@ -148,7 +157,13 @@ public class GWTPropertyDescriptor implements IsSerializable
 
         for (GWTPropertyValidator v : s.getPropertyValidators())
         {
-            propertyValidators.add(new GWTPropertyValidator(v));
+            GWTPropertyValidator gpv = new GWTPropertyValidator(v);
+            if (isNew)
+            {
+                gpv.setRowId(0);
+                gpv.setNew(true);
+            }
+            propertyValidators.add(gpv);
         }
 
         for (GWTConditionalFormat f : s.getConditionalFormats())

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -476,12 +476,17 @@ public class DomainUtil
 
     public static GWTPropertyDescriptor getPropertyDescriptor(DomainProperty prop)
     {
-        return getPropertyDescriptor(prop.getPropertyDescriptor());
+        return getPropertyDescriptor(prop, false);
     }
 
     public static GWTPropertyDescriptor getPropertyDescriptor(PropertyDescriptor prop)
     {
         return getPropertyDescriptor(prop, false);
+    }
+
+    public static GWTPropertyDescriptor getPropertyDescriptor(DomainProperty prop, boolean copy)
+    {
+        return getPropertyDescriptor(prop.getPropertyDescriptor(), copy);
     }
 
     public static GWTPropertyDescriptor getPropertyDescriptor(PropertyDescriptor prop, boolean copy)
@@ -543,7 +548,7 @@ public class DomainUtil
 
             Map<String, String> properties = new HashMap<>(pv.getProperties());
             // add in the TextChoice validValues here so that the client side code doesn't have to do the same
-            // parsing of the validator expression (i.e. sorting, trimming, removing duplicates, etc.)
+            // parsing of the validator expression (i.e., sorting, trimming, removing duplicates, etc.)
             if (PropertyValidatorType.TextChoice.equals(gpv.getType()))
             {
                 List<String> validValues = PropertyService.get().getTextChoiceValidatorOptions(pv);

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -159,18 +159,17 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
             gwtDomain.setDefaultValuesURL(setDefaultValuesAction.getLocalURIString());
             gwtDomain.setProvisioned(domain.isProvisioned());
 
+            List<GWTPropertyDescriptor> fields = new ArrayList<>();
             Set<String> mandatoryPropertyDescriptors = new CaseInsensitiveHashSet(domain.getDomainKind().getMandatoryPropertyNames(domain));
 
-            Map<String, GWTPropertyDescriptor> fieldMap = new HashMap<>();
+            Map<String, GWTPropertyDescriptor> domainFields = new HashMap<>();
             for (GWTPropertyDescriptor field : gwtDomain.getFields())
-                fieldMap.put(field.getName(), field);
+                domainFields.put(field.getName(), field);
 
             for (DomainProperty prop : domain.getProperties())
             {
-                GWTPropertyDescriptor gwtProp = fieldMap.get(prop.getName());
-
-                if (copy)
-                    gwtProp.setPropertyId(0);
+                GWTPropertyDescriptor domainField = domainFields.get(prop.getName());
+                GWTPropertyDescriptor gwtProp = new GWTPropertyDescriptor(domainField, copy);
 
                 if (gwtProp.getDefaultValueType() == null)
                 {
@@ -183,6 +182,8 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                     {
                         prop.setDefaultValueTypeEnum(DefaultValueType.FIXED_EDITABLE);
                     }
+                    else
+                        gwtProp.setDefaultValueType(gwtDomain.getDefaultDefaultValueType());
                 }
 
                 if (AbstractAssayProvider.TARGET_STUDY_PROPERTY_NAME.equals(gwtProp.getName()))
@@ -210,8 +211,12 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
 
                     gwtProp.setFilterCriteria(FilterCriteria.toGWTFilterCriteria(fieldFilterCriteria));
                 }
+
+                fields.add(gwtProp);
             }
 
+            fields.addAll(gwtDomain.getCalculatedFields());
+            gwtDomain.setFields(fields);
             gwtDomain.setMandatoryFieldNames(mandatoryPropertyDescriptors);
 
             if (isResultsDomain)

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -16,7 +16,6 @@
 
 package org.labkey.assay;
 
-import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -160,13 +159,19 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
             gwtDomain.setDefaultValuesURL(setDefaultValuesAction.getLocalURIString());
             gwtDomain.setProvisioned(domain.isProvisioned());
 
-            List<GWTPropertyDescriptor> gwtProps = new ArrayList<>();
-            Map<DomainProperty, Object> defaultValues = domainInfo.getValue();
             Set<String> mandatoryPropertyDescriptors = new CaseInsensitiveHashSet(domain.getDomainKind().getMandatoryPropertyNames(domain));
+
+            Map<String, GWTPropertyDescriptor> fieldMap = new HashMap<>();
+            for (GWTPropertyDescriptor field : gwtDomain.getFields())
+                fieldMap.put(field.getName(), field);
 
             for (DomainProperty prop : domain.getProperties())
             {
-                GWTPropertyDescriptor gwtProp = getPropertyDescriptor(prop, copy);
+                GWTPropertyDescriptor gwtProp = fieldMap.get(prop.getName());
+
+                if (copy)
+                    gwtProp.setPropertyId(0);
+
                 if (gwtProp.getDefaultValueType() == null)
                 {
                     // Explicitly set these "special" properties NOT to remember the user's last entered
@@ -178,21 +183,19 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                     {
                         prop.setDefaultValueTypeEnum(DefaultValueType.FIXED_EDITABLE);
                     }
-                    else
-                        gwtProp.setDefaultValueType(gwtDomain.getDefaultDefaultValueType());
                 }
 
-                Object defaultValue = defaultValues.get(prop);
-                if (AbstractAssayProvider.TARGET_STUDY_PROPERTY_NAME.equals(gwtProp.getName()) && defaultValue instanceof String)
+                if (AbstractAssayProvider.TARGET_STUDY_PROPERTY_NAME.equals(gwtProp.getName()))
                 {
-                    Container studyContainer = ContainerManager.getForId((String) defaultValue);
-                    if (studyContainer != null)
-                        gwtProp.setDefaultDisplayValue(studyContainer.getPath());
+                    Object defaultValue = domainInfo.getValue().get(prop);
+                    if (defaultValue instanceof String containerId)
+                    {
+                        Container studyContainer = ContainerManager.getForId(containerId);
+                        if (studyContainer != null)
+                            gwtProp.setDefaultDisplayValue(studyContainer.getPath());
+                    }
                 }
-                else
-                    gwtProp.setDefaultDisplayValue(DomainUtil.getFormattedDefaultValue(getUser(), prop, defaultValue));
 
-                gwtProp.setDefaultValue(ConvertUtils.convert(defaultValue));
                 if (provider.isMandatoryDomainProperty(domain, prop.getName()))
                     mandatoryPropertyDescriptors.add(prop.getName());
 
@@ -207,12 +210,8 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
 
                     gwtProp.setFilterCriteria(FilterCriteria.toGWTFilterCriteria(fieldFilterCriteria));
                 }
-
-                gwtProps.add(gwtProp);
             }
 
-            gwtProps.addAll(gwtDomain.getCalculatedFields());
-            gwtDomain.setFields(gwtProps);
             gwtDomain.setMandatoryFieldNames(mandatoryPropertyDescriptors);
 
             if (isResultsDomain)
@@ -346,15 +345,6 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
     private GWTContainer convertToGWTContainer(Container c)
     {
         return new GWTContainer(c.getId(), c.getRowId(), c.getPath(), c.getName());
-    }
-
-    private GWTPropertyDescriptor getPropertyDescriptor(DomainProperty prop, boolean copy)
-    {
-        GWTPropertyDescriptor gwtProp = DomainUtil.getPropertyDescriptor(prop);
-        if (copy)
-            gwtProp.setPropertyId(0);
-
-        return gwtProp;
     }
 
     private void setPlateTemplateList(AssayProvider provider, GWTProtocol protocol)

--- a/assay/src/org/labkey/assay/AssayIntegrationTestCase.jsp
+++ b/assay/src/org/labkey/assay/AssayIntegrationTestCase.jsp
@@ -708,4 +708,43 @@
 
         assertEquals(0, updatedRun.getMaterialInputs().size());
     }
+
+    @Test
+    public void testDomainFieldConfiguration() throws Exception
+    {
+        // Validates assay domain fields are configured as expected by DomainUtil and not overwritten
+        // Arrange
+        var sampleTypeName = "Does Not Exist";
+        var lookupName = "Field100 ABCDEFGHIJKLMNOPQRSTUVWXYZ%()=+-[]_|*`'\":;<>?!@#^AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRRSSTTU)";
+        var assayPair = createAssay(context, true, true);
+        var domainService = new AssayDomainServiceImpl(context);
+        var gwtProtocol = domainService.getAssayDefinition(assayPair.second.getRowId(), false);
+
+        // Update the assay design to refer to a non-existent sample type
+        {
+            var resultDomain = getResultDomain(gwtProtocol);
+            var resultFields = resultDomain.getFields(true);
+
+            GWTPropertyDescriptor invalidSampleLookup = new GWTPropertyDescriptor("SampleTypeLookup", "string");
+            invalidSampleLookup.setLookupSchema(SamplesSchema.SCHEMA_NAME);
+            invalidSampleLookup.setLookupQuery(sampleTypeName);
+            invalidSampleLookup.setName(lookupName);
+            resultFields.add(invalidSampleLookup);
+            resultDomain.setFields(resultFields);
+            gwtProtocol = domainService.saveChanges(gwtProtocol, true);
+        }
+
+        // Act
+        var updatedResultsDomain = getResultDomain(gwtProtocol);
+
+        // Assert
+        var lookup = updatedResultsDomain.getFieldByName(lookupName);
+        assertFalse("Expected lookup to be marked as invalid since sample type does not exist by that name", lookup.getLookupIsValid());
+        assertEquals("Expected lookup query to point to non-existent sample type", sampleTypeName, lookup.getLookupQuery());
+    }
+
+    private GWTDomain<GWTPropertyDescriptor> getResultDomain(GWTProtocol protocol)
+    {
+        return protocol.getDomains().stream().filter(d -> "Data".equals(d.getQueryName())).findFirst().orElseThrow();
+    }
 %>

--- a/assay/src/org/labkey/assay/AssayIntegrationTestCase.jsp
+++ b/assay/src/org/labkey/assay/AssayIntegrationTestCase.jsp
@@ -140,37 +140,28 @@
         assayTemplate.setEditableResults(true);
         List<GWTDomain<GWTPropertyDescriptor>> domains = assayTemplate.getDomains();
 
-        // clear the batch domain fields
-        GWTDomain<GWTPropertyDescriptor> batchDomain = domains.stream().filter(d -> "Batch Fields".equals(d.getName())).findFirst().orElseThrow();
-        batchDomain.getFields(true).clear();
-
-        // clear the run domain fields
-        GWTDomain<GWTPropertyDescriptor> runDomain = domains.stream().filter(d -> "Run Fields".equals(d.getName())).findFirst().orElseThrow();
-        runDomain.getFields(true).clear();
-
-        // clear the result domain fields and add a sample lookup
-        GWTDomain<GWTPropertyDescriptor> resultDomain = domains.stream().filter(d -> "Data Fields".equals(d.getName())).findFirst().orElseThrow();
-        resultDomain.getFields(true).clear();
+        List<GWTPropertyDescriptor> runFields = new ArrayList<>();
+        List<GWTPropertyDescriptor> resultFields = new ArrayList<>();
 
         if (editableRunsAndResults)
         {
             GWTPropertyDescriptor runProp = new GWTPropertyDescriptor("runProp", "int");
-            runDomain.getFields(true).add(runProp);
+            runFields.add(runProp);
             GWTPropertyDescriptor resultProp = new GWTPropertyDescriptor("resultProp", "int");
-            resultDomain.getFields(true).add(resultProp);
+            resultFields.add(resultProp);
         }
 
         // Lookup to exp.Materials on run domain
         GWTPropertyDescriptor runExpMaterialLookup = new GWTPropertyDescriptor("RunExpMaterialsLookup", "int");
         runExpMaterialLookup.setLookupSchema(ExpSchema.SCHEMA_NAME);
         runExpMaterialLookup.setLookupQuery(ExpSchema.TableType.Materials.name());
-        runDomain.getFields(true).add(runExpMaterialLookup);
+        runFields.add(runExpMaterialLookup);
 
         // Lookup to exp.Materials on results domain
         GWTPropertyDescriptor resultExpMaterialLookup = new GWTPropertyDescriptor("ResultExpMaterialsLookup", "int");
         resultExpMaterialLookup.setLookupSchema(ExpSchema.SCHEMA_NAME);
         resultExpMaterialLookup.setLookupQuery(ExpSchema.TableType.Materials.name());
-        resultDomain.getFields(true).add(resultExpMaterialLookup);
+        resultFields.add(resultExpMaterialLookup);
 
         if (includeSampleTypeLookups)
         {
@@ -180,14 +171,26 @@
             GWTPropertyDescriptor sampleTypeLookup = new GWTPropertyDescriptor("SampleTypeLookup", "string");
             sampleTypeLookup.setLookupSchema(SamplesSchema.SCHEMA_NAME);
             sampleTypeLookup.setLookupQuery(sampleType.getName());
-            resultDomain.getFields(true).add(sampleTypeLookup);
+            resultFields.add(sampleTypeLookup);
 
             // Lookup to exp.materials.<sample type name>
             GWTPropertyDescriptor expMaterialsSampleTypeLookup = new GWTPropertyDescriptor("ExpMaterialSampleTypeLookup", "int");
             expMaterialsSampleTypeLookup.setLookupSchema(ExpSchema.SCHEMA_EXP_MATERIALS.toString());
             expMaterialsSampleTypeLookup.setLookupQuery(sampleType.getName());
-            resultDomain.getFields(true).add(expMaterialsSampleTypeLookup);
+            resultFields.add(expMaterialsSampleTypeLookup);
         }
+
+        // clear the batch domain fields
+        GWTDomain<GWTPropertyDescriptor> batchDomain = domains.stream().filter(d -> "Batch Fields".equals(d.getName())).findFirst().orElseThrow();
+        batchDomain.setFields(Collections.emptyList());
+
+        // set the run domain fields
+        GWTDomain<GWTPropertyDescriptor> runDomain = domains.stream().filter(d -> "Run Fields".equals(d.getName())).findFirst().orElseThrow();
+        runDomain.setFields(runFields);
+
+        // set the result domain fields
+        GWTDomain<GWTPropertyDescriptor> resultDomain = domains.stream().filter(d -> "Data Fields".equals(d.getName())).findFirst().orElseThrow();
+        resultDomain.setFields(resultFields);
 
         // create the assay
         log.info("creating assay");


### PR DESCRIPTION
#### Rationale
While testing changes in #6883 related to https://github.com/LabKey/internal-issues/issues/657 I discovered that it was not round-tripping the `lookupIsValid` property on the result domain field as I would have expected. Come to find out that `AssayDomainServiceImpl.getDomain()` is unintentionally overwriting property descriptor processing done by `DomainUtil.getDomainDescriptor()`. This updates assay domain processing to perform a deep copy of the fields procured by the domain and then apply assay-specific overrides on those fields.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1579

#### Changes
- Update `AssayDomainServiceImpl.getDomain()` to no longer overwrite fields
- Remove duplicative processing of default values
- Update and add tests
