### PR TITLE
Plate Hit: filter out preexisting hits match on Long

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3176,7 +3176,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                     SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("ResultId"), rowIds, CompareType.IN);
                     filter.addCondition(FieldKey.fromParts("ProtocolId"), protocol.getRowId());
 
-                    Set<Integer> preexistingHits = new HashSet<>(new TableSelector(hitTable, Collections.singleton("ResultId"), filter, null).getArrayList(Integer.class));
+                    Set<Long> preexistingHits = new HashSet<>(new TableSelector(hitTable, Collections.singleton("ResultId"), filter, null).getArrayList(Long.class));
                     rowIds.removeAll(preexistingHits);
                 }
 

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3176,7 +3176,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
                     SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("ResultId"), rowIds, CompareType.IN);
                     filter.addCondition(FieldKey.fromParts("ProtocolId"), protocol.getRowId());
 
-                    Set<Long> preexistingHits = new HashSet<>(new TableSelector(hitTable, Collections.singleton("ResultId"), filter, null).getArrayList(Long.class));
+                    Set<Long> preexistingHits = new LongHashSet(new TableSelector(hitTable, Collections.singleton("ResultId"), filter, null).getArrayList(Long.class));
                     rowIds.removeAll(preexistingHits);
                 }
 


### PR DESCRIPTION
#### Rationale
Plate hit selection removes any preexisting hits from the set to be modified prior to checking the requested hits. This is now comparing an `Integer` to a `Long` which is not desired.

#### Related Pull Requests
- #6911

#### Changes
- Use `Long` instead of `Integer` to match other changes