### PR TITLE
Fix folder import with domain containing special characters

### DIFF
--- a/experiment/src/org/labkey/experiment/samples/AbstractExpFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/AbstractExpFolderImporter.java
@@ -272,14 +272,11 @@ public abstract class AbstractExpFolderImporter implements FolderImporter
             for (ExpObject expObject : expObjects)
             {
                 String tableName = expObject.getName();
-                // tsv file name might have been generated from a sanitized table name
-                String fileName = FileUtil.makeLegalName(tableName);
-                if (dataFileMap.containsKey(fileName) || dataFileMap.containsKey(tableName))
+                // tsv file name will have been generated from a sanitized table name
+                String fileName = FileUtil.makeLegalName(tableName + ".tsv");
+                if (dataFileMap.containsKey(fileName))
                 {
                     String dataFileName = dataFileMap.get(fileName);
-                    if (dataFileName == null)
-                        dataFileName = dataFileMap.get(tableName);
-
                     TableInfo tinfo = userSchema.getTable(tableName);
                     if (tinfo != null)
                     {

--- a/experiment/src/org/labkey/experiment/samples/AbstractExpFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/AbstractExpFolderImporter.java
@@ -272,11 +272,14 @@ public abstract class AbstractExpFolderImporter implements FolderImporter
             for (ExpObject expObject : expObjects)
             {
                 String tableName = expObject.getName();
-                // tsv file name will have been generated from a sanitized table name
+                // tsv file name might have been generated from a sanitized table name
                 String fileName = FileUtil.makeLegalName(tableName);
-                if (dataFileMap.containsKey(fileName))
+                if (dataFileMap.containsKey(fileName) || dataFileMap.containsKey(tableName))
                 {
                     String dataFileName = dataFileMap.get(fileName);
+                    if (dataFileName == null)
+                        dataFileName = dataFileMap.get(tableName);
+
                     TableInfo tinfo = userSchema.getTable(tableName);
                     if (tinfo != null)
                     {

--- a/experiment/src/org/labkey/experiment/samples/DataClassFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/DataClassFolderImporter.java
@@ -85,7 +85,7 @@ public class DataClassFolderImporter extends AbstractExpFolderImporter
         {
             if (file.toLowerCase().endsWith(".tsv") && file.startsWith(DataClassFolderWriter.DATA_CLASS_PREFIX))
             {
-                dataClassDataFiles.put(FileUtil.getBaseName(file.substring(DataClassFolderWriter.DATA_CLASS_PREFIX.length())), file);
+                dataClassDataFiles.put(FileUtil.getBaseName(file.substring(DataClassFolderWriter.DATA_CLASS_PREFIX.length()) + ".tsv"), file);
             }
         }
 

--- a/experiment/src/org/labkey/experiment/samples/SampleStatusFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleStatusFolderImporter.java
@@ -74,7 +74,7 @@ public class SampleStatusFolderImporter extends SampleTypeFolderImporter
                 {
                     if (file.startsWith(SampleTypeFolderWriter.SAMPLE_STATUS_PREFIX))
                     {
-                        sampleStatusDataFiles.put(FileUtil.getBaseName(file.substring(SampleTypeFolderWriter.SAMPLE_STATUS_PREFIX.length())), file);
+                        sampleStatusDataFiles.put(FileUtil.getBaseName(file.substring(SampleTypeFolderWriter.SAMPLE_STATUS_PREFIX.length()) + ".tsv"), file);
                     }
                 }
             }

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeFolderImporter.java
@@ -67,7 +67,7 @@ public class SampleTypeFolderImporter extends AbstractExpFolderImporter
         {
             if (file.toLowerCase().endsWith(".tsv") && file.startsWith(SampleTypeFolderWriter.SAMPLE_TYPE_PREFIX))
             {
-                sampleTypeDataFiles.put(FileUtil.getBaseName(file.substring(SampleTypeFolderWriter.SAMPLE_TYPE_PREFIX.length())), file);
+                sampleTypeDataFiles.put(FileUtil.getBaseName(file.substring(SampleTypeFolderWriter.SAMPLE_TYPE_PREFIX.length()) + ".tsv"), file);
             }
         }
 


### PR DESCRIPTION
#### Rationale
When a domain name ends with a dot (.) character, FiltUtil.makeLegalName would convert that . to _ when trying to match its import file during folder import. The conversion of dot to _ only happens when the dot is the last character in the filename. The logic is flawed in that it doesn't take into the ".tsv" suffix, which would mean the dot is in fact not the last character in the filename.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1842
- https://github.com/LabKey/labkey-ui-premium/pull/804
- https://github.com/LabKey/platform/pull/6915
- https://github.com/LabKey/limsModules/pull/1594
- https://github.com/LabKey/testAutomation/pull/2617

#### Changes
- Pass full file name to `FileUtil.makeLegalName` to get the correct file name.

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->