### PR TITLE
Don't need to check for SearchService; it falls back to a no-op now

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -178,11 +178,8 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
         
         SearchService ss = SearchService.get();
 
-        if (null != ss)
-        {
-            ss.addSearchCategory(AnnouncementManager.searchCategory);
-            ss.addDocumentProvider(this);
-        }
+        ss.addSearchCategory(AnnouncementManager.searchCategory);
+        ss.addDocumentProvider(this);
 
         FolderSerializationRegistry fsr = FolderSerializationRegistry.get();
         if (null != fsr)

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -1910,12 +1910,8 @@ public class ContainerManager
 
         LOG.debug("Starting container delete for " + c.getContainerNoun(true) + " " + c.getPath());
 
-        SearchService ss = SearchService.get();
-        if (ss != null)
-        {
-            // Tell the search indexer to drop work for the container that's about to be deleted
-            ss.purgeForContainer(c);
-        }
+        // Tell the search indexer to drop work for the container that's about to be deleted
+        SearchService.get().purgeForContainer(c);
 
         DbScope.RetryFn<Boolean> tryDeleteContainer = (tx) ->
         {

--- a/api/src/org/labkey/api/search/SearchResultTemplate.java
+++ b/api/src/org/labkey/api/search/SearchResultTemplate.java
@@ -79,19 +79,15 @@ public interface SearchResultTemplate
                 break;
         }
 
-        SearchService ss = SearchService.get();
-        if (ss != null)
+        List<SearchCategory> categories = SearchService.get().getCategories(category);
+
+        if (null != categories)
         {
-            List<SearchCategory> categories = ss.getCategories(category);
+            List<String> list = categories.stream()
+                .map(SearchCategory::getDescription)
+                .toList();
 
-            if (null != categories)
-            {
-                List<String> list = categories.stream()
-                    .map(SearchCategory::getDescription)
-                    .toList();
-
-                title += " for " + StringUtilsLabKey.joinWithConjunction(list, "and");
-            }
+            title += " for " + StringUtilsLabKey.joinWithConjunction(list, "and");
         }
 
         root.addChild(title);

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -97,7 +97,7 @@ public interface SearchService extends SearchMXBean
     // marker value for documents with indexing errors
     Date failDate = new Timestamp(DateUtil.parseISODateTime("1899-12-30"));
 
-    static final SearchService NO_OP = new NoopSearchService();
+    SearchService NO_OP = new NoopSearchService();
 
     static @NotNull SearchService get()
     {

--- a/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResource.java
@@ -185,9 +185,8 @@ public abstract class AbstractWebdavResource extends AbstractResource implements
     @Override
     public void setLastIndexed(long indexed, long modified)
     {
-        SearchService ss = SearchService.get();
-        if (isFile() && ss != null)
-            ss.setLastIndexedForPath(getPath(), indexed, modified);
+        if (isFile())
+            SearchService.get().setLastIndexedForPath(getPath(), indexed, modified);
     }
 
     @Override

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -202,33 +202,30 @@ public class AssayModule extends SpringModule
         PlateManager.get().registerLsidHandlers();
         SearchService ss = SearchService.get();
 
-        if (null != ss)
-        {
-            // ASSAY_CATEGORY
-            ss.addSearchCategory(AssayManager.get().ASSAY_CATEGORY);
-            ss.addResourceResolver(AssayManager.get().ASSAY_CATEGORY.getName(), AssayDocumentProvider.getSearchResolver());
-            ss.addDocumentProvider(new AssayDocumentProvider());
+        // ASSAY_CATEGORY
+        ss.addSearchCategory(AssayManager.get().ASSAY_CATEGORY);
+        ss.addResourceResolver(AssayManager.get().ASSAY_CATEGORY.getName(), AssayDocumentProvider.getSearchResolver());
+        ss.addDocumentProvider(new AssayDocumentProvider());
 
-            // ASSAY_RUN_CATEGORY
-            ss.addSearchCategory(AssayManager.get().ASSAY_RUN_CATEGORY);
-            ss.addResourceResolver(AssayManager.get().ASSAY_RUN_CATEGORY.getName(), AssayRunDocumentProvider.getResourceResolver());
-            ss.addDocumentProvider(new AssayRunDocumentProvider());
+        // ASSAY_RUN_CATEGORY
+        ss.addSearchCategory(AssayManager.get().ASSAY_RUN_CATEGORY);
+        ss.addResourceResolver(AssayManager.get().ASSAY_RUN_CATEGORY.getName(), AssayRunDocumentProvider.getResourceResolver());
+        ss.addDocumentProvider(new AssayRunDocumentProvider());
 
-            // ASSAY_BATCH_CATEGORY
-            ss.addSearchCategory(AssayManager.get().ASSAY_BATCH_CATEGORY);
-            ss.addResourceResolver(AssayManager.get().ASSAY_BATCH_CATEGORY.getName(), AssayBatchDocumentProvider.getResourceResolver());
-            ss.addDocumentProvider(new AssayBatchDocumentProvider());
+        // ASSAY_BATCH_CATEGORY
+        ss.addSearchCategory(AssayManager.get().ASSAY_BATCH_CATEGORY);
+        ss.addResourceResolver(AssayManager.get().ASSAY_BATCH_CATEGORY.getName(), AssayBatchDocumentProvider.getResourceResolver());
+        ss.addDocumentProvider(new AssayBatchDocumentProvider());
 
-            // PLATE_CATEGORY
-            ss.addSearchCategory(PlateManager.get().PLATE_CATEGORY);
-            ss.addResourceResolver(PlateManager.get().PLATE_CATEGORY.getName(), PlateDocumentProvider.getResourceResolver());
-            ss.addDocumentProvider(new PlateDocumentProvider());
+        // PLATE_CATEGORY
+        ss.addSearchCategory(PlateManager.get().PLATE_CATEGORY);
+        ss.addResourceResolver(PlateManager.get().PLATE_CATEGORY.getName(), PlateDocumentProvider.getResourceResolver());
+        ss.addDocumentProvider(new PlateDocumentProvider());
 
-            // PLATE_SET_CATEGORY
-            ss.addSearchCategory(PlateManager.get().PLATE_SET_CATEGORY);
-            ss.addResourceResolver(PlateManager.get().PLATE_SET_CATEGORY.getName(), PlateSetDocumentProvider.getResourceResolver());
-            ss.addDocumentProvider(new PlateSetDocumentProvider());
-        }
+        // PLATE_SET_CATEGORY
+        ss.addSearchCategory(PlateManager.get().PLATE_SET_CATEGORY);
+        ss.addResourceResolver(PlateManager.get().PLATE_SET_CATEGORY.getName(), PlateSetDocumentProvider.getResourceResolver());
+        ss.addDocumentProvider(new PlateSetDocumentProvider());
 
         // add a container listener so we'll know when our container is deleted:
         ContainerManager.addContainerListener(new AssayContainerListener());

--- a/core/src/org/labkey/core/CoreContainerListener.java
+++ b/core/src/org/labkey/core/CoreContainerListener.java
@@ -38,6 +38,7 @@ import org.labkey.api.view.Portal;
 import java.beans.PropertyChangeEvent;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 
 public class CoreContainerListener implements ContainerManager.ContainerListener
 {
@@ -54,9 +55,7 @@ public class CoreContainerListener implements ContainerManager.ContainerListener
     {
         String message = auditMsg == null ? c.getContainerNoun(true) + " " + c.getName() + " was created" : auditMsg;
         addAuditEvent(user, c, message);
-        SearchService ss = SearchService.get();
-        if (ss != null)
-            ((CoreModule)ModuleLoader.getInstance().getCoreModule()).enumerateDocuments(ss.defaultTask().getQueue(c, SearchService.PRIORITY.modified), null);
+        ((CoreModule)ModuleLoader.getInstance().getCoreModule()).enumerateDocuments(SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified), null);
     }
 
     @Override
@@ -110,16 +109,12 @@ public class CoreContainerListener implements ContainerManager.ContainerListener
         Container c = evt.container;
         ((CoreModule) ModuleLoader.getInstance().getCoreModule()).enumerateDocuments(SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified), null);
 
-        switch (evt.property)
+        if (Objects.requireNonNull(evt.property) == ContainerManager.Property.Name)
         {
-            case Name:
-            {
-                String oldValue = (String) evt.getOldValue();
-                String newValue = (String) evt.getNewValue();
-                String message = c.getName() + " was renamed from " + oldValue + " to " + newValue;
-                addAuditEvent(evt.user, c, message);
-                break;
-            }
+            String oldValue = (String) evt.getOldValue();
+            String newValue = (String) evt.getNewValue();
+            String message = c.getName() + " was renamed from " + oldValue + " to " + newValue;
+            addAuditEvent(evt.user, c, message);
         }
     }
 }

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1130,17 +1130,14 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         }
 
         SearchService ss = SearchService.get();
-        if (null != ss)
-        {
-            ss.addDocumentParser(new TabLoader.CsvFactoryNoConversions());
-            ss.addDocumentProvider(this);
+        ss.addDocumentParser(new TabLoader.CsvFactoryNoConversions());
+        ss.addDocumentProvider(this);
 
-            // Register indexable DataLoaders with the search service
-            DataLoaderServiceImpl.get().getFactories()
-                .stream()
-                .filter(DataLoaderFactory::indexable)
-                .forEach(ss::addDocumentParser);
-        }
+        // Register indexable DataLoaders with the search service
+        DataLoaderServiceImpl.get().getFactories()
+            .stream()
+            .filter(DataLoaderFactory::indexable)
+            .forEach(ss::addDocumentParser);
 
         OptionalFeatureService.get().addExperimentalFeatureFlag(AppProps.EXPERIMENTAL_NO_GUESTS,
             "No Guest Account",

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -3716,12 +3716,8 @@ public class AdminController extends SpringActionController
             Introspector.flushCaches();
             LOG.info("Purging all caches");
             CacheManager.clearAllKnownCaches();
-            SearchService ss = SearchService.get();
-            if (null != ss)
-            {
-                LOG.info("Purging SearchService queues");
-                ss.purgeQueues();
-            }
+            LOG.info("Purging SearchService queues");
+            SearchService.get().purgeQueues();
         }
 
         @Override

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -438,9 +438,7 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
 
     private void deleteIndexedAttachment(String parent, String name)
     {
-        SearchService ss = SearchService.get();
-        if (ss != null)
-            ss.deleteResource(makeDocId(parent, name));
+        SearchService.get().deleteResource(makeDocId(parent, name));
         new SqlExecutor(CoreSchema.getInstance().getSchema()).execute(new SQLFragment(
             "UPDATE core.Documents SET LastIndexed = NULL WHERE LastIndexed IS NOT NULL AND Parent = ? AND DocumentName = ?", parent, name)
         );
@@ -549,7 +547,6 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
     @Override
     public void moveAttachments(Container newContainer, List<AttachmentParent> parents, User auditUser) throws IOException
     {
-        SearchService ss = SearchService.get();
         for (AttachmentParent parent : parents)
         {
             checkSecurityPolicy(auditUser, parent);

--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -801,9 +801,7 @@ public class DavController extends SpringActionController
                 setLastError(dex);
                 if (dex.getStatus().equals(WebdavStatus.SC_NOT_FOUND))
                 {
-                    SearchService ss = SearchService.get();
-                    if (null != ss)
-                        ss.notFound((URLHelper)getRequest().getAttribute(ViewServlet.ORIGINAL_URL_URLHELPER));
+                    SearchService.get().notFound((URLHelper)getRequest().getAttribute(ViewServlet.ORIGINAL_URL_URLHELPER));
                 }
                 getResponse().sendError(dex.getStatus(), dex.getMessage());
 
@@ -6503,9 +6501,7 @@ public class DavController extends SpringActionController
     private void removeFromIndex(WebdavResource r)
     {
         _log.debug("removeFromIndex: " + r.getPath());
-        SearchService ss = SearchService.get();
-        if (null != ss)
-            ss.deleteResource(r.getDocumentId());
+        SearchService.get().deleteResource(r.getDocumentId());
     }
 
 

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -2038,19 +2038,15 @@ public class ExpDataIterators
             }
             else
             {
-                final SearchService ss = SearchService.get();
-                if (null != ss)
-                {
-                    final ArrayList<String> lsids = new ArrayList<>(_lsids);
-                    final ArrayList<Long> rowIds = new LongArrayList(_rowIds);
-                    Collections.sort(rowIds);
-                    final Runnable indexTask = _indexFunction.apply(new SearchIndexDataKeys(rowIds, lsids));
+                final ArrayList<String> lsids = new ArrayList<>(_lsids);
+                final ArrayList<Long> rowIds = new LongArrayList(_rowIds);
+                Collections.sort(rowIds);
+                final Runnable indexTask = _indexFunction.apply(new SearchIndexDataKeys(rowIds, lsids));
 
-                    if (null != DbScope.getLabKeyScope())
-                        DbScope.getLabKeyScope().addCommitTask(indexTask, DbScope.CommitTaskOption.POSTCOMMIT);
-                    else
-                        indexTask.run();
-                }
+                if (null != DbScope.getLabKeyScope())
+                    DbScope.getLabKeyScope().addCommitTask(indexTask, DbScope.CommitTaskOption.POSTCOMMIT);
+                else
+                    indexTask.run();
             }
             return hasNext;
         }

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -353,9 +353,7 @@ public class ExperimentModule extends SpringModule
 
     private void addDataResourceResolver(String categoryName)
     {
-        SearchService ss = SearchService.get();
-
-        ss.addResourceResolver(categoryName, new SearchService.ResourceResolver()
+        SearchService.get().addResourceResolver(categoryName, new SearchService.ResourceResolver()
         {
             @Override
             public WebdavResource resolve(@NotNull String resourceIdentifier)
@@ -394,9 +392,7 @@ public class ExperimentModule extends SpringModule
 
     private void addDataClassResourceResolver(String categoryName)
     {
-        SearchService ss = SearchService.get();
-
-        ss.addResourceResolver(categoryName, new SearchService.ResourceResolver(){
+        SearchService.get().addResourceResolver(categoryName, new SearchService.ResourceResolver(){
             @Override
             public Map<String, Object> getCustomSearchJson(User user, @NotNull String resourceIdentifier)
             {
@@ -420,9 +416,7 @@ public class ExperimentModule extends SpringModule
 
     private void addSampleTypeResourceResolver(String categoryName)
     {
-        SearchService ss = SearchService.get();
-
-        ss.addResourceResolver(categoryName, new SearchService.ResourceResolver(){
+        SearchService.get().addResourceResolver(categoryName, new SearchService.ResourceResolver(){
             @Override
             public Map<String, Object> getCustomSearchJson(User user, @NotNull String resourceIdentifier)
             {
@@ -446,9 +440,7 @@ public class ExperimentModule extends SpringModule
 
     private void addSampleResourceResolver(String categoryName)
     {
-        SearchService ss = SearchService.get();
-
-        ss.addResourceResolver(categoryName, new SearchService.ResourceResolver(){
+        SearchService.get().addResourceResolver(categoryName, new SearchService.ResourceResolver(){
             @Override
             public Map<String, Object> getCustomSearchJson(User user, @NotNull String resourceIdentifier)
             {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -6052,13 +6052,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         QueryService.get().fireQueryDeleted(user, c, null, ExpSchema.SCHEMA_EXP_DATA, singleton(dataClass.getName()));
 
         // remove DataClass from search index
-        SearchService ss = SearchService.get();
-        if (null != ss)
+        try (Timing ignored = MiniProfiler.step("search docs"))
         {
-            try (Timing ignored = MiniProfiler.step("search docs"))
-            {
-                ss.deleteResource(dataClass.getDocumentId());
-            }
+            SearchService.get().deleteResource(dataClass.getDocumentId());
         }
     }
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -7422,10 +7422,6 @@ public class ExperimentController extends SpringActionController
         @Override
         public Object execute(Object o, BindException errors) throws Exception
         {
-            SearchService search = SearchService.get();
-            if (search == null)
-                return null;
-
             List<Map<String, Object>> notInIndex = new ArrayList<>(100);
 
             List<? extends ExpDataClass> list = ExperimentService.get().getDataClasses(getContainer(), getUser(), false);
@@ -7436,7 +7432,7 @@ public class ExperimentController extends SpringActionController
                     String docId = d.getDocumentId();
                     if (docId != null)
                     {
-                        SearchService.SearchHit hit = search.find(docId);
+                        SearchService.SearchHit hit = SearchService.get().find(docId);
                         if (hit == null)
                         {
                             JSONObject props = ExperimentJSONConverter.serializeData(d, getUser(), ExperimentJSONConverter.DEFAULT_SETTINGS);

--- a/issues/src/org/labkey/issue/IssuesModule.java
+++ b/issues/src/org/labkey/issue/IssuesModule.java
@@ -144,13 +144,10 @@ public class IssuesModule extends DefaultModule implements SearchService.Documen
 
         SearchService ss = SearchService.get();
 
-        if (null != ss)
-        {
-            ss.addSearchCategory(IssueManager.searchCategory);
-            ss.addResourceResolver("issue", IssueManager.getSearchResolver());
-            ss.addDocumentProvider(this);
-            ss.addSearchResultTemplate(new IssuesController.IssueSearchResultTemplate());
-        }
+        ss.addSearchCategory(IssueManager.searchCategory);
+        ss.addResourceResolver("issue", IssueManager.getSearchResolver());
+        ss.addDocumentProvider(this);
+        ss.addSearchResultTemplate(new IssuesController.IssueSearchResultTemplate());
 
         UsageMetricsService svc = UsageMetricsService.get();
         if (svc != null)

--- a/list/src/org/labkey/list/ListModule.java
+++ b/list/src/org/labkey/list/ListModule.java
@@ -138,11 +138,8 @@ public class ListModule extends SpringModule
         }
 
         SearchService ss = SearchService.get();
-        if (null != ss)
-        {
-            ss.addDocumentProvider(ListManager.get());
-            ss.addSearchCategory(ListManager.listCategory);
-        }
+        ss.addDocumentProvider(ListManager.get());
+        ss.addSearchCategory(ListManager.listCategory);
 
         AdminLinkManager.getInstance().addListener((adminNavTree, container, user) ->
         {

--- a/list/src/org/labkey/list/model/ListManager.java
+++ b/list/src/org/labkey/list/model/ListManager.java
@@ -921,20 +921,14 @@ public class ListManager implements SearchService.DocumentProvider
     // Un-index the entire list doc, but leave the list items alone
     private void deleteIndexedEntireListDoc(ListDefinition list)
     {
-        SearchService ss = SearchService.get();
-
-        if (null != ss)
-            ss.deleteResource(getDocumentId(list));
+        SearchService.get().deleteResource(getDocumentId(list));
     }
 
 
     // Un-index all list items, but leave the entire list doc alone
     private void deleteIndexedItems(ListDefinition list)
     {
-        SearchService ss = SearchService.get();
-
-        if (null != ss)
-            ss.deleteResourcesForPrefix(getDocumentId(list, null));
+        SearchService.get().deleteResourcesForPrefix(getDocumentId(list, null));
     }
 
 

--- a/pipeline/src/org/labkey/pipeline/api/PipelineManager.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineManager.java
@@ -196,9 +196,7 @@ public class PipelineManager
                 }
 
                 org.labkey.api.util.Path davPath = WebdavService.getPath().append(container.getParsedPath()).append(FileContentService.PIPELINE_LINK);
-                SearchService ss = SearchService.get();
-                if (null != ss)
-                    ss.addPathToCrawl(davPath, null);
+                SearchService.get().addPathToCrawl(davPath, null);
             }
         }
         finally

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -276,12 +276,9 @@ public class QueryModule extends DefaultModule
         }
 
         SearchService ss = SearchService.get();
+        ss.addDocumentProvider(ExternalSchemaDocumentProvider.getInstance());
+        ss.addSearchCategory(ExternalSchemaDocumentProvider.externalTableCategory);
 
-        if (null != ss)
-        {
-            ss.addDocumentProvider(ExternalSchemaDocumentProvider.getInstance());
-            ss.addSearchCategory(ExternalSchemaDocumentProvider.externalTableCategory);
-        }
         if (null != PropertyService.get())
             PropertyService.get().registerDomainKind(new SimpleTableDomainKind());
 

--- a/search/src/org/labkey/search/SearchContainerListener.java
+++ b/search/src/org/labkey/search/SearchContainerListener.java
@@ -30,11 +30,7 @@ public class SearchContainerListener extends ContainerManager.AbstractContainerL
     @Override
     public void containerCreated(Container c, User user)
     {
-        SearchService ss = SearchService.get();
-        if (null != ss)
-        {
-            DavCrawler.getInstance().addPathToCrawl(WebdavService.getPath().append(c.getParsedPath()), null);
-        }
+        DavCrawler.getInstance().addPathToCrawl(WebdavService.getPath().append(c.getParsedPath()), null);
     }
 
     @Override

--- a/search/src/org/labkey/search/SearchController.java
+++ b/search/src/org/labkey/search/SearchController.java
@@ -280,13 +280,8 @@ public class SearchController extends SpringActionController
         @Override
         public ModelAndView getView(AdminForm form, boolean reshow, BindException errors)
         {
-            SearchService ss = SearchService.get();
-
-            if (null == ss)
-                throw new ConfigurationException("Search is misconfigured");
-
             @SuppressWarnings({"ThrowableResultOfMethodCallIgnored"})
-            Throwable t = ss.getConfigurationError();
+            Throwable t = SearchService.get().getConfigurationError();
 
             VBox vbox = new VBox();
 
@@ -324,11 +319,6 @@ public class SearchController extends SpringActionController
         public boolean handlePost(AdminForm form, BindException errors)
         {
             SearchService ss = SearchService.get();
-            if (null == ss)
-            {
-                errors.reject(ERROR_MSG, "Indexing service is not running");
-                return false;
-            }
 
             if (form.isStart())
             {
@@ -788,8 +778,6 @@ public class SearchController extends SpringActionController
             _category = form.getCategory();
             _scope = form.getSearchScope();
             _form = form;
-
-            SearchService ss = SearchService.get();
 
             if (null == _scope || null == _scope.getRoot(getContainer()))
             {

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -139,27 +139,23 @@ public class SearchModule extends DefaultModule
                 @Override
                 public void handle(Map<SearchStartupProperties, StartupPropertyEntry> properties)
                 {
-                    SearchService ss = SearchService.get();
-                    if (null == ss)
-                        LOG.error("Search service is not present");
-                    else
-                        properties.forEach((ssp, sp) -> {
-                            try
-                            {
-                                ssp.setProperty(ss, _searchIndexStartupHandler, sp.getValue());
-                            }
-                            catch (Exception e)
-                            {
-                                LOG.error("Exception while attempting to set startup property", e);
-                            }
-                        });
+                    properties.forEach((ssp, sp) -> {
+                        try
+                        {
+                            ssp.setProperty(SearchService.get(), _searchIndexStartupHandler, sp.getValue());
+                        }
+                        catch (Exception e)
+                        {
+                            LOG.error("Exception while attempting to set startup property", e);
+                        }
+                    });
                 }
             }
         );
 
         final SearchService ss = SearchService.get();
 
-        if (null != ss)
+        if (ss != SearchService.NO_OP)
         {
             AdminConsole.addLink(AdminConsole.SettingsLinkType.Management, "full-text search", new ActionURL(SearchController.AdminAction.class, null));
 
@@ -195,15 +191,12 @@ public class SearchModule extends DefaultModule
     {
         SearchService ss = SearchService.get();
 
-        if (null != ss)
-        {
-            // Execute any reindexing operations in the background to not block startup, Issue #48960
-            JobRunner.getDefault().execute(() -> {
-                _searchIndexStartupHandler.reindexIfNeeded(ss);
-                ss.start();
-                DavCrawler.getInstance().start();
-            });
-        }
+        // Execute any reindexing operations in the background to not block startup, Issue #48960
+        JobRunner.getDefault().execute(() -> {
+            _searchIndexStartupHandler.reindexIfNeeded(ss);
+            ss.start();
+            DavCrawler.getInstance().start();
+        });
     }
 
     private final SearchIndexStartupHandler _searchIndexStartupHandler = new SearchIndexStartupHandler();

--- a/search/src/org/labkey/search/model/SavePaths.java
+++ b/search/src/org/labkey/search/model/SavePaths.java
@@ -467,11 +467,6 @@ public class SavePaths implements DavCrawler.SavePaths
 
     private static DbSchema getSearchSchema()
     {
-        SearchService ss = SearchService.get();
-
-        if (null != ss)
-            return ss.getSchema();
-        else
-            return null;
+        return SearchService.get().getSchema();
     }
 }

--- a/search/src/org/labkey/search/view/indexerAdmin.jsp
+++ b/search/src/org/labkey/search/view/indexerAdmin.jsp
@@ -45,7 +45,7 @@ String indexDirectoryPath = null != indexDirectory ? indexDirectory.getPath() : 
         <table><tr><td><span style="color:green;"><br><%=h(form.getMessage())%><br></span></td></tr></table><%
     }
 
-if (null == ss)
+if (ss == SearchService.NO_OP)
 {
     %>Indexing service is not configured.<%
 }

--- a/search/src/org/labkey/search/view/indexerStats.jsp
+++ b/search/src/org/labkey/search/view/indexerStats.jsp
@@ -27,7 +27,7 @@
 <%
 SearchService ss = SearchService.get();
 
-if (null == ss)
+if (ss == SearchService.NO_OP)
 {
     %>Indexing service is not configured.<%
 }

--- a/search/src/org/labkey/search/view/searchStats.jsp
+++ b/search/src/org/labkey/search/view/searchStats.jsp
@@ -26,7 +26,7 @@
 <%
 SearchService ss = SearchService.get();
 
-if (null == ss)
+if (ss == SearchService.NO_OP)
 {
     %>Indexing service is not configured.<%
 }

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -4224,9 +4224,7 @@ public class StudyManager
     private void unindexDataset(DatasetDefinition ds)
     {
         String docid = "dataset:" + new Path(ds.getContainer().getId(), String.valueOf(ds.getDatasetId()));
-        SearchService ss = SearchService.get();
-        if (null != ss)
-            ss.deleteResource(docid);
+        SearchService.get().deleteResource(docid);
     }
 
     public static void indexDatasets(SearchService.TaskIndexingQueue queue, Date modifiedSince)

--- a/wiki/src/org/labkey/wiki/WikiController.java
+++ b/wiki/src/org/labkey/wiki/WikiController.java
@@ -152,9 +152,7 @@ public class WikiController extends SpringActionController
         {
             VBox vbox = new VBox();
 
-            SearchService ss = SearchService.get();
-            if (null != ss)
-                vbox.addView(ss.getSearchView(false, 0, false, true));
+            vbox.addView(SearchService.get().getSearchView(false, 0, false, true));
 
             for (WikiPartFactory factory : WikiManager.get().getWikiPartFactories())
             {
@@ -1185,9 +1183,7 @@ public class WikiController extends SpringActionController
                 //set new page title to be the name.
                 _wikiversion.setTitle(name);
                 // check if this is a search result hit
-                SearchService ss = SearchService.get();
-                if (ss != null)
-                    ss.notFound(getViewContext().getActionURL());
+                SearchService.get().notFound(getViewContext().getActionURL());
             }
             else
             {

--- a/wiki/src/org/labkey/wiki/WikiModule.java
+++ b/wiki/src/org/labkey/wiki/WikiModule.java
@@ -114,11 +114,8 @@ public class WikiModule extends CodeOnlyModule implements SearchService.Document
             bootstrap(moduleContext);
 
         SearchService ss = SearchService.get();
-        if (null != ss)
-        {
-            ss.addSearchCategory(WikiManager.searchCategory);
-            ss.addDocumentProvider(this);
-        }
+        ss.addSearchCategory(WikiManager.searchCategory);
+        ss.addDocumentProvider(this);
 
         FolderSerializationRegistry.get().addFactories(new WikiWriterFactory(), new WikiImporterFactory());
 


### PR DESCRIPTION
#### Rationale
Recent work on the search queue introduced a no-op implementation for the service. Thus, we don't need to check if it's null anymore.

#### Changes
- Just use the available `SearchService` and let it do nothing if it chooses

#### Tasks 📍
- Manual Testing - N/A
- Needs Automation - N/A
