### PR TITLE
Issue 53616: Assay creation attempt after an error results in error

### DIFF
--- a/assay/src/org/labkey/assay/AssayManager.java
+++ b/assay/src/org/labkey/assay/AssayManager.java
@@ -40,6 +40,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ContainerType;
+import org.labkey.api.data.DatabaseCache;
 import org.labkey.api.data.MenuButton;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlSelector;
@@ -139,7 +140,23 @@ public class AssayManager implements AssayService
     };
 
     /** Cache the protocols defined in a given container, which we can quickly compose to get the protocols in scope */
-    private static final Cache<Container, List<ExpProtocol>> PROTOCOL_CACHE = CacheManager.getCache(CacheManager.UNLIMITED, TimeUnit.HOURS.toMillis(1), "Assay protocols");
+    private static final Cache<Container, List<ExpProtocol>> PROTOCOL_CACHE = DatabaseCache.get(ExperimentService.get().getSchema().getScope(), CacheManager.UNLIMITED, TimeUnit.HOURS.toMillis(1), "Assay protocols", (c, argument) ->
+    {
+        List<ExpProtocol> result = new ArrayList<>();
+
+        // Filter to just the ones that have an AssayProvider associated with them
+        for (ExpProtocol protocol : ExperimentService.get().getExpProtocols(c))
+        {
+            AssayProvider p = AssayManager.get().getProvider(protocol);
+            if (p != null)
+            {
+                // We don't want anyone editing our cached object
+                protocol.lock();
+                result.add(protocol);
+            }
+        }
+        return result.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(result);
+    });
 
     private static final List<AssayListener> _listeners = new CopyOnWriteArrayList<>();
     private final List<AssayProvider> _providers = new CopyOnWriteArrayList<>();
@@ -365,23 +382,7 @@ public class AssayManager implements AssayService
 
         for (Container containerInScope : container.getContainersFor(ContainerType.DataType.protocol))
         {
-            List<ExpProtocol> ids = PROTOCOL_CACHE.get(containerInScope, null, (c, argument) ->
-            {
-                List<ExpProtocol> result = new ArrayList<>();
-
-                // Filter to just the ones that have an AssayProvider associated with them
-                for (ExpProtocol protocol : ExperimentService.get().getExpProtocols(c))
-                {
-                    AssayProvider p = getProvider(protocol);
-                    if (p != null)
-                    {
-                        // We don't want anyone editing our cached object
-                        protocol.lock();
-                        result.add(protocol);
-                    }
-                }
-                return result.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(result);
-            });
+            List<ExpProtocol> ids = PROTOCOL_CACHE.get(containerInScope);
             allProtocols.addAll(ids);
         }
 

--- a/study/test/src/org/labkey/test/tests/study/AssayTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AssayTest.java
@@ -18,6 +18,8 @@ package org.labkey.test.tests.study;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.assay.AssayListCommand;
+import org.labkey.remoteapi.assay.AssayListResponse;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
@@ -39,8 +41,11 @@ import org.labkey.test.util.StudyHelper;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @Category({Daily.class, Assays.class})
 public class AssayTest extends AbstractAssayTest
@@ -48,8 +53,10 @@ public class AssayTest extends AbstractAssayTest
     private static final String INVESTIGATOR = "Dr. No";
     private static final String GRANT = "SPECTRE";
     private static final String DESCRIPTION = "World Domination.";
+    private static final String ISSUE_53616_ASSAY = "Issue53616Assay";
+    private static final String ISSUE_53616_PROJECT = "Issue53616Project" + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
     private static final String SAMPLE_FIELD_TEST_ASSAY = "SampleFieldTestAssay";
-    private static final String SAMPLE_FIELD_PROJECT_NAME = "Sample Field Test Project";
+    private static final String SAMPLE_FIELD_PROJECT_NAME = "Sample Field Test Project" + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
 
     @Override
     protected String getProjectName()
@@ -64,10 +71,39 @@ public class AssayTest extends AbstractAssayTest
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
         //should also delete the groups
-        _containerHelper.deleteProject(getProjectName(), afterTest);
-        _containerHelper.deleteProject(SAMPLE_FIELD_PROJECT_NAME, afterTest);
+        _containerHelper.deleteProject(getProjectName(), false);
+        _containerHelper.deleteProject(SAMPLE_FIELD_PROJECT_NAME, false);
+        _containerHelper.deleteProject(ISSUE_53616_PROJECT, false);
 
         _userHelper.deleteUsers(false, TEST_ASSAY_USR_PI1, TEST_ASSAY_USR_TECH1);
+    }
+
+    // Issue 53616: Assay creation attempt after an error results in "Assay protocol already exists for this name."
+    @Test
+    public void testFailedCreation() throws Exception
+    {
+        _containerHelper.createProject(ISSUE_53616_PROJECT, "Assay");
+        goToProjectHome(ISSUE_53616_PROJECT);
+
+        log("Create test assay");
+        ReactAssayDesignerPage assayDesignerPage = _assayHelper.createAssayDesign("General", ISSUE_53616_ASSAY)
+                .setDescription(TEST_ASSAY_DESC);
+
+        DomainFormPanel resultsPanel = assayDesignerPage.goToBatchFields().removeAllFields(false); //remove preset result fields
+        resultsPanel.addField("TooLongFieldName".repeat(20));
+
+        log("Save initial assay design with sample field set to 'All Samples'");
+        List<String> errors = assayDesignerPage.clickSaveExpectingErrors();
+        assertEquals("Wrong number of errors", 1, errors.size());
+        assertTrue("Wrong error message: " + errors.get(0), errors.get(0).startsWith("Name cannot exceed 200 characters, but was"));
+
+        resultsPanel.removeAllFields(false);
+        resultsPanel.addField("ShortAndSweet");
+        assayDesignerPage.clickFinish();
+
+        AssayListCommand command = new AssayListCommand();
+        AssayListResponse response = command.execute(createDefaultConnection(), ISSUE_53616_PROJECT);
+        assertNotNull("Didn't find expected assay design", response.getDefinition(ISSUE_53616_ASSAY));
     }
 
     /**
@@ -94,8 +130,7 @@ public class AssayTest extends AbstractAssayTest
         viewCrossFolderData();
         verifyStudyList();
         verifyRunDeletionRecallsDatasetRows();
-        // TODO: Turn this on once file browser migration is complete.
-        //verifyWebdavTree();
+        verifyWebdavTree();
         goBack();
     }
 

--- a/study/test/src/org/labkey/test/tests/study/AssayTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AssayTest.java
@@ -131,7 +131,6 @@ public class AssayTest extends AbstractAssayTest
         verifyStudyList();
         verifyRunDeletionRecallsDatasetRows();
         verifyWebdavTree();
-        goBack();
     }
 
     @Test

--- a/study/test/src/org/labkey/test/tests/study/AssayTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AssayTest.java
@@ -261,7 +261,7 @@ public class AssayTest extends AbstractAssayTest
     private void verifyWebdavTree()
     {
         beginAt("_webdav");
-        _fileBrowserHelper.selectFileBrowserItem(getProjectName() + "/Studies/Study 1");
+        _fileBrowserHelper.selectFileBrowserItem(getProjectName() + "/Studies/Study 1/");
         assertTextPresent("@pipeline", 2);
         Locator.XPathLocator l = Locator.xpath("//span[text()='@pipeline']");
         assertElementPresent(l,  1);

--- a/study/test/src/org/labkey/test/tests/study/AssayTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AssayTest.java
@@ -262,7 +262,6 @@ public class AssayTest extends AbstractAssayTest
     {
         beginAt("_webdav");
         _fileBrowserHelper.selectFileBrowserItem(getProjectName() + "/Studies/Study 1/");
-        assertTextPresent("@pipeline", 2);
         Locator.XPathLocator l = Locator.xpath("//span[text()='@pipeline']");
         assertElementPresent(l,  1);
     }


### PR DESCRIPTION
#### Rationale
We're not using a transaction-aware cache, so we're ending up caching an assay design that didn't actually get committed to the DB because the attempt failed.

#### Changes
- Switch to a `DatabaseCache`

#### Tasks 📍
- [x] Manual Testing @cnathe 
- [x] Needs Automation
- [x] Verify Fix
