### PR TITLE
Improve logging when a dataset snapshot can't be refreshed

### DIFF
--- a/api/src/org/labkey/api/query/snapshot/QuerySnapshotService.java
+++ b/api/src/org/labkey/api/query/snapshot/QuerySnapshotService.java
@@ -108,7 +108,7 @@ public class QuerySnapshotService
         /**
          * Returns the audit history view for a snapshot.
          */
-        HttpView createAuditView(QuerySnapshotForm form) throws Exception;
+        HttpView<?> createAuditView(QuerySnapshotForm form, BindException errors) throws Exception;
 
         /**
          * Returns the list of valid display columns for a specified QueryForm. The list of columns

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -5323,7 +5323,7 @@ public class StudyController extends BaseStudyController
                 boolean showHistory = BooleanUtils.toBoolean(getViewContext().getActionURL().getParameter("showHistory"));
                 if (showHistory)
                 {
-                    HttpView historyView = provider.createAuditView(form);
+                    HttpView<?> historyView = provider.createAuditView(form, errors);
                     if (historyView != null)
                         box.addView(historyView);
                 }

--- a/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
+++ b/study/src/org/labkey/study/dataset/DatasetSnapshotProvider.java
@@ -58,7 +58,6 @@ import org.labkey.api.reader.TabLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.Study;
-import org.labkey.api.study.StudyService;
 import org.labkey.api.study.model.ParticipantGroup;
 import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.ExceptionUtil;
@@ -69,6 +68,7 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
 import org.labkey.study.StudySchema;
+import org.labkey.study.StudyServiceImpl;
 import org.labkey.study.controllers.StudyController;
 import org.labkey.study.model.DatasetDefinition;
 import org.labkey.study.model.DatasetDomainKind;
@@ -197,7 +197,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
                     ptids.addAll(Arrays.asList(group.getParticipantIds()));
                 }
             }
-            SimpleFilter.InClause inClause = new SimpleFilter.InClause(FieldKey.fromParts(StudyService.get().getSubjectColumnName(qsDef.getContainer())), ptids);
+            SimpleFilter.InClause inClause = new SimpleFilter.InClause(FieldKey.fromParts(StudyServiceImpl.get().getSubjectColumnName(qsDef.getContainer())), ptids);
             filter.addClause(inClause);
         }
         return filter;
@@ -396,42 +396,6 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
         return null;
     }
 
-    /**
-     * Create a column map for parsing the generated tsv from the query view. We only want to map
-     * non-default columns, and need to build a map that goes from TSV header to PropertyURI
-     */
-    private Map<String, String> getColumnMap(Domain d, QueryView view, List<FieldKey> fieldKeys, Map<FieldKey, ColumnInfo> fieldMap)
-    {
-        Map<String, String> columnMap = new CaseInsensitiveHashMap<>();
-        Study study = StudyManager.getInstance().getStudy(view.getContainer());
-
-        if (fieldMap != null)
-        {
-            if (fieldKeys.isEmpty())
-            {
-                fieldKeys = new ArrayList<>();
-                for (DisplayColumn dc : view.getDisplayColumns())
-                {
-                    ColumnInfo colInfo = dc.getColumnInfo();
-                    if (colInfo != null)
-                        fieldKeys.add(colInfo.getFieldKey());
-                }
-            }
-
-            for (FieldKey fieldKey : fieldKeys)
-            {
-                ColumnInfo col = fieldMap.get(fieldKey);
-                if (col != null && !DatasetDefinition.isDefaultFieldName(col.getName(), study))
-                {
-                    // The key of the entry is the same code that generates the TSV header lines for
-                    // TSVGridWriter.ColumnHeaderType.queryColumnName. It would be nice to use the code directly.
-                    columnMap.put(FieldKey.fromString(col.getName()).toDisplayString(), getPropertyURI(d, col));
-                }
-            }
-        }
-        return columnMap;
-    }
-
     @Override
     public synchronized ActionURL updateSnapshot(QuerySnapshotForm form, BindException errors, boolean suppressVisitManagerRecalc) throws Exception
     {
@@ -544,7 +508,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
                 }
             }
         }
-        errors.reject(SpringActionController.ERROR_MSG, "Unable to create a QueryDefinition for the source query, it may no longer exist.");
+        errors.reject(SpringActionController.ERROR_MSG, "Unable to create a QueryDefinition for the source query for snapshot " + form.getSnapshotName() + " in " + form.getViewContext().getContainer().getPath() + ", it may no longer exist.");
         return null;
     }
 
@@ -581,7 +545,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
     }
 
     @Override
-    public HttpView createAuditView(QuerySnapshotForm form)
+    public HttpView<?> createAuditView(QuerySnapshotForm form, BindException errors)
     {
         ViewContext context = form.getViewContext();
         QuerySnapshotDefinition def = QueryService.get().getSnapshotDef(context.getContainer(), form.getSchemaName(), form.getSnapshotName());
@@ -601,7 +565,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
                     settings.setBaseFilter(filter);
                     settings.setQueryName(DatasetAuditProvider.DATASET_AUDIT_EVENT);
 
-                    return schema.createView(context, settings);
+                    return schema.createView(context, settings, errors);
                 }
                 return null;
             }
@@ -677,18 +641,11 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
 
     private static List<QuerySnapshotDefinition> getDependencies(SnapshotDependency.SourceDataType sourceData)
     {
-        List<QuerySnapshotDefinition> dependencies = new ArrayList<>();
-
-        switch (sourceData.getType())
+        return switch (sourceData.getType())
         {
-            case dataset:
-                dependencies = _datasetDependency.getDependencies(sourceData);
-                break;
-            case participantCategory:
-                dependencies = _categoryDependency.getDependencies(sourceData);
-                break;
-        }
-        return dependencies;
+            case dataset -> _datasetDependency.getDependencies(sourceData);
+            case participantCategory -> _categoryDependency.getDependencies(sourceData);
+        };
     }
 
     private static class QuerySnapshotDependencyThread extends Thread implements ShutdownListener
@@ -744,7 +701,7 @@ public class DatasetSnapshotProvider extends AbstractSnapshotProvider implements
         }
     }
 
-    // Unfortunately complex generics here. In English, the container key of the outer map is the source
+    // Unfortunately, complex generics here. In English, the container key of the outer map is the source
     // container where the dataset change events are generated. The value is a map from the study that
     // contains the snapshot datasets to a list of snapshots that need to be refreshed.
     private static final Map<Container, List<SnapshotDependency.SourceDataType>> _coalesceMap = new HashMap<>();


### PR DESCRIPTION
#### Rationale
This logging isn't very helpful at tracking down the problem:

```
org.springframework.validation.BeanPropertyBindingResult: 1 errors
Error in object 'command': codes [command,]; arguments []; default message [Unable to create a QueryDefinition for the source query, it may no longer exist.]
```

#### Changes
- Include container and snapshot name in the log message
- Code cleanup - generics, delete dead code, deprecation warnings, etc

#### Tasks 📍
- ~~[ ] Manual Testing~~
- ~~[ ] Needs Automation~~
