### PR TITLE
Improve generics around QueryPropertyChange, other misc cleanup

### DIFF
--- a/api/src/org/labkey/api/query/AbstractQueryChangeListener.java
+++ b/api/src/org/labkey/api/query/AbstractQueryChangeListener.java
@@ -40,13 +40,13 @@ public abstract class AbstractQueryChangeListener implements QueryChangeListener
     protected abstract void queryCreated(User user, Container container, ContainerFilter scope, SchemaKey schema, String query);
 
     @Override
-    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange> changes)
+    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange<?>> changes)
     {
-        for (QueryPropertyChange change : changes)
+        for (QueryPropertyChange<?> change : changes)
             queryChanged(user, container, scope, schema, change);
     }
 
-    protected abstract void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, QueryPropertyChange change);
+    protected abstract void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, QueryPropertyChange<?> change);
 
     @Override
     public void queryDeleted(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull Collection<String> queries)

--- a/api/src/org/labkey/api/query/QueryChangeListener.java
+++ b/api/src/org/labkey/api/query/QueryChangeListener.java
@@ -61,7 +61,7 @@ public interface QueryChangeListener
      * @param property The QueryProperty that has changed.
      * @param changes The set of change events.  Each QueryPropertyChange is associated with a single table or query.
      */
-    void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange> changes);
+    void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange<?>> changes);
 
     /**
      * This method is called when a set of tables or queries are deleted from the given container and schema.

--- a/api/src/org/labkey/api/query/QueryDefinition.java
+++ b/api/src/org/labkey/api/query/QueryDefinition.java
@@ -155,8 +155,8 @@ public interface QueryDefinition
      * TableQueryDefinition and file-based queries cannot be deleted.
      * Fires the {@link QueryChangeListener#queryChanged(User, Container, ContainerFilter, SchemaKey, QueryProperty, Collection)} event.
      */
-    Collection<QueryPropertyChange> save(User user, Container container) throws SQLException;
-    Collection<QueryPropertyChange> save(User user, Container container, boolean fireChangeEvent) throws SQLException;
+    Collection<QueryPropertyChange<?>> save(User user, Container container) throws SQLException;
+    Collection<QueryPropertyChange<?>> save(User user, Container container, boolean fireChangeEvent) throws SQLException;
 
     /**
      * Delete the QueryDefinition.

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -409,11 +409,11 @@ public interface QueryService
                 "%s was inserted or updated.",
                 "inserted or updated");
 
-        String _commentDetailed;
-        String _commentDetailedFormat;
-        String _commentSummary;
-        String _verbPastTense;
-        static String vowels = "aeiou";
+        final String _commentDetailed;
+        final String _commentDetailedFormat;
+        final String _commentSummary;
+        final String _verbPastTense;
+        final static String vowels = "aeiou";
 
         AuditAction(String commentSummary, String commentDetailedFormat, String verbPastTense)
         {
@@ -476,7 +476,7 @@ public interface QueryService
 
     Collection<String> getQueryDependents(User user, Container container, ContainerFilter scope, SchemaKey schema, Collection<String> queries);
     void fireQueryCreated(User user, Container container, ContainerFilter scope, SchemaKey schema, Collection<String> queries);
-    void fireQueryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, QueryChangeListener.QueryProperty property, Collection<QueryChangeListener.QueryPropertyChange> changes);
+    void fireQueryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, QueryChangeListener.QueryProperty property, Collection<QueryChangeListener.QueryPropertyChange<?>> changes);
     void fireQueryDeleted(User user, Container container, ContainerFilter scope, SchemaKey schema, Collection<String> queries);
 
 

--- a/api/src/org/labkey/api/reader/BufferedReader.java
+++ b/api/src/org/labkey/api/reader/BufferedReader.java
@@ -35,6 +35,7 @@ This implementation has only been changed as follows
  */
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.util.IntegerUtils;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -476,7 +477,7 @@ public class BufferedReader extends Reader {
                 return 0;
             }
             if (count - pos >= amount) {
-                pos += amount;
+                pos = IntegerUtils.asInteger(pos + amount);
                 return amount;
             }
 
@@ -487,7 +488,7 @@ public class BufferedReader extends Reader {
                     return read;
                 }
                 if (count - pos >= amount - read) {
-                    pos += amount - read;
+                    pos = IntegerUtils.asInteger(pos + amount - read);
                     return amount;
                 }
                 // Couldn't get all the characters, skip what we read

--- a/api/src/org/labkey/api/reports/report/ReportDescriptor.java
+++ b/api/src/org/labkey/api/reports/report/ReportDescriptor.java
@@ -588,7 +588,7 @@ public class ReportDescriptor extends Entity implements SecurableResource, Clone
 
     // Let subclasses decide how they need to handle query/schema name changes, return true if changes have been made to the
     // descriptor. It is up to the caller to save the report changes
-    public boolean updateSchemaQueryNameReferences(Collection<QueryChangeListener.QueryPropertyChange> changes, User user, Container container, boolean isSchemaUpdate)
+    public boolean updateSchemaQueryNameReferences(Collection<QueryChangeListener.QueryPropertyChange<?>> changes, User user, Container container, boolean isSchemaUpdate)
     {
         return false;
     }

--- a/api/src/org/labkey/api/visualization/GenericChartReportDescriptor.java
+++ b/api/src/org/labkey/api/visualization/GenericChartReportDescriptor.java
@@ -17,26 +17,13 @@ package org.labkey.api.visualization;
 
 import org.json.JSONObject;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.TableInfo;
 import org.labkey.api.exp.property.DomainProperty;
-import org.labkey.api.query.CustomView;
 import org.labkey.api.query.QueryChangeListener;
-import org.labkey.api.query.QueryDefinition;
-import org.labkey.api.query.QueryException;
-import org.labkey.api.query.QueryService;
-import org.labkey.api.query.QuerySettings;
-import org.labkey.api.query.QueryView;
-import org.labkey.api.query.UserSchema;
-import org.labkey.api.query.ValidationException;
 import org.labkey.api.reports.model.ReportPropsManager;
 import org.labkey.api.reports.report.view.ReportUtil;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
-import org.labkey.api.view.ViewContext;
-import org.labkey.api.writer.ContainerUser;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -83,7 +70,7 @@ public class GenericChartReportDescriptor extends VisualizationReportDescriptor
     }
 
     @Override
-    public boolean updateSchemaQueryNameReferences(Collection<QueryChangeListener.QueryPropertyChange> changes, User user, Container container, boolean isSchemaUpdate)
+    public boolean updateSchemaQueryNameReferences(Collection<QueryChangeListener.QueryPropertyChange<?>> changes, User user, Container container, boolean isSchemaUpdate)
     {
         if (getJSON() != null)
         {
@@ -95,7 +82,7 @@ public class GenericChartReportDescriptor extends VisualizationReportDescriptor
             String schemaName = queryJson.optString("schemaName", null);
             if ((queryName != null && !isSchemaUpdate) || (schemaName != null && isSchemaUpdate))
             {
-                for (QueryChangeListener.QueryPropertyChange qpc : changes)
+                for (QueryChangeListener.QueryPropertyChange<?> qpc : changes)
                 {
                     if (isSchemaUpdate)
                     {
@@ -203,65 +190,5 @@ public class GenericChartReportDescriptor extends VisualizationReportDescriptor
         newJson.put("chartConfig", newChartConfig);
 
         return newJson.toString();
-    }
-
-    public QueryView getSourceQueryView(ViewContext viewContext, String schemaName, String queryName, String viewName, String dataRegionName) throws ValidationException
-    {
-        UserSchema schema = QueryService.get().getUserSchema(viewContext.getUser(), viewContext.getContainer(), schemaName);
-        if (schema == null)
-        {
-            throw new ValidationException("Invalid schema name: " + schemaName + ". ");
-        }
-        QuerySettings settings = schema.getSettings(viewContext, dataRegionName == null ? "query" : dataRegionName, queryName, viewName);
-        QueryView queryView = schema.createView(viewContext, settings, null);
-        if (queryView == null)
-        {
-            throw new ValidationException("Invalid query/view.");
-        }
-
-        return queryView;
-    }
-
-    // TODO: Delete?
-    private List<DisplayColumn> getDisplayColumns(ContainerUser context, String schemaName, String queryName, String viewName) throws ValidationException
-    {
-        UserSchema schema = QueryService.get().getUserSchema(context.getUser(), context.getContainer(), schemaName);
-        if (schema == null)
-        {
-            throw new ValidationException("Invalid schema name: " + schemaName + ". ");
-        }
-        QueryDefinition queryDefinition = schema.getQueryDef(queryName);
-        if (queryDefinition == null)
-            queryDefinition = QueryService.get().createQueryDefForTable(schema, queryName);
-
-        if (queryDefinition != null)
-        {
-            List<QueryException> errors = new ArrayList<>();
-            TableInfo tableInfo = queryDefinition.getTable(schema, errors, true);
-            if (tableInfo != null)
-            {
-                if (errors.isEmpty())
-                {
-                    CustomView customView = QueryService.get().getCustomView(context.getUser(), context.getContainer(), null, schemaName, queryName, viewName);
-                    return queryDefinition.getDisplayColumns(customView, tableInfo);
-                }
-                else
-                {
-                    StringBuilder sb = new StringBuilder();
-                    String delim = "";
-
-                    for (QueryException error : errors)
-                    {
-                        sb.append(delim).append(error.getMessage());
-                        delim = "\n";
-                    }
-                    throw new ValidationException("Unable to get table or query: " + sb);
-                }
-            }
-            else
-                throw new ValidationException("Unable to create the source table: " + queryName + " it may no longer exist, or you don't have access to it.");
-        }
-        else
-            throw new ValidationException("Unable to get a query definition for table : " + queryName);
     }
 }

--- a/api/src/org/labkey/api/visualization/TimeChartReportDescriptor.java
+++ b/api/src/org/labkey/api/visualization/TimeChartReportDescriptor.java
@@ -173,7 +173,7 @@ public class TimeChartReportDescriptor extends VisualizationReportDescriptor
     }
 
     @Override
-    public boolean updateSchemaQueryNameReferences(Collection<QueryChangeListener.QueryPropertyChange> changes, User user, Container container, boolean isSchemaUpdate)
+    public boolean updateSchemaQueryNameReferences(Collection<QueryChangeListener.QueryPropertyChange<?>> changes, User user, Container container, boolean isSchemaUpdate)
     {
         if (getJSON() != null)
         {
@@ -188,7 +188,7 @@ public class TimeChartReportDescriptor extends VisualizationReportDescriptor
 
             // most property updates only care about the query name old value string and new value string
             Map<String, String> nameChangeMap = new HashMap<>();
-            for (QueryChangeListener.QueryPropertyChange qpc : changes)
+            for (QueryChangeListener.QueryPropertyChange<?> qpc : changes)
             {
                 nameChangeMap.put((String)qpc.getOldValue(), (String)qpc.getNewValue());
             }
@@ -331,13 +331,13 @@ public class TimeChartReportDescriptor extends VisualizationReportDescriptor
         return false;
     }
 
-    private boolean updateJSONObjectQueryNameReference(JSONObject json, boolean isSchemaChange, Collection<QueryChangeListener.QueryPropertyChange> changes)
+    private boolean updateJSONObjectQueryNameReference(JSONObject json, boolean isSchemaChange, Collection<QueryChangeListener.QueryPropertyChange<?>> changes)
     {
         String propName = isSchemaChange ? "schemaName" : "queryName";
         String oldValue = json.optString(propName, null);
         if (oldValue != null)
         {
-            for (QueryChangeListener.QueryPropertyChange qpc : changes)
+            for (QueryChangeListener.QueryPropertyChange<?> qpc : changes)
             {
                 if (oldValue.equals(qpc.getOldValue()))
                 {

--- a/experiment/src/org/labkey/experiment/ExperimentQueryChangeListener.java
+++ b/experiment/src/org/labkey/experiment/ExperimentQueryChangeListener.java
@@ -63,7 +63,7 @@ public class ExperimentQueryChangeListener implements QueryChangeListener
     }
 
     @Override
-    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange> changes)
+    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange<?>> changes)
     {
         boolean isSamples = schema.toString().equalsIgnoreCase("samples");
         boolean isData = schema.toString().equalsIgnoreCase("exp.data");
@@ -74,7 +74,7 @@ public class ExperimentQueryChangeListener implements QueryChangeListener
             return;
 
         Map<String, String> queryNameChangeMap = new CaseInsensitiveHashMap<>();
-        for (QueryPropertyChange qpc : changes)
+        for (QueryPropertyChange<?> qpc : changes)
         {
             String oldVal = (String)qpc.getOldValue();
             String newVal = (String)qpc.getNewValue();

--- a/experiment/src/org/labkey/experiment/PropertyQueryChangeListener.java
+++ b/experiment/src/org/labkey/experiment/PropertyQueryChangeListener.java
@@ -61,13 +61,13 @@ public class PropertyQueryChangeListener implements QueryChangeListener
     }
 
     @Override
-    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange> changes)
+    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange<?>> changes)
     {
         // is there any other schema change other than assay renaming?
         boolean isSchemaChange = schema.toString().toLowerCase().startsWith("assay.general.");
 
         Map<String, String> queryNameChangeMap = new CaseInsensitiveHashMap<>();
-        for (QueryPropertyChange qpc : changes)
+        for (QueryPropertyChange<?> qpc : changes)
         {
             String oldVal = qpc.getOldValue() != null ? qpc.getOldValue().toString() : null;
             String newVal = qpc.getNewValue() != null ? qpc.getNewValue().toString() : null;

--- a/query/src/org/labkey/query/CustomViewQueryChangeListener.java
+++ b/query/src/org/labkey/query/CustomViewQueryChangeListener.java
@@ -55,7 +55,7 @@ public class CustomViewQueryChangeListener implements QueryChangeListener
     }
 
     @Override
-    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange> changes)
+    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange<?>> changes)
     {
         if (property.equals(QueryProperty.Name))
         {
@@ -150,7 +150,7 @@ public class CustomViewQueryChangeListener implements QueryChangeListener
         return sb.toString();
     }
 
-    private void _updateCustomViewQueryNameChange(User user, Container container, SchemaKey schemaKey, Collection<QueryPropertyChange> changes)
+    private void _updateCustomViewQueryNameChange(User user, Container container, SchemaKey schemaKey, Collection<QueryPropertyChange<?>> changes)
     {
         // most property updates only care about the query name old value string and new value string
         Map<String, String> queryNameChangeMap = new CaseInsensitiveHashMap<>();
@@ -191,10 +191,10 @@ public class CustomViewQueryChangeListener implements QueryChangeListener
         }
     }
 
-    private void _updateCustomViewSchemaNameChange(User user, Container container, Collection<QueryPropertyChange> changes)
+    private void _updateCustomViewSchemaNameChange(User user, Container container, Collection<QueryPropertyChange<?>> changes)
     {
         Map<String, String> schemaNameChangeMap = new CaseInsensitiveHashMap<>();
-        for (QueryPropertyChange qpc : changes)
+        for (QueryPropertyChange<?> qpc : changes)
         {
             if (qpc.getOldValue().equals(qpc.getNewValue()))
                 continue;

--- a/query/src/org/labkey/query/LinkedSchemaQueryDefinition.java
+++ b/query/src/org/labkey/query/LinkedSchemaQueryDefinition.java
@@ -168,13 +168,13 @@ public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
     }
 
     @Override
-    public Collection<QueryChangeListener.QueryPropertyChange> save(User user, Container container)
+    public Collection<QueryChangeListener.QueryPropertyChange<?>> save(User user, Container container)
     {
         return save(user, container, true);
     }
 
     @Override
-    public Collection<QueryChangeListener.QueryPropertyChange> save(User user, Container container, boolean fireChangeEvent)
+    public Collection<QueryChangeListener.QueryPropertyChange<?>> save(User user, Container container, boolean fireChangeEvent)
     {
         if (!getContainer().equals(container))
             throw new UnauthorizedException("Can only be saved in the linked schema container");
@@ -218,7 +218,7 @@ public class LinkedSchemaQueryDefinition extends QueryDefinitionImpl
             }
         }
 
-        Collection<QueryChangeListener.QueryPropertyChange> changes = _changes;
+        Collection<QueryChangeListener.QueryPropertyChange<?>> changes = _changes;
         _changes = null;
         _dirty = false;
         return changes;

--- a/query/src/org/labkey/query/ModuleCustomQueryDefinition.java
+++ b/query/src/org/labkey/query/ModuleCustomQueryDefinition.java
@@ -125,7 +125,7 @@ public class ModuleCustomQueryDefinition extends CustomQueryDefinitionImpl
     }
 
     @Override
-    public Collection<QueryChangeListener.QueryPropertyChange> save(User user, Container container)
+    public Collection<QueryChangeListener.QueryPropertyChange<?>> save(User user, Container container)
     {
         return save(user, container, true);
     }
@@ -137,7 +137,7 @@ public class ModuleCustomQueryDefinition extends CustomQueryDefinitionImpl
     }
 
     @Override
-    public Collection<QueryChangeListener.QueryPropertyChange> save(User user, Container container, boolean fireChangeEvent)
+    public Collection<QueryChangeListener.QueryPropertyChange<?>> save(User user, Container container, boolean fireChangeEvent)
     {
         if (!_dirty)
             return null;
@@ -199,7 +199,7 @@ public class ModuleCustomQueryDefinition extends CustomQueryDefinitionImpl
             QueryServiceImpl.get().uncacheModuleResources(ModuleLoader.getInstance().getModule(_moduleName));
         }
 
-        Collection<QueryChangeListener.QueryPropertyChange> changes = _changes;
+        Collection<QueryChangeListener.QueryPropertyChange<?>> changes = _changes;
         _changes = null;
         _dirty = false;
         return changes;

--- a/query/src/org/labkey/query/QueryDefQueryChangeListener.java
+++ b/query/src/org/labkey/query/QueryDefQueryChangeListener.java
@@ -20,7 +20,7 @@ public class QueryDefQueryChangeListener implements QueryChangeListener
     {}
 
     @Override
-    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange> changes)
+    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange<?>> changes)
     {
         if (property.equals(QueryProperty.Name))
         {

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -18,6 +18,7 @@ package org.labkey.query;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.xmlbeans.XmlError;
@@ -93,7 +94,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
 
     protected UserSchema _schema = null;
     protected QueryDef _queryDef;
-    protected List<QueryPropertyChange> _changes = null;
+    protected List<QueryPropertyChange<?>> _changes = null;
 
     protected boolean _dirty;
     private ContainerFilter _containerFilter;
@@ -699,13 +700,13 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
     }
 
     @Override
-    public Collection<QueryPropertyChange> save(User user, Container container)
+    public Collection<QueryPropertyChange<?>> save(User user, Container container)
     {
         return save(user, container, true);
     }
 
     @Override
-    public Collection<QueryPropertyChange> save(User user, Container container, boolean fireChangeEvent)
+    public Collection<QueryPropertyChange<?>> save(User user, Container container, boolean fireChangeEvent)
     {
         setDefinitionContainer(container);
         if (!_dirty)
@@ -732,7 +733,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
             }
         }
 
-        Collection<QueryPropertyChange> changes = _changes;
+        Collection<QueryPropertyChange<?>> changes = _changes;
         _changes = null;
         _dirty = false;
         return changes;
@@ -841,21 +842,14 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
             TableInfo table = getTable(null, true);
             if (table != null)
             {
-                switch (action)
+                url = switch (action)
                 {
-                    case insertQueryRow:
-                        url = table.getInsertURL(container);
-                        break;
-                    case deleteQueryRows:
-                        url = table.getDeleteURL(container);
-                        break;
-                    case executeQuery:
-                        url = table.getGridURL(container);
-                        break;
-                    case importData:
-                        url = table.getImportDataURL(container);
-                        break;
-                }
+                    case insertQueryRow -> table.getInsertURL(container);
+                    case deleteQueryRows -> table.getDeleteURL(container);
+                    case executeQuery -> table.getGridURL(container);
+                    case importData -> table.getImportDataURL(container);
+                    default -> url;
+                };
             }
 
             if (url == AbstractTableInfo.LINK_DISABLER_ACTION_URL)
@@ -890,17 +884,12 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
             table = getTable(null, true);
             if (table != null)
             {
-                switch (action)
+                expr = switch (action)
                 {
-                    case detailsQueryRow:
-                        expr = table.getDetailsURL(null, container);
-                        break;
-
-                    case updateQueryRow:
-                    case updateQueryRows:
-                        expr = table.getUpdateURL(null, container);
-                        break;
-                }
+                    case detailsQueryRow -> table.getDetailsURL(null, container);
+                    case updateQueryRow, updateQueryRows -> table.getUpdateURL(null, container);
+                    default -> expr;
+                };
 
                 if (expr == AbstractTableInfo.LINK_DISABLER)
                     return null;
@@ -956,7 +945,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
     @Override
     public void setDescription(String description)
     {
-        if (StringUtils.equals(getDescription(), description))
+        if (Strings.CS.equals(getDescription(), description))
             return;
         String oldDescription = getDescription();
         edit().setDescription(description);

--- a/query/src/org/labkey/query/QueryImporter.java
+++ b/query/src/org/labkey/query/QueryImporter.java
@@ -130,7 +130,7 @@ public class QueryImporter implements FolderImporter
 
             // Map of new and updated queries by schema
             Map<SchemaKey, List<String>> createdQueries = new LinkedHashMap<>();
-            Map<Pair<SchemaKey, QueryProperty>, List<QueryPropertyChange>> changedQueries = new LinkedHashMap<>();
+            Map<Pair<SchemaKey, QueryProperty>, List<QueryPropertyChange<?>>> changedQueries = new LinkedHashMap<>();
 
             // import custom queries along with metadata xml
             for (String sqlFileName : sqlFileNames)
@@ -191,11 +191,11 @@ public class QueryImporter implements FolderImporter
             }
 
             // fire query changed events (one set of changes per container/schema/queryproperty)
-            for (Map.Entry<Pair<SchemaKey, QueryProperty>, List<QueryPropertyChange>> entry : changedQueries.entrySet())
+            for (Map.Entry<Pair<SchemaKey, QueryProperty>, List<QueryPropertyChange<?>>> entry : changedQueries.entrySet())
             {
                 SchemaKey schemaKey = entry.getKey().first;
                 QueryProperty property = entry.getKey().second;
-                List<QueryPropertyChange> changes = entry.getValue();
+                List<QueryPropertyChange<?>> changes = entry.getValue();
                 QueryService.get().fireQueryChanged(ctx.getUser(), ctx.getContainer(), null, schemaKey, property, changes);
             }
 
@@ -206,7 +206,7 @@ public class QueryImporter implements FolderImporter
 
     private void createQueryDef(FolderImportContext ctx,
                                 Map<SchemaKey, List<String>> createdQueries,
-                                Map<Pair<SchemaKey, QueryProperty>, List<QueryPropertyChange>> changedQueries,
+                                Map<Pair<SchemaKey, QueryProperty>, List<QueryPropertyChange<?>>> changedQueries,
                                 @NotNull String metaFileName, @NotNull QueryDocument queryDoc,
                                 @Nullable String sqlFileName, @Nullable String sql)
             throws SQLException
@@ -281,7 +281,7 @@ public class QueryImporter implements FolderImporter
         queryDef.setDescription(queryXml.getDescription());
         queryDef.setMetadataXml(metadataXml);
 
-        Collection<QueryPropertyChange> changes = queryDef.save(ctx.getUser(), ctx.getContainer(), false);
+        Collection<QueryPropertyChange<?>> changes = queryDef.save(ctx.getUser(), ctx.getContainer(), false);
         if (created)
         {
             List<String> queries = createdQueries.computeIfAbsent(schemaKey, k -> new ArrayList<>());
@@ -289,11 +289,11 @@ public class QueryImporter implements FolderImporter
         }
         else if (changes != null)
         {
-            for (QueryPropertyChange change : changes)
+            for (QueryPropertyChange<?> change : changes)
             {
                 // Group changed queries by schemaKey/QueryProperty
                 Pair<SchemaKey, QueryProperty> key = Pair.of(schemaKey, change.getProperty());
-                List<QueryPropertyChange> changesBySchemaProperty = changedQueries.computeIfAbsent(key, k -> new ArrayList<>());
+                List<QueryPropertyChange<?>> changesBySchemaProperty = changedQueries.computeIfAbsent(key, k -> new ArrayList<>());
                 changesBySchemaProperty.add(change);
             }
         }

--- a/query/src/org/labkey/query/QueryServiceImpl.java
+++ b/query/src/org/labkey/query/QueryServiceImpl.java
@@ -3249,7 +3249,7 @@ public class QueryServiceImpl implements QueryService
     }
 
     @Override
-    public void fireQueryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, QueryChangeListener.QueryProperty property, Collection<QueryPropertyChange> changes)
+    public void fireQueryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, QueryChangeListener.QueryProperty property, Collection<QueryPropertyChange<?>> changes)
     {
         QueryManager.get().fireQueryChanged(user, container, scope, schema, property, changes);
     }
@@ -3431,7 +3431,7 @@ public class QueryServiceImpl implements QueryService
         if (to instanceof QueryTableInfo)
             return true;
 
-         DomainKind dk = to.getDomainKind();
+         DomainKind<?> dk = to.getDomainKind();
          if (dk != null && dk.isUserCreatedType())
              return true;
 

--- a/query/src/org/labkey/query/QuerySnapshotQueryChangeListener.java
+++ b/query/src/org/labkey/query/QuerySnapshotQueryChangeListener.java
@@ -44,7 +44,7 @@ public class QuerySnapshotQueryChangeListener implements QueryChangeListener
     }
 
     @Override
-    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange> changes)
+    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange<?>> changes)
     {
         if (property.equals(QueryProperty.Name))
         {
@@ -68,11 +68,11 @@ public class QuerySnapshotQueryChangeListener implements QueryChangeListener
         return Collections.emptyList();
     }
 
-    private void _updateQuerySnapshotQueryNameChange(User user, Container container, SchemaKey schemaKey, Collection<QueryPropertyChange> changes)
+    private void _updateQuerySnapshotQueryNameChange(User user, Container container, SchemaKey schemaKey, Collection<QueryPropertyChange<?>> changes)
     {
         // most property updates only care about the query name old value string and new value string
         Map<String, String> queryNameChangeMap = new HashMap<>();
-        for (QueryPropertyChange qpc : changes)
+        for (QueryPropertyChange<?> qpc : changes)
         {
             String oldVal = (String)qpc.getOldValue();
             String newVal = (String)qpc.getNewValue();
@@ -108,10 +108,10 @@ public class QuerySnapshotQueryChangeListener implements QueryChangeListener
         }
     }
 
-    private void _updateQuerySnapshotSchemaNameChange(User user, Container container, Collection<QueryPropertyChange> changes)
+    private void _updateQuerySnapshotSchemaNameChange(User user, Container container, Collection<QueryPropertyChange<?>> changes)
     {
         Map<String, String> schemaNameChangeMap = new HashMap<>();
-        for (QueryPropertyChange qpc : changes)
+        for (QueryPropertyChange<?> qpc : changes)
         {
             if (qpc.getOldValue().equals(qpc.getNewValue()))
                 continue;

--- a/query/src/org/labkey/query/TableQueryDefinition.java
+++ b/query/src/org/labkey/query/TableQueryDefinition.java
@@ -278,7 +278,7 @@ public class TableQueryDefinition extends QueryDefinitionImpl
     }
 
     @Override
-    public Collection<QueryChangeListener.QueryPropertyChange> save(User user, Container container, boolean fireChangeEvent)
+    public Collection<QueryChangeListener.QueryPropertyChange<?>> save(User user, Container container, boolean fireChangeEvent)
     {
         if (getMetadataXml() == null)
         {

--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -518,7 +518,7 @@ public class QueryManager
             l.queryCreated(user, container, scope, schema, queries);
     }
 
-    public void fireQueryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryChangeListener.QueryProperty property, @NotNull Collection<QueryPropertyChange> changes)
+    public void fireQueryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryChangeListener.QueryProperty property, @NotNull Collection<QueryPropertyChange<?>> changes)
     {
         QueryService.get().updateLastModified();
         assert checkChanges(property, changes);
@@ -527,7 +527,7 @@ public class QueryManager
     }
 
     // Checks all changes have the correct property and type.
-    private boolean checkChanges(QueryChangeListener.QueryProperty property, Collection<QueryPropertyChange> changes)
+    private boolean checkChanges(QueryChangeListener.QueryProperty property, Collection<QueryPropertyChange<?>> changes)
     {
         if (property == null)
         {

--- a/query/src/org/labkey/query/reports/ReportQueryChangeListener.java
+++ b/query/src/org/labkey/query/reports/ReportQueryChangeListener.java
@@ -74,7 +74,7 @@ class ReportQueryChangeListener implements QueryChangeListener, CustomViewChange
     }
 
     @Override
-    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange> changes)
+    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange<?>> changes)
     {
         if (property.equals(QueryProperty.Name))
         {
@@ -122,13 +122,13 @@ class ReportQueryChangeListener implements QueryChangeListener, CustomViewChange
         return Collections.emptyList();
     }
 
-    private void _updateReportQueryNameChange(User user, Container container, SchemaKey schemaKey, Collection<QueryPropertyChange> changes)
+    private void _updateReportQueryNameChange(User user, Container container, SchemaKey schemaKey, Collection<QueryPropertyChange<?>> changes)
     {
         Logger logger = LogManager.getLogger(ReportQueryChangeListener.class);
 
         // most property updates only care about the query name old value string and new value string
         Map<String, String> queryNameChangeMap = new HashMap<>();
-        for (QueryPropertyChange qpc : changes)
+        for (QueryPropertyChange<?> qpc : changes)
         {
             String oldVal = (String)qpc.getOldValue();
             String newVal = (String)qpc.getNewValue();
@@ -195,12 +195,12 @@ class ReportQueryChangeListener implements QueryChangeListener, CustomViewChange
         }
     }
 
-    private void _updateReportSchemaNameChange(User user, Container container, Collection<QueryPropertyChange> changes)
+    private void _updateReportSchemaNameChange(User user, Container container, Collection<QueryPropertyChange<?>> changes)
     {
         Logger logger = LogManager.getLogger(ReportQueryChangeListener.class);
 
         Map<String, String> schemaNameChangeMap = new HashMap<>();
-        for (QueryPropertyChange qpc : changes)
+        for (QueryPropertyChange<?> qpc : changes)
         {
             if (qpc.getOldValue().equals(qpc.getNewValue()))
                 continue;

--- a/study/src/org/labkey/study/controllers/StudyController.java
+++ b/study/src/org/labkey/study/controllers/StudyController.java
@@ -1805,7 +1805,7 @@ public class StudyController extends BaseStudyController
             QueryUpdateService qus = studyProperties.getUpdateService();
             if (null == qus)
                 throw new UnauthorizedException();
-            try (DbScope.Transaction transaction = studyProperties.getSchema().getScope().ensureTransaction())
+            try (DbScope.Transaction transaction = StudySchema.getInstance().getSchema().getScope().ensureTransaction())
             {
                 BatchValidationException batchErrors = new BatchValidationException();
                 qus.updateRows(getUser(), getContainer(), Collections.singletonList(values), Collections.singletonList(values), batchErrors, null, null);
@@ -2216,7 +2216,7 @@ public class StudyController extends BaseStudyController
     }
 
     @RequiresPermission(ManageStudyPermission.class)
-    public class StudyScheduleAction extends SimpleViewAction
+    public class StudyScheduleAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
@@ -2942,7 +2942,7 @@ public class StudyController extends BaseStudyController
         public ModelAndView getView(IdForm form, BindException errors) throws Exception
         {
             UploadLog ul = StudyPublishManager.getInstance().getUploadLog(getContainer(), form.getId());
-            PageFlowUtil.streamFile(getViewContext().getResponse(), new File(ul.getFilePath()), true);
+            PageFlowUtil.streamFile(getViewContext().getResponse(), new File(ul.getFilePath()).toPath(), true);
 
             return null;
         }

--- a/study/src/org/labkey/study/query/QueryDatasetQueryChangeListener.java
+++ b/study/src/org/labkey/study/query/QueryDatasetQueryChangeListener.java
@@ -25,11 +25,11 @@ public class QueryDatasetQueryChangeListener implements QueryChangeListener
     }
 
     @Override
-    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange> changes)
+    public void queryChanged(User user, Container container, ContainerFilter scope, SchemaKey schema, @NotNull QueryProperty property, @NotNull Collection<QueryPropertyChange<?>> changes)
     {
         if (property.equals(QueryProperty.Name))
         {
-            for (QueryPropertyChange change : changes)
+            for (QueryPropertyChange<?> change : changes)
             {
                 String oldVal = (String)change.getOldValue();
                 String newVal = (String)change.getNewValue();

--- a/study/src/org/labkey/study/reports/ParticipantReportDescriptor.java
+++ b/study/src/org/labkey/study/reports/ParticipantReportDescriptor.java
@@ -74,7 +74,7 @@ public class ParticipantReportDescriptor extends ReportDescriptor
     }
 
     @Override
-    public boolean updateSchemaQueryNameReferences(Collection<QueryChangeListener.QueryPropertyChange> changes, User user, Container container, boolean isSchemaUpdate)
+    public boolean updateSchemaQueryNameReferences(Collection<QueryChangeListener.QueryPropertyChange<?>> changes, User user, Container container, boolean isSchemaUpdate)
     {
         if (getProperty(ParticipantReport.MEASURES_PROP) != null)
         {
@@ -108,13 +108,13 @@ public class ParticipantReportDescriptor extends ReportDescriptor
         return false;
     }
 
-    private boolean updateJSONObjectQueryNameReference(JSONObject json, Collection<QueryChangeListener.QueryPropertyChange> changes, boolean isSchemaUpdate)
+    private boolean updateJSONObjectQueryNameReference(JSONObject json, Collection<QueryChangeListener.QueryPropertyChange<?>> changes, boolean isSchemaUpdate)
     {
         String queryName = json.getString("queryName");
         String schemaName = json.getString("schemaName");
         if ((queryName != null && !isSchemaUpdate) || (schemaName != null && isSchemaUpdate))
         {
-            for (QueryChangeListener.QueryPropertyChange qpc : changes)
+            for (QueryChangeListener.QueryPropertyChange<?> qpc : changes)
             {
                 if (isSchemaUpdate)
                 {
@@ -139,7 +139,7 @@ public class ParticipantReportDescriptor extends ReportDescriptor
     public LinkedHashSet<ClientDependency> getClientDependencies()
     {
         LinkedHashSet<ClientDependency> d = super.getClientDependencies();
-        JspView v = new JspView<>(getViewClass());
+        JspView<?> v = new JspView<>(getViewClass());
         d.addAll(v.getClientDependencies());
         return d;
     }


### PR DESCRIPTION
#### Rationale
Reducing warnings helps us focus on new potential problems

#### Changes
- Use generics
- Delete dead code
- Make long->int conversion more explicit
- Other minor cleanup
- Attempt to make code flow analysis more in StudyController

#### Tasks 📍
- Manual Testing - N/A
- Needs Automation - N/A
