### PR TITLE
Issue 53036: LKSM: Aliquot registration event in timeline polish

### DIFF
--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -826,7 +826,18 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                 .map(ImportAliasable::getName)
                 .collect(Collectors.toSet());
 
-        return new CaseInsensitiveHashSet(fields);
+        Set<String> metaFieldNames = new CaseInsensitiveHashSet(fields);
+        for (String fieldName : fields)
+        {
+            ColumnInfo columnInfo = getQueryTable().getColumn(fieldName);
+            if (columnInfo != null)
+            {
+                metaFieldNames.add(columnInfo.getLabel());
+                metaFieldNames.add(columnInfo.getAlias().getId());
+            }
+        }
+
+        return metaFieldNames;
     }
 
     public static boolean isAliquotStatusChangeNeedRecalc(Collection<Long> availableStatuses, Long oldStatus, Long newStatus)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -826,6 +826,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                 .map(ImportAliasable::getName)
                 .collect(Collectors.toSet());
 
+        // Issue 53036: also include column labels and aliases
         Set<String> metaFieldNames = new CaseInsensitiveHashSet(fields);
         for (String fieldName : fields)
         {


### PR DESCRIPTION
#### Rationale
Aliquot's inherited parent field values shouldn't be in audit log. When querying for existing aliquot rows, those fields should be removed from the map that's passed to AuditHandler to build change details. This PR handles removing of parent fields for field whose label or alias might be different from field name.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1856
- https://github.com/LabKey/labkey-ui-premium/pull/821
- https://github.com/LabKey/platform/pull/7066
- https://github.com/LabKey/limsModules/pull/1684

#### Changes
- check for label and alias when excluding parent fields from aliquot existing data

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->