### PR TITLE
Assay: retain primary result file when located in temp directory

### DIFF
--- a/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
+++ b/api/src/org/labkey/api/assay/DefaultAssayRunCreator.java
@@ -105,6 +105,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.unmodifiableCollection;
+import static org.labkey.api.assay.AssayFileWriter.TEMP_DIR_NAME;
 
 public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> implements AssayRunCreator<ProviderType>
 {
@@ -497,7 +498,9 @@ public class DefaultAssayRunCreator<ProviderType extends AbstractAssayProvider> 
         {
             // Issue 51300: don't keep the primary file if the new run failed to save
             FileLike primaryFile = context.getUploadedData().get(AssayDataCollector.PRIMARY_FILE);
-            if (primaryFile != null && primaryFile.exists())
+
+            // If the uploaded file is in the temp directory, then do not delete it as it may be reused in the next import attempt.
+            if (primaryFile != null && primaryFile.exists() && !primaryFile.getPath().contains(TEMP_DIR_NAME))
                 primaryFile.delete();
         }
         catch (IOException e)


### PR DESCRIPTION
#### Rationale
Following #6952 there were test failures in both AssayTransformWarningTest.testJavaTransformWarning and AssayTransformWarningTest.testRTransformWarning related to the fact that the uploaded data is no longer available even though the user elected to reuse the previously uploaded file.

This puts a specific check in place when attempting to clean up the primary results file to not clean it up if it is located in the ".uploadTemp" directory as that will be cleaned up by other handling.

#### Related Pull Requests
- #6952

#### Changes
- Check if ".uploadTemp" is in the primary results file path and only delete if it is not