### PR TITLE
Modify container filter for the plate set data generator

### DIFF
--- a/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
+++ b/assay/src/org/labkey/assay/data/generator/PlateSetDataGenerator.java
@@ -234,7 +234,7 @@ public class PlateSetDataGenerator extends DataGenerator<PlateSetDataGenerator.C
             // for now assay plate sets will have distinct samples per plate (even though this is not enforced)
             samplesNeeded = plateWells * getConfig().getPlatesPerPlateset();
 
-        List<Integer> ids = selectExistingSampleIds(samplesNeeded, samplesNeeded, ContainerFilter.current(this));
+        List<Integer> ids = selectExistingSampleIds(samplesNeeded, samplesNeeded, ContainerFilter.Type.CurrentPlusProject.create(getContainer(), getUser()));
         if (ids.size() < samplesNeeded)
             throw new IllegalStateException(String.format("There are not enough samples to properly plate all of the data, you need at least (%d) samples.", samplesNeeded));
 


### PR DESCRIPTION
#### Rationale
Update the data generator container filter for finding samples to use in plate set creation. This allows project and folder scoped samples.