### PR TITLE
Remove coerceTypes call from AbstractQueryUpdateService

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -550,15 +550,7 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         }
 
         preImportDIBValidation(null, colNames);
-
-        List<Map<String, Object>> convertedRows = new ArrayList<>();
-        for (int i = 0; i < rows.size(); i++)
-        {
-            Map<String, Object> row = rows.get(i);
-            row = coerceTypes(row);
-            convertedRows.add(row);
-        }
-        return MapDataIterator.of(colNames, convertedRows, debugName);
+        return MapDataIterator.of(colNames, rows, debugName);
     }
 
 


### PR DESCRIPTION
#### Rationale
Remove unnecessary value type coercion in `AbstractQueryUpdateService` that is causing loss of specificity in date conversions.

#### Related Pull Requests
- #6847

#### Changes
- Remove calls to the deprecated `coerceTypes()` as this is already handled by conversion in `StandardDataIteratorBuilder` and other places.