### PR TITLE
Issue 53494: Deadlock between sample type design update and indexer

### DIFF
--- a/api/src/org/labkey/api/cache/BlockingCache.java
+++ b/api/src/org/labkey/api/cache/BlockingCache.java
@@ -96,9 +96,12 @@ public class BlockingCache<K, V> implements Cache<K, V>
     {
         Wrapper<V> w;
 
+        if (null == loader)
+            loader = _loader;
+
         try (var ignored = DebugInfoDumper.pushThreadDumpContext(this.getClass().getSimpleName() + ".get(" + key + ")"))
         {
-            synchronized(_cache)
+            synchronized (loader == null ? _cache : loader.getSyncObject(_cache))
             {
                 w = _cache.get(key);
                 if (null == w)
@@ -153,9 +156,6 @@ public class BlockingCache<K, V> implements Cache<K, V>
 
             try
             {
-                if (null == loader)
-                    loader = _loader;
-
                 if (null == loader)
                     throw new IllegalStateException("cache loader was not provided");
 

--- a/api/src/org/labkey/api/cache/Cache.java
+++ b/api/src/org/labkey/api/cache/Cache.java
@@ -42,21 +42,14 @@ public interface Cache<K, V>
      */
     int removeUsingFilter(Predicate<K> filter);
 
-    class StringPrefixFilter implements Predicate<String>
-    {
-        private final String _prefix;
-
-        public StringPrefixFilter(String prefix)
+    record StringPrefixFilter(String prefix) implements Predicate<String>
         {
-            _prefix = prefix;
+            @Override
+            public boolean test(String s)
+            {
+                return s.startsWith(prefix);
+            }
         }
-
-        @Override
-        public boolean test(String s)
-        {
-            return s.startsWith(_prefix);
-        }
-    }
 
     Set<K> getKeys();
 

--- a/api/src/org/labkey/api/cache/CacheLoader.java
+++ b/api/src/org/labkey/api/cache/CacheLoader.java
@@ -25,4 +25,13 @@ import org.jetbrains.annotations.Nullable;
 public interface CacheLoader<K, V>
 {
     V load(@NotNull K key, @Nullable Object argument);
+
+    /**
+     * Returns an object that can be used to synchronize access to the cache. Typically, the cache itself but it's
+     * OK to swap with another lock object when running inside of a transaction to reduce the likelihood of deadlocks.
+     */
+    default Object getSyncObject(Cache<?, ?> cache)
+    {
+        return cache;
+    }
 }

--- a/api/src/org/labkey/api/data/TransactionCache.java
+++ b/api/src/org/labkey/api/data/TransactionCache.java
@@ -69,6 +69,23 @@ public class TransactionCache<K, V> implements Cache<K, V>
         return get(key, null, null);
     }
 
+
+    /** A dummy loader that never fetches a value. Lets us see if the shared cache already has a value for this key. */
+    private final CacheLoader<K, V> _nonLoader = new CacheLoader<K, V>()
+    {
+        @Override
+        public V load(@NotNull K key, @Nullable Object argument)
+        {
+            throw new MissingCacheEntryException();
+        }
+
+        @Override
+        public Object getSyncObject(Cache<?, ?> cache)
+        {
+            return TransactionCache.this;
+        }
+    };
+
     @Override
     public V get(@NotNull K key, Object arg, @Nullable CacheLoader<K, V> loader)
     {
@@ -85,9 +102,7 @@ public class TransactionCache<K, V> implements Cache<K, V>
             try
             {
                 // Entry has not been modified in the private cache, so read through to shared cache
-                v = _sharedCache.get(key, null, (key1, argument) -> {
-                    throw new MissingCacheEntryException();
-                });
+                v = _sharedCache.get(key, null, _nonLoader);
                 // Shared cache has an entry for this key, so return it and don't invoke the loader
                 if (null == v)
                     v = NULL_MARKER; // Cached miss in shared cache; use null marker to skip loading. Issue 47234

--- a/api/src/org/labkey/api/query/UserSchema.java
+++ b/api/src/org/labkey/api/query/UserSchema.java
@@ -273,7 +273,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
         if (!canReadSchema())
             return null; // See #21014
 
-        TableInfo table = null;
+        TableInfo table;
         String cacheKey = cacheKey(name, cf, includeExtraMetadata, forWrite);
         if (null != cacheKey)
         {
@@ -281,8 +281,7 @@ abstract public class UserSchema extends AbstractSchema implements MemTrackable
             if (null != table)
                 return table;
         }
-        if (null == table)
-            table = createTable(name, cf, includeExtraMetadata);
+        table = createTable(name, cf, includeExtraMetadata);
         Object torq;
 
         if (table != null)

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -931,8 +931,6 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
             }
         }
 
-        // NOTE cacheMaterialSource() of course calls transactioncache.put(), which does not alter the shared cache! (BUG?)
-        // Just call uncache(), and let normal cache loading do its thing
         SampleTypeServiceImpl.get().clearMaterialSourceCache(getContainer());
     }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -1108,7 +1108,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 oldProps.put("DashboardContainerExclusions", exclusionChanges.first);
                 newProps.put("DashboardContainerExclusions", exclusionChanges.second);
             }
-try { Thread.sleep(60000); } catch (InterruptedException e) { }
+
             errors = DomainUtil.updateDomainDescriptor(original, update, container, user, hasNameChange, changeDetails.toString(), auditUserComment, oldProps, newProps);
 
             if (!errors.hasErrors())

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -42,6 +42,7 @@ import org.labkey.api.data.AuditConfigurable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.DatabaseCache;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DbSequence;
@@ -102,7 +103,6 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.MetadataUnavailableException;
 import org.labkey.api.query.QueryChangeListener;
-import org.labkey.api.query.QueryKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.SimpleValidationError;
@@ -141,7 +141,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
@@ -190,10 +189,11 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
     private static final Logger LOG = LogHelper.getLogger(SampleTypeServiceImpl.class, "Info about sample type operations");
 
-    // SampleType -> Container cache
+    /** SampleType LSID -> Container cache */
     private final Cache<String, String> sampleTypeCache = CacheManager.getStringKeyCache(CacheManager.UNLIMITED, CacheManager.DAY, "SampleType to container");
 
-    private final Cache<String, SortedSet<MaterialSource>> materialSourceCache = CacheManager.getBlockingStringKeyCache(CacheManager.UNLIMITED, CacheManager.DAY, "Material sources", (container, argument) ->
+    /** ContainerId -> MaterialSources */
+    private final Cache<String, SortedSet<MaterialSource>> materialSourceCache = DatabaseCache.get(ExperimentServiceImpl.get().getSchema().getScope(), CacheManager.UNLIMITED, CacheManager.DAY, "Material sources", (container, argument) ->
     {
         Container c = ContainerManager.getForId(container);
         if (c == null)
@@ -903,9 +903,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                     else
                         ExperimentService.get().ensureDataTypeContainerExclusionsNonAdmin(ExperimentService.DataTypeForExclusion.DashboardSampleType, st.getRowId(), c, u);
                     transaction.addCommitTask(() -> clearMaterialSourceCache(c), DbScope.CommitTaskOption.IMMEDIATE, POSTCOMMIT, POSTROLLBACK);
-                    transaction.addCommitTask(() -> {
-                        indexSampleType(SampleTypeService.get().getSampleType(domain.getTypeURI()), SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified));
-                    }, POSTCOMMIT);
+                    transaction.addCommitTask(() -> indexSampleType(SampleTypeService.get().getSampleType(domain.getTypeURI()), SearchService.get().defaultTask().getQueue(c, SearchService.PRIORITY.modified)), POSTCOMMIT);
 
                     return st;
                 }
@@ -961,8 +959,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         public DbSequence getDbSequence(Date date)
         {
             Pair<String,Integer> seqName = getSequenceName(date);
-            final DbSequence seq = DbSequenceManager.getPreallocatingSequence(ContainerManager.getRoot(), seqName.first, seqName.second, 100);
-            return seq;
+            return DbSequenceManager.getPreallocatingSequence(ContainerManager.getRoot(), seqName.first, seqName.second, 100);
         }
     }
 
@@ -1032,7 +1029,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             validateSampleTypeName(container, user, newName, oldSampleTypeName.equalsIgnoreCase(newName));
             hasNameChange = true;
             st.setName(newName);
-            changeDetails.append("The name of the sample type '" + oldSampleTypeName + "' was changed to '" + newName + "'.");
+            changeDetails.append("The name of the sample type '").append(oldSampleTypeName).append("' was changed to '").append(newName).append("'.");
         }
 
         String newDescription = StringUtils.trimToNull(update.getDescription());
@@ -1111,7 +1108,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 oldProps.put("DashboardContainerExclusions", exclusionChanges.first);
                 newProps.put("DashboardContainerExclusions", exclusionChanges.second);
             }
-
+try { Thread.sleep(60000); } catch (InterruptedException e) { }
             errors = DomainUtil.updateDomainDescriptor(original, update, container, user, hasNameChange, changeDetails.toString(), auditUserComment, oldProps, newProps);
 
             if (!errors.hasErrors())
@@ -1544,7 +1541,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             return null;
 
         Unit totalUnit = null;
-        String totalUnitsStr = null;
+        String totalUnitsStr;
         if (!StringUtils.isEmpty(sampleTypeUnitsStr))
             totalUnitsStr = sampleTypeUnitsStr;
         else if (!StringUtils.isEmpty(sampleItemUnitsStr))
@@ -1864,9 +1861,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 if (inventoryService != null)
                 {
                     Map<String, Integer> inventoryCounts = inventoryService.moveSamples(sampleIds, targetContainer, user);
-                    inventoryCounts.forEach((key, count) -> {
-                        updateCounts.compute(key, (k, c) -> c == null ? count : c + count);
-                    });
+                    inventoryCounts.forEach((key, count) -> updateCounts.compute(key, (k, c) -> c == null ? count : c + count));
                 }
 
                 // create summary audit entries for the source and target containers
@@ -2213,7 +2208,6 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         Container seqContainer = container.getProject();
         DbSequenceManager.delete(seqContainer, seqName);
         DbSequenceManager.invalidatePreallocatingSequence(container, seqName, 0);
-        return;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We can improve our synchronization to help reduce deadlock potential when loading caches inside of transactions.

#### Changes
- Switch to use DB/Transaction aware caching for sample types
- When checking the shared cache within a transaction, avoid using the same sync object since we won't be loading anyway
