### PR TITLE
Issue 53764: JS error attempting to create a new standard assay design

### DIFF
--- a/assay/src/client/AssayTypeSelect/AssayTypeSelect.tsx
+++ b/assay/src/client/AssayTypeSelect/AssayTypeSelect.tsx
@@ -73,7 +73,7 @@ const AssayTypeSelect = memo(() => {
             })
         } else {
             window.location.href = ActionURL.buildURL('assay', 'designer', container, {
-                'providerName': assayPickerSelection.provider.name,
+                'providerName': assayPickerSelection.provider ? assayPickerSelection.provider.name : GENERAL_ASSAY_PROVIDER_NAME,
                 'returnUrl': returnUrl
             });
         }


### PR DESCRIPTION
#### Rationale
In some configurations, you had to toggle to a specialty assay and then back to the standard assay to successfully create one.

#### Changes
- Default to the general/standard assay type

#### Tasks 📍
- [x] Manual Testing @labkey-klum 
- Needs Automation - N/A
