### PR TITLE
Issue 53796: DataRegion.getChecked() incorrectly HTML encodes

### DIFF
--- a/api/src/org/labkey/api/data/DataRegion.java
+++ b/api/src/org/labkey/api/data/DataRegion.java
@@ -1911,7 +1911,7 @@ public class DataRegion extends DisplayElement
                 // of values (even if they're empty) between commas for deterministic parsing (bug 6755)
                 checkboxValue.append(and);
                 if (null != v)
-                    checkboxValue.append(PageFlowUtil.filter(v.toString()));
+                    checkboxValue.append(v);
                 and = ",";
             }
         }
@@ -1924,7 +1924,7 @@ public class DataRegion extends DisplayElement
                 // of values (even if they're empty) between commas for deterministic parsing (bug 6755)
                 checkboxValue.append(and);
                 if (null != v)
-                    checkboxValue.append(PageFlowUtil.filter(v.toString()));
+                    checkboxValue.append(v);
                 and = ",";
             }
         }


### PR DESCRIPTION
#### Rationale
We're double-encoding the value for record selectors in standard LKS grid views.

#### Changes
- Don't double-encode

#### Tasks 📍
- [x] Manual Testing @labkey-adam 
  - Verified that keys containing HTML characters work as expected for export selected (various formats), sign selected, and delete selected 
- [x] Needs Automation
