### PR TITLE
Modernize some controller-first URLs to support basic functionality

### DIFF
--- a/api/webapp/clientapi/ext3/FileSystem.js
+++ b/api/webapp/clientapi/ext3/FileSystem.js
@@ -213,7 +213,7 @@ LABKEY.FileSystem.Util = new function(){
                     var name = record.get("name");
                     var i = name.lastIndexOf(".");
                     var ext = i >= 0 ? name.substring(i) : name;
-                    value = LABKEY.contextPath + "/project/icon.view?name=" + ext;
+                    value = LABKEY.contextPath + "/project-icon.view?name=" + ext;
                 }
             }
             var img = {tag:'img', width:16, height:16, src:value, id:'img'+(++imgSeed)};

--- a/core/src/org/labkey/core/webdav/WebdavServlet.java
+++ b/core/src/org/labkey/core/webdav/WebdavServlet.java
@@ -21,6 +21,11 @@ package org.labkey.core.webdav;
  * Date: Apr 17, 2008
  */
 
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.hc.core5.http.HttpStatus;
@@ -38,11 +43,6 @@ import org.labkey.api.view.ViewServlet;
 import org.labkey.api.webdav.WebdavResolver;
 import org.labkey.api.webdav.WebdavResolverImpl;
 
-import jakarta.servlet.RequestDispatcher;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
@@ -134,7 +134,7 @@ public class WebdavServlet extends HttpServlet
             try {response.reset();}catch(IllegalStateException x){/*pass*/}
         }
 
-        ActionURL dispatchUrl = new ActionURL("/" + DavController.name + "/" + method.toLowerCase() + ".view");
+        ActionURL dispatchUrl = new ActionURL(DavController.name, method.toLowerCase(), null);
         dispatchUrl.addParameters(helper.getParameters());
         dispatchUrl.replaceParameter("path",fullPath);
         dispatchUrl.setScheme(request.getScheme());

--- a/core/src/org/labkey/core/webdav/davListing.jsp
+++ b/core/src/org/labkey/core/webdav/davListing.jsp
@@ -23,6 +23,8 @@
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.api.webdav.WebdavResource" %>
 <%@ page import="org.labkey.core.webdav.DavController" %>
+<%@ page import="java.lang.Override" %>
+<%@ page import="java.lang.String" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
     @Override
@@ -41,20 +43,17 @@
 
     Ext4.onReady(function() {
 
-        var url = new URL(document.URL);
-        var returnUrl = encodeURIComponent(url.pathname + url.search);
-
         var loginAction = new Ext4.Action({
             text : 'Login',
             handler : function () {
-                window.location = LABKEY.contextPath + '/home/login-login.view?returnUrl=' + returnUrl;
+                window.location = LABKEY.ActionURL.buildURL('login', 'login', null, {returnUrl: window.location});
             }
         });
 
         var logoutAction = new Ext4.Action({
             text : 'Logout',
             handler : function () {
-                LABKEY.Utils.postToAction(LABKEY.contextPath + '/home/login-logout.view?returnUrl=' + returnUrl);
+                LABKEY.Utils.postToAction(LABKEY.ActionURL.buildURL('login', 'logout', null, {returnUrl: window.location}));
             }
         });
 

--- a/core/src/org/labkey/core/webdav/davListing.jsp
+++ b/core/src/org/labkey/core/webdav/davListing.jsp
@@ -15,15 +15,14 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.labkey.api.premium.PremiumService" %>
 <%@ page import="org.labkey.api.settings.AppProps" %>
+<%@ page import="org.labkey.api.util.JavaScriptFragment" %>
 <%@ page import="org.labkey.api.util.Path" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.api.webdav.WebdavResource" %>
 <%@ page import="org.labkey.core.webdav.DavController" %>
-<%@ page import="org.labkey.api.premium.PremiumService" %>
-<%@ page import="org.apache.commons.lang3.StringUtils" %>
-<%@ page import="org.labkey.api.util.JavaScriptFragment" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%!
     @Override
@@ -48,14 +47,14 @@
         var loginAction = new Ext4.Action({
             text : 'Login',
             handler : function () {
-                window.location = LABKEY.contextPath + '/login/home/login.view?returnUrl=' + returnUrl;
+                window.location = LABKEY.contextPath + '/home/login-login.view?returnUrl=' + returnUrl;
             }
         });
 
         var logoutAction = new Ext4.Action({
             text : 'Logout',
             handler : function () {
-                window.location = LABKEY.contextPath + '/login/home/logout.view?returnUrl=' + returnUrl;
+                LABKEY.Utils.postToAction(LABKEY.contextPath + '/home/login-logout.view?returnUrl=' + returnUrl);
             }
         });
 

--- a/core/webapp/mothership.js
+++ b/core/webapp/mothership.js
@@ -282,7 +282,7 @@ LABKEY.Mothership = (function () {
         // CONSIDER: Remove the _mothership flag and use a site-setting to suppress mothership reporting of client-side exceptions.
         if (_mothership) {
             try {
-                send(LABKEY.contextPath + '/admin/logClientException.api', {
+                send(LABKEY.contextPath + '/admin-logClientException.api', {
                     username: LABKEY.user ? LABKEY.user.email : 'Unknown',
                     //site: window.location.host,
                     //version: LABKEY.versionString || 'Unknown',

--- a/core/webapp/mothership.js
+++ b/core/webapp/mothership.js
@@ -282,7 +282,7 @@ LABKEY.Mothership = (function () {
         // CONSIDER: Remove the _mothership flag and use a site-setting to suppress mothership reporting of client-side exceptions.
         if (_mothership) {
             try {
-                send(LABKEY.contextPath + '/admin-logClientException.api', {
+                send(LABKEY.ActionURL.buildURL('admin', 'logClientException.api'), {
                     username: LABKEY.user ? LABKEY.user.email : 'Unknown',
                     //site: window.location.host,
                     //version: LABKEY.versionString || 'Unknown',


### PR DESCRIPTION
#### Rationale
Running with the `rejectControllerFirstUrls` revealed that we use controller-first URLs to fetch certain CSS and JS files and to log client exceptions. This breaks some pretty basic functionality (including the ability to disable experimental features).

#### Related Pull Requests
- #6990 

#### Changes
- Update some controller-first URLs to support basic functionality