### PR TITLE
Escape special characters in form field names

### DIFF
--- a/api/src/org/labkey/api/data/MVDisplayColumn.java
+++ b/api/src/org/labkey/api/data/MVDisplayColumn.java
@@ -17,6 +17,7 @@
 package org.labkey.api.data;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.query.QueryUpdateForm;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.PageFlowUtil;
@@ -49,7 +50,7 @@ public class MVDisplayColumn extends DataColumn
     {
         Object mvIndicatorObject = mvIndicatorColumn.getValue(ctx);
         if (null == mvIndicatorObject)
-            mvIndicatorObject = ctx.get("quf_" + mvIndicatorColumn.getName());
+            mvIndicatorObject = ctx.get(QueryUpdateForm.PREFIX + mvIndicatorColumn.getName());
         if (mvIndicatorObject != null)
             return mvIndicatorObject.toString();
         return null;

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -561,7 +561,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
     }
 
     /**
-     * Get case-insensitive map of typed values for each of the columns and mvColumns in the table if available.
+     * Returns a case-insensitive map of typed values for each of the columns and mvColumns in the table if available.
      * @param includeUntyped The result map will include the String value that wasn't converted.
      * @return CaseInsensitiveHashMap of typed values.
      */
@@ -572,18 +572,10 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
         for (ColumnInfo column : getTable().getColumns())
         {
             if (hasTypedValue(column))
-            {
                 values.put(column.getName(), getTypedValue(column));
-                continue;
-            }
-
-            if (includeUntyped && contains(column))
-            {
+            else if (includeUntyped && contains(column))
                 values.put(column.getName(), get(column));
-                continue;
-            }
-
-            if (getRequest() instanceof MultipartHttpServletRequest request)
+            else if (getRequest() instanceof MultipartHttpServletRequest request)
             {
                 String fieldName = getMultiPartFormFieldName(column);
                 Object typedValue = getTypedValues().get(fieldName);
@@ -594,18 +586,24 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
                 {
                     MultipartFile file = request.getFile(fieldName);
                     if (file != null)
-                        values.put(column.getName(), (file.getOriginalFilename() == null || file.getOriginalFilename().isEmpty()) ? null : file);
+                    {
+                        // Check if the file was removed
+                        if (file.getOriginalFilename() == null || file.getOriginalFilename().isEmpty())
+                            values.put(column.getName(), null);
+                        else
+                            values.put(column.getName(), file);
+                    }
                 }
             }
 
             if (column.isMvEnabled())
             {
                 ColumnInfo mvColumn = getTable().getColumn(column.getMvColumnName());
-                if (mvColumn != null)
+                if (null != mvColumn)
                 {
                     if (hasTypedValue(mvColumn))
                         values.put(mvColumn.getName(), getTypedValue(mvColumn));
-                    else if (includeUntyped && contains(column))
+                    else if (includeUntyped && contains(mvColumn))
                         values.put(mvColumn.getName(), get(mvColumn));
                 }
             }
@@ -615,7 +613,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
     }
 
     /**
-     * Get case-insensitive map of typed values for each of the columns and mvColumns in the table if available.
+     * Returns a case-insensitive map of typed values for each of the columns and mvColumns in the table if available.
      * @return CaseInsensitiveHashMap of typed values.
      */
     public CaseInsensitiveHashMap<Object> getTypedColumns()

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -35,7 +35,6 @@ import org.labkey.api.action.NullSafeBindException;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.ontology.Quantity;
-import org.labkey.api.query.SchemaKey;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.Permission;
@@ -566,51 +565,43 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
      * @param includeUntyped The result map will include the String value that wasn't converted.
      * @return CaseInsensitiveHashMap of typed values.
      */
-    public Map<String,Object> getTypedColumns(boolean includeUntyped)
+    public CaseInsensitiveHashMap<Object> getTypedColumns(boolean includeUntyped)
     {
-        Map<String, Object> values = new CaseInsensitiveHashMap<>();
+        CaseInsensitiveHashMap<Object> values = new CaseInsensitiveHashMap<>();
+
         for (ColumnInfo column : getTable().getColumns())
         {
             if (hasTypedValue(column))
-                values.put(column.getName(), getTypedValue(column));
-            else if (includeUntyped && contains(column))
-                values.put(column.getName(), get(column));
-            else if (column.getName().contains("\"") && getViewContext().getRequest() instanceof MultipartHttpServletRequest)
             {
-                String quoteEncodedFieldName = getMultiPartFormFieldName(column);
-                boolean isFileColFileRemoved = false;
-                if (values.get(column.getName()) == null && File.class.equals(column.getJavaClass()))
-                {
-                    MultipartHttpServletRequest request = (MultipartHttpServletRequest) getRequest();
-                    MultipartFile f = request.getFile(quoteEncodedFieldName);
-                    isFileColFileRemoved = f != null && (f.getOriginalFilename() == null || f.getOriginalFilename().isEmpty());
-                }
-
-                if (isFileColFileRemoved)
-                    values.put(column.getName(), null);
-                else
-                {
-                    Object value = getTypedValues().get(quoteEncodedFieldName);
-                    if (value != null)
-                        values.put(column.getName(), value);
-                }
+                values.put(column.getName(), getTypedValue(column));
+                continue;
             }
 
-            // Check if there was a file uploaded for the column's value
-            if (values.get(column.getName()) == null && File.class.equals(column.getJavaClass()) && getRequest() instanceof MultipartHttpServletRequest request)
+            if (includeUntyped && contains(column))
             {
-                MultipartFile f = request.getFile(getFormFieldName(column));
-                // Only set the parameter value if there was a form element that was posted
-                if (f != null)
+                values.put(column.getName(), get(column));
+                continue;
+            }
+
+            if (getRequest() instanceof MultipartHttpServletRequest request)
+            {
+                String fieldName = getMultiPartFormFieldName(column);
+                Object typedValue = getTypedValues().get(fieldName);
+
+                if (typedValue != null)
+                    values.put(column.getName(), typedValue);
+                else if (File.class.equals(column.getJavaClass()))
                 {
-                    values.put(column.getName(), f.getOriginalFilename() == null || f.getOriginalFilename().isEmpty() ? null : f);
+                    MultipartFile file = request.getFile(fieldName);
+                    if (file != null)
+                        values.put(column.getName(), (file.getOriginalFilename() == null || file.getOriginalFilename().isEmpty()) ? null : file);
                 }
             }
 
             if (column.isMvEnabled())
             {
                 ColumnInfo mvColumn = getTable().getColumn(column.getMvColumnName());
-                if (null != mvColumn)
+                if (mvColumn != null)
                 {
                     if (hasTypedValue(mvColumn))
                         values.put(mvColumn.getName(), getTypedValue(mvColumn));
@@ -619,6 +610,7 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
                 }
             }
         }
+
         return values;
     }
 
@@ -626,11 +618,10 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
      * Get case-insensitive map of typed values for each of the columns and mvColumns in the table if available.
      * @return CaseInsensitiveHashMap of typed values.
      */
-    public Map<String,Object> getTypedColumns()
+    public CaseInsensitiveHashMap<Object> getTypedColumns()
     {
         return getTypedColumns(false);
     }
-
 
     /**
      * Set a map of real values. This will reset the matching strings stored in the object.
@@ -791,7 +782,6 @@ public class TableViewForm extends ViewForm implements DynaBean, HasBindParamete
     {
         return getFormFieldName(column);
     }
-
 
     @Nullable
     public ColumnInfo getColumnByFormFieldName(@NotNull String name)

--- a/api/src/org/labkey/api/query/QueryUpdateForm.java
+++ b/api/src/org/labkey/api/query/QueryUpdateForm.java
@@ -69,25 +69,59 @@ public class QueryUpdateForm extends TableViewForm
         }
     }
 
+    // RFC 2616 / RFC 7230: Escape characters inside the field name
+    private static final char BACKSLASH = '\\';
+    private static final String SPECIAL_CHARS = BACKSLASH + "\";=,";
+
     @Override
     @Nullable
-    public ColumnInfo getColumnByFormFieldName(@NotNull String name)
+    public ColumnInfo getColumnByFormFieldName(@NotNull String fieldName)
     {
-        if (!_ignorePrefix && name.length() < PREFIX.length())
+        if (!_ignorePrefix && fieldName.length() < PREFIX.length())
             return null;
 
-        return getTable().getColumn(_ignorePrefix ? name : name.substring(PREFIX.length()));
+        var columnName = _ignorePrefix ? fieldName : fieldName.substring(PREFIX.length());
+
+        StringBuilder sb = new StringBuilder(columnName.length());
+        boolean escaping = false;
+        for (char c : columnName.toCharArray())
+        {
+            if (escaping)
+            {
+                sb.append(c);
+                escaping = false;
+            }
+            else if (c == BACKSLASH)
+                escaping = true;
+            else
+                sb.append(c);
+        }
+
+        if (escaping)
+            throw new IllegalArgumentException("Invalid escape at end of encoded name: " + columnName);
+
+        return getTable().getColumn(sb.toString());
     }
 
     @Override
     public String getFormFieldName(@NotNull ColumnInfo column)
     {
-        return (_ignorePrefix ? "" : PREFIX) + column.getName();
+        String columnName = column.getName();
+        StringBuilder sb = new StringBuilder();
+        for (char c : columnName.toCharArray())
+        {
+            if (SPECIAL_CHARS.indexOf(c) >= 0)
+                sb.append(BACKSLASH);
+            sb.append(c);
+        }
+
+        String fieldName = sb.toString();
+        return _ignorePrefix ? fieldName : PREFIX + fieldName;
     }
 
     @Override
     public String getMultiPartFormFieldName(@NotNull ColumnInfo column)
     {
-        return (_ignorePrefix ? "" : PREFIX) + DataIteratorUtil.MatchType.multiPartFormData.getMatchedName(column.getName());
+        return DataIteratorUtil.MatchType.multiPartFormData.getMatchedName(getFormFieldName(column));
     }
 }

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
@@ -3,7 +3,6 @@ package org.labkey.test.tests.study;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.Nullable;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -46,6 +45,7 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
 {
     private static final String EXCLUDED_CHARS = "\""; // this gets encoded as %22 when the form data is sent.
     private static final String IMPORT_PROJECT = "StudyDatasetFileFieldFolderImportProject";
+    // Include a "\" character at the end of the file field name to verify it round trips with escaped form field characters
     private static final String FILE_FIELD_1 = TestDataGenerator.randomFieldName("File Field 1", EXCLUDED_CHARS, DomainUtils.DomainKind.StudyDatasetDate) + "\\";
     private static final String FILE_FIELD_2 = TestDataGenerator.randomFieldName("File Field 2", EXCLUDED_CHARS, DomainUtils.DomainKind.StudyDatasetDate);
     private static final String INT_FIELD = TestDataGenerator.randomFieldName("Int Field", EXCLUDED_CHARS, DomainUtils.DomainKind.StudyDatasetDate);

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
@@ -18,13 +18,13 @@ import org.labkey.test.components.ext4.Checkbox;
 import org.labkey.test.pages.DatasetInsertPage;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.ViewDatasetDataPage;
+import org.labkey.test.pages.query.UpdateQueryRowPage;
 import org.labkey.test.pages.study.DatasetDesignerPage;
 import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.util.AuditLogHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.DomainUtils;
-import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.FileBrowserHelper;
 import org.labkey.test.util.PasswordUtil;
@@ -117,11 +117,11 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
                 AuditLogHelper.COL_FILE_AUDIT_PROVIDED_FILE, inputFile.getName()
         )));
         log("Edit the dataset");
-        DataRegionTable table = new DataRegionTable("Dataset", getDriver());
-        table.clickEditRow(0);
-        setFormElement(Locator.name(EscapeUtil.getFormFieldName(TEXT_FIELD)), "Welcome..!");
-        checker().verifyTrue("File is not present ",  isElementPresent(Locator.linkContainingText("remove")));
-        clickButton("Submit");
+        UpdateQueryRowPage updatePage = new DataRegionTable("Dataset", getDriver())
+                .clickEditRow(0)
+                .setField(TEXT_FIELD, "Welcome..!");
+        checker().verifyTrue("File is not present ", isElementPresent(Locator.linkContainingText("remove")));
+        updatePage.submit();
 
         log("Verify file field is not deleted after edit");
         File downloadedFile = doAndWaitForDownload(() -> waitAndClick(WAIT_FOR_JAVASCRIPT, Locator.tagWithAttribute("a", "title", "Download attached file"), 0));
@@ -162,22 +162,22 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
                 .selectDatasetByName(datasetName)
                 .clickViewData();
 
-        table = new DataRegionTable("Dataset", getDriver());
-        table.clickEditRow(0);
-        checker().verifyTrue("File is not present ",  isElementPresent(Locator.linkContainingText("remove")));
-        setFormElement(Locator.name(EscapeUtil.getFormFieldName(INT_FIELD)), "NOT A NUMBER");
-        clickButton("Submit");
+        updatePage = new DataRegionTable("Dataset", getDriver())
+                .clickEditRow(0);
+        checker().verifyTrue("File is not present ", isElementPresent(Locator.linkContainingText("remove")));
+        updatePage.setField(INT_FIELD, "NOT A NUMBER");
+        updatePage.submitExpectingError();
 
         // assert correct reshow with error
         assertTextPresent("Could not convert value:");
-        checker().verifyTrue("File is not present ",  isElementPresent(Locator.linkContainingText("remove")));
+        checker().verifyTrue("File is not present ", isElementPresent(Locator.linkContainingText("remove")));
 
         // Issue 53320: Update a file field with a different file
         click(Locator.linkContainingText("remove"));
         File updateFile = TestFileUtils.getSampleData("fileTypes/pdf_sample.pdf");
-        setFormElement(Locator.name(EscapeUtil.getFormFieldName(INT_FIELD)), "2");
-        setFormElement(Locator.name(EscapeUtil.getFormFieldName(FILE_FIELD_1)), updateFile.toString());
-        clickButton("Submit");
+        updatePage.setField(INT_FIELD, "2");
+        updatePage.setField(FILE_FIELD_1, updateFile);
+        updatePage.submit();
 
         FileBrowserHelper.FileDetailInfo fileInfoImportedFile = FileBrowserHelper.getFileDetailInfo(IMPORT_PROJECT, "sample.txt");
 
@@ -209,8 +209,9 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
         importFilePathError("1", "2", ".");
         importFilePathError("1", "2", "../..");
         // happy case, import/update/merge with valid file path
+        // TODO: This should verify the rows in the data region after import
         importDataPage.setCopyPasteMerge(false, false);
-        String header = "ParticipantId\tSequenceNum\tfileField\n";
+        String header = "ParticipantId\tSequenceNum\t" + FILE_FIELD_1 + "\n";
         String data =  "2\t3\t" + fileInfoImportedFile.absoluteFilePath() + "\n" +
                 "3\t4\t" + fileInfoImportedFile.dataFileUrl() + "\n" +
                 "4\t5\t" + fileInfoImportedFile.webDavUrl() + "\n" +
@@ -245,7 +246,7 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
         {
             waitForElementToBeVisible(Locator.xpath("//div[contains(@class, 'labkey-error')][contains(text(),'Invalid file path: " + filePath + "')]"));
         }
-        catch(NoSuchElementException nse)
+        catch (NoSuchElementException nse)
         {
             checker().fatal().error("Invalid file path error not present.");
         }

--- a/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDatasetFileFieldTest.java
@@ -3,6 +3,7 @@ package org.labkey.test.tests.study;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -24,6 +25,7 @@ import org.labkey.test.util.AuditLogHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.DomainUtils;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.FileBrowserHelper;
 import org.labkey.test.util.PasswordUtil;
@@ -38,18 +40,13 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-/*
-Added the test to provide additional test coverage for below mentioned issue
-https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=42309
- */
-
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 10)
 public class StudyDatasetFileFieldTest extends BaseWebDriverTest
 {
     private static final String EXCLUDED_CHARS = "\""; // this gets encoded as %22 when the form data is sent.
     private static final String IMPORT_PROJECT = "StudyDatasetFileFieldFolderImportProject";
-    private static final String FILE_FIELD_1 = TestDataGenerator.randomFieldName("File Field 1", EXCLUDED_CHARS, DomainUtils.DomainKind.StudyDatasetDate);
+    private static final String FILE_FIELD_1 = TestDataGenerator.randomFieldName("File Field 1", EXCLUDED_CHARS, DomainUtils.DomainKind.StudyDatasetDate) + "\\";
     private static final String FILE_FIELD_2 = TestDataGenerator.randomFieldName("File Field 2", EXCLUDED_CHARS, DomainUtils.DomainKind.StudyDatasetDate);
     private static final String INT_FIELD = TestDataGenerator.randomFieldName("Int Field", EXCLUDED_CHARS, DomainUtils.DomainKind.StudyDatasetDate);
     private static final String TEXT_FIELD = TestDataGenerator.randomFieldName("Text Field", EXCLUDED_CHARS, DomainUtils.DomainKind.StudyDatasetDate);
@@ -93,7 +90,7 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
         _containerHelper.deleteProject(IMPORT_PROJECT, false);
     }
 
-    @Test
+    @Test // Issue 42309
     public void testFileField() throws IOException, CommandException
     {
         new ApiPermissionsHelper(this)
@@ -122,7 +119,7 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
         log("Edit the dataset");
         DataRegionTable table = new DataRegionTable("Dataset", getDriver());
         table.clickEditRow(0);
-        setFormElement(Locator.name("quf_" + TEXT_FIELD), "Welcome..!");
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(TEXT_FIELD)), "Welcome..!");
         checker().verifyTrue("File is not present ",  isElementPresent(Locator.linkContainingText("remove")));
         clickButton("Submit");
 
@@ -152,13 +149,9 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
         String expectedText;
 
         if (SystemUtils.IS_OS_WINDOWS)
-        {
             expectedText = "datasetdata\\sample.txt";
-        }
         else
-        {
             expectedText = "datasetdata/sample.txt";
-        }
 
         assertElementPresent("Did not find the expected sample.txt from the imported dataset.", Locator.tagContainingText("a", expectedText), 1);
         downloadedFile = doAndWaitForDownload(() -> waitAndClick(WAIT_FOR_JAVASCRIPT, Locator.tagWithAttribute("a", "title", "Download attached file"), 0));
@@ -172,23 +165,23 @@ public class StudyDatasetFileFieldTest extends BaseWebDriverTest
         table = new DataRegionTable("Dataset", getDriver());
         table.clickEditRow(0);
         checker().verifyTrue("File is not present ",  isElementPresent(Locator.linkContainingText("remove")));
-        setFormElement(Locator.name("quf_" + INT_FIELD), "NOT A NUMBER");
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(INT_FIELD)), "NOT A NUMBER");
         clickButton("Submit");
 
         // assert correct reshow with error
         assertTextPresent("Could not convert value:");
         checker().verifyTrue("File is not present ",  isElementPresent(Locator.linkContainingText("remove")));
 
-        // Issue : 53320. Update a file field with a different file
+        // Issue 53320: Update a file field with a different file
         click(Locator.linkContainingText("remove"));
         File updateFile = TestFileUtils.getSampleData("fileTypes/pdf_sample.pdf");
-        setFormElement(Locator.name("quf_" + INT_FIELD), "2");
-        setFormElement(Locator.name("quf_" + FILE_FIELD_1), updateFile.toString());
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(INT_FIELD)), "2");
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(FILE_FIELD_1)), updateFile.toString());
         clickButton("Submit");
 
-        FileBrowserHelper.FileDetailInfo fileInfoImportedFile = _fileBrowserHelper.getFileDetailInfo(IMPORT_PROJECT, "sample.txt");
+        FileBrowserHelper.FileDetailInfo fileInfoImportedFile = FileBrowserHelper.getFileDetailInfo(IMPORT_PROJECT, "sample.txt");
 
-        // error case: import, update, merge with invalid file path
+        // error case: import, update, merge with an invalid file path
         ViewDatasetDataPage datasetDataPage = new ViewDatasetDataPage(getDriver());
         ImportDataPage importDataPage = datasetDataPage.importBulkData();
         importDataPage.setCopyPasteMerge(false, false);

--- a/study/test/src/org/labkey/test/tests/study/StudyDateBasedTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyDateBasedTest.java
@@ -21,26 +21,25 @@ import org.labkey.test.categories.Daily;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Created by RyanS on 5/18/2017.
- */
 @Category({Daily.class})
 public class StudyDateBasedTest extends AbstractStudyTimeKeyFieldTest
 {
-//    @Override
-//    protected String getProjectName()
-//    {
-//        return "DateBasedStudyVerifyProject";
-//    }
     @Override
-    protected int getDatasetCount(){return 35;}
+    protected int getDatasetCount()
+    {
+        return 35;
+    }
 
     @Override
     protected String getHeaderName()
-    {return "4b$PAsian";}
+    {
+        return "4b$PAsian";
+    }
 
     @Override
-    public void runApiTests(){}
+    public void runApiTests()
+    {
+    }
 
     @Override
     protected void doCreateSteps()

--- a/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
@@ -43,6 +43,7 @@ import org.labkey.test.params.FieldDefinition;
 import org.labkey.test.params.FieldKey;
 import org.labkey.test.tests.StudyBaseTest;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.StudyHelper;
 import org.labkey.test.util.TextSearcher;
@@ -912,7 +913,7 @@ public class StudySimpleExportTest extends StudyBaseTest
     {
         for (Object key : formData.keySet())
         {
-            String name = (formFieldPrefix != null ? formFieldPrefix : "") + key.toString();
+            String name = EscapeUtil.getFormFieldName(key.toString(), formFieldPrefix);
             Locator option = Locator.tagWithName("select", name);
             Locator field = Locator.name(name);
             log("setting form element: " + name);

--- a/study/test/src/org/labkey/test/tests/study/StudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyTest.java
@@ -250,7 +250,9 @@ public class StudyTest extends StudyBaseTest
     }
 
     protected String getHeaderName()
-    {return "DEMasian";}
+    {
+        return "DEMasian";
+    }
 
     protected void emptyParticipantPickerList()
     {
@@ -396,7 +398,6 @@ public class StudyTest extends StudyBaseTest
     protected static final String LABEL_FIELD = "groupLabel";
     protected static final String ID_FIELD = "participantIdentifiers";
 
-
     /**
      * This is a test of the participant picker/classification creation UI.
      */
@@ -446,7 +447,7 @@ public class StudyTest extends StudyBaseTest
         clickAndWait(Locator.linkWithText(DEMOGRAPHICS_TITLE));
 
         // verify warn on no selection
-        if(!isQuickTest())
+        if (!isQuickTest())
         {
             //nav trail check
             clickAndWait(Locator.linkContainingText("999320016"));
@@ -478,7 +479,7 @@ public class StudyTest extends StudyBaseTest
         setFormElement(Locator.name(LABEL_FIELD), "Participant Group from Grid");
         clickButtonContainingText("Save");
 
-        if(!isQuickTest())
+        if (!isQuickTest())
         {
             BootstrapMenu.find(getDriver(), "Groups").clickSubMenu(true, "Participant Group from Grid");
             waitForElement(Locator.paginationText(selectedIDs.length));
@@ -675,7 +676,7 @@ public class StudyTest extends StudyBaseTest
         setFormElement(Locator.name(LABEL_FIELD), listName);
         DataRegionTable table = DataRegion(getDriver()).withName("demoDataRegion").timeout(WAIT_FOR_PAGE).waitFor();
 
-        if(filtered)
+        if (filtered)
         {
             table.setFilter(getHeaderName(), "Equals", "0", 0);
             waitForElement(Locator.paginationText(21));
@@ -720,7 +721,7 @@ public class StudyTest extends StudyBaseTest
     @LogMethod
     protected void verifyStudyAndDatasets(boolean isVisitBased)
     {
-        if(isVisitBased)
+        if (isVisitBased)
         {
             goToProjectHome();
             verifyDemographics();
@@ -896,7 +897,7 @@ public class StudyTest extends StudyBaseTest
                 .setType(FieldDefinition.ColumnType.MultiLine);
         DatasetPropertiesPage propertiesPage = editDatasetPage.clickSave();
 
-        if(isVisitBased)
+        if (isVisitBased)
         {
             log("creating the participant/visit comment dataset");
             editDatasetPage = propertiesPage.clickManageDatasets()
@@ -929,7 +930,7 @@ public class StudyTest extends StudyBaseTest
         doAndWaitForPageToLoad(() -> selectOptionByText(Locator.name("participantCommentDatasetId"), PARTICIPANT_CMT_DATASET));
         selectOptionByText(Locator.name("participantCommentProperty"), PARTICIPANT_COMMENT_LABEL);
 
-        if(isVisitBased)
+        if (isVisitBased)
         {
             doAndWaitForPageToLoad(() -> selectOptionByText(Locator.name("participantVisitCommentDatasetId"), PARTICIPANT_VISIT_CMT_DATASET));
             selectOptionByText(Locator.name("participantVisitCommentProperty"), PARTICIPANT_VISIT_COMMENT_LABEL);
@@ -944,10 +945,11 @@ public class StudyTest extends StudyBaseTest
         BootstrapMenu.find(getDriver(),"Comments and QC").clickSubMenu(true,"Manage Mouse Comments");
 
         int datasetAuditEventCount = getDatasetAuditEventCount(); //inserting a new event should increase this by 1;
-        DataRegionTable.findDataRegion(this).clickInsertNewRow();
-        setFormElement(Locator.name(EscapeUtil.getFormFieldName("MouseId")), "999320812");
-        setFormElement(Locator.name(EscapeUtil.getFormFieldName(COMMENT_FIELD_NAME)), "Mouse Comment");
-        clickButton("Submit");
+        DataRegionTable.findDataRegion(this)
+                .clickInsertNewRow()
+                .setField("MouseId", "999320812")
+                .setField(COMMENT_FIELD_NAME, "Mouse Comment")
+                .submit();
         //Issue 14894: Datasets no longer audit row insertion
         verifyAuditEventAdded(datasetAuditEventCount);
 

--- a/study/test/src/org/labkey/test/tests/study/StudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyTest.java
@@ -47,6 +47,7 @@ import org.labkey.test.util.AuditLogHelper;
 import org.labkey.test.util.ChartHelper;
 import org.labkey.test.util.DataRegionExportHelper;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PasswordUtil;
@@ -944,8 +945,8 @@ public class StudyTest extends StudyBaseTest
 
         int datasetAuditEventCount = getDatasetAuditEventCount(); //inserting a new event should increase this by 1;
         DataRegionTable.findDataRegion(this).clickInsertNewRow();
-        setFormElement(Locator.name("quf_MouseId"), "999320812");
-        setFormElement(Locator.name("quf_" + COMMENT_FIELD_NAME), "Mouse Comment");
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName("MouseId")), "999320812");
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(COMMENT_FIELD_NAME)), "Mouse Comment");
         clickButton("Submit");
         //Issue 14894: Datasets no longer audit row insertion
         verifyAuditEventAdded(datasetAuditEventCount);
@@ -970,7 +971,7 @@ public class StudyTest extends StudyBaseTest
         checkCheckbox(Locator.name(".toggle"));
         BootstrapMenu.find(getDriver(), "Comments and QC").clickSubMenu(true, "Set Vial Comment or QC State for Selected");
         BootstrapMenu.find(getDriver(),"Copy or Move Comment(s)").clickSubMenu(true, "Copy", "To Mouse", "999320812");
-        setFormElement(Locator.name("quf_" + COMMENT_FIELD_NAME), "Copied PTID Comment");
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(COMMENT_FIELD_NAME)), "Copied PTID Comment");
         clickButton("Submit");
         assertTextPresent("Copied PTID Comment");
 
@@ -981,7 +982,7 @@ public class StudyTest extends StudyBaseTest
             BootstrapMenu.find(getDriver(), "Copy or Move Comment(s)").clickSubMenu(false, "Move", "To Mouse", "999320812");
             acceptAlert();
         });
-        setFormElement(Locator.name("quf_" + COMMENT_FIELD_NAME), "Moved PTID Comment");
+        setFormElement(Locator.name(EscapeUtil.getFormFieldName(COMMENT_FIELD_NAME)), "Moved PTID Comment");
         clickButton("Submit");
         assertElementPresent(Locator.tagContainingText("td", "Moved PTID Comment"));
         assertElementNotPresent(Locator.tagContainingText("td", "Mouse Comment"));


### PR DESCRIPTION
#### Rationale
Certain "special" characters (e.g., `" ; = , \`) can cause issues when not escaped in `multipart/form-data` in Tomcat. For example, the "name" of the property is extracted from:

`form-data; name="field\"; filename="spread.xlsx";`

is expected to be `field\`, however, it is parsed as `field\"; filename="spread.xlsx";` because the backlash is recognized as escaping the `"` after  `field\`. The fix is to escape the backslash like this:

`form-data; name="field\\"; filename="spread.xlsx";`

Unfortunately, it is not clear to me why we need to do this as it seems like [the standard states](https://www.rfc-editor.org/rfc/rfc822#section-3.3) that as long as the string is quoted (e.g., `name"field\";` not `name=field\;`) which appears to be what we are receiving. This fix is currently targeted only for `QueryUpdateForm` which is used for our standard query insert/update forms.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7033
- https://github.com/LabKey/limsModules/pull/1661
- https://github.com/LabKey/testAutomation/pull/2683
- https://github.com/LabKey/premiumModules/pull/353

#### Changes
- Update `QueryUpdateForm.getFormFieldName()` and `getColumnByFormFieldName()` to escape and account for special characters in form field names.
- Update `QueryUpdateForm.getMultiPartFormFieldName()` to make use of `getFormFieldName()` to get appropriate escaping.
- Update tests to use `EscapeUtils.getFormFieldName()`.
- Add explicit regression test coverage.

#### Tasks 📍
- [x] Manual Testing @labkey-tchad 
- [x] Needs Automation