### PR TITLE
Consolidate XML parsing initialization, remove some casts

### DIFF
--- a/api/src/org/labkey/api/cache/ehcache/EhSimpleCache.java
+++ b/api/src/org/labkey/api/cache/ehcache/EhSimpleCache.java
@@ -52,7 +52,7 @@ class EhSimpleCache<K, V> implements SimpleCache<K, V>
     public void put(@NotNull K key, V value, long timeToLive)
     {
         Element element = new Element(key, value);
-        element.setTimeToLive(IntegerUtils.asInteger(timeToLive) / 1000);
+        element.setTimeToLive(IntegerUtils.asInteger(timeToLive / 1000)); // Convert from ms to sec
         _cache.put(element);
     }
 

--- a/api/src/org/labkey/api/cache/ehcache/EhSimpleCache.java
+++ b/api/src/org/labkey/api/cache/ehcache/EhSimpleCache.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.CacheType;
 import org.labkey.api.cache.SimpleCache;
+import org.labkey.api.util.IntegerUtils;
 
 import java.util.HashSet;
 import java.util.List;
@@ -51,7 +52,7 @@ class EhSimpleCache<K, V> implements SimpleCache<K, V>
     public void put(@NotNull K key, V value, long timeToLive)
     {
         Element element = new Element(key, value);
-        element.setTimeToLive((int)timeToLive / 1000);
+        element.setTimeToLive(IntegerUtils.asInteger(timeToLive) / 1000);
         _cache.put(element);
     }
 

--- a/api/src/org/labkey/api/data/Aggregate.java
+++ b/api/src/org/labkey/api/data/Aggregate.java
@@ -567,13 +567,13 @@ public class Aggregate
         {
             o = rs.getObject(aggColName);
             // TODO: Handle BigDecimal values
-            if (o instanceof Number)
+            if (o instanceof Number n)
             {
-                double resultValue = ((Number)o).doubleValue();
+                double resultValue = n.doubleValue();
                 if (resultValue == Math.floor(resultValue))
-                    o = Long.valueOf((long) resultValue);
+                    o = n.longValue();
                 else
-                    o = Double.valueOf(resultValue);
+                    o = resultValue;
             }
         }
 

--- a/api/src/org/labkey/api/data/DbSchemaCache.java
+++ b/api/src/org/labkey/api/data/DbSchemaCache.java
@@ -42,7 +42,6 @@ public class DbSchemaCache
 
     // Ask the DbSchemaType how long to cache each schema
     private final CacheTimeChooser<String> SCHEMA_CACHE_TIME_CHOOSER = (key, argument) -> {
-        @SuppressWarnings({"unchecked"})
         SchemaDetails details = (SchemaDetails)argument;
         return details.getType().getCacheTimeToLive();
     };

--- a/api/src/org/labkey/api/data/DbSequence.java
+++ b/api/src/org/labkey/api/data/DbSequence.java
@@ -139,11 +139,11 @@ public class DbSequence
         }
 
         /* package */
-        synchronized long reserveSequentialBlock(int count)
+        synchronized long reserveSequentialBlock(long count)
         {
             if (null == _lastReservedValue || _currentValue+count > _lastReservedValue)
             {
-                Pair<Long, Long> reserved = DbSequenceManager.reserve(this, Math.max(count,_batchSize));
+                Pair<Long, Long> reserved = DbSequenceManager.reserve(this, Math.max(count, _batchSize));
                 _currentValue = reserved.first;
                 _lastReservedValue = reserved.second;
             }

--- a/api/src/org/labkey/api/data/DbSequenceManager.java
+++ b/api/src/org/labkey/api/data/DbSequenceManager.java
@@ -37,6 +37,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -106,8 +107,8 @@ public class DbSequenceManager
         return _sequences.computeIfAbsent(key, (k) -> new DbSequence.Preallocate(c, name, ensure(c, name, id), batchSize));
     }
 
-    /* This is not a recommended, but if you get stuck and need to reserve a block at once */
-    public static long reserveSequentialBlock(DbSequence seq, int count)
+    /* This is not recommended, but if you get stuck and need to reserve a block at once */
+    public static long reserveSequentialBlock(DbSequence seq, long count)
     {
         if (!(seq instanceof DbSequence.Preallocate))
             throw new IllegalStateException();
@@ -123,10 +124,7 @@ public class DbSequenceManager
     {
         Integer rowId = getRowId(c, name, id, withUpdateLock);
 
-        if (null != rowId)
-            return rowId;
-        else
-            return create(c, name, id, withUpdateLock);
+        return Objects.requireNonNullElseGet(rowId, () -> create(c, name, id, withUpdateLock));
     }
 
     public static @Nullable Integer getRowId(Container c, String name, long id)
@@ -289,7 +287,7 @@ public class DbSequenceManager
     // .first value returned is 'current', call to next() should return current+1
     // .second value is reserved for use by caller
     // in other words, next() should return values [pair.first+1, pair.second] inclusive
-    static Pair<Long,Long> reserve(DbSequence sequence, int count)
+    static Pair<Long,Long> reserve(DbSequence sequence, long count)
     {
         TableInfo tinfo = getTableInfo();
 

--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisProtocol.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisProtocol.java
@@ -28,6 +28,7 @@ import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineProtocol;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.writer.PrintWriters;
 import org.xml.sax.InputSource;
@@ -105,7 +106,7 @@ public abstract class AbstractFileAnalysisProtocol<JOB extends AbstractFileAnaly
             String line;
             while ((line = reader.readLine()) != null)
                 stripped.append(line.trim());
-            DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            DocumentBuilder db = XmlBeansUtil.getDocumentBuilder();
             DOMSource xmlInput = new DOMSource(db.parse(new InputSource(new StringReader(stripped.toString()))));
             StreamResult xmlOutput = new StreamResult(new StringWriter());
             Transformer transformer = TransformerFactory.newInstance().newTransformer();

--- a/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisProtocol.java
+++ b/api/src/org/labkey/api/pipeline/file/AbstractFileAnalysisProtocol.java
@@ -28,13 +28,13 @@ import org.labkey.api.pipeline.PipelineJob;
 import org.labkey.api.pipeline.PipelineProtocol;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.writer.PrintWriters;
 import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -106,7 +106,7 @@ public abstract class AbstractFileAnalysisProtocol<JOB extends AbstractFileAnaly
             String line;
             while ((line = reader.readLine()) != null)
                 stripped.append(line.trim());
-            DocumentBuilder db = XmlBeansUtil.getDocumentBuilder();
+            DocumentBuilder db = XmlBeansUtil.DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
             DOMSource xmlInput = new DOMSource(db.parse(new InputSource(new StringReader(stripped.toString()))));
             StreamResult xmlOutput = new StreamResult(new StringWriter());
             Transformer transformer = TransformerFactory.newInstance().newTransformer();
@@ -255,7 +255,15 @@ public abstract class AbstractFileAnalysisProtocol<JOB extends AbstractFileAnaly
     protected ParamParser parse()
     {
         ParamParser parser = getFactory().createParamParser();
-        parser.parse(new ReaderInputStream(new StringReader(xml), Charset.defaultCharset()));
+        try
+        {
+            parser.parse(new ReaderInputStream.Builder().setReader(new StringReader(xml)).setCharset(Charset.defaultCharset()).get());
+        }
+        catch (IOException e)
+        {
+            // Shouldn't happen since we already had the content in-memory as a String
+            throw UnexpectedException.wrap(e);
+        }
         return parser;
     }
 
@@ -278,7 +286,7 @@ public abstract class AbstractFileAnalysisProtocol<JOB extends AbstractFileAnaly
     public abstract List<FileType> getInputTypes();
     
     @Override
-    public abstract AbstractFileAnalysisProtocolFactory getFactory();
+    public abstract AbstractFileAnalysisProtocolFactory<?> getFactory();
 
     public abstract JOB createPipelineJob(ViewBackgroundInfo info,
                                           PipeRoot root, List<Path> filesInput,

--- a/api/src/org/labkey/api/reports/report/RedirectReport.java
+++ b/api/src/org/labkey/api/reports/report/RedirectReport.java
@@ -21,8 +21,10 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
+import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.ViewContext;
 
 import java.net.MalformedURLException;
@@ -35,7 +37,7 @@ import java.net.URL;
  */
 public abstract class RedirectReport extends AbstractReport
 {
-    private static final Logger LOG = LogManager.getLogger(RedirectReport.class);
+    private static final Logger LOG = LogHelper.getLogger(RedirectReport.class, "Reports that send the user to some other URL");
 
     public static final String REDIRECT_URL = ReportDescriptor.Prop.redirectUrl.name();
     public static final String TARGET = "target";
@@ -45,7 +47,7 @@ public abstract class RedirectReport extends AbstractReport
     }
 
     @Override
-    public HttpView renderReport(ViewContext context)
+    public HttpView<?> renderReport(ViewContext context)
     {
         String url = getUrl(context.getContainer());
 
@@ -53,7 +55,7 @@ public abstract class RedirectReport extends AbstractReport
         if (context.get(renderParam.reportWebPart.name()) != null)
             return new JspView<>("/org/labkey/api/reports/report/view/redirectReportWebPart.jsp", this);
 
-        return HttpView.redirect(url);
+        throw new RedirectException(url);
     }
 
     @Override

--- a/api/src/org/labkey/api/search/AbstractXMLDocumentParser.java
+++ b/api/src/org/labkey/api/search/AbstractXMLDocumentParser.java
@@ -22,8 +22,6 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,7 +42,7 @@ public abstract class AbstractXMLDocumentParser extends AbstractDocumentParser
     {
         try (BufferedInputStream buffered = new BufferedInputStream(stream))
         {
-            XmlBeansUtil.createSAXParser().parse(buffered, createSAXHandler(handler));
+            XmlBeansUtil.SAX_PARSER_FACTORY.newSAXParser().parse(buffered, createSAXHandler(handler));
         }
         catch (ParserConfigurationException e)
         {

--- a/api/src/org/labkey/api/search/AbstractXMLDocumentParser.java
+++ b/api/src/org/labkey/api/search/AbstractXMLDocumentParser.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.search;
 
+import org.labkey.api.util.XmlBeansUtil;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
@@ -23,6 +24,7 @@ import org.xml.sax.helpers.DefaultHandler;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashSet;
@@ -40,13 +42,9 @@ public abstract class AbstractXMLDocumentParser extends AbstractDocumentParser
     @Override
     public void parseContent(InputStream stream, ContentHandler handler) throws IOException, SAXException
     {
-        try
+        try (BufferedInputStream buffered = new BufferedInputStream(stream))
         {
-            SAXParser parser = SAXParserFactory.newInstance().newSAXParser();
-            parser.getXMLReader().setFeature("http://xml.org/sax/features/validation", false);
-            parser.getXMLReader().setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            parser.getXMLReader().setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            parser.parse(stream, createSAXHandler(handler));
+            XmlBeansUtil.createSAXParser().parse(buffered, createSAXHandler(handler));
         }
         catch (ParserConfigurationException e)
         {

--- a/api/src/org/labkey/api/util/HttpsUtil.java
+++ b/api/src/org/labkey/api/util/HttpsUtil.java
@@ -62,7 +62,7 @@ public class HttpsUtil
 
 
     /** Attempts a connection to the testURL, returning null on success and a Pair with error message and (possibly null) response code on failure */
-    public static @Nullable Pair<String, Integer> testSslUrl(URL testURL, String advice)
+    public static @Nullable Pair<String, Integer> testHttpsUrl(URL testURL, String advice)
     {
         try
         {
@@ -152,7 +152,7 @@ public class HttpsUtil
 
                 // Now switch to a URL, since that's what testSslUrl() requires
                 URL testURL = new URL(helper.getURIString());
-                Pair<String, Integer> sslResult = HttpsUtil.testSslUrl(testURL,
+                Pair<String, Integer> sslResult = HttpsUtil.testHttpsUrl(testURL,
                     "This LabKey Server instance is configured to require secure connections on port " + redirectPort + ", but it does not appear to be responding " +
                     "to HTTPS requests at " + testURL + ". Please see " + new HelpTopic("stagingServerTips").getHelpTopicHref() + " for " +
                     "details about how to turn off the SSL redirect settings in the database.");

--- a/api/src/org/labkey/api/util/JavaScriptFragment.java
+++ b/api/src/org/labkey/api/util/JavaScriptFragment.java
@@ -8,7 +8,6 @@ import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.JavaScriptDisplayColumn;
 import org.labkey.api.view.UnauthorizedException;
 
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.io.IOException;
@@ -81,8 +80,7 @@ public class JavaScriptFragment implements SafeToRender, DOM.Renderable
     {
         try
         {
-            XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-            XMLStreamReader reader = inputFactory.createXMLStreamReader(new StringReader(metadataText));
+            XMLStreamReader reader = XmlBeansUtil.createStreamReaderFactory().createXMLStreamReader(new StringReader(metadataText));
 
             // Issue 48660 - disallow JavaScriptDisplayColumn for non-developers
             // When we're inside a <className> element, accumulate the contents to check when we hit the closing tag

--- a/api/src/org/labkey/api/util/JavaScriptFragment.java
+++ b/api/src/org/labkey/api/util/JavaScriptFragment.java
@@ -1,7 +1,7 @@
 package org.labkey.api.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
@@ -42,7 +42,7 @@ public class JavaScriptFragment implements SafeToRender, DOM.Renderable
             return EMPTY;
         // even with unsafe() a javascript fragment can never contain the sequence "</[Ss][Cc][Rr][Ii][Pp][Tt]>"
         // since </ is not legal javascript syntax we escape it
-        s = StringUtils.replace(s, "</", "<\\/");
+        s = Strings.CS.replace(s, "</", "<\\/");
         return new JavaScriptFragment(s);
     }
 
@@ -52,7 +52,7 @@ public class JavaScriptFragment implements SafeToRender, DOM.Renderable
         if (null == s)
             return JavaScriptFragment.NULL;
         var js = PageFlowUtil.jsString(s);
-        assert !StringUtils.contains(js, "</");
+        assert !Strings.CS.contains(js, "</");
         return new JavaScriptFragment(js);
     }
 
@@ -64,7 +64,7 @@ public class JavaScriptFragment implements SafeToRender, DOM.Renderable
         try
         {
             String s = JsonUtil.DEFAULT_MAPPER.writeValueAsString(value);
-            if (StringUtils.contains(s, "</"))
+            if (Strings.CS.contains(s, "</"))
                 throw new IllegalStateException("Error encoding JSON object");
             return new JavaScriptFragment(s);
         }
@@ -80,7 +80,7 @@ public class JavaScriptFragment implements SafeToRender, DOM.Renderable
     {
         try
         {
-            XMLStreamReader reader = XmlBeansUtil.createStreamReaderFactory().createXMLStreamReader(new StringReader(metadataText));
+            XMLStreamReader reader = XmlBeansUtil.XML_INPUT_FACTORY.createXMLStreamReader(new StringReader(metadataText));
 
             // Issue 48660 - disallow JavaScriptDisplayColumn for non-developers
             // When we're inside a <className> element, accumulate the contents to check when we hit the closing tag

--- a/api/src/org/labkey/api/util/XmlBeansUtil.java
+++ b/api/src/org/labkey/api/util/XmlBeansUtil.java
@@ -28,10 +28,8 @@ import org.labkey.api.security.User;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.stream.XMLInputFactory;
 import java.util.Collection;
@@ -123,46 +121,36 @@ public class XmlBeansUtil
         cursor.dispose();
     }
 
-    /**
-     * Return JAXP document builder instance.
-     */
-    public static DocumentBuilder getDocumentBuilder()
+    /** XML parsing factories preconfigured to prevent XML external entity references (XXE) */
+    public static final SAXParserFactory SAX_PARSER_FACTORY;
+    public static final XMLInputFactory XML_INPUT_FACTORY;
+    public static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY;
+
+    static
     {
-        DocumentBuilder documentBuilder;
-        DocumentBuilderFactory documentBuilderFactory;
+        XML_INPUT_FACTORY = XMLInputFactory.newInstance();
+        XML_INPUT_FACTORY.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        XML_INPUT_FACTORY.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+
+        SAX_PARSER_FACTORY = SAXParserFactory.newInstance();
         try
         {
-            documentBuilderFactory = DocumentBuilderFactory.newInstance();
-            documentBuilderFactory.setNamespaceAware(true);
-            // Prevent XXE by disabling DTDs and external entities
-            documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            documentBuilderFactory.setXIncludeAware(false);
-            documentBuilderFactory.setExpandEntityReferences(false);
-            documentBuilder = documentBuilderFactory.newDocumentBuilder();
+            SAX_PARSER_FACTORY.setNamespaceAware(true);
+            SAX_PARSER_FACTORY.setFeature("http://xml.org/sax/features/validation", false);
+            SAX_PARSER_FACTORY.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            SAX_PARSER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+
+            DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
+            DOCUMENT_BUILDER_FACTORY.setNamespaceAware(true);
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            DOCUMENT_BUILDER_FACTORY.setXIncludeAware(false);
+            DOCUMENT_BUILDER_FACTORY.setExpandEntityReferences(false);
         }
-        catch (ParserConfigurationException e)
+        catch (ParserConfigurationException | SAXException e)
         {
             throw UnexpectedException.wrap(e);
         }
-        return documentBuilder;
-    }
-
-    public static XMLInputFactory createStreamReaderFactory()
-    {
-        XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-        inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-        inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-        return inputFactory;
-    }
-
-    public static SAXParser createSAXParser() throws ParserConfigurationException, SAXException
-    {
-        SAXParser parser = SAXParserFactory.newInstance().newSAXParser();
-        parser.getXMLReader().setFeature("http://xml.org/sax/features/validation", false);
-        parser.getXMLReader().setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        parser.getXMLReader().setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        return parser;
     }
 }

--- a/api/src/org/labkey/api/util/XmlBeansUtil.java
+++ b/api/src/org/labkey/api/util/XmlBeansUtil.java
@@ -26,16 +26,18 @@ import org.labkey.api.data.Container;
 import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.LookAndFeelProperties;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLInputFactory;
 import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedList;
 
-/**
- * User: adam
- * Date: May 25, 2009
- * Time: 9:26:59 AM
- */
 public class XmlBeansUtil
 {
     private XmlBeansUtil()
@@ -119,5 +121,48 @@ public class XmlBeansUtil
         XmlCursor cursor = doc.newCursor();
         cursor.insertComment(comment);
         cursor.dispose();
+    }
+
+    /**
+     * Return JAXP document builder instance.
+     */
+    public static DocumentBuilder getDocumentBuilder()
+    {
+        DocumentBuilder documentBuilder;
+        DocumentBuilderFactory documentBuilderFactory;
+        try
+        {
+            documentBuilderFactory = DocumentBuilderFactory.newInstance();
+            documentBuilderFactory.setNamespaceAware(true);
+            // Prevent XXE by disabling DTDs and external entities
+            documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            documentBuilderFactory.setXIncludeAware(false);
+            documentBuilderFactory.setExpandEntityReferences(false);
+            documentBuilder = documentBuilderFactory.newDocumentBuilder();
+        }
+        catch (ParserConfigurationException e)
+        {
+            throw UnexpectedException.wrap(e);
+        }
+        return documentBuilder;
+    }
+
+    public static XMLInputFactory createStreamReaderFactory()
+    {
+        XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+        inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        return inputFactory;
+    }
+
+    public static SAXParser createSAXParser() throws ParserConfigurationException, SAXException
+    {
+        SAXParser parser = SAXParserFactory.newInstance().newSAXParser();
+        parser.getXMLReader().setFeature("http://xml.org/sax/features/validation", false);
+        parser.getXMLReader().setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        parser.getXMLReader().setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        return parser;
     }
 }

--- a/api/src/org/labkey/api/view/HttpView.java
+++ b/api/src/org/labkey/api/view/HttpView.java
@@ -595,18 +595,12 @@ public abstract class HttpView<ModelBean> extends DefaultModelAndView<ModelBean>
     public static HttpView<?> redirect(URLHelper url, boolean allowAbsoluteUrl)
     {
         String redirectUrl = (!allowAbsoluteUrl || url.isLocalUri(getRootContext())) ? url.getLocalURIString() : url.getURIString();
-        return redirect(redirectUrl);
+        throw new RedirectException(redirectUrl);
     }
 
     public static HttpView<?> redirect(ActionURL url)
     {
-        return redirect(url.getLocalURIString());
-    }
-
-    @Deprecated(forRemoval = true) // Use ActionURL or URLHelper variant instead. TODO: Remove
-    public static HttpView<?> redirect(String url)
-    {
-        throw new RedirectException(url);
+        throw new RedirectException(url.getLocalURIString());
     }
 
     /**

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -1346,7 +1346,7 @@ public class AdminController extends SpringActionController
             if (form.isSslRequired() && !(request.isSecure() && (form.getSslPort() == request.getServerPort())))
             {
                 URL testURL = new URL("https", request.getServerName(), form.getSslPort(), AppProps.getInstance().getContextPath());
-                Pair<String, Integer> sslResponse = HttpsUtil.testSslUrl(testURL, "Ensure that the web server is configured for SSL and the port is correct. If SSL is enabled, try saving these settings while connected via SSL.");
+                Pair<String, Integer> sslResponse = HttpsUtil.testHttpsUrl(testURL, "Ensure that the web server is configured for SSL and the port is correct. If SSL is enabled, try saving these settings while connected via SSL.");
 
                 if (sslResponse != null)
                 {

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -1412,7 +1412,7 @@ public class DavController extends SpringActionController
                 {
                     if (is.available() > 0)
                     {
-                        DocumentBuilder documentBuilder = XmlBeansUtil.getDocumentBuilder();
+                        DocumentBuilder documentBuilder = XmlBeansUtil.DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
                         Document document = documentBuilder.parse(is);
 
                         // Get the root element of the document
@@ -2839,14 +2839,14 @@ public class DavController extends SpringActionController
             {
                 if (is.available() > 0)
                 {
-                    DocumentBuilder documentBuilder = XmlBeansUtil.getDocumentBuilder();
                     try
                     {
+                        DocumentBuilder documentBuilder = XmlBeansUtil.DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
                         // TODO : Process this request body
                         documentBuilder.parse(new InputSource(is));
                         throw new DavException(WebdavStatus.SC_NOT_IMPLEMENTED);
                     }
-                    catch (SAXException saxe)
+                    catch (SAXException | ParserConfigurationException e)
                     {
                         // Parse error - assume invalid content
                         throw new DavException(WebdavStatus.SC_UNSUPPORTED_MEDIA_TYPE);
@@ -3976,17 +3976,17 @@ public class DavController extends SpringActionController
 
             Node lockInfoNode = null;
 
-            DocumentBuilder documentBuilder = XmlBeansUtil.getDocumentBuilder();
 
             try
             {
+                DocumentBuilder documentBuilder = XmlBeansUtil.DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
                 Document document = documentBuilder.parse(new InputSource(getRequest().getInputStream()));
 
                 // Get the root element of the document
                 Element rootElement = document.getDocumentElement();
                 lockInfoNode = rootElement;
             }
-            catch (IOException | SAXException e)
+            catch (IOException | SAXException | ParserConfigurationException e)
             {
                 lockRequestType = LOCK_REFRESH;
             }

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -1412,7 +1412,7 @@ public class DavController extends SpringActionController
                 {
                     if (is.available() > 0)
                     {
-                        DocumentBuilder documentBuilder = getDocumentBuilder();
+                        DocumentBuilder documentBuilder = XmlBeansUtil.getDocumentBuilder();
                         Document document = documentBuilder.parse(is);
 
                         // Get the root element of the document
@@ -2839,7 +2839,7 @@ public class DavController extends SpringActionController
             {
                 if (is.available() > 0)
                 {
-                    DocumentBuilder documentBuilder = getDocumentBuilder();
+                    DocumentBuilder documentBuilder = XmlBeansUtil.getDocumentBuilder();
                     try
                     {
                         // TODO : Process this request body
@@ -3976,7 +3976,7 @@ public class DavController extends SpringActionController
 
             Node lockInfoNode = null;
 
-            DocumentBuilder documentBuilder = getDocumentBuilder();
+            DocumentBuilder documentBuilder = XmlBeansUtil.getDocumentBuilder();
 
             try
             {
@@ -5989,32 +5989,8 @@ public class DavController extends SpringActionController
         return null;
     }
 
-
     /**
-     * Return JAXP document builder instance.
-     */
-    private DocumentBuilder getDocumentBuilder()
-            throws DavException
-    {
-        DocumentBuilder documentBuilder;
-        DocumentBuilderFactory documentBuilderFactory;
-        try
-        {
-            documentBuilderFactory = DocumentBuilderFactory.newInstance();
-            documentBuilderFactory.setNamespaceAware(true);
-            documentBuilder = documentBuilderFactory.newDocumentBuilder();
-        }
-        catch (ParserConfigurationException e)
-        {
-            throw new DavException(e);
-        }
-        return documentBuilder;
-    }
-
-
-
-    /**
-     * Holds a lock information.
+     * Holds lock information.
      */
     private static class LockInfo
     {

--- a/pipeline/src/org/labkey/pipeline/analysis/FileAnalysisProtocol.java
+++ b/pipeline/src/org/labkey/pipeline/analysis/FileAnalysisProtocol.java
@@ -21,7 +21,6 @@ import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.TaskId;
 import org.labkey.api.pipeline.file.AbstractFileAnalysisJob;
 import org.labkey.api.pipeline.file.AbstractFileAnalysisProtocol;
-import org.labkey.api.pipeline.file.AbstractFileAnalysisProtocolFactory;
 import org.labkey.api.util.FileType;
 import org.labkey.api.view.ViewBackgroundInfo;
 
@@ -50,7 +49,7 @@ public class FileAnalysisProtocol extends AbstractFileAnalysisProtocol<AbstractF
     }
 
     @Override
-    public AbstractFileAnalysisProtocolFactory getFactory()
+    public FileAnalysisProtocolFactory getFactory()
     {
         return _factory;
     }

--- a/specimen/src/org/labkey/specimen/importer/SpecimenImporter.java
+++ b/specimen/src/org/labkey/specimen/importer/SpecimenImporter.java
@@ -1370,7 +1370,7 @@ public class SpecimenImporter extends SpecimenTableManager
 
             /* HACK, we don't do this anywhere else, but we need to get a block of continuous IDS to make this work */
             // row_number() starts at 1 so subtract 1
-            long start = DbSequenceManager.reserveSequentialBlock(seq, (int)count);
+            long start = DbSequenceManager.reserveSequentialBlock(seq, count);
             start -= 1;
 
             SQLFragment insertMaterialFragment = new SQLFragment(insertMaterialSQL, start, start, info.getContainer().getId(), cpasType, createdTimestamp);


### PR DESCRIPTION
#### Rationale
Clear up usage of deprecated methods, avoid downcasting from `long`->`int`, improve parsing configuration.

#### Changes
- Centralize XML parser factory initialization and consistently set features
- Update DbSequence to handle `long`
- Swap out uses of deprecated methods

#### Tasks 📍
- [ ] Manual Testing
- Needs Automation - N/A
