### PR TITLE
Add missing query parameter value to visit summary query

### DIFF
--- a/study/src/org/labkey/study/visitmanager/SequenceVisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/SequenceVisitManager.java
@@ -144,8 +144,9 @@ public class SequenceVisitManager extends VisitManager
                     sql.append("SELECT ").append(selectCols);
                     sql.append("\nFROM ").append(studyData.getFromSQL(alias));
                     sql.append(" INNER JOIN study.ParticipantVisit PV ON (")
-                            .append("PV.ParticipantId = ").append(participant.getValueSql(alias)).append(" AND \n\tPV.SequenceNum = ")
+                            .append(container.getValueSql(alias)).append(" = ? AND \n\tPV.ParticipantId = ").append(participant.getValueSql(alias)).append(" AND \n\tPV.SequenceNum = ")
                             .append(sequencenum.getValueSql(alias)).append(" AND\n\t").append(container.getValueSql(alias)).append("=PV.Container AND \n" + "\tPV.CohortID = ?)\n");
+                    sql.add(getStudy().getContainer());
                     sql.add(cohortFilter.getCohortId());
                     sql.append(" LEFT OUTER JOIN (").append(sqlSequenceVisitMap).append(") AS SVM ON ")
                             .append(sequencenum.getValueSql(alias)).append(" = SVM.SequenceNum AND ")

--- a/study/src/org/labkey/study/visitmanager/SequenceVisitManager.java
+++ b/study/src/org/labkey/study/visitmanager/SequenceVisitManager.java
@@ -144,7 +144,7 @@ public class SequenceVisitManager extends VisitManager
                     sql.append("SELECT ").append(selectCols);
                     sql.append("\nFROM ").append(studyData.getFromSQL(alias));
                     sql.append(" INNER JOIN study.ParticipantVisit PV ON (")
-                            .append(container.getValueSql(alias)).append(" = ? AND \n\tPV.ParticipantId = ").append(participant.getValueSql(alias)).append(" AND \n\tPV.SequenceNum = ")
+                            .append("PV.ParticipantId = ").append(participant.getValueSql(alias)).append(" AND \n\tPV.SequenceNum = ")
                             .append(sequencenum.getValueSql(alias)).append(" AND\n\t").append(container.getValueSql(alias)).append("=PV.Container AND \n" + "\tPV.CohortID = ?)\n");
                     sql.add(cohortFilter.getCohortId());
                     sql.append(" LEFT OUTER JOIN (").append(sqlSequenceVisitMap).append(") AS SVM ON ")


### PR DESCRIPTION
#### Rationale
`SequenceVisitManager.getVisitSummarySql` doesn't add parameter values for all of the parameters it adds to the query generated for a `DATA_COLLECTION` cohort filter.

This was found by the crawler doing parameter injection. I'm not sure what the expected path is to invoke this code but it appears to have had this problem since [sometime in 2019](https://github.com/LabKey/platform/commit/7136eff0#diff-874fe4527f70f915428b016fe6386cf5f4b01990bcc298854408ce707299ac90L98-R113).
```
org.springframework.dao.DataIntegrityViolationException: ExecutingSelector; No value specified for parameter 3.
	at org.springframework.jdbc.support.SQLStateSQLExceptionTranslator.doTranslate(SQLStateSQLExceptionTranslator.java:118) ~[spring-jdbc-6.2.10.jar:6.2.10]
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:107) ~[spring-jdbc-6.2.10.jar:6.2.10]
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:116) ~[spring-jdbc-6.2.10.jar:6.2.10]
	at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:116) ~[spring-jdbc-6.2.10.jar:6.2.10]
	at org.labkey.api.data.ExceptionFramework$1.translate(ExceptionFramework.java:43) ~[api-25.10-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutingSelector$ExecutingResultSetFactory.handleSqlException(SqlExecutingSelector.java:553) ~[api-25.10-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutingSelector$ExecutingResultSetFactory.handleResultSet(SqlExecutingSelector.java:457) ~[api-25.10-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutingSelector.getResultSet(SqlExecutingSelector.java:193) ~[api-25.10-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutingSelector.getResultSet(SqlExecutingSelector.java:233) ~[api-25.10-SNAPSHOT.jar:?]
	at org.labkey.study.visitmanager.VisitManager.getVisitSummary(VisitManager.java:231) ~[study-25.10-SNAPSHOT.jar:?]
	at org.labkey.study.controllers.StudyController$OverviewAction.getView(StudyController.java:720) ~[study-25.10-SNAPSHOT.jar:?]
	at org.labkey.study.controllers.StudyController$OverviewAction.getView(StudyController.java:694) ~[study-25.10-SNAPSHOT.jar:?]
```

#### Related Pull Requests
- https://github.com/LabKey/platform/commit/7136eff0

#### Changes
- Add missing query parameter value to visit summary query

<!--
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->