### PR TITLE
Work around issue with getIndexInfo() on SQL Server

### DIFF
--- a/api/src/org/labkey/api/data/CachedResultSets.java
+++ b/api/src/org/labkey/api/data/CachedResultSets.java
@@ -56,7 +56,17 @@ public class CachedResultSets
                 list.add(factory.getRowMap(rs));
 
             // If we have another row, then we're not complete
-            boolean isComplete = !rs.next();
+            boolean isComplete = true;
+
+            // TODO: Remove this try/catch once SQL Server driver fixes getIndexInfo()
+            try
+            {
+                isComplete = !rs.next();
+            }
+            catch (SQLException ignored)
+            {
+                // tolerate this for now
+            }
 
             return new CachedResultSet(md, list, isComplete, stackTrace);
         }


### PR DESCRIPTION
#### Rationale
After upgrading the Microsoft SQL Server JDBC driver to 13.2.0.jre11, various tests starting failing because its new `getIndexInfo()` implementation returns a ResultSet that throws if `next()` is called after the results have been exhausted. More details: https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53885

#### Related Pull Requests
- https://github.com/LabKey/server/pull/1173

#### Tasks 📍
- [ ] ~~Manual Testing / Verify Fix~~
- [x] Needs Automation - No, existing tests caught this