### PR TITLE
Throw InvalidPathException for prohibited path appending

### DIFF
--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -822,9 +822,7 @@ public class FileUtil
     public static File appendPath(File dir, org.labkey.api.util.Path originalPath)
     {
         org.labkey.api.util.Path path = originalPath.normalize();
-        if (path == null)
-            throw new InvalidPathException(originalPath.toString(), "Invalid path");
-        if (!path.isEmpty() && "..".equals(path.get(0)))
+        if (path == null || (!path.isEmpty() && "..".equals(path.get(0))))
             throw new InvalidPathException(originalPath.toString(), "Path to parent not allowed");
         @SuppressWarnings("SSBasedInspection")
         var ret = new File(dir, path.toString());
@@ -866,7 +864,7 @@ public class FileUtil
         var ret = new File(dir, name);
 
         if (!URIUtil.isDescendant(dir.toURI(), ret.toURI()))
-            throw new InvalidPathException(name, "Path to parent not allowed");
+            throw new InvalidPathException(name, "Name didn't resolve to a descendant of " + dir);
         return ret;
     }
 
@@ -877,7 +875,7 @@ public class FileUtil
         var ret = dir.resolve(name);
 
         if (!ret.normalize().startsWith(dir.normalize()))
-            throw new InvalidPathException(name, "Invalid file or directory name");
+            throw new InvalidPathException(name, "Name didn't resolve to a descendant of " + dir);
         return ret;
     }
 

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -65,6 +65,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -821,12 +822,14 @@ public class FileUtil
     public static File appendPath(File dir, org.labkey.api.util.Path originalPath)
     {
         org.labkey.api.util.Path path = originalPath.normalize();
-        if (path == null || (!path.isEmpty() && "..".equals(path.get(0))))
-            throw new IllegalArgumentException("Bad path: " + originalPath);
+        if (path == null)
+            throw new InvalidPathException(originalPath.toString(), "Invalid path");
+        if (!path.isEmpty() && "..".equals(path.get(0)))
+            throw new InvalidPathException(originalPath.toString(), "Path to parent not allowed");
         @SuppressWarnings("SSBasedInspection")
         var ret = new File(dir, path.toString());
         if (!URIUtil.isDescendant(dir.toURI(), ret.toURI()))
-            throw new IllegalArgumentException(path.toString());
+            throw new InvalidPathException(originalPath.toString(), "Path to parent not allowed");
         return ret;
     }
 
@@ -836,7 +839,7 @@ public class FileUtil
     {
         path = path.normalize();
         if (!path.isEmpty() && "..".equals(path.get(0)))
-            throw new IllegalArgumentException(path.toString());
+            throw new InvalidPathException(path.toString(), "Path to parent not allowed");
         return dir.resolveFile(path);
     }
 
@@ -863,7 +866,7 @@ public class FileUtil
         var ret = new File(dir, name);
 
         if (!URIUtil.isDescendant(dir.toURI(), ret.toURI()))
-            throw new IllegalArgumentException(name);
+            throw new InvalidPathException(name, "Path to parent not allowed");
         return ret;
     }
 
@@ -874,7 +877,7 @@ public class FileUtil
         var ret = dir.resolve(name);
 
         if (!ret.normalize().startsWith(dir.normalize()))
-            throw new IllegalArgumentException(name);
+            throw new InvalidPathException(name, "Invalid file or directory name");
         return ret;
     }
 
@@ -883,12 +886,11 @@ public class FileUtil
     // this check that a name is a valid path part (e.g. filename) and is not path like.
     private static void legalPathPartThrow(String name)
     {
-        if (StringUtils.contains(name, '/'))
-            throw new IllegalArgumentException(name);
-        if (StringUtils.contains(name, File.separatorChar))
-            throw new IllegalArgumentException(name);
+        int invalidCharacterIndex = StringUtils.indexOfAny(name, '/', File.separatorChar);
+        if (invalidCharacterIndex >= 0)
+            throw new InvalidPathException(name, "Invalid file or directory name", invalidCharacterIndex);
         if (".".equals(name) || "..".equals(name))
-            throw new IllegalArgumentException(name);
+            throw new InvalidPathException(name, "Invalid file or directory name");
     }
 
 


### PR DESCRIPTION
#### Rationale
We throw `IllegalArgumentException` when `FileUtil` is used to append file paths in a way we don't like. Using a more specific exception -- `InvalidPathException` -- for prohibited path appending will allow callers to do specific error handling. It will also fall under some existing error handling, such as in `PipelineProtocolFactory.getProtocolFile`.

The crawler has hit this error a couple of times:
```
java.lang.IllegalArgumentException: ">'>'"</script><img src="x" onerror="alert('8(')">.xml
	at org.labkey.api.util.FileUtil.legalPathPartThrow(FileUtil.java:887) ~[api-25.10-SNAPSHOT.jar:?]
	at org.labkey.api.util.FileUtil.appendName(FileUtil.java:873) ~[api-25.10-SNAPSHOT.jar:?]
	at org.labkey.api.pipeline.PipelineProtocolFactory.getProtocolFile(PipelineProtocolFactory.java:131) ~[api-25.10-SNAPSHOT.jar:?]
	at org.labkey.api.pipeline.file.AbstractFileAnalysisProtocolFactory.getProtocol(AbstractFileAnalysisProtocolFactory.java:365) ~[api-25.10-SNAPSHOT.jar:?]
	at org.labkey.pipeline.analysis.AnalysisController$ProtocolDetailsAction.getView(AnalysisController.java:495) ~[pipeline-25.10-SNAPSHOT.jar:?]
	at org.labkey.pipeline.analysis.AnalysisController$ProtocolDetailsAction.getView(AnalysisController.java:478) ~[pipeline-25.10-SNAPSHOT.jar:?]
```

#### Related Pull Requests
- #5912 

#### Changes
- Throw InvalidPathException for prohibited path appending