### PR TITLE
Avoid NPE when container is gone; reuse TableInfos for indexing

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -742,6 +742,9 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
             if (!(tableInfo instanceof ExpDataClassDataTableImpl expDataClassDataTable))
                 throw new IllegalArgumentException(String.format("Unable to index data class item in %s. Table must be an instance of %s", dc.getName(), ExpDataClassDataTableImpl.class.getName()));
 
+            if (!expDataClassDataTable.getDataClass().equals(dc))
+                throw new IllegalArgumentException(String.format("Data class table mismatch for %s", dc.getName()));
+
             // Collect other text columns and lookup display columns
             getIndexValues(props, expDataClassDataTable, identifiersHi, identifiersMed, identifiersLo, keywordsHi, keywordsMed, keywordsLo, jsonData);
         }

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialImpl.java
@@ -404,6 +404,9 @@ public class ExpMaterialImpl extends AbstractRunItemImpl<Material> implements Ex
             if (!(tableInfo instanceof ExpMaterialTableImpl expMaterialTable))
                 throw new IllegalArgumentException(String.format("Unable to index material in %s. Table must be an instance of %s", st.getName(), ExpMaterialTableImpl.class.getName()));
 
+            if (!expMaterialTable.getSampleType().equals(st))
+                throw new IllegalArgumentException(String.format("Sample type table mismatch for %s", st.getName()));
+
             getCustomIndexValues(props, expMaterialTable, identifiersHi, keyworksHi, jsonData);
         }
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -314,6 +314,8 @@ import static org.labkey.api.exp.api.ExperimentService.asLong;
 import static org.labkey.api.exp.api.NameExpressionOptionService.NAME_EXPRESSION_REQUIRED_MSG;
 import static org.labkey.api.exp.api.NameExpressionOptionService.NAME_EXPRESSION_REQUIRED_MSG_WITH_SUBFOLDERS;
 import static org.labkey.api.exp.api.ProvenanceService.PROVENANCE_PROTOCOL_LSID;
+import static org.labkey.api.exp.query.ExpSchema.SCHEMA_EXP_DATA;
+import static org.labkey.api.exp.query.SamplesSchema.SCHEMA_SAMPLES;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.rollup;
 
 public class ExperimentServiceImpl implements ExperimentService, ObjectReferencer, SearchService.DocumentProvider
@@ -1043,11 +1045,20 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         selector.setJdbcCaching(false);
         MutableInt maxRowIdProcessed = new MutableInt(minRowId);
 
+        // Avoid creating a new TableInfo for each sample type we encounter
+        Map<Long, TableInfo> tables = new HashMap<>();
+
         // Work in modest block sizes and fetch as a list so we don't keep the ResultSet open, which could lock the tables
         List<Material> materials = selector.getArrayList(Material.class);
         materials.forEach(m -> {
             ExpMaterialImpl expMaterial = new ExpMaterialImpl(m);
-            expMaterial.index(queue, null);
+            ExpSampleType sampleType = expMaterial.getSampleType();
+            TableInfo table = null;
+            if (sampleType != null)
+            {
+                table = tables.computeIfAbsent(sampleType.getRowId(), st -> QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_SAMPLES).getTable(sampleType.getName()));
+            }
+            expMaterial.index(queue, table);
             maxRowIdProcessed.setValue(Math.max(maxRowIdProcessed.getValue(), expMaterial.getRowId()));
         });
 
@@ -1081,11 +1092,22 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         selector.setJdbcCaching(false);
         MutableInt maxRowIdProcessed = new MutableInt(minRowId);
 
+        // Avoid creating a new TableInfo for each data class we encounter
+        Map<Long, TableInfo> tables = new HashMap<>();
+
         // Work in modest block sizes and fetch as a list so we don't keep the ResultSet open, which could lock the tables
         List<Data> data = selector.getArrayList(Data.class);
         data.forEach(d -> {
             ExpDataImpl expData = new ExpDataImpl(d);
-            expData.index(queue, null);
+
+            ExpDataClassImpl dataClass = expData.getDataClass();
+            TableInfo table = null;
+            if (dataClass != null)
+            {
+                table = tables.computeIfAbsent(dataClass.getRowId(), dc -> QueryService.get().getUserSchema(User.getSearchUser(), container, SCHEMA_EXP_DATA).getTable(dataClass.getName()));
+            }
+
+            expData.index(queue, table);
             maxRowIdProcessed.setValue(Math.max(maxRowIdProcessed.getValue(), expData.getRowId()));
         });
 

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -459,10 +459,6 @@ public class SearchController extends SpringActionController
         public ActionURL getRedirectURL(ReturnUrlForm form)
         {
             SearchService ss = SearchService.get();
-    
-            if (null == ss)
-                return null;
-
             SearchService.IndexTask defaultTask = ss.defaultTask();
             for (SearchService.IndexTask task : ss.getTasks())
             {
@@ -484,9 +480,6 @@ public class SearchController extends SpringActionController
         public ActionURL getRedirectURL(ReturnUrlForm form)
         {
             SearchService ss = SearchService.get();
-
-            if (null == ss)
-                return null;
 
             ss.addPathToCrawl(
                     WebdavService.getPath().append(getContainer().getParsedPath()),
@@ -545,9 +538,6 @@ public class SearchController extends SpringActionController
         {
             SearchService ss = SearchService.get();
 
-            if (null == ss)
-                return null;
-
             SearchService.IndexTask task = null;
 
             try (var ignored = SpringActionController.ignoreSqlUpdates())
@@ -584,10 +574,6 @@ public class SearchController extends SpringActionController
         public ApiResponse execute(SearchForm form, BindException errors)
         {
             SearchService ss = SearchService.get();
-            if (null == ss)
-            {
-                throw new NotFoundException();
-            }
 
             audit(form);
 
@@ -804,11 +790,6 @@ public class SearchController extends SpringActionController
             _form = form;
 
             SearchService ss = SearchService.get();
-
-            if (null == ss)
-            {
-                throw new NotFoundException("Search service is not registered");
-            }
 
             if (null == _scope || null == _scope.getRoot(getContainer()))
             {

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Multiset;
 import com.google.common.collect.Multiset.Entry;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -679,17 +680,20 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     @Override
     public void purgeForContainer(@NotNull Container container)
     {
+        MutableInt count = new MutableInt(0);
         Predicate<Item> itemChecker = (i) -> {
             boolean result = container.getEntityId().equals(i._containerId) && i._pri != PRIORITY.delete;
             if (result)
             {
                 // Let the task know too, treating them as failures (since they were not successfully indexed)
                 i._task.completeItem(i, false);
+                count.increment();
             }
             return result;
         };
         _runQueue.removeIf(itemChecker);
         _itemQueue.removeIf(itemChecker);
+        logQueueStatus("Purged " + count.intValue() + " items from the search queue for container " + container.getPath());
     }
 
     @Override
@@ -1076,10 +1080,6 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
             try
             {
-// UNDONE: only pause the crawler for now, don't want to worry about the queue growing unchecked
-//                    if (!waitForRunning())
-//                        continue;
-
                 i = _runQueue.poll(30, TimeUnit.SECONDS);
 
                 if (null != i)
@@ -1089,6 +1089,23 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                     {
                         try {Thread.sleep(100);}catch(InterruptedException ignored){}
                     }
+
+                    Container c;
+                    if (item._containerId != null)
+                    {
+                        c = ContainerManager.getForId(item._containerId);
+                        if (c == null)
+                        {
+                            logQueueStatus("runRunnable:container not found for " + item._containerId);
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        c = null;
+                    }
+
+                    // Hand off a queue that piggybacks on the same priority as the original work
                     item._run.accept(new TaskIndexingQueue()
                     {
                         @Override
@@ -1110,7 +1127,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                         @Override
                         public Container getContainer()
                         {
-                            return ContainerManager.getForId(item._containerId);
+                            return c;
                         }
                     });
                 }


### PR DESCRIPTION
#### Rationale
More iteration to avoid deadlocks and other exceptions when indexing

#### Changes
- Cache and reuse `TableInfo` when doing full indexing pass on samples and data
- Double-check container is still available before executing next indexing runnable

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->