### PR TITLE
Clear more code analysis warnings

### DIFF
--- a/api/src/org/labkey/api/data/TransactionFilter.java
+++ b/api/src/org/labkey/api/data/TransactionFilter.java
@@ -61,12 +61,17 @@ public class TransactionFilter implements Filter
             this(request, System.currentTimeMillis());
         }
 
-        @Override
-        public String toString()
+        public String toLogString()
         {
             String url = getUrl();
             Principal user = request.getUserPrincipal();
             return url + " running for " + (System.currentTimeMillis() - startTime) + "ms by " + (user == null ? "guest" : user.getName());
+        }
+
+        @Override
+        public @NotNull String toString()
+        {
+            throw new UnsupportedOperationException("Use toLogString() instead");
         }
 
         public @NotNull String getUrl()
@@ -117,7 +122,7 @@ public class TransactionFilter implements Filter
                                 {
                                     try (DbScope.ConnectionSharingCloseable ignored = DbScope.shareConnections(thread, Thread.currentThread()))
                                     {
-                                        _log.info("Timing out request for {} on thread {}", tracker, thread);
+                                        _log.info("Timing out request for {} on thread {}", tracker.toLogString(), thread);
                                         DbScope.closeConnectionsForCurrentThreadWithoutReleasingLocks();
                                         PipelineJobService.get().killProcessesForThread(thread);
                                     }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -191,7 +191,7 @@ public abstract class SqlDialect
                 if (null != uri)
                 {
                     sb.append("\t");
-                    sb.append(uri);
+                    sb.append(uri.toLogString());
                     sb.append("\n");
                 }
 

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -1211,6 +1211,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     }
 
     File _resourceDirectory;
+    java.nio.file.Path _resourceDirectoryPath;
     File NULL_FILE = new File("....");
 
     public File getResourceDirectory()
@@ -1219,8 +1220,33 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         {
             File dir = computeResourceDirectory();
             _resourceDirectory = null==dir ? NULL_FILE : dir;
+            _resourceDirectoryPath = null==dir ? null : dir.toPath();
+            if (_resourceDirectoryPath != null)
+            {
+                _resourceDirectoryPath = _resourceDirectoryPath.normalize();
+            }
         }
         return NULL_FILE==_resourceDirectory ? null : _resourceDirectory;
+    }
+
+    private java.nio.file.Path getResourceDirectoryPath()
+    {
+        getResourceDirectory();
+        return _resourceDirectoryPath;
+    }
+
+    @Override
+    public boolean isUnderResourcesDirectory(java.nio.file.Path path)
+    {
+        if (path == null)
+        {
+            return true;
+        }
+        if (getResourceDirectoryPath() != null)
+        {
+            return path.normalize().startsWith(getResourceDirectoryPath());
+        }
+        return false;
     }
 
     protected File computeResourceDirectory()
@@ -1278,7 +1304,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
 
     protected File getResourceDirectory(File dir)
     {
-        File resourcesDir = new File(dir, "resources");
+        File resourcesDir = FileUtil.appendName(dir, "resources");
 
         // If we have a "resources" directory then look for resources there (Java module layout)
         // If not, treat all top-level directories as resource directories (simple module layout)

--- a/api/src/org/labkey/api/module/Module.java
+++ b/api/src/org/labkey/api/module/Module.java
@@ -67,6 +67,8 @@ public interface Module
     /** Register filters and their mappings. */
     default void registerFilters(ServletContext servletCtx) {}
 
+    default boolean isUnderResourcesDirectory(java.nio.file.Path path) { return false; }
+
     enum TabDisplayMode
     {
         DISPLAY_NEVER,

--- a/api/src/org/labkey/api/pipeline/PipelineProtocolFactory.java
+++ b/api/src/org/labkey/api/pipeline/PipelineProtocolFactory.java
@@ -128,7 +128,7 @@ public abstract class PipelineProtocolFactory<T extends PipelineProtocol>
 
     public Path getProtocolFile(PipeRoot root, String name, boolean archived)
     {
-        return getProtocolDir(root, archived).resolve(name + ".xml");
+        return FileUtil.appendName(getProtocolDir(root, archived), name + ".xml");
     }
 
     /** @return sorted list of protocol names */

--- a/api/src/org/labkey/api/util/DebugInfoDumper.java
+++ b/api/src/org/labkey/api/util/DebugInfoDumper.java
@@ -417,7 +417,7 @@ public class DebugInfoDumper
 
         TransactionFilter.RequestTracker uri = TransactionFilter.getRequestSummary(thread);
         if (null != uri)
-            logWriter.debug(uri.toString());
+            logWriter.debug(uri.toLogString());
 
         for (var i=0 ; i<stack.length ; i++)
         {

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -873,7 +873,7 @@ public class FileUtil
         legalPathPartThrow(name);
         var ret = dir.resolve(name);
 
-        if (!dir.normalize().startsWith(ret.normalize()))
+        if (!ret.normalize().startsWith(dir.normalize()))
             throw new IllegalArgumentException(name);
         return ret;
     }

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -867,6 +867,17 @@ public class FileUtil
         return ret;
     }
 
+    /* Only returns an immediate child */
+    public static Path appendName(Path dir, String name)
+    {
+        legalPathPartThrow(name);
+        var ret = dir.resolve(name);
+
+        if (!dir.normalize().startsWith(ret.normalize()))
+            throw new IllegalArgumentException(name);
+        return ret;
+    }
+
 
     // narrower check than isLegalName() or isAllowedFileName()
     // this check that a name is a valid path part (e.g. filename) and is not path like.

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -3817,7 +3817,7 @@ public class AdminController extends SpringActionController
                         String threadInfo = thread.getName();
                         TransactionFilter.RequestTracker uri = TransactionFilter.getRequestSummary(thread);
                         if (null != uri)
-                            threadInfo += "; processing URL " + uri;
+                            threadInfo += "; processing URL " + uri.toLogString();
                         activeThreads.add(threadInfo);
                     }
                 }

--- a/core/src/org/labkey/core/admin/threads.jsp
+++ b/core/src/org/labkey/core/admin/threads.jsp
@@ -62,7 +62,7 @@ for (Thread t : bean.threads)
         }
         TransactionFilter.RequestTracker uri = TransactionFilter.getRequestSummary(t);
         if (null != uri)
-        { %>    For URL <%= h(uri + "\n") %><%
+        { %>    For URL <%= h(uri.toLogString() + "\n") %><%
         }
 
 

--- a/core/src/org/labkey/core/query/PostgresStatActivityTable.java
+++ b/core/src/org/labkey/core/query/PostgresStatActivityTable.java
@@ -248,7 +248,7 @@ public class PostgresStatActivityTable extends AbstractPostgresAdminOnlyTable
                 if (request != null)
                 {
                     out.write(separator);
-                    out.write(request);
+                    out.write(request.toLogString());
                 }
             }
         }

--- a/query/src/org/labkey/query/ModuleCustomQueryDefinition.java
+++ b/query/src/org/labkey/query/ModuleCustomQueryDefinition.java
@@ -70,6 +70,15 @@ public class ModuleCustomQueryDefinition extends CustomQueryDefinitionImpl
                 queryXML = new File(path.substring(0, path.length()-FILE_EXTENSION.length()) + META_FILE_EXTENSION);
             }
         }
+        // Check that the files are under the root for the module's resources
+        if (querySQL != null && !moduleQueryDef.getModule().isUnderResourcesDirectory(querySQL.toPath()))
+        {
+            throw new IllegalArgumentException("SQL file is not under the resources directory for module " + moduleQueryDef.getModule().getName());
+        }
+        if (queryXML != null && !moduleQueryDef.getModule().isUnderResourcesDirectory(queryXML.toPath()))
+        {
+            throw new IllegalArgumentException("query.xml file is not under the resources directory for module " + moduleQueryDef.getModule().getName());
+        }
         _resourceSqlFile = querySQL;
         _resourceQueryXmlFile = queryXML;
     }


### PR DESCRIPTION
#### Rationale
We can make our code easier to analyze, and clean up some potential problems too.

#### Changes
- Stop using `toString()` on `RequestTracker` to avoid confusion
- Improve checks for file parent directory

#### Tasks 📍
- Manual Testing - N/A
- Needs Automation - N/A
