### PR TITLE
Revise file/attachment exception handling

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -943,7 +943,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                             }
                             catch (ConvertHelper.FileConversionException e)
                             {
-                                throw new ApiUsageException(e);
+                                errors.add(new PropertyValidationError(e.getMessage(), pd.getName()));
                             }
                         }
                     }

--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -482,23 +482,25 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
 
             return batch;
         }
-        catch (ExperimentException | IOException | ConvertHelper.FileConversionException e)
+        catch (ExperimentException | IOException | ConvertHelper.FileConversionException | BatchValidationException e)
         {
+            // TODO: This is better done as a post-rollback task on the transaction
             // clean up the run results file dir here if it was created, for non-async imports
             AssayResultsFileWriter<?> resultsFileWriter = new AssayResultsFileWriter<>(context.getProtocol(), run, null);
             resultsFileWriter.cleanupPostedFiles(context.getContainer(), false);
 
             cleanPrimaryFile(context);
 
-            if (e instanceof ExperimentException)
-                throw (ExperimentException)e;
-            else if (e instanceof ConvertHelper.FileConversionException)
-                throw new ApiUsageException(e.getMessage(), e);
-            else
-                throw new ExperimentException(e);
-        }
-        catch (BatchValidationException e)
-        {
+            if (e instanceof ExperimentException ee)
+                throw ee;
+
+            // HACK: Rethrowing these as ApiUsageException avoids any upstream consequences of wrapping them in ExperimentException.
+            // Namely, that they are logged to the server/mothership. There has to be a better way.
+            if (e instanceof ConvertHelper.FileConversionException fce)
+                throw new ApiUsageException(fce.getMessage(), fce);
+            else if (e instanceof BatchValidationException bve)
+                throw new ApiUsageException(bve.getMessage(), bve);
+
             throw new ExperimentException(e);
         }
     }

--- a/api/src/org/labkey/api/dataiterator/AttachmentDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/AttachmentDataIterator.java
@@ -43,10 +43,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 
-/**
- * Moved from ListQueryUpdateService.java
- * by iansigmon on 2/16/16.
- */
 public class AttachmentDataIterator extends WrapperDataIterator
 {
     final VirtualFile attachmentDir;
@@ -92,19 +88,21 @@ public class AttachmentDataIterator extends WrapperDataIterator
             for (_AttachmentUploadHelper p : attachmentColumns)
             {
                 Object attachmentValue = get(p.index);
+                if (null == attachmentValue)
+                    continue;
+
                 String filename;
                 AttachmentFile attachmentFile;
 
-                if (null == attachmentValue)
-                    continue;
-                else if (attachmentValue instanceof String str)
+                if (attachmentValue instanceof String str)
                 {
                     if (null == attachmentDir)
                     {
-                        errors.addRowError(new ValidationException("Row " + get(0) + ": " + "Can't upload '" + str + "' to field " + p.domainProperty.getName() + " with type " + p.domainProperty.getType().getLabel() + "."));
+                        errors.addRowError(propertyValidationException(p.domainProperty, attachmentValue));
                         return false;
                     }
-                    filename = (String) attachmentValue;
+
+                    filename = str;
                     InputStream aIS = attachmentDir.getDir(p.domainProperty.getName()).getInputStream(p.uniquifier.uniquify(filename));
                     if (aIS == null)
                     {
@@ -113,25 +111,25 @@ public class AttachmentDataIterator extends WrapperDataIterator
                     }
                     attachmentFile = new InputStreamAttachmentFile(aIS, filename);
                 }
-                else if (attachmentValue instanceof AttachmentFile)
+                else if (attachmentValue instanceof AttachmentFile file)
                 {
-                    attachmentFile = (AttachmentFile) attachmentValue;
+                    attachmentFile = file;
                     filename = attachmentFile.getFilename();
                 }
-                else if (attachmentValue instanceof File)
+                else if (attachmentValue instanceof File file)
                 {
-                    attachmentFile = new FileAttachmentFile((File) attachmentValue);
+                    attachmentFile = new FileAttachmentFile(file);
                     filename = attachmentFile.getFilename();
                 }
                 else
                 {
-                    errors.addRowError(new ValidationException("Row " + get(0) + ": " + "Unable to create attachment file."));
+                    errors.addRowError(propertyValidationException(p.domainProperty, attachmentValue));
                     return false;
                 }
 
                 if (entityIdIndex == 0)
                 {
-                    errors.addRowError(new ValidationException("Row " + get(0) + ": " + "Unable to create attachment file."));
+                    errors.addRowError(rowValidationException("Unable to create attachment file."));
                     return false;
                 }
 
@@ -170,6 +168,16 @@ public class AttachmentDataIterator extends WrapperDataIterator
                 }
             }
         }
+    }
+
+    private ValidationException propertyValidationException(DomainProperty property, Object value)
+    {
+        return rowValidationException(String.format("Can't upload '%s' to field %s with type %s.", value, property.getName(), property.getType().getLabel()));
+    }
+
+    private ValidationException rowValidationException(String message)
+    {
+        return new ValidationException("Row " + get(0) + ": " + message);
     }
 
     public static DataIteratorBuilder getAttachmentDataIteratorBuilder(TableInfo ti, @NotNull final DataIteratorBuilder builder,


### PR DESCRIPTION
#### Rationale
This addresses several test failures due to changes in #6941 which resulted in different, albeit desired, conversion exception handling of file/attachment fields.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6949
- https://github.com/LabKey/limsModules/pull/1620
- https://github.com/LabKey/testAutomation/pull/2643

#### Changes
- Revise `AttachmentDataIterator` to give more informative error in non-string value case.
- Assimilate `BatchValidationException` handling when creating a run 😿.