### PR TITLE
Issue 53562: Cap max blob size in database configuration option

### DIFF
--- a/api/src/org/labkey/api/settings/WriteableAppProps.java
+++ b/api/src/org/labkey/api/settings/WriteableAppProps.java
@@ -39,6 +39,9 @@ public class WriteableAppProps extends AppPropsImpl
 {
     private final Container _container;
 
+    // Issue 53562: Cap max blob size
+    public static final int SOFT_MAX_BLOB_SIZE = 200 * 1024 * 1024;
+
     public WriteableAppProps(Container c)
     {
         _container = c;
@@ -72,21 +75,29 @@ public class WriteableAppProps extends AppPropsImpl
 
     public void setSSLPort(int port)
     {
+        if (port < 0 || port > 65535)
+            throw new IllegalArgumentException("Invalid port number: " + port);
         storeIntValue(sslPort, port);
     }
 
     public void setMemoryUsageDumpInterval(int interval)
     {
+        if (interval < 0)
+            throw new IllegalArgumentException("memoryUsageDumpInterval must be >= 0");
         storeIntValue(memoryUsageDumpInterval, interval);
     }
 
     public void setReadOnlyHttpRequestTimeout(int timeout)
     {
+        if (timeout < 0)
+            throw new IllegalArgumentException("readOnlyHttpRequestTimeout must be >= 0");
         storeIntValue(readOnlyHttpRequestTimeout, timeout);
     }
 
     public void setMaxBLOBSize(int maxSize)
     {
+        if (maxSize < 0)
+            throw new IllegalArgumentException("maxBLOBSize must be >= 0");
         storeIntValue(maxBLOBSize, maxSize);
     }
 

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1314,6 +1314,27 @@ public class AdminController extends SpringActionController
             {
                 errors.reject(ERROR_MSG, "Cannot enable the ribbon message without providing a message to show");
             }
+            if (form.getMaxBLOBSize() < 0)
+            {
+                errors.reject(ERROR_MSG, "Maximum BLOB size cannot be negative");
+            }
+            int hardCap = Math.max(WriteableAppProps.SOFT_MAX_BLOB_SIZE, AppProps.getInstance().getMaxBLOBSize());
+            if (form.getMaxBLOBSize() > hardCap)
+            {
+                errors.reject(ERROR_MSG, "Maximum BLOB size cannot be set higher than " + hardCap + " bytes");
+            }
+            if (form.getSslPort() < 1 || form.getSslPort() > 65535)
+            {
+                errors.reject(ERROR_MSG, "HTTPS port must be between 1 and 65,535");
+            }
+            if (form.getReadOnlyHttpRequestTimeout() < 0)
+            {
+                errors.reject(ERROR_MSG, "HTTP timeout must be non-negative");
+            }
+            if (form.getMemoryUsageDumpInterval() < 0)
+            {
+                errors.reject(ERROR_MSG, "Memory logging frequency must be non-negative");
+            }
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
We don't want admins to sign up for BLOB sizes that are likely to yield OutOfMemoryErrors. We can do better at validating other site settings too.

#### Changes
- Don't let BLOB sizes go higher than 200MB, or any higher than they already are when existing value is > 200MB
- Validate other integer Site Settings during save

#### Tasks
- [x] Manual Testing
- [x] Needs Automation
- [x] Verify Fix
