### PR TITLE
Drop viability schema on SQL Server

### DIFF
--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-25.004-25.005.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-25.004-25.005.sql
@@ -1,3 +1,6 @@
+-- Viability no longer supports SQL Server, but its old schema may have been left behind. Ensure it and its FK to ObjectId are dropped.
+EXEC core.fn_dropifexists '*', 'viability', 'SCHEMA';
+
 -- Drop foreign keys that involve ObjectIds
 ALTER TABLE exp.Edge DROP CONSTRAINT FK_Edge_From_Object;
 ALTER TABLE exp.Edge DROP CONSTRAINT FK_Edge_To_Object;


### PR DESCRIPTION
#### Rationale
Several developers have run into INT --> BIGINT upgrade problems on SQL Server because their database included an old `viability` schema with an FK to `exp.Object.ObjectId`. Drop that schema if it exists.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6911

No testing needed, IMO.