### PR TITLE
Helper to create dataset categories with retry

### DIFF
--- a/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
@@ -12,15 +12,11 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
-import org.labkey.test.components.ext4.Window;
 import org.labkey.test.pages.query.ExecuteQueryPage;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
-import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PermissionsHelper;
 import org.labkey.test.util.StudyHelper;
-import org.openqa.selenium.Keys;
-import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.util.List;
@@ -299,20 +295,8 @@ public class AutoLinkToStudyTest extends BaseWebDriverTest
     private void createDatasetCategory(String projectName, String name)
     {
         goToProjectHome(projectName);
-        goToManageViews();
-        Locator.linkWithText("Manage Categories").findElement(getDriver()).click();
-        _extHelper.waitForExtDialog("Manage Categories");
-        Window<?> categoryWindow = new Window.WindowFinder(getDriver()).withTitle("Manage Categories").waitFor();
-        categoryWindow.clickButton("New Category", 0);
-        WebElement newCategoryField = Locator.input("label").withAttributeContaining("id", "textfield").notHidden().waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT);
-        actionClear(newCategoryField);
-        sleep(500);
-        newCategoryField.sendKeys(name);
-        sleep(500);
-        newCategoryField.sendKeys(Keys.ENTER);
-        waitForElement(Ext4Helper.Locators.window("Manage Categories").append("//div").withText(name));
-        clickButton("Done", 0);
-        _extHelper.waitForExtDialogToDisappear("Manage Categories");
+        goToManageViews()
+                .createCategory(name);
     }
 
     private String getCategory(String projectName, String datasetName)


### PR DESCRIPTION
#### Rationale
We have several tests that create dataset categories. They all have slightly different variations of the same code and all fail intermittently on TeamCity. We should unify them and add some retry logic to reduce the noise and simplify maintenance.
I'm starting with `AutoLinkToStudyTest` and `SampleTypeLinkToStudyTest`.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2626

#### Changes
- Helper to create dataset categories with retry