### PR TITLE
ensure non-null project for domain and property descriptors

### DIFF
--- a/api/src/org/labkey/api/exp/DomainDescriptor.java
+++ b/api/src/org/labkey/api/exp/DomainDescriptor.java
@@ -200,7 +200,7 @@ public final class DomainDescriptor
     public Container getProject()
     {
         var c = getContainer();
-        return null == c ? null : c.getProject();
+        return null == c ? null : (c.getProject() != null ? c.getProject() : c);
     }
 
     public int getTitlePropertyId()

--- a/api/src/org/labkey/api/exp/PropertyDescriptor.java
+++ b/api/src/org/labkey/api/exp/PropertyDescriptor.java
@@ -307,7 +307,7 @@ public class PropertyDescriptor extends ColumnRenderPropertiesImpl implements Pa
     public Container getProject()
     {
         var c = getContainer();
-        return null == c ? null : c.getProject();
+        return null == c ? null : (c.getProject() != null ? c.getProject() : c);
     }
 
     public void setProject(Container proj)

--- a/query/webapp/dataview/DataViewsPanel.js
+++ b/query/webapp/dataview/DataViewsPanel.js
@@ -510,9 +510,9 @@ Ext4.define('LABKEY.ext4.DataViewsPanel', {
                     handler.call(scope || this, json);
                 }
             },
-            failure : function() {
-                Ext4.Msg.alert('Failure');
-            },
+            failure : LABKEY.Utils.getCallbackWrapper(function(json) {
+                Ext4.Msg.alert('Get Configuration Failure', LABKEY.Utils.encodeHtml(json.exception));
+            }, null, true),
             scope : this
         });
     },
@@ -1403,9 +1403,9 @@ Ext4.define('LABKEY.ext4.DataViewsPanel', {
                                 else
                                     this.getFullStore().load();
                             },
-                            failure : function() {
-                                Ext4.Msg.alert('Failure');
-                            },
+                            failure : LABKEY.Utils.getCallbackWrapper(function(json) {
+                                Ext4.Msg.alert('Customize View Failure', LABKEY.Utils.encodeHtml(json.exception));
+                            }, null, true),
                             scope : this
                         });
                     }


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53630)

For both `DomainDescriptor` and `PropertyDescriptor` the project field has a not null database constraint. Recent changes to stop holding onto `Container` instances broke some of this when the container was root. This just restores the prior behavior and also updates the data views panel to show something more helpful than an empty dialog when errors like this occur.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6971
- https://github.com/LabKey/testAutomation/pull/2657

#### Tasks 📍
- [x] Needs Automation
- [x] Verify Fix @labkey-adam 
