### PR TITLE
Entropy score only the first 100 characters of password

### DIFF
--- a/api/src/org/labkey/api/security/EntropyPasswordValidator.java
+++ b/api/src/org/labkey/api/security/EntropyPasswordValidator.java
@@ -54,7 +54,9 @@ public abstract class EntropyPasswordValidator implements PasswordValidator
 
     public static double score(String password, User user)
     {
-        return calculateEntropy(filter(password.toCharArray(), user));
+        // Score only the first 100 characters, Issue 53814
+        String shorter = password.substring(0, 100);
+        return calculateEntropy(filter(shorter.toCharArray(), user));
     }
 
     // Calculate bits of entropy based on https://www.omnicalculator.com/other/password-entropy

--- a/api/src/org/labkey/api/security/EntropyPasswordValidator.java
+++ b/api/src/org/labkey/api/security/EntropyPasswordValidator.java
@@ -55,7 +55,7 @@ public abstract class EntropyPasswordValidator implements PasswordValidator
     public static double score(String password, User user)
     {
         // Score only the first 100 characters, Issue 53814
-        String shorter = password.substring(0, 100);
+        String shorter = StringUtils.truncate(password, 100);
         return calculateEntropy(filter(shorter.toCharArray(), user));
     }
 


### PR DESCRIPTION
#### Rationale
We think a recent labkey.org 504 could have been caused by entropy scoring an excessively long password. https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53814

We don't have a repro, but scoring only the first 100 characters seems like a reasonable precaution to limit DOS attacks.