### PR TITLE
PropertyController validation related API actions to extend ReadOnlyApiAction

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
+++ b/experiment/src/org/labkey/experiment/controllers/property/PropertyController.java
@@ -480,7 +480,7 @@ public class PropertyController extends SpringActionController
 
     @Marshal(Marshaller.Jackson)
     @RequiresPermission(ReadPermission.class)
-    public static class ValidateNameExpressionsAction extends MutatingApiAction<DomainApiForm>
+    public static class ValidateNameExpressionsAction extends ReadOnlyApiAction<DomainApiForm>
     {
         @Override
         protected ObjectMapper createRequestObjectMapper()
@@ -509,7 +509,7 @@ public class PropertyController extends SpringActionController
 
     @Marshal(Marshaller.Jackson)
     @RequiresPermission(ReadPermission.class)
-    public static class ValidateDomainAndFieldNamesAction extends MutatingApiAction<DomainApiForm>
+    public static class ValidateDomainAndFieldNamesAction extends ReadOnlyApiAction<DomainApiForm>
     {
         @Override
         protected ObjectMapper createRequestObjectMapper()
@@ -552,6 +552,7 @@ public class PropertyController extends SpringActionController
                 {
                     try
                     {
+                        field.setPropertyURI(DomainUtil.createUniquePropertyURI(typeURI, "1000", new CaseInsensitiveHashSet()));
                         DomainProperty dp = DomainUtil.addProperty(domain, field, new HashMap<>(), new CaseInsensitiveHashSet(), results);
                         OntologyManager.validatePropertyDescriptor(dp.getPropertyDescriptor());
                     }


### PR DESCRIPTION
#### Rationale
A couple validation API actions in the PropertyController currently extend MutatingApiAction, but that is likely inadvertent and they should be extending ReadOnlyApiAction.

#### Changes
- change ValidateDomainAndFieldNamesAction and ValidateNameExpressionsAction to extend ReadOnlyApiAction
