### PR TITLE
Issue 53608: Handle deployments without the assay module

### DIFF
--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -6469,7 +6469,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (newProtocol)
             {
                 // if protocol exists, throw error
-                if (AssayService.get().getAssayProtocolByName(protocol.getContainer(), protocol.getName()) != null)
+                if (AssayService.get() != null && AssayService.get().getAssayProtocolByName(protocol.getContainer(), protocol.getName()) != null)
                     throw new RuntimeSQLException(new SQLException("Assay design with name '" + protocol.getName() + "' already exists."));
 
                 result = Table.insert(user, getTinfoProtocol(), protocol);


### PR DESCRIPTION
#### Rationale
Many failures in Sample Manager Starter, which doesn't have the Assay module.

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_ProductSuites_SampleManagerStarter_SampleManagerStarterPostgres_Batch_4_2/3644738

```
java.lang.NullPointerException: Cannot invoke "org.labkey.api.assay.AssayService.getAssayProtocolByName(org.labkey.api.data.Container, String)" because the return value of "org.labkey.api.assay.AssayService.get()" is null
    at org.labkey.experiment.api.ExperimentServiceImpl.saveProtocol(ExperimentServiceImpl.java:6472) ~[experiment-25.9-SNAPSHOT.jar:?]
    at org.labkey.experiment.api.ExperimentServiceImpl.saveProtocol(ExperimentServiceImpl.java:6450) ~[experiment-25.9-SNAPSHOT.jar:?]
    at org.labkey.experiment.api.ExperimentServiceImpl.insertSimpleProtocol(ExperimentServiceImpl.java:8486) ~[experiment-25.9-SNAPSHOT.jar:?]
    at org.labkey.experiment.api.ExperimentServiceImpl.ensureSampleDerivationProtocol(ExperimentServiceImpl.java:7657) ~[experiment-25.9-SNAPSHOT.jar:?]
```
  
#### Changes
- Check for the service before using it

#### Tasks 📍
- [x] Needs Automation
