### PR TITLE
Fix SMUserTest.testCustomUserField

### DIFF
--- a/core/src/org/labkey/core/user/UserController.java
+++ b/core/src/org/labkey/core/user/UserController.java
@@ -1188,9 +1188,8 @@ public class UserController extends SpringActionController
         public Object execute(UpdateUserDetailsForm form, BindException errors) throws Exception
         {
             Container root = ContainerManager.getRoot();
-            UserSchema schema = new CoreQuerySchema(getUser(), getContainer());
+            UserSchema schema = new CoreQuerySchema(getUser(), getContainer(), form.mustCheckPermissions(getUser(), form.getUserId()));
             UsersTable table = (UsersTable)schema.getTable(CoreQuerySchema.USERS_TABLE_NAME, false);
-            table.setMustCheckPermissions(form.mustCheckPermissions(getUser(), form.getUserId()));
 
             ApiSimpleResponse response = new ApiSimpleResponse();
             try (DbScope.Transaction transaction = table.getSchema().getScope().ensureTransaction())


### PR DESCRIPTION
#### Rationale
My recent change to avoid using the `form` to get the schema (for static code analysis purposes) initialized the schema a little differently, breaking setting custom fields when impersonating a different user. SMUserTest.testCustomUserField noticed.

#### Changes
- Pass the same flag for permission checking to the schema instead of setting on the table

#### Tasks 📍
- [x] Manual Testing
- Needs Automation - N/A - caught by existing coverage
