### PR TITLE
Suppress NPE logging for malformed wiki

### DIFF
--- a/core/src/org/radeox/macro/CodeMacro.java
+++ b/core/src/org/radeox/macro/CodeMacro.java
@@ -136,7 +136,8 @@ public class CodeMacro extends LocalePreserved {
 
     FilterContext context = new BaseFilterContext();
     context.setRenderContext(initialContext);
-    String result = formatter.filter(params.getContent(), context);
+    String input = params.getContent();
+    String result = input == null ? "" : formatter.filter(input, context);
 
     writer.write(start);
     writer.write(replace(result.trim()));


### PR DESCRIPTION
#### Rationale
A malformed wiki can produce copious NPEs in the logs from Radeox

```
WARN  RegexReplaceFilter       2025-09-10T09:28:28,139 ps-jsse-nio-443-exec-136 : Problem rendering wiki: org.radeox.macro.code.JavaCodeFilter@449acfe8 in org.radeox.engine.context.BaseInitialRenderContext@c14ab2f Wiki 'sampleIDs' version 54 in /SampleManagerHelp with regex "(([^"\\]|\.)*)"
java.lang.NullPointerException: Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null
	at java.base/java.util.regex.Matcher.getTextLength(Matcher.java:1769) ~[?:?]
	at java.base/java.util.regex.Matcher.reset(Matcher.java:415) ~[?:?]
	at java.base/java.util.regex.Matcher.<init>(Matcher.java:252) ~[?:?]
	at java.base/java.util.regex.Pattern.matcher(Pattern.java:1134) ~[?:?]
	at org.radeox.regex.JdkMatcher.<init>(JdkMatcher.java:67) ~[core-25.9-SNAPSHOT.jar:?]
	at org.radeox.regex.Matcher.create(Matcher.java:46) ~[core-25.9-SNAPSHOT.jar:?]
	at org.radeox.filter.regex.RegexReplaceFilter.filter(RegexReplaceFilter.java:77) ~[core-25.9-SNAPSHOT.jar:?]
	at org.radeox.macro.CodeMacro.execute(CodeMacro.java:139) ~[core-25.9-SNAPSHOT.jar:?]
	at org.radeox.filter.MacroFilter.handleMatch(MacroFilter.java:112) ~[core-25.9-SNAPSHOT.jar:?]
	at org.radeox.filter.regex.RegexTokenFilter.lambda$filter$0(RegexTokenFilter.java:89) ~[core-25.9-SNAPSHOT.jar:?]
```

#### Changes
- Degrade during rendering without throwing NPEs

#### Tasks 📍
- Manual Testing - N/A
- Needs Automation - N/A
