### PR TITLE
Add `DomainUtil.getNamesAndLabels` utility method for use in reserving variants of column names 

### DIFF
--- a/api/src/org/labkey/api/audit/query/AbstractAuditDomainKind.java
+++ b/api/src/org/labkey/api/audit/query/AbstractAuditDomainKind.java
@@ -302,7 +302,7 @@ public abstract class AbstractAuditDomainKind extends DomainKind<JSONObject>
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         Set<String> names = new HashSet<>();
 

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -44,8 +44,8 @@ import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.TemplateInfo;
 import org.labkey.api.exp.property.AbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
-import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.ExpSampleTypeTable;
 import org.labkey.api.exp.query.SamplesSchema;
@@ -109,13 +109,12 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
             new PropertyStorageSpec("name", JdbcType.VARCHAR, 200)
         )));
 
-        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainKind.namesAndLabels(
+        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.namesAndLabels(
                 BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()))
         );
-        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(COMMON_RESERVED_PROPERTY_NAMES));
-        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(Arrays.stream(ExpSampleTypeTable.Column.values()).map(Enum::name).toList()));
-        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(Arrays.stream(ExpMaterialTable.Column.values()).map(Enum::name).toList()));
-        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(List.of(
+        RESERVED_NAMES.addAll(DomainUtil.namesAndLabels(Arrays.stream(ExpSampleTypeTable.Column.values()).map(Enum::name).toList()));
+        RESERVED_NAMES.addAll(DomainUtil.namesAndLabels(Arrays.stream(ExpMaterialTable.Column.values()).map(Enum::name).toList()));
+        RESERVED_NAMES.addAll(DomainUtil.namesAndLabels(List.of(
                 "SampleType", // Issue 52716
                 "Protocol", // alias for "SourceProtocolApplication"
                 "SampleTypeUnits", // alias for MetricUnit
@@ -133,7 +132,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
                 "Amount", // alias for storedAmount
                 "RunId"
         )));
-        RESERVED_NAMES.addAll(ALIQUOT_ROLLUP_FIELD_LABELS);
+        RESERVED_NAMES.addAll(DomainUtil.namesAndLabels(ALIQUOT_ROLLUP_FIELD_LABELS));
         RESERVED_NAMES.addAll(InventoryService.InventoryStatusColumn.namesAndLabels());
 
         FOREIGN_KEYS = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -127,6 +127,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
                 "AliquotUnit",
                 "ExpirationDate", // alias for MaterialExpDate
                 "Ancestors",
+                "Container",
                 "SampleID", // alias for Name
                 "Status",
                 "Amount", // alias for storedAmount

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -18,13 +18,11 @@ package org.labkey.api.exp.api;
 
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.compliance.ComplianceService;
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
@@ -46,6 +44,7 @@ import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.TemplateInfo;
 import org.labkey.api.exp.property.AbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.exp.query.ExpMaterialTable;
 import org.labkey.api.exp.query.ExpSampleTypeTable;
@@ -110,38 +109,31 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
             new PropertyStorageSpec("name", JdbcType.VARCHAR, 200)
         )));
 
-        RESERVED_NAMES = BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet());
-        RESERVED_NAMES.addAll(Arrays.stream(ExpSampleTypeTable.Column.values()).map(ExpSampleTypeTable.Column::name).toList());
-        RESERVED_NAMES.addAll(Arrays.stream(ExpSampleTypeTable.Column.values()).map(col -> ColumnInfo.labelFromName(col.name())).toList());
-        RESERVED_NAMES.addAll(Arrays.stream(ExpMaterialTable.Column.values()).map(ExpMaterialTable.Column::name).toList());
-        RESERVED_NAMES.addAll(Arrays.stream(ExpMaterialTable.Column.values()).map(col -> ColumnInfo.labelFromName(col.name())).toList());
-        RESERVED_NAMES.add("Sample Type"); // Issue 52716
-        RESERVED_NAMES.add("SampleType"); // Issue 52716
-        RESERVED_NAMES.add("Protocol"); // alias for "SourceProtocolApplication"
-        RESERVED_NAMES.add("SampleTypeUnits"); // alias for MetricUnit
-        RESERVED_NAMES.add("Sample Type Units");
-        RESERVED_NAMES.add("CpasType");
-        RESERVED_NAMES.add("Cpas Type");
-        RESERVED_NAMES.add(ExpMaterial.ALIQUOTED_FROM_INPUT);
-        RESERVED_NAMES.add("Aliquoted From");
+        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainKind.namesAndLabels(
+                BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()))
+        );
+        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(COMMON_RESERVED_PROPERTY_NAMES));
+        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(Arrays.stream(ExpSampleTypeTable.Column.values()).map(Enum::name).toList()));
+        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(Arrays.stream(ExpMaterialTable.Column.values()).map(Enum::name).toList()));
+        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(List.of(
+                "SampleType", // Issue 52716
+                "Protocol", // alias for "SourceProtocolApplication"
+                "SampleTypeUnits", // alias for MetricUnit
+                "CpasType",
+                ExpMaterial.ALIQUOTED_FROM_INPUT,
+                "AliquotTotalVolume", // Issue 52158
+                "AliquotedFromParent",
+                "RootMaterial",
+                "RecomputeRollup",
+                "AliquotUnit",
+                "ExpirationDate", // alias for MaterialExpDate
+                "Ancestors",
+                "SampleID", // alias for Name
+                "Status",
+                "Amount", // alias for storedAmount
+                "RunId"
+        )));
         RESERVED_NAMES.addAll(ALIQUOT_ROLLUP_FIELD_LABELS);
-        RESERVED_NAMES.add("AliquotTotalVolume"); // Issue 52158: Sample Manager: data type reserved field name and label inconsistencies
-        RESERVED_NAMES.add("Aliquot Total Volume"); // Issue 52158: Sample Manager: data type reserved field name and label inconsistencies
-        RESERVED_NAMES.add("Aliquoted From Parent");
-        RESERVED_NAMES.add("Root Material");
-        RESERVED_NAMES.add("RecomputeRollup");
-        RESERVED_NAMES.add("Recompute Rollup");
-        RESERVED_NAMES.add("Aliquot Unit");
-        RESERVED_NAMES.add("ExpirationDate"); // alias for MaterialExpDate
-        RESERVED_NAMES.add("Expiration Date");
-        RESERVED_NAMES.add("Ancestors");
-        RESERVED_NAMES.add("Container");
-        RESERVED_NAMES.add("SampleID"); // alias for Name
-        RESERVED_NAMES.add("Sample ID");
-        RESERVED_NAMES.add("Status");
-        RESERVED_NAMES.add("Amount"); // alias for storedAmount
-        RESERVED_NAMES.add("RunId"); // Issue 50461
-        RESERVED_NAMES.add("Run Id");
         RESERVED_NAMES.addAll(InventoryService.InventoryStatusColumn.namesAndLabels());
 
         FOREIGN_KEYS = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -109,12 +109,12 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
             new PropertyStorageSpec("name", JdbcType.VARCHAR, 200)
         )));
 
-        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.namesAndLabels(
+        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(
                 BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()))
         );
-        RESERVED_NAMES.addAll(DomainUtil.namesAndLabels(Arrays.stream(ExpSampleTypeTable.Column.values()).map(Enum::name).toList()));
-        RESERVED_NAMES.addAll(DomainUtil.namesAndLabels(Arrays.stream(ExpMaterialTable.Column.values()).map(Enum::name).toList()));
-        RESERVED_NAMES.addAll(DomainUtil.namesAndLabels(List.of(
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(Arrays.stream(ExpSampleTypeTable.Column.values()).map(Enum::name).toList()));
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(Arrays.stream(ExpMaterialTable.Column.values()).map(Enum::name).toList()));
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(List.of(
                 "SampleType", // Issue 52716
                 "Protocol", // alias for "SourceProtocolApplication"
                 "SampleTypeUnits", // alias for MetricUnit
@@ -132,7 +132,7 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
                 "Amount", // alias for storedAmount
                 "RunId"
         )));
-        RESERVED_NAMES.addAll(DomainUtil.namesAndLabels(ALIQUOT_ROLLUP_FIELD_LABELS));
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(ALIQUOT_ROLLUP_FIELD_LABELS));
         RESERVED_NAMES.addAll(InventoryService.InventoryStatusColumn.namesAndLabels());
 
         FOREIGN_KEYS = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(
@@ -261,13 +261,13 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return getReservedPropertyNames(domain, user, false);
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user, boolean forCreate)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user, boolean forCreate)
     {
         Set<String> reserved = new CaseInsensitiveHashSet(RESERVED_NAMES);
 

--- a/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeDomainKind.java
@@ -109,12 +109,10 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
             new PropertyStorageSpec("name", JdbcType.VARCHAR, 200)
         )));
 
-        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(
-                BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()))
-        );
-        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(Arrays.stream(ExpSampleTypeTable.Column.values()).map(Enum::name).toList()));
-        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(Arrays.stream(ExpMaterialTable.Column.values()).map(Enum::name).toList()));
-        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(List.of(
+        Set<String> names = BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet());
+        names.addAll(Arrays.stream(ExpSampleTypeTable.Column.values()).map(Enum::name).toList());
+        names.addAll(Arrays.stream(ExpMaterialTable.Column.values()).map(Enum::name).toList());
+        names.addAll(List.of(
                 "SampleType", // Issue 52716
                 "Protocol", // alias for "SourceProtocolApplication"
                 "SampleTypeUnits", // alias for MetricUnit
@@ -132,8 +130,9 @@ public class SampleTypeDomainKind extends AbstractDomainKind<SampleTypeDomainKin
                 "Status",
                 "Amount", // alias for storedAmount
                 "RunId"
-        )));
-        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(ALIQUOT_ROLLUP_FIELD_LABELS));
+        ));
+        names.addAll(ALIQUOT_ROLLUP_FIELD_LABELS);
+        RESERVED_NAMES = DomainUtil.getNamesAndLabels(names);
         RESERVED_NAMES.addAll(InventoryService.InventoryStatusColumn.namesAndLabels());
 
         FOREIGN_KEYS = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -20,7 +20,6 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchemaType;
@@ -37,7 +36,6 @@ import org.labkey.api.exp.TemplateInfo;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
@@ -50,8 +48,6 @@ import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.data.xml.domainTemplate.DomainTemplateType;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -61,38 +57,8 @@ import java.util.stream.Collectors;
 
 abstract public class DomainKind<T> implements Handler<String>
 {
-    protected static final Set<String>  COMMON_RESERVED_PROPERTY_NAMES = new CaseInsensitiveHashSet();
-
-    static
-    {
-        COMMON_RESERVED_PROPERTY_NAMES.add("RowId");
-        COMMON_RESERVED_PROPERTY_NAMES.add("LSID");
-        COMMON_RESERVED_PROPERTY_NAMES.add("Name");
-        COMMON_RESERVED_PROPERTY_NAMES.add("Container");
-        COMMON_RESERVED_PROPERTY_NAMES.add("Folder");
-        COMMON_RESERVED_PROPERTY_NAMES.add("CreatedBy");
-        COMMON_RESERVED_PROPERTY_NAMES.add("Created");
-        COMMON_RESERVED_PROPERTY_NAMES.add("ModifiedBy");
-        COMMON_RESERVED_PROPERTY_NAMES.add("Modified");
-        COMMON_RESERVED_PROPERTY_NAMES.add("LastIndexed");
-        COMMON_RESERVED_PROPERTY_NAMES.add("*"); // Issue 53416
-    }
-
     public static final Logger LOG = LogHelper.getLogger(DomainKind.class, "Generic domain kind activities.");
     abstract public String getKindName();
-
-    public static Set<String> namesAndLabels(Collection<String> names)
-    {
-        Set<String> values = new CaseInsensitiveHashSet();
-        for (String name : names)
-        {
-            values.add(name);
-            String label = ColumnInfo.labelFromName(name);
-            values.add(label);
-            values.add(label.replaceAll("\\s", ""));
-        }
-        return values;
-    }
 
     /**
      * Return a class of DomainKind's bean which carries domain specific properties.

--- a/api/src/org/labkey/api/exp/property/DomainKind.java
+++ b/api/src/org/labkey/api/exp/property/DomainKind.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchemaType;
@@ -36,6 +37,7 @@ import org.labkey.api.exp.TemplateInfo;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
@@ -48,6 +50,8 @@ import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.data.xml.domainTemplate.DomainTemplateType;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -57,8 +61,38 @@ import java.util.stream.Collectors;
 
 abstract public class DomainKind<T> implements Handler<String>
 {
+    protected static final Set<String>  COMMON_RESERVED_PROPERTY_NAMES = new CaseInsensitiveHashSet();
+
+    static
+    {
+        COMMON_RESERVED_PROPERTY_NAMES.add("RowId");
+        COMMON_RESERVED_PROPERTY_NAMES.add("LSID");
+        COMMON_RESERVED_PROPERTY_NAMES.add("Name");
+        COMMON_RESERVED_PROPERTY_NAMES.add("Container");
+        COMMON_RESERVED_PROPERTY_NAMES.add("Folder");
+        COMMON_RESERVED_PROPERTY_NAMES.add("CreatedBy");
+        COMMON_RESERVED_PROPERTY_NAMES.add("Created");
+        COMMON_RESERVED_PROPERTY_NAMES.add("ModifiedBy");
+        COMMON_RESERVED_PROPERTY_NAMES.add("Modified");
+        COMMON_RESERVED_PROPERTY_NAMES.add("LastIndexed");
+        COMMON_RESERVED_PROPERTY_NAMES.add("*"); // Issue 53416
+    }
+
     public static final Logger LOG = LogHelper.getLogger(DomainKind.class, "Generic domain kind activities.");
     abstract public String getKindName();
+
+    public static Set<String> namesAndLabels(Collection<String> names)
+    {
+        Set<String> values = new CaseInsensitiveHashSet();
+        for (String name : names)
+        {
+            values.add(name);
+            String label = ColumnInfo.labelFromName(name);
+            values.add(label);
+            values.add(label.replaceAll("\\s", ""));
+        }
+        return values;
+    }
 
     /**
      * Return a class of DomainKind's bean which carries domain specific properties.

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -1436,7 +1436,7 @@ public class DomainUtil
 
             if (ILLEGAL_PROPERTY_NAMES.contains(name.trim()))
             {
-                exception.addError(new SimpleValidationError(getDomainErrorMessage(updates, "The name '" + name + "' is not allowed.")));
+                exception.addError(new SimpleValidationError(getDomainErrorMessage(updates, "The field name '" + name + "' is not allowed.")));
             }
 
             Matcher expMatcher = SUBSTITUTION_EXP_PATTERN.matcher(name);

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -1536,7 +1536,7 @@ public class DomainUtil
         return null;
     }
 
-    public static Set<String> nameAndLabels(String name)
+    public static Set<String> getNameAndLabels(String name)
     {
         Set<String> values = new CaseInsensitiveHashSet();
         values.add(name);
@@ -1546,7 +1546,7 @@ public class DomainUtil
         return values;
     }
 
-    public static Set<String> namesAndLabels(Collection<String> names)
+    public static Set<String> getNamesAndLabels(Collection<String> names)
     {
         Set<String> values = new CaseInsensitiveHashSet();
         for (String name : names)

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -116,6 +116,7 @@ public class DomainUtil
 {
     private static final Logger LOG = LogManager.getLogger(DomainUtil.class);
     public static final String ILLEGAL_DOMAIN_NAME_CHARSET = "<>[]{};,`\"~!@#$%^*=|?\\";
+    public static final Set<String> ILLEGAL_PROPERTY_NAMES = Set.of("*"); // Issue 53416
 
     private DomainUtil()
     {
@@ -1433,6 +1434,11 @@ public class DomainUtil
                 continue;
             }
 
+            if (ILLEGAL_PROPERTY_NAMES.contains(name.trim()))
+            {
+                exception.addError(new SimpleValidationError(getDomainErrorMessage(updates, "The name '" + name + "' is not allowed.")));
+            }
+
             Matcher expMatcher = SUBSTITUTION_EXP_PATTERN.matcher(name);
             if (expMatcher.find())
             {
@@ -1528,5 +1534,28 @@ public class DomainUtil
             return propertyIdMap;
         }
         return null;
+    }
+
+    public static Set<String> nameAndLabels(String name)
+    {
+        Set<String> values = new CaseInsensitiveHashSet();
+        values.add(name);
+        String label = ColumnInfo.labelFromName(name);
+        values.add(label);
+        values.add(label.replaceAll("\\s", ""));
+        return values;
+    }
+
+    public static Set<String> namesAndLabels(Collection<String> names)
+    {
+        Set<String> values = new CaseInsensitiveHashSet();
+        for (String name : names)
+        {
+            values.add(name);
+            String label = ColumnInfo.labelFromName(name);
+            values.add(label);
+            values.add(label.replaceAll("\\s", ""));
+        }
+        return values;
     }
 }

--- a/api/src/org/labkey/api/exp/property/TestDomainKind.java
+++ b/api/src/org/labkey/api/exp/property/TestDomainKind.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.exp.property;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.data.Container;
@@ -147,7 +148,7 @@ public class TestDomainKind extends DomainKind<JSONObject>
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         throw new UnsupportedOperationException();
     }

--- a/api/src/org/labkey/api/query/SimpleTableDomainKind.java
+++ b/api/src/org/labkey/api/query/SimpleTableDomainKind.java
@@ -15,12 +15,11 @@
  */
 package org.labkey.api.query;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerType;
@@ -34,6 +33,7 @@ import org.labkey.api.exp.XarFormatException;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.property.BaseAbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.xar.LsidUtils;
 import org.labkey.api.gwt.client.model.GWTDomain;
@@ -242,21 +242,16 @@ public class SimpleTableDomainKind extends BaseAbstractDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         SimpleUserSchema.SimpleTable table = domain != null ? getTable(domain, user) : null;
         if (table != null)
         {
-            // return the set of built-in column names.
-            return Sets.newHashSet(Iterables.transform(table.getBuiltInColumns(),
-                new Function<ColumnInfo, String>() {
-                    @Override
-                    public String apply(ColumnInfo col)
-                    {
-                        return col.getName();
-                    }
-                }
-            ));
+            Set<String> set = new CaseInsensitiveHashSet();
+            ((Iterable<ColumnInfo>) table.getBuiltInColumns()).forEach(col -> {
+                set.addAll(DomainUtil.getNameAndLabels(col.getName()));
+            });
+            return set;
         }
         return Collections.emptySet();
     }

--- a/assay/api-src/org/labkey/api/assay/AssayBatchDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayBatchDomainKind.java
@@ -15,15 +15,15 @@
  */
 package org.labkey.api.assay;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.Domain;
-import org.labkey.api.exp.property.DomainKind;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.query.ExpExperimentTable;
 import org.labkey.api.security.User;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -35,9 +35,9 @@ public class AssayBatchDomainKind extends AssayDomainKind
     private static final Set<String> RESERVED_NAMES;
 
     static {
-        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainKind.namesAndLabels(COMMON_RESERVED_PROPERTY_NAMES));
-        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(Arrays.stream(ExpExperimentTable.Column.values()).map( ExpExperimentTable.Column::name).toList()));
-        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(List.of("AssayId")));
+        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(Arrays.stream(ExpExperimentTable.Column.values()).map( ExpExperimentTable.Column::name).toList()));
+        RESERVED_NAMES.addAll(getAssayReservedPropertyNames());
+        RESERVED_NAMES.addAll(DomainUtil.getNameAndLabels("AssayId"));
     }
     public AssayBatchDomainKind()
     {
@@ -51,7 +51,7 @@ public class AssayBatchDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return RESERVED_NAMES;
     }

--- a/assay/api-src/org/labkey/api/assay/AssayBatchDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayBatchDomainKind.java
@@ -35,7 +35,7 @@ public class AssayBatchDomainKind extends AssayDomainKind
     private static final Set<String> RESERVED_NAMES;
 
     static {
-        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(Arrays.stream(ExpExperimentTable.Column.values()).map( ExpExperimentTable.Column::name).toList()));
+        RESERVED_NAMES = DomainUtil.getNamesAndLabels(Arrays.stream(ExpExperimentTable.Column.values()).map(ExpExperimentTable.Column::name).toList());
         RESERVED_NAMES.addAll(getAssayReservedPropertyNames());
         RESERVED_NAMES.addAll(DomainUtil.getNameAndLabels("AssayId"));
     }

--- a/assay/api-src/org/labkey/api/assay/AssayBatchDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayBatchDomainKind.java
@@ -15,11 +15,15 @@
  */
 package org.labkey.api.assay;
 
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.query.ExpExperimentTable;
 import org.labkey.api.security.User;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -28,6 +32,13 @@ import java.util.Set;
  */
 public class AssayBatchDomainKind extends AssayDomainKind
 {
+    private static final Set<String> RESERVED_NAMES;
+
+    static {
+        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainKind.namesAndLabels(COMMON_RESERVED_PROPERTY_NAMES));
+        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(Arrays.stream(ExpExperimentTable.Column.values()).map( ExpExperimentTable.Column::name).toList()));
+        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(List.of("AssayId")));
+    }
     public AssayBatchDomainKind()
     {
         super(ExpProtocol.ASSAY_DOMAIN_BATCH);
@@ -42,14 +53,7 @@ public class AssayBatchDomainKind extends AssayDomainKind
     @Override
     public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        Set<String> result = super.getAssayReservedPropertyNames();
-        for (ExpExperimentTable.Column column : ExpExperimentTable.Column.values())
-        {
-            result.add(column.toString());
-        }
-        result.add("AssayId");
-        result.add("Assay Id");
-        return result;
+        return RESERVED_NAMES;
     }
 
     @Override

--- a/assay/api-src/org/labkey/api/assay/AssayDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayDomainKind.java
@@ -33,6 +33,7 @@ import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.exp.property.BaseAbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.gwt.client.model.GWTDomain;
@@ -48,6 +49,7 @@ import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.writer.ContainerUser;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -55,6 +57,20 @@ public abstract class AssayDomainKind extends BaseAbstractDomainKind
 {
     private final String _namespacePrefix;
     private final Priority _priority;
+    private static final Set<String> RESERVED_NAMES;
+    static {
+        Set<String> s = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(List.of(
+            "RowId",
+            "Container",
+            "LSID",
+            "Owner",
+            "CreatedBy",
+            "Created",
+            "ModifiedBy",
+            "Modified"
+        )));
+        RESERVED_NAMES = Collections.unmodifiableSet(s);
+    }
 
     protected AssayDomainKind(String namespacePrefix)
     {
@@ -210,19 +226,9 @@ public abstract class AssayDomainKind extends BaseAbstractDomainKind
         return PropertyService.get().getDomain(container, dd.getDomainURI(), forUpdate);
     }
 
-    protected Set<String> getAssayReservedPropertyNames()
+    protected static Set<String> getAssayReservedPropertyNames()
     {
-        Set<String> result = new CaseInsensitiveHashSet();
-        result.add("RowId");
-        result.add("Row Id");
-        result.add("Container");
-        result.add("LSID");
-        result.add("Owner");
-        result.add("CreatedBy");
-        result.add("Created");
-        result.add("ModifiedBy");
-        result.add("Modified");
-        return result;
+        return RESERVED_NAMES;
     }
 
     @Override

--- a/assay/api-src/org/labkey/api/assay/AssayDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayDomainKind.java
@@ -59,7 +59,7 @@ public abstract class AssayDomainKind extends BaseAbstractDomainKind
     private final Priority _priority;
     private static final Set<String> RESERVED_NAMES;
     static {
-        Set<String> s = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(List.of(
+        Set<String> s = DomainUtil.getNamesAndLabels(List.of(
             "RowId",
             "Container",
             "LSID",
@@ -68,7 +68,8 @@ public abstract class AssayDomainKind extends BaseAbstractDomainKind
             "Created",
             "ModifiedBy",
             "Modified"
-        )));
+        ));
+        // make this an unmodifiable set because many domains build from this set but shouldn't alter the base set
         RESERVED_NAMES = Collections.unmodifiableSet(s);
     }
 

--- a/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultDomainKind.java
@@ -16,6 +16,8 @@
 
 package org.labkey.api.assay;
 
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
@@ -25,6 +27,7 @@ import org.labkey.api.exp.OntologyManager;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.util.PageFlowUtil;
@@ -32,6 +35,7 @@ import org.labkey.api.util.Pair;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.labkey.api.assay.AssayFileWriter.DIR_NAME;
@@ -42,6 +46,13 @@ import static org.labkey.api.data.Table.MODIFIED_COLUMN_NAME;
 
 public class AssayResultDomainKind extends AssayDomainKind
 {
+    private static final Set<String> RESERVED_NAMES;
+    static
+    {
+        RESERVED_NAMES = new CaseInsensitiveHashSet(getAssayReservedPropertyNames());
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(List.of("Run", "DataId")));
+    }
+
     public enum Column
     {
         Plate,
@@ -119,12 +130,9 @@ public class AssayResultDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        Set<String> result = getAssayReservedPropertyNames();
-        result.add("Run");
-        result.add("DataId");
-        return result;
+        return RESERVED_NAMES;
     }
 
     @Override

--- a/assay/api-src/org/labkey/api/assay/AssayRunDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayRunDomainKind.java
@@ -35,7 +35,7 @@ public class AssayRunDomainKind extends AssayDomainKind
     static
     {
         RESERVED_NAMES = new CaseInsensitiveHashSet(getAssayReservedPropertyNames());
-        RESERVED_NAMES.addAll(DomainUtil.getNameAndLabels("AsasyId"));
+        RESERVED_NAMES.addAll(DomainUtil.getNameAndLabels("AssayId"));
         RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(
                 Arrays.stream(ExpRunTable.Column.values()).map(Enum::name).collect(Collectors.toSet())
         ));

--- a/assay/api-src/org/labkey/api/assay/AssayRunDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayRunDomainKind.java
@@ -15,17 +15,32 @@
  */
 package org.labkey.api.assay;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.query.ExpRunTable;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
 
+import java.util.Arrays;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class AssayRunDomainKind extends AssayDomainKind
 {
+    private static final Set<String> RESERVED_NAMES;
+    static
+    {
+        RESERVED_NAMES = new CaseInsensitiveHashSet(getAssayReservedPropertyNames());
+        RESERVED_NAMES.addAll(DomainUtil.getNameAndLabels("AsasyId"));
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(
+                Arrays.stream(ExpRunTable.Column.values()).map(Enum::name).collect(Collectors.toSet())
+        ));
+    }
+
     public AssayRunDomainKind()
     {
         super(ExpProtocol.ASSAY_DOMAIN_RUN);
@@ -38,16 +53,9 @@ public class AssayRunDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        Set<String> result = getAssayReservedPropertyNames();
-        for (ExpRunTable.Column column : ExpRunTable.Column.values())
-        {
-            result.add(column.toString());
-        }
-        result.add("AssayId");
-        result.add("Assay Id");
-        return result;
+        return RESERVED_NAMES;
     }
 
     @Override

--- a/assay/api-src/org/labkey/api/assay/AssayRunDomainKind.java
+++ b/assay/api-src/org/labkey/api/assay/AssayRunDomainKind.java
@@ -26,6 +26,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -34,11 +35,11 @@ public class AssayRunDomainKind extends AssayDomainKind
     private static final Set<String> RESERVED_NAMES;
     static
     {
-        RESERVED_NAMES = new CaseInsensitiveHashSet(getAssayReservedPropertyNames());
-        RESERVED_NAMES.addAll(DomainUtil.getNameAndLabels("AssayId"));
-        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(
-                Arrays.stream(ExpRunTable.Column.values()).map(Enum::name).collect(Collectors.toSet())
-        ));
+        Set<String> names = new HashSet<>(getAssayReservedPropertyNames());
+        names.add("AssayId");
+        names.addAll(Arrays.stream(ExpRunTable.Column.values()).map(Enum::name).collect(Collectors.toSet()));
+
+        RESERVED_NAMES = DomainUtil.getNamesAndLabels(names);
     }
 
     public AssayRunDomainKind()

--- a/assay/src/org/labkey/assay/DefaultAssayDomainKind.java
+++ b/assay/src/org/labkey/assay/DefaultAssayDomainKind.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.assay;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.AssayDomainKind;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.property.Domain;
@@ -42,7 +43,7 @@ public class DefaultAssayDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return getAssayReservedPropertyNames();
     }

--- a/assay/src/org/labkey/assay/PlateBasedAssaySampleTypeDomainKind.java
+++ b/assay/src/org/labkey/assay/PlateBasedAssaySampleTypeDomainKind.java
@@ -34,6 +34,7 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.api.exp.api.SampleTypeDomainKind;
 
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -56,9 +57,9 @@ public class PlateBasedAssaySampleTypeDomainKind extends SampleTypeDomainKind
             }
 
             @Override
-            public Set<String> getReservedPropertyNames(Domain domain, User user)
+            public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
             {
-                return null;
+                return Collections.emptySet();
             }
         };
     }

--- a/assay/src/org/labkey/assay/plate/PlateMetadataDomainKind.java
+++ b/assay/src/org/labkey/assay/plate/PlateMetadataDomainKind.java
@@ -73,7 +73,7 @@ public class PlateMetadataDomainKind extends BaseAbstractDomainKind
 
     static
     {
-        RESERVED_NAMES = new CaseInsensitiveHashSet(Arrays.stream(Column.values()).map(Enum::name).toList());
+        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(Arrays.stream(Column.values()).map(Enum::name).toList()));
         INDEXES = Set.of(new PropertyStorageSpec.Index(true, Column.Lsid.name()));
         REQUIRED_PROPS = List.of(
                 new PropertyStorageSpec(Column.Amount.name(), JdbcType.DOUBLE),
@@ -217,7 +217,7 @@ public class PlateMetadataDomainKind extends BaseAbstractDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return RESERVED_NAMES;
     }

--- a/assay/src/org/labkey/assay/plate/PlateMetadataDomainKind.java
+++ b/assay/src/org/labkey/assay/plate/PlateMetadataDomainKind.java
@@ -73,7 +73,7 @@ public class PlateMetadataDomainKind extends BaseAbstractDomainKind
 
     static
     {
-        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(Arrays.stream(Column.values()).map(Enum::name).toList()));
+        RESERVED_NAMES = DomainUtil.getNamesAndLabels(Arrays.stream(Column.values()).map(Enum::name).toList());
         INDEXES = Set.of(new PropertyStorageSpec.Index(true, Column.Lsid.name()));
         REQUIRED_PROPS = List.of(
                 new PropertyStorageSpec(Column.Amount.name(), JdbcType.DOUBLE),

--- a/assay/src/org/labkey/assay/plate/PlateReplicateStatsDomainKind.java
+++ b/assay/src/org/labkey/assay/plate/PlateReplicateStatsDomainKind.java
@@ -1,5 +1,6 @@
 package org.labkey.assay.plate;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.assay.AbstractTsvAssayProvider;
 import org.labkey.api.assay.AssayDomainKind;
 import org.labkey.api.assay.plate.PlateSet;
@@ -50,7 +51,7 @@ public class PlateReplicateStatsDomainKind extends AssayDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return getAssayReservedPropertyNames();
     }

--- a/core/src/org/labkey/core/query/UsersDomainKind.java
+++ b/core/src/org/labkey/core/query/UsersDomainKind.java
@@ -15,8 +15,10 @@
  */
 package org.labkey.core.query;
 
+import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -31,6 +33,7 @@ import org.labkey.api.exp.TemplateInfo;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.module.ModuleContext;
@@ -57,23 +60,26 @@ import java.util.Set;
 public class UsersDomainKind extends SimpleTableDomainKind
 {
     public static final String NAME = "CoreUsersTable";
-    private static final Set<String> _reservedNames = new HashSet<>();
+    private static final Set<String> _reservedNames = new CaseInsensitiveHashSet();
     private static final List<PropertyDescriptorSpec> _requiredProperties = new ArrayList<>();
 
     static {
-        _reservedNames.add("Email");
-        _reservedNames.add("_ts");
-        _reservedNames.add("EntityId");
-        _reservedNames.add("CreatedBy");
-        _reservedNames.add("Created");
-        _reservedNames.add("ModifiedBy");
-        _reservedNames.add("Modified");
-        _reservedNames.add("Owner");
-        _reservedNames.add("UserId");
-        _reservedNames.add("DisplayName");
-        _reservedNames.add("LastLogin");
-        _reservedNames.add("Active");
-        _reservedNames.add("ExpirationDate");
+        _reservedNames.addAll(DomainUtil.getNamesAndLabels(List.of(
+                "Email",
+                "_ts",
+                "EntityId",
+                "CreatedBy",
+                "Created",
+                "ModifiedBy",
+                "Modified",
+                "Owner",
+                "UserId",
+                "DisplayName",
+                "LastLogin",
+                "Active",
+                "ExpirationDate"
+        )));
+
 
         _requiredProperties.add(new PropertyDescriptorSpec("FirstName", PropertyType.STRING, 64, false));
         _requiredProperties.add(new PropertyDescriptorSpec("LastName", PropertyType.STRING, 64, false));
@@ -154,7 +160,7 @@ public class UsersDomainKind extends SimpleTableDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return _reservedNames;
     }

--- a/core/src/org/labkey/core/query/UsersDomainKind.java
+++ b/core/src/org/labkey/core/query/UsersDomainKind.java
@@ -60,11 +60,11 @@ import java.util.Set;
 public class UsersDomainKind extends SimpleTableDomainKind
 {
     public static final String NAME = "CoreUsersTable";
-    private static final Set<String> _reservedNames = new CaseInsensitiveHashSet();
+    private static final Set<String> _reservedNames;
     private static final List<PropertyDescriptorSpec> _requiredProperties = new ArrayList<>();
 
     static {
-        _reservedNames.addAll(DomainUtil.getNamesAndLabels(List.of(
+        _reservedNames = DomainUtil.getNamesAndLabels(List.of(
                 "Email",
                 "_ts",
                 "EntityId",
@@ -78,7 +78,7 @@ public class UsersDomainKind extends SimpleTableDomainKind
                 "LastLogin",
                 "Active",
                 "ExpirationDate"
-        )));
+        ));
 
 
         _requiredProperties.add(new PropertyDescriptorSpec("FirstName", PropertyType.STRING, 64, false));

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -70,6 +70,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -100,14 +101,13 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
                 new PropertyStorageSpec("classid", JdbcType.INTEGER)
         )));
 
-        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(
-                BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()))
-        );
-        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(Arrays.stream(ExpDataClassDataTable.Column.values()).map(ExpDataClassDataTable.Column::name).toList()));
-        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(List.of(
-                "RunId", // Issue 50461
-                "Container"
-        )));
+        Set<String> names = new HashSet<>();
+        names.addAll(BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()));
+        names.addAll(Arrays.stream(ExpDataClassDataTable.Column.values()).map(ExpDataClassDataTable.Column::name).toList());
+        names.add("RunId"); // Issue 50461
+        names.add("Container");
+
+        RESERVED_NAMES = DomainUtil.getNamesAndLabels(names);
 
         FOREIGN_KEYS = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(
                 // NOTE: We join to exp.data using LSID instead of rowid for insert performance -- we will generate

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -105,7 +105,8 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
         );
         RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(Arrays.stream(ExpDataClassDataTable.Column.values()).map(ExpDataClassDataTable.Column::name).toList()));
         RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(List.of(
-                "RunId" // Issue 50461
+                "RunId", // Issue 50461
+                "Container"
         )));
 
         FOREIGN_KEYS = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -45,7 +45,7 @@ import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.AbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
-import org.labkey.api.exp.property.DomainKind;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.query.DataClassUserSchema;
 import org.labkey.api.exp.query.ExpDataClassDataTable;
 import org.labkey.api.gwt.client.DefaultValueType;
@@ -100,13 +100,11 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
                 new PropertyStorageSpec("classid", JdbcType.INTEGER)
         )));
 
-
-        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainKind.namesAndLabels(
+        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(
                 BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()))
         );
-        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(COMMON_RESERVED_PROPERTY_NAMES));
-        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(Arrays.stream(ExpDataClassDataTable.Column.values()).map(ExpDataClassDataTable.Column::name).toList()));
-        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(List.of(
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(Arrays.stream(ExpDataClassDataTable.Column.values()).map(ExpDataClassDataTable.Column::name).toList()));
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(List.of(
                 "RunId" // Issue 50461
         )));
 
@@ -223,7 +221,7 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return RESERVED_NAMES;
     }

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.compliance.ComplianceService;
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchema;
@@ -46,6 +45,7 @@ import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.api.SampleTypeService;
 import org.labkey.api.exp.property.AbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainKind;
 import org.labkey.api.exp.query.DataClassUserSchema;
 import org.labkey.api.exp.query.ExpDataClassDataTable;
 import org.labkey.api.gwt.client.DefaultValueType;
@@ -101,12 +101,14 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
         )));
 
 
-        RESERVED_NAMES = new CaseInsensitiveHashSet(BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()));
-        RESERVED_NAMES.addAll(Arrays.stream(ExpDataClassDataTable.Column.values()).map(ExpDataClassDataTable.Column::name).toList());
-        RESERVED_NAMES.addAll(Arrays.stream(ExpDataClassDataTable.Column.values()).map(col -> ColumnInfo.labelFromName(col.name())).toList());
-        RESERVED_NAMES.add("Container");
-        RESERVED_NAMES.add("RunId"); // Issue 50461
-        RESERVED_NAMES.add("Run Id");
+        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainKind.namesAndLabels(
+                BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()))
+        );
+        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(COMMON_RESERVED_PROPERTY_NAMES));
+        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(Arrays.stream(ExpDataClassDataTable.Column.values()).map(ExpDataClassDataTable.Column::name).toList()));
+        RESERVED_NAMES.addAll(DomainKind.namesAndLabels(List.of(
+                "RunId" // Issue 50461
+        )));
 
         FOREIGN_KEYS = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(
                 // NOTE: We join to exp.data using LSID instead of rowid for insert performance -- we will generate

--- a/experiment/src/org/labkey/experiment/api/VocabularyDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/VocabularyDomainKind.java
@@ -40,9 +40,9 @@ public class VocabularyDomainKind extends BaseAbstractDomainKind
     private static final Set<String> RESERVED_PROPERTY_NAMES;
     static
     {
-        RESERVED_PROPERTY_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(
+        RESERVED_PROPERTY_NAMES = DomainUtil.getNamesAndLabels(
                 List.of("RowId", "LSID", "EntityId", "Container", "Folder", "CreatedBy", "Created", "ModifiedBy", "Modified", "Owner", "LastIndexed")
-        ));
+        );
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/VocabularyDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/VocabularyDomainKind.java
@@ -1,6 +1,7 @@
 package org.labkey.experiment.api;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
@@ -26,7 +27,6 @@ import org.labkey.api.vocabulary.security.DesignVocabularyPermission;
 import org.labkey.api.writer.ContainerUser;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +37,13 @@ import java.util.Set;
 public class VocabularyDomainKind extends BaseAbstractDomainKind
 {
     public static final String KIND_NAME = "Vocabulary";
+    private static final Set<String> RESERVED_PROPERTY_NAMES;
+    static
+    {
+        RESERVED_PROPERTY_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(
+                List.of("RowId", "LSID", "EntityId", "Container", "Folder", "CreatedBy", "Created", "ModifiedBy", "Modified", "Owner", "LastIndexed")
+        ));
+    }
 
     @Override
     public String getKindName()
@@ -72,21 +79,9 @@ public class VocabularyDomainKind extends BaseAbstractDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        Set<String> reservedProperties = new HashSet<>();
-        reservedProperties.add("RowId");
-        reservedProperties.add("LSID");
-        reservedProperties.add("EntityId");
-        reservedProperties.add("Container");
-        reservedProperties.add("Folder");
-        reservedProperties.add("CreatedBy");
-        reservedProperties.add("Created");
-        reservedProperties.add("ModifiedBy");
-        reservedProperties.add("Modified");
-        reservedProperties.add("Owner");
-        reservedProperties.add("LastIndexed");
-        return reservedProperties;
+        return RESERVED_PROPERTY_NAMES;
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -98,6 +98,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1712,9 +1713,9 @@ renaming a property AND toggling mvindicator on in the same change.
                 }
 
                 @Override
-                public Set<String> getReservedPropertyNames(Domain domain, User user)
+                public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
                 {
-                    return Set.of();
+                    return Collections.emptySet();
                 }
 
                 @Override

--- a/filecontent/src/org/labkey/filecontent/FilePropertiesDomainKind.java
+++ b/filecontent/src/org/labkey/filecontent/FilePropertiesDomainKind.java
@@ -33,6 +33,7 @@ import org.labkey.api.writer.ContainerUser;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -59,10 +60,10 @@ public class FilePropertiesDomainKind extends BaseAbstractDomainKind
     private static final Set<String> _reservedFieldSet;
 
     static {
-        Set<String> s = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(RESERVED_FIELDS));
+        Set<String> s = new HashSet<>(RESERVED_FIELDS);
 
-        s.addAll(DomainUtil.getNamesAndLabels(Arrays.stream(ExpDataTable.Column.values()).map(Enum::name).collect(Collectors.toSet())));
-        _reservedFieldSet = Collections.unmodifiableSet(s);
+        s.addAll(Arrays.stream(ExpDataTable.Column.values()).map(Enum::name).collect(Collectors.toSet()));
+        _reservedFieldSet = Collections.unmodifiableSet(DomainUtil.getNamesAndLabels(s));
     }
 
     @Override

--- a/filecontent/src/org/labkey/filecontent/FilePropertiesDomainKind.java
+++ b/filecontent/src/org/labkey/filecontent/FilePropertiesDomainKind.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.filecontent;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.SQLFragment;
@@ -22,6 +23,7 @@ import org.labkey.api.exp.Lsid;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.property.BaseAbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.query.ExpDataTable;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.security.User;
@@ -33,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * User: klum
@@ -56,10 +59,9 @@ public class FilePropertiesDomainKind extends BaseAbstractDomainKind
     private static final Set<String> _reservedFieldSet;
 
     static {
-        Set<String> s = new CaseInsensitiveHashSet(RESERVED_FIELDS);
+        Set<String> s = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(RESERVED_FIELDS));
 
-        for (ExpDataTable.Column col : ExpDataTable.Column.values())
-            s.add(col.name());
+        s.addAll(DomainUtil.getNamesAndLabels(Arrays.stream(ExpDataTable.Column.values()).map(Enum::name).collect(Collectors.toSet())));
         _reservedFieldSet = Collections.unmodifiableSet(s);
     }
 
@@ -101,7 +103,7 @@ public class FilePropertiesDomainKind extends BaseAbstractDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return _reservedFieldSet;
     }
@@ -116,12 +118,6 @@ public class FilePropertiesDomainKind extends BaseAbstractDomainKind
     public DefaultValueType[] getDefaultValueOptions(Domain domain)
     {
         return new DefaultValueType[] { DefaultValueType.FIXED_EDITABLE, DefaultValueType.FIXED_NON_EDITABLE };
-    }
-
-    @Override
-    public DefaultValueType getDefaultDefaultType(Domain domain)
-    {
-        return DefaultValueType.FIXED_EDITABLE;
     }
 
     @Override

--- a/issues/src/org/labkey/issue/query/IssueDefDomainKind.java
+++ b/issues/src/org/labkey/issue/query/IssueDefDomainKind.java
@@ -16,6 +16,8 @@
 package org.labkey.issue.query;
 
 import com.google.common.collect.Sets;
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PropertyStorageSpec;
@@ -23,6 +25,7 @@ import org.labkey.api.exp.DomainNotFoundException;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainTemplate;
 import org.labkey.api.exp.property.DomainTemplateGroup;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.issues.AbstractIssuesListDefDomainKind;
 import org.labkey.api.query.BatchValidationException;
@@ -83,23 +86,23 @@ public class IssueDefDomainKind extends AbstractIssuesListDefDomainKind
                 new PropertyStorageSpec.ForeignKey(RESOLUTION_LOOKUP, "Lists", RESOLUTION_LOOKUP, "value", null, false)
         )));
 
-        RESERVED_NAMES = BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet());
-        RESERVED_NAMES.addAll(Arrays.asList("RowId", "Name"));
-        RESERVED_NAMES.addAll(REQUIRED_PROPERTIES
+        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet())));
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(Arrays.asList("RowId", "Name")));
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(REQUIRED_PROPERTIES
                 .stream()
-                .filter(p -> !OPTIONAL_NAMES.contains(p.getName()))
                 .map(PropertyStorageSpec::getName)
-                .collect(Collectors.toSet()));
+                .filter(name -> !OPTIONAL_NAMES.contains(name))
+                .collect(Collectors.toSet())));
 
-        // field names that are contained in the issues table that get's joined to the provisioned table
-        RESERVED_NAMES.addAll(Arrays.asList("IssueId", "AssignedTo", "Modified", "ModifiedBy",
+        // field names that are contained in the issues table that gets joined to the provisioned table
+        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(Arrays.asList("IssueId", "AssignedTo", "Modified", "ModifiedBy",
                                             "Created", "CreatedBy", "Resolved", "ResolvedBy", "Status", "BuildFound",
-                                            "Tag", "Resolution", "Duplicate", "ClosedBy", "Closed", "LastIndexed", "IssueDefId"));
+                                            "Tag", "Resolution", "Duplicate", "ClosedBy", "Closed", "LastIndexed", "IssueDefId")));
 
         MANDATORY_PROPERTIES = REQUIRED_PROPERTIES
                 .stream()
-                .filter(p -> !OPTIONAL_NAMES.contains(p.getName()))
                 .map(PropertyStorageSpec::getName)
+                .filter(name -> !OPTIONAL_NAMES.contains(name))
                 .collect(Collectors.toSet());
     }
 
@@ -110,7 +113,7 @@ public class IssueDefDomainKind extends AbstractIssuesListDefDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return RESERVED_NAMES;
     }

--- a/issues/src/org/labkey/issue/query/IssueDefDomainKind.java
+++ b/issues/src/org/labkey/issue/query/IssueDefDomainKind.java
@@ -86,18 +86,20 @@ public class IssueDefDomainKind extends AbstractIssuesListDefDomainKind
                 new PropertyStorageSpec.ForeignKey(RESOLUTION_LOOKUP, "Lists", RESOLUTION_LOOKUP, "value", null, false)
         )));
 
-        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet())));
-        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(Arrays.asList("RowId", "Name")));
-        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(REQUIRED_PROPERTIES
+        Set<String> names = new HashSet<>();
+        names.addAll(BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()));
+        names.addAll(REQUIRED_PROPERTIES
                 .stream()
                 .map(PropertyStorageSpec::getName)
                 .filter(name -> !OPTIONAL_NAMES.contains(name))
-                .collect(Collectors.toSet())));
-
+                .collect(Collectors.toSet()));
+        names.add("RowId");
+        names.add("Name");
         // field names that are contained in the issues table that gets joined to the provisioned table
-        RESERVED_NAMES.addAll(DomainUtil.getNamesAndLabels(Arrays.asList("IssueId", "AssignedTo", "Modified", "ModifiedBy",
-                                            "Created", "CreatedBy", "Resolved", "ResolvedBy", "Status", "BuildFound",
-                                            "Tag", "Resolution", "Duplicate", "ClosedBy", "Closed", "LastIndexed", "IssueDefId")));
+        names.addAll(Arrays.asList("IssueId", "AssignedTo", "Modified", "ModifiedBy",
+                "Created", "CreatedBy", "Resolved", "ResolvedBy", "Status", "BuildFound",
+                "Tag", "Resolution", "Duplicate", "ClosedBy", "Closed", "LastIndexed", "IssueDefId"));
+        RESERVED_NAMES = DomainUtil.getNamesAndLabels(names);
 
         MANDATORY_PROPERTIES = REQUIRED_PROPERTIES
                 .stream()

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -107,8 +107,8 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
                 new PropertyStorageSpec("lastIndexed", JdbcType.TIMESTAMP),
                 new PropertyStorageSpec("container", JdbcType.GUID).setNullable(false),
                 new PropertyStorageSpec(DataIntegrationService.Columns.TransformImportHash.getColumnName(), JdbcType.VARCHAR,  256));
-        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(
-                BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet())));
+        RESERVED_NAMES = DomainUtil.getNamesAndLabels(
+                BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()));
     }
 
     public void setListDefinition(ListDefinitionImpl list)

--- a/list/src/org/labkey/list/model/ListDomainKind.java
+++ b/list/src/org/labkey/list/model/ListDomainKind.java
@@ -27,7 +27,6 @@ import org.labkey.api.compliance.ComplianceService;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PropertyStorageSpec;
@@ -96,6 +95,7 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
     private final static Set<PropertyStorageSpec> BASE_PROPERTIES;
     private ListDefinitionImpl _list;
     private final static int MAX_NAME_LENGTH = 200;
+    private static final Set<String> RESERVED_NAMES;
 
     static
     {
@@ -107,6 +107,8 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
                 new PropertyStorageSpec("lastIndexed", JdbcType.TIMESTAMP),
                 new PropertyStorageSpec("container", JdbcType.GUID).setNullable(false),
                 new PropertyStorageSpec(DataIntegrationService.Columns.TransformImportHash.getColumnName(), JdbcType.VARCHAR,  256));
+        RESERVED_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(
+                BASE_PROPERTIES.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet())));
     }
 
     public void setListDefinition(ListDefinitionImpl list)
@@ -240,15 +242,9 @@ public abstract class ListDomainKind extends AbstractDomainKind<ListDomainKindPr
     abstract Collection<KeyType> getSupportedKeyTypes();
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        Set<String> properties = new CaseInsensitiveHashSet();
-        for (PropertyStorageSpec pss : BASE_PROPERTIES)
-        {
-            properties.add(pss.getName());
-        }
-
-        return Collections.unmodifiableSet(properties);
+       return RESERVED_NAMES;
     }
 
     @Override

--- a/study/api-src/org/labkey/api/specimen/model/AbstractSpecimenDomainKind.java
+++ b/study/api-src/org/labkey/api/specimen/model/AbstractSpecimenDomainKind.java
@@ -34,6 +34,7 @@ import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.BaseAbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.query.SimpleValidationError;
@@ -143,9 +144,9 @@ public abstract class AbstractSpecimenDomainKind extends BaseAbstractDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        return new HashSet<>();
+        return Collections.emptySet();
     }
 
     @Override

--- a/study/api-src/org/labkey/api/specimen/model/SpecimenDomainKind.java
+++ b/study/api-src/org/labkey/api/specimen/model/SpecimenDomainKind.java
@@ -25,6 +25,7 @@ import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.query.PropertyValidationError;
@@ -46,6 +47,8 @@ import java.util.Set;
 
 public final class SpecimenDomainKind extends AbstractSpecimenDomainKind
 {
+    private static final Set<String> RESERVED_FIELD_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(List.of(COMMENTS, COLUMN)));
+
     private static final String NAME = "Specimen";
     private static final String NAMESPACE_PREFIX = "Specimen";
 
@@ -224,11 +227,8 @@ public final class SpecimenDomainKind extends AbstractSpecimenDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        Set<String> names = new HashSet<>();
-        names.add(COMMENTS);
-        names.add(COLUMN);
-        return names;
+        return RESERVED_FIELD_NAMES;
     }
 }

--- a/study/api-src/org/labkey/api/specimen/model/SpecimenDomainKind.java
+++ b/study/api-src/org/labkey/api/specimen/model/SpecimenDomainKind.java
@@ -47,7 +47,7 @@ import java.util.Set;
 
 public final class SpecimenDomainKind extends AbstractSpecimenDomainKind
 {
-    private static final Set<String> RESERVED_FIELD_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(List.of(COMMENTS, COLUMN)));
+    private static final Set<String> RESERVED_FIELD_NAMES = DomainUtil.getNamesAndLabels(List.of(COMMENTS, COLUMN));
 
     private static final String NAME = "Specimen";
     private static final String NAMESPACE_PREFIX = "Specimen";

--- a/study/api-src/org/labkey/api/specimen/model/SpecimenEventDomainKind.java
+++ b/study/api-src/org/labkey/api/specimen/model/SpecimenEventDomainKind.java
@@ -19,11 +19,13 @@ package org.labkey.api.specimen.model;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.query.PropertyValidationError;
@@ -44,6 +46,8 @@ import java.util.Set;
 
 public final class SpecimenEventDomainKind extends AbstractSpecimenDomainKind
 {
+    private static final Set<String> RESERVED_FIELD_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNameAndLabels(COLUMN));
+
     private static final String NAME = "SpecimenEvent";
     private static final String NAMESPACE_PREFIX = "SpecimenEvent";
 
@@ -264,10 +268,8 @@ public final class SpecimenEventDomainKind extends AbstractSpecimenDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        Set<String> names = new HashSet<>();
-        names.add(COLUMN);
-        return names;
+        return RESERVED_FIELD_NAMES;
     }
 }

--- a/study/api-src/org/labkey/api/specimen/model/VialDomainKind.java
+++ b/study/api-src/org/labkey/api/specimen/model/VialDomainKind.java
@@ -26,6 +26,7 @@ import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainProperty;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.query.PropertyValidationError;
@@ -47,6 +48,8 @@ import java.util.Set;
 
 public final class VialDomainKind extends AbstractSpecimenDomainKind
 {
+    private static final Set<String> RESERVED_FIELD_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(List.of(COMMENTS, COLUMN)));
+
     private static final String NAME = "Vial";
     private static final String NAMESPACE_PREFIX = "Vial";
 
@@ -228,11 +231,8 @@ public final class VialDomainKind extends AbstractSpecimenDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        Set<String> names = new HashSet<>();
-        names.add(COMMENTS);
-        names.add(COLUMN);
-        return names;
+        return RESERVED_FIELD_NAMES;
     }
 }

--- a/study/api-src/org/labkey/api/specimen/model/VialDomainKind.java
+++ b/study/api-src/org/labkey/api/specimen/model/VialDomainKind.java
@@ -48,7 +48,7 @@ import java.util.Set;
 
 public final class VialDomainKind extends AbstractSpecimenDomainKind
 {
-    private static final Set<String> RESERVED_FIELD_NAMES = new CaseInsensitiveHashSet(DomainUtil.getNamesAndLabels(List.of(COMMENTS, COLUMN)));
+    private static final Set<String> RESERVED_FIELD_NAMES = DomainUtil.getNamesAndLabels(List.of(COMMENTS, COLUMN));
 
     private static final String NAME = "Vial";
     private static final String NAMESPACE_PREFIX = "Vial";

--- a/study/api-src/org/labkey/api/studydesign/query/AbstractStudyDesignDomainKind.java
+++ b/study/api-src/org/labkey/api/studydesign/query/AbstractStudyDesignDomainKind.java
@@ -65,9 +65,7 @@ public abstract class AbstractStudyDesignDomainKind extends BaseAbstractDomainKi
         baseFields.add(createFieldSpec("ModifiedBy", JdbcType.INTEGER));
 
         BASE_FIELDS = Collections.unmodifiableSet(baseFields);
-        RESERVED_PROPERTY_NAMES = new CaseInsensitiveHashSet(
-                DomainUtil.getNamesAndLabels(baseFields.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()))
-        );
+        RESERVED_PROPERTY_NAMES = DomainUtil.getNamesAndLabels(baseFields.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()));
     }
 
     private final Set<PropertyStorageSpec> _standardFields = new LinkedHashSet<>(BASE_FIELDS);

--- a/study/api-src/org/labkey/api/studydesign/query/AbstractStudyDesignDomainKind.java
+++ b/study/api-src/org/labkey/api/studydesign/query/AbstractStudyDesignDomainKind.java
@@ -15,6 +15,8 @@
  */
 package org.labkey.api.studydesign.query;
 
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
@@ -27,6 +29,7 @@ import org.labkey.api.exp.XarFormatException;
 import org.labkey.api.exp.api.ExperimentUrls;
 import org.labkey.api.exp.property.BaseAbstractDomainKind;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.xar.LsidUtils;
 import org.labkey.api.query.QueryAction;
@@ -37,9 +40,9 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.writer.ContainerUser;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public abstract class AbstractStudyDesignDomainKind extends BaseAbstractDomainKind
 {
@@ -50,6 +53,7 @@ public abstract class AbstractStudyDesignDomainKind extends BaseAbstractDomainKi
     private static final String DOMAIN_LSID_TEMPLATE = "${FolderLSIDBase}:${TableName}";
 
     private static final Set<PropertyStorageSpec> BASE_FIELDS;
+    private static final Set<String> RESERVED_PROPERTY_NAMES;
 
     static
     {
@@ -61,6 +65,9 @@ public abstract class AbstractStudyDesignDomainKind extends BaseAbstractDomainKi
         baseFields.add(createFieldSpec("ModifiedBy", JdbcType.INTEGER));
 
         BASE_FIELDS = Collections.unmodifiableSet(baseFields);
+        RESERVED_PROPERTY_NAMES = new CaseInsensitiveHashSet(
+                DomainUtil.getNamesAndLabels(baseFields.stream().map(PropertyStorageSpec::getName).collect(Collectors.toSet()))
+        );
     }
 
     private final Set<PropertyStorageSpec> _standardFields = new LinkedHashSet<>(BASE_FIELDS);
@@ -159,14 +166,9 @@ public abstract class AbstractStudyDesignDomainKind extends BaseAbstractDomainKi
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        Set<String> names = new HashSet<>();
-
-        for (PropertyStorageSpec spec : getBaseProperties(domain))
-            names.add(spec.getName());
-
-        return names;
+        return RESERVED_PROPERTY_NAMES;
     }
 
     protected static PropertyStorageSpec createFieldSpec(String name, JdbcType jdbcType)

--- a/study/src/org/labkey/study/model/BaseStudyDomainKind.java
+++ b/study/src/org/labkey/study/model/BaseStudyDomainKind.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.study.model;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
@@ -72,7 +73,7 @@ public abstract class BaseStudyDomainKind extends BaseAbstractDomainKind
     protected abstract TableInfo getTableInfo();
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         TableInfo table = getTableInfo();
         return table.getColumnNameSet();

--- a/study/src/org/labkey/study/model/ContinuousDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/ContinuousDatasetDomainKind.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.study.model;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.security.User;
 import org.labkey.api.study.TimepointType;
@@ -55,7 +56,7 @@ public class ContinuousDatasetDomainKind extends DatasetDomainKind
 
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         HashSet<String> fields = new HashSet<>(getStudySubjectReservedName(domain));
         fields.addAll(DatasetDefinition.DEFAULT_ABSOLUTE_DATE_FIELDS);

--- a/study/src/org/labkey/study/model/DatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DatasetDomainKind.java
@@ -283,21 +283,21 @@ public abstract class DatasetDomainKind extends AbstractDomainKind<DatasetDomain
     // Issue 43898: Add the study subject name column to reserved fields
     protected Set<String> getStudySubjectReservedName(Domain domain)
     {
-        HashSet<String> fields = new HashSet<>();
+        HashSet<String> fields = new CaseInsensitiveHashSet();
         if (null != domain)
         {
             Study study = StudyManager.getInstance().getStudy(domain.getContainer());
             if (null != study)
             {
                 String participantIdField = study.getSubjectColumnName();
-                fields.add(participantIdField);
+                fields.addAll(DomainUtil.getNameAndLabels(participantIdField));
             }
         }
         return Collections.unmodifiableSet(fields);
     }
 
     @Override
-    public abstract Set<String> getReservedPropertyNames(Domain domain, User user);
+    public abstract @NotNull Set<String> getReservedPropertyNames(Domain domain, User user);
 
     @Override
     public Set<PropertyStorageSpec> getBaseProperties(Domain domain)

--- a/study/src/org/labkey/study/model/DateDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/DateDatasetDomainKind.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.study.model;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.security.User;
 import org.labkey.api.study.TimepointType;
@@ -57,7 +58,7 @@ public class DateDatasetDomainKind extends DatasetDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         HashSet<String> fields = new HashSet<>(getStudySubjectReservedName(domain));
         fields.addAll(DatasetDefinition.DEFAULT_RELATIVE_DATE_FIELDS);

--- a/study/src/org/labkey/study/model/TestDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/TestDatasetDomainKind.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.study.model;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.security.User;
@@ -48,7 +49,7 @@ public class TestDatasetDomainKind extends DatasetDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
         return Collections.emptySet();
     }

--- a/study/src/org/labkey/study/model/VisitDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/VisitDatasetDomainKind.java
@@ -63,8 +63,8 @@ public class VisitDatasetDomainKind extends DatasetDomainKind
     @Override
     public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        HashSet<String> fields = new CaseInsensitiveHashSet(getStudySubjectReservedName(domain));
-        fields.addAll(DomainUtil.getNamesAndLabels(DatasetDefinition.DEFAULT_VISIT_FIELDS));
+        Set<String> fields = DomainUtil.getNamesAndLabels(DatasetDefinition.DEFAULT_VISIT_FIELDS);
+        fields.addAll(getStudySubjectReservedName(domain));
 
         return Collections.unmodifiableSet(fields);
     }

--- a/study/src/org/labkey/study/model/VisitDatasetDomainKind.java
+++ b/study/src/org/labkey/study/model/VisitDatasetDomainKind.java
@@ -15,8 +15,11 @@
  */
 package org.labkey.study.model;
 
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.exp.property.Domain;
+import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.security.User;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
@@ -57,10 +60,10 @@ public class VisitDatasetDomainKind extends DatasetDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    public @NotNull Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        HashSet<String> fields = new HashSet<>(getStudySubjectReservedName(domain));
-        fields.addAll(DatasetDefinition.DEFAULT_VISIT_FIELDS);
+        HashSet<String> fields = new CaseInsensitiveHashSet(getStudySubjectReservedName(domain));
+        fields.addAll(DomainUtil.getNamesAndLabels(DatasetDefinition.DEFAULT_VISIT_FIELDS));
 
         return Collections.unmodifiableSet(fields);
     }


### PR DESCRIPTION
#### Rationale
Because we generally allow users to provide either the name of a field or its label during import, we should consistently be reserving both the name and the label for each domain so there will not be ambiguity when trying to resolve a column during import. This PR gets us closer to consistency by adding a utility method that will create the set of reservable strings given a field's name and then uses that in various domains, also making more of the reserved field sets static constants.

#### Related Pull Requests
- https://github.com/LabKey/clientModules/pull/61
- https://github.com/LabKey/commonAssays/pull/930
- https://github.com/LabKey/limsModules/pull/1682

#### Changes
- Add `DomainUtil.getNamesAndLabels`
- Add `DomainUtil.getNameAndLabels`
- Update various domains to use these new methods
- Mark `getReservedPropertyNames` as `@NotNull`


#### Tasks 📍
- [ ] ~Manual Testing~
- [ ] Code Review @XingY 
- [ ] ~Needs Automation~
