### PR TITLE
Stop passing in a null User

### DIFF
--- a/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
+++ b/study/src/org/labkey/study/importer/CreateChildStudyPipelineJob.java
@@ -187,7 +187,7 @@ public class CreateChildStudyPipelineJob extends AbstractStudyPipelineJob
                         // also add the visits included in this dataset
                         if (selectedVisits != null)
                         {
-                            for (Visit visit : StudyManager.getInstance().getVisitsForDataset(sourceStudy.getContainer(), startDateDataset.getDatasetId()))
+                            for (Visit visit : StudyManager.getInstance().getVisitsForDataset(user, sourceStudy.getContainer(), startDateDataset.getDatasetId()))
                                 selectedVisits.add(visit.getId());
                         }
                     }

--- a/study/src/org/labkey/study/model/DatasetDefinition.java
+++ b/study/src/org/labkey/study/model/DatasetDefinition.java
@@ -650,17 +650,17 @@ public class DatasetDefinition extends AbstractStudyEntity<Integer, DatasetDefin
      *
      * TODO convert usages of DatasetDefinition.getTableInfo() to use StudyQuerySchema.getTable()
      */
-    public DatasetSchemaTableInfo getDatasetSchemaTableInfo(User user) throws UnauthorizedException
+    public DatasetSchemaTableInfo getDatasetSchemaTableInfo(@NotNull User user) throws UnauthorizedException
     {
         return getDatasetSchemaTableInfo(user, true, false);
     }
 
-    public DatasetSchemaTableInfo getDatasetSchemaTableInfo(User user, boolean checkPermission) throws UnauthorizedException
+    public DatasetSchemaTableInfo getDatasetSchemaTableInfo(@NotNull User user, boolean checkPermission) throws UnauthorizedException
     {
         return getDatasetSchemaTableInfo(user, checkPermission, false);
     }
 
-    public DatasetSchemaTableInfo getDatasetSchemaTableInfo(User user, boolean checkPermission, boolean multiContainer) throws UnauthorizedException
+    public DatasetSchemaTableInfo getDatasetSchemaTableInfo(@NotNull User user, boolean checkPermission, boolean multiContainer) throws UnauthorizedException
     {
         //noinspection ConstantConditions
         if (user == null && checkPermission)

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -1797,7 +1797,7 @@ public class StudyManager
         return defaultQCState;
     }
 
-    private Map<String, VisitImpl> getVisitsForDataRows(DatasetDefinition def, Collection<String> dataLsids)
+    private Map<String, VisitImpl> getVisitsForDataRows(User user, DatasetDefinition def, Collection<String> dataLsids)
     {
         final Map<String, VisitImpl> visits = new HashMap<>();
 
@@ -1807,7 +1807,7 @@ public class StudyManager
         final Study study = def.getStudy();
         final Study visitStudy = getStudyForVisits(study);
 
-        TableInfo ds = def.getDatasetSchemaTableInfo(null, false);
+        TableInfo ds = def.getDatasetSchemaTableInfo(user, false);
 
         SQLFragment sql = new SQLFragment();
         sql.append("SELECT sd.LSID AS LSID, v.RowId AS RowId FROM ").append(ds.getFromSQL("sd")).append("\n" +
@@ -1833,12 +1833,12 @@ public class StudyManager
         return visits;
     }
 
-    public List<VisitImpl> getVisitsForDataset(Container container, int datasetId)
+    public List<VisitImpl> getVisitsForDataset(User user, Container container, int datasetId)
     {
         List<VisitImpl> visits = new ArrayList<>();
 
         DatasetDefinition def = getDatasetDefinition(getStudy(container), datasetId);
-        TableInfo ds = def.getDatasetSchemaTableInfo(null, false);
+        TableInfo ds = def.getDatasetSchemaTableInfo(user, false);
 
         final Study study = def.getStudy();
         final Study visitStudy = getStudyForVisits(study);
@@ -1871,7 +1871,7 @@ public class StudyManager
 
         Map<String, VisitImpl> lsidVisits = null;
         if (!def.isDemographicData())
-            lsidVisits = getVisitsForDataRows(def, lsids);
+            lsidVisits = getVisitsForDataRows(user, def, lsids);
         List<Map<String, Object>> rows = def.getDatasetRows(user, lsids);
         if (rows.isEmpty())
             return;

--- a/study/src/org/labkey/study/model/StudyManager.java
+++ b/study/src/org/labkey/study/model/StudyManager.java
@@ -1797,7 +1797,7 @@ public class StudyManager
         return defaultQCState;
     }
 
-    private Map<String, VisitImpl> getVisitsForDataRows(User user, DatasetDefinition def, Collection<String> dataLsids)
+    private Map<String, VisitImpl> getVisitsForDataRows(@NotNull User user, DatasetDefinition def, Collection<String> dataLsids)
     {
         final Map<String, VisitImpl> visits = new HashMap<>();
 
@@ -1833,7 +1833,7 @@ public class StudyManager
         return visits;
     }
 
-    public List<VisitImpl> getVisitsForDataset(User user, Container container, int datasetId)
+    public List<VisitImpl> getVisitsForDataset(@NotNull User user, Container container, int datasetId)
     {
         List<VisitImpl> visits = new ArrayList<>();
 

--- a/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySimpleExportTest.java
@@ -29,6 +29,7 @@ import org.labkey.test.categories.Daily;
 import org.labkey.test.components.DomainDesignerPage;
 import org.labkey.test.components.domain.DomainFormPanel;
 import org.labkey.test.components.ext4.Window;
+import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.pages.ImportDataPage;
 import org.labkey.test.pages.core.admin.BaseSettingsPage;
@@ -161,6 +162,11 @@ public class StudySimpleExportTest extends StudyBaseTest
         fieldsEditor.addField(new FieldDefinition("TestDate", FieldDefinition.ColumnType.DateAndTime).setLabel("TestDate"));
         // "TestDateTime" format will default to date-time
         fieldsEditor.addField(new FieldDefinition("TestDateTime", FieldDefinition.ColumnType.DateAndTime).setLabel("TestDateTime"));
+
+        // Issue 53929 : regression for updating QC state on dataset with a lookup
+        fieldsEditor.addField("Location").setType(FieldDefinition.ColumnType.Integer)
+                .setLookup(new FieldDefinition.IntLookup(null, "study", "Location"));
+
         editDatasetPage
             .clickSave()
             .clickViewData()
@@ -204,6 +210,17 @@ public class StudySimpleExportTest extends StudyBaseTest
             .setDefaultDirectEntryQCState("Third QC State")
             .setDefaultVisibility("Public data")
             .clickSave();
+
+        // Issue 53929 : set the QC state, no server side errors should occur
+        clickFolder(getFolderName());
+        clickAndWait(Locator.linkWithText("1 dataset"));
+        clickAndWait(Locator.linkWithText(TEST_DATASET_NAME));
+        BootstrapMenu.find(getDriver(), "QC State").clickSubMenu(true, "All data");
+        new DataRegionTable("Dataset", this).checkAll();
+        BootstrapMenu.find(getDriver(), "QC State").clickSubMenu(true, "Update state of selected rows");
+        selectOptionByText(Locator.name("newState"), "First QC State");
+        setFormElement(Locator.name("comments"), "Setting QC state.");
+        clickButton("Update Status");
 
         log("QC States: export study folder to the pipeline as individual files");
         exportFolderAsIndividualFiles(getFolderName(), false, false, false);


### PR DESCRIPTION
#### Rationale
[related issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53929)

Addresses an issue where we were failing to propagate the user object when updating the QC state for a dataset with a lookup field. This PR also contains the regression test for the issue.

#### Tasks 📍
- [x] Needs Automation
- [x] Verify Fix
