### PR TITLE
Prevent showing audit count warning if module startup is still in progress

### DIFF
--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -193,7 +193,8 @@ public class ExperimentUpgradeCode implements UpgradeCode
         }
     }
 
-    // called from exp-25.007-25.008.sql
+    // called from exp-25.009-25.010.sql
+    // When this is removed, the ExperimentWarningProvider class can also be removed.
     @SuppressWarnings("unused")
     public static void upgradeAmountsAndUnits(ModuleContext context)
     {

--- a/experiment/src/org/labkey/experiment/ExperimentWarningProvider.java
+++ b/experiment/src/org/labkey/experiment/ExperimentWarningProvider.java
@@ -12,6 +12,7 @@ import org.labkey.api.data.PropertyManager;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.util.HtmlString;
@@ -26,9 +27,13 @@ public class ExperimentWarningProvider implements WarningProvider
     @Override
     public void addDynamicWarnings(@NotNull Warnings warnings, @Nullable ViewContext context, boolean showAllWarnings)
     {
+        if (!ModuleLoader.getInstance().isStartupComplete())
+            return;
+
         PropertyManager.WritablePropertyMap props = PropertyManager.getWritableProperties(ExperimentModule.AMOUNT_AND_UNIT_UPGRADE_PROP, false);
         if (props == null || props.isEmpty())
             return;
+
         String expectedCount = props.get(ExperimentModule.AUDIT_COUNT_PROP);
         String transactionIdStr = props.get(ExperimentModule.TRANSACTION_ID_PROP);
         if (StringUtils.isEmpty(expectedCount) || StringUtils.isEmpty(transactionIdStr))

--- a/experiment/src/org/labkey/experiment/ExperimentWarningProvider.java
+++ b/experiment/src/org/labkey/experiment/ExperimentWarningProvider.java
@@ -20,6 +20,7 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.template.WarningProvider;
 import org.labkey.api.view.template.Warnings;
 
+// Remove this class when the exp-25.009-25.010.sql script is no longer in use.
 public class ExperimentWarningProvider implements WarningProvider
 {
     private Long _actualRecordCount;


### PR DESCRIPTION
#### Rationale
If the "startup in progress" page refreshes while the system is in the process of adding audit logs for the upgrade script for amounts and units, it will stash the audit log count too early and show a warning before all logs have been created. This PR doesn't generate the warning until module startup is complete and thus all audit logs have been written.

#### Related Pull Requests
- #6994

#### Changes
- Add check for module startup complete

#### Tasks 📍
- [x] Manual Testing @labkey-jeckels 

