### PR TITLE
Backport: Fix link reports

### DIFF
--- a/api/src/org/labkey/api/view/HttpView.java
+++ b/api/src/org/labkey/api/view/HttpView.java
@@ -603,6 +603,7 @@ public abstract class HttpView<ModelBean> extends DefaultModelAndView<ModelBean>
         return new HttpRedirectView(url.getLocalURIString());
     }
 
+    @Deprecated(forRemoval = true) // Use ActionURL or URLHelper variant instead. TODO: Remove
     public static HttpView<?> redirect(String url)
     {
         return new HttpRedirectView(url);

--- a/query/src/org/labkey/query/reports/ReportsController.java
+++ b/query/src/org/labkey/query/reports/ReportsController.java
@@ -150,6 +150,7 @@ import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.Portal;
+import org.labkey.api.view.RedirectException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.VBox;
 import org.labkey.api.view.ViewBackgroundInfo;
@@ -198,7 +199,6 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.labkey.api.reports.model.ViewCategoryManager.UNCATEGORIZED_ROWID;
 import static org.labkey.api.util.DOM.DIV;
-import static org.labkey.api.util.DOM.SPAN;
 import static org.labkey.api.util.DOM.cl;
 
 /**
@@ -1020,9 +1020,15 @@ public class ReportsController extends SpringActionController
             {
                 reportView = _report.getRunReportView(getViewContext());
             }
+            catch (RedirectException re)
+            {
+                // Link reports throw RedirectException... pass it on
+                throw re;
+            }
             catch (RuntimeException e)
             {
-                return new HtmlView(SPAN(cl("labkey-error"), e.getMessage(), ". Unable to create report."));
+                String message = Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName()) + ". Unable to create report.";
+                return HtmlView.err(message);
             }
 
             if (!isPrint() && !(reportView instanceof HttpRedirectView) && DiscussionService.get() != null)


### PR DESCRIPTION
#### Rationale
This fix is needed alongside another recent backport. Resolves test failures in NonStudyReportsTest and LinkedReportTest.

#### Changes
- Backport - let RedirectException propagate