### PR TITLE
Cache SelectRowsStreamHack results to a file to avoid leaving the connection open

### DIFF
--- a/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -16,6 +16,7 @@
 package org.labkey.remoteapi;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.Container;
 import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
@@ -23,10 +24,18 @@ import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.WrapperDataIterator;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.JSONDataLoader;
+import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * NOTE: This class only exists to use internal classes of the remoteapi package that we haven't exposed to the public yet.
@@ -39,6 +48,8 @@ import java.io.InputStream;
  */
 public class SelectRowsStreamHack
 {
+    private static final Logger _log = LogHelper.getLogger(SelectRowsStreamHack.class, "Information related to streaming of SelectRows results");
+
     public static DataIteratorBuilder go(Connection cn, String container, SelectRowsCommand cmd, Container targetContainer) throws IOException, CommandException
     {
         return new DataIteratorBuilder()
@@ -58,9 +69,47 @@ public class SelectRowsStreamHack
                 {
                     throw new RuntimeException("Failed to execute remote query", e);
                 }
+
+                // NOTE: this is just a placeholder for a configurable parameter. Or maybe it should just be the default?
+                boolean saveResponseToTempFile = true;
+
                 try
                 {
-                    final InputStream is = response.getInputStream();
+                    final InputStream is;
+                    if (saveResponseToTempFile)
+                    {
+                        final File tempFile = FileUtil.createTempFile("SelectRows-", ".tmp");
+                        _log.debug("Downloading SelectRows JSON to file: " + tempFile);
+
+                        try (OutputStream os = new BufferedOutputStream(new FileOutputStream(tempFile)); InputStream ris = new BufferedInputStream(response.getInputStream()))
+                        {
+                            IOUtils.copy(ris, os);
+                        }
+
+                        is = new BufferedInputStream(new FileInputStream(tempFile))
+                        {
+                            @Override
+                            public void close() throws IOException
+                            {
+                                super.close();
+
+                                if (tempFile.exists())
+                                {
+                                    _log.debug("Deleting temporary file used to download SelectRows results: " + tempFile);
+                                    if (!tempFile.delete())
+                                    {
+                                        _log.warn("Unable to delete SelectRowsStreamHack temp file: " + tempFile);
+                                    }
+                                }
+                            }
+                        };
+                        _log.debug("Finished saving SelectRows results");
+                    }
+                    else
+                    {
+                        is = response.getInputStream();
+                    }
+
                     final JSONDataLoader loader = new JSONDataLoader(is, targetContainer);
                     WrapperDataIterator wrapper = new WrapperDataIterator(loader.getDataIterator(context))
                     {
@@ -88,5 +137,4 @@ public class SelectRowsStreamHack
             }
         };
     }
-
 }

--- a/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -81,11 +81,12 @@ public class SelectRowsStreamHack
                     if (saveResponseToTempFile)
                     {
                         final File tempFile = FileUtil.createTempFile("SelectRows-", ".tmp.gz");
-                        _log.debug("Downloading SelectRows JSON to file: " + tempFile);
-
                         try (OutputStream os = new BufferedOutputStream(new GZIPOutputStream(new FileOutputStream(tempFile))); InputStream ris = new BufferedInputStream(response.getInputStream()))
                         {
+                            _log.debug("Downloading SelectRows JSON to file: " + tempFile);
                             IOUtils.copy(ris, os);
+                            _log.debug("Finished saving SelectRows results");
+
                         }
 
                         is = new BufferedInputStream(new GZIPInputStream(new FileInputStream(tempFile)))
@@ -105,7 +106,6 @@ public class SelectRowsStreamHack
                                 }
                             }
                         };
-                        _log.debug("Finished saving SelectRows results");
                     }
                     else
                     {

--- a/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -101,7 +101,7 @@ public class SelectRowsStreamHack
                                     _log.debug("Deleting temporary file used to download SelectRows results: " + tempFile);
                                     if (!tempFile.delete())
                                     {
-                                        _log.warn("Unable to delete SelectRowsStreamHack temp file: " + tempFile);
+                                        _log.error("Unable to delete SelectRowsStreamHack temp file: " + tempFile);
                                     }
                                 }
                             }

--- a/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -36,6 +36,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 /**
  * NOTE: This class only exists to use internal classes of the remoteapi package that we haven't exposed to the public yet.
@@ -78,15 +80,15 @@ public class SelectRowsStreamHack
                     final InputStream is;
                     if (saveResponseToTempFile)
                     {
-                        final File tempFile = FileUtil.createTempFile("SelectRows-", ".tmp");
+                        final File tempFile = FileUtil.createTempFile("SelectRows-", ".tmp.gz");
                         _log.debug("Downloading SelectRows JSON to file: " + tempFile);
 
-                        try (OutputStream os = new BufferedOutputStream(new FileOutputStream(tempFile)); InputStream ris = new BufferedInputStream(response.getInputStream()))
+                        try (OutputStream os = new BufferedOutputStream(new GZIPOutputStream(new FileOutputStream(tempFile))); InputStream ris = new BufferedInputStream(response.getInputStream()))
                         {
                             IOUtils.copy(ris, os);
                         }
 
-                        is = new BufferedInputStream(new FileInputStream(tempFile))
+                        is = new BufferedInputStream(new GZIPInputStream(new FileInputStream(tempFile)))
                         {
                             @Override
                             public void close() throws IOException


### PR DESCRIPTION
This is related to: https://www.labkey.org/ONPRC/Support%20Tickets/issues-details.view?issueId=53621.

LabKey remote ETLs use the java client api to make SelectRows requests to a server. If the source table is large, and/or if the local import process takes a long time, this can lead to intermittent errors. This PR changes the pattern in SelectRowsStreamHack to immediately read the results of SelectRows to a tempfile, and then return an InputStream over that file. 

Note: as-is, there is no configurability over that behavior. I dont see any uses of SelectRowsStreamHack outside of ETLs. It probably wouldnt hurt to turn the tempfile behavior on all of the time, but it seems to only really matter for large requests.

Also, while I believe this code is handling cleanup (i.e., closing connections and deleting files), it would be helpful if someone looked critically at these aspects of the PR.