### PR TITLE
Issue 53672: List export / import roundtrip issue with long key name

### DIFF
--- a/list/src/org/labkey/list/model/ListImporter.java
+++ b/list/src/org/labkey/list/model/ListImporter.java
@@ -289,8 +289,9 @@ public class ListImporter
                                             sequence = "list." + sequence;
                                     }
 
-                                    SQLFragment keyupdate = new SQLFragment("SELECT setval(").appendStringLiteral(sequence,dialect);
-                                    keyupdate.append(", coalesce((SELECT MAX(").append(dialect.quoteIdentifier(def.getKeyName().toLowerCase())).append(")+1 FROM ").append(tableName);
+                                    String keyStorageColName = def.getDomain().getPropertyByName(def.getKeyName()).getPropertyDescriptor().getStorageColumnName();
+                                    SQLFragment keyupdate = new SQLFragment("SELECT setval(").appendStringLiteral(sequence, dialect);
+                                    keyupdate.append(", coalesce((SELECT MAX(").append(dialect.quoteIdentifier(keyStorageColName)).append(")+1 FROM ").append(tableName);
                                     keyupdate.append("), 1), false)");
                                     new SqlExecutor(ti.getSchema()).execute(keyupdate);
                                 }

--- a/list/src/org/labkey/list/model/ListImporter.java
+++ b/list/src/org/labkey/list/model/ListImporter.java
@@ -291,7 +291,7 @@ public class ListImporter
 
                                     String keyStorageColName = def.getDomain().getPropertyByName(def.getKeyName()).getPropertyDescriptor().getStorageColumnName();
                                     SQLFragment keyupdate = new SQLFragment("SELECT setval(").appendStringLiteral(sequence, dialect);
-                                    keyupdate.append(", coalesce((SELECT MAX(").append(dialect.quoteIdentifier(keyStorageColName)).append(")+1 FROM ").append(tableName);
+                                    keyupdate.append(", coalesce((SELECT MAX(").append(dialect.quoteIdentifier(keyStorageColName.toLowerCase())).append(")+1 FROM ").append(tableName);
                                     keyupdate.append("), 1), false)");
                                     new SqlExecutor(ti.getSchema()).execute(keyupdate);
                                 }


### PR DESCRIPTION
#### Rationale
We should round-trip list archives without errors, even with an egregiously long key field name.

#### Changes
- Use the storage column name when generating SQL

#### Tasks 📍
- [x] Manual Testing @cnathe 
- [x] Needs Automation
- [x] Verify Fix