### PR TITLE
Issue 53804: Don't infer types for initial load of data of cross-type import

### DIFF
--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4505,6 +4505,8 @@ public class ExperimentController extends SpringActionController
         @Override
         protected void configureLoader(DataLoader loader) throws IOException
         {
+            if (getOptionParamValue(Params.crossTypeImport) || getOptionParamValue(Params.crossFolderImport))
+                loader.setInferTypes(false);
             configureLoader(loader, _target, getRenamedColumns(), allowLineageColumns(), getLineageImportAliases());
         }
     }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4505,7 +4505,7 @@ public class ExperimentController extends SpringActionController
         @Override
         protected void configureLoader(DataLoader loader) throws IOException
         {
-            if (getOptionParamValue(Params.crossTypeImport) || getOptionParamValue(Params.crossFolderImport))
+            if (getOptionParamValue(Params.crossTypeImport))
                 loader.setInferTypes(false);
             configureLoader(loader, _target, getRenamedColumns(), allowLineageColumns(), getLineageImportAliases());
         }


### PR DESCRIPTION
#### Rationale
Issue [53804](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53804). When doing a cross-type  samples import, we don't need or want to infer the types for the original file that contains data for all the sample types since the field types inferred may not be the same for all sample types in the file. (Whether we need to infer the field types when we know the sample type is a different question for a different day.)

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1642

#### Changes
- Set inferTypes to false for the loader of a the full file

#### Tasks 📍
- [x] Manual Testing @XingY 
- [x] Needs Automation
- [x] Verify Fix
