### PR TITLE
Issue 53825: LKSM/LKB: Sample Timeline entries for lineage updates with domains containing & or . may be incorrect

### DIFF
--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -98,8 +98,11 @@ public interface AuditHandler
             String encodedInputColumn = ExperimentService.getEncodedLineageKey(lcName);
             if (encodedInputColumn != null)
             {
-                isExpInput = true;
-                nameFromAlias = encodedInputColumn;
+                if (row.containsKey(encodedInputColumn))
+                {
+                    isExpInput = true;
+                    nameFromAlias = encodedInputColumn;
+                }
             }
             else
                 nameFromAlias = lcName;

--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -95,17 +95,11 @@ public interface AuditHandler
             String lcName = nameFromAlias.toLowerCase();
             // Preserve casing of inputs so we can show the names properly
             boolean isExpInput = false;
-            if (lcName.startsWith(ExpData.DATA_INPUTS_PREFIX.toLowerCase()) || lcName.startsWith(ExpMaterial.MATERIAL_INPUTS_PREFIX.toLowerCase()))
+            String encodedInputColumn = ExperimentService.getEncodedLineageKey(lcName);
+            if (encodedInputColumn != null)
             {
-                String[] parts = nameFromAlias.split("/", 2);
-                String prefix = parts[0];
-                String dataType = parts[1];
-                // MaterialInputs/datypeTypeEncoded
-                if (row.containsKey(prefix + "/" + QueryKey.encodePart(dataType)))
-                {
-                    isExpInput = true;
-                    nameFromAlias = prefix + "/" + QueryKey.encodePart(dataType);
-                }
+                isExpInput = true;
+                nameFromAlias = encodedInputColumn;
             }
             else
                 nameFromAlias = lcName;
@@ -184,20 +178,12 @@ public interface AuditHandler
         Set<String> existingEncodedInputColumns = new CaseInsensitiveHashSet();
         for (String fieldName : existingRow.keySet())
         {
-            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUTS_PREFIX.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUTS_PREFIX.toLowerCase()))
-            {
-                // Issue 53825: LKSM/LKB: Sample Timeline entries for lineage updates with domains containing & or . may be incorrect
-                String[] parts = fieldName.split("/", 2);
-                if (parts.length == 2)
-                {
-                    String prefix = parts[0];
-                    String dataType = parts[1];
-                    existingEncodedInputColumns.add(prefix + "/" + QueryKey.encodePart(dataType));
-                }
-            }
+            String existingEncodedInputColumn = ExperimentService.getEncodedLineageKey(fieldName);
+            if (existingEncodedInputColumn != null)
+                existingEncodedInputColumns.add(existingEncodedInputColumn);
         }
         row.forEach((fieldName, value) -> {
-            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUTS_PREFIX.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUTS_PREFIX.toLowerCase()))
+            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUTS_PREFIX_LC) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUTS_PREFIX_LC))
                 if (!originalRow.containsKey(fieldName) && !existingEncodedInputColumns.contains(fieldName))
                 {
                     modifiedRow.put(fieldName, value);

--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -181,8 +181,8 @@ public interface AuditHandler
 
         // we want to include the fields that indicate parent lineage has changed.
         // Note that we don't need to check for output fields because lineage can be modified only by changing inputs not outputs
-        Set<String> originalEncodedInputColumns = new CaseInsensitiveHashSet();
-        for (String fieldName : row.keySet())
+        Set<String> existingEncodedInputColumns = new CaseInsensitiveHashSet();
+        for (String fieldName : existingRow.keySet())
         {
             if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase()))
             {
@@ -190,12 +190,12 @@ public interface AuditHandler
                 String[] parts = fieldName.split("/", 2);
                 String prefix = parts[0];
                 String dataType = parts[1];
-                originalEncodedInputColumns.add(prefix + "/" + QueryKey.encodePart(dataType));
+                existingEncodedInputColumns.add(prefix + "/" + QueryKey.encodePart(dataType));
             }
         }
         row.forEach((fieldName, value) -> {
             if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase()))
-                if (!originalRow.containsKey(fieldName) && !originalEncodedInputColumns.contains(fieldName))
+                if (!originalRow.containsKey(fieldName) && !existingEncodedInputColumns.contains(fieldName))
                 {
                     modifiedRow.put(fieldName, value);
                 }

--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -2,6 +2,7 @@ package org.labkey.api.audit;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.MultiValuedForeignKey;
@@ -177,6 +178,29 @@ public interface AuditHandler
                 modifiedRow.put(nameFromAlias, entry.getValue());
             }
         }
+
+        // we want to include the fields that indicate parent lineage has changed.
+        // Note that we don't need to check for output fields because lineage can be modified only by changing inputs not outputs
+        Set<String> originalEncodedInputColumns = new CaseInsensitiveHashSet();
+        for (String fieldName : row.keySet())
+        {
+            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase()))
+            {
+                // Issue 53825: LKSM/LKB: Sample Timeline entries for lineage updates with domains containing & or . may be incorrect
+                String[] parts = fieldName.split("/", 2);
+                String prefix = parts[0];
+                String dataType = parts[1];
+                originalEncodedInputColumns.add(prefix + "/" + QueryKey.encodePart(dataType));
+            }
+        }
+        row.forEach((fieldName, value) -> {
+            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase()))
+                if (!originalRow.containsKey(fieldName) && !originalEncodedInputColumns.contains(fieldName))
+                {
+                    modifiedRow.put(fieldName, value);
+                }
+        });
+
         return new Pair<>(originalRow, modifiedRow);
     }
 }

--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -184,7 +184,7 @@ public interface AuditHandler
         Set<String> existingEncodedInputColumns = new CaseInsensitiveHashSet();
         for (String fieldName : existingRow.keySet())
         {
-            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase()))
+            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUTS_PREFIX.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUTS_PREFIX.toLowerCase()))
             {
                 // Issue 53825: LKSM/LKB: Sample Timeline entries for lineage updates with domains containing & or . may be incorrect
                 String[] parts = fieldName.split("/", 2);
@@ -197,7 +197,7 @@ public interface AuditHandler
             }
         }
         row.forEach((fieldName, value) -> {
-            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase()))
+            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUTS_PREFIX.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUTS_PREFIX.toLowerCase()))
                 if (!originalRow.containsKey(fieldName) && !existingEncodedInputColumns.contains(fieldName))
                 {
                     modifiedRow.put(fieldName, value);

--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -188,9 +188,12 @@ public interface AuditHandler
             {
                 // Issue 53825: LKSM/LKB: Sample Timeline entries for lineage updates with domains containing & or . may be incorrect
                 String[] parts = fieldName.split("/", 2);
-                String prefix = parts[0];
-                String dataType = parts[1];
-                existingEncodedInputColumns.add(prefix + "/" + QueryKey.encodePart(dataType));
+                if (parts.length == 2)
+                {
+                    String prefix = parts[0];
+                    String dataType = parts[1];
+                    existingEncodedInputColumns.add(prefix + "/" + QueryKey.encodePart(dataType));
+                }
             }
         }
         row.forEach((fieldName, value) -> {

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -71,6 +71,7 @@ import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.RecordedActionSet;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FilteredTable;
+import org.labkey.api.query.QueryKey;
 import org.labkey.api.query.QueryViewProvider;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
@@ -502,6 +503,22 @@ public interface ExperimentService extends ExperimentRunTypeSource
                ExpMaterial.MATERIAL_INPUT_PARENT.equalsIgnoreCase(prefix) ||
                ExpData.DATA_OUTPUT_CHILD.equalsIgnoreCase(prefix) ||
                ExpMaterial.MATERIAL_OUTPUT_CHILD.equalsIgnoreCase(prefix);
+    }
+
+    // convert MaterialInputs/Blood/Type to MaterialInputs/Blood$SType
+    static @Nullable String getEncodedLineageKey(String inputColumn /*not encoded*/)
+    {
+        if (inputColumn.toLowerCase().startsWith(ExpData.DATA_INPUTS_PREFIX_LC) || inputColumn.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUTS_PREFIX_LC))
+        {
+            String[] parts = inputColumn.split("/", 2);
+            if (parts.length != 2)
+                return null;
+            String prefix = parts[0];
+            String dataType = parts[1];
+            return prefix + "/" + QueryKey.encodePart(dataType);
+        }
+
+        return null;
     }
 
     static Pair<String, String> parseInputOutputAlias(String columnName)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -100,6 +100,7 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.MetadataUnavailableException;
 import org.labkey.api.query.QueryChangeListener;
+import org.labkey.api.query.QueryKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.SimpleValidationError;
@@ -1176,9 +1177,21 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     {
         // we want to include the fields that indicate parent lineage has changed.
         // Note that we don't need to check for output fields because lineage can be modified only by changing inputs not outputs
+        Set<String> originalEncodedInputColumns = new CaseInsensitiveHashSet();
+        for (String fieldName : originalRow.keySet())
+        {
+            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase()))
+            {
+                // Issue 53825: LKSM/LKB: Sample Timeline entries for lineage updates with domains containing & or . may be incorrect
+                String[] parts = fieldName.split("/", 2);
+                String prefix = parts[0];
+                String dataType = parts[1];
+                originalEncodedInputColumns.add(prefix + "/" + QueryKey.encodePart(dataType));
+            }
+        }
         updatedRow.forEach((fieldName, value) -> {
             if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase()))
-                if (!originalRow.containsKey(fieldName))
+                if (!originalRow.containsKey(fieldName) && !originalEncodedInputColumns.contains(fieldName))
                 {
                     modifiedRow.put(fieldName, value);
                 }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1172,32 +1172,6 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         return createAuditRecord(c, tInfo, String.format(action.getCommentSummary(), rowCount), userComment, row);
     }
 
-    @Override
-    protected void addDetailedModifiedFields(Map<String, Object> originalRow, Map<String, Object> modifiedRow, Map<String, Object> updatedRow)
-    {
-        // we want to include the fields that indicate parent lineage has changed.
-        // Note that we don't need to check for output fields because lineage can be modified only by changing inputs not outputs
-        Set<String> originalEncodedInputColumns = new CaseInsensitiveHashSet();
-        for (String fieldName : originalRow.keySet())
-        {
-            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase()))
-            {
-                // Issue 53825: LKSM/LKB: Sample Timeline entries for lineage updates with domains containing & or . may be incorrect
-                String[] parts = fieldName.split("/", 2);
-                String prefix = parts[0];
-                String dataType = parts[1];
-                originalEncodedInputColumns.add(prefix + "/" + QueryKey.encodePart(dataType));
-            }
-        }
-        updatedRow.forEach((fieldName, value) -> {
-            if (fieldName.toLowerCase().startsWith(ExpData.DATA_INPUT_PARENT.toLowerCase()) || fieldName.toLowerCase().startsWith(ExpMaterial.MATERIAL_INPUT_PARENT.toLowerCase()))
-                if (!originalRow.containsKey(fieldName) && !originalEncodedInputColumns.contains(fieldName))
-                {
-                    modifiedRow.put(fieldName, value);
-                }
-        });
-    }
-
     private SampleTimelineAuditEvent createAuditRecord(Container c, AuditConfigurable tInfo, String comment, String userComment, @Nullable Map<String, Object> row)
     {
         return createAuditRecord(c, tInfo, comment, userComment, null, row, null);


### PR DESCRIPTION
#### Rationale
When building detailed audit, it's assumed existingRow contains all relevant field, which is not true for the scenario when a new type is added as parent. Newly established parent type fields only exist in the new incoming row, but absent from the original data row. A addDetailedModifiedFields util is added for that scenario to account for new parents. This PR fixes 2 issues related to that util:
1. this is only done for samples, and not dataclass
2. the comparison of field doesn't take encoding difference into consieration

This is revealed by TC failure:
[SMSampleTimelineLineageTest.testAddAndDeleteWithMultipleParents](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_SampleManagerGPostgres/3653532?buildTab=tests&status=failed&name=SMSampleTimelineLineageTest.testAddAndDeleteWithMultipleParents)
Lineage update again shows parents of [NA]
The updated fields in the event detail are not as expected.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7005

#### Changes
- check for encoded key when determine if need to add to detailed change list
- move util to AuditHandler to support dataclass audit detail.

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->