### PR TITLE
Remote API stream to file

### DIFF
--- a/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -122,8 +122,7 @@ public class SelectRowsStreamHack
                         public void close() throws IOException
                         {
                             // close the InputStream and http connection
-                            if (is != null)
-                                IOUtils.closeQuietly(is);
+                            IOUtils.closeQuietly(is);
                             response.close();
 
                             // close the JSONDataLoader
@@ -212,20 +211,16 @@ public class SelectRowsStreamHack
 
                 // Now try this using an InputStream that will fail:
                 preexistingTempFiles = getMatchingTempFileNames();
-                boolean exceptionThrown = false;
 
                 SelfDestructiveInputStream sdic = new SelfDestructiveInputStream(100, 10);
                 try
                 {
                     dib = SelectRowsStreamHack.go(cn, ContainerManager.getHomeContainer().getPath(), cmd, targetContainer, sdic);
-                    List<Map<String, Object>> results = dib.getDataIterator(dic).stream().toList();
+                    @SuppressWarnings("unused") List<Map<String, Object>> results = dib.getDataIterator(dic).stream().toList();
+                    fail("SelfDestructiveInputStream did not throw an exception!");
                 }
-                catch (Exception e)
-                {
-                    exceptionThrown = true;
-                }
+                catch (Exception ignored) {}
 
-                assertTrue("SelfDestructiveInputStream did not throw an exception!", exceptionThrown);
                 assertTrue("SelfDestructiveInputStream was not closed!", sdic.isCloseCalled());
 
                 actualTempFiles = getMatchingTempFileNames();
@@ -236,7 +231,9 @@ public class SelectRowsStreamHack
 
         private Set<String> getMatchingTempFileNames()
         {
-            return Arrays.stream(Objects.requireNonNull(new File(System.getProperty("java.io.tmpdir")).list((dir, name) -> name.startsWith(TEMP_FILE_PREFIX) & name.endsWith(TEMP_FILE_SUFFIX)))).collect(Collectors.toSet());
+            return Arrays.stream(Objects.requireNonNull(new File(System.getProperty("java.io.tmpdir")).
+                    list((dir, name) -> name.startsWith(TEMP_FILE_PREFIX) &&
+                            name.endsWith(TEMP_FILE_SUFFIX)))).collect(Collectors.toSet());
         }
 
         private static class SelfDestructiveInputStream extends InputStream

--- a/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -16,6 +16,7 @@
 package org.labkey.remoteapi;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.Container;
 import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
@@ -23,10 +24,20 @@ import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.WrapperDataIterator;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.JSONDataLoader;
+import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 /**
  * NOTE: This class only exists to use internal classes of the remoteapi package that we haven't exposed to the public yet.
@@ -39,6 +50,8 @@ import java.io.InputStream;
  */
 public class SelectRowsStreamHack
 {
+    private static final Logger _log = LogHelper.getLogger(SelectRowsStreamHack.class, "Information related to streaming of SelectRows results");
+
     public static DataIteratorBuilder go(Connection cn, String container, SelectRowsCommand cmd, Container targetContainer) throws IOException, CommandException
     {
         return new DataIteratorBuilder()
@@ -60,7 +73,36 @@ public class SelectRowsStreamHack
                 }
                 try
                 {
-                    final InputStream is = response.getInputStream();
+                    final InputStream is;
+                    final File tempFile = FileUtil.createTempFile("SelectRows-", ".tmp.gz");
+                    tempFile.deleteOnExit();
+
+                    try (OutputStream os = new BufferedOutputStream(new GZIPOutputStream(new FileOutputStream(tempFile))); InputStream ris = response.getInputStream())
+                    {
+                        _log.debug("Downloading SelectRows JSON to file: " + tempFile);
+                        IOUtils.copy(ris, os);
+                        _log.debug("Finished saving SelectRows results");
+
+                    }
+
+                    is = new BufferedInputStream(new GZIPInputStream(new FileInputStream(tempFile)))
+                    {
+                        @Override
+                        public void close() throws IOException
+                        {
+                            super.close();
+
+                            if (tempFile.exists())
+                            {
+                                _log.debug("Deleting temporary file used to download SelectRows results: " + tempFile);
+                                if (!tempFile.delete())
+                                {
+                                    _log.error("Unable to delete SelectRowsStreamHack temp file: " + tempFile);
+                                }
+                            }
+                        }
+                    };
+
                     final JSONDataLoader loader = new JSONDataLoader(is, targetContainer);
                     WrapperDataIterator wrapper = new WrapperDataIterator(loader.getDataIterator(context))
                     {
@@ -88,5 +130,4 @@ public class SelectRowsStreamHack
             }
         };
     }
-
 }

--- a/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -17,14 +17,21 @@ package org.labkey.remoteapi;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+import org.junit.Test;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.dataiterator.DataIterator;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
 import org.labkey.api.dataiterator.WrapperDataIterator;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.JSONDataLoader;
+import org.labkey.api.security.SecurityManager;
+import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.TestContext;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 
@@ -36,6 +43,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -52,7 +65,16 @@ public class SelectRowsStreamHack
 {
     private static final Logger _log = LogHelper.getLogger(SelectRowsStreamHack.class, "Information related to streaming of SelectRows results");
 
+    private static final String TEMP_FILE_PREFIX = "SelectRows-";
+    private static final String TEMP_FILE_SUFFIX = ".tmp.gz";
+
     public static DataIteratorBuilder go(Connection cn, String container, SelectRowsCommand cmd, Container targetContainer) throws IOException, CommandException
+    {
+        return  go(cn, container, cmd, targetContainer, null);
+    }
+
+    // This private method and alternateInputStream are only intended for testing purposes:
+    private static DataIteratorBuilder go(Connection cn, String container, SelectRowsCommand cmd, Container targetContainer, @Nullable InputStream alternateInputStream) throws IOException, CommandException
     {
         return new DataIteratorBuilder()
         {
@@ -71,37 +93,27 @@ public class SelectRowsStreamHack
                 {
                     throw new RuntimeException("Failed to execute remote query", e);
                 }
+
                 try
                 {
-                    final InputStream is;
-                    final File tempFile = FileUtil.createTempFile("SelectRows-", ".tmp.gz");
+                    final File tempFile = FileUtil.createTempFile(TEMP_FILE_PREFIX, TEMP_FILE_SUFFIX);
                     tempFile.deleteOnExit();
 
-                    try (OutputStream os = new BufferedOutputStream(new GZIPOutputStream(new FileOutputStream(tempFile))); InputStream ris = response.getInputStream())
+                    try (OutputStream os = new BufferedOutputStream(new GZIPOutputStream(new FileOutputStream(tempFile))); InputStream ris = (alternateInputStream == null ? response.getInputStream() : alternateInputStream))
                     {
                         _log.debug("Downloading SelectRows JSON to file: " + tempFile);
                         IOUtils.copy(ris, os);
                         _log.debug("Finished saving SelectRows results");
+                    }
+                    catch (Exception e)
+                    {
+                        _log.error("Error loading SelectRows results", e);
+                        ensureTempFileDeleted(tempFile);
 
+                        throw e;
                     }
 
-                    is = new BufferedInputStream(new GZIPInputStream(new FileInputStream(tempFile)))
-                    {
-                        @Override
-                        public void close() throws IOException
-                        {
-                            super.close();
-
-                            if (tempFile.exists())
-                            {
-                                _log.debug("Deleting temporary file used to download SelectRows results: " + tempFile);
-                                if (!tempFile.delete())
-                                {
-                                    _log.error("Unable to delete SelectRowsStreamHack temp file: " + tempFile);
-                                }
-                            }
-                        }
-                    };
+                    final InputStream is = getFileDeletingInputStream(tempFile);
 
                     final JSONDataLoader loader = new JSONDataLoader(is, targetContainer);
                     WrapperDataIterator wrapper = new WrapperDataIterator(loader.getDataIterator(context))
@@ -116,6 +128,8 @@ public class SelectRowsStreamHack
 
                             // close the JSONDataLoader
                             super.close();
+
+                            ensureTempFileDeleted(tempFile);
                         }
                     };
                     wrapper.setDebugName("SelectRows:JSONDataLoader");
@@ -128,6 +142,149 @@ public class SelectRowsStreamHack
                     return null;
                 }
             }
+
+            private static InputStream getFileDeletingInputStream(final File tempFile) throws IOException
+            {
+                return new BufferedInputStream(new GZIPInputStream(new FileInputStream(tempFile)))
+                {
+                    @Override
+                    public void close() throws IOException
+                    {
+                        super.close();
+
+                        ensureTempFileDeleted(tempFile);
+                    }
+                };
+            }
+
+            private static void ensureTempFileDeleted(@Nullable File tempFile)
+            {
+                if (tempFile == null)
+                {
+                    return;
+                }
+
+                if (tempFile.exists())
+                {
+                    _log.debug("Deleting temporary file used to download SelectRows results: {}", tempFile);
+                    if (!tempFile.delete())
+                    {
+                        _log.error("Unable to delete SelectRowsStreamHack temp file: {}", tempFile);
+                    }
+                }
+            }
         };
+    }
+
+    public static class TestCase extends Assert
+    {
+        @Test
+        public void testFileDeletion() throws Exception
+        {
+            try (var session = SecurityManager.createTransformSession(TestContext.get().getRequest(), TestContext.get().getRequest().getSession()))
+            {
+                String baseURL = AppProps.getInstance().getBaseServerUrl() + AppProps.getInstance().getContextPath();
+                Connection cn = new Connection(baseURL, new ApiKeyCredentialsProvider(session.getApiKey()));
+
+                SelectRowsCommand cmd = new SelectRowsCommand("core", "containers");
+                Container targetContainer = ContainerManager.getHomeContainer();
+                final long expectedRows = cmd.execute(cn, ContainerManager.getHomeContainer().getPath()).getRowCount().longValue();
+
+                Set<String> preexistingTempFiles = getMatchingTempFileNames();
+
+                DataIteratorBuilder dib = SelectRowsStreamHack.go(cn, ContainerManager.getHomeContainer().getPath(), cmd, targetContainer);
+                DataIteratorContext dic = new DataIteratorContext();
+
+                DataIterator di = dib.getDataIterator(dic);
+
+                // This should create the file:
+                Set<String> actualTempFiles = getMatchingTempFileNames();
+                assertEquals("Temp file not created", preexistingTempFiles.size() + 1, actualTempFiles.size());
+
+                // This should iterate and close the stream:
+                long actualCount = di.stream().count();
+                assertEquals("Incorrect row count", expectedRows, actualCount);
+
+                // The file should be deleted now:
+                actualTempFiles = getMatchingTempFileNames();
+                actualTempFiles.removeAll(preexistingTempFiles);
+                assertEquals("Temp files were not deleted, found: " + actualTempFiles.size(), 0, actualTempFiles.size());
+
+                // Now try this using an InputStream that will fail:
+                preexistingTempFiles = getMatchingTempFileNames();
+                boolean exceptionThrown = false;
+
+                SelfDestructiveInputStream sdic = new SelfDestructiveInputStream(100, 10);
+                try
+                {
+                    dib = SelectRowsStreamHack.go(cn, ContainerManager.getHomeContainer().getPath(), cmd, targetContainer, sdic);
+                    List<Map<String, Object>> results = dib.getDataIterator(dic).stream().toList();
+                }
+                catch (Exception e)
+                {
+                    exceptionThrown = true;
+                }
+
+                assertTrue("SelfDestructiveInputStream did not throw an exception!", exceptionThrown);
+                assertTrue("SelfDestructiveInputStream was not closed!", sdic.isCloseCalled());
+
+                actualTempFiles = getMatchingTempFileNames();
+                actualTempFiles.removeAll(preexistingTempFiles);
+                assertEquals("Temp files were not deleted, found: " + actualTempFiles.size(), 0, actualTempFiles.size());
+            }
+        }
+
+        private Set<String> getMatchingTempFileNames()
+        {
+            return Arrays.stream(Objects.requireNonNull(new File(System.getProperty("java.io.tmpdir")).list((dir, name) -> name.startsWith(TEMP_FILE_PREFIX) & name.endsWith(TEMP_FILE_SUFFIX)))).collect(Collectors.toSet());
+        }
+
+        private static class SelfDestructiveInputStream extends InputStream
+        {
+            private final long _maxReads;
+            private final long _delayMs;
+
+            private long _count = 0;
+            private boolean _closeCalled = false;
+
+            public SelfDestructiveInputStream(long maxReads, long delayMs)
+            {
+                _maxReads = maxReads;
+                _delayMs = delayMs;
+            }
+
+            @Override
+            public int read() throws IOException
+            {
+                try
+                {
+                    Thread.sleep(_delayMs);
+                }
+                catch (InterruptedException e)
+                {
+                    throw new IOException(e);
+                }
+
+                _count++;
+                if (_count >= _maxReads)
+                {
+                    throw new IOException("I'm throwing an IOException!");
+                }
+
+                return 0;
+            }
+
+            @Override
+            public void close() throws IOException
+            {
+                _closeCalled = true;
+                super.close();
+            }
+
+            public boolean isCloseCalled()
+            {
+                return _closeCalled;
+            }
+        }
     }
 }

--- a/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -66,7 +66,7 @@ public class SelectRowsStreamHack
     private static final Logger _log = LogHelper.getLogger(SelectRowsStreamHack.class, "Information related to streaming of SelectRows results");
 
     private static final String TEMP_FILE_PREFIX = "SelectRows-";
-    private static final String TEMP_FILE_SUFFIX = ".tmp.gz";
+    private static final String TEMP_FILE_SUFFIX = ".remote.tmp.gz";
 
     public static DataIteratorBuilder go(Connection cn, String container, SelectRowsCommand cmd, Container targetContainer) throws IOException, CommandException
     {

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -127,6 +127,7 @@ import org.labkey.query.sql.SqlParser;
 import org.labkey.query.view.InheritedQueryDataViewProvider;
 import org.labkey.query.view.QueryDataViewProvider;
 import org.labkey.query.view.QueryWebPartFactory;
+import org.labkey.remoteapi.SelectRowsStreamHack;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -356,7 +357,8 @@ public class QueryModule extends DefaultModule
             QueryServiceImpl.TestCase.class,
             RolapReader.RolapTest.class,
             RolapTestCase.class,
-            ServerManager.TestCase.class
+            ServerManager.TestCase.class,
+            SelectRowsStreamHack.TestCase.class
         );
     }
 


### PR DESCRIPTION
#### Rationale
The current remote streaming API will keep a connection open while processing rows in the data iterator. This can cause connection timeout issues with large tables if there is a lot of processing in triggers or other data iterator steps. The refactor in this PR will stream the remote server response to file before any processing in the dataiterator, then stream from file into the dataiterator. This will be the default method for streaming from remote API.

This PR is based on the related PR from @bbimber. Thanks Ben.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7021
- https://github.com/LabKey/premiumModules/pull/363

#### Changes
- Save remote server response to temp file.
- Pass stream from file to dataiterator.
- Cleanup file when done.