### PR TITLE
Add Directive.Script in ContentSecurityPolicyFilter.registerAllowedSources

### DIFF
--- a/api/src/org/labkey/api/security/Directive.java
+++ b/api/src/org/labkey/api/security/Directive.java
@@ -14,6 +14,7 @@ public enum Directive implements StartupProperty, SafeToRenderEnum
     Frame("frame-src", "Sources for iframes"),
     Image("image-src", "Sources for images"),
     Object("object-src", "Sources for objects"), // Issue 53226
+    Script("script-src-elem", "Sources for scripts"),
     Style("style-src", "Sources for stylesheets");
 
     private final String _cspDirective;

--- a/api/src/org/labkey/api/security/Directive.java
+++ b/api/src/org/labkey/api/security/Directive.java
@@ -14,7 +14,7 @@ public enum Directive implements StartupProperty, SafeToRenderEnum
     Frame("frame-src", "Sources for iframes"),
     Image("image-src", "Sources for images"),
     Object("object-src", "Sources for objects"), // Issue 53226
-    Script("script-src-elem", "Sources for scripts"),
+    Script("script-src", "Sources for scripts"),
     Style("style-src", "Sources for stylesheets");
 
     private final String _cspDirective;


### PR DESCRIPTION
Hey @labkey-adam,

OHSU servers has a CloudFlare WAF, which seems to be adding some JS code that's getting flagged by the CSP reports. Is this PR a reasonable approach toward this?

An example is:
```
{
  "labkeyVersion": "25.3-SNAPSHOT",
  "ip": "184.101.22.241, 162.158.187.76",
  "csp-report": {
    "referrer": "https://mgap.ohsu.edu/project/mGAP/begin.view?pageId=overview",
    "status-code": 200,
    "disposition": "report",
    "script-sample": "",
    "violated-directive": "script-src-elem",
    "original-policy": "default-src 'self' ; connect-src 'self' https://code.jquery.com https://*.fontawesome.com https://jbrowse.org https://s3.amazonaws.com https://ftp.ncbi.nlm.nih.gov https://cdn.datatables.net ; object-src 'none' ; style-src 'self' 'unsafe-inline' https://www.gstatic.com https://code.jquery.com https://cdn.datatables.net ; img-src 'self' data: https://cdn.datatables.net ; font-src 'self' data: https://*.fontawesome.com ; script-src 'unsafe-eval' 'strict-dynamic' 'nonce-1c2aa3050d6bed7d' ; base-uri 'self' ; frame-ancestors 'self' ; frame-src 'self'  ; report-uri /admin-contentSecurityPolicyReport.api?cspVersion=r11&labkeyVersion=25.3-SNAPSHOT",
    "document-uri": "https://mgap.ohsu.edu/mGAP/project-begin.view?pageId=datasets",
    "effective-directive": "script-src-elem",
    "blocked-uri": "https://mgap.ohsu.edu/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"
  },
  "user": "<EMAIL>",
  "cspVersion": "r11",
  "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
}
```