### PR TITLE
Issue 53699: avoid BufferUnderflowException when parsing JSON payload

### DIFF
--- a/api/src/org/labkey/api/action/BaseApiAction.java
+++ b/api/src/org/labkey/api/action/BaseApiAction.java
@@ -39,6 +39,7 @@ import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.ResponseHelper;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.BadRequestException;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
@@ -52,6 +53,7 @@ import org.springframework.web.servlet.ModelAndView;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.SocketTimeoutException;
 import java.time.Duration;
@@ -511,12 +513,23 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
 
     private @Nullable JSONObject getJsonObject() throws IOException
     {
+        HttpServletRequest request = getViewContext().getRequest();
+        if (request == null)
+            return null;
+
+        String characterEncoding = request.getCharacterEncoding();
+        if (characterEncoding == null)
+            characterEncoding = StringUtilsLabKey.DEFAULT_CHARSET.name();
+
         long maxLength = getMaximumJsonInputLength();
-        try (Reader r = getViewContext().getRequest().getReader();
-            Reader jsonReader = maxLength > 0 ? new StrictBoundedReader(r, maxLength) : r)
+
+        // Issue 53699: Use request.getInputStream() instead of request.getReader() to
+        // avoid BufferUnderflowException when processing multibyte character JSON payloads.
+        try (Reader streamReader = new InputStreamReader(request.getInputStream(), characterEncoding);
+             Reader jsonReader = maxLength > 0 ? new StrictBoundedReader(streamReader, maxLength) : streamReader)
         {
-            JSONTokener tokener = new JSONTokener(r);
-            return tokener.more() ? new JSONObject(new JSONTokener(jsonReader)) : null;
+            JSONTokener tokener = new JSONTokener(jsonReader);
+            return tokener.more() ? new JSONObject(tokener) : null;
         }
     }
 

--- a/api/src/org/labkey/api/data/validator/LengthValidator.java
+++ b/api/src/org/labkey/api/data/validator/LengthValidator.java
@@ -35,8 +35,9 @@ public class LengthValidator extends AbstractColumnValidator
     {
         if (value instanceof String s)
         {
-            if (s.length() > scale)
-                return "Value is too long for column '" + _columnName + "', a maximum length of " + scale + " is allowed. The supplied value, '" + StringUtils.abbreviateMiddle(s, "...", 50) + "', was " + s.length() + " characters long.";
+            int charLength = Character.codePointCount(s, 0, s.length());
+            if (charLength > scale)
+                return "Value is too long for column '" + _columnName + "', a maximum length of " + scale + " is allowed. The supplied value, '" + StringUtils.abbreviateMiddle(s, "...", 50) + "', was " + charLength + " characters long.";
         }
 
         return null;


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53699](https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=53699) by utilizing `request.getInputStream()` rather than `request.getReader()` to avoid a `BufferUnderflowException` coming from the reader configuration when parsing JSON.

I was unable to determine the exact configuration problem of the reader and if it is a bug in the reader or not.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2632

#### Changes
- Utilize `request.getInputStream()` rather than `request.getReader()` to avoid `BufferUnderflowException` coming from the reader configuration when parsing JSON.

#### Tasks 📍
- [x] Manual Testing / Verify Fix
- [x] Needs Automation