### PR TITLE
Fix file path validation with non root contextPath, update error msg for saveBatch invalid file, etc

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -1223,11 +1223,17 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
             }
             catch (ConversionException e)
             {
-                String message = ConvertHelper.getStandardConversionErrorMessage(value, label, type);
-                if (e.getCause() instanceof ArithmeticException)
-                    message += ": " + e.getCause().getLocalizedMessage();
+                String message;
+                if (e instanceof ConvertHelper.FileConversionException fce)
+                    message = fce.getMessage();
                 else
-                    message += ".";
+                {
+                    message = ConvertHelper.getStandardConversionErrorMessage(value, label, type);
+                    if (e.getCause() instanceof ArithmeticException)
+                        message += ": " + e.getCause().getLocalizedMessage();
+                    else
+                        message += ".";
+                }
 
                 // Attempt to resolve lookups by display value
                 boolean skipError = false;

--- a/api/src/org/labkey/api/data/ExpDataFileConverter.java
+++ b/api/src/org/labkey/api/data/ExpDataFileConverter.java
@@ -364,8 +364,8 @@ public class ExpDataFileConverter
 
         // toss in here an additional check, if starts with HTTP then try to use _webdav to resolve it
         // MAKE sure that the security is in place - figure out what container it is in
-        String webdav = value.toString();
-        if (null != StringUtils.trimToNull(webdav))
+        String rootSubstitutedPath = getFileRootSubstitutedFilePath(value.toString(), fileRootPath);;
+        if (null != StringUtils.trimToNull(rootSubstitutedPath))
         {
             if (assayResultFileRoot != null)
             {
@@ -373,7 +373,7 @@ public class ExpDataFileConverter
                 {
                     for (int i = 0; i < 5; i++) // try up to 5 times to find a case-sensitive match
                     {
-                        String resultsFileName = FileUtil.getAppendedFileName(webdav, i);
+                        String resultsFileName = FileUtil.getAppendedFileName(rootSubstitutedPath, i);
                         FileLike assayResultFile = assayResultFileRoot.resolveChild(resultsFileName);
 
                         if (!assayResultFile.isFile())
@@ -390,7 +390,9 @@ public class ExpDataFileConverter
 
             }
 
-            webdav = getFileRootSubstitutedFilePath(webdav, fileRootPath);
+            String webdav = rootSubstitutedPath;
+            if (webdav.startsWith(AppProps.getInstance().getContextPath()))
+                webdav = webdav.substring(AppProps.getInstance().getContextPath().length());
             Path path = Path.decode(FileUtil.encodeForURL(webdav, true /*Issue 51207*/).replace(AppProps.getInstance().getBaseServerUrl() + AppProps.getInstance().getContextPath(), ""));
             WebdavResource resource = WebdavService.get().getResolver().lookup(path);
             if (resource != null && resource.isFile())
@@ -440,7 +442,7 @@ public class ExpDataFileConverter
         }
 
         // Otherwise, treat it as a plain path (processed by getFileRootSubstitutedFilePath)
-        return FILE_CONVERTER.convert(File.class, webdav);
+        return FILE_CONVERTER.convert(File.class, rootSubstitutedPath);
     }
 
     // if two files were uploaded with the same name but different casing, then the file system will uniquify the names

--- a/study/test/src/org/labkey/test/tests/study/AssayTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AssayTest.java
@@ -18,11 +18,13 @@ package org.labkey.test.tests.study;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.assay.AssayListCommand;
 import org.labkey.remoteapi.assay.AssayListResponse;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
 import org.labkey.test.components.CustomizeView;
@@ -35,12 +37,14 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.experiment.SampleTypeDefinition;
 import org.labkey.test.tests.AbstractAssayTest;
 import org.labkey.test.tests.AuditLogTest;
+import org.labkey.test.util.AuditLogHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.SampleTypeHelper;
 import org.labkey.test.util.StudyHelper;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -267,7 +271,7 @@ public class AssayTest extends AbstractAssayTest
     }
 
     @LogMethod
-    private void editResults()
+    private void editResults() throws IOException, CommandException
     {
         // Verify that the results aren't editable by default
         navigateToFolder(getProjectName(), TEST_ASSAY_FLDR_LAB1);
@@ -310,15 +314,13 @@ public class AssayTest extends AbstractAssayTest
         });
 
         // Verify that the edit was audited
+        AuditLogHelper auditLogHelper = new AuditLogHelper(this, () -> WebTestHelper.getRemoteApiConnection(false));
+        auditLogHelper.checkAuditEventDiffCount(getProjectName(), AuditLogHelper.AuditEvent.QUERY_UPDATE_AUDIT_EVENT, List.of(0/*delete*/, 4/*edit*/));
+
         goToSchemaBrowser();
         viewQueryData("auditLog", "ExperimentAuditEvent");
-        assertTextPresent(
-                "Data row, id ",
-                ", edited in " + TEST_ASSAY + ".",
-                "Specimen ID changed from 'AAA07XK5-05' to 'EditedSpecimenID'",
-                "Visit ID changed from '601.0' to '601.5",
-                "testAssayDataProp5 changed from blank to '514801'",
-                "Deleted data row, id ");
+        assertTextPresent("1 data row has been edited in " + TEST_ASSAY + ".");
+
     }
 
     /**

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
@@ -130,7 +130,7 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
         File downloadedFile = doAndWaitForDownload(() -> waitAndClick(WAIT_FOR_JAVASCRIPT, Locator.tagWithAttribute("a", "title", "Download attached file"), 0));
         checker().verifyTrue("Incorrect file name ", FileUtils.contentEquals(downloadedFile, inputFile));
 
-        FileBrowserHelper.FileDetailInfo fileInfoOriginalFile = _fileBrowserHelper.getFileDetailInfo(getProjectName(), "sample.txt");
+        FileBrowserHelper.FileDetailInfo fileInfoOriginalFile = FileBrowserHelper.getFileDetailInfo(getProjectName(), "sample.txt");
 
         goToFolderManagement().goToExportTab();
         new Checkbox(Locator.tagWithText("label", "Files").precedingSibling("input").findElement(getDriver())).check();


### PR DESCRIPTION
#### Rationale
[SampleTypeTest](https://teamcity.labkey.org/buildConfiguration/LabKey_259Release_Community_DailyPostgres2/3650323?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests&class=SampleTypeTest).testFilePathOnBulkImport: this test failure revealed an issue with absolute webdav file path validation when the path contains server non-root contextPath
[AssayAPITest](https://teamcity.labkey.org/buildConfiguration/LabKey_259Release_Community_DailyPostgres2/3650323?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test&class=AssayAPITest): with https://github.com/LabKey/platform/pull/6952 , saveBatch modified when Run properties are saved and as a result, invalid file errors are now different. 
See https://github.com/LabKey/testAutomation/pull/2668 for additional rationale.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2668
- https://github.com/LabKey/platform/pull/7002
- https://github.com/LabKey/limsModules/pull/1645

#### Changes
- Update error message for invalid file path for saveBatch api. 
- [AssayTest](https://teamcity.labkey.org/buildConfiguration/LabKey_259Release_Community_DailyPostgres2/3650323?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests.study&class=AssayTest).[testAssaySecurity](https://teamcity.labkey.org/buildConfiguration/LabKey_259Release_Community_DailyPostgres2/3650323?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+): update test to check QueryUpdateEvent instead of ExperimentEvent for assay result audit details
- Update usages to refer to method statically.