### PR TITLE
Propagate all existing issue fields for validation

### DIFF
--- a/api/src/org/labkey/api/exp/property/Lookup.java
+++ b/api/src/org/labkey/api/exp/property/Lookup.java
@@ -39,7 +39,7 @@ public class Lookup
     public Lookup(Container c, String schema, String query)
     {
         _container = c;
-        _schemaKey = null == schema ? null : SchemaKey.fromString(schema);
+        _schemaKey = SchemaKey.fromString(schema);
         _queryName = query;
     }
 

--- a/api/src/org/labkey/api/query/QueryKey.java
+++ b/api/src/org/labkey/api/query/QueryKey.java
@@ -18,6 +18,7 @@ package org.labkey.api.query;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.util.PageFlowUtil;
 
 import java.io.Serializable;
@@ -92,7 +93,7 @@ import java.util.Objects;
         return ret;
     }
 
-    static protected <T extends QueryKey<T>> T fromString(Factory<T> factory, String divider, String str)
+    static protected <T extends QueryKey<T>> T fromString(Factory<T> factory, String divider, @Nullable String str)
     {
         if (str == null)
             return null;

--- a/api/src/org/labkey/api/query/SchemaKey.java
+++ b/api/src/org/labkey/api/query/SchemaKey.java
@@ -18,6 +18,7 @@ package org.labkey.api.query;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.commons.beanutils.ConversionException;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -53,7 +54,7 @@ public class SchemaKey extends QueryKey<SchemaKey>
      * parts of the SchemaKey, and will enable us to maintain flexibility to change the
      * escaping algorithm.
      */
-    static public SchemaKey fromString(String str)
+    static public SchemaKey fromString(@Nullable String str)
     {
         return QueryKey.fromString(FACTORY, DIVIDER, str);
     }

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -752,7 +752,7 @@ public class IssuesController extends SpringActionController
                         for (String prop : rec.keySet())
                         {
                             Object value = rec.get(prop);
-                            stringMap.put(prop, value.toString());
+                            stringMap.put(prop, JSONObject.NULL.equals(value) ? null : value.toString());
                         }
                         form.setStrings(stringMap);
                         _issueForms.add(form);
@@ -822,6 +822,8 @@ public class IssuesController extends SpringActionController
                         if (!IssueDefDomainKind.RESOLUTION_LOOKUP.equalsIgnoreCase(prop.getName()))
                             stringMap.computeIfAbsent(prop.getName(), (propName) -> Objects.toString(prevIssueProps.get(propName), null));
                     }
+                    // Be sure that the posted values take precedence, even if they're null
+                    stringMap.putAll(issuesForm.getStrings());
                     issuesForm.setStrings(stringMap);
                 }
                 IssueObject issue = issuesForm.getBean();
@@ -844,7 +846,7 @@ public class IssuesController extends SpringActionController
                 {
                     Issue.action action = getAction(issuesForm);
 
-                    if (action !=  Issue.action.insert)
+                    if (action != Issue.action.insert)
                     {
                         // if we are updating an existing issue pull in existing values
                         IssueObject prevIssue = IssueManager.getIssue(getContainer(), getUser(), issuesForm.getIssueId());

--- a/issues/src/org/labkey/issue/IssuesController.java
+++ b/issues/src/org/labkey/issue/IssuesController.java
@@ -817,7 +817,7 @@ public class IssuesController extends SpringActionController
                     Map<String, Object> prevIssueProps = prevIssue == null ? Collections.emptyMap() : prevIssue.getProperties();
 
                     Map<String, String> stringMap = new CaseInsensitiveHashMap<>(issuesForm.getStrings());
-                    for (PropertyStorageSpec prop : kind.getRequiredProperties())
+                    for (DomainProperty prop : issueListDef.getDomain(getUser()).getProperties())
                     {
                         if (!IssueDefDomainKind.RESOLUTION_LOOKUP.equalsIgnoreCase(prop.getName()))
                             stringMap.computeIfAbsent(prop.getName(), (propName) -> Objects.toString(prevIssueProps.get(propName), null));

--- a/issues/src/org/labkey/issue/model/IssueListDef.java
+++ b/issues/src/org/labkey/issue/model/IssueListDef.java
@@ -38,6 +38,7 @@ import org.labkey.api.issues.AbstractIssuesListDefDomainKind;
 import org.labkey.api.issues.IssuesSchema;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.SchemaKey;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
@@ -46,7 +47,6 @@ import org.labkey.api.util.UnexpectedException;
 import org.labkey.issue.query.IssueDefDomainKind;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -158,7 +158,7 @@ public class IssueListDef extends Entity
 
     private static String generateDomainURI(Container c, User user, String name, String kindName)
     {
-        DomainKind domainKind = PropertyService.get().getDomainKindByName(kindName);
+        DomainKind<?> domainKind = PropertyService.get().getDomainKindByName(kindName);
         return domainKind.generateDomainURI(IssuesSchema.getInstance().getSchemaName(), name, c, user);
     }
 
@@ -296,7 +296,7 @@ public class IssueListDef extends Entity
             if (foreignKeyMap.containsKey(spec.getName()))
             {
                 PropertyStorageSpec.ForeignKey fk = foreignKeyMap.get(spec.getName());
-                Lookup lookup = new Lookup(domain.getContainer(), fk.getSchemaName(), domainKind.getLookupTableName(getName(), fk.getTableName()));
+                Lookup lookup = new Lookup(domain.getContainer(), SchemaKey.fromString(fk.getSchemaName()), domainKind.getLookupTableName(getName(), fk.getTableName()));
 
                 prop.setLookup(lookup);
             }


### PR DESCRIPTION
#### Rationale
I'm working on a script to bulk resolve issues. It's using the `issues-issues` API. That fails when there's an admin-defined field that's marked as required and the API request doesn't provide a value. It should use existing values for validation purposes when there's no value provided.

#### Changes
- Propagate all existing values as defaults, not just the ones that are mandatory to include in the domain
- Handle nulls in the incoming data and properly unset values
- Minor code cleanup

#### Tasks 📍
- [x] Manual Testing @labkey-klum 
- [x] Needs Automation
