### PR TITLE
Issue 53803: differentiate import container filtering

### DIFF
--- a/api/src/org/labkey/api/data/ContainerFilter.java
+++ b/api/src/org/labkey/api/data/ContainerFilter.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.security.SecurityLogger;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.Permission;
@@ -1205,6 +1206,46 @@ public abstract class ContainerFilter
         }
     }
 
+    /**
+     * This container filter type is uniquely specified for the scenario of importing data cross-folder.
+     * - When importing in a project, the scope of the data is the project, and all subfolders plus shared.
+     * - When importing into a subfolder, the scope of the data is the subfolder, and the project plus shared.
+     * - However, when resolving the scope of a lookup within that data during an import, we retain the behavior from
+     *  {@link QueryService#getContainerFilterForLookups}.
+     * See Issue 52504, Issue 53803
+     */
+    public static class ProductFolderImport extends ContainerFilterWithPermission
+    {
+        ContainerFilterWithPermission _cf;
+
+        public ProductFolderImport(Container c, User user)
+        {
+            super(c, user);
+
+            if (c.isProject())
+                _cf = new AllInProjectPlusShared(c, user);
+            else
+                _cf = new CurrentPlusProjectAndShared(c, user);
+        }
+
+        @Override
+        public @Nullable Collection<GUID> generateIds(Container currentContainer, Class<? extends Permission> permission, Set<Role> roles)
+        {
+            return _cf.generateIds(currentContainer, permission, roles);
+        }
+
+        public @NotNull ContainerFilter getContainerFilterForLookups(Container container, User user)
+        {
+            var cf = QueryService.get().getContainerFilterForLookups(container, user);
+            return cf == null ? this : cf;
+        }
+
+        @Override
+        public Type getType()
+        {
+            return null;
+        }
+    }
 
     public static class InternalNoContainerFilter extends ContainerFilter
     {

--- a/api/src/org/labkey/api/exp/PropertyColumn.java
+++ b/api/src/org/labkey/api/exp/PropertyColumn.java
@@ -188,12 +188,15 @@ public class PropertyColumn extends LookupColumn
             var lookupCf = cf;
 
             // Issue 52504: Use proper container filter for lookups
-            // HACK: Issue 53803: Only apply lookup for insert when container filter is AllInProjectPlusShared
-            if (pd.isLookup() && lookupCf instanceof ContainerFilter.AllInProjectPlusShared)
+            if (pd.isLookup())
             {
-                var _cf = QueryService.get().getContainerFilterForLookups(container, user);
-                if (_cf != null)
-                    lookupCf = _cf;
+                // Issue 53803: Only apply lookup for insert/import -- see setContainerFilterForImport()
+                if (lookupCf instanceof ContainerFilter.AllInProjectPlusShared || lookupCf instanceof ContainerFilter.CurrentPlusProjectAndShared)
+                {
+                    var _cf = QueryService.get().getContainerFilterForLookups(container, user);
+                    if (_cf != null)
+                        lookupCf = _cf;
+                }
             }
 
             to.setFk(PdLookupForeignKey.create(to.getParentTable().getUserSchema(), user, container, pd, lookupCf));

--- a/api/src/org/labkey/api/exp/PropertyColumn.java
+++ b/api/src/org/labkey/api/exp/PropertyColumn.java
@@ -35,7 +35,6 @@ import org.labkey.api.exp.property.IPropertyValidator;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.PdLookupForeignKey;
-import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.security.User;
 import org.labkey.api.study.assay.FileLinkDisplayColumn;
@@ -43,15 +42,11 @@ import org.labkey.api.util.CachingSupplier;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Supplier;
-
 
 /**
  * {@link ColumnInfo} which is specified via an ontology-managed property, and may be persisted in exp.ObjectProperty or
  * in a hard table managed by {@link org.labkey.api.exp.api.StorageProvisioner}.
- * User: migra
- * Date: Sep 20, 2005
  */
 public class PropertyColumn extends LookupColumn
 {
@@ -188,16 +183,8 @@ public class PropertyColumn extends LookupColumn
             var lookupCf = cf;
 
             // Issue 52504: Use proper container filter for lookups
-            if (pd.isLookup())
-            {
-                // Issue 53803: Only apply lookup for insert/import -- see setContainerFilterForImport()
-                if (lookupCf instanceof ContainerFilter.AllInProjectPlusShared || lookupCf instanceof ContainerFilter.CurrentPlusProjectAndShared)
-                {
-                    var _cf = QueryService.get().getContainerFilterForLookups(container, user);
-                    if (_cf != null)
-                        lookupCf = _cf;
-                }
-            }
+            if (pd.isLookup() && lookupCf instanceof ContainerFilter.ProductFolderImport pfi)
+                lookupCf = pfi.getContainerFilterForLookups(container, user);
 
             to.setFk(PdLookupForeignKey.create(to.getParentTable().getUserSchema(), user, container, pd, lookupCf));
         }
@@ -389,5 +376,4 @@ public class PropertyColumn extends LookupColumn
     {
         return _pd.isVocabulary();
     }
-
 }

--- a/api/src/org/labkey/api/exp/PropertyColumn.java
+++ b/api/src/org/labkey/api/exp/PropertyColumn.java
@@ -188,7 +188,8 @@ public class PropertyColumn extends LookupColumn
             var lookupCf = cf;
 
             // Issue 52504: Use proper container filter for lookups
-            if (pd.isLookup())
+            // HACK: Issue 53803: Only apply lookup for insert when container filter is AllInProjectPlusShared
+            if (pd.isLookup() && lookupCf instanceof ContainerFilter.AllInProjectPlusShared)
             {
                 var _cf = QueryService.get().getContainerFilterForLookups(container, user);
                 if (_cf != null)

--- a/assay/src/org/labkey/assay/AssayController.java
+++ b/assay/src/org/labkey/assay/AssayController.java
@@ -364,6 +364,8 @@ public class AssayController extends SpringActionController
 
     public static Map<String, Object> serializeAssayDefinition(ExpProtocol protocol, AssayProvider provider, Container c, User user)
     {
+        AssayProtocolSchema schema = provider.createProtocolSchema(user, c, protocol, null);
+
         Map<String, Object> assayProperties = new HashMap<>();
         assayProperties.put("type", provider.getName());
         assayProperties.put("projectLevel", protocol.getContainer().isProject());
@@ -372,7 +374,7 @@ public class AssayController extends SpringActionController
         assayProperties.put("name", protocol.getName());
         assayProperties.put("id", protocol.getRowId());
         assayProperties.put("status", protocol.getStatus());
-        assayProperties.put("protocolSchemaName", provider.createProtocolSchema(user, c, protocol, null).getSchemaName());
+        assayProperties.put("protocolSchemaName", schema.getSchemaName());
         assayProperties.put("importController", provider.getImportURL(c, protocol).getController());
         assayProperties.put("importAction", provider.getImportURL(c, protocol).getAction());
         assayProperties.put("reRunSupport", provider.getReRunSupport());
@@ -383,7 +385,6 @@ public class AssayController extends SpringActionController
         assayProperties.put("plateEnabled", provider.isPlateMetadataEnabled(protocol));
 
         // XXX: UGLY: Get the TableInfo associated with the Domain -- loop over all tables and ask for the Domains.
-        AssayProtocolSchema schema = provider.createProtocolSchema(user, c, protocol, null);
         Set<String> tableNames = schema.getTableNames();
         Map<String, TableInfo> tableInfoMap = new HashMap<>();
         for (String tableName : tableNames)

--- a/core/webapp/mothership.js
+++ b/core/webapp/mothership.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /*
  * Copyright (c) 2012-2017 LabKey Corporation
  *
@@ -844,5 +843,5 @@ LABKEY.Mothership = (function () {
         /** Render a little window displaying the 10 most recent errors collected. */
         renderLastErrors : renderLastErrors,
     };
-})() = LABKEY.Mothership;
+})();
 

--- a/core/webapp/mothership.js
+++ b/core/webapp/mothership.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /*
  * Copyright (c) 2012-2017 LabKey Corporation
  *
@@ -128,7 +129,10 @@ LABKEY.Mothership = (function () {
 
             // Non-fatal ResizeObserver loop detection
             'ResizeObserver loop limit exceeded',
-            'ResizeObserver loop completed with undelivered notifications.'
+            'ResizeObserver loop completed with undelivered notifications.',
+
+            // Issue 53517: suppress TypeError in Safari
+            'TypeError: null is not an object (evaluating \'document.body.scrollHeight\')'
         ];
 
         for (i = 0; i < ignoreMsgs.length; i++) {
@@ -840,5 +844,5 @@ LABKEY.Mothership = (function () {
         /** Render a little window displaying the 10 most recent errors collected. */
         renderLastErrors : renderLastErrors,
     };
-})();
+})() = LABKEY.Mothership;
 

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -830,6 +830,8 @@ public class ExpDataIterators
         {
             ContainerFilter cf;
 
+            // If this is changed from AllInProjectPlusShared consider how this will affect
+            // Issue 53803 -- see the corresponding change in PropertyColumn.
             if (container.isProject())
                 cf = new ContainerFilter.AllInProjectPlusShared(container, user);
             else

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -827,17 +827,7 @@ public class ExpDataIterators
     public static void setContainerFilterForImport(QueryDefinition qDef, Container container, User user)
     {
         if (container.isProductFoldersEnabled())
-        {
-            ContainerFilter cf;
-
-            // If this is changed from AllInProjectPlusShared consider how this will affect
-            // Issue 53803 -- see the corresponding change in PropertyColumn.
-            if (container.isProject())
-                cf = new ContainerFilter.AllInProjectPlusShared(container, user);
-            else
-                cf = new ContainerFilter.CurrentPlusProjectAndShared(container, user);
-            qDef.setContainerFilter(cf);
-        }
+            qDef.setContainerFilter(new ContainerFilter.ProductFolderImport(container, user));
     }
 
     /* setup mini dataiterator pipeline to process lineage */


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53803](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53803) by introducing a new `ContainerFilter.ProductFilterImport` that encapsulates the behavior desired for processing lookups when importing data in a product folder. This is then checked when initializing column container filtering. With this reading data will continue to percolate the specified container filter down to lookup columns and importing data will instantiate and use the container filter specified by `ProductFilterImport`.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1639

#### Changes
- Introduce `ContainerFilter.ProductFilterImport` and pass to the configured query definition for use when initializing column container filtering.
- [Issue 53517](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53517): Stop logging specific client-side TypeError to mothership (no manual testing necessary)
- Update `assay-assayList.api` to only resolve schema once. This call is relatively expensive and we are supplying the same configuration.

#### Tasks
- [x] Manual Testing / Verify Fix @labkey-susanh 📍
- [x] Needs Automation