### PR TITLE
Issue 53608 and 53680: Trouble with namings

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -315,8 +315,6 @@ import static org.labkey.api.util.IntegerUtils.asLong;
 import static org.labkey.api.exp.api.NameExpressionOptionService.NAME_EXPRESSION_REQUIRED_MSG;
 import static org.labkey.api.exp.api.NameExpressionOptionService.NAME_EXPRESSION_REQUIRED_MSG_WITH_SUBFOLDERS;
 import static org.labkey.api.exp.api.ProvenanceService.PROVENANCE_PROTOCOL_LSID;
-import static org.labkey.api.exp.query.ExpSchema.SCHEMA_EXP_DATA;
-import static org.labkey.api.exp.query.SamplesSchema.SCHEMA_SAMPLES;
 import static org.labkey.api.util.IntegerUtils.asLongElseNull;
 import static org.labkey.experiment.api.SampleTypeServiceImpl.SampleChangeType.rollup;
 
@@ -6470,9 +6468,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (newProtocol)
             {
                 // if protocol exists, throw error
-                ExpProtocol existing = getExpProtocol(protocol.getContainer(), protocol.getName());
-                if (existing != null && protocol.getLSIDNamespacePrefix().equals("GeneralAssayProtocol") && existing.getLSIDNamespacePrefix().equals("GeneralAssayProtocol"))
-                    throw new RuntimeSQLException(new SQLException("Assay design with name '" + existing.getName() + "' already exists."));
+                if (AssayService.get().getAssayProtocolByName(protocol.getContainer(), protocol.getName()) != null)
+                    throw new RuntimeSQLException(new SQLException("Assay design with name '" + protocol.getName() + "' already exists."));
 
                 result = Table.insert(user, getTinfoProtocol(), protocol);
             }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -6469,9 +6469,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             boolean newProtocol = protocol.getRowId() == 0;
             if (newProtocol)
             {
-                // if protocol exist, throw error
+                // if protocol exists, throw error
                 ExpProtocol existing = getExpProtocol(protocol.getContainer(), protocol.getName());
-                if (existing != null && protocol.getLSIDNamespacePrefix().equals("GeneralAssayProtocol"))
+                if (existing != null && protocol.getLSIDNamespacePrefix().equals("GeneralAssayProtocol") && existing.getLSIDNamespacePrefix().equals("GeneralAssayProtocol"))
                     throw new RuntimeSQLException(new SQLException("Assay design with name '" + existing.getName() + "' already exists."));
 
                 result = Table.insert(user, getTinfoProtocol(), protocol);

--- a/experiment/src/org/labkey/experiment/defaults/DefaultValueServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/defaults/DefaultValueServiceImpl.java
@@ -64,7 +64,7 @@ public class DefaultValueServiceImpl implements DefaultValueService
         if (kind != null && kind.isUserCreatedType())
         {
             Lsid domainLsid = new Lsid(domain.getTypeURI());
-            return (new Lsid(DOMAIN_DEFAULT_VALUE_LSID_PREFIX, suffix, Lsid.decodePart(domainLsid.getObjectId()))).toString();
+            return (new Lsid(DOMAIN_DEFAULT_VALUE_LSID_PREFIX, suffix, domainLsid.getObjectId())).toString();
         }
         else // for internal domains (such as audit domains), the domain name and objectId are often not the same.
             return (new Lsid(DOMAIN_DEFAULT_VALUE_LSID_PREFIX, suffix, domain.getName())).toString();

--- a/experiment/src/org/labkey/experiment/defaults/DefaultValueServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/defaults/DefaultValueServiceImpl.java
@@ -78,7 +78,7 @@ public class DefaultValueServiceImpl implements DefaultValueService
         if (kind != null && kind.isUserCreatedType())
         {
             Lsid domainLsid = new Lsid(domain.getTypeURI());
-            return (new Lsid(USER_DEFAULT_VALUE_DOMAIN_PARENT, suffix, Lsid.decodePart(domainLsid.getObjectId()))).toString();
+            return (new Lsid(USER_DEFAULT_VALUE_DOMAIN_PARENT, suffix, domainLsid.getObjectId())).toString();
         }
         else // for internal domains (such as audit domains), the domain name and objectId are often not the same.
             return (new Lsid(USER_DEFAULT_VALUE_DOMAIN_PARENT, suffix, domain.getName())).toString();


### PR DESCRIPTION
#### Rationale
Issue [53608](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53608) - The names for assays and workflow templates should not interfere with each other
Issue [53680](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53608) - Extra decoding of LSID objectId is not needed and causes problems.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1632

#### Changes
- Check that both protocols are of the same type and both are assay protocols
- Remove extra call for decoding the domain ObjectId part

#### Tasks 📍
- [x] Manual Testing @labkey-chrisj 
- [x] Needs Automation 
- [x] Verify Fix @labkey-jeckels 
