### PR TITLE
Issue 53578: Remove sample references in plate well table upon sample delete

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -5017,13 +5017,8 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
 
         // Issue 53578: Clear foreign key references in the well table when materials are deleted
         var wellTable = PlateSchema.getWellTable(container, user, ContainerFilter.getUnsafeEverythingFilter());
-        var updateSql = new SQLFragment("UPDATE assay.Well")
-                .append(" SET SampleId = NULL WHERE SampleId ")
+        var updateSql = new SQLFragment("UPDATE assay.Well SET SampleId = NULL WHERE SampleId ")
                 .appendInClause(materials.stream().map(ExpObject::getRowId).toList(), wellTable.getSqlDialect());
-
-        // TODO: Should we audit this somehow?
-        // TODO: What do we do about the blatant business rules violations this can incur?
-        //  Should we prevent the delete? Could depend on if this is a container or sample type delete or a simple deletion of the samples.
 
         new SqlExecutor(wellTable.getSchema()).execute(updateSql);
     }

--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -88,6 +88,7 @@ import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.OntologyObject;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
+import org.labkey.api.exp.api.ExpMaterial;
 import org.labkey.api.exp.api.ExpObject;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
@@ -5006,6 +5007,25 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         }
 
         return new HydratedResult(plates, context.platedSampleIds().isEmpty() ? null : context.platedSampleIds().size(), existingPlates);
+    }
+
+    @Override
+    public void beforeMaterialDelete(List<? extends ExpMaterial> materials, Container container, User user)
+    {
+        if (materials == null || materials.isEmpty())
+            return;
+
+        // Issue 53578: Clear foreign key references in the well table when materials are deleted
+        var wellTable = PlateSchema.getWellTable(container, user, ContainerFilter.getUnsafeEverythingFilter());
+        var updateSql = new SQLFragment("UPDATE assay.Well")
+                .append(" SET SampleId = NULL WHERE SampleId ")
+                .appendInClause(materials.stream().map(ExpObject::getRowId).toList(), wellTable.getSqlDialect());
+
+        // TODO: Should we audit this somehow?
+        // TODO: What do we do about the blatant business rules violations this can incur?
+        //  Should we prevent the delete? Could depend on if this is a container or sample type delete or a simple deletion of the samples.
+
+        new SqlExecutor(wellTable.getSchema()).execute(updateSql);
     }
 
     private class BulkPlateIndexer extends Thread

--- a/assay/src/org/labkey/assay/plate/PlateManagerTest.java
+++ b/assay/src/org/labkey/assay/plate/PlateManagerTest.java
@@ -1895,6 +1895,65 @@ public final class PlateManagerTest
 //        updateWells(List.of(wellC3, wellC4));
     }
 
+    @Test // Issue 53578
+    public void testDeleteSampleWellReferencesUponSampleDelete() throws Exception
+    {
+        // Arrange
+        var props = List.of(new GWTPropertyDescriptor("name", "string"));
+        var sampleTypeToBeDeleted = SampleTypeService.get().createSampleType(container, user, "SampleTypeDelete53578", null, props, emptyList(), -1, -1, -1, -1, "ST-${genId}", null);
+
+        // Create samples in two different sample types
+        var sampleRowIds = createSamples(3, sampleTypeToBeDeleted).stream().map(ExpObject::getRowId).sorted().toList();
+        var defaultSampleRowIds = createSamples(2).stream().map(ExpObject::getRowId).sorted().toList();
+
+        var pps = new PlateSetImpl();
+        pps.setType(PlateSetType.primary);
+
+        var wellData = List.of(
+            createWellRow("A1", "SAMPLE", sampleRowIds.get(0)),
+            createWellRow("A2", "SAMPLE", sampleRowIds.get(1)),
+            createWellRow("A3", "SAMPLE", sampleRowIds.get(2)),
+            createWellRow("B4", "SAMPLE", defaultSampleRowIds.get(0)),
+            createWellRow("C1", "SAMPLE", defaultSampleRowIds.get(1))
+        );
+
+        var plateData = List.of(new PlateManager.PlateData(null, PLATE_TYPE_12_WELLS.getRowId(), null, null, wellData));
+        var PPS = createPlateSet(pps, plateData, null);
+        var ppsPlateRowId = PPS.getPlates().get(0).getRowId();
+
+        var aps = new PlateSetImpl();
+        aps.setType(PlateSetType.assay);
+        var APS = createPlateSet(aps, plateData, PPS.getRowId());
+        var apsPlateRowId = APS.getPlates().get(0).getRowId();
+
+        // Act
+        // Formerly, this would result in a foreign key violation on the assay.well table
+        sampleTypeToBeDeleted.delete(user);
+
+        // Assert
+        // Verify sample references have been removed from every plate
+        for (var plateRowId : List.of(ppsPlateRowId, apsPlateRowId))
+        {
+            try (var r = getPlateWellResults(plateRowId))
+            {
+                while (r.next())
+                {
+                    var sampleId = r.getInt(FieldKey.fromParts("sampleId"));
+                    var wellPosition = r.getString(FieldKey.fromParts("position"));
+
+                    switch (wellPosition)
+                    {
+                        // Expect only samples from the default sample type to remain in wells as
+                        // the other sample type has been deleted.
+                        case "B4" -> assertEquals(defaultSampleRowIds.get(0).intValue(), sampleId);
+                        case "C1" -> assertEquals(defaultSampleRowIds.get(1).intValue(), sampleId);
+                        default -> assertEquals(0, sampleId);
+                    }
+                }
+            }
+        }
+    }
+
     private Plate createPlate(@NotNull PlateType plateType) throws Exception
     {
         return createPlate(plateType, null, null, null);
@@ -1973,6 +2032,11 @@ public final class PlateManagerTest
     }
 
     private List<ExpMaterial> createSamples(int numSamples) throws Exception
+    {
+        return createSamples(numSamples, sampleType);
+    }
+
+    private List<ExpMaterial> createSamples(int numSamples, ExpSampleType sampleType) throws Exception
     {
         List<Map<String, Object>> rows = new ArrayList<>();
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4813,18 +4813,18 @@ public class QueryController extends SpringActionController
         }
 
         @NotNull
-        protected TableInfo getTableInfo(Container container, User user, String schemaName, String queryName)
+        protected TableInfo getTableInfo(Container container, User user, String schemaName, String queryName) throws ValidationException
         {
             if (null == schemaName || null == queryName)
-                throw new IllegalArgumentException("You must supply a schemaName and queryName!");
+                throw new ValidationException("You must supply a schemaName and queryName!");
 
             UserSchema schema = QueryService.get().getUserSchema(user, container, schemaName);
             if (null == schema)
-                throw new IllegalArgumentException("The schema '" + schemaName + "' does not exist.");
+                throw new ValidationException("The schema '" + schemaName + "' does not exist.", "schemaName");
 
             TableInfo table = schema.getTableForInsert(queryName);
             if (table == null)
-                throw new IllegalArgumentException("The query '" + queryName + "' in the schema '" + schemaName + "' does not exist.");
+                throw new ValidationException("The query '" + queryName + "' in the schema '" + schemaName + "' does not exist.", "queryName");
             return table;
         }
     }

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4813,18 +4813,18 @@ public class QueryController extends SpringActionController
         }
 
         @NotNull
-        protected TableInfo getTableInfo(Container container, User user, String schemaName, String queryName) throws ValidationException
+        protected TableInfo getTableInfo(Container container, User user, String schemaName, String queryName)
         {
             if (null == schemaName || null == queryName)
-                throw new ValidationException("You must supply a schemaName and queryName!");
+                throw new IllegalArgumentException("You must supply a schemaName and queryName!");
 
             UserSchema schema = QueryService.get().getUserSchema(user, container, schemaName);
             if (null == schema)
-                throw new ValidationException("The schema '" + schemaName + "' does not exist.", "schemaName");
+                throw new IllegalArgumentException("The schema '" + schemaName + "' does not exist.");
 
             TableInfo table = schema.getTableForInsert(queryName);
             if (table == null)
-                throw new ValidationException("The query '" + queryName + "' in the schema '" + schemaName + "' does not exist.", "queryName");
+                throw new IllegalArgumentException("The query '" + queryName + "' in the schema '" + schemaName + "' does not exist.");
             return table;
         }
     }


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53578](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53578) by clearing foreign key references to samples from the `assay.well` table prior to sample deletion.

#### Changes
- Update the `assay.well.sampleId` column values to `NULL` upon sample deletion for the deleted samples
- Add regression test coverage

#### Tasks
- [x] Manual Testing @labkey-klum 
  - Verified previous and new behavior.
- [x] Needs Automation