### PR TITLE
Allow "Date" as alias for "Created" column in audit event tables

### DIFF
--- a/api/src/org/labkey/api/audit/query/DefaultAuditTypeTable.java
+++ b/api/src/org/labkey/api/audit/query/DefaultAuditTypeTable.java
@@ -169,8 +169,19 @@ public class DefaultAuditTypeTable extends FilteredTable<UserSchema>
         if (col != null)
             return col;
 
-        // Handle the old style 'intKey1' and 'key1' columns
-        String newName = _legacyNameMap.get(FieldKey.fromParts(name));
+        String newName = null;
+
+        if (_legacyNameMap.isEmpty())
+        {
+            // Backward compatibility with widely used legacy name
+            if ("Date".equalsIgnoreCase(name))
+                newName = "Created";
+        }
+        else
+        {
+            // Handle the old style 'intKey1' and 'key1' columns
+            newName = _legacyNameMap.get(FieldKey.fromParts(name));
+        }
         col = super.resolveColumn(newName);
         if (col != null)
         {


### PR DESCRIPTION
#### Rationale
Fix a bunch of cranky tests and queries. Spend time on more important things.

Probably obvious: this alias will persist after the legacy "audit" table and `_legacyNameMap` are removed (25.12+), though the code here will get simplified

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6903

Testing? Automated tests have discovered all the problems and automated tests shall verify the fix, IMO