### PR TITLE
Don't serialize the generated attachment URL on export.

### DIFF
--- a/list/src/org/labkey/list/model/ListWriter.java
+++ b/list/src/org/labkey/list/model/ListWriter.java
@@ -474,6 +474,11 @@ public class ListWriter
                     // Write URL, if exists, from property descriptor
                     if (null != propertyDescriptor.getURL())
                         columnXml.setUrl(propertyDescriptor.getURL().toXML());
+                    else if (column.getPropertyType() == PropertyType.ATTACHMENT)
+                    {
+                        // Issue 53505 : don't serialize the download URL if it wasn't set on the property descriptor
+                        columnXml.unsetUrl();
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Rationale
[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53505)

The list attachment field download URL contains token replacement of the field name that can cause list import issues. There isn't really a need to serialize this to the list archive unless a user has explicitly set it on the `PropertyDescriptor`. The code change needs to unset the value since the base class `writeColumn` doesn't make this distinction. 

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/2624
