### PR TITLE
Fix bug in Ext4 store layer when table has more than one PK

### DIFF
--- a/api/webapp/clientapi/ext4/data/Proxy.js
+++ b/api/webapp/clientapi/ext4/data/Proxy.js
@@ -224,7 +224,7 @@ Ext4.define('LABKEY.ext4.data.AjaxProxy', {
 
                 // NOTE: if the 'id' property of the ApiQueryResponse is null, which will occur if there is more than 1 PK (see ApiQueryResponse.getMetaData()),
                 // then we need to ensure the original values of keyFields are still included in oldKeys. The check against record.modified should ensure we send the original value
-                this.reader.metaData.fields.filter(f => f.isKeyField).map(f => f.name).forEach(keyFieldName => {
+                this.reader?.metaData?.fields.filter(f => f.isKeyField).map(f => f.name).forEach(keyFieldName => {
                     oldKeys[keyFieldName] = record.modified?.hasOwnProperty(keyFieldName) ? record.modified[keyFieldName] : record.get(keyFieldName);
                 })
 

--- a/api/webapp/clientapi/ext4/data/Proxy.js
+++ b/api/webapp/clientapi/ext4/data/Proxy.js
@@ -222,7 +222,13 @@ Ext4.define('LABKEY.ext4.data.AjaxProxy', {
                 oldKeys[this.reader.getIdProperty()] = id;
                 oldKeys['_internalId'] = record.internalId;  //NOTE: also include internalId for records that do not have a server-assigned PK yet
 
-                if (command.command == 'delete'){
+                // NOTE: if the 'id' property of the ApiQueryResponse is null, which will occur if there is more than 1 PK (see ApiQueryResponse.getMetaData()),
+                // then we need to ensure the original values of keyFields are still included in oldKeys. The check against record.modified should ensure we send the original value
+                this.reader.metaData.fields.filter(f => f.isKeyField).map(f => f.name).forEach(keyFieldName => {
+                    oldKeys[keyFieldName] = record.modified?.hasOwnProperty(keyFieldName) ? record.modified[keyFieldName] : record.get(keyFieldName);
+                })
+
+                if (command.command === 'delete'){
                     command.rows.push(this.getRowData(record));
                 }
                 else {


### PR DESCRIPTION
I found a bug that will occur in the Ext4 store layer in fringe cases when the table has more than one PK. When this happens:

- ApiQueryResponse will write the property 'id' into the JSON only when there is a single PK: https://github.com/LabKey/platform/blob/f1e6c1e3715f4b3350c1559b9e55c2d340138ee8/api/src/org/labkey/api/action/ApiQueryResponse.java#L411
- If there's a single PK, 'id' is written, and the ExjJS Reader will store that: https://github.com/LabKey/platform/blob/f1e6c1e3715f4b3350c1559b9e55c2d340138ee8/api/webapp/clientapi/ext4/data/Reader.js#L32. If there are multiple PKs, this doesnt happen, and the model doesnt store the name of the PKs
- When the ExtJS Proxy submits data back to SaveRows, it looks at reader.getIdProperty() and uses that to populate "oldKeys' in the JSON. Since we never set the idProperty, this fails to include any of the PKs: https://github.com/LabKey/platform/blob/f1e6c1e3715f4b3350c1559b9e55c2d340138ee8/api/webapp/clientapi/ext4/data/Proxy.js#L218
- The result is that oldKeys lacks the PKs and the update fails.

This PR inspects the field objects, and if any are tagged as isKeyField, it will include their values in oldKeys.
