### PR TITLE
Issue 53416: Don't allow * as a field name

### DIFF
--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -116,6 +116,7 @@ public class DomainUtil
 {
     private static final Logger LOG = LogManager.getLogger(DomainUtil.class);
     public static final String ILLEGAL_DOMAIN_NAME_CHARSET = "<>[]{};,`\"~!@#$%^*=|?\\";
+    public static final Set<String> ILLEGAL_PROPERTY_NAMES = Set.of("*"); // Issue 53416
 
     private DomainUtil()
     {
@@ -1431,6 +1432,11 @@ public class DomainUtil
             {
                 exception.addError(new SimpleValidationError(getDomainErrorMessage(updates, "Please provide a name for each field.")));
                 continue;
+            }
+
+            if (ILLEGAL_PROPERTY_NAMES.contains(name.trim()))
+            {
+                exception.addError(new SimpleValidationError(getDomainErrorMessage(updates, "The field name '" + name + "' is not allowed.")));
             }
 
             Matcher expMatcher = SUBSTITUTION_EXP_PATTERN.matcher(name);


### PR DESCRIPTION
#### Rationale
Issue [53416](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53416) - When there is a field called "*" in your domain and you ask for a subset of fields that includes that field, you will actually get back all the fields. This causes problems with out bulk update processing (at least).

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1679

#### Changes
- Add a check in `DomainUtil.validateProperties` to check for illegal names (currently just the *)

#### Tasks 📍
- [ ] ~Manual Testing~
- [x] Needs Automation
