### PR TITLE
Fix locked project permission

### DIFF
--- a/api/src/org/labkey/api/security/permissions/CanAccessLockedProjectsPermission.java
+++ b/api/src/org/labkey/api/security/permissions/CanAccessLockedProjectsPermission.java
@@ -12,6 +12,7 @@ public class CanAccessLockedProjectsPermission extends AbstractPermission
         super("Can Access Locked Projects", "Allows admins to access locked projects");
     }
 
+    // This prevents the dataset security UI (datasets.jsp) from attempting to examine this role
     @Override
     public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
     {

--- a/api/src/org/labkey/api/security/permissions/CanAccessLockedProjectsPermission.java
+++ b/api/src/org/labkey/api/security/permissions/CanAccessLockedProjectsPermission.java
@@ -1,5 +1,8 @@
 package org.labkey.api.security.permissions;
 
+import org.labkey.api.security.SecurableResource;
+import org.labkey.api.security.SecurityPolicy;
+
 // Assigned to Site, Application, and Project admins so they can access locked projects. Also used as a contextual role
 // to bypass the locked project check for specific scenarios (e.g., update user profile page).
 public class CanAccessLockedProjectsPermission extends AbstractPermission
@@ -7,5 +10,11 @@ public class CanAccessLockedProjectsPermission extends AbstractPermission
     public CanAccessLockedProjectsPermission()
     {
         super("Can Access Locked Projects", "Allows admins to access locked projects");
+    }
+
+    @Override
+    public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
+    {
+        return false;
     }
 }


### PR DESCRIPTION
#### Rationale
`StudySecurityTest` started failing when I registered my new `CanAccessLockedProjectsPermission` as a role. This role/permission is used only in code so we can designate it as never "applicable"; that appeases the dataset security UI.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6951