### PR TITLE
Fix import alias update on data type renaming involving slash

### DIFF
--- a/experiment/src/org/labkey/experiment/ExperimentQueryChangeListener.java
+++ b/experiment/src/org/labkey/experiment/ExperimentQueryChangeListener.java
@@ -88,7 +88,7 @@ public class ExperimentQueryChangeListener implements QueryChangeListener
         {
             String newQueryName = queryNameChangeMap.get(oldQueryName);
 
-            String searchStr = "\"" + (prefix + oldQueryName).replaceAll("/", "\\\\/") + "\""; // slash needs to be escaped with backslash for sql
+            String searchStr = "\"" + (prefix + oldQueryName).replaceAll("/", "\\\\/") + "\""; // LabKeyObjectMapper enables JsonWriteFeature.ESCAPE_FORWARD_SLASHES
             String replaceStr = "\"" + (prefix + newQueryName).replace("/", "\\\\/") + "\"";
 
             for (ExpSampleTypeImpl sampleType : getRenamedSampleTypes(container, searchStr))

--- a/experiment/src/org/labkey/experiment/ExperimentQueryChangeListener.java
+++ b/experiment/src/org/labkey/experiment/ExperimentQueryChangeListener.java
@@ -82,14 +82,14 @@ public class ExperimentQueryChangeListener implements QueryChangeListener
                 queryNameChangeMap.put((String)qpc.getOldValue(), (String)qpc.getNewValue());
         }
 
-        String prefix = (isSamples ? MATERIAL_INPUTS : DATA_INPUTS) + "\\/";
+        String prefix = isSamples ? MATERIAL_INPUTS_ALIAS_PREFIX : DATA_INPUTS_ALIAS_PREFIX;
 
         for (String oldQueryName : queryNameChangeMap.keySet())
         {
             String newQueryName = queryNameChangeMap.get(oldQueryName);
 
-            String searchStr = "\"" + prefix + oldQueryName + "\"";
-            String replaceStr = "\"" + prefix.replace("\\/", "\\\\/") + newQueryName + "\"";
+            String searchStr = "\"" + (prefix + oldQueryName).replaceAll("/", "\\\\/") + "\""; // slash needs to be escaped with backslash for sql
+            String replaceStr = "\"" + (prefix + newQueryName).replace("/", "\\\\/") + "\"";
 
             for (ExpSampleTypeImpl sampleType : getRenamedSampleTypes(container, searchStr))
             {
@@ -116,13 +116,12 @@ public class ExperimentQueryChangeListener implements QueryChangeListener
         if (!isSamples && !isData)
             return;
 
-        String prefix = (isSamples ? MATERIAL_INPUTS : DATA_INPUTS) + "\\/";
-        String parsedPrefix = isSamples ? MATERIAL_INPUTS_ALIAS_PREFIX : DATA_INPUTS_ALIAS_PREFIX;
+        String prefix = isSamples ? MATERIAL_INPUTS_ALIAS_PREFIX : DATA_INPUTS_ALIAS_PREFIX;
 
         for (String removed : queries)
         {
-            String inputType = parsedPrefix + removed;
-            String searchStr = "\"" + prefix + removed + "\"";
+            String inputType = prefix + removed;
+            String searchStr = "\"" + inputType.replaceAll("/", "\\\\/") + "\"";
 
             for (ExpSampleTypeImpl sampleType : getRenamedSampleTypes(container, searchStr))
             {


### PR DESCRIPTION
#### Rationale
When a data type name contains slash, or if it's renamed to a new name containing slash, the import aliases defined on that other types that references this data type fails to update automatically. This is revealed by intermittent test failure: 
[SMSampleCreateWithAliasesTest.testCreateAndUpdateWithAliases](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_SampleManagerEPostgres/3628124?buildTab=tests&expandedTest=build%3A%28id%3A3628124%29%2Cid%3A2000000165)

LabKeyObjectMapper has JsonWriteFeature.ESCAPE_FORWARD_SLASHES enabled. The string value of import aliases needs to escape accordingly.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6937
- https://github.com/LabKey/limsModules/pull/1611

#### Changes
- escape slash when querying and updating import aliases

#### Tasks 📍
- [x] Needs Automation