### PR TITLE
Issues 53985 & 53588: Add CheckedOut column to Sample Type grids

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -188,6 +188,8 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         SAMPLE_ALT_IMPORT_NAME_COLS.put("SampleId", "Name");
         SAMPLE_ALT_IMPORT_NAME_COLS.put("Sample Id", "Name");
         SAMPLE_ALT_IMPORT_NAME_COLS.put("ExpirationDate", "MaterialExpDate");
+        SAMPLE_ALT_IMPORT_NAME_COLS.put("Entered Storage", "Stored");
+        SAMPLE_ALT_IMPORT_NAME_COLS.put("EnteredStorage", "Stored");
     }
 
     public enum Options


### PR DESCRIPTION
#### Rationale
[Issue 52985: LKSM: Add CheckedOut date/time stamp as an available column in grids](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=52985)
[Issue 53588: LKSM/LKB: CheckedOut column is ignored for cross-type or cross-folder import or update](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53588)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1577

#### Changes
- Add import name mapping for "Entered Storage" and "EnteredStorage" for consistent error message handling
