### PR TITLE
Issue 53498: reject string attachment values for query insert/update api

### DIFF
--- a/api/src/org/labkey/api/dataiterator/AttachmentDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/AttachmentDataIterator.java
@@ -80,14 +80,15 @@ public class AttachmentDataIterator extends WrapperDataIterator
     }
 
     @Override
-    public boolean next()
+    public boolean next() throws BatchValidationException
     {
+        boolean ret = super.next();
+        if (!ret)
+            return false;
+
         ArrayList<AttachmentFile> attachmentFiles = null;
         try
         {
-            boolean ret = super.next();
-            if (!ret)
-                return false;
             for (_AttachmentUploadHelper p : attachmentColumns)
             {
                 Object attachmentValue = get(p.index);

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -1881,9 +1881,8 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                     value = null;
                 }
             }
-            else if (value instanceof String filePath)
-                return ExpDataFileConverter.convert(filePath);
-            return value;
+
+            return ExpDataFileConverter.convert(value);
         }
     }
 

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -716,8 +716,8 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
             {
                 try
                 {
-                    if (PropertyType.FILE_LINK.equals(col.getPropertyType()) && value instanceof String strVal)
-                        value = ExpDataFileConverter.convert(strVal);
+                    if (PropertyType.FILE_LINK.equals(col.getPropertyType()))
+                        value = ExpDataFileConverter.convert(value);
                     else
                         value = ConvertUtils.convert(value.toString(), col.getJavaObjectClass());
                 }
@@ -1022,6 +1022,9 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
      */
     public static Object saveFile(User user, Container container, String name, Object value, @Nullable FileLike dirPath) throws ValidationException, QueryUpdateServiceException
     {
+        if (!(value instanceof MultipartFile) && !(value instanceof SpringAttachmentFile))
+            throw new ValidationException("Invalid file value");
+
         String auditMessageFormat = "Saved file '%s' for field '%s' in folder %s.";
         FileLike file = null;
         try
@@ -1042,8 +1045,9 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
                 event.setComment(String.format(auditMessageFormat, multipartFile.getOriginalFilename(), name, container.getPath()));
                 event.setProvidedFileName(multipartFile.getOriginalFilename());
             }
-            else if (value instanceof SpringAttachmentFile saf)
+            else
             {
+                SpringAttachmentFile saf = (SpringAttachmentFile) value;
                 file = FileUtil.findUniqueFileName(saf.getFilename(), dir);
                 checkFileUnderRoot(container, file);
                 saf.saveTo(file);
@@ -1059,9 +1063,6 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         {
             throw new QueryUpdateServiceException(e);
         }
-
-        if (file == null)
-            return value;
 
         ensureExpData(user, container, file.toNioPathForRead().toFile());
         return file;

--- a/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/DefaultQueryUpdateService.java
@@ -26,6 +26,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.ExpDataFileConverter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MvUtil;
@@ -854,6 +855,10 @@ public class DefaultQueryUpdateService extends AbstractQueryUpdateService
                     }
                     return ConvertUtils.convert(value.toString(), col.getJdbcType().getJavaClass());
             }
+        }
+        catch (ConvertHelper.FileConversionException e)
+        {
+            throw new ValidationException(e.getMessage());
         }
         catch (ConversionException e)
         {

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2115,9 +2115,7 @@ public class ExpDataIterators
                             }
                         }
 
-                        if (value instanceof String filePath)
-                            return ExpDataFileConverter.convert(filePath);
-                        return value;
+                        return ExpDataFileConverter.convert(value);
                     };
                 }
             }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -1315,20 +1315,35 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
             // Replace attachment columns with filename and keep AttachmentFiles
             Map<String, Object> rowStripped = new CaseInsensitiveHashMap<>();
             Map<String, Object> attachments = new CaseInsensitiveHashMap<>();
-            row.forEach((name, value) -> {
-                if (isAttachmentProperty(name) && value instanceof AttachmentFile file)
+            for (Map.Entry<String, Object> entry : row.entrySet())
+            {
+                String name = entry.getKey();
+                Object value = entry.getValue();
+                if (isAttachmentProperty(name))
                 {
-                    if (null != file.getFilename())
+                    if (value instanceof AttachmentFile file)
                     {
-                        rowStripped.put(name, file.getFilename());
-                        attachments.put(name, value);
+                        if (null != file.getFilename())//
+                        {
+                            rowStripped.put(name, file.getFilename());
+                            attachments.put(name, value);
+                        }
                     }
+                    else if (value instanceof String strVal)
+                    {
+                        if (!StringUtils.isEmpty(strVal)) // Issue 53498: string value for attachment field is not allowed
+                            throw new ValidationException("Can't upload '" + strVal + "' to field " + name + " with type Attachment.");
+                        else
+                            rowStripped.put(name, value); // if blank, remove attachment
+                    }
+                    else
+                        rowStripped.put(name, value); // if null, remove attachment
                 }
                 else
                 {
                     rowStripped.put(name, value);
                 }
-            });
+            }
 
             for (String vocabularyDomainName : getVocabularyDomainProviders().keySet())
             {

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -1329,15 +1329,13 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                             attachments.put(name, value);
                         }
                     }
-                    else if (value instanceof String strVal)
+                    else if (value != null && !StringUtils.isEmpty(String.valueOf(value)))
                     {
-                        if (!StringUtils.isEmpty(strVal)) // Issue 53498: string value for attachment field is not allowed
-                            throw new ValidationException("Can't upload '" + strVal + "' to field " + name + " with type Attachment.");
-                        else
-                            rowStripped.put(name, value); // if blank, remove attachment
+                        // Issue 53498: string value for attachment field is not allowed
+                        throw new ValidationException("Can't upload '" + value + "' to field " + name + " with type Attachment.");
                     }
                     else
-                        rowStripped.put(name, value); // if null, remove attachment
+                        rowStripped.put(name, value); // if null or empty, remove attachment
                 }
                 else
                 {

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -1323,7 +1323,7 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 {
                     if (value instanceof AttachmentFile file)
                     {
-                        if (null != file.getFilename())//
+                        if (null != file.getFilename())
                         {
                             rowStripped.put(name, file.getFilename());
                             attachments.put(name, value);

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -344,10 +344,9 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
                         if (null != file.getFilename())
                             attachmentFiles.add(file);
                     }
-                    else if (r.getValue() instanceof String strVal)
+                    else if (r.getValue() != null && !StringUtils.isEmpty(String.valueOf(r.getValue())))
                     {
-                        if (!StringUtils.isEmpty(strVal)) // Issue 53498: string value for attachment field is not allowed
-                            throw new ValidationException("Can't upload '" + strVal + "' to field " + r.getKey() + " with type Attachment.");
+                        throw new ValidationException("Can't upload '" + r.getValue() + "' to field " + r.getKey() + " with type Attachment.");
                     }
                 }
             }

--- a/list/src/org/labkey/list/model/ListQueryUpdateService.java
+++ b/list/src/org/labkey/list/model/ListQueryUpdateService.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.list.model;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.announcements.DiscussionService;
@@ -342,6 +343,11 @@ public class ListQueryUpdateService extends DefaultQueryUpdateService
                     {
                         if (null != file.getFilename())
                             attachmentFiles.add(file);
+                    }
+                    else if (r.getValue() instanceof String strVal)
+                    {
+                        if (!StringUtils.isEmpty(strVal)) // Issue 53498: string value for attachment field is not allowed
+                            throw new ValidationException("Can't upload '" + strVal + "' to field " + r.getKey() + " with type Attachment.");
                     }
                 }
             }


### PR DESCRIPTION
#### Rationale
This PR is the follow up work for https://github.com/LabKey/platform/pull/6894 that went to 25.7, that made attachment columns rejecting string type values on import. This PR handles attachment value validation for insert/update api. 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6928
- https://github.com/LabKey/limsModules/pull/1606
- https://github.com/LabKey/testAutomation/pull/2629
- https://github.com/LabKey/platform/pull/6894

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->

#### Tasks 📍
- [x] Manual Testing @labkey-chrisj 
- [x] Needs Automation
- [x] Verify Fix @labkey-chrisj 