### PR TITLE
Move unescapeBackslashes to a deprecated feature

### DIFF
--- a/api/src/org/labkey/api/reader/TabLoader.java
+++ b/api/src/org/labkey/api/reader/TabLoader.java
@@ -30,6 +30,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.dataiterator.HashDataIterator;
 import org.labkey.api.iterator.BeanIterator;
 import org.labkey.api.iterator.CloseableIterator;
+import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.JunitUtil;
@@ -67,6 +68,8 @@ import java.util.stream.Collectors;
  */
 public class TabLoader extends DataLoader
 {
+    public static final String FEATUREFLAG_UNESCAPE_BACKSLASH  = "dataloader-unescape-backslashes";
+
     public static final FileType TSV_FILE_TYPE = new TabFileType(Arrays.asList(".tsv", ".txt"), ".tsv", "text/tab-separated-values");
     public static final FileType CSV_FILE_TYPE = new TabFileType(Collections.singletonList(".csv"), ".csv", "text/comma-separated-values");
 
@@ -200,7 +203,7 @@ public class TabLoader extends DataLoader
 
     private boolean _parseQuotes = true;
     private boolean _parseEnclosedQuotes = false; // only treat quote as quote if it comes in pairs, otherwise treat it as a regular character
-    private boolean _unescapeBackslashes = true;
+    private boolean _unescapeBackslashes = AppProps.getInstance().isOptionalFeatureEnabled(FEATUREFLAG_UNESCAPE_BACKSLASH);
 
     // Infer whether there are headers
     public TabLoader(File inputFile)

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -543,6 +543,11 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             "Resolve Missing Lookup Values to Null",
             "When Lookup Validation for a field is not selected and lookup by alternate key is enabled, resolves missing lookup values to null instead of throwing an error. This option will be removed in LabKey Server v25.11.",
             false, false, OptionalFeatureService.FeatureType.Deprecated));
+        OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(TabLoader.FEATUREFLAG_UNESCAPE_BACKSLASH,
+                "Resolve Missing Lookup Values to Null",
+                "When Lookup Validation for a field is not selected and lookup by alternate key is enabled, resolves missing lookup values to null instead of throwing an error. This option will be removed in LabKey Server v25.11.",
+                false, false, OptionalFeatureService.FeatureType.Deprecated));
+
 
         SiteValidationService svc = SiteValidationService.get();
         if (null != svc)

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -544,8 +544,8 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             "When Lookup Validation for a field is not selected and lookup by alternate key is enabled, resolves missing lookup values to null instead of throwing an error. This option will be removed in LabKey Server v25.11.",
             false, false, OptionalFeatureService.FeatureType.Deprecated));
         OptionalFeatureService.get().addFeatureFlag(new OptionalFeatureFlag(TabLoader.FEATUREFLAG_UNESCAPE_BACKSLASH,
-                "Resolve Missing Lookup Values to Null",
-                "When Lookup Validation for a field is not selected and lookup by alternate key is enabled, resolves missing lookup values to null instead of throwing an error. This option will be removed in LabKey Server v25.11.",
+                "Unescape backslash character on import",
+                "Treat backslash '\\' character as an escape character when loading data from file.",
                 false, false, OptionalFeatureService.FeatureType.Deprecated));
 
 

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
@@ -243,7 +243,7 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
 
     private void importFilePathError(String participantId, String sequenceNum, String filePath)
     {
-        String pasteData = TestDataUtils.tsvStringFromRowMapsEscapeBackslash(List.of(
+        String pasteData = TestDataUtils.tsvStringFromRowMaps(List.of(
                 Map.of("ParticipantId", participantId, "SequenceNum", sequenceNum, FILE_FIELD_1, filePath)),
                 List.of("ParticipantId", "SequenceNum", FILE_FIELD_1), true);
         setFormElement(Locator.name("text"), pasteData);


### PR DESCRIPTION
#### Rationale
Backslash are not quoted when exporting as CSV or TSV. However, our DataLoader that reads from csv/tsv assumes that backslashes should come in as quoted, or else it would be treated as an escape character. This PR changes the behavior of TabLoader to only treat backslash as escape character if the new optional feature flag "Unescape backslash character on import" is enabled.

 - Issue [53584](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53584): When updating from file, fields with names this/that or single space get 'these fields are unknown and will be ignored' warnings
 - Issue [53585](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53585): TabLoader: unescaping backslash caused unexpected behavior during import
 - Issue [53257](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53257): Editable Grid for Assay Designs: Backslashes Require Escape

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6922
- https://github.com/LabKey/testAutomation/pull/2625
- https://github.com/LabKey/limsModules/pull/1603

#### Changes
- set _unescapeBackslashes to respect optional feature flag "Unescape backslash character on import"

#### Tasks 📍
- [x] Automated Test Code review @labkey-danield 
- [x] Code Review @cnathe 
- [x] Manual Testing @labkey-danield 
  - [x] regression test naming expression with special characters that uses backslash to escape
- [x] Automation
- [ ] Verify Fix