### PR TITLE
Plateset worklist excel export lacks file extension

### DIFF
--- a/assay/src/org/labkey/assay/plate/PlateManager.java
+++ b/assay/src/org/labkey/assay/plate/PlateManager.java
@@ -3671,7 +3671,7 @@ public class PlateManager implements PlateService, AssayListener, ExperimentList
         else
         {
             ArrayExcelWriter xlWriter = new ArrayExcelWriter(rows, cols);
-            xlWriter.setFullFileName(fileName);
+            xlWriter.setFullFileName(fileName + ".xlsx");
             xlWriter.renderWorkbook(response);
         }
     }


### PR DESCRIPTION
#### Rationale
The exported plate set worklist excel file name consist of source plateset name + self plate name. It is currently missing ".xslx" file extension. This is resulting in FireFox attempting to rename the file (when there is a patten of ". " [PlateSetWorklistTest.testSourceAndDestMappingMismatches](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres/3659623?buildTab=tests&status=failed&name=org.labkey.test.tests.biologics.plates.PlateSetWorklistTest.testSourceAndDestMappingMismatches) dot followed by space) and prompting user to confirm such renaming before saving. 

[PlateSetWorklistTest.testSourceAndDestMappingMismatches](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres/3659623?buildTab=tests&status=failed&name=org.labkey.test.tests.biologics.plates.PlateSetWorklistTest.testSourceAndDestMappingMismatches)

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- add ".xlxs" file extension to plateset worklist excel export

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->