### PR TITLE
Make NavTree links respect Cmd/Ctrl-click

### DIFF
--- a/api/src/org/labkey/api/view/NavTree.java
+++ b/api/src/org/labkey/api/view/NavTree.java
@@ -745,7 +745,7 @@ public class NavTree implements Collapsible
                     config.addHandlerForQuerySelector(
                             "A.noFollowNavigate",
                             "click",
-                            "this.href = this.href + this.dataset['query']; return true;");
+                            "this.href = this.href + this.dataset['query']; this.dataset['query'] = ''; return true;");
                     cls = StringUtils.trimToEmpty(cls) + " noFollowNavigate";
                 }
             }

--- a/api/src/org/labkey/api/view/NavTree.java
+++ b/api/src/org/labkey/api/view/NavTree.java
@@ -745,7 +745,7 @@ public class NavTree implements Collapsible
                     config.addHandlerForQuerySelector(
                             "A.noFollowNavigate",
                             "click",
-                            "window.open(this.href + this.dataset['query'], this.target||'_self'); return false;");
+                            "this.href = this.href + this.dataset['query']; return true;");
                     cls = StringUtils.trimToEmpty(cls) + " noFollowNavigate";
                 }
             }


### PR DESCRIPTION
#### Rationale
Cmd-click typically opens links in a new tab (Ctrl-click on Windows). A [change earlier this year](https://github.com/LabKey/platform/pull/6504) broke that functionality for LKS `NavTree` links. This includes the Admin and User menus, DataRegion menus, and many others.

This fix might not be sufficient: [Issue 53629: NavMenu doesn't open in new tab correctly](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53629)

#### Related Pull Requests
- N/A

#### Changes
- Make NavTree links respect Cmd/Ctrl-click

#### Tasks 📍
- [x] Manual Testing @labkey-chrisj 
- [x] Needs Automation @labkey-tchad 
- [x] Code Review @labkey-matthewb 