### PR TITLE
Track and report index information via a list of records

### DIFF
--- a/api/src/org/labkey/api/data/AbstractForeignKey.java
+++ b/api/src/org/labkey/api/data/AbstractForeignKey.java
@@ -24,6 +24,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.collections.NamedObjectList;
+import org.labkey.api.data.TableInfo.IndexDef;
 import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListService;
 import org.labkey.api.exp.property.Domain;
@@ -36,7 +37,6 @@ import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
 import org.labkey.data.xml.queryCustomView.FilterType;
 
@@ -384,15 +384,15 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
 
         Set<ColumnInfo> seen = new HashSet<>();
         List<List<ColumnInfo>> candidates = new ArrayList<>();
-        for (Pair<TableInfo.IndexType, List<ColumnInfo>> index : lookupTable.getUniqueIndices().values())
+        for (IndexDef def : lookupTable.getUniqueIndices().values())
         {
-            if (index.getKey() != TableInfo.IndexType.Unique)
+            if (def.indexType() != TableInfo.IndexType.Unique)
                 continue;
 
-            if (index.getValue().size() != 1)
+            if (def.columns().size() != 1)
                 continue;
 
-            ColumnInfo col = index.getValue().get(0);
+            ColumnInfo col = def.columns().get(0);
             if (seen.contains(col))
                 continue;
             seen.add(col);
@@ -403,7 +403,7 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
             if (!col.getJdbcType().isText())
                 continue;
 
-            candidates.add(index.getValue());
+            candidates.add(def.columns());
         }
 
         ColumnInfo titleCol = lookupTable.getTitleColumn() != null ? lookupTable.getColumn(lookupTable.getTitleColumn()) : null;

--- a/api/src/org/labkey/api/data/AbstractForeignKey.java
+++ b/api/src/org/labkey/api/data/AbstractForeignKey.java
@@ -24,7 +24,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveMapWrapper;
 import org.labkey.api.collections.NamedObjectList;
-import org.labkey.api.data.TableInfo.IndexDef;
+import org.labkey.api.data.TableInfo.IndexDefinition;
 import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListService;
 import org.labkey.api.exp.property.Domain;
@@ -384,7 +384,7 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
 
         Set<ColumnInfo> seen = new HashSet<>();
         List<List<ColumnInfo>> candidates = new ArrayList<>();
-        for (IndexDef def : lookupTable.getUniqueIndices().values())
+        for (IndexDefinition def : lookupTable.getUniqueIndices().values())
         {
             if (def.indexType() != TableInfo.IndexType.Unique)
                 continue;

--- a/api/src/org/labkey/api/data/AbstractForeignKey.java
+++ b/api/src/org/labkey/api/data/AbstractForeignKey.java
@@ -384,7 +384,7 @@ public abstract class AbstractForeignKey implements ForeignKey, Cloneable
 
         Set<ColumnInfo> seen = new HashSet<>();
         List<List<ColumnInfo>> candidates = new ArrayList<>();
-        for (IndexDefinition def : lookupTable.getUniqueIndices().values())
+        for (IndexDefinition def : lookupTable.getUniqueIndices())
         {
             if (def.indexType() != TableInfo.IndexType.Unique)
                 continue;

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -242,14 +242,14 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
     @NotNull
     @Override
-    public Map<String, IndexDef> getUniqueIndices()
+    public Map<String, IndexDefinition> getUniqueIndices()
     {
         return Collections.emptyMap();
     }
 
     @NotNull
     @Override
-    public Map<String, IndexDef> getAllIndices()
+    public Map<String, IndexDefinition> getAllIndices()
     {
         return Collections.emptyMap();
     }
@@ -259,8 +259,8 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     public List<ColumnInfo> getAlternateKeyColumns()
     {
         List<ColumnInfo> pkCols = getPkColumns();
-        Map<String, IndexDef> indices = getUniqueIndices();
-        for (IndexDef def : indices.values())
+        Map<String, IndexDefinition> indices = getUniqueIndices();
+        for (IndexDefinition def : indices.values())
         {
             if (def.indexType() == IndexType.Primary)
                 continue;

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -242,16 +242,16 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
     @NotNull
     @Override
-    public Map<String, IndexDefinition> getUniqueIndices()
+    public List<IndexDefinition> getUniqueIndices()
     {
-        return Collections.emptyMap();
+        return List.of();
     }
 
     @NotNull
     @Override
-    public Map<String, IndexDefinition> getAllIndices()
+    public List<IndexDefinition> getAllIndices()
     {
-        return Collections.emptyMap();
+        return List.of();
     }
 
     @NotNull
@@ -259,8 +259,7 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     public List<ColumnInfo> getAlternateKeyColumns()
     {
         List<ColumnInfo> pkCols = getPkColumns();
-        Map<String, IndexDefinition> indices = getUniqueIndices();
-        for (IndexDefinition def : indices.values())
+        for (IndexDefinition def : getUniqueIndices())
         {
             if (def.indexType() == IndexType.Primary)
                 continue;

--- a/api/src/org/labkey/api/data/AbstractTableInfo.java
+++ b/api/src/org/labkey/api/data/AbstractTableInfo.java
@@ -242,14 +242,14 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
 
     @NotNull
     @Override
-    public Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
+    public Map<String, IndexDef> getUniqueIndices()
     {
         return Collections.emptyMap();
     }
 
     @NotNull
     @Override
-    public Map<String, Pair<IndexType, List<ColumnInfo>>> getAllIndices()
+    public Map<String, IndexDef> getAllIndices()
     {
         return Collections.emptyMap();
     }
@@ -259,13 +259,13 @@ abstract public class AbstractTableInfo implements TableInfo, AuditConfigurable,
     public List<ColumnInfo> getAlternateKeyColumns()
     {
         List<ColumnInfo> pkCols = getPkColumns();
-        Map<String, Pair<IndexType, List<ColumnInfo>>> indices = getUniqueIndices();
-        for (Pair<IndexType, List<ColumnInfo>> pair : indices.values())
+        Map<String, IndexDef> indices = getUniqueIndices();
+        for (IndexDef def : indices.values())
         {
-            if (pair.getKey() == IndexType.Primary)
+            if (def.indexType() == IndexType.Primary)
                 continue;
 
-            return pair.getValue();
+            return def.columns();
         }
 
         return pkCols;

--- a/api/src/org/labkey/api/data/EnumTableInfo.java
+++ b/api/src/org/labkey/api/data/EnumTableInfo.java
@@ -21,10 +21,9 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Exposes a Java enum as a virtual query table. Useful for creating lookups when it's really a hard-coded list
@@ -177,24 +176,21 @@ public class EnumTableInfo<EnumType extends Enum<EnumType>> extends VirtualTable
     }
 
     @Override
-    public @NotNull Map<String, IndexDefinition> getAllIndices()
+    public @NotNull List<IndexDefinition> getAllIndices()
     {
-        Map<String, IndexDefinition> indices = new HashMap<>();
-        String name = "pk_rowId";
-        indices.put(name, new IndexDefinition(name, IndexType.Primary, List.of(getColumn("RowId")), null));
-        indices.putAll(getUniqueIndices());
+        List<IndexDefinition> indices = new ArrayList<>();
+        indices.add(new IndexDefinition("pk_rowId", IndexType.Primary, List.of(getColumn("RowId")), null));
+        indices.addAll(getUniqueIndices());
         return indices;
     }
 
     @NotNull
     @Override
-    public Map<String, IndexDefinition> getUniqueIndices()
+    public List<IndexDefinition> getUniqueIndices()
     {
-        Map<String, IndexDefinition> indices = new HashMap<>();
-        String name = "uq_value";
-        indices.put(name, new IndexDefinition(name, IndexType.Unique, List.of(getColumn("Value")), null));
-        name = "uq_ordinal";
-        indices.put(name, new IndexDefinition(name, IndexType.Unique, List.of(getColumn("Ordinal")), null));
+        List<IndexDefinition> indices = new ArrayList<>();
+        indices.add(new IndexDefinition("uq_value", IndexType.Unique, List.of(getColumn("Value")), null));
+        indices.add(new IndexDefinition("uq_ordinal", IndexType.Unique, List.of(getColumn("Ordinal")), null));
         return indices;
     }
 }

--- a/api/src/org/labkey/api/data/EnumTableInfo.java
+++ b/api/src/org/labkey/api/data/EnumTableInfo.java
@@ -181,7 +181,7 @@ public class EnumTableInfo<EnumType extends Enum<EnumType>> extends VirtualTable
     {
         Map<String, IndexDefinition> indices = new HashMap<>();
         String name = "pk_rowId";
-        indices.put("pk_rowId", new IndexDefinition(name, IndexType.Primary, List.of(getColumn("RowId")), null));
+        indices.put(name, new IndexDefinition(name, IndexType.Primary, List.of(getColumn("RowId")), null));
         indices.putAll(getUniqueIndices());
         return indices;
     }

--- a/api/src/org/labkey/api/data/EnumTableInfo.java
+++ b/api/src/org/labkey/api/data/EnumTableInfo.java
@@ -20,9 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.util.Pair;
 
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -31,8 +29,6 @@ import java.util.Map;
 /**
  * Exposes a Java enum as a virtual query table. Useful for creating lookups when it's really a hard-coded list
  * of possible values that the code needs to match up against exactly. 
- * User: jeckels
- * Date: Jun 2, 2008
 */
 public class EnumTableInfo<EnumType extends Enum<EnumType>> extends VirtualTable<UserSchema>
 {
@@ -181,21 +177,24 @@ public class EnumTableInfo<EnumType extends Enum<EnumType>> extends VirtualTable
     }
 
     @Override
-    public @NotNull Map<String, Pair<IndexType, List<ColumnInfo>>> getAllIndices()
+    public @NotNull Map<String, IndexDef> getAllIndices()
     {
-        Map<String, Pair<IndexType, List<ColumnInfo>>> indices = new HashMap<>();
-        indices.put("pk_rowId", Pair.of(IndexType.Primary, Arrays.asList(getColumn("RowId"))));
+        Map<String, IndexDef> indices = new HashMap<>();
+        String name = "pk_rowId";
+        indices.put("pk_rowId", new IndexDef(name, IndexType.Primary, List.of(getColumn("RowId")), null));
         indices.putAll(getUniqueIndices());
         return indices;
     }
 
     @NotNull
     @Override
-    public Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
+    public Map<String, IndexDef> getUniqueIndices()
     {
-        Map<String, Pair<IndexType, List<ColumnInfo>>> indices = new HashMap<>();
-        indices.put("uq_value", Pair.of(IndexType.Unique, Arrays.asList(getColumn("Value"))));
-        indices.put("uq_oridinal", Pair.of(IndexType.Unique, Arrays.asList(getColumn("Ordinal"))));
+        Map<String, IndexDef> indices = new HashMap<>();
+        String name = "uq_value";
+        indices.put(name, new IndexDef(name, IndexType.Unique, List.of(getColumn("Value")), null));
+        name = "uq_ordinal";
+        indices.put(name, new IndexDef(name, IndexType.Unique, List.of(getColumn("Ordinal")), null));
         return indices;
     }
 }

--- a/api/src/org/labkey/api/data/EnumTableInfo.java
+++ b/api/src/org/labkey/api/data/EnumTableInfo.java
@@ -177,24 +177,24 @@ public class EnumTableInfo<EnumType extends Enum<EnumType>> extends VirtualTable
     }
 
     @Override
-    public @NotNull Map<String, IndexDef> getAllIndices()
+    public @NotNull Map<String, IndexDefinition> getAllIndices()
     {
-        Map<String, IndexDef> indices = new HashMap<>();
+        Map<String, IndexDefinition> indices = new HashMap<>();
         String name = "pk_rowId";
-        indices.put("pk_rowId", new IndexDef(name, IndexType.Primary, List.of(getColumn("RowId")), null));
+        indices.put("pk_rowId", new IndexDefinition(name, IndexType.Primary, List.of(getColumn("RowId")), null));
         indices.putAll(getUniqueIndices());
         return indices;
     }
 
     @NotNull
     @Override
-    public Map<String, IndexDef> getUniqueIndices()
+    public Map<String, IndexDefinition> getUniqueIndices()
     {
-        Map<String, IndexDef> indices = new HashMap<>();
+        Map<String, IndexDefinition> indices = new HashMap<>();
         String name = "uq_value";
-        indices.put(name, new IndexDef(name, IndexType.Unique, List.of(getColumn("Value")), null));
+        indices.put(name, new IndexDefinition(name, IndexType.Unique, List.of(getColumn("Value")), null));
         name = "uq_ordinal";
-        indices.put(name, new IndexDef(name, IndexType.Unique, List.of(getColumn("Ordinal")), null));
+        indices.put(name, new IndexDefinition(name, IndexType.Unique, List.of(getColumn("Ordinal")), null));
         return indices;
     }
 }

--- a/api/src/org/labkey/api/data/SchemaColumnMetaData.java
+++ b/api/src/org/labkey/api/data/SchemaColumnMetaData.java
@@ -347,19 +347,17 @@ public class SchemaColumnMetaData
 
                 String primaryKeyName = ti.getPrimaryKeyName();
                 Set<String> ignoreIndex = new HashSet<>();
-                Map<String, IndexDefinition> indexMap = new HashMap<>();
+                Map<String, IndexDefinition> indexMap = new CaseInsensitiveHashMap<>();
                 uqSelector.forEach(rs -> {
                     String colName = rs.getString("COLUMN_NAME");
                     String indexName = rs.getString("INDEX_NAME");
                     if (indexName == null)
                         return;
 
-                    indexName = indexName.toLowerCase();
-
                     IndexDefinition def = indexMap.get(indexName);
                     if (def == null)
                     {
-                        IndexType indexType = (indexName.equals(primaryKeyName) ? IndexType.Primary : rs.getBoolean("NON_UNIQUE") ? IndexType.NonUnique : IndexType.Unique);
+                        IndexType indexType = (indexName.equalsIgnoreCase(primaryKeyName) ? IndexType.Primary : rs.getBoolean("NON_UNIQUE") ? IndexType.NonUnique : IndexType.Unique);
                         @Nullable String filterCondition = scope.getSqlDialect().getIndexFilterCondition(rs, schema.getName(), ti.getName(), indexName);
                         indexMap.put(indexName, def = new IndexDefinition(indexName, indexType, new ArrayList<>(2), filterCondition));
                     }
@@ -378,11 +376,11 @@ public class SchemaColumnMetaData
                 Map<String, IndexDefinition> uniqueIndexMap = new HashMap<>();
                 Map<String, IndexDefinition> allIndexMap = new HashMap<>();
 
-                // Search for the primary key and change that index type to Primary
+                // Fill in the maps
                 for (IndexDefinition def : indexMap.values())
                 {
                     allIndexMap.put(def.name(), def);
-                    if (!def.indexType().isUnique())
+                    if (def.indexType().isUnique())
                         uniqueIndexMap.put(def.name(), def);
                 }
 
@@ -400,7 +398,7 @@ public class SchemaColumnMetaData
     protected void addColumn(MutableColumnInfo column)
     {
         if (getColumn(column.getName()) != null)
-            _log.warn("Duplicate column '" + column.getName() + "' on table '" + _tinfo.getName() + "'");
+            _log.warn("Duplicate column '{}' on table '{}'", column.getName(), _tinfo.getName());
 
         _columns.add(column);
         assert null == column.getFieldKey().getParent();

--- a/api/src/org/labkey/api/data/SchemaColumnMetaData.java
+++ b/api/src/org/labkey/api/data/SchemaColumnMetaData.java
@@ -373,8 +373,8 @@ public class SchemaColumnMetaData
                 // Remove ignored indices
                 ignoreIndex.forEach(indexMap::remove);
 
-                Map<String, IndexDefinition> uniqueIndexMap = new HashMap<>();
-                Map<String, IndexDefinition> allIndexMap = new HashMap<>();
+                Map<String, IndexDefinition> uniqueIndexMap = new CaseInsensitiveHashMap<>();
+                Map<String, IndexDefinition> allIndexMap = new CaseInsensitiveHashMap<>();
 
                 // Fill in the maps
                 for (IndexDefinition def : indexMap.values())

--- a/api/src/org/labkey/api/data/SchemaColumnMetaData.java
+++ b/api/src/org/labkey/api/data/SchemaColumnMetaData.java
@@ -63,8 +63,8 @@ public class SchemaColumnMetaData
     private List<ColumnInfo> _pkColumns;
     private String _titleColumn = null;
     private boolean _hasDefaultTitleColumn = true;
-    private Map<String, IndexDefinition> _uniqueIndices;
-    private Map<String, IndexDefinition> _allIndices;
+    private List<IndexDefinition> _uniqueIndices;
+    private List<IndexDefinition> _allIndices;
 
     private static final Logger _log = LogHelper.getLogger(SchemaColumnMetaData.class, "Extracts column metadata through JDBC and schema-scoped XML overrides");
 
@@ -332,8 +332,8 @@ public class SchemaColumnMetaData
         String schemaName = schema.getName();
         if (!ti.getSqlDialect().canCheckIndices(ti))
         {
-            _uniqueIndices = Collections.emptyMap();
-            _allIndices = Collections.emptyMap();
+            _uniqueIndices = Collections.emptyList();
+            _allIndices = Collections.emptyList();
         }
         else
         {
@@ -373,19 +373,19 @@ public class SchemaColumnMetaData
                 // Remove ignored indices
                 ignoreIndex.forEach(indexMap::remove);
 
-                Map<String, IndexDefinition> uniqueIndexMap = new CaseInsensitiveHashMap<>();
-                Map<String, IndexDefinition> allIndexMap = new CaseInsensitiveHashMap<>();
+                List<IndexDefinition> uniqueIndices = new ArrayList<>();
+                List<IndexDefinition> allIndices = new ArrayList<>();
 
-                // Fill in the maps
+                // Remove ignored indices and fill in the lists
                 for (IndexDefinition def : indexMap.values())
                 {
-                    allIndexMap.put(def.name(), def);
+                    allIndices.add(def);
                     if (def.indexType().isUnique())
-                        uniqueIndexMap.put(def.name(), def);
+                        uniqueIndices.add(def);
                 }
 
-                _uniqueIndices = Collections.unmodifiableMap(uniqueIndexMap);
-                _allIndices = Collections.unmodifiableMap(allIndexMap);
+                _uniqueIndices = Collections.unmodifiableList(uniqueIndices);
+                _allIndices = Collections.unmodifiableList(allIndices);
             }
         }
     }
@@ -542,7 +542,7 @@ public class SchemaColumnMetaData
         return _pkColumnNames;
     }
 
-    public @NotNull Map<String, IndexDefinition> getUniqueIndices()
+    public @NotNull List<IndexDefinition> getUniqueIndices()
     {
         if (_uniqueIndices == null)
         {
@@ -558,7 +558,7 @@ public class SchemaColumnMetaData
         return _uniqueIndices;
     }
 
-    public @NotNull Map<String, IndexDefinition> getAllIndices()
+    public @NotNull List<IndexDefinition> getAllIndices()
     {
         if (_allIndices == null)
         {

--- a/api/src/org/labkey/api/data/SchemaColumnMetaData.java
+++ b/api/src/org/labkey/api/data/SchemaColumnMetaData.java
@@ -21,7 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
-import org.labkey.api.data.TableInfo.IndexDef;
+import org.labkey.api.data.TableInfo.IndexDefinition;
 import org.labkey.api.data.TableInfo.IndexType;
 import org.labkey.api.data.dialect.JdbcMetaDataLocator;
 import org.labkey.api.data.dialect.PkMetaDataReader;
@@ -63,8 +63,8 @@ public class SchemaColumnMetaData
     private List<ColumnInfo> _pkColumns;
     private String _titleColumn = null;
     private boolean _hasDefaultTitleColumn = true;
-    private Map<String, IndexDef> _uniqueIndices;
-    private Map<String, IndexDef> _allIndices;
+    private Map<String, IndexDefinition> _uniqueIndices;
+    private Map<String, IndexDefinition> _allIndices;
 
     private static final Logger _log = LogHelper.getLogger(SchemaColumnMetaData.class, "Extracts column metadata through JDBC and schema-scoped XML overrides");
 
@@ -347,7 +347,7 @@ public class SchemaColumnMetaData
 
                 String primaryKeyName = ti.getPrimaryKeyName();
                 Set<String> ignoreIndex = new HashSet<>();
-                Map<String, IndexDef> indexMap = new HashMap<>();
+                Map<String, IndexDefinition> indexMap = new HashMap<>();
                 uqSelector.forEach(rs -> {
                     String colName = rs.getString("COLUMN_NAME");
                     String indexName = rs.getString("INDEX_NAME");
@@ -356,12 +356,12 @@ public class SchemaColumnMetaData
 
                     indexName = indexName.toLowerCase();
 
-                    IndexDef def = indexMap.get(indexName);
+                    IndexDefinition def = indexMap.get(indexName);
                     if (def == null)
                     {
                         IndexType indexType = (indexName.equals(primaryKeyName) ? IndexType.Primary : rs.getBoolean("NON_UNIQUE") ? IndexType.NonUnique : IndexType.Unique);
                         @Nullable String filterCondition = scope.getSqlDialect().getIndexFilterCondition(rs, schema.getName(), ti.getName(), indexName);
-                        indexMap.put(indexName, def = new IndexDef(indexName, indexType, new ArrayList<>(2), filterCondition));
+                        indexMap.put(indexName, def = new IndexDefinition(indexName, indexType, new ArrayList<>(2), filterCondition));
                     }
 
                     ColumnInfo colInfo = getColumn(colName);
@@ -375,11 +375,11 @@ public class SchemaColumnMetaData
                 // Remove ignored indices
                 ignoreIndex.forEach(indexMap::remove);
 
-                Map<String, IndexDef> uniqueIndexMap = new HashMap<>();
-                Map<String, IndexDef> allIndexMap = new HashMap<>();
+                Map<String, IndexDefinition> uniqueIndexMap = new HashMap<>();
+                Map<String, IndexDefinition> allIndexMap = new HashMap<>();
 
                 // Search for the primary key and change that index type to Primary
-                for (IndexDef def : indexMap.values())
+                for (IndexDefinition def : indexMap.values())
                 {
                     allIndexMap.put(def.name(), def);
                     if (!def.indexType().isUnique())
@@ -544,7 +544,7 @@ public class SchemaColumnMetaData
         return _pkColumnNames;
     }
 
-    public @NotNull Map<String, IndexDef> getUniqueIndices()
+    public @NotNull Map<String, IndexDefinition> getUniqueIndices()
     {
         if (_uniqueIndices == null)
         {
@@ -560,7 +560,7 @@ public class SchemaColumnMetaData
         return _uniqueIndices;
     }
 
-    public @NotNull Map<String, IndexDef> getAllIndices()
+    public @NotNull Map<String, IndexDefinition> getAllIndices()
     {
         if (_allIndices == null)
         {

--- a/api/src/org/labkey/api/data/SchemaColumnMetaData.java
+++ b/api/src/org/labkey/api/data/SchemaColumnMetaData.java
@@ -19,7 +19,10 @@ package org.labkey.api.data;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.data.TableInfo.IndexDef;
+import org.labkey.api.data.TableInfo.IndexType;
 import org.labkey.api.data.dialect.JdbcMetaDataLocator;
 import org.labkey.api.data.dialect.PkMetaDataReader;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -31,7 +34,6 @@ import org.labkey.api.sql.LabKeySql;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.DebugInfoDumper;
 import org.labkey.api.util.ExceptionUtil;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.data.xml.ColumnType;
 import org.labkey.data.xml.TableType;
@@ -50,11 +52,6 @@ import java.util.TreeMap;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-/*
-* User: adam
-* Date: Jun 29, 2011
-* Time: 3:02:47 PM
-*/
 public class SchemaColumnMetaData
 {
     private final SchemaTableInfo _tinfo;
@@ -66,8 +63,8 @@ public class SchemaColumnMetaData
     private List<ColumnInfo> _pkColumns;
     private String _titleColumn = null;
     private boolean _hasDefaultTitleColumn = true;
-    private Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> _uniqueIndices;
-    private Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> _allIndices;
+    private Map<String, IndexDef> _uniqueIndices;
+    private Map<String, IndexDef> _allIndices;
 
     private static final Logger _log = LogHelper.getLogger(SchemaColumnMetaData.class, "Extracts column metadata through JDBC and schema-scoped XML overrides");
 
@@ -348,8 +345,9 @@ public class SchemaColumnMetaData
                             return dbmd.getIndexInfo(l.getCatalogName(), l.getSchemaName(), l.getTableName(), uniqueIndicesOnly, true);
                         }));
 
+                String primaryKeyName = ti.getPrimaryKeyName();
                 Set<String> ignoreIndex = new HashSet<>();
-                Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> indexMap = new HashMap<>();
+                Map<String, IndexDef> indexMap = new HashMap<>();
                 uqSelector.forEach(rs -> {
                     String colName = rs.getString("COLUMN_NAME");
                     String indexName = rs.getString("INDEX_NAME");
@@ -358,11 +356,12 @@ public class SchemaColumnMetaData
 
                     indexName = indexName.toLowerCase();
 
-                    Pair<TableInfo.IndexType, List<ColumnInfo>> pair = indexMap.get(indexName);
-                    if (pair == null)
+                    IndexDef def = indexMap.get(indexName);
+                    if (def == null)
                     {
-                        TableInfo.IndexType indexType = rs.getBoolean("NON_UNIQUE")?TableInfo.IndexType.NonUnique:TableInfo.IndexType.Unique;
-                        indexMap.put(indexName, pair = Pair.of(indexType, new ArrayList<>(2)));
+                        IndexType indexType = (indexName.equals(primaryKeyName) ? IndexType.Primary : rs.getBoolean("NON_UNIQUE") ? IndexType.NonUnique : IndexType.Unique);
+                        @Nullable String filterCondition = rs.getString("FILTER_CONDITION");
+                        indexMap.put(indexName, def = new IndexDef(indexName, indexType, new ArrayList<>(2), filterCondition));
                     }
 
                     ColumnInfo colInfo = getColumn(colName);
@@ -370,35 +369,23 @@ public class SchemaColumnMetaData
                     if (colInfo == null)
                         ignoreIndex.add(indexName);
                     else
-                        pair.getValue().add(colInfo);
+                        def.addColumn(colInfo);
                 });
 
                 // Remove ignored indices
                 ignoreIndex.forEach(indexMap::remove);
 
-                Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> uniqueIndexMap = new HashMap<>();
-                Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> allIndexMap = new HashMap<>();
-                String primaryKeyName = ti.getPrimaryKeyName();
+                Map<String, IndexDef> uniqueIndexMap = new HashMap<>();
+                Map<String, IndexDef> allIndexMap = new HashMap<>();
 
                 // Search for the primary key and change that index type to Primary
-                for (Map.Entry<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> entry : indexMap.entrySet())
+                for (IndexDef def : indexMap.values())
                 {
-                    if (entry.getKey().equals(primaryKeyName))
-                    {
-                        List<ColumnInfo> cols = entry.getValue().getValue();
-                        Pair<TableInfo.IndexType, List<ColumnInfo>> indexTypeListPair = Pair.of(TableInfo.IndexType.Primary, cols);
-                        uniqueIndexMap.put(entry.getKey(), indexTypeListPair);
-                        allIndexMap.put(entry.getKey(), indexTypeListPair);
-                    }
-                    else
-                    {
-                        if (entry.getValue().getKey()== TableInfo.IndexType.Unique)
-                        {
-                            uniqueIndexMap.put(entry.getKey(), entry.getValue());
-                        }
-                        allIndexMap.put(entry.getKey(), entry.getValue());
-                    }
+                    allIndexMap.put(def.name(), def);
+                    if (!def.indexType().isUnique())
+                        uniqueIndexMap.put(def.name(), def);
                 }
+
                 _uniqueIndices = Collections.unmodifiableMap(uniqueIndexMap);
                 _allIndices = Collections.unmodifiableMap(allIndexMap);
             }
@@ -557,9 +544,9 @@ public class SchemaColumnMetaData
         return _pkColumnNames;
     }
 
-    public @NotNull Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> getUniqueIndices()
+    public @NotNull Map<String, IndexDef> getUniqueIndices()
     {
-        if(_uniqueIndices == null)
+        if (_uniqueIndices == null)
         {
             try
             {
@@ -573,9 +560,9 @@ public class SchemaColumnMetaData
         return _uniqueIndices;
     }
 
-    public @NotNull Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> getAllIndices()
+    public @NotNull Map<String, IndexDef> getAllIndices()
     {
-        if(_allIndices == null)
+        if (_allIndices == null)
         {
             try
             {

--- a/api/src/org/labkey/api/data/SchemaColumnMetaData.java
+++ b/api/src/org/labkey/api/data/SchemaColumnMetaData.java
@@ -360,7 +360,7 @@ public class SchemaColumnMetaData
                     if (def == null)
                     {
                         IndexType indexType = (indexName.equals(primaryKeyName) ? IndexType.Primary : rs.getBoolean("NON_UNIQUE") ? IndexType.NonUnique : IndexType.Unique);
-                        @Nullable String filterCondition = rs.getString("FILTER_CONDITION");
+                        @Nullable String filterCondition = scope.getSqlDialect().getIndexFilterCondition(rs, schema.getName(), ti.getName(), indexName);
                         indexMap.put(indexName, def = new IndexDef(indexName, indexType, new ArrayList<>(2), filterCondition));
                     }
 

--- a/api/src/org/labkey/api/data/SchemaTableInfo.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfo.java
@@ -307,14 +307,14 @@ public class SchemaTableInfo implements TableInfo, UpdateableTableInfo, AuditCon
     }
 
     @Override @NotNull
-    public Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
+    public Map<String, IndexDef> getUniqueIndices()
     {
         return getColumnMetaData().getUniqueIndices();
     }
 
     @NotNull
     @Override
-    public Map<String, Pair<IndexType, List<ColumnInfo>>> getAllIndices()
+    public Map<String, IndexDef> getAllIndices()
     {
         return getColumnMetaData().getAllIndices();
     }

--- a/api/src/org/labkey/api/data/SchemaTableInfo.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfo.java
@@ -307,14 +307,14 @@ public class SchemaTableInfo implements TableInfo, UpdateableTableInfo, AuditCon
     }
 
     @Override @NotNull
-    public Map<String, IndexDefinition> getUniqueIndices()
+    public List<IndexDefinition> getUniqueIndices()
     {
         return getColumnMetaData().getUniqueIndices();
     }
 
     @NotNull
     @Override
-    public Map<String, IndexDefinition> getAllIndices()
+    public List<IndexDefinition> getAllIndices()
     {
         return getColumnMetaData().getAllIndices();
     }

--- a/api/src/org/labkey/api/data/SchemaTableInfo.java
+++ b/api/src/org/labkey/api/data/SchemaTableInfo.java
@@ -307,14 +307,14 @@ public class SchemaTableInfo implements TableInfo, UpdateableTableInfo, AuditCon
     }
 
     @Override @NotNull
-    public Map<String, IndexDef> getUniqueIndices()
+    public Map<String, IndexDefinition> getUniqueIndices()
     {
         return getColumnMetaData().getUniqueIndices();
     }
 
     @NotNull
     @Override
-    public Map<String, IndexDef> getAllIndices()
+    public Map<String, IndexDefinition> getAllIndices()
     {
         return getColumnMetaData().getAllIndices();
     }

--- a/api/src/org/labkey/api/data/TableChange.java
+++ b/api/src/org/labkey/api/data/TableChange.java
@@ -18,6 +18,7 @@ package org.labkey.api.data;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.PropertyStorageSpec.Index;
+import org.labkey.api.data.TableInfo.IndexDefinition;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainKind;
@@ -145,7 +146,7 @@ public class TableChange
             TableInfo storageTableInfo = schema.getTable(_domain.getStorageTableName());
             if (storageTableInfo != null)
             {
-                for (TableInfo.IndexDefinition index : storageTableInfo.getAllIndices().values())
+                for (IndexDefinition index : storageTableInfo.getAllIndices())
                 {
                     List<String> columnNames = index.columns().stream().map(ColumnInfo::getName).collect(Collectors.toList());
 

--- a/api/src/org/labkey/api/data/TableChange.java
+++ b/api/src/org/labkey/api/data/TableChange.java
@@ -21,7 +21,6 @@ import org.labkey.api.data.PropertyStorageSpec.Index;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainKind;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.logging.LogHelper;
 
 import java.util.ArrayList;
@@ -146,14 +145,14 @@ public class TableChange
             TableInfo storageTableInfo = schema.getTable(_domain.getStorageTableName());
             if (storageTableInfo != null)
             {
-                for (Pair<TableInfo.IndexType, List<ColumnInfo>> index : storageTableInfo.getAllIndices().values())
+                for (TableInfo.IndexDef index : storageTableInfo.getAllIndices().values())
                 {
-                    List<String> columnNames = index.getValue().stream().map(ColumnInfo::getName).collect(Collectors.toList());
+                    List<String> columnNames = index.columns().stream().map(ColumnInfo::getName).collect(Collectors.toList());
 
                     // CONSIDER: Move this re-classification of the non-unique index as a unique index into SchemaColumnMetaData.loadUniqueIndices()
                     // SQLServer creates a non-unique index for single large text columns with a "_hashed_" prefix.
                     // The uniqueness is enforced by a database trigger.
-                    boolean unique = index.first == TableInfo.IndexType.Unique ||
+                    boolean unique = index.indexType() == TableInfo.IndexType.Unique ||
                             (schema.getSqlDialect().isSqlServer() && columnNames.size() == 1 && columnNames.get(0).startsWith(PropertyStorageSpec.HASHED_COLUMN_PREFIX));
 
                     // remove the _hashed_ column prefix for SQLServer

--- a/api/src/org/labkey/api/data/TableChange.java
+++ b/api/src/org/labkey/api/data/TableChange.java
@@ -145,7 +145,7 @@ public class TableChange
             TableInfo storageTableInfo = schema.getTable(_domain.getStorageTableName());
             if (storageTableInfo != null)
             {
-                for (TableInfo.IndexDef index : storageTableInfo.getAllIndices().values())
+                for (TableInfo.IndexDefinition index : storageTableInfo.getAllIndices().values())
                 {
                     List<String> columnNames = index.columns().stream().map(ColumnInfo::getName).collect(Collectors.toList());
 

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -140,11 +140,11 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
 
     /** Gets all the constraints that guarantee uniqueness in the underlying table. This includes both PRIMARY KEY and UNIQUE constraints */
     @NotNull
-    Map<String, IndexDef> getUniqueIndices();
+    Map<String, IndexDefinition> getUniqueIndices();
 
     /** Gets all the indices from the underlying table. This includes PRIMARY KEY and UNIQUE constraints, as well as non-unique INDEX */
     @NotNull
-    Map<String, IndexDef> getAllIndices();
+    Map<String, IndexDefinition> getAllIndices();
 
     class _DoNothingAuditHandler implements AuditHandler
     {
@@ -203,7 +203,7 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
         }
     }
 
-    record IndexDef(String name, IndexType indexType, List<ColumnInfo> columns, @Nullable String filterCondition)
+    record IndexDefinition(String name, IndexType indexType, List<ColumnInfo> columns, @Nullable String filterCondition)
     {
         void addColumn(ColumnInfo column)
         {

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -138,13 +138,13 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
 
     @NotNull List<ColumnInfo> getPkColumns();
 
-    /** Gets all of the constraints that guarantee uniqueness in the underlying table. This includes both PRIMARY KEY and UNIQUE constraints */
+    /** Gets all the constraints that guarantee uniqueness in the underlying table. This includes both PRIMARY KEY and UNIQUE constraints */
     @NotNull
-    Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices();
+    Map<String, IndexDef> getUniqueIndices();
 
-    /** Gets all of the indices from the underlying table. This includes PRIMARY KEY and UNIQUE constraints, as well as non-unique INDEX */
+    /** Gets all the indices from the underlying table. This includes PRIMARY KEY and UNIQUE constraints, as well as non-unique INDEX */
     @NotNull
-    Map<String, Pair<IndexType, List<ColumnInfo>>> getAllIndices();
+    Map<String, IndexDef> getAllIndices();
 
     class _DoNothingAuditHandler implements AuditHandler
     {
@@ -200,6 +200,14 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
                 }
             }
             throw new EnumConstantNotPresentException(IndexType.class, xmlIndexType.toString());
+        }
+    }
+
+    record IndexDef(String name, IndexType indexType, List<ColumnInfo> columns, @Nullable String filterCondition)
+    {
+        void addColumn(ColumnInfo column)
+        {
+            columns.add(column);
         }
     }
 

--- a/api/src/org/labkey/api/data/TableInfo.java
+++ b/api/src/org/labkey/api/data/TableInfo.java
@@ -140,11 +140,11 @@ public interface TableInfo extends TableDescription, HasPermission, SchemaTreeNo
 
     /** Gets all the constraints that guarantee uniqueness in the underlying table. This includes both PRIMARY KEY and UNIQUE constraints */
     @NotNull
-    Map<String, IndexDefinition> getUniqueIndices();
+    List<IndexDefinition> getUniqueIndices();
 
     /** Gets all the indices from the underlying table. This includes PRIMARY KEY and UNIQUE constraints, as well as non-unique INDEX */
     @NotNull
-    Map<String, IndexDefinition> getAllIndices();
+    List<IndexDefinition> getAllIndices();
 
     class _DoNothingAuditHandler implements AuditHandler
     {

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -2139,6 +2139,12 @@ public abstract class SqlDialect
         throw new UnsupportedOperationException(getClass().getSimpleName() + " does not implement");
     }
 
+    public @Nullable String getIndexFilterCondition(ResultSet rs, String schemaName, String tableName, String indexName) throws SQLException
+    {
+        // Most dialects return filter conditions in the ResultSet returned by getIndexInfo()
+        return rs.getString("FILTER_CONDITION");
+    }
+
     public static class DialectTestCase
     {
         DbScope s;

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -51,7 +51,7 @@ import org.labkey.api.data.MvUtil;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableDescription;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableInfo.IndexDef;
+import org.labkey.api.data.TableInfo.IndexDefinition;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.TestSchema;
 import org.labkey.api.exp.MvFieldWrapper;
@@ -244,7 +244,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                 // - Has a single primary key
                 // - Has a unique index over a single column that isn't the primary key
                 // - The column in the unique index must be a string type
-                for (IndexDef def : _targetTable.getUniqueIndices().values())
+                for (IndexDefinition def : _targetTable.getUniqueIndices().values())
                 {
                     if (def.indexType() != TableInfo.IndexType.Unique)
                         continue;

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -244,7 +244,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                 // - Has a single primary key
                 // - Has a unique index over a single column that isn't the primary key
                 // - The column in the unique index must be a string type
-                for (IndexDefinition def : _targetTable.getUniqueIndices().values())
+                for (IndexDefinition def : _targetTable.getUniqueIndices())
                 {
                     if (def.indexType() != TableInfo.IndexType.Unique)
                         continue;

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -51,6 +51,7 @@ import org.labkey.api.data.MvUtil;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableDescription;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableInfo.IndexDef;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.TestSchema;
 import org.labkey.api.exp.MvFieldWrapper;
@@ -243,15 +244,15 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
                 // - Has a single primary key
                 // - Has a unique index over a single column that isn't the primary key
                 // - The column in the unique index must be a string type
-                for (Pair<TableInfo.IndexType, List<ColumnInfo>> index : _targetTable.getUniqueIndices().values())
+                for (IndexDef def : _targetTable.getUniqueIndices().values())
                 {
-                    if (index.getKey() != TableInfo.IndexType.Unique)
+                    if (def.indexType() != TableInfo.IndexType.Unique)
                         continue;
 
-                    if (index.getValue().size() != 1)
+                    if (def.columns().size() != 1)
                         continue;
 
-                    ColumnInfo col = index.getValue().get(0);
+                    ColumnInfo col = def.columns().get(0);
                     if (!seen.add(col))
                         continue;
 

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -41,7 +41,7 @@ import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.data.SchemaTableInfo;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableInfo.IndexDef;
+import org.labkey.api.data.TableInfo.IndexDefinition;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.dataiterator.DataIteratorUtil;
 import org.labkey.api.defaults.DefaultValueService;
@@ -363,7 +363,7 @@ public class DomainUtil
         if (domainKind.allowUniqueConstraintProperties())
         {
             SchemaTableInfo schemaTableInfo = StorageProvisioner.get().getSchemaTableInfo(domain);
-            Map<String, IndexDef> allIndices = schemaTableInfo.getAllIndices();
+            Map<String, IndexDefinition> allIndices = schemaTableInfo.getAllIndices();
             if (!allIndices.isEmpty())
             {
                 List<GWTIndex> indices = allIndices.values().stream()

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -363,10 +363,10 @@ public class DomainUtil
         if (domainKind.allowUniqueConstraintProperties())
         {
             SchemaTableInfo schemaTableInfo = StorageProvisioner.get().getSchemaTableInfo(domain);
-            Map<String, IndexDefinition> allIndices = schemaTableInfo.getAllIndices();
+            List<IndexDefinition> allIndices = schemaTableInfo.getAllIndices();
             if (!allIndices.isEmpty())
             {
-                List<GWTIndex> indices = allIndices.values().stream()
+                List<GWTIndex> indices = allIndices.stream()
                     .filter(index -> !index.indexType().equals(TableInfo.IndexType.Primary))
                     .map(index -> new GWTIndex(index.columns().stream().map(ColumnInfo::getColumnName).toList(), index.indexType().isUnique()))
                     .toList();

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -41,6 +41,7 @@ import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.data.SchemaTableInfo;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableInfo.IndexDef;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.dataiterator.DataIteratorUtil;
 import org.labkey.api.defaults.DefaultValueService;
@@ -82,7 +83,6 @@ import org.labkey.api.util.GUID;
 import org.labkey.api.util.JdbcUtil;
 import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.UnauthorizedException;
@@ -363,13 +363,13 @@ public class DomainUtil
         if (domainKind.allowUniqueConstraintProperties())
         {
             SchemaTableInfo schemaTableInfo = StorageProvisioner.get().getSchemaTableInfo(domain);
-            Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> allIndices = schemaTableInfo.getAllIndices();
+            Map<String, IndexDef> allIndices = schemaTableInfo.getAllIndices();
             if (!allIndices.isEmpty())
             {
                 List<GWTIndex> indices = allIndices.values().stream()
-                        .filter(index -> !index.getKey().equals(TableInfo.IndexType.Primary))
-                        .map(index -> new GWTIndex(index.getValue().stream().map(ColumnInfo::getColumnName).toList(), index.getKey().isUnique()))
-                        .toList();
+                    .filter(index -> !index.indexType().equals(TableInfo.IndexType.Primary))
+                    .map(index -> new GWTIndex(index.columns().stream().map(ColumnInfo::getColumnName).toList(), index.indexType().isUnique()))
+                    .toList();
 
                 gwtDomain.setIndices(indices);
             }

--- a/api/src/org/labkey/api/query/FilteredTable.java
+++ b/api/src/org/labkey/api/query/FilteredTable.java
@@ -45,7 +45,6 @@ import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.util.ContainerContext;
 import org.labkey.api.util.ExceptionUtil;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
@@ -816,38 +815,38 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
 
     @NotNull
     @Override
-    public Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
+    public Map<String, IndexDef> getUniqueIndices()
     {
         return Collections.unmodifiableMap(wrapTableIndices(getRealTable()));
     }
 
-    protected Map<String, Pair<IndexType, List<ColumnInfo>>> wrapTableIndices(TableInfo table)
+    protected Map<String, IndexDef> wrapTableIndices(TableInfo table)
     {
-        Map<String, Pair<IndexType, List<ColumnInfo>>> indices = table.getUniqueIndices();
+        Map<String, IndexDef> indices = table.getUniqueIndices();
         return getStringPairMap(indices);
     }
 
     @NotNull
     @Override
-    public Map<String, Pair<IndexType, List<ColumnInfo>>> getAllIndices()
+    public Map<String, IndexDef> getAllIndices()
     {
         return Collections.unmodifiableMap(wrapTableAllIndices(getRealTable()));
     }
 
-    protected Map<String, Pair<IndexType, List<ColumnInfo>>> wrapTableAllIndices(TableInfo table)
+    protected Map<String, IndexDef> wrapTableAllIndices(TableInfo table)
     {
-        Map<String, Pair<IndexType, List<ColumnInfo>>> indices = table.getAllIndices();
+        Map<String, IndexDef> indices = table.getAllIndices();
         return getStringPairMap(indices);
     }
 
     @NotNull
-    private Map<String, Pair<IndexType, List<ColumnInfo>>> getStringPairMap(Map<String, Pair<IndexType, List<ColumnInfo>>> indices)
+    private Map<String, IndexDef> getStringPairMap(Map<String, IndexDef> indices)
     {
-        Map<String, Pair<IndexType, List<ColumnInfo>>> ret = new HashMap<>();
-        for (Map.Entry<String, Pair<IndexType, List<ColumnInfo>>> entry : indices.entrySet())
+        Map<String, IndexDef> ret = new HashMap<>();
+        for (IndexDef def : indices.values())
         {
-            List<ColumnInfo> indexCols = new ArrayList<>(entry.getValue().getValue().size());
-            for (ColumnInfo col : entry.getValue().getValue())
+            List<ColumnInfo> indexCols = new ArrayList<>(def.columns().size());
+            for (ColumnInfo col : def.columns())
             {
                 ColumnInfo c = getColumn(col.getFieldKey());
                 if (c != null)
@@ -855,7 +854,7 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
             }
 
             if (!indexCols.isEmpty())
-                ret.put(entry.getKey(), Pair.of(entry.getValue().getKey(), indexCols));
+                ret.put(def.name(), new IndexDef(def.name(), def.indexType(), indexCols, def.filterCondition()));
         }
 
         return ret;

--- a/api/src/org/labkey/api/query/FilteredTable.java
+++ b/api/src/org/labkey/api/query/FilteredTable.java
@@ -815,35 +815,35 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
 
     @NotNull
     @Override
-    public Map<String, IndexDef> getUniqueIndices()
+    public Map<String, IndexDefinition> getUniqueIndices()
     {
         return Collections.unmodifiableMap(wrapTableIndices(getRealTable()));
     }
 
-    protected Map<String, IndexDef> wrapTableIndices(TableInfo table)
+    protected Map<String, IndexDefinition> wrapTableIndices(TableInfo table)
     {
-        Map<String, IndexDef> indices = table.getUniqueIndices();
+        Map<String, IndexDefinition> indices = table.getUniqueIndices();
         return getStringPairMap(indices);
     }
 
     @NotNull
     @Override
-    public Map<String, IndexDef> getAllIndices()
+    public Map<String, IndexDefinition> getAllIndices()
     {
         return Collections.unmodifiableMap(wrapTableAllIndices(getRealTable()));
     }
 
-    protected Map<String, IndexDef> wrapTableAllIndices(TableInfo table)
+    protected Map<String, IndexDefinition> wrapTableAllIndices(TableInfo table)
     {
-        Map<String, IndexDef> indices = table.getAllIndices();
+        Map<String, IndexDefinition> indices = table.getAllIndices();
         return getStringPairMap(indices);
     }
 
     @NotNull
-    private Map<String, IndexDef> getStringPairMap(Map<String, IndexDef> indices)
+    private Map<String, IndexDefinition> getStringPairMap(Map<String, IndexDefinition> indices)
     {
-        Map<String, IndexDef> ret = new HashMap<>();
-        for (IndexDef def : indices.values())
+        Map<String, IndexDefinition> ret = new HashMap<>();
+        for (IndexDefinition def : indices.values())
         {
             List<ColumnInfo> indexCols = new ArrayList<>(def.columns().size());
             for (ColumnInfo col : def.columns())
@@ -854,7 +854,7 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
             }
 
             if (!indexCols.isEmpty())
-                ret.put(def.name(), new IndexDef(def.name(), def.indexType(), indexCols, def.filterCondition()));
+                ret.put(def.name(), new IndexDefinition(def.name(), def.indexType(), indexCols, def.filterCondition()));
         }
 
         return ret;

--- a/api/src/org/labkey/api/query/FilteredTable.java
+++ b/api/src/org/labkey/api/query/FilteredTable.java
@@ -55,7 +55,6 @@ import org.labkey.data.xml.TableType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -815,35 +814,35 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
 
     @NotNull
     @Override
-    public Map<String, IndexDefinition> getUniqueIndices()
+    public List<IndexDefinition> getUniqueIndices()
     {
-        return Collections.unmodifiableMap(wrapTableIndices(getRealTable()));
+        return Collections.unmodifiableList(wrapTableIndices(getRealTable()));
     }
 
-    protected Map<String, IndexDefinition> wrapTableIndices(TableInfo table)
+    protected List<IndexDefinition> wrapTableIndices(TableInfo table)
     {
-        Map<String, IndexDefinition> indices = table.getUniqueIndices();
+        List<IndexDefinition> indices = table.getUniqueIndices();
         return getStringPairMap(indices);
     }
 
     @NotNull
     @Override
-    public Map<String, IndexDefinition> getAllIndices()
+    public List<IndexDefinition> getAllIndices()
     {
-        return Collections.unmodifiableMap(wrapTableAllIndices(getRealTable()));
+        return Collections.unmodifiableList(wrapTableAllIndices(getRealTable()));
     }
 
-    protected Map<String, IndexDefinition> wrapTableAllIndices(TableInfo table)
+    protected List<IndexDefinition> wrapTableAllIndices(TableInfo table)
     {
-        Map<String, IndexDefinition> indices = table.getAllIndices();
+        List<IndexDefinition> indices = table.getAllIndices();
         return getStringPairMap(indices);
     }
 
     @NotNull
-    private Map<String, IndexDefinition> getStringPairMap(Map<String, IndexDefinition> indices)
+    private List<IndexDefinition> getStringPairMap(List<IndexDefinition> indices)
     {
-        Map<String, IndexDefinition> ret = new HashMap<>();
-        for (IndexDefinition def : indices.values())
+        List<IndexDefinition> ret = new ArrayList<>();
+        for (IndexDefinition def : indices)
         {
             List<ColumnInfo> indexCols = new ArrayList<>(def.columns().size());
             for (ColumnInfo col : def.columns())
@@ -854,7 +853,7 @@ public class FilteredTable<SchemaType extends UserSchema> extends AbstractContai
             }
 
             if (!indexCols.isEmpty())
-                ret.put(def.name(), new IndexDefinition(def.name(), def.indexType(), indexCols, def.filterCondition()));
+                ret.add(new IndexDefinition(def.name(), def.indexType(), indexCols, def.filterCondition()));
         }
 
         return ret;

--- a/core/src/org/labkey/core/query/UsersTable.java
+++ b/core/src/org/labkey/core/query/UsersTable.java
@@ -463,11 +463,11 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
     }
 
     @Override
-    public @NotNull Map<String, IndexDef> getUniqueIndices()
+    public @NotNull Map<String, IndexDefinition> getUniqueIndices()
     {
-        Map<String, IndexDef> unique = new HashMap<>(super.getUniqueIndices());
+        Map<String, IndexDefinition> unique = new HashMap<>(super.getUniqueIndices());
         String name = "uq_users_email";
-        unique.put(name, new IndexDef(name, IndexType.Unique, getColumns("Email"), null));
+        unique.put(name, new IndexDefinition(name, IndexType.Unique, getColumns("Email"), null));
         return unique;
     }
 

--- a/core/src/org/labkey/core/query/UsersTable.java
+++ b/core/src/org/labkey/core/query/UsersTable.java
@@ -86,7 +86,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -463,11 +462,10 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
     }
 
     @Override
-    public @NotNull Map<String, IndexDefinition> getUniqueIndices()
+    public @NotNull List<IndexDefinition> getUniqueIndices()
     {
-        Map<String, IndexDefinition> unique = new HashMap<>(super.getUniqueIndices());
-        String name = "uq_users_email";
-        unique.put(name, new IndexDefinition(name, IndexType.Unique, getColumns("Email"), null));
+        List<IndexDefinition> unique = new ArrayList<>(super.getUniqueIndices());
+        unique.add(new IndexDefinition("uq_users_email", IndexType.Unique, getColumns("Email"), null));
         return unique;
     }
 

--- a/core/src/org/labkey/core/query/UsersTable.java
+++ b/core/src/org/labkey/core/query/UsersTable.java
@@ -70,7 +70,6 @@ import org.labkey.api.security.roles.SeeUserAndGroupDetailsRole;
 import org.labkey.api.thumbnail.ImageStreamThumbnailProvider;
 import org.labkey.api.thumbnail.ThumbnailService;
 import org.labkey.api.util.DateUtil;
-import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
@@ -464,10 +463,11 @@ public class UsersTable extends SimpleUserSchema.SimpleTable<UserSchema>
     }
 
     @Override
-    public @NotNull Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
+    public @NotNull Map<String, IndexDef> getUniqueIndices()
     {
-        Map<String, Pair<IndexType, List<ColumnInfo>>> unique = new HashMap<>(super.getUniqueIndices());
-        unique.put("uq_users_email", Pair.of(IndexType.Unique, getColumns("Email")));
+        Map<String, IndexDef> unique = new HashMap<>(super.getUniqueIndices());
+        String name = "uq_users_email";
+        unique.put(name, new IndexDef(name, IndexType.Unique, getColumns("Email"), null));
         return unique;
     }
 

--- a/devtools/src/org/labkey/devtools/ToolsController.java
+++ b/devtools/src/org/labkey/devtools/ToolsController.java
@@ -769,7 +769,7 @@ public class ToolsController extends SpringActionController
                     try
                     {
                         // All writers are closed below
-                        WriterContext context = getFileWriter(overlap.schemaName());
+                        WriterContext context = getWriterContext(overlap.schemaName());
                         if (type.writeScript(context.getWriter(), overlap))
                             context.setModified();
                     }
@@ -781,7 +781,7 @@ public class ToolsController extends SpringActionController
             }
             finally
             {
-                closeAllWriters();
+                closeAllContexts();
             }
 
             return true;
@@ -834,11 +834,11 @@ public class ToolsController extends SpringActionController
             }
         }
 
-        private final Map<String, WriterContext> _writerMap = new HashMap<>();
+        private final Map<String, WriterContext> _writerContextMap = new HashMap<>();
 
-        private WriterContext getFileWriter(String schemaName) throws IOException
+        private WriterContext getWriterContext(String schemaName) throws IOException
         {
-            return _writerMap.computeIfAbsent(schemaName, n -> {
+            return _writerContextMap.computeIfAbsent(schemaName, n -> {
 
                 DbSchema schema = DbSchema.get(schemaName, DbSchemaType.Module);
                 Module module = schema.getModule();
@@ -870,9 +870,9 @@ public class ToolsController extends SpringActionController
             return schemaName + "-" + Formats.f3.format(startVersion) + "-" + Formats.f3.format(startVersion + 0.001) + ".sql";
         }
 
-        private void closeAllWriters()
+        private void closeAllContexts()
         {
-            _writerMap.values().forEach(context -> {
+            _writerContextMap.values().forEach(context -> {
                 try
                 {
                     context.close();
@@ -974,7 +974,7 @@ public class ToolsController extends SpringActionController
 
     protected enum OverlapType
     {
-        UniqueOverlappingNonUnique("column sets that overlap at the start, but the first index is a unique constraint. These are likely valid")
+        UniqueOverlappingNonUnique("column lists that overlap at the start, but the first index is a unique constraint. These are likely valid")
         {
             @Override
             boolean writeScript(Writer writer, Overlap overlap)
@@ -982,7 +982,7 @@ public class ToolsController extends SpringActionController
                 return false; // Write nothing
             }
         },
-        OverlappingWithDifferentFilter("column sets that overlap at the start, but with different filter conditions. These are likely valid")
+        OverlappingWithDifferentFilter("column lists that overlap at the start, but with different filter conditions. These are likely valid")
         {
             @Override
             boolean writeScript(Writer writer, Overlap overlap)
@@ -990,7 +990,7 @@ public class ToolsController extends SpringActionController
                 return false; // Write nothing
             }
         },
-        Identical("identical column sets")
+        Identical("identical column lists")
         {
             @Override
             boolean writeScript(Writer writer, Overlap overlap) throws IOException
@@ -1043,7 +1043,7 @@ public class ToolsController extends SpringActionController
                 return overlap.indexDef1.name() + " vs. " + overlap.indexDef2.name() + ": " + join(overlap.indexDef1.columns());
             }
         },
-        Overlapping("column sets that overlap at the start")
+        Overlapping("column lists that overlap at the start")
         {
             @Override
             boolean writeScript(Writer writer, Overlap overlap) throws IOException

--- a/devtools/src/org/labkey/devtools/ToolsController.java
+++ b/devtools/src/org/labkey/devtools/ToolsController.java
@@ -910,14 +910,14 @@ public class ToolsController extends SpringActionController
                 .flatMap(schema -> schema.getTableNames().stream().map(schema::getTable))
                 .forEach(table -> {
                     var indices = table.getAllIndices();
-                    indices.forEach((indexName1, indexDef1) -> indices.forEach((indexName2, indexDef2) -> {
+                    indices.forEach(indexDef1 -> indices.forEach(indexDef2 -> {
                         if (indexDef1 != indexDef2)
                         {
                             OverlapType type = overlap(indexDef1, indexDef2);
 
                             if (type != null)
                             {
-                                if (type != OverlapType.Identical || !alreadySeen(indexName1, indexName2))
+                                if (type != OverlapType.Identical || !alreadySeen(indexDef1.name(), indexDef2.name()))
                                     multiMap.put(type, new Overlap(table.getSchema().getName(), table.getName(), indexDef1, indexDef2));
                             }
                         }

--- a/devtools/src/org/labkey/devtools/ToolsController.java
+++ b/devtools/src/org/labkey/devtools/ToolsController.java
@@ -15,7 +15,7 @@ import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.FileSqlScriptProvider;
-import org.labkey.api.data.TableInfo.IndexDef;
+import org.labkey.api.data.TableInfo.IndexDefinition;
 import org.labkey.api.data.TableInfo.IndexType;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.module.Module;
@@ -936,7 +936,7 @@ public class ToolsController extends SpringActionController
             return !_alreadySeen.add(key);
         }
 
-        private @Nullable OverlapType overlap(IndexDef index1, IndexDef index2)
+        private @Nullable OverlapType overlap(IndexDefinition index1, IndexDefinition index2)
         {
             String key1 = getKey(index1.columns());
             String key2 = getKey(index2.columns());
@@ -970,7 +970,7 @@ public class ToolsController extends SpringActionController
         }
     }
 
-    protected record Overlap(String schemaName, String tableName, IndexDef indexDef1, IndexDef indexDef2) {}
+    protected record Overlap(String schemaName, String tableName, IndexDefinition indexDef1, IndexDefinition indexDef2) {}
 
     protected enum OverlapType
     {

--- a/devtools/src/org/labkey/devtools/ToolsController.java
+++ b/devtools/src/org/labkey/devtools/ToolsController.java
@@ -974,7 +974,7 @@ public class ToolsController extends SpringActionController
 
     protected enum OverlapType
     {
-        UniqueOverlappingNonUnique("column lists that overlap at the start, but the first index is a unique constraint. These are likely valid")
+        UniqueOverlappingNonUnique("a column list that overlaps another index's column list at the start, but the first index is a unique constraint. These are likely valid")
         {
             @Override
             boolean writeScript(Writer writer, Overlap overlap)
@@ -982,7 +982,7 @@ public class ToolsController extends SpringActionController
                 return false; // Write nothing
             }
         },
-        OverlappingWithDifferentFilter("column lists that overlap at the start, but with different filter conditions. These are likely valid")
+        OverlappingWithDifferentFilter("a column list that overlaps another index's column list at the start, but with different filter conditions. These are likely valid")
         {
             @Override
             boolean writeScript(Writer writer, Overlap overlap)
@@ -990,7 +990,7 @@ public class ToolsController extends SpringActionController
                 return false; // Write nothing
             }
         },
-        Identical("identical column lists")
+        Identical("a column list that's identical to another index's column list")
         {
             @Override
             boolean writeScript(Writer writer, Overlap overlap) throws IOException
@@ -1043,7 +1043,7 @@ public class ToolsController extends SpringActionController
                 return overlap.indexDef1.name() + " vs. " + overlap.indexDef2.name() + ": " + join(overlap.indexDef1.columns());
             }
         },
-        Overlapping("column lists that overlap at the start")
+        Overlapping("a column list that overlaps another index's column list at the start")
         {
             @Override
             boolean writeScript(Writer writer, Overlap overlap) throws IOException

--- a/devtools/src/org/labkey/devtools/ToolsController.java
+++ b/devtools/src/org/labkey/devtools/ToolsController.java
@@ -15,6 +15,7 @@ import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.FileSqlScriptProvider;
+import org.labkey.api.data.TableInfo.IndexDef;
 import org.labkey.api.data.TableInfo.IndexType;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.module.Module;
@@ -31,7 +32,6 @@ import org.labkey.api.util.Formats;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.vcs.Vcs;
@@ -769,8 +769,9 @@ public class ToolsController extends SpringActionController
                     try
                     {
                         // All writers are closed below
-                        Writer writer = getFileWriter(overlap.schemaName());
-                        type.writeScript(writer, overlap);
+                        WriterContext context = getFileWriter(overlap.schemaName());
+                        if (type.writeScript(context.getWriter(), overlap))
+                            context.setModified();
                     }
                     catch (IOException e)
                     {
@@ -786,9 +787,56 @@ public class ToolsController extends SpringActionController
             return true;
         }
 
-        private final Map<String, Writer> _writerMap = new HashMap<>();
+        private static class WriterContext
+        {
+            private final File _scriptDirectory;
+            private final String _filename;
+            private final File _scriptFile;
+            private final Writer _writer;
 
-        private Writer getFileWriter(String schemaName) throws IOException
+            private boolean _modified = false;
+
+            public WriterContext(File scriptDirectory, String filename) throws IOException
+            {
+                _scriptDirectory = scriptDirectory;
+                _filename = filename;
+                // Create script file
+                _scriptFile = FileUtil.appendName(scriptDirectory, filename);
+                FileUtil.createNewFile(_scriptFile);
+                _writer = new BufferedWriter(new FileWriter(_scriptFile, StringUtilsLabKey.DEFAULT_CHARSET));
+            }
+
+            public Writer getWriter()
+            {
+                return _writer;
+            }
+
+            public void setModified()
+            {
+                _modified = true;
+            }
+
+            public void close() throws IOException
+            {
+                _writer.close();
+
+                if (_modified)
+                {
+                    // Add to VCS
+                    Vcs vcs = VcsService.get().getVcs(_scriptDirectory);
+                    if (null != vcs)
+                        vcs.addFile(_filename);
+                }
+                else
+                {
+                    _scriptFile.delete();
+                }
+            }
+        }
+
+        private final Map<String, WriterContext> _writerMap = new HashMap<>();
+
+        private WriterContext getFileWriter(String schemaName) throws IOException
         {
             return _writerMap.computeIfAbsent(schemaName, n -> {
 
@@ -808,13 +856,7 @@ public class ToolsController extends SpringActionController
 
                 try
                 {
-                    // Create script file and add to VCS
-                    File file = FileUtil.appendName(scriptDirectory, filename);
-                    FileUtil.createNewFile(file);
-                    Vcs vcs = VcsService.get().getVcs(scriptDirectory);
-                    if (null != vcs)
-                        vcs.addFile(filename);
-                    return new BufferedWriter(new FileWriter(file, StringUtilsLabKey.DEFAULT_CHARSET));
+                    return new WriterContext(scriptDirectory, filename);
                 }
                 catch (IOException e)
                 {
@@ -830,10 +872,10 @@ public class ToolsController extends SpringActionController
 
         private void closeAllWriters()
         {
-            _writerMap.values().forEach(writer -> {
+            _writerMap.values().forEach(context -> {
                 try
                 {
-                    writer.close();
+                    context.close();
                 }
                 catch (IOException e)
                 {
@@ -871,12 +913,12 @@ public class ToolsController extends SpringActionController
                     indices.forEach((indexName1, indexDef1) -> indices.forEach((indexName2, indexDef2) -> {
                         if (indexDef1 != indexDef2)
                         {
-                            OverlapType type = overlap(indexDef1.getKey(), indexDef1.getValue(), indexDef2.getKey(), indexDef2.getValue());
+                            OverlapType type = overlap(indexDef1, indexDef2);
 
                             if (type != null)
                             {
                                 if (type != OverlapType.Identical || !alreadySeen(indexName1, indexName2))
-                                    multiMap.put(type, new Overlap(table.getSchema().getName(), table.getName(), indexName1, indexDef1, indexName2, indexDef2));
+                                    multiMap.put(type, new Overlap(table.getSchema().getName(), table.getName(), indexDef1, indexDef2));
                             }
                         }
                     }));
@@ -894,18 +936,19 @@ public class ToolsController extends SpringActionController
             return !_alreadySeen.add(key);
         }
 
-        private @Nullable OverlapType overlap(IndexType type1, List<ColumnInfo> cols1, IndexType type2, List<ColumnInfo> cols2)
+        private @Nullable OverlapType overlap(IndexDef index1, IndexDef index2)
         {
-            String key1 = getKey(cols1);
-            String key2 = getKey(cols2);
+            String key1 = getKey(index1.columns());
+            String key2 = getKey(index2.columns());
+            boolean sameFilterConditions = Objects.equals(index1.filterCondition(), index2.filterCondition());
             if (key1.equals(key2))
-                return OverlapType.Identical;
+                return sameFilterConditions ? OverlapType.Identical : OverlapType.OverlappingWithDifferentFilter;
             if (key2.startsWith(key1))
             {
-                if (type2 == IndexType.NonUnique && (type1 == IndexType.Primary || type1 == IndexType.Unique))
+                if (index2.indexType() == IndexType.NonUnique && (index1.indexType() == IndexType.Primary || index1.indexType() == IndexType.Unique))
                     return OverlapType.UniqueOverlappingNonUnique;
                 else
-                    return OverlapType.Overlap;
+                    return sameFilterConditions ? OverlapType.Overlapping : OverlapType.OverlappingWithDifferentFilter;
             }
             return null;
         }
@@ -927,48 +970,56 @@ public class ToolsController extends SpringActionController
         }
     }
 
-    protected record Overlap(String schemaName, String tableName, String indexName1, Pair<IndexType, List<ColumnInfo>> indexDef1, String indexName2, Pair<IndexType, List<ColumnInfo>> indexDef2) {}
+    protected record Overlap(String schemaName, String tableName, IndexDef indexDef1, IndexDef indexDef2) {}
 
     protected enum OverlapType
     {
         UniqueOverlappingNonUnique("column sets that overlap at the start, but the first index is a unique constraint. These are likely valid")
         {
             @Override
-            void writeScript(Writer writer, Overlap overlap)
+            boolean writeScript(Writer writer, Overlap overlap)
             {
-                // Do nothing -- these are valid
+                return false; // Write nothing
+            }
+        },
+        OverlappingWithDifferentFilter("column sets that overlap at the start, but with different filter conditions. These are likely valid")
+        {
+            @Override
+            boolean writeScript(Writer writer, Overlap overlap)
+            {
+                return false; // Write nothing
             }
         },
         Identical("identical column sets")
         {
             @Override
-            void writeScript(Writer writer, Overlap overlap) throws IOException
+            boolean writeScript(Writer writer, Overlap overlap) throws IOException
             {
-                IndexType type1 = overlap.indexDef1.getKey();
-                IndexType type2 = overlap.indexDef2.getKey();
+                IndexType type1 = overlap.indexDef1.indexType();
+                IndexType type2 = overlap.indexDef2.indexType();
                 String dropIndex = null;
                 String otherIndex = null;
 
                 // Prefer to drop the non-PK, then prefer the non-unique, otherwise "drop" them both (let the human decide)
                 if (type1 == IndexType.Primary)
                 {
-                    dropIndex = overlap.indexName2;
-                    otherIndex = overlap.indexName1;
+                    dropIndex = overlap.indexDef2.name();
+                    otherIndex = overlap.indexDef1.name();
                 }
                 else if (type2 == IndexType.Primary)
                 {
-                    dropIndex = overlap.indexName1;
-                    otherIndex = overlap.indexName2;
+                    dropIndex = overlap.indexDef1.name();
+                    otherIndex = overlap.indexDef2.name();
                 }
                 else if (type1 == IndexType.Unique && type2 == IndexType.NonUnique)
                 {
-                    dropIndex = overlap.indexName2;
-                    otherIndex = overlap.indexName1;
+                    dropIndex = overlap.indexDef2.name();
+                    otherIndex = overlap.indexDef1.name();
                 }
                 else if (type2 == IndexType.Unique && type1 == IndexType.NonUnique)
                 {
-                    dropIndex = overlap.indexName1;
-                    otherIndex = overlap.indexName2;
+                    dropIndex = overlap.indexDef1.name();
+                    otherIndex = overlap.indexDef2.name();
                 }
 
                 if (dropIndex != null)
@@ -978,24 +1029,27 @@ public class ToolsController extends SpringActionController
                 else
                 {
                     writer.write("TODO: Human, please help!! You should drop only one of the following, but I couldn't decide which one:\n");
-                    dropIndex(writer, overlap.schemaName, overlap.tableName, overlap.indexName1, overlap.indexName2);
-                    dropIndex(writer, overlap.schemaName, overlap.tableName, overlap.indexName2, overlap.indexName1);
+                    dropIndex(writer, overlap.schemaName, overlap.tableName, overlap.indexDef1.name(), overlap.indexDef2.name());
+                    dropIndex(writer, overlap.schemaName, overlap.tableName, overlap.indexDef2.name(), overlap.indexDef1.name());
                     writer.write('\n');
                 }
+
+                return true;
             }
 
             @Override
             String getMessage(Overlap overlap)
             {
-                return overlap.indexName1 + " vs. " + overlap.indexName2 + ": " + join(overlap.indexDef1.getValue());
+                return overlap.indexDef1.name() + " vs. " + overlap.indexDef2.name() + ": " + join(overlap.indexDef1.columns());
             }
         },
-        Overlap("column sets that overlap at the start")
+        Overlapping("column sets that overlap at the start")
         {
             @Override
-            void writeScript(Writer writer, Overlap overlap) throws IOException
+            boolean writeScript(Writer writer, Overlap overlap) throws IOException
             {
-                dropIndex(writer, overlap.schemaName, overlap.tableName, overlap.indexName1, overlap.indexName2);
+                dropIndex(writer, overlap.schemaName, overlap.tableName, overlap.indexDef1.name(), overlap.indexDef2.name());
+                return true;
             }
         };
 
@@ -1011,11 +1065,12 @@ public class ToolsController extends SpringActionController
             return _description;
         }
 
-        abstract void writeScript(Writer writer, Overlap overlap) throws IOException;
+        // Return true if content has been written to the script file
+        abstract boolean writeScript(Writer writer, Overlap overlap) throws IOException;
 
         String getMessage(Overlap overlap)
         {
-            return overlap.indexName1 + " " + join(overlap.indexDef1.getValue()) + " vs. " + overlap.indexName2 + " " + join(overlap.indexDef2.getValue());
+            return overlap.indexDef1.name() + " " + join(overlap.indexDef1.columns()) + " vs. " + overlap.indexDef2.name() + " " + join(overlap.indexDef2.columns());
         }
 
         protected List<String> join(List<ColumnInfo> cols)

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-25.010-25.011.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-25.010-25.011.sql
@@ -1,0 +1,10 @@
+-- This index overlaps with uq_conditionalformat_propertyid_sortorder
+DROP INDEX exp.idx_conditionalformat_propertyid;
+-- This index overlaps with uq_alias_name
+DROP INDEX exp.ix_alias_name;
+-- This index overlaps with uq_dataclass_container_name
+DROP INDEX exp.ix_dataclass_container;
+-- This index overlaps with uq_protocolappparam_ord
+DROP INDEX exp.ix_protocolapplicationparameter_appid;
+-- This index overlaps with uq_protocolparameter_ord
+DROP INDEX exp.ix_protocolparameter_protocolid;

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-0.000-24.000.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-0.000-24.000.sql
@@ -60,6 +60,15 @@ CREATE TABLE exp.Protocol
     CONSTRAINT UQ_Protocol_LSID UNIQUE (LSID)
 );
 
+/* exp-11.20-11.30.sql */
+
+CREATE INDEX IDX_Protocol_Container ON exp.Protocol (Container)
+GO
+
+DELETE FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
+
+ALTER TABLE exp.Protocol ADD CONSTRAINT FK_Protocol_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
+
 CREATE TABLE exp.Experiment
 (
     RowId INT IDENTITY (1, 1) NOT NULL,
@@ -85,6 +94,10 @@ CREATE TABLE exp.Experiment
 CREATE INDEX IX_Experiment_Container ON exp.Experiment(Container);
 CREATE INDEX IDX_Experiment_BatchProtocolId ON exp.Experiment(BatchProtocolId);
 
+-- Now that runs that might have been pointing to them for their batch are deleted, clean up orphaned experiments/run groups/batches
+DELETE FROM exp.Experiment WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
+
+ALTER TABLE exp.Experiment ADD CONSTRAINT FK_Experiment_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
 CREATE TABLE exp.ExperimentRun
 (
     RowId INT IDENTITY (1, 1) NOT NULL,
@@ -107,6 +120,45 @@ CREATE TABLE exp.ExperimentRun
 CREATE CLUSTERED INDEX IX_CL_ExperimentRun_Container ON exp.ExperimentRun(Container);
 CREATE INDEX IX_ExperimentRun_ProtocolLSID ON exp.ExperimentRun(ProtocolLSID);
 
+DELETE FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
+
+ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_ExperimentRun_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
+ALTER TABLE exp.ExperimentRun ADD JobId INTEGER;
+
+--experiment module depends on pipeline, so this should be ok
+ALTER TABLE exp.ExperimentRun ADD
+    CONSTRAINT FK_ExperimentRun_JobId FOREIGN KEY (JobId)
+        REFERENCES pipeline.statusfiles (RowId);
+
+-- Change exp.ExperimentRun.Name from VARCHAR(100) to VARCHAR(200) to match other experiment table name columns
+ALTER TABLE exp.ExperimentRun ALTER COLUMN Name NVARCHAR(200);
+
+-- Add a column to track the chaining of original and replaced runs
+ALTER TABLE exp.ExperimentRun ADD ReplacedByRunId INT;
+
+ALTER TABLE exp.ExperimentRun ADD
+    CONSTRAINT FK_ExperimentRun_ReplacedByRunId FOREIGN KEY (ReplacedByRunId)
+        REFERENCES exp.ExperimentRun (RowId);
+
+CREATE INDEX IDX_ExperimentRun_ReplacedByRunId ON exp.ExperimentRun(ReplacedByRunId);
+
+-- Add batchId column to run table
+ALTER TABLE exp.ExperimentRun
+   ADD BatchId INT;
+
+ALTER TABLE exp.ExperimentRun
+  ADD CONSTRAINT FK_ExperimentRun_BatchId FOREIGN KEY (BatchId) REFERENCES exp.Experiment (RowId);
+
+CREATE INDEX IX_ExperimentRun_BatchId
+  ON exp.ExperimentRun(BatchId);
+
+GO
+
+ALTER TABLE exp.experimentrun ADD objectid INT;
+ALTER TABLE exp.experimentrun ALTER COLUMN objectid INT NOT NULL;
+CREATE UNIQUE INDEX idx_experimentrun_objectid ON exp.experimentrun (objectid);
+ALTER TABLE exp.ExperimentRun ADD LastIndexed DATETIME NULL;
+
 CREATE TABLE exp.ProtocolApplication
 (
     RowId INT IDENTITY (1, 1) NOT NULL,
@@ -126,6 +178,17 @@ CREATE TABLE exp.ProtocolApplication
 );
 CREATE CLUSTERED INDEX IX_CL_ProtocolApplication_RunId ON exp.ProtocolApplication(RunId);
 CREATE INDEX IX_ProtocolApplication_ProtocolLSID ON exp.ProtocolApplication(ProtocolLSID);
+
+DELETE FROM exp.ProtocolApplication WHERE
+	ProtocolLSID IN (SELECT Lsid FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
+	OR RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
+
+-- add start time, end time, and record count to protocol application table for ETL tasks and others
+ALTER TABLE exp.ProtocolApplication ADD StartTime DATETIME NULL;
+ALTER TABLE exp.ProtocolApplication ADD EndTime DATETIME NULL;
+ALTER TABLE exp.ProtocolApplication ADD RecordCount INT NULL;
+
+ALTER TABLE exp.ProtocolApplication ALTER COLUMN Comments NVARCHAR(MAX);
 
 CREATE TABLE exp.Data
 (
@@ -152,6 +215,30 @@ CREATE CLUSTERED INDEX IX_CL_Data_RunId ON exp.Data(RunId);
 CREATE INDEX IX_Data_Container ON exp.Data(Container);
 CREATE INDEX IX_Data_SourceApplicationId ON exp.Data(SourceApplicationId);
 CREATE INDEX IX_Data_DataFileUrl ON exp.Data(DataFileUrl);
+
+ALTER TABLE exp.Data ADD Generated BIT NOT NULL DEFAULT 0;
+GO
+
+ALTER TABLE exp.data ADD description NVARCHAR(4000);
+GO
+
+ALTER TABLE exp.data ADD classId INT;
+GO
+
+-- Within a DataClass, name must be unique.  If DataClass is null, duplicate names are allowed.
+CREATE UNIQUE INDEX UQ_Data_DataClass_Name ON exp.data(classId, name) WHERE classId IS NOT NULL;
+
+ALTER TABLE exp.data ALTER COLUMN cpastype nvarchar(300);
+
+ALTER TABLE exp.Data ADD LastIndexed DATETIME NULL;
+-- Issue 35817 - widen column to allow for longer paths and file names
+ALTER TABLE exp.Data ALTER COLUMN DataFileURL NVARCHAR(600);
+
+UPDATE exp.data SET datafileurl = 'file:///' + substring(datafileurl, 7, 600) WHERE datafileurl LIKE 'file:/_%' AND datafileurl NOT LIKE 'file:///%' AND datafileurl IS NOT NULL;
+
+ALTER TABLE exp.data ADD ObjectId INT;
+ALTER TABLE exp.data ALTER COLUMN objectid INT NOT NULL;
+CREATE UNIQUE INDEX idx_data_objectid ON exp.data (objectid);
 
 /*
    Make PropertyDescriptor consistent with OWL terms, and also work for storing NCI_Thesaurus concepts
@@ -197,6 +284,40 @@ CREATE TABLE exp.PropertyDescriptor
 );
 CREATE INDEX IX_PropertyDescriptor_Container ON exp.PropertyDescriptor(Container);
 
+ALTER TABLE exp.PropertyDescriptor ADD CreatedBy USERID NULL;
+ALTER TABLE exp.PropertyDescriptor ADD Created DATETIME NULL;
+ALTER TABLE exp.PropertyDescriptor ADD ModifiedBy USERID NULL;
+ALTER TABLE exp.PropertyDescriptor ADD Modified DATETIME NULL;
+ALTER TABLE exp.PropertyDescriptor ADD CONSTRAINT FK_PropertyDescriptor_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
+ALTER TABLE exp.PropertyDescriptor ADD FacetingBehaviorType NVARCHAR(40) NOT NULL DEFAULT 'AUTOMATIC';
+ALTER TABLE exp.PropertyDescriptor ADD Protected BIT NOT NULL DEFAULT '0';
+ALTER TABLE exp.PropertyDescriptor ALTER COLUMN lookupschema NVARCHAR(200);
+ALTER TABLE exp.PropertyDescriptor ALTER COLUMN lookupquery NVARCHAR(200);
+ALTER TABLE exp.PropertyDescriptor ADD ExcludeFromShifting BIT NOT NULL DEFAULT '0';
+ALTER TABLE exp.propertydescriptor ADD Scale INT NOT NULL DEFAULT 0;
+ALTER TABLE exp.PropertyDescriptor ADD KeyVariable BIT NOT NULL DEFAULT '0';
+ALTER TABLE exp.PropertyDescriptor ADD DefaultScale NVARCHAR(40) NOT NULL DEFAULT 'LINEAR';
+ALTER TABLE exp.PropertyDescriptor ADD StorageColumnName NVARCHAR(100) NULL;
+GO
+
+EXEC sp_rename 'exp.PropertyDescriptor.KeyVariable', 'RecommendedVariable', 'COLUMN';
+
+ALTER TABLE exp.PropertyDescriptor ADD Phi NVARCHAR(20) NOT NULL DEFAULT 'NotPHI';
+GO
+
+EXEC core.fn_dropifexists 'PropertyDescriptor', 'exp', 'COLUMN', 'Protected';
+GO
+
+ALTER TABLE exp.PropertyDescriptor ADD RedactedText NVARCHAR(450) NULL;
+GO
+
+ALTER TABLE exp.PropertyDescriptor ADD mvIndicatorStorageColumnName NVARCHAR(120);
+GO
+
+ALTER TABLE exp.PropertyDescriptor ADD TextExpression nvarchar(200) NULL
+
+ALTER TABLE exp.PropertyDescriptor ALTER COLUMN PropertyURI NVARCHAR(300) NOT NULL;
+
 CREATE TABLE exp.DataInput
 (
     DataId INT NOT NULL,
@@ -209,6 +330,11 @@ CREATE TABLE exp.DataInput
 );
 CREATE INDEX IX_DataInput_TargetApplicationId ON exp.DataInput(TargetApplicationId);
 CREATE INDEX IDX_DataInput_Role ON exp.DataInput(Role);
+
+-- Add reference from DataInput to the ProtocolInputId that it corresponds to
+ALTER TABLE exp.DataInput ADD ProtocolInputId INT NULL;
+
+CREATE INDEX IX_DataInput_ProtocolInputId ON exp.DataInput (ProtocolInputId);
 
 CREATE TABLE exp.Material
 (
@@ -238,6 +364,32 @@ CREATE INDEX IX_Material_SourceApplicationId ON exp.Material(SourceApplicationId
 CREATE INDEX IX_Material_CpasType ON exp.Material(CpasType);
 CREATE INDEX IDX_Material_LSID ON exp.Material(LSID);
 
+UPDATE exp.Material SET RunId = NULL WHERE RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.containers));
+
+UPDATE exp.Material SET SourceApplicationId = NULL WHERE SourceApplicationId IN (SELECT RowId FROM exp.ProtocolApplication WHERE RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.containers)));
+
+/* exp-15.10-15.20.sql */
+
+EXECUTE core.fn_dropifexists 'material', 'exp', 'INDEX', 'idx_material_AK';
+
+-- shouldn't be any null names, but just to be safe
+UPDATE exp.material SET name='NULL' WHERE name IS NULL;
+ALTER TABLE exp.material ALTER COLUMN name NVARCHAR(200) NOT NULL;
+
+CREATE UNIQUE INDEX idx_material_AK ON exp.material (container, cpastype, name) WHERE cpastype IS NOT NULL;
+GO
+
+ALTER TABLE exp.material ADD description NVARCHAR(4000);
+
+ALTER TABLE exp.material ADD objectid INT;
+GO
+
+ALTER TABLE exp.material ALTER COLUMN objectid INT NOT NULL;
+GO
+
+CREATE UNIQUE INDEX idx_material_objectid ON exp.material (objectid);
+GO
+
 CREATE TABLE exp.MaterialInput
 (
     MaterialId INT NOT NULL,
@@ -250,6 +402,11 @@ CREATE TABLE exp.MaterialInput
 );
 CREATE INDEX IX_MaterialInput_TargetApplicationId ON exp.MaterialInput(TargetApplicationId);
 CREATE INDEX IDX_MaterialInput_Role ON exp.MaterialInput(Role);
+
+-- Add reference from MaterialInput to the ProtocolInputId that it corresponds to
+ALTER TABLE exp.MaterialInput ADD ProtocolInputId INT NULL;
+
+CREATE INDEX IX_MaterialInput_ProtocolInputId ON exp.MaterialInput (ProtocolInputId);
 
 CREATE TABLE exp.MaterialSource
 (
@@ -273,6 +430,23 @@ CREATE TABLE exp.MaterialSource
     CONSTRAINT UQ_MaterialSource_LSID UNIQUE (LSID),
 );
 CREATE INDEX IX_MaterialSource_Container ON exp.MaterialSource(Container);
+
+DELETE FROM exp.MaterialSource WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
+
+ALTER TABLE exp.MaterialSource ADD CONSTRAINT FK_MaterialSource_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
+-- Change exp.MaterialSource.Name from VARCHAR(50) to VARCHAR(100). Going to 200 to match other experiment tables
+ -- hits limits with domain URIs, etc
+ALTER TABLE exp.MaterialSource ALTER COLUMN Name NVARCHAR(100);
+
+ALTER TABLE exp.MaterialSource ADD NameExpression NVARCHAR(200) NULL;
+
+ALTER TABLE exp.materialsource ALTER COLUMN nameexpression NVARCHAR(500);
+
+ALTER TABLE exp.MaterialSource ADD LastIndexed DATETIME NULL;
+
+ALTER TABLE exp.MaterialSource ADD MaterialParentImportAliasMap NVARCHAR(4000) NULL;
+
+ALTER TABLE exp.MaterialSource ADD LabelColor NVARCHAR(7) NULL;
 
 CREATE TABLE exp.Object
 (
@@ -308,6 +482,9 @@ CREATE TABLE exp.ObjectProperty
 );
 CREATE INDEX IDX_ObjectProperty_PropertyId ON exp.ObjectProperty(PropertyId);
 
+-- Then delete orphaned properties and their values
+DELETE FROM exp.ObjectProperty WHERE PropertyId IN (SELECT PropertyId FROM exp.PropertyDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
+
 CREATE TABLE exp.ProtocolAction
 (
     RowId INT IDENTITY (10, 10) NOT NULL,
@@ -322,6 +499,10 @@ CREATE TABLE exp.ProtocolAction
 );
 CREATE INDEX IX_ProtocolAction_ChildProtocolId ON exp.ProtocolAction(ChildProtocolId);
 
+DELETE FROM exp.ProtocolAction WHERE
+	ParentProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
+	OR ChildProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
+
 CREATE TABLE exp.ProtocolActionPredecessor
 (
     ActionId INT NOT NULL,
@@ -332,6 +513,10 @@ CREATE TABLE exp.ProtocolActionPredecessor
     CONSTRAINT FK_ActionPredecessor_Predecessor_ProtocolAction FOREIGN KEY (PredecessorId) REFERENCES exp.ProtocolAction (RowId)
 );
 CREATE INDEX IX_ProtocolActionPredecessor_PredecessorId ON exp.ProtocolActionPredecessor(PredecessorId);
+
+DELETE FROM exp.ProtocolActionPredecessor WHERE ActionId IN (SELECT RowId FROM exp.ProtocolAction WHERE
+	ParentProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
+	OR ChildProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers)));
 
 CREATE TABLE exp.ProtocolParameter
 (
@@ -351,6 +536,9 @@ CREATE TABLE exp.ProtocolParameter
 );
 CREATE INDEX IX_ProtocolParameter_ProtocolId ON exp.ProtocolParameter(ProtocolId);
 
+-- Next, clean up orphaned protocols
+DELETE FROM exp.ProtocolParameter WHERE ProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
+
 CREATE TABLE exp.ProtocolApplicationParameter
 (
     RowId INT IDENTITY (1, 1) NOT NULL,
@@ -369,6 +557,11 @@ CREATE TABLE exp.ProtocolApplicationParameter
 );
 CREATE INDEX IX_ProtocolApplicationParameter_AppId ON exp.ProtocolApplicationParameter(ProtocolApplicationId);
 
+DELETE FROM exp.ProtocolApplicationParameter WHERE ProtocolApplicationId IN
+	(SELECT RowId FROM exp.ProtocolApplication WHERE
+		ProtocolLSID IN (SELECT Lsid FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
+		OR RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers)));
+
 CREATE TABLE exp.DomainDescriptor
 (
     DomainId INT IDENTITY (1, 1) NOT NULL,
@@ -386,6 +579,24 @@ CREATE TABLE exp.DomainDescriptor
 );
 CREATE INDEX IX_DomainDescriptor_Container ON exp.DomainDescriptor(Container);
 
+-- Then orphaned domains
+DELETE FROM exp.DomainDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
+
+-- Finally, add some FKs so we don't get into this horrible state again
+ALTER TABLE exp.DomainDescriptor ADD CONSTRAINT FK_DomainDescriptor_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
+ALTER TABLE exp.DomainDescriptor DROP CONSTRAINT uq_domainuricontainer;
+ALTER TABLE exp.DomainDescriptor DROP CONSTRAINT uq_domaindescriptor;
+
+ALTER TABLE exp.DomainDescriptor ADD CONSTRAINT uq_domaindescriptor UNIQUE (DomainURI, Project);
+
+ALTER TABLE exp.DomainDescriptor ADD _ts ROWVERSION;
+ALTER TABLE exp.DomainDescriptor ADD ModifiedBy USERID;
+ALTER TABLE exp.DomainDescriptor ADD Modified DATETIME DEFAULT GETDATE();
+GO
+
+ALTER TABLE exp.DomainDescriptor ADD TemplateInfo NVARCHAR(4000) NULL;
+ALTER TABLE exp.DomainDescriptor ALTER COLUMN DomainURI NVARCHAR(300) NOT NULL;
+
 CREATE TABLE exp.PropertyDomain
 (
     PropertyId INT NOT NULL,
@@ -399,6 +610,12 @@ CREATE TABLE exp.PropertyDomain
 );
 CREATE INDEX IX_PropertyDomain_DomainId ON exp.PropertyDomain(DomainID);
 
+-- Next, work on properties and domains
+-- Start by deleting from juntion table between properties and domains
+DELETE FROM exp.PropertyDomain WHERE
+	PropertyId IN (SELECT PropertyId FROM exp.PropertyDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
+	OR DomainId IN (SELECT DomainId FROM exp.DomainDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
+
 CREATE TABLE exp.RunList
 (
     ExperimentId INT NOT NULL,
@@ -410,6 +627,19 @@ CREATE TABLE exp.RunList
 );
 CREATE INDEX IX_RunList_ExperimentRunId ON exp.RunList(ExperimentRunId);
 
+-- Clean up orphaned experiment objects that were not properly deleted when their container was deleted
+-- Then, add real FKs to ensure we don't orphan rows in the future
+
+-- First clean up memberships in run groups for orphaned runs and experiments
+DELETE FROM exp.RunList WHERE ExperimentId IN (SELECT RowId FROM exp.Experiment WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
+DELETE FROM exp.RunList WHERE ExperimentRunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
+
+ALTER TABLE exp.RunList ADD Created TIMESTAMP;
+ALTER TABLE exp.RunList ADD CreatedBy INT;
+
+ALTER TABLE exp.RunList DROP COLUMN Created;
+ALTER TABLE exp.RunList ADD Created DATETIME;
+
 CREATE TABLE exp.ActiveMaterialSource
 (
     Container ENTITYID NOT NULL,
@@ -420,6 +650,15 @@ CREATE TABLE exp.ActiveMaterialSource
     CONSTRAINT FK_ActiveMaterialSource_MaterialSourceLSID FOREIGN KEY (MaterialSourceLSID) REFERENCES exp.MaterialSource(LSID)
 );
 CREATE INDEX IX_ActiveMaterialSource_MaterialSourceLSID ON exp.ActiveMaterialSource(MaterialSourceLSID);
+
+-- Delete orphaned sample types/material sources
+DELETE FROM exp.ActiveMaterialSource WHERE MaterialSourceLSID IN (SELECT Lsid FROM exp.MaterialSource WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
+
+/* exp-18.30-19.10.sql */
+
+-- Removing active sample types
+EXEC core.fn_dropifexists 'ActiveMaterialSource', 'exp', 'TABLE', NULL;
+GO
 
 CREATE TABLE exp.list
 (
@@ -449,55 +688,59 @@ CREATE TABLE exp.list
 );
 CREATE INDEX IDX_List_DomainId ON exp.List(DomainId);
 
-CREATE TABLE exp.IndexInteger
-(
-    ListId INT NOT NULL,
-    "Key" INT NOT NULL,
-    ObjectId INT NULL,
-    EntityId ENTITYID, -- Used for discussions & attachments
+ALTER TABLE exp.List ADD CONSTRAINT FK_List_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
+-- Use prefix naming to better match new field names
+EXEC sp_rename 'exp.List.IndexMetaData', 'MetaDataIndex', 'COLUMN';
 
-    CONSTRAINT PK_IndexInteger PRIMARY KEY(ListId, "Key"),
-    CONSTRAINT FK_IndexInteger_List FOREIGN KEY (ListId) REFERENCES exp.List(RowId),
-    CONSTRAINT FK_IndexInteger_Object FOREIGN KEY (ObjectId) REFERENCES exp.Object(ObjectId)
-);
-CREATE INDEX IDX_IndexInteger_ObjectId ON exp.IndexInteger(ObjectId);
+ALTER TABLE exp.list ADD EntireListIndex BIT NOT NULL DEFAULT 0;
+ALTER TABLE exp.list ADD EntireListTitleSetting INT NOT NULL DEFAULT 0;
+ALTER TABLE exp.list ADD EntireListTitleTemplate NVARCHAR(1000) NULL;
+ALTER TABLE exp.list ADD EntireListBodyTemplate NVARCHAR(1000) NULL;
+ALTER TABLE exp.list ADD EntireListBodySetting INT NOT NULL DEFAULT 0;
 
-CREATE TABLE exp.IndexVarchar
-(
-    ListId INT NOT NULL,
-    "Key" VARCHAR(300) NOT NULL,
-    ObjectId INT NULL,
-    EntityId ENTITYID, -- Used for discussions & attachments
+ALTER TABLE exp.list ADD EachItemIndex BIT NOT NULL DEFAULT 0;
+ALTER TABLE exp.list ADD EachItemTitleSetting INT NOT NULL DEFAULT 0;
+ALTER TABLE exp.list ADD EachItemTitleTemplate NVARCHAR(1000) NULL;
+ALTER TABLE exp.list ADD EachItemBodySetting INT NOT NULL DEFAULT 0;
+ALTER TABLE exp.list ADD EachItemBodyTemplate NVARCHAR(1000) NULL;
 
-    CONSTRAINT PK_IndexVarchar PRIMARY KEY(ListId, "Key"),
-    CONSTRAINT FK_IndexVarchar_List FOREIGN KEY (ListId) REFERENCES exp.List(RowId),
-    CONSTRAINT FK_IndexVarchar_Object FOREIGN KEY (ObjectId) REFERENCES exp.Object(ObjectId)
-);
-CREATE INDEX IDX_IndexVarchar_ObjectId ON exp.IndexVarchar(ObjectId);
+ALTER TABLE exp.List ADD LastIndexed DATETIME NULL;
 
-CREATE TABLE exp.PropertyValidator
-(
-    RowId INT IDENTITY(1,1) NOT NULL,
-    Name NVARCHAR(50) NOT NULL,
-    Description NVARCHAR(200),
-    TypeURI NVARCHAR(200) NOT NULL,
-    Expression TEXT,
-    Properties TEXT,
-    ErrorMessage TEXT,
-    Container ENTITYID NOT NULL,
+-- Merge the "metadata only" and "entire list data" settings, migrating them to a single boolean (EntireListIndex) plus
+-- a setting denoting what to index (EntireListIndexSetting = metadata only (0), item data only (1), or both (2))
 
-    CONSTRAINT PK_RowId PRIMARY KEY (RowId)
-);
+ALTER TABLE exp.List ADD EntireListIndexSetting INT NOT NULL DEFAULT 0;  -- Metadata only, the default
+GO
 
-CREATE TABLE exp.ValidatorReference
-(
-    ValidatorId INT NOT NULL,
-    PropertyId INT NOT NULL,
+UPDATE exp.List SET EntireListIndexSetting = 1 WHERE MetaDataIndex = 0 AND EntireListIndex = 1; -- Item data only
+UPDATE exp.List SET EntireListIndexSetting = 2 WHERE MetaDataIndex = 1 AND EntireListIndex = 1;  -- Meta data and item data
 
-    CONSTRAINT PK_ValidatorReference PRIMARY KEY (ValidatorId, PropertyId),
-    CONSTRAINT FK_PropertyValidator_ValidatorId FOREIGN KEY (ValidatorId) REFERENCES exp.PropertyValidator (RowId),
-    CONSTRAINT FK_PropertyDescriptor_PropertyId FOREIGN KEY (PropertyId) REFERENCES exp.PropertyDescriptor (PropertyId)
-);
+UPDATE exp.List SET EntireListIndex = 1 WHERE MetaDataIndex = 1;   -- Turn on EntireListIndex if metadata was being indexed
+
+-- Must drop default constraint before dropping column
+EXEC core.fn_dropifexists @objname='List', @objschema='exp', @objtype='DEFAULT', @subobjname='MetaDataIndex'
+
+ALTER TABLE exp.List DROP COLUMN MetaDataIndex;
+
+ALTER TABLE exp.List DROP CONSTRAINT PK_List;
+ALTER TABLE exp.List ADD CONSTRAINT UQ_RowId UNIQUE (RowId);
+-- Now add ListId column...
+ALTER TABLE exp.List ADD ListId INT NULL;
+GO
+
+-- ...populate it with the current values of RowId...
+UPDATE exp.List SET ListId = RowId;
+ALTER TABLE exp.List ALTER COLUMN ListId INT NOT NULL;
+GO
+
+-- ...and create the new PK (Container, ListId)
+ALTER TABLE exp.List ADD CONSTRAINT PK_List PRIMARY KEY (Container, ListId);
+
+EXEC core.fn_dropifexists 'list', 'exp', 'CONSTRAINT', 'UQ_RowId';
+EXEC core.fn_dropifexists 'list', 'exp', 'COLUMN', 'rowid';
+
+ALTER TABLE exp.list ADD FileAttachmentIndex BIT CONSTRAINT DF__list__FileAttachmentIndex DEFAULT 0 NOT NULL;
+GO
 
 CREATE TABLE exp.ConditionalFormat
 (
@@ -516,16 +759,409 @@ CREATE TABLE exp.ConditionalFormat
     CONSTRAINT UQ_ConditionalFormat_PropertyId_SortOrder UNIQUE (PropertyId, SortOrder)
 );
 CREATE INDEX IDX_ConditionalFormat_PropertyId ON exp.ConditionalFormat(PropertyId);
+GO
+
+CREATE TABLE exp.AssayQCFlag
+(
+    RowId INT IDENTITY (1, 1) NOT NULL,
+    RunId INT NOT NULL,
+    FlagType VARCHAR(40) NOT NULL,
+    Description TEXT NULL,
+    Comment TEXT NULL,
+    Enabled BIT NOT NULL,
+    Created DATETIME  NULL,
+    CreatedBy INT NULL,
+    Modified DATETIME  NULL,
+    ModifiedBy INT NULL
+);
+
+ALTER TABLE exp.AssayQCFlag ADD CONSTRAINT PK_AssayQCFlag PRIMARY KEY (RowId);
+
+ALTER TABLE exp.AssayQCFlag ADD CONSTRAINT FK_AssayQCFlag_EunId FOREIGN KEY (RunId) REFERENCES exp.ExperimentRun (RowId);
+
+CREATE INDEX IX_AssayQCFlag_RunId ON exp.AssayQCFlag(RunId);
+
+ALTER TABLE exp.AssayQCFlag ADD IntKey1 INT NULL;
+ALTER TABLE exp.AssayQCFlag ADD IntKey2 INT NULL;
+
+CREATE INDEX IX_AssayQCFlag_IntKeys ON exp.AssayQCFlag(IntKey1, IntKey2);
+
+ALTER TABLE exp.AssayQCFlag ADD Key1 NVARCHAR(50);
+ALTER TABLE exp.AssayQCFlag ADD Key2 NVARCHAR(50);
+
+CREATE INDEX IX_AssayQCFlag_Keys ON exp.AssayQCFlag(Key1, Key2);
+
+CREATE TABLE exp.DataClass
+(
+    RowId INT IDENTITY(1,1) NOT NULL,
+    Name NVARCHAR(200) NOT NULL,
+    LSID LSIDtype NOT NULL,
+    Container EntityId NOT NULL,
+    Created DATETIME NULL,
+    CreatedBy INT NULL,
+    Modified DATETIME NULL,
+    ModifiedBy INT NULL,
+    Description NTEXT NULL,
+    MaterialSourceId INT NULL,
+    NameExpression NVARCHAR(200) NULL,
+
+    CONSTRAINT PK_DataClass PRIMARY KEY (RowId),
+    CONSTRAINT UQ_DataClass_LSID UNIQUE (LSID),
+    CONSTRAINT UQ_DataClass_Container_Name UNIQUE (Container, Name),
+
+    CONSTRAINT FK_DataClass_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId),
+    CONSTRAINT FK_DataClass_MaterialSource FOREIGN KEY (MaterialSourceId) REFERENCES exp.MaterialSource (RowId)
+);
+CREATE INDEX IX_DataClass_Container ON exp.DataClass(Container);
+
+ALTER TABLE exp.data ADD CONSTRAINT FK_Data_DataClass FOREIGN KEY (classId) REFERENCES exp.DataClass (rowid);
+
+ALTER TABLE exp.dataclass ALTER COLUMN nameexpression NVARCHAR(500);
+
+ALTER TABLE exp.DataClass ADD Category NVARCHAR(20) NULL;
+
+ALTER TABLE exp.DataClass ADD LastIndexed DATETIME NULL;
+
+CREATE TABLE exp.Alias
+(
+    RowId INT IDENTITY (1, 1) NOT NULL,
+    Created DATETIME,
+    CreatedBy INT,
+    Modified DATETIME,
+    ModifiedBy INT,
+
+    Name NVARCHAR(500) NOT NULL,
+
+    CONSTRAINT PK_Alias PRIMARY KEY (RowId),
+    CONSTRAINT UQ_Alias_Name UNIQUE (Name)
+);
+
+CREATE INDEX IX_Alias_Name ON exp.Alias(Name);
+
+CREATE TABLE exp.DataAliasMap
+(
+    LSID LSIDtype NOT NULL,
+    Alias INT NOT NULL,
+    Container EntityId NOT NULL,
+
+    CONSTRAINT PK_DataAliasMap PRIMARY KEY (LSID, Alias),
+    CONSTRAINT FK_DataAlias_RowId FOREIGN KEY (Alias) REFERENCES exp.Alias(RowId)
+);
+
+ALTER TABLE exp.DataAliasMap ADD CONSTRAINT FK_DataAlias_LSID FOREIGN KEY (LSID) REFERENCES exp.Data(LSID);
+CREATE INDEX IX_DataAliasMap ON exp.DataAliasMap(LSID, Alias, Container);
+
+CREATE TABLE exp.MaterialAliasMap
+(
+    LSID LSIDtype NOT NULL,
+    Alias INT NOT NULL,
+    Container EntityId NOT NULL,
+
+    CONSTRAINT PK_MaterialAliasMap PRIMARY KEY (LSID, Alias),
+    CONSTRAINT FK_MaterialAlias_RowId FOREIGN KEY (Alias) REFERENCES exp.Alias(RowId)
+);
+
+ALTER TABLE exp.MaterialAliasMap ADD CONSTRAINT FK_MaterialAlias_LSID FOREIGN KEY (LSID) REFERENCES exp.Material(LSID);
+CREATE INDEX IX_MaterialAliasMap ON exp.MaterialAliasMap(LSID, Alias, Container);
+
+CREATE TABLE exp.Edge
+(
+    FromObjectId INT NOT NULL,
+--    FromLsid LSIDtype NOT NULL,
+    ToObjectId INT NOT NULL,
+--    ToLsid LSIDtype NOT NULL,
+    RunId INT NOT NULL,
+
+    CONSTRAINT FK_Edge_From_Object FOREIGN KEY (FromObjectId) REFERENCES exp.object (objectid),
+    CONSTRAINT FK_Edge_To_Object FOREIGN KEY (ToObjectId) REFERENCES exp.object (objectid),
+    CONSTRAINT FK_Edge_RunId_Run FOREIGN KEY (RunId) REFERENCES exp.ExperimentRun (RowId),
+-- for query performance
+    CONSTRAINT UQ_Edge_FromTo_RunId UNIQUE (FromObjectId, ToObjectId, RunId),
+    CONSTRAINT UQ_Edge_ToFrom_RunId UNIQUE (ToObjectId, FromObjectId, RunId)
+);
+GO
+
+CREATE TABLE exp.ProtocolInput
+(
+    RowId INT IDENTITY (1,1) NOT NULL,
+    Name NVARCHAR(300) NOT NULL,
+    LSID LSIDtype NOT NULL,
+    ProtocolId INT NOT NULL,
+    Input BIT NOT NULL,
+
+    -- One of 'Material' or 'Data'
+    ObjectType NVARCHAR(8) NOT NULL,
+
+    -- DataClassId may be non-null when ObjectType='Data'
+    DataClassId INT NULL,
+    -- MaterialSourceId may be non-null when ObjectType='Material'
+    MaterialSourceId INT NULL,
+
+    CriteriaName NVARCHAR(50) NULL,
+    CriteriaConfig NTEXT NULL,
+    MinOccurs INT NOT NULL,
+    MaxOccurs INT NULL,
+
+    CONSTRAINT PK_ProtocolInput_RowId PRIMARY KEY (RowId),
+    CONSTRAINT FK_ProtocolInput_ProtocolId FOREIGN KEY (ProtocolId) REFERENCES exp.Protocol (RowId),
+    CONSTRAINT FK_ProtocolInput_DataClassId FOREIGN KEY (DataClassId) REFERENCES exp.DataClass (RowId),
+    CONSTRAINT FK_ProtocolInput_MaterialSourceId FOREIGN KEY (MaterialSourceId) REFERENCES exp.MaterialSource (RowId)
+);
+
+CREATE INDEX IX_ProtocolInput_ProtocolId ON exp.ProtocolInput (ProtocolId);
+CREATE INDEX IX_ProtocolInput_DataClassId ON exp.ProtocolInput (DataClassId);
+CREATE INDEX IX_ProtocolInput_MaterialSourceId ON exp.ProtocolInput (MaterialSourceId);
+
+ALTER TABLE exp.MaterialInput ADD CONSTRAINT FK_MaterialInput_ProtocolInput FOREIGN KEY (ProtocolInputId) REFERENCES exp.ProtocolInput (RowId);
+
+ALTER TABLE exp.DataInput ADD CONSTRAINT FK_DataInput_ProtocolInput FOREIGN KEY (ProtocolInputId) REFERENCES exp.ProtocolInput (RowId);
+
+CREATE TABLE exp.PropertyValidator
+(
+    RowId        int identity(1,1) not null,
+    Name         NVARCHAR(50) not null,
+    Description  NVARCHAR(200),
+    TypeURI      NVARCHAR(200) not null,
+    Expression   NVARCHAR(MAX),
+    ErrorMessage NVARCHAR(MAX),
+    Properties   NVARCHAR(MAX),
+    Container    entityid not null constraint fk_pv_container references core.containers (entityid),
+    PropertyId   int not null constraint fk_pv_descriptor references exp.propertydescriptor,
+    constraint pk_propertyvalidator primary key (container, propertyid, rowid)
+);
+GO
+
+CREATE INDEX ix_propertyvalidator_propertyid on exp.PropertyValidator(PropertyId);
+
+ALTER TABLE exp.PropertyDescriptor DROP COLUMN OntologyURI;
+ALTER TABLE exp.PropertyDescriptor DROP COLUMN SearchTerms;
+ALTER TABLE exp.PropertyDescriptor DROP COLUMN SemanticType;
+GO
+
+ALTER TABLE exp.PropertyDescriptor ADD PrincipalConceptCode NVARCHAR(50) NULL;
+GO
+
+ALTER TABLE exp.PropertyDescriptor ADD SourceOntology NVARCHAR(20) NULL;
+ALTER TABLE exp.PropertyDescriptor ADD ConceptImportColumn NVARCHAR(200) NULL;
+ALTER TABLE exp.PropertyDescriptor ADD ConceptLabelColumn NVARCHAR(200) NULL;
+GO
+
+ALTER TABLE exp.PropertyDescriptor ADD DerivationDataScope NVARCHAR(20) NULL;
+ALTER TABLE exp.PropertyDescriptor ADD ConceptSubtree NVARCHAR(MAX) NULL;
+
+UPDATE exp.propertydescriptor SET scale=4000 WHERE propertyuri LIKE '%WorkflowTask#AssayTypes';
+
+ALTER TABLE exp.PropertyDescriptor ADD Scannable BIT NOT NULL DEFAULT 0;
+GO
+
+ALTER TABLE exp.MaterialSource ADD MetricUnit NVARCHAR(10) NULL;
+GO
+
+ALTER TABLE exp.MaterialSource ADD AutoLinkTargetContainer ENTITYID NULL;
+
+ALTER TABLE exp.MaterialSource ADD AutoLinkCategory NVARCHAR(200) NULL;
+
+ALTER TABLE exp.MaterialSource ADD AliquotNameExpression NVARCHAR(200) NULL;
+
+ALTER TABLE exp.MaterialSource ADD Category NVARCHAR(20) NULL;
+
+EXEC core.fn_dropifexists 'materialsource', 'exp', 'CONSTRAINT', 'UQ_MaterialSource_Container_Name';
+
+-- create exp.object for exp.data without one
+INSERT INTO exp.object (objecturi, container)
+SELECT D.lsid as objecturi, D.container as container
+FROM exp.data D LEFT OUTER JOIN exp.object O ON D.lsid = O.objecturi
+WHERE O.objecturi IS NULL;
+
+ALTER TABLE exp.material ADD CONSTRAINT FK_Material_Lsid FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
+ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_Lsid FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
+ALTER TABLE exp.material ADD CONSTRAINT FK_Material_ObjectId FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
+ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_ObjectId FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
+GO
+
+-- fixup exp.data.objectid to be consistent with the lsid of the exp.object
+UPDATE exp.data
+SET objectid = (SELECT O.objectid FROM exp.object O WHERE O.objecturi = lsid)
+WHERE rowid IN (
+    SELECT rowid
+    FROM exp.data D
+    LEFT OUTER JOIN exp.object O ON D.lsid = O.objecturi
+    WHERE D.objectid != O.objectid
+);
+
+-- add constraints for lsid -> exp.object
+ALTER TABLE exp.data ADD CONSTRAINT FK_Data_Lsid
+    FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
+-- add constraints for objectid -> exp.object
+ALTER TABLE exp.data ADD CONSTRAINT FK_Data_ObjectId
+    FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
+/* 21.xxx SQL scripts */
+
+-- Most major file systems cap file lengths at 255 characters. Let's do the same
+ALTER TABLE exp.data ALTER COLUMN Name NVARCHAR(255);
+
+ALTER TABLE exp.Material ADD RootMaterialLSID LSIDtype NULL;
+ALTER TABLE exp.Material ADD AliquotedFromLSID LSIDtype NULL;
+GO
+
+ALTER TABLE exp.Material ADD SampleState INT;
+GO
+ALTER TABLE exp.Material ADD CONSTRAINT FK_Material_SampleState FOREIGN KEY (SampleState) REFERENCES core.DataStates (RowId);
+
+ALTER TABLE exp.Material ADD RecomputeRollup BIT NULL CONSTRAINT DF_recomputeRollup DEFAULT(0);
+ALTER TABLE exp.Material ADD AliquotCount INT NULL;
+ALTER TABLE exp.Material ADD AliquotVolume FLOAT NULL;
+ALTER TABLE exp.Material ADD AliquotUnit NVARCHAR(10) NULL;
+GO
+
+CREATE INDEX IDX_exp_material_recompute ON exp.Material (container, rowid, lsid) WHERE RecomputeRollup=1;
+
+ALTER TABLE exp.Material ADD MaterialSourceId INT NULL;
+GO
+CREATE INDEX IDX_material_name_sourceid ON exp.Material (name, materialSourceId);
+GO
+
+ALTER TABLE exp.Material ADD MaterialExpDate DATETIME NULL;
+
+ALTER TABLE exp.Material ADD StoredAmount DOUBLE PRECISION;
+ALTER TABLE exp.Material ADD Units NVARCHAR(20);
+GO
+
+EXEC core.fn_dropifexists 'Material', 'exp', 'INDEX', 'IDX_exp_material_recompute';
+
+EXEC core.fn_dropifexists 'Material', 'exp', 'CONSTRAINT', 'DF_recomputeRollup';
+
+ALTER TABLE exp.Material DROP COLUMN RecomputeRollup;
+
+ALTER TABLE exp.Material ADD AvailableAliquotCount INT NULL;
+ALTER TABLE exp.Material ADD AvailableAliquotVolume FLOAT NULL;
+
+ALTER TABLE exp.material ALTER COLUMN rootmateriallsid LSIDtype NOT NULL;
+
+CREATE INDEX uq_material_rootlsid on exp.material (rootmateriallsid);
+
+-- this is duplicative of constraint uq_material_lsid
+EXEC core.fn_dropifexists 'material', 'exp', 'INDEX', 'idx_material_lsid';
+
+-- Add new "RootMaterialRowId" column
+ALTER TABLE exp.Material ADD rootmaterialrowid INTEGER NULL;
+GO
+
+-- Add NOT NULL constraint to "RootMaterialRowId"
+ALTER TABLE exp.Material ALTER COLUMN rootmaterialrowid INTEGER NOT NULL;
+GO
+
+-- Add FK on "RootMaterialRowId"
+-- See exp-23.012-23.013.sql
+-- ALTER TABLE exp.Material ADD CONSTRAINT FK_Material_RootMaterialRowId
+--     FOREIGN KEY (RootMaterialRowId) REFERENCES exp.Material (RowId);
+-- GO
+
+CREATE INDEX ix_material_rootmaterialrowid ON exp.Material (rootmaterialrowid);
+GO
+
+-- Remove the "RootMaterialLSID" column
+EXEC core.fn_dropifexists 'material', 'exp', 'INDEX', 'uq_material_rootlsid';
+EXEC core.fn_dropifexists 'material', 'exp', 'COLUMN', 'rootmateriallsid';
+
+-- It is possible for parent samples of aliquots to be moved to a subfolder where upon deletion
+-- of the subfolder we need to delete the parent sample but the aliquot still exists.
+EXEC core.fn_dropifexists 'material', 'exp', 'constraint', 'FK_Material_RootMaterialRowId';
+ALTER TABLE exp.List ADD Category NVARCHAR(20) NULL;
+
+/* 22.xxx SQL scripts */
+
+ALTER TABLE exp.list ALTER COLUMN Name NVARCHAR(200);
+GO
+
+-- These columns have been unused for years. https://github.com/LabKey/platform/pull/4549 cleaned up all code references.
+-- Use fb_dropIfExists() to drop default constraint before dropping each column.
+EXEC core.fn_dropifexists 'List', 'exp', 'COLUMN', 'EntireListTitleSetting';
+EXEC core.fn_dropifexists 'List', 'exp', 'COLUMN', 'EachItemTitleSetting';
+
+-- move the StudyPublishProtocol container to the shared folder
+UPDATE exp.protocol
+    SET container = (SELECT entityid FROM core.containers WHERE name = 'Shared')
+    WHERE lsid LIKE 'urn:lsid:labkey.org:Protocol:StudyPublishProtocol%';
+
+ALTER TABLE exp.Protocol ADD Status NVARCHAR(60);
+GO
+UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun';
+
+UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun' AND Status IS NULL;
+
+ALTER TABLE exp.ProtocolApplication ADD EntityId ENTITYID;
 
 GO
+
+UPDATE exp.ProtocolApplication SET EntityId = NEWID();
+
+ALTER TABLE exp.ProtocolApplication ALTER COLUMN EntityId ENTITYID NOT NULL;
+
+ALTER TABLE exp.ExperimentRun ADD WorkflowTask INT;
+GO
+ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId) ON DELETE SET NULL;
+
+CREATE INDEX IDX_ExperimentRun_WorkflowTask ON exp.ExperimentRun(WorkflowTask);
+CREATE TABLE exp.ObjectLegacyNames
+(
+    RowId INT IDENTITY (1, 1) NOT NULL,
+    ObjectId INT NOT NULL,
+    ObjectType NVARCHAR(20) NOT NULL,
+    Name NVARCHAR(200) NOT NULL,
+    Created DATETIME NULL,
+    CreatedBy INT NULL,
+    Modified DATETIME NULL,
+    ModifiedBy INT NULL,
+
+    CONSTRAINT PK_ObjectLegacyNames PRIMARY KEY (RowId)
+);
+GO
+ALTER TABLE exp.Edge DROP CONSTRAINT UQ_Edge_FromTo_RunId;
+ALTER TABLE exp.Edge DROP CONSTRAINT UQ_Edge_ToFrom_RunId;
+
+ALTER TABLE exp.Edge ALTER COLUMN RunId INT NULL;
+
+ALTER TABLE exp.Edge ADD SourceId INT NULL;
+ALTER TABLE exp.Edge ADD SourceKey NVARCHAR(200) NULL;
+
+ALTER TABLE exp.Edge ADD CONSTRAINT FK_Edge_SourceId_Object FOREIGN KEY (SourceId) REFERENCES exp.Object (Objectid);
+ALTER TABLE exp.Edge ADD CONSTRAINT UQ_Edge_FromTo_RunId_SourceId_SourceKey UNIQUE (FromObjectId, ToObjectId, RunId, SourceId, SourceKey);
+
+CREATE INDEX IX_Edge_ToObjectId ON exp.Edge(ToObjectId);
+CREATE INDEX IX_Edge_SourceId ON exp.Edge(SourceId);
+GO
+
+CREATE INDEX IDX_Edge_RunId ON exp.Edge(RunId);
+
+ALTER TABLE exp.DomainDescriptor ADD SystemFieldConfig NVARCHAR(MAX) NULL;
+
+ALTER TABLE exp.DataClass ADD dataparentimportaliasmap NVARCHAR(4000) NULL;
+
+CREATE TABLE exp.DataTypeExclusion
+(
+    RowId INT IDENTITY (1, 1) NOT NULL,
+    DataTypeRowId INT NOT NULL,
+    DataType NVARCHAR(20) NOT NULL,
+    ExcludedContainer EntityId NOT NULL,
+    Created DATETIME NULL,
+    CreatedBy INT NULL,
+    Modified DATETIME NULL,
+    ModifiedBy INT NULL,
+
+    CONSTRAINT PK_DataTypeExclusion PRIMARY KEY (RowId),
+    CONSTRAINT UQ_DataTypeExclusion_LSID UNIQUE (DataTypeRowId, DataType, ExcludedContainer)
+);
+GO
+
 -- Create procs used by Ontology Manager
 CREATE PROCEDURE exp.getObjectProperties(@container ENTITYID, @lsid LSIDType) AS
 BEGIN
     SELECT * FROM exp.ObjectPropertiesView
     WHERE Container = @container AND ObjectURI = @lsid
 END
-
 GO
+
 CREATE PROCEDURE exp.ensureObject(@container ENTITYID, @lsid LSIDType, @ownerObjectId INTEGER) AS
 BEGIN
     DECLARE @objectid AS INTEGER
@@ -540,8 +1176,8 @@ BEGIN
     COMMIT
     SELECT @objectid
 END
-
 GO
+
 CREATE PROCEDURE exp.deleteObject(@container ENTITYID, @lsid LSIDType) AS
 BEGIN
     SET NOCOUNT ON
@@ -557,8 +1193,8 @@ BEGIN
         DELETE exp.Object WHERE ObjectId = @objectid
     COMMIT
 END
-
 GO
+
 -- internal methods
 CREATE PROCEDURE exp._insertFloatProperty(@objectid INTEGER, @propid INTEGER, @float FLOAT) AS
 BEGIN
@@ -566,23 +1202,22 @@ BEGIN
     INSERT INTO exp.ObjectProperty (ObjectId, PropertyId, TypeTag, FloatValue)
     VALUES (@objectid, @propid, 'f', @float)
 END
-
 GO
+
 CREATE PROCEDURE exp._insertDateTimeProperty(@objectid INTEGER, @propid INTEGER, @datetime DATETIME) AS
 BEGIN
     IF (@propid IS NULL OR @objectid IS NULL) RETURN
     INSERT INTO exp.ObjectProperty (ObjectId, PropertyId, TypeTag, DateTimeValue)
     VALUES (@objectid, @propid, 'd', @datetime)
 END
-
 GO
+
 CREATE PROCEDURE exp._insertStringProperty(@objectid INTEGER, @propid INTEGER, @string VARCHAR(400)) AS
 BEGIN
     IF (@propid IS NULL OR @objectid IS NULL) RETURN
     INSERT INTO exp.ObjectProperty (ObjectId, PropertyId, TypeTag, StringValue)
     VALUES (@objectid, @propid, 's', @string)
 END
-
 GO
 --
 -- Set the same property on multiple objects (e.g. impoirt a column of datea)
@@ -618,8 +1253,8 @@ BEGIN
         EXEC exp._insertFloatProperty @objectid10, @propertyid, @float10
     COMMIT
 END
-
 GO
+
 CREATE PROCEDURE exp.setStringProperties(@propertyid INTEGER,
     @objectid1 INTEGER, @string1 VARCHAR(400),
     @objectid2 INTEGER, @string2 VARCHAR(400),
@@ -648,8 +1283,8 @@ BEGIN
         EXEC exp._insertStringProperty @objectid10, @propertyid, @string10
     COMMIT
 END
-
 GO
+
 CREATE PROCEDURE exp.setDateTimeProperties(@propertyid INTEGER,
     @objectid1 INTEGER, @datetime1 DATETIME,
     @objectid2 INTEGER, @datetime2 DATETIME,
@@ -678,8 +1313,8 @@ BEGIN
         EXEC exp._insertDateTimeProperty @objectid10, @propertyid, @datetime10
     COMMIT
 END
-
 GO
+
 CREATE PROCEDURE exp.deleteObjectById(@container ENTITYID, @objectid INTEGER) AS
 BEGIN
     SET NOCOUNT ON
@@ -694,927 +1329,4 @@ BEGIN
         DELETE exp.Object WHERE ObjectId = @objectid
     COMMIT
 END
-
 GO
-
-/* exp-11.20-11.30.sql */
-
-CREATE INDEX IDX_Protocol_Container ON exp.Protocol (Container)
-GO
-
-/* exp-11.30-12.10.sql */
-
-CREATE TABLE exp.AssayQCFlag
-(
-    RowId INT IDENTITY (1, 1) NOT NULL,
-    RunId INT NOT NULL,
-    FlagType VARCHAR(40) NOT NULL,
-    Description TEXT NULL,
-    Comment TEXT NULL,
-    Enabled BIT NOT NULL,
-    Created DATETIME  NULL,
-    CreatedBy INT NULL,
-    Modified DATETIME  NULL,
-    ModifiedBy INT NULL
-);
-
-ALTER TABLE exp.AssayQCFlag ADD CONSTRAINT PK_AssayQCFlag PRIMARY KEY (RowId);
-
-ALTER TABLE exp.AssayQCFlag ADD CONSTRAINT FK_AssayQCFlag_EunId FOREIGN KEY (RunId) REFERENCES exp.ExperimentRun (RowId);
-
-CREATE INDEX IX_AssayQCFlag_RunId ON exp.AssayQCFlag(RunId);
-
-ALTER TABLE exp.AssayQCFlag ADD IntKey1 INT NULL;
-ALTER TABLE exp.AssayQCFlag ADD IntKey2 INT NULL;
-
-CREATE INDEX IX_AssayQCFlag_IntKeys ON exp.AssayQCFlag(IntKey1, IntKey2);
-
-ALTER TABLE exp.AssayQCFlag ADD Key1 NVARCHAR(50);
-ALTER TABLE exp.AssayQCFlag ADD Key2 NVARCHAR(50);
-
-CREATE INDEX IX_AssayQCFlag_Keys ON exp.AssayQCFlag(Key1, Key2);
-
-ALTER TABLE exp.PropertyDescriptor ADD CreatedBy USERID NULL;
-ALTER TABLE exp.PropertyDescriptor ADD Created DATETIME NULL;
-ALTER TABLE exp.PropertyDescriptor ADD ModifiedBy USERID NULL;
-ALTER TABLE exp.PropertyDescriptor ADD Modified DATETIME NULL;
-
--- Clean up orphaned experiment objects that were not properly deleted when their container was deleted
--- Then, add real FKs to ensure we don't orphan rows in the future
-
--- First clean up memberships in run groups for orphaned runs and experiments
-DELETE FROM exp.RunList WHERE ExperimentId IN (SELECT RowId FROM exp.Experiment WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-DELETE FROM exp.RunList WHERE ExperimentRunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
--- Disconnect datas and materials from runs that are going away
-UPDATE exp.Data SET RunId = NULL WHERE RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.containers));
-UPDATE exp.Material SET RunId = NULL WHERE RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.containers));
-
-UPDATE exp.Data SET SourceApplicationId = NULL WHERE SourceApplicationId IN (SELECT RowId FROM exp.ProtocolApplication WHERE RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.containers)));
-UPDATE exp.Material SET SourceApplicationId = NULL WHERE SourceApplicationId IN (SELECT RowId FROM exp.ProtocolApplication WHERE RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.containers)));
-
--- Clean up orphaned runs and their objects
-DELETE FROM exp.DataInput WHERE TargetApplicationId IN
-	(SELECT RowId FROM exp.ProtocolApplication WHERE
-		ProtocolLSID IN (SELECT Lsid FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
-		OR RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers)));
-
-DELETE FROM exp.MaterialInput WHERE TargetApplicationId IN
-	(SELECT RowId FROM exp.ProtocolApplication WHERE
-		ProtocolLSID IN (SELECT Lsid FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
-		OR RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers)));
-
-DELETE FROM exp.ProtocolApplicationParameter WHERE ProtocolApplicationId IN
-	(SELECT RowId FROM exp.ProtocolApplication WHERE
-		ProtocolLSID IN (SELECT Lsid FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
-		OR RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers)));
-
-DELETE FROM exp.ProtocolApplication WHERE
-	ProtocolLSID IN (SELECT Lsid FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
-	OR RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
-DELETE FROM exp.AssayQCFlag WHERE RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
-DELETE FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
-
--- Now that runs that might have been pointing to them for their batch are deleted, clean up orphaned experiments/run groups/batches
-DELETE FROM exp.Experiment WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
-
--- Next, clean up orphaned protocols
-DELETE FROM exp.ProtocolParameter WHERE ProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
-DELETE FROM exp.ProtocolActionPredecessor WHERE ActionId IN (SELECT RowId FROM exp.ProtocolAction WHERE
-	ParentProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
-	OR ChildProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers)));
-
-DELETE FROM exp.ProtocolAction WHERE
-	ParentProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
-	OR ChildProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
-DELETE FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
-
--- Delete orphaned sample types/material sources
-DELETE FROM exp.ActiveMaterialSource WHERE MaterialSourceLSID IN (SELECT Lsid FROM exp.MaterialSource WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
-DELETE FROM exp.MaterialSource WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
-
--- Next, work on properties and domains
--- Start by deleting from juntion table between properties and domains
-DELETE FROM exp.PropertyDomain WHERE
-	PropertyId IN (SELECT PropertyId FROM exp.PropertyDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
-	OR DomainId IN (SELECT DomainId FROM exp.DomainDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
--- Then orphaned domains
-DELETE FROM exp.DomainDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
-
--- Next, orphaned validators and their usages
-DELETE FROM exp.ValidatorReference WHERE
-	ValidatorId IN (SELECT RowId FROM exp.PropertyValidator WHERE Container IN (SELECT EntityId FROM core.Containers))
-	OR PropertyId IN (SELECT PropertyId FROM exp.PropertyDescriptor WHERE Container IN (SELECT EntityId FROM core.Containers));
-
-DELETE FROM exp.PropertyValidator WHERE Container IN (SELECT EntityId FROM core.Containers);
-
--- Clean up conditional formats attached to delete property descriptors
-DELETE FROM exp.ConditionalFormat WHERE PropertyId IN (SELECT PropertyId FROM exp.PropertyDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
--- Then delete orphaned properties and their values
-DELETE FROM exp.ObjectProperty WHERE PropertyId IN (SELECT PropertyId FROM exp.PropertyDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
-DELETE FROM exp.PropertyDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
-
--- Delete orphaned lists too
-DELETE FROM exp.List WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
-
--- Finally, add some FKs so we don't get into this horrible state again
-ALTER TABLE exp.DomainDescriptor ADD CONSTRAINT FK_DomainDescriptor_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
-ALTER TABLE exp.Experiment ADD CONSTRAINT FK_Experiment_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
-ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_ExperimentRun_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
-ALTER TABLE exp.List ADD CONSTRAINT FK_List_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
-ALTER TABLE exp.MaterialSource ADD CONSTRAINT FK_MaterialSource_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
-ALTER TABLE exp.PropertyDescriptor ADD CONSTRAINT FK_PropertyDescriptor_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
-ALTER TABLE exp.PropertyValidator ADD CONSTRAINT FK_PropertyValidator_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
-ALTER TABLE exp.Protocol ADD CONSTRAINT FK_Protocol_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
-
-CREATE INDEX idx_propertyvalidator_container ON exp.PropertyValidator (Container);
-
--- Clean up DataInputs that were attached as run outputs in error
-DELETE FROM exp.DataInput WHERE DataId IN
-  (SELECT di.DataId
-   FROM exp.DataInput di, exp.Data d, exp.ExperimentRun r
-   WHERE di.DataId = d.RowId
-     AND d.RunId = r.RowId
-     AND r.lsid LIKE '%:NabAssayRun.%'
-     AND r.protocollsid LIKE '%:NabAssayProtocol.%'
-     AND di.role LIKE '%;%.xls');
-
-/* exp-12.10-12.20.sql */
-
-ALTER TABLE exp.PropertyDescriptor ADD FacetingBehaviorType NVARCHAR(40) NOT NULL DEFAULT 'AUTOMATIC';
-
-ALTER TABLE exp.IndexVarchar ADD CreatedBy USERID NULL;
-ALTER TABLE exp.IndexVarchar ADD Created DATETIME NULL;
-ALTER TABLE exp.IndexVarchar ADD ModifiedBy USERID NULL;
-ALTER TABLE exp.IndexVarchar ADD Modified DATETIME NULL;
-ALTER TABLE exp.IndexVarchar ADD LastIndexed DATETIME NULL;
-
-ALTER TABLE exp.IndexInteger ADD CreatedBy USERID NULL;
-ALTER TABLE exp.IndexInteger ADD Created DATETIME NULL;
-ALTER TABLE exp.IndexInteger ADD ModifiedBy USERID NULL;
-ALTER TABLE exp.IndexInteger ADD Modified DATETIME NULL;
-ALTER TABLE exp.IndexInteger ADD LastIndexed DATETIME NULL;
-
--- Use prefix naming to better match new field names
-EXEC sp_rename 'exp.List.IndexMetaData', 'MetaDataIndex', 'COLUMN';
-
-ALTER TABLE exp.list ADD EntireListIndex BIT NOT NULL DEFAULT 0;
-ALTER TABLE exp.list ADD EntireListTitleSetting INT NOT NULL DEFAULT 0;
-ALTER TABLE exp.list ADD EntireListTitleTemplate NVARCHAR(1000) NULL;
-ALTER TABLE exp.list ADD EntireListBodyTemplate NVARCHAR(1000) NULL;
-ALTER TABLE exp.list ADD EntireListBodySetting INT NOT NULL DEFAULT 0;
-
-ALTER TABLE exp.list ADD EachItemIndex BIT NOT NULL DEFAULT 0;
-ALTER TABLE exp.list ADD EachItemTitleSetting INT NOT NULL DEFAULT 0;
-ALTER TABLE exp.list ADD EachItemTitleTemplate NVARCHAR(1000) NULL;
-ALTER TABLE exp.list ADD EachItemBodySetting INT NOT NULL DEFAULT 0;
-ALTER TABLE exp.list ADD EachItemBodyTemplate NVARCHAR(1000) NULL;
-
-ALTER TABLE exp.List ADD LastIndexed DATETIME NULL;
-
--- Merge the "meta data only" and "entire list data" settings, migrating them to a single boolean (EntireListIndex) plus
--- a setting denoting what to index (EntireListIndexSetting = meta data only (0), item data only (1), or both (2))
-
-ALTER TABLE exp.List ADD EntireListIndexSetting INT NOT NULL DEFAULT 0;  -- Meta data only, the default
-GO
-
-UPDATE exp.List SET EntireListIndexSetting = 1 WHERE MetaDataIndex = 0 AND EntireListIndex = 1; -- Item data only
-UPDATE exp.List SET EntireListIndexSetting = 2 WHERE MetaDataIndex = 1 AND EntireListIndex = 1;  -- Meta data and item data
-
-UPDATE exp.List SET EntireListIndex = 1 WHERE MetaDataIndex = 1;   -- Turn on EntireListIndex if meta data was being indexed
-
--- Must drop default constraint before dropping column
-EXEC core.fn_dropifexists @objname='List', @objschema='exp', @objtype='DEFAULT', @subobjname='MetaDataIndex'
-
-ALTER TABLE exp.List DROP COLUMN MetaDataIndex;
-
-ALTER TABLE exp.ExperimentRun ADD JobId INTEGER;
-
---experiment module depends on pipeline, so this should be ok
-ALTER TABLE exp.ExperimentRun ADD
-    CONSTRAINT FK_ExperimentRun_JobId FOREIGN KEY (JobId)
-        REFERENCES pipeline.statusfiles (RowId);
-
--- Change exp.MaterialSource.Name from VARCHAR(50) to VARCHAR(100). Going to 200 to match other experiment tables
- -- hits limits with domain URIs, etc
-ALTER TABLE exp.MaterialSource ALTER COLUMN Name NVARCHAR(100);
-
--- Change exp.ExperimentRun.Name from VARCHAR(100) to VARCHAR(200) to match other experiment table name columns
-ALTER TABLE exp.ExperimentRun ALTER COLUMN Name NVARCHAR(200);
-
--- Rename any list field named Created, CreatedBy, Modified, or ModifiedBy since these are now built-in columns on every list
-UPDATE exp.PropertyDescriptor SET Name = Name + '_99' WHERE LOWER(Name) IN ('created', 'createdby', 'modified', 'modifiedby') AND
-    PropertyId IN (SELECT PropertyId FROM exp.PropertyDomain pdom INNER JOIN exp.List l ON pdom.DomainId = l.DomainId);
-
-/* exp-12.20-12.30.sql */
-
-ALTER TABLE exp.PropertyDescriptor ADD Protected BIT NOT NULL DEFAULT '0';
-
--- Add a column to track the chaining of original and replaced runs
-ALTER TABLE exp.ExperimentRun ADD ReplacedByRunId INT;
-
-ALTER TABLE exp.ExperimentRun ADD
-    CONSTRAINT FK_ExperimentRun_ReplacedByRunId FOREIGN KEY (ReplacedByRunId)
-        REFERENCES exp.ExperimentRun (RowId);
-
-CREATE INDEX IDX_ExperimentRun_ReplacedByRunId ON exp.ExperimentRun(ReplacedByRunId);
-
-ALTER TABLE exp.DomainDescriptor DROP CONSTRAINT uq_domainuricontainer;
-ALTER TABLE exp.DomainDescriptor DROP CONSTRAINT uq_domaindescriptor;
-
-ALTER TABLE exp.DomainDescriptor ADD CONSTRAINT uq_domaindescriptor UNIQUE (DomainURI, Project);
-
-ALTER TABLE exp.RunList ADD Created TIMESTAMP;
-ALTER TABLE exp.RunList ADD CreatedBy INT;
-
-ALTER TABLE exp.RunList DROP COLUMN Created;
-ALTER TABLE exp.RunList ADD Created DATETIME;
-
-ALTER TABLE exp.PropertyDescriptor ALTER COLUMN lookupschema NVARCHAR(200);
-ALTER TABLE exp.PropertyDescriptor ALTER COLUMN lookupquery NVARCHAR(200);
-
-/* exp-12.30-13.10.sql */
-
-ALTER TABLE exp.PropertyDescriptor ADD ExcludeFromShifting BIT NOT NULL DEFAULT '0';
-
-/* exp-13.10-13.20.sql */
-
--- Use a container-scoped sequence for lists; each folder maintains a distinct, auto-incrementing sequence of List IDs
-
--- We're changing the exp.List PK from (RowId) to (Container, ListId), but we still need to keep the RowId around
--- since the index tables need it. (When we convert lists to hard tables we can drop the index tables and the RowId.)
-
--- First, drop FKs that depend on the RowId PK, add the unique constraint, and then recreate the FKs
-ALTER TABLE exp.IndexInteger DROP CONSTRAINT FK_IndexInteger_List;
-ALTER TABLE exp.IndexVarchar DROP CONSTRAINT FK_IndexVarchar_List;
-ALTER TABLE exp.List DROP CONSTRAINT PK_List;
-ALTER TABLE exp.List ADD CONSTRAINT UQ_RowId UNIQUE (RowId);
-ALTER TABLE exp.IndexInteger ADD CONSTRAINT FK_IndexInteger_List FOREIGN KEY(ListId) REFERENCES exp.List(RowId);
-ALTER TABLE exp.IndexVarchar ADD CONSTRAINT FK_IndexVarchar_List FOREIGN KEY(ListId) REFERENCES exp.List(RowId);
-
--- Now add ListId column...
-ALTER TABLE exp.List ADD ListId INT NULL;
-GO
-
--- ...populate it with the current values of RowId...
-UPDATE exp.List SET ListId = RowId;
-ALTER TABLE exp.List ALTER COLUMN ListId INT NOT NULL;
-GO
-
--- ...and create the new PK (Container, ListId)
-ALTER TABLE exp.List ADD CONSTRAINT PK_List PRIMARY KEY (Container, ListId);
-
--- add start time, end time, and record count to protocol application table for ETL tasks and others
-ALTER TABLE exp.ProtocolApplication ADD StartTime DATETIME NULL;
-ALTER TABLE exp.ProtocolApplication ADD EndTime DATETIME NULL;
-ALTER TABLE exp.ProtocolApplication ADD RecordCount INT NULL;
-
-/* exp-13.30-14.10.sql */
-
-ALTER TABLE exp.propertydescriptor ADD Scale INT NOT NULL DEFAULT 0;
-
-/* exp-14.10-14.20.sql */
-
-ALTER TABLE exp.PropertyDescriptor ADD KeyVariable BIT NOT NULL DEFAULT '0';
-ALTER TABLE exp.PropertyDescriptor ADD DefaultScale NVARCHAR(40) NOT NULL DEFAULT 'LINEAR';
-
-/* exp-14.20-14.30.sql */
-
-ALTER TABLE exp.PropertyDescriptor ADD StorageColumnName NVARCHAR(100) NULL;
-GO
-
-UPDATE exp.propertydescriptor
-SET storagecolumnname=name
-WHERE EXISTS (SELECT * FROM
-  exp.propertydomain DP inner join exp.domaindescriptor DD on DP.domainid = DD.domainid
-WHERE DD.storagetablename is not null and propertydescriptor.propertyid = DP.propertyid);
-
--- Add batchId column to run table
-ALTER TABLE exp.ExperimentRun
-   ADD BatchId INT;
-
-ALTER TABLE exp.ExperimentRun
-  ADD CONSTRAINT FK_ExperimentRun_BatchId FOREIGN KEY (BatchId) REFERENCES exp.Experiment (RowId);
-
-CREATE INDEX IX_ExperimentRun_BatchId
-  ON exp.ExperimentRun(BatchId);
-
-GO
-
-UPDATE exp.ExperimentRun SET BatchId = (
-  SELECT e.RowId AS BatchId
-    FROM exp.Experiment e
-    WHERE
-      e.BatchProtocolId IS NOT NULL
-      AND e.RowId = (
-        SELECT MIN(ExperimentId) FROM exp.Experiment e, exp.RunList rl
-        WHERE e.RowId = rl.ExperimentId
-        AND rl.ExperimentRunId = ExperimentRun.RowId
-      )
-);
-
-/* exp-14.30-15.10.sql */
-
-ALTER TABLE exp.DomainDescriptor ADD _ts ROWVERSION;
-ALTER TABLE exp.DomainDescriptor ADD ModifiedBy USERID;
-ALTER TABLE exp.DomainDescriptor ADD Modified DATETIME DEFAULT GETDATE();
-GO
-
-/* exp-15.10-15.20.sql */
-
-EXECUTE core.fn_dropifexists 'material', 'exp', 'INDEX', 'idx_material_AK';
-
--- shouldn't be any null names, but just to be safe
-UPDATE exp.material SET name='NULL' WHERE name IS NULL;
-ALTER TABLE exp.material ALTER COLUMN name NVARCHAR(200) NOT NULL;
-
-CREATE UNIQUE INDEX idx_material_AK ON exp.material (container, cpastype, name) WHERE cpastype IS NOT NULL;
-GO
-
-EXEC sp_rename 'exp.PropertyDescriptor.KeyVariable', 'RecommendedVariable', 'COLUMN';
-
-ALTER TABLE exp.Data ADD Generated BIT NOT NULL DEFAULT 0;
-
-GO
-
-/* exp-15.30-16.10.sql */
-
-
-CREATE TABLE exp.DataClass
-(
-    RowId INT IDENTITY(1,1) NOT NULL,
-    Name NVARCHAR(200) NOT NULL,
-    LSID LSIDtype NOT NULL,
-    Container EntityId NOT NULL,
-    Created DATETIME NULL,
-    CreatedBy INT NULL,
-    Modified DATETIME NULL,
-    ModifiedBy INT NULL,
-    Description NTEXT NULL,
-    MaterialSourceId INT NULL,
-    NameExpression NVARCHAR(200) NULL,
-
-    CONSTRAINT PK_DataClass PRIMARY KEY (RowId),
-    CONSTRAINT UQ_DataClass_LSID UNIQUE (LSID),
-    CONSTRAINT UQ_DataClass_Container_Name UNIQUE (Container, Name),
-
-    CONSTRAINT FK_DataClass_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId),
-    CONSTRAINT FK_DataClass_MaterialSource FOREIGN KEY (MaterialSourceId) REFERENCES exp.MaterialSource (RowId)
-);
-CREATE INDEX IX_DataClass_Container ON exp.DataClass(Container);
-
-
-ALTER TABLE exp.data
-  ADD description NVARCHAR(4000);
-
-GO
-
-ALTER TABLE exp.data
-  ADD classId INT;
-
-GO
-
-ALTER TABLE exp.data
-  ADD CONSTRAINT FK_Data_DataClass FOREIGN KEY (classId) REFERENCES exp.DataClass (rowid);
-
--- Within a DataClass, name must be unique.  If DataClass is null, duplicate names are allowed.
-CREATE UNIQUE INDEX UQ_Data_DataClass_Name
-  ON exp.data(classId, name) WHERE classId IS NOT NULL;
-
-CREATE TABLE exp.Alias
-(
-    RowId INT IDENTITY (1, 1) NOT NULL,
-    Created DATETIME,
-    CreatedBy INT,
-    Modified DATETIME,
-    ModifiedBy INT,
-
-    Name NVARCHAR(500) NOT NULL,
-
-    CONSTRAINT PK_Alias PRIMARY KEY (RowId),
-    CONSTRAINT UQ_Alias_Name UNIQUE (Name)
-);
-
-CREATE TABLE exp.DataAliasMap
-(
-    LSID LSIDtype NOT NULL,
-    Alias INT NOT NULL,
-    Container EntityId NOT NULL,
-
-    CONSTRAINT PK_DataAliasMap PRIMARY KEY (LSID, Alias),
-    CONSTRAINT FK_DataAlias_RowId FOREIGN KEY (Alias) REFERENCES exp.Alias(RowId)
-);
-
-CREATE TABLE exp.MaterialAliasMap
-(
-    LSID LSIDtype NOT NULL,
-    Alias INT NOT NULL,
-    Container EntityId NOT NULL,
-
-    CONSTRAINT PK_MaterialAliasMap PRIMARY KEY (LSID, Alias),
-    CONSTRAINT FK_MaterialAlias_RowId FOREIGN KEY (Alias) REFERENCES exp.Alias(RowId)
-);
-
-CREATE INDEX IX_Alias_Name ON exp.Alias(Name);
-
-ALTER TABLE exp.DataAliasMap ADD CONSTRAINT FK_DataAlias_LSID FOREIGN KEY (LSID) REFERENCES exp.Data(LSID);
-CREATE INDEX IX_DataAliasMap ON exp.DataAliasMap(LSID, Alias, Container);
-
-ALTER TABLE exp.MaterialAliasMap ADD CONSTRAINT FK_MaterialAlias_LSID FOREIGN KEY (LSID) REFERENCES exp.Material(LSID);
-CREATE INDEX IX_MaterialAliasMap ON exp.MaterialAliasMap(LSID, Alias, Container);
-
-/* exp-16.10-16.20.sql */
-
-ALTER TABLE exp.data
-    ALTER COLUMN cpastype nvarchar(300);
-
-UPDATE exp.data
-    SET cpastype = (SELECT lsid FROM exp.dataclass WHERE exp.data.classId = exp.dataclass.rowid)
-    WHERE classid IS NOT NULL;
-
-ALTER TABLE exp.Data ADD LastIndexed DATETIME NULL;
-ALTER TABLE exp.DomainDescriptor ADD TemplateInfo NVARCHAR(4000) NULL;
-
-/* exp-16.30-17.10.sql */
-
-ALTER TABLE exp.MaterialSource ADD NameExpression NVARCHAR(200) NULL;
-
-ALTER TABLE exp.material
-    ADD description NVARCHAR(4000);
-
-EXEC core.fn_dropifexists 'indexinteger', 'exp', 'TABLE';
-EXEC core.fn_dropifexists 'indexvarchar', 'exp', 'TABLE';
-EXEC core.fn_dropifexists 'list', 'exp', 'CONSTRAINT', 'UQ_RowId';
-EXEC core.fn_dropifexists 'list', 'exp', 'COLUMN', 'rowid';
-
-/* exp-17.10-17.20.sql */
-
-ALTER TABLE exp.list ADD FileAttachmentIndex BIT CONSTRAINT DF__list__FileAttachmentIndex DEFAULT 0 NOT NULL;
-GO
-
-/* exp-17.20-17.30.sql */
-
-ALTER TABLE exp.PropertyDescriptor ADD Phi NVARCHAR(20) NOT NULL DEFAULT 'NotPHI';
-GO
-UPDATE exp.PropertyDescriptor SET Phi='Limited' WHERE Protected='TRUE';
-GO
-
-EXEC core.fn_dropifexists 'PropertyDescriptor', 'exp', 'COLUMN', 'Protected';
-GO
-
-ALTER TABLE exp.PropertyDescriptor ADD RedactedText NVARCHAR(450) NULL;
-GO
-
-ALTER TABLE exp.PropertyDescriptor ADD mvIndicatorStorageColumnName NVARCHAR(120);
-GO
-
-/* exp-17.30-18.10.sql */
-
-CREATE TABLE exp.Edge
-(
-  FromLsid LSIDtype NOT NULL,
-  ToLsid LSIDtype NOT NULL,
-  RunId INT NOT NULL,
-
-  CONSTRAINT FK_Edge_FromLsid_Object FOREIGN KEY (FromLsid) REFERENCES exp.object (objecturi),
-  CONSTRAINT FK_Edge_ToLsid_Object FOREIGN KEY (ToLsid) REFERENCES exp.object (objecturi),
-  CONSTRAINT FK_Edge_RunId_Run FOREIGN KEY (RunId) REFERENCES exp.ExperimentRun (RowId),
-  CONSTRAINT UQ_Edge_FromLsid_ToLsid_RunId UNIQUE (FromLsid, ToLsid, RunId)
-);
-
-/* exp-18.10-18.20.sql */
-
-ALTER TABLE exp.PropertyDescriptor
-  ADD TextExpression nvarchar(200) NULL
-
-ALTER TABLE exp.DomainDescriptor ALTER COLUMN DomainURI NVARCHAR(300) NOT NULL;
-ALTER TABLE exp.PropertyDescriptor ALTER COLUMN PropertyURI NVARCHAR(300) NOT NULL;
-
-/* exp-18.20-18.30.sql */
-
-CREATE TABLE exp.ProtocolInput
-(
-  RowId INT IDENTITY (1,1) NOT NULL,
-  Name NVARCHAR(300) NOT NULL,
-  LSID LSIDtype NOT NULL,
-  ProtocolId INT NOT NULL,
-  Input BIT NOT NULL,
-
-  -- One of 'Material' or 'Data'
-  ObjectType NVARCHAR(8) NOT NULL,
-
-  -- DataClassId may be non-null when ObjectType='Data'
-  DataClassId INT NULL,
-  -- MaterialSourceId may be non-null when ObjectType='Material'
-  MaterialSourceId INT NULL,
-
-  CriteriaName NVARCHAR(50) NULL,
-  CriteriaConfig NTEXT NULL,
-  MinOccurs INT NOT NULL,
-  MaxOccurs INT NULL,
-
-  CONSTRAINT PK_ProtocolInput_RowId PRIMARY KEY (RowId),
-  CONSTRAINT FK_ProtocolInput_ProtocolId FOREIGN KEY (ProtocolId) REFERENCES exp.Protocol (RowId),
-  CONSTRAINT FK_ProtocolInput_DataClassId FOREIGN KEY (DataClassId) REFERENCES exp.DataClass (RowId),
-  CONSTRAINT FK_ProtocolInput_MaterialSourceId FOREIGN KEY (MaterialSourceId) REFERENCES exp.MaterialSource (RowId)
-);
-
-CREATE INDEX IX_ProtocolInput_ProtocolId ON exp.ProtocolInput (ProtocolId);
-CREATE INDEX IX_ProtocolInput_DataClassId ON exp.ProtocolInput (DataClassId);
-CREATE INDEX IX_ProtocolInput_MaterialSourceId ON exp.ProtocolInput (MaterialSourceId);
-
-
--- Add reference from MaterialInput to the ProtocolInputId that it corresponds to
-ALTER TABLE exp.MaterialInput
-  ADD ProtocolInputId INT NULL;
-
-ALTER TABLE exp.MaterialInput
-  ADD CONSTRAINT FK_MaterialInput_ProtocolInput FOREIGN KEY (ProtocolInputId) REFERENCES exp.ProtocolInput (RowId);
-
-CREATE INDEX IX_MaterialInput_ProtocolInputId ON exp.MaterialInput (ProtocolInputId);
-
-
--- Add reference from DataInput to the ProtocolInputId that it corresponds to
-ALTER TABLE exp.DataInput
-  ADD ProtocolInputId INT NULL;
-
-ALTER TABLE exp.DataInput
-  ADD CONSTRAINT FK_DataInput_ProtocolInput FOREIGN KEY (ProtocolInputId) REFERENCES exp.ProtocolInput (RowId);
-
-CREATE INDEX IX_DataInput_ProtocolInputId ON exp.DataInput (ProtocolInputId);
-
--- Issue 35817 - widen column to allow for longer paths and file names
-ALTER TABLE exp.Data ALTER COLUMN DataFileURL NVARCHAR(600);
-
-/* exp-18.30-19.10.sql */
-
--- Removing active sample types
-EXEC core.fn_dropifexists 'ActiveMaterialSource', 'exp', 'TABLE', NULL;
-GO
-
-ALTER TABLE exp.materialsource
-  ALTER COLUMN nameexpression NVARCHAR(500);
-
-ALTER TABLE exp.dataclass
-  ALTER COLUMN nameexpression NVARCHAR(500);
-
-UPDATE exp.data SET datafileurl = 'file:///' + substring(datafileurl, 7, 600) WHERE datafileurl LIKE 'file:/_%' AND datafileurl NOT LIKE 'file:///%' AND datafileurl IS NOT NULL;
-
-/* exp-19.10-19.20.sql */
-
-DROP TABLE exp.Edge;
-GO
-
-CREATE TABLE exp.Edge
-(
-    FromObjectId INT NOT NULL,
---    FromLsid LSIDtype NOT NULL,
-    ToObjectId INT NOT NULL,
---    ToLsid LSIDtype NOT NULL,
-    RunId INT NOT NULL,
-
-    CONSTRAINT FK_Edge_From_Object FOREIGN KEY (FromObjectId) REFERENCES exp.object (objectid),
-    CONSTRAINT FK_Edge_To_Object FOREIGN KEY (ToObjectId) REFERENCES exp.object (objectid),
-    CONSTRAINT FK_Edge_RunId_Run FOREIGN KEY (RunId) REFERENCES exp.ExperimentRun (RowId),
--- for query performance
-    CONSTRAINT UQ_Edge_FromTo_RunId UNIQUE (FromObjectId, ToObjectId, RunId),
-    CONSTRAINT UQ_Edge_ToFrom_RunId UNIQUE (ToObjectId, FromObjectId, RunId)
-);
-GO
-
-ALTER TABLE exp.MaterialSource ADD LastIndexed DATETIME NULL;
-
-ALTER TABLE exp.MaterialSource
-    ADD MaterialParentImportAliasMap NVARCHAR(4000) NULL;
-
-/* exp-19.20-19.30.sql */
-
-ALTER TABLE exp.data ADD ObjectId INT;
-ALTER TABLE exp.experimentrun ADD objectid INT;
-ALTER TABLE exp.material ADD objectid INT;
-GO
-
-
-INSERT INTO exp.object (objecturi, container)
-SELECT D.lsid as objecturi, D.container as container
-FROM exp.data D
-WHERE D.lsid NOT IN (SELECT O.objecturi FROM exp.object O);
-
-UPDATE exp.data
-SET objectid = (select O.objectid from exp.object O where O.objecturi = lsid);
-
-
-INSERT INTO exp.object (objecturi, container)
-SELECT ER.lsid as objecturi, ER.container as container
-FROM exp.experimentrun ER
-WHERE ER.lsid NOT IN (SELECT O.objecturi FROM exp.object O);
-
-UPDATE exp.experimentrun
-SET objectid = (select O.objectid from exp.object O where O.objecturi = lsid);
-
-
-INSERT INTO exp.object (objecturi, container, ownerobjectid)
-SELECT M.lsid as objecturi,M.container as container,
-       (select O.objectid from exp.materialsource MS left outer join exp.object O ON MS.lsid = O.objecturi WHERE MS.lsid = M.cpastype) as ownerobjectid
-FROM exp.material M
-WHERE M.lsid NOT IN (SELECT O.objecturi FROM exp.object O);
-
-UPDATE exp.material
-SET objectid = (select O.objectid from exp.object O where O.objecturi = lsid);
-
-
-ALTER TABLE exp.data ALTER COLUMN objectid INT NOT NULL;
-ALTER TABLE exp.experimentrun ALTER COLUMN objectid INT NOT NULL;
-ALTER TABLE exp.material ALTER COLUMN objectid INT NOT NULL;
-GO
-
-CREATE UNIQUE INDEX idx_data_objectid ON exp.data (objectid);
-CREATE UNIQUE INDEX idx_experimentrun_objectid ON exp.experimentrun (objectid);
-CREATE UNIQUE INDEX idx_material_objectid ON exp.material (objectid);
-GO
-
-ALTER TABLE exp.ExperimentRun ADD LastIndexed DATETIME NULL;
-
-ALTER TABLE exp.ProtocolApplication ALTER COLUMN Comments NVARCHAR(MAX);
-
-ALTER TABLE exp.DataClass ADD Category NVARCHAR(20) NULL;
-
-ALTER TABLE exp.DataClass ADD LastIndexed DATETIME NULL;
-
-ALTER TABLE exp.MaterialSource ADD LabelColor NVARCHAR(7) NULL;
-
-EXEC sp_rename 'exp.propertyvalidator', 'pv_old'
-GO
-
-CREATE TABLE exp.PropertyValidator
-(
-    RowId        int identity(1,1) not null,
-    Name         NVARCHAR(50) not null,
-    Description  NVARCHAR(200),
-    TypeURI      NVARCHAR(200) not null,
-    Expression   NVARCHAR(MAX),
-    ErrorMessage NVARCHAR(MAX),
-    Properties   NVARCHAR(MAX),
-    Container    entityid not null constraint fk_pv_container references core.containers (entityid),
-    PropertyId   int not null constraint fk_pv_descriptor references exp.propertydescriptor,
-    constraint pk_propertyvalidator primary key (container, propertyid, rowid)
-);
-GO
-
-INSERT INTO exp.propertyvalidator(propertyid, name, description, typeuri, expression, properties, errormessage, container)
-SELECT VR.propertyid, PV.name, PV.description, PV.typeuri, PV.expression, PV.properties, PV.errormessage, PV.container
-FROM exp.pv_old PV INNER JOIN exp.validatorreference VR ON PV.rowid = VR.validatorid
-ORDER BY container, propertyid;
-
-CREATE INDEX ix_propertyvalidator_propertyid on exp.PropertyValidator(PropertyId);
-
-DROP TABLE exp.validatorreference;
-DROP TABLE exp.pv_old;
-GO
-
-ALTER TABLE exp.PropertyDescriptor DROP COLUMN OntologyURI;
-ALTER TABLE exp.PropertyDescriptor DROP COLUMN SearchTerms;
-ALTER TABLE exp.PropertyDescriptor DROP COLUMN SemanticType;
-GO
-
-ALTER TABLE exp.PropertyDescriptor ADD PrincipalConceptCode NVARCHAR(50) NULL;
-GO
-
-ALTER TABLE exp.MaterialSource ADD MetricUnit NVARCHAR(10) NULL;
-GO
-
-ALTER TABLE exp.PropertyDescriptor ADD SourceOntology NVARCHAR(20) NULL;
-ALTER TABLE exp.PropertyDescriptor ADD ConceptImportColumn NVARCHAR(200) NULL;
-ALTER TABLE exp.PropertyDescriptor ADD ConceptLabelColumn NVARCHAR(200) NULL;
-GO
-
--- create exp.object for exp.data without one
-INSERT INTO exp.object (objecturi, container)
-SELECT D.lsid as objecturi, D.container as container
-FROM exp.data D LEFT OUTER JOIN exp.object O ON D.lsid = O.objecturi
-WHERE O.objecturi IS NULL;
-
--- fixup exp.data.objectid to be consistent with the lsid of the exp.object
-UPDATE exp.data
-SET objectid = (SELECT O.objectid FROM exp.object O WHERE O.objecturi = lsid)
-WHERE rowid IN (
-    SELECT rowid
-    FROM exp.data D
-    LEFT OUTER JOIN exp.object O ON D.lsid = O.objecturi
-    WHERE D.objectid != O.objectid
-);
-
--- add constraints for lsid -> exp.object
-ALTER TABLE exp.data ADD CONSTRAINT FK_Data_Lsid
-    FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
-ALTER TABLE exp.material ADD CONSTRAINT FK_Material_Lsid
-    FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
-ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_Lsid
-    FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
-
--- add constraints for objectid -> exp.object
-ALTER TABLE exp.data ADD CONSTRAINT FK_Data_ObjectId
-    FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
-ALTER TABLE exp.material ADD CONSTRAINT FK_Material_ObjectId
-    FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
-ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_ObjectId
-    FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
-GO
-
-/* 21.xxx SQL scripts */
-
--- Most major file systems cap file lengths at 255 characters. Let's do the same
-ALTER TABLE exp.data ALTER COLUMN Name NVARCHAR(255);
-
-ALTER TABLE exp.PropertyDescriptor ADD DerivationDataScope NVARCHAR(20) NULL;
-ALTER TABLE exp.Material ADD RootMaterialLSID LSIDtype NULL;
-ALTER TABLE exp.Material ADD AliquotedFromLSID LSIDtype NULL;
-GO
-
-ALTER TABLE exp.MaterialSource ADD AutoLinkTargetContainer ENTITYID NULL;
-
-ALTER TABLE exp.List ADD Category NVARCHAR(20) NULL;
-
-ALTER TABLE exp.PropertyDescriptor ADD ConceptSubtree NVARCHAR(MAX) NULL;
-
--- move the StudyPublishProtocol container to the shared folder
-UPDATE exp.protocol
-    SET container = (SELECT entityid FROM core.containers WHERE name = 'Shared')
-    WHERE lsid LIKE 'urn:lsid:labkey.org:Protocol:StudyPublishProtocol%';
-
-UPDATE exp.propertydescriptor SET scale=4000 WHERE propertyuri LIKE '%WorkflowTask#AssayTypes';
-
-ALTER TABLE exp.MaterialSource ADD AutoLinkCategory NVARCHAR(200) NULL;
-
-ALTER TABLE exp.MaterialSource ADD AliquotNameExpression NVARCHAR(200) NULL;
-
-ALTER TABLE exp.Material ADD SampleState INT;
-GO
-ALTER TABLE exp.Material ADD CONSTRAINT FK_Material_SampleState FOREIGN KEY (SampleState) REFERENCES core.DataStates (RowId);
-
-ALTER TABLE exp.ProtocolApplication ADD EntityId ENTITYID;
-
-GO
-
-UPDATE exp.ProtocolApplication SET EntityId = NEWID();
-
-ALTER TABLE exp.ProtocolApplication ALTER COLUMN EntityId ENTITYID NOT NULL;
-
-ALTER TABLE exp.MaterialSource ADD Category NVARCHAR(20) NULL;
-
-ALTER TABLE exp.ExperimentRun ADD WorkflowTask INT;
-GO
-ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId) ON DELETE SET NULL;
-
-ALTER TABLE exp.Protocol ADD Status NVARCHAR(60);
-GO
-UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun';
-
-ALTER TABLE exp.Material ADD RecomputeRollup BIT NULL CONSTRAINT DF_recomputeRollup DEFAULT(0);
-ALTER TABLE exp.Material ADD AliquotCount INT NULL;
-ALTER TABLE exp.Material ADD AliquotVolume FLOAT NULL;
-ALTER TABLE exp.Material ADD AliquotUnit NVARCHAR(10) NULL;
-GO
-UPDATE exp.Material SET RecomputeRollup=1 WHERE lsid IN
-                                                (
-                                                    SELECT distinct rootMaterialLsid FROM exp.material
-                                                );
-GO
-CREATE INDEX IDX_exp_material_recompute ON exp.Material (container, rowid, lsid) WHERE RecomputeRollup=1;
-
-ALTER TABLE exp.PropertyDescriptor ADD Scannable BIT NOT NULL DEFAULT 0;
-GO
-
-/* 22.xxx SQL scripts */
-
-ALTER TABLE exp.list ALTER COLUMN Name NVARCHAR(200);
-GO
-
-UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun' AND Status IS NULL;
-
-CREATE TABLE exp.ObjectLegacyNames
-(
-    RowId INT IDENTITY (1, 1) NOT NULL,
-    ObjectId INT NOT NULL,
-    ObjectType NVARCHAR(20) NOT NULL,
-    Name NVARCHAR(200) NOT NULL,
-    Created DATETIME NULL,
-    CreatedBy INT NULL,
-    Modified DATETIME NULL,
-    ModifiedBy INT NULL,
-
-    CONSTRAINT PK_ObjectLegacyNames PRIMARY KEY (RowId)
-);
-GO
-ALTER TABLE exp.Material ADD MaterialSourceId INT NULL;
-GO
-UPDATE exp.Material SET MaterialSourceId = (
-    SELECT distinct rowId FROM exp.materialSource WHERE materialSource.lsid = Material.cpastype
-) WHERE Material.cpastype <> 'Material';
-GO
-CREATE INDEX IDX_material_name_sourceid ON exp.Material (name, materialSourceId);
-GO
-
-EXEC core.fn_dropifexists 'materialsource', 'exp', 'CONSTRAINT', 'UQ_MaterialSource_Container_Name';
-
-ALTER TABLE exp.Edge DROP CONSTRAINT UQ_Edge_FromTo_RunId;
-ALTER TABLE exp.Edge DROP CONSTRAINT UQ_Edge_ToFrom_RunId;
-
-ALTER TABLE exp.Edge ALTER COLUMN RunId INT NULL;
-
-ALTER TABLE exp.Edge ADD SourceId INT NULL;
-ALTER TABLE exp.Edge ADD SourceKey NVARCHAR(200) NULL;
-
-ALTER TABLE exp.Edge ADD CONSTRAINT FK_Edge_SourceId_Object FOREIGN KEY (SourceId) REFERENCES exp.Object (Objectid);
-ALTER TABLE exp.Edge ADD CONSTRAINT UQ_Edge_FromTo_RunId_SourceId_SourceKey UNIQUE (FromObjectId, ToObjectId, RunId, SourceId, SourceKey);
-
-CREATE INDEX IX_Edge_ToObjectId ON exp.Edge(ToObjectId);
-CREATE INDEX IX_Edge_SourceId ON exp.Edge(SourceId);
-GO
-
-/* 23.xxx SQL scripts */
-
-ALTER TABLE exp.Material ADD MaterialExpDate DATETIME NULL;
-
-ALTER TABLE exp.DomainDescriptor ADD SystemFieldConfig NVARCHAR(MAX) NULL;
-
-ALTER TABLE exp.Material ADD StoredAmount DOUBLE PRECISION;
-ALTER TABLE exp.Material ADD Units NVARCHAR(20);
-GO
-
-EXEC core.fn_dropifexists 'Material', 'exp', 'INDEX', 'IDX_exp_material_recompute';
-
-EXEC core.fn_dropifexists 'Material', 'exp', 'CONSTRAINT', 'DF_recomputeRollup';
-
-ALTER TABLE exp.Material DROP COLUMN RecomputeRollup;
-
-ALTER TABLE exp.DataClass
-    ADD dataparentimportaliasmap NVARCHAR(4000) NULL;
-
-CREATE TABLE exp.DataTypeExclusion
-(
-    RowId INT IDENTITY (1, 1) NOT NULL,
-    DataTypeRowId INT NOT NULL,
-    DataType NVARCHAR(20) NOT NULL,
-    ExcludedContainer EntityId NOT NULL,
-    Created DATETIME NULL,
-    CreatedBy INT NULL,
-    Modified DATETIME NULL,
-    ModifiedBy INT NULL,
-
-    CONSTRAINT PK_DataTypeExclusion PRIMARY KEY (RowId),
-    CONSTRAINT UQ_DataTypeExclusion_LSID UNIQUE (DataTypeRowId, DataType, ExcludedContainer)
-);
-
-ALTER TABLE exp.Material ADD AvailableAliquotCount INT NULL;
-ALTER TABLE exp.Material ADD AvailableAliquotVolume FLOAT NULL;
-
--- These columns have been unused for years. https://github.com/LabKey/platform/pull/4549 cleaned up all code references.
--- Use fb_dropIfExists() to drop default constraint before dropping each column.
-EXEC core.fn_dropifexists 'List', 'exp', 'COLUMN', 'EntireListTitleSetting';
-EXEC core.fn_dropifexists 'List', 'exp', 'COLUMN', 'EachItemTitleSetting';
-
-ALTER TABLE exp.material
-    ALTER COLUMN rootmateriallsid LSIDtype NOT NULL;
-
-CREATE INDEX uq_material_rootlsid
-    on exp.material (rootmateriallsid);
-
--- this is duplicative of constraint uq_material_lsid
-EXEC core.fn_dropifexists 'material', 'exp', 'INDEX', 'idx_material_lsid';
-
-CREATE INDEX IDX_ExperimentRun_WorkflowTask ON exp.ExperimentRun(WorkflowTask);
-CREATE INDEX IDX_Edge_RunId ON exp.Edge(RunId);
-
--- Add new "RootMaterialRowId" column
-ALTER TABLE exp.Material ADD rootmaterialrowid INTEGER NULL;
-GO
-
--- Add NOT NULL constraint to "RootMaterialRowId"
-ALTER TABLE exp.Material ALTER COLUMN rootmaterialrowid INTEGER NOT NULL;
-GO
-
--- Add FK on "RootMaterialRowId"
--- See exp-23.012-23.013.sql
--- ALTER TABLE exp.Material ADD CONSTRAINT FK_Material_RootMaterialRowId
---     FOREIGN KEY (RootMaterialRowId) REFERENCES exp.Material (RowId);
--- GO
-
-CREATE INDEX ix_material_rootmaterialrowid ON exp.Material (rootmaterialrowid);
-GO
-
--- Remove the "RootMaterialLSID" column
-EXEC core.fn_dropifexists 'material', 'exp', 'INDEX', 'uq_material_rootlsid';
-EXEC core.fn_dropifexists 'material', 'exp', 'COLUMN', 'rootmateriallsid';
-
--- It is possible for parent samples of aliquots to be moved to a subfolder where upon deletion
--- of the subfolder we need to delete the parent sample but the aliquot still exists.
-EXEC core.fn_dropifexists 'material', 'exp', 'constraint', 'FK_Material_RootMaterialRowId';

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-0.000-24.000.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-0.000-24.000.sql
@@ -23,6 +23,13 @@
 CREATE SCHEMA exp;
 GO
 
+-- Provisioned schema used by DataClassDomainKind
+CREATE SCHEMA expdataclass;
+GO
+
+CREATE SCHEMA expsampleset
+GO
+
 EXEC sp_addtype 'LSIDtype', 'NVARCHAR(300)';
 GO
 
@@ -1025,20 +1032,9 @@ GO
 
 EXECUTE core.fn_dropifexists 'material', 'exp', 'INDEX', 'idx_material_AK';
 
--- shouldn't any null names, but just to be safe
+-- shouldn't be any null names, but just to be safe
 UPDATE exp.material SET name='NULL' WHERE name IS NULL;
 ALTER TABLE exp.material ALTER COLUMN name NVARCHAR(200) NOT NULL;
-
-WITH nonunique AS (
-    SELECT container, cpastype, name
-    FROM exp.material
-      WHERE cpastype IS NOT NULL
-    GROUP BY container, cpastype, name
-    HAVING COUNT(*) > 1)
-UPDATE exp.material
-SET Name = Name + ' - ' + CAST(RowId AS NVARCHAR(11))
-FROM exp.material M
-WHERE EXISTS (SELECT * FROM nonunique NU WHERE M.container=NU.container AND M.cpastype=NU.cpastype AND M.name=NU.name);
 
 CREATE UNIQUE INDEX idx_material_AK ON exp.material (container, cpastype, name) WHERE cpastype IS NOT NULL;
 GO
@@ -1051,9 +1047,6 @@ GO
 
 /* exp-15.30-16.10.sql */
 
--- Provisioned schema used by DataClassDomainKind
-CREATE SCHEMA expdataclass;
-GO
 
 CREATE TABLE exp.DataClass
 (
@@ -1164,12 +1157,6 @@ EXEC core.fn_dropifexists 'list', 'exp', 'COLUMN', 'rowid';
 
 /* exp-17.10-17.20.sql */
 
-EXEC core.fn_dropifexists 'list', 'exp', 'CONSTRAINT', 'DF__list__FileAttachmentIndex';
-
-IF EXISTS( SELECT TOP 1 1 FROM sys.objects o INNER JOIN sys.columns c ON o.object_id = c.object_id WHERE o.name = 'list' AND c.name = 'FileAttachmentIndex')
-  ALTER TABLE exp.list DROP COLUMN FileAttachmentIndex
-GO
-
 ALTER TABLE exp.list ADD FileAttachmentIndex BIT CONSTRAINT DF__list__FileAttachmentIndex DEFAULT 0 NOT NULL;
 GO
 
@@ -1272,9 +1259,6 @@ ALTER TABLE exp.Data ALTER COLUMN DataFileURL NVARCHAR(600);
 -- Removing active sample types
 EXEC core.fn_dropifexists 'ActiveMaterialSource', 'exp', 'TABLE', NULL;
 GO
-
-CREATE SCHEMA expsampleset
-go
 
 ALTER TABLE exp.materialsource
   ALTER COLUMN nameexpression NVARCHAR(500);

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-0.000-24.000.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-0.000-24.000.sql
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* exp-0.00-11.20.sql */
-
 /*
  *  Creates experiment annotation tables in the exp schema base on FuGE-OM types
  */
@@ -60,14 +58,13 @@ CREATE TABLE exp.Protocol
     CONSTRAINT UQ_Protocol_LSID UNIQUE (LSID)
 );
 
-/* exp-11.20-11.30.sql */
-
 CREATE INDEX IDX_Protocol_Container ON exp.Protocol (Container)
 GO
 
-DELETE FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
-
 ALTER TABLE exp.Protocol ADD CONSTRAINT FK_Protocol_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
+
+ALTER TABLE exp.Protocol ADD Status NVARCHAR(60);
+GO
 
 CREATE TABLE exp.Experiment
 (
@@ -93,11 +90,8 @@ CREATE TABLE exp.Experiment
 );
 CREATE INDEX IX_Experiment_Container ON exp.Experiment(Container);
 CREATE INDEX IDX_Experiment_BatchProtocolId ON exp.Experiment(BatchProtocolId);
-
--- Now that runs that might have been pointing to them for their batch are deleted, clean up orphaned experiments/run groups/batches
-DELETE FROM exp.Experiment WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
-
 ALTER TABLE exp.Experiment ADD CONSTRAINT FK_Experiment_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
+
 CREATE TABLE exp.ExperimentRun
 (
     RowId INT IDENTITY (1, 1) NOT NULL,
@@ -120,8 +114,6 @@ CREATE TABLE exp.ExperimentRun
 CREATE CLUSTERED INDEX IX_CL_ExperimentRun_Container ON exp.ExperimentRun(Container);
 CREATE INDEX IX_ExperimentRun_ProtocolLSID ON exp.ExperimentRun(ProtocolLSID);
 
-DELETE FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
-
 ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_ExperimentRun_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
 ALTER TABLE exp.ExperimentRun ADD JobId INTEGER;
 
@@ -143,14 +135,11 @@ ALTER TABLE exp.ExperimentRun ADD
 CREATE INDEX IDX_ExperimentRun_ReplacedByRunId ON exp.ExperimentRun(ReplacedByRunId);
 
 -- Add batchId column to run table
-ALTER TABLE exp.ExperimentRun
-   ADD BatchId INT;
+ALTER TABLE exp.ExperimentRun ADD BatchId INT;
 
-ALTER TABLE exp.ExperimentRun
-  ADD CONSTRAINT FK_ExperimentRun_BatchId FOREIGN KEY (BatchId) REFERENCES exp.Experiment (RowId);
+ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_ExperimentRun_BatchId FOREIGN KEY (BatchId) REFERENCES exp.Experiment (RowId);
 
-CREATE INDEX IX_ExperimentRun_BatchId
-  ON exp.ExperimentRun(BatchId);
+CREATE INDEX IX_ExperimentRun_BatchId ON exp.ExperimentRun(BatchId);
 
 GO
 
@@ -158,6 +147,10 @@ ALTER TABLE exp.experimentrun ADD objectid INT;
 ALTER TABLE exp.experimentrun ALTER COLUMN objectid INT NOT NULL;
 CREATE UNIQUE INDEX idx_experimentrun_objectid ON exp.experimentrun (objectid);
 ALTER TABLE exp.ExperimentRun ADD LastIndexed DATETIME NULL;
+
+ALTER TABLE exp.ExperimentRun ADD WorkflowTask INT;
+GO
+CREATE INDEX IDX_ExperimentRun_WorkflowTask ON exp.ExperimentRun(WorkflowTask);
 
 CREATE TABLE exp.ProtocolApplication
 (
@@ -179,16 +172,19 @@ CREATE TABLE exp.ProtocolApplication
 CREATE CLUSTERED INDEX IX_CL_ProtocolApplication_RunId ON exp.ProtocolApplication(RunId);
 CREATE INDEX IX_ProtocolApplication_ProtocolLSID ON exp.ProtocolApplication(ProtocolLSID);
 
-DELETE FROM exp.ProtocolApplication WHERE
-	ProtocolLSID IN (SELECT Lsid FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
-	OR RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
 -- add start time, end time, and record count to protocol application table for ETL tasks and others
 ALTER TABLE exp.ProtocolApplication ADD StartTime DATETIME NULL;
 ALTER TABLE exp.ProtocolApplication ADD EndTime DATETIME NULL;
 ALTER TABLE exp.ProtocolApplication ADD RecordCount INT NULL;
 
 ALTER TABLE exp.ProtocolApplication ALTER COLUMN Comments NVARCHAR(MAX);
+
+ALTER TABLE exp.ProtocolApplication ADD EntityId ENTITYID;
+GO
+
+ALTER TABLE exp.ProtocolApplication ALTER COLUMN EntityId ENTITYID NOT NULL;
+
+ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId) ON DELETE SET NULL;
 
 CREATE TABLE exp.Data
 (
@@ -234,11 +230,12 @@ ALTER TABLE exp.Data ADD LastIndexed DATETIME NULL;
 -- Issue 35817 - widen column to allow for longer paths and file names
 ALTER TABLE exp.Data ALTER COLUMN DataFileURL NVARCHAR(600);
 
-UPDATE exp.data SET datafileurl = 'file:///' + substring(datafileurl, 7, 600) WHERE datafileurl LIKE 'file:/_%' AND datafileurl NOT LIKE 'file:///%' AND datafileurl IS NOT NULL;
-
 ALTER TABLE exp.data ADD ObjectId INT;
 ALTER TABLE exp.data ALTER COLUMN objectid INT NOT NULL;
 CREATE UNIQUE INDEX idx_data_objectid ON exp.data (objectid);
+
+-- Most major file systems cap file lengths at 255 characters. Let's do the same
+ALTER TABLE exp.data ALTER COLUMN Name NVARCHAR(255);
 
 /*
    Make PropertyDescriptor consistent with OWL terms, and also work for storing NCI_Thesaurus concepts
@@ -309,14 +306,20 @@ EXEC core.fn_dropifexists 'PropertyDescriptor', 'exp', 'COLUMN', 'Protected';
 GO
 
 ALTER TABLE exp.PropertyDescriptor ADD RedactedText NVARCHAR(450) NULL;
-GO
-
 ALTER TABLE exp.PropertyDescriptor ADD mvIndicatorStorageColumnName NVARCHAR(120);
-GO
-
 ALTER TABLE exp.PropertyDescriptor ADD TextExpression nvarchar(200) NULL
-
 ALTER TABLE exp.PropertyDescriptor ALTER COLUMN PropertyURI NVARCHAR(300) NOT NULL;
+ALTER TABLE exp.PropertyDescriptor DROP COLUMN OntologyURI;
+ALTER TABLE exp.PropertyDescriptor DROP COLUMN SearchTerms;
+ALTER TABLE exp.PropertyDescriptor DROP COLUMN SemanticType;
+ALTER TABLE exp.PropertyDescriptor ADD PrincipalConceptCode NVARCHAR(50) NULL;
+ALTER TABLE exp.PropertyDescriptor ADD SourceOntology NVARCHAR(20) NULL;
+ALTER TABLE exp.PropertyDescriptor ADD ConceptImportColumn NVARCHAR(200) NULL;
+ALTER TABLE exp.PropertyDescriptor ADD ConceptLabelColumn NVARCHAR(200) NULL;
+ALTER TABLE exp.PropertyDescriptor ADD DerivationDataScope NVARCHAR(20) NULL;
+ALTER TABLE exp.PropertyDescriptor ADD ConceptSubtree NVARCHAR(MAX) NULL;
+ALTER TABLE exp.PropertyDescriptor ADD Scannable BIT NOT NULL DEFAULT 0;
+GO
 
 CREATE TABLE exp.DataInput
 (
@@ -364,16 +367,8 @@ CREATE INDEX IX_Material_SourceApplicationId ON exp.Material(SourceApplicationId
 CREATE INDEX IX_Material_CpasType ON exp.Material(CpasType);
 CREATE INDEX IDX_Material_LSID ON exp.Material(LSID);
 
-UPDATE exp.Material SET RunId = NULL WHERE RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.containers));
-
-UPDATE exp.Material SET SourceApplicationId = NULL WHERE SourceApplicationId IN (SELECT RowId FROM exp.ProtocolApplication WHERE RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.containers)));
-
-/* exp-15.10-15.20.sql */
-
 EXECUTE core.fn_dropifexists 'material', 'exp', 'INDEX', 'idx_material_AK';
 
--- shouldn't be any null names, but just to be safe
-UPDATE exp.material SET name='NULL' WHERE name IS NULL;
 ALTER TABLE exp.material ALTER COLUMN name NVARCHAR(200) NOT NULL;
 
 CREATE UNIQUE INDEX idx_material_AK ON exp.material (container, cpastype, name) WHERE cpastype IS NOT NULL;
@@ -390,6 +385,73 @@ GO
 CREATE UNIQUE INDEX idx_material_objectid ON exp.material (objectid);
 GO
 
+ALTER TABLE exp.Material ADD RootMaterialLSID LSIDtype NULL;
+ALTER TABLE exp.Material ADD AliquotedFromLSID LSIDtype NULL;
+GO
+
+ALTER TABLE exp.Material ADD SampleState INT;
+GO
+ALTER TABLE exp.Material ADD CONSTRAINT FK_Material_SampleState FOREIGN KEY (SampleState) REFERENCES core.DataStates (RowId);
+
+ALTER TABLE exp.Material ADD RecomputeRollup BIT NULL CONSTRAINT DF_recomputeRollup DEFAULT(0);
+ALTER TABLE exp.Material ADD AliquotCount INT NULL;
+ALTER TABLE exp.Material ADD AliquotVolume FLOAT NULL;
+ALTER TABLE exp.Material ADD AliquotUnit NVARCHAR(10) NULL;
+GO
+
+CREATE INDEX IDX_exp_material_recompute ON exp.Material (container, rowid, lsid) WHERE RecomputeRollup=1;
+
+ALTER TABLE exp.Material ADD MaterialSourceId INT NULL;
+GO
+CREATE INDEX IDX_material_name_sourceid ON exp.Material (name, materialSourceId);
+GO
+
+ALTER TABLE exp.Material ADD MaterialExpDate DATETIME NULL;
+
+ALTER TABLE exp.Material ADD StoredAmount DOUBLE PRECISION;
+ALTER TABLE exp.Material ADD Units NVARCHAR(20);
+GO
+
+EXEC core.fn_dropifexists 'Material', 'exp', 'INDEX', 'IDX_exp_material_recompute';
+
+EXEC core.fn_dropifexists 'Material', 'exp', 'CONSTRAINT', 'DF_recomputeRollup';
+
+ALTER TABLE exp.Material DROP COLUMN RecomputeRollup;
+
+ALTER TABLE exp.Material ADD AvailableAliquotCount INT NULL;
+ALTER TABLE exp.Material ADD AvailableAliquotVolume FLOAT NULL;
+
+ALTER TABLE exp.material ALTER COLUMN rootmateriallsid LSIDtype NOT NULL;
+
+CREATE INDEX uq_material_rootlsid on exp.material (rootmateriallsid);
+
+-- this is duplicative of constraint uq_material_lsid
+EXEC core.fn_dropifexists 'material', 'exp', 'INDEX', 'idx_material_lsid';
+
+-- Add new "RootMaterialRowId" column
+ALTER TABLE exp.Material ADD rootmaterialrowid INTEGER NULL;
+GO
+
+-- Add NOT NULL constraint to "RootMaterialRowId"
+ALTER TABLE exp.Material ALTER COLUMN rootmaterialrowid INTEGER NOT NULL;
+GO
+
+-- Add FK on "RootMaterialRowId"
+-- See exp-23.012-23.013.sql
+-- ALTER TABLE exp.Material ADD CONSTRAINT FK_Material_RootMaterialRowId
+--     FOREIGN KEY (RootMaterialRowId) REFERENCES exp.Material (RowId);
+-- GO
+
+CREATE INDEX ix_material_rootmaterialrowid ON exp.Material (rootmaterialrowid);
+GO
+
+-- Remove the "RootMaterialLSID" column
+EXEC core.fn_dropifexists 'material', 'exp', 'INDEX', 'uq_material_rootlsid';
+EXEC core.fn_dropifexists 'material', 'exp', 'COLUMN', 'rootmateriallsid';
+
+-- It is possible for parent samples of aliquots to be moved to a subfolder where upon deletion
+-- of the subfolder we need to delete the parent sample but the aliquot still exists.
+EXEC core.fn_dropifexists 'material', 'exp', 'constraint', 'FK_Material_RootMaterialRowId';
 CREATE TABLE exp.MaterialInput
 (
     MaterialId INT NOT NULL,
@@ -431,8 +493,6 @@ CREATE TABLE exp.MaterialSource
 );
 CREATE INDEX IX_MaterialSource_Container ON exp.MaterialSource(Container);
 
-DELETE FROM exp.MaterialSource WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
-
 ALTER TABLE exp.MaterialSource ADD CONSTRAINT FK_MaterialSource_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
 -- Change exp.MaterialSource.Name from VARCHAR(50) to VARCHAR(100). Going to 200 to match other experiment tables
  -- hits limits with domain URIs, etc
@@ -448,6 +508,19 @@ ALTER TABLE exp.MaterialSource ADD MaterialParentImportAliasMap NVARCHAR(4000) N
 
 ALTER TABLE exp.MaterialSource ADD LabelColor NVARCHAR(7) NULL;
 
+ALTER TABLE exp.MaterialSource ADD MetricUnit NVARCHAR(10) NULL;
+GO
+
+ALTER TABLE exp.MaterialSource ADD AutoLinkTargetContainer ENTITYID NULL;
+
+ALTER TABLE exp.MaterialSource ADD AutoLinkCategory NVARCHAR(200) NULL;
+
+ALTER TABLE exp.MaterialSource ADD AliquotNameExpression NVARCHAR(200) NULL;
+
+ALTER TABLE exp.MaterialSource ADD Category NVARCHAR(20) NULL;
+
+EXEC core.fn_dropifexists 'materialsource', 'exp', 'CONSTRAINT', 'UQ_MaterialSource_Container_Name';
+
 CREATE TABLE exp.Object
 (
     ObjectId INT IDENTITY(1,1) NOT NULL,
@@ -462,6 +535,17 @@ CREATE TABLE exp.Object
 );
 CREATE CLUSTERED INDEX IDX_Object_ContainerOwnerObjectId ON exp.Object (Container, OwnerObjectId, ObjectId);
 CREATE INDEX IX_Object_OwnerObjectId ON exp.Object(OwnerObjectId);
+
+ALTER TABLE exp.material ADD CONSTRAINT FK_Material_Lsid FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
+ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_Lsid FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
+ALTER TABLE exp.material ADD CONSTRAINT FK_Material_ObjectId FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
+ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_ObjectId FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
+GO
+
+-- add constraints for lsid -> exp.object
+ALTER TABLE exp.data ADD CONSTRAINT FK_Data_Lsid FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
+-- add constraints for objectid -> exp.object
+ALTER TABLE exp.data ADD CONSTRAINT FK_Data_ObjectId FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
 
 -- todo this index is in pqsql script.  Needed here?
 -- CREATE INDEX IDX_MaterialInput_TargetApplicationId ON exp.MaterialInput(TargetApplicationId);
@@ -482,9 +566,6 @@ CREATE TABLE exp.ObjectProperty
 );
 CREATE INDEX IDX_ObjectProperty_PropertyId ON exp.ObjectProperty(PropertyId);
 
--- Then delete orphaned properties and their values
-DELETE FROM exp.ObjectProperty WHERE PropertyId IN (SELECT PropertyId FROM exp.PropertyDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
 CREATE TABLE exp.ProtocolAction
 (
     RowId INT IDENTITY (10, 10) NOT NULL,
@@ -499,10 +580,6 @@ CREATE TABLE exp.ProtocolAction
 );
 CREATE INDEX IX_ProtocolAction_ChildProtocolId ON exp.ProtocolAction(ChildProtocolId);
 
-DELETE FROM exp.ProtocolAction WHERE
-	ParentProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
-	OR ChildProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
 CREATE TABLE exp.ProtocolActionPredecessor
 (
     ActionId INT NOT NULL,
@@ -513,10 +590,6 @@ CREATE TABLE exp.ProtocolActionPredecessor
     CONSTRAINT FK_ActionPredecessor_Predecessor_ProtocolAction FOREIGN KEY (PredecessorId) REFERENCES exp.ProtocolAction (RowId)
 );
 CREATE INDEX IX_ProtocolActionPredecessor_PredecessorId ON exp.ProtocolActionPredecessor(PredecessorId);
-
-DELETE FROM exp.ProtocolActionPredecessor WHERE ActionId IN (SELECT RowId FROM exp.ProtocolAction WHERE
-	ParentProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
-	OR ChildProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers)));
 
 CREATE TABLE exp.ProtocolParameter
 (
@@ -536,9 +609,6 @@ CREATE TABLE exp.ProtocolParameter
 );
 CREATE INDEX IX_ProtocolParameter_ProtocolId ON exp.ProtocolParameter(ProtocolId);
 
--- Next, clean up orphaned protocols
-DELETE FROM exp.ProtocolParameter WHERE ProtocolId IN (SELECT RowId FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
 CREATE TABLE exp.ProtocolApplicationParameter
 (
     RowId INT IDENTITY (1, 1) NOT NULL,
@@ -557,11 +627,6 @@ CREATE TABLE exp.ProtocolApplicationParameter
 );
 CREATE INDEX IX_ProtocolApplicationParameter_AppId ON exp.ProtocolApplicationParameter(ProtocolApplicationId);
 
-DELETE FROM exp.ProtocolApplicationParameter WHERE ProtocolApplicationId IN
-	(SELECT RowId FROM exp.ProtocolApplication WHERE
-		ProtocolLSID IN (SELECT Lsid FROM exp.Protocol WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
-		OR RunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers)));
-
 CREATE TABLE exp.DomainDescriptor
 (
     DomainId INT IDENTITY (1, 1) NOT NULL,
@@ -579,10 +644,7 @@ CREATE TABLE exp.DomainDescriptor
 );
 CREATE INDEX IX_DomainDescriptor_Container ON exp.DomainDescriptor(Container);
 
--- Then orphaned domains
-DELETE FROM exp.DomainDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers);
-
--- Finally, add some FKs so we don't get into this horrible state again
+-- Add some FKs
 ALTER TABLE exp.DomainDescriptor ADD CONSTRAINT FK_DomainDescriptor_Container FOREIGN KEY (Container) REFERENCES core.Containers (EntityId);
 ALTER TABLE exp.DomainDescriptor DROP CONSTRAINT uq_domainuricontainer;
 ALTER TABLE exp.DomainDescriptor DROP CONSTRAINT uq_domaindescriptor;
@@ -596,6 +658,7 @@ GO
 
 ALTER TABLE exp.DomainDescriptor ADD TemplateInfo NVARCHAR(4000) NULL;
 ALTER TABLE exp.DomainDescriptor ALTER COLUMN DomainURI NVARCHAR(300) NOT NULL;
+ALTER TABLE exp.DomainDescriptor ADD SystemFieldConfig NVARCHAR(MAX) NULL;
 
 CREATE TABLE exp.PropertyDomain
 (
@@ -610,12 +673,6 @@ CREATE TABLE exp.PropertyDomain
 );
 CREATE INDEX IX_PropertyDomain_DomainId ON exp.PropertyDomain(DomainID);
 
--- Next, work on properties and domains
--- Start by deleting from juntion table between properties and domains
-DELETE FROM exp.PropertyDomain WHERE
-	PropertyId IN (SELECT PropertyId FROM exp.PropertyDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers))
-	OR DomainId IN (SELECT DomainId FROM exp.DomainDescriptor WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
 CREATE TABLE exp.RunList
 (
     ExperimentId INT NOT NULL,
@@ -627,38 +684,8 @@ CREATE TABLE exp.RunList
 );
 CREATE INDEX IX_RunList_ExperimentRunId ON exp.RunList(ExperimentRunId);
 
--- Clean up orphaned experiment objects that were not properly deleted when their container was deleted
--- Then, add real FKs to ensure we don't orphan rows in the future
-
--- First clean up memberships in run groups for orphaned runs and experiments
-DELETE FROM exp.RunList WHERE ExperimentId IN (SELECT RowId FROM exp.Experiment WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-DELETE FROM exp.RunList WHERE ExperimentRunId IN (SELECT RowId FROM exp.ExperimentRun WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
-ALTER TABLE exp.RunList ADD Created TIMESTAMP;
 ALTER TABLE exp.RunList ADD CreatedBy INT;
-
-ALTER TABLE exp.RunList DROP COLUMN Created;
 ALTER TABLE exp.RunList ADD Created DATETIME;
-
-CREATE TABLE exp.ActiveMaterialSource
-(
-    Container ENTITYID NOT NULL,
-    MaterialSourceLSID LSIDtype NOT NULL,
-
-    CONSTRAINT PK_ActiveMaterialSource PRIMARY KEY (Container),
-    CONSTRAINT FK_ActiveMaterialSource_Container FOREIGN KEY (Container) REFERENCES core.Containers(EntityId),
-    CONSTRAINT FK_ActiveMaterialSource_MaterialSourceLSID FOREIGN KEY (MaterialSourceLSID) REFERENCES exp.MaterialSource(LSID)
-);
-CREATE INDEX IX_ActiveMaterialSource_MaterialSourceLSID ON exp.ActiveMaterialSource(MaterialSourceLSID);
-
--- Delete orphaned sample types/material sources
-DELETE FROM exp.ActiveMaterialSource WHERE MaterialSourceLSID IN (SELECT Lsid FROM exp.MaterialSource WHERE Container NOT IN (SELECT EntityId FROM core.Containers));
-
-/* exp-18.30-19.10.sql */
-
--- Removing active sample types
-EXEC core.fn_dropifexists 'ActiveMaterialSource', 'exp', 'TABLE', NULL;
-GO
 
 CREATE TABLE exp.list
 (
@@ -712,11 +739,6 @@ ALTER TABLE exp.List ADD LastIndexed DATETIME NULL;
 ALTER TABLE exp.List ADD EntireListIndexSetting INT NOT NULL DEFAULT 0;  -- Metadata only, the default
 GO
 
-UPDATE exp.List SET EntireListIndexSetting = 1 WHERE MetaDataIndex = 0 AND EntireListIndex = 1; -- Item data only
-UPDATE exp.List SET EntireListIndexSetting = 2 WHERE MetaDataIndex = 1 AND EntireListIndex = 1;  -- Meta data and item data
-
-UPDATE exp.List SET EntireListIndex = 1 WHERE MetaDataIndex = 1;   -- Turn on EntireListIndex if metadata was being indexed
-
 -- Must drop default constraint before dropping column
 EXEC core.fn_dropifexists @objname='List', @objschema='exp', @objtype='DEFAULT', @subobjname='MetaDataIndex'
 
@@ -725,12 +747,7 @@ ALTER TABLE exp.List DROP COLUMN MetaDataIndex;
 ALTER TABLE exp.List DROP CONSTRAINT PK_List;
 ALTER TABLE exp.List ADD CONSTRAINT UQ_RowId UNIQUE (RowId);
 -- Now add ListId column...
-ALTER TABLE exp.List ADD ListId INT NULL;
-GO
-
--- ...populate it with the current values of RowId...
-UPDATE exp.List SET ListId = RowId;
-ALTER TABLE exp.List ALTER COLUMN ListId INT NOT NULL;
+ALTER TABLE exp.List ADD ListId INT NOT NULL;
 GO
 
 -- ...and create the new PK (Container, ListId)
@@ -741,6 +758,16 @@ EXEC core.fn_dropifexists 'list', 'exp', 'COLUMN', 'rowid';
 
 ALTER TABLE exp.list ADD FileAttachmentIndex BIT CONSTRAINT DF__list__FileAttachmentIndex DEFAULT 0 NOT NULL;
 GO
+
+ALTER TABLE exp.List ADD Category NVARCHAR(20) NULL;
+
+ALTER TABLE exp.list ALTER COLUMN Name NVARCHAR(200);
+GO
+
+-- These columns have been unused for years. https://github.com/LabKey/platform/pull/4549 cleaned up all code references.
+-- Use fb_dropIfExists() to drop default constraint before dropping each column.
+EXEC core.fn_dropifexists 'List', 'exp', 'COLUMN', 'EntireListTitleSetting';
+EXEC core.fn_dropifexists 'List', 'exp', 'COLUMN', 'EachItemTitleSetting';
 
 CREATE TABLE exp.ConditionalFormat
 (
@@ -822,6 +849,8 @@ ALTER TABLE exp.DataClass ADD Category NVARCHAR(20) NULL;
 
 ALTER TABLE exp.DataClass ADD LastIndexed DATETIME NULL;
 
+ALTER TABLE exp.DataClass ADD dataparentimportaliasmap NVARCHAR(4000) NULL;
+
 CREATE TABLE exp.Alias
 (
     RowId INT IDENTITY (1, 1) NOT NULL,
@@ -881,6 +910,23 @@ CREATE TABLE exp.Edge
 );
 GO
 
+ALTER TABLE exp.Edge DROP CONSTRAINT UQ_Edge_FromTo_RunId;
+ALTER TABLE exp.Edge DROP CONSTRAINT UQ_Edge_ToFrom_RunId;
+
+ALTER TABLE exp.Edge ALTER COLUMN RunId INT NULL;
+
+ALTER TABLE exp.Edge ADD SourceId INT NULL;
+ALTER TABLE exp.Edge ADD SourceKey NVARCHAR(200) NULL;
+
+ALTER TABLE exp.Edge ADD CONSTRAINT FK_Edge_SourceId_Object FOREIGN KEY (SourceId) REFERENCES exp.Object (Objectid);
+ALTER TABLE exp.Edge ADD CONSTRAINT UQ_Edge_FromTo_RunId_SourceId_SourceKey UNIQUE (FromObjectId, ToObjectId, RunId, SourceId, SourceKey);
+
+CREATE INDEX IX_Edge_ToObjectId ON exp.Edge(ToObjectId);
+CREATE INDEX IX_Edge_SourceId ON exp.Edge(SourceId);
+GO
+
+CREATE INDEX IDX_Edge_RunId ON exp.Edge(RunId);
+
 CREATE TABLE exp.ProtocolInput
 (
     RowId INT IDENTITY (1,1) NOT NULL,
@@ -933,176 +979,6 @@ GO
 
 CREATE INDEX ix_propertyvalidator_propertyid on exp.PropertyValidator(PropertyId);
 
-ALTER TABLE exp.PropertyDescriptor DROP COLUMN OntologyURI;
-ALTER TABLE exp.PropertyDescriptor DROP COLUMN SearchTerms;
-ALTER TABLE exp.PropertyDescriptor DROP COLUMN SemanticType;
-GO
-
-ALTER TABLE exp.PropertyDescriptor ADD PrincipalConceptCode NVARCHAR(50) NULL;
-GO
-
-ALTER TABLE exp.PropertyDescriptor ADD SourceOntology NVARCHAR(20) NULL;
-ALTER TABLE exp.PropertyDescriptor ADD ConceptImportColumn NVARCHAR(200) NULL;
-ALTER TABLE exp.PropertyDescriptor ADD ConceptLabelColumn NVARCHAR(200) NULL;
-GO
-
-ALTER TABLE exp.PropertyDescriptor ADD DerivationDataScope NVARCHAR(20) NULL;
-ALTER TABLE exp.PropertyDescriptor ADD ConceptSubtree NVARCHAR(MAX) NULL;
-
-UPDATE exp.propertydescriptor SET scale=4000 WHERE propertyuri LIKE '%WorkflowTask#AssayTypes';
-
-ALTER TABLE exp.PropertyDescriptor ADD Scannable BIT NOT NULL DEFAULT 0;
-GO
-
-ALTER TABLE exp.MaterialSource ADD MetricUnit NVARCHAR(10) NULL;
-GO
-
-ALTER TABLE exp.MaterialSource ADD AutoLinkTargetContainer ENTITYID NULL;
-
-ALTER TABLE exp.MaterialSource ADD AutoLinkCategory NVARCHAR(200) NULL;
-
-ALTER TABLE exp.MaterialSource ADD AliquotNameExpression NVARCHAR(200) NULL;
-
-ALTER TABLE exp.MaterialSource ADD Category NVARCHAR(20) NULL;
-
-EXEC core.fn_dropifexists 'materialsource', 'exp', 'CONSTRAINT', 'UQ_MaterialSource_Container_Name';
-
--- create exp.object for exp.data without one
-INSERT INTO exp.object (objecturi, container)
-SELECT D.lsid as objecturi, D.container as container
-FROM exp.data D LEFT OUTER JOIN exp.object O ON D.lsid = O.objecturi
-WHERE O.objecturi IS NULL;
-
-ALTER TABLE exp.material ADD CONSTRAINT FK_Material_Lsid FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
-ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_Lsid FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
-ALTER TABLE exp.material ADD CONSTRAINT FK_Material_ObjectId FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
-ALTER TABLE exp.experimentrun ADD CONSTRAINT FK_ExperimentRun_ObjectId FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
-GO
-
--- fixup exp.data.objectid to be consistent with the lsid of the exp.object
-UPDATE exp.data
-SET objectid = (SELECT O.objectid FROM exp.object O WHERE O.objecturi = lsid)
-WHERE rowid IN (
-    SELECT rowid
-    FROM exp.data D
-    LEFT OUTER JOIN exp.object O ON D.lsid = O.objecturi
-    WHERE D.objectid != O.objectid
-);
-
--- add constraints for lsid -> exp.object
-ALTER TABLE exp.data ADD CONSTRAINT FK_Data_Lsid
-    FOREIGN KEY (lsid) REFERENCES exp.object (objecturi);
--- add constraints for objectid -> exp.object
-ALTER TABLE exp.data ADD CONSTRAINT FK_Data_ObjectId
-    FOREIGN KEY (objectid) REFERENCES exp.object (objectid);
-/* 21.xxx SQL scripts */
-
--- Most major file systems cap file lengths at 255 characters. Let's do the same
-ALTER TABLE exp.data ALTER COLUMN Name NVARCHAR(255);
-
-ALTER TABLE exp.Material ADD RootMaterialLSID LSIDtype NULL;
-ALTER TABLE exp.Material ADD AliquotedFromLSID LSIDtype NULL;
-GO
-
-ALTER TABLE exp.Material ADD SampleState INT;
-GO
-ALTER TABLE exp.Material ADD CONSTRAINT FK_Material_SampleState FOREIGN KEY (SampleState) REFERENCES core.DataStates (RowId);
-
-ALTER TABLE exp.Material ADD RecomputeRollup BIT NULL CONSTRAINT DF_recomputeRollup DEFAULT(0);
-ALTER TABLE exp.Material ADD AliquotCount INT NULL;
-ALTER TABLE exp.Material ADD AliquotVolume FLOAT NULL;
-ALTER TABLE exp.Material ADD AliquotUnit NVARCHAR(10) NULL;
-GO
-
-CREATE INDEX IDX_exp_material_recompute ON exp.Material (container, rowid, lsid) WHERE RecomputeRollup=1;
-
-ALTER TABLE exp.Material ADD MaterialSourceId INT NULL;
-GO
-CREATE INDEX IDX_material_name_sourceid ON exp.Material (name, materialSourceId);
-GO
-
-ALTER TABLE exp.Material ADD MaterialExpDate DATETIME NULL;
-
-ALTER TABLE exp.Material ADD StoredAmount DOUBLE PRECISION;
-ALTER TABLE exp.Material ADD Units NVARCHAR(20);
-GO
-
-EXEC core.fn_dropifexists 'Material', 'exp', 'INDEX', 'IDX_exp_material_recompute';
-
-EXEC core.fn_dropifexists 'Material', 'exp', 'CONSTRAINT', 'DF_recomputeRollup';
-
-ALTER TABLE exp.Material DROP COLUMN RecomputeRollup;
-
-ALTER TABLE exp.Material ADD AvailableAliquotCount INT NULL;
-ALTER TABLE exp.Material ADD AvailableAliquotVolume FLOAT NULL;
-
-ALTER TABLE exp.material ALTER COLUMN rootmateriallsid LSIDtype NOT NULL;
-
-CREATE INDEX uq_material_rootlsid on exp.material (rootmateriallsid);
-
--- this is duplicative of constraint uq_material_lsid
-EXEC core.fn_dropifexists 'material', 'exp', 'INDEX', 'idx_material_lsid';
-
--- Add new "RootMaterialRowId" column
-ALTER TABLE exp.Material ADD rootmaterialrowid INTEGER NULL;
-GO
-
--- Add NOT NULL constraint to "RootMaterialRowId"
-ALTER TABLE exp.Material ALTER COLUMN rootmaterialrowid INTEGER NOT NULL;
-GO
-
--- Add FK on "RootMaterialRowId"
--- See exp-23.012-23.013.sql
--- ALTER TABLE exp.Material ADD CONSTRAINT FK_Material_RootMaterialRowId
---     FOREIGN KEY (RootMaterialRowId) REFERENCES exp.Material (RowId);
--- GO
-
-CREATE INDEX ix_material_rootmaterialrowid ON exp.Material (rootmaterialrowid);
-GO
-
--- Remove the "RootMaterialLSID" column
-EXEC core.fn_dropifexists 'material', 'exp', 'INDEX', 'uq_material_rootlsid';
-EXEC core.fn_dropifexists 'material', 'exp', 'COLUMN', 'rootmateriallsid';
-
--- It is possible for parent samples of aliquots to be moved to a subfolder where upon deletion
--- of the subfolder we need to delete the parent sample but the aliquot still exists.
-EXEC core.fn_dropifexists 'material', 'exp', 'constraint', 'FK_Material_RootMaterialRowId';
-ALTER TABLE exp.List ADD Category NVARCHAR(20) NULL;
-
-/* 22.xxx SQL scripts */
-
-ALTER TABLE exp.list ALTER COLUMN Name NVARCHAR(200);
-GO
-
--- These columns have been unused for years. https://github.com/LabKey/platform/pull/4549 cleaned up all code references.
--- Use fb_dropIfExists() to drop default constraint before dropping each column.
-EXEC core.fn_dropifexists 'List', 'exp', 'COLUMN', 'EntireListTitleSetting';
-EXEC core.fn_dropifexists 'List', 'exp', 'COLUMN', 'EachItemTitleSetting';
-
--- move the StudyPublishProtocol container to the shared folder
-UPDATE exp.protocol
-    SET container = (SELECT entityid FROM core.containers WHERE name = 'Shared')
-    WHERE lsid LIKE 'urn:lsid:labkey.org:Protocol:StudyPublishProtocol%';
-
-ALTER TABLE exp.Protocol ADD Status NVARCHAR(60);
-GO
-UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun';
-
-UPDATE exp.Protocol SET Status = 'Active' WHERE ApplicationType = 'ExperimentRun' AND Status IS NULL;
-
-ALTER TABLE exp.ProtocolApplication ADD EntityId ENTITYID;
-
-GO
-
-UPDATE exp.ProtocolApplication SET EntityId = NEWID();
-
-ALTER TABLE exp.ProtocolApplication ALTER COLUMN EntityId ENTITYID NOT NULL;
-
-ALTER TABLE exp.ExperimentRun ADD WorkflowTask INT;
-GO
-ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId) ON DELETE SET NULL;
-
-CREATE INDEX IDX_ExperimentRun_WorkflowTask ON exp.ExperimentRun(WorkflowTask);
 CREATE TABLE exp.ObjectLegacyNames
 (
     RowId INT IDENTITY (1, 1) NOT NULL,
@@ -1117,26 +993,6 @@ CREATE TABLE exp.ObjectLegacyNames
     CONSTRAINT PK_ObjectLegacyNames PRIMARY KEY (RowId)
 );
 GO
-ALTER TABLE exp.Edge DROP CONSTRAINT UQ_Edge_FromTo_RunId;
-ALTER TABLE exp.Edge DROP CONSTRAINT UQ_Edge_ToFrom_RunId;
-
-ALTER TABLE exp.Edge ALTER COLUMN RunId INT NULL;
-
-ALTER TABLE exp.Edge ADD SourceId INT NULL;
-ALTER TABLE exp.Edge ADD SourceKey NVARCHAR(200) NULL;
-
-ALTER TABLE exp.Edge ADD CONSTRAINT FK_Edge_SourceId_Object FOREIGN KEY (SourceId) REFERENCES exp.Object (Objectid);
-ALTER TABLE exp.Edge ADD CONSTRAINT UQ_Edge_FromTo_RunId_SourceId_SourceKey UNIQUE (FromObjectId, ToObjectId, RunId, SourceId, SourceKey);
-
-CREATE INDEX IX_Edge_ToObjectId ON exp.Edge(ToObjectId);
-CREATE INDEX IX_Edge_SourceId ON exp.Edge(SourceId);
-GO
-
-CREATE INDEX IDX_Edge_RunId ON exp.Edge(RunId);
-
-ALTER TABLE exp.DomainDescriptor ADD SystemFieldConfig NVARCHAR(MAX) NULL;
-
-ALTER TABLE exp.DataClass ADD dataparentimportaliasmap NVARCHAR(4000) NULL;
 
 CREATE TABLE exp.DataTypeExclusion
 (
@@ -1154,7 +1010,7 @@ CREATE TABLE exp.DataTypeExclusion
 );
 GO
 
--- Create procs used by Ontology Manager
+-- Create procedures used by Ontology Manager
 CREATE PROCEDURE exp.getObjectProperties(@container ENTITYID, @lsid LSIDType) AS
 BEGIN
     SELECT * FROM exp.ObjectPropertiesView
@@ -1219,8 +1075,9 @@ BEGIN
     VALUES (@objectid, @propid, 's', @string)
 END
 GO
+
 --
--- Set the same property on multiple objects (e.g. impoirt a column of datea)
+-- Set the same property on multiple objects (e.g. import a column of data)
 --
 -- fast method for importing ObjectProperties (need to wrap with datalayer code)
 --

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-25.010-25.011.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-25.010-25.011.sql
@@ -1,0 +1,10 @@
+-- This index overlaps with uq_conditionalformat_propertyid_sortorder
+DROP INDEX idx_conditionalformat_propertyid ON exp.ConditionalFormat;
+-- This index overlaps with uq_alias_name
+DROP INDEX ix_alias_name ON exp.Alias;
+-- This index overlaps with uq_dataclass_container_name
+DROP INDEX ix_dataclass_container ON exp.DataClass;
+-- This index overlaps with uq_protocolappparam_ord
+DROP INDEX ix_protocolapplicationparameter_appid ON exp.ProtocolApplicationParameter;
+-- This index overlaps with uq_protocolparameter_ord
+DROP INDEX ix_protocolparameter_protocolid ON exp.ProtocolParameter;

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -196,7 +196,7 @@ public class ExperimentModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 25.010;
+        return 25.011;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -17,8 +17,8 @@ package org.labkey.experiment.api;
 
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.converters.IntegerConverter;
-import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Level;
@@ -786,20 +786,20 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
     @NotNull
     @Override
-    public Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
+    public Map<String, IndexDef> getUniqueIndices()
     {
-        Map<String, Pair<IndexType, List<ColumnInfo>>> indices = new HashMap<>(super.getUniqueIndices());
+        Map<String, IndexDef> indices = new HashMap<>(super.getUniqueIndices());
         indices.putAll(wrapTableIndices(_dataClassDataTableSupplier.get()));
 
         // Issue 46948: RemapCache unable to resolve ExpData objects with addition of ClassId column
         // RemapCache is used to findExpData using name/rowId remap.
         // The addition of "ClassId" column to the TableInfo is causing violation of RemapCache's requirement of "unique index over a single column that isn't the primary key".
         // Because this is a joined table between exp.data and the dataclass provisioned table, it's safe to ignore "ClassId" as part of the unique key.
-        Map<String, Pair<IndexType, List<ColumnInfo>>> filteredIndices = new HashMap<>();
-        for (Map.Entry<String, Pair<IndexType, List<ColumnInfo>>> index : indices.entrySet())
+        Map<String, IndexDef> filteredIndices = new HashMap<>();
+        for (IndexDef def : indices.values())
         {
-            IndexType type = index.getValue().getKey();
-            List<ColumnInfo> columns = index.getValue().getValue();
+            IndexType type = def.indexType();
+            List<ColumnInfo> columns = def.columns();
 
             List<ColumnInfo> filteredColumns = new ArrayList<>();
             if (type == IndexType.Unique && columns.size() > 1)
@@ -813,16 +813,16 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 }
             }
 
-            filteredIndices.put(index.getKey(), new Pair<>(type, filteredColumns.isEmpty() ? columns : filteredColumns));
+            filteredIndices.put(def.name(), new IndexDef(def.name(), def.indexType(), filteredColumns.isEmpty() ? columns : filteredColumns, def.filterCondition()));
         }
         return Collections.unmodifiableMap(filteredIndices);
     }
 
     @NotNull
     @Override
-    public Map<String, Pair<IndexType, List<ColumnInfo>>> getAllIndices()
+    public Map<String, IndexDef> getAllIndices()
     {
-        Map<String, Pair<IndexType, List<ColumnInfo>>> indices = new HashMap<>(super.getAllIndices());
+        Map<String, IndexDef> indices = new HashMap<>(super.getAllIndices());
         indices.putAll(wrapTableIndices(_dataClassDataTableSupplier.get()));
         return Collections.unmodifiableMap(indices);
     }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -786,17 +786,17 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
     @NotNull
     @Override
-    public Map<String, IndexDef> getUniqueIndices()
+    public Map<String, IndexDefinition> getUniqueIndices()
     {
-        Map<String, IndexDef> indices = new HashMap<>(super.getUniqueIndices());
+        Map<String, IndexDefinition> indices = new HashMap<>(super.getUniqueIndices());
         indices.putAll(wrapTableIndices(_dataClassDataTableSupplier.get()));
 
         // Issue 46948: RemapCache unable to resolve ExpData objects with addition of ClassId column
         // RemapCache is used to findExpData using name/rowId remap.
         // The addition of "ClassId" column to the TableInfo is causing violation of RemapCache's requirement of "unique index over a single column that isn't the primary key".
         // Because this is a joined table between exp.data and the dataclass provisioned table, it's safe to ignore "ClassId" as part of the unique key.
-        Map<String, IndexDef> filteredIndices = new HashMap<>();
-        for (IndexDef def : indices.values())
+        Map<String, IndexDefinition> filteredIndices = new HashMap<>();
+        for (IndexDefinition def : indices.values())
         {
             IndexType type = def.indexType();
             List<ColumnInfo> columns = def.columns();
@@ -813,16 +813,16 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 }
             }
 
-            filteredIndices.put(def.name(), new IndexDef(def.name(), def.indexType(), filteredColumns.isEmpty() ? columns : filteredColumns, def.filterCondition()));
+            filteredIndices.put(def.name(), new IndexDefinition(def.name(), def.indexType(), filteredColumns.isEmpty() ? columns : filteredColumns, def.filterCondition()));
         }
         return Collections.unmodifiableMap(filteredIndices);
     }
 
     @NotNull
     @Override
-    public Map<String, IndexDef> getAllIndices()
+    public Map<String, IndexDefinition> getAllIndices()
     {
-        Map<String, IndexDef> indices = new HashMap<>(super.getAllIndices());
+        Map<String, IndexDefinition> indices = new HashMap<>(super.getAllIndices());
         indices.putAll(wrapTableIndices(_dataClassDataTableSupplier.get()));
         return Collections.unmodifiableMap(indices);
     }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTableImpl.java
@@ -786,17 +786,17 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
 
     @NotNull
     @Override
-    public Map<String, IndexDefinition> getUniqueIndices()
+    public List<IndexDefinition> getUniqueIndices()
     {
-        Map<String, IndexDefinition> indices = new HashMap<>(super.getUniqueIndices());
-        indices.putAll(wrapTableIndices(_dataClassDataTableSupplier.get()));
+        List<IndexDefinition> indices = new ArrayList<>(super.getUniqueIndices());
+        indices.addAll(wrapTableIndices(_dataClassDataTableSupplier.get()));
 
         // Issue 46948: RemapCache unable to resolve ExpData objects with addition of ClassId column
         // RemapCache is used to findExpData using name/rowId remap.
         // The addition of "ClassId" column to the TableInfo is causing violation of RemapCache's requirement of "unique index over a single column that isn't the primary key".
         // Because this is a joined table between exp.data and the dataclass provisioned table, it's safe to ignore "ClassId" as part of the unique key.
-        Map<String, IndexDefinition> filteredIndices = new HashMap<>();
-        for (IndexDefinition def : indices.values())
+        List<IndexDefinition> filteredIndices = new ArrayList<>();
+        for (IndexDefinition def : indices)
         {
             IndexType type = def.indexType();
             List<ColumnInfo> columns = def.columns();
@@ -813,18 +813,18 @@ public class ExpDataClassDataTableImpl extends ExpRunItemTableImpl<ExpDataClassD
                 }
             }
 
-            filteredIndices.put(def.name(), new IndexDefinition(def.name(), def.indexType(), filteredColumns.isEmpty() ? columns : filteredColumns, def.filterCondition()));
+            filteredIndices.add(new IndexDefinition(def.name(), def.indexType(), filteredColumns.isEmpty() ? columns : filteredColumns, def.filterCondition()));
         }
-        return Collections.unmodifiableMap(filteredIndices);
+        return Collections.unmodifiableList(filteredIndices);
     }
 
     @NotNull
     @Override
-    public Map<String, IndexDefinition> getAllIndices()
+    public List<IndexDefinition> getAllIndices()
     {
-        Map<String, IndexDefinition> indices = new HashMap<>(super.getAllIndices());
-        indices.putAll(wrapTableIndices(_dataClassDataTableSupplier.get()));
-        return Collections.unmodifiableMap(indices);
+        List<IndexDefinition> indices = new ArrayList<>(super.getAllIndices());
+        indices.addAll(wrapTableIndices(_dataClassDataTableSupplier.get()));
+        return Collections.unmodifiableList(indices);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1631,18 +1631,18 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
     @NotNull
     @Override
-    public Map<String, IndexDefinition> getUniqueIndices()
+    public List<IndexDefinition> getUniqueIndices()
     {
         // Rewrite the "idx_material_ak" unique index over "Folder", "SampleSet", "Name" to just "Name"
         // Issue 25397: Don't include the "idx_material_ak" index if the "Name" column hasn't been added to the table.
         // Some FKs to ExpMaterialTable don't include the "Name" column (e.g. NabBaseTable.Specimen)
         String indexName = "idx_material_ak";
-        Map<String, IndexDefinition> ret = new HashMap<>(super.getUniqueIndices());
+        List<IndexDefinition> ret = new ArrayList<>(super.getUniqueIndices());
         if (getColumn("Name") != null)
-            ret.put(indexName, new IndexDefinition(indexName, IndexType.Unique, Arrays.asList(getColumn("Name")), null));
+            ret.add(new IndexDefinition(indexName, IndexType.Unique, Arrays.asList(getColumn("Name")), null));
         else
-            ret.remove(indexName);
-        return Collections.unmodifiableMap(ret);
+            ret.removeIf(   def -> def.name().equals(indexName));
+        return Collections.unmodifiableList(ret);
     }
 
 

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1631,15 +1631,15 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
     @NotNull
     @Override
-    public Map<String, IndexDef> getUniqueIndices()
+    public Map<String, IndexDefinition> getUniqueIndices()
     {
         // Rewrite the "idx_material_ak" unique index over "Folder", "SampleSet", "Name" to just "Name"
         // Issue 25397: Don't include the "idx_material_ak" index if the "Name" column hasn't been added to the table.
         // Some FKs to ExpMaterialTable don't include the "Name" column (e.g. NabBaseTable.Specimen)
         String indexName = "idx_material_ak";
-        Map<String, IndexDef> ret = new HashMap<>(super.getUniqueIndices());
+        Map<String, IndexDefinition> ret = new HashMap<>(super.getUniqueIndices());
         if (getColumn("Name") != null)
-            ret.put(indexName, new IndexDef(indexName, IndexType.Unique, Arrays.asList(getColumn("Name")), null));
+            ret.put(indexName, new IndexDefinition(indexName, IndexType.Unique, Arrays.asList(getColumn("Name")), null));
         else
             ret.remove(indexName);
         return Collections.unmodifiableMap(ret);

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -1631,16 +1631,17 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
 
     @NotNull
     @Override
-    public Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
+    public Map<String, IndexDef> getUniqueIndices()
     {
         // Rewrite the "idx_material_ak" unique index over "Folder", "SampleSet", "Name" to just "Name"
         // Issue 25397: Don't include the "idx_material_ak" index if the "Name" column hasn't been added to the table.
         // Some FKs to ExpMaterialTable don't include the "Name" column (e.g. NabBaseTable.Specimen)
-        Map<String, Pair<IndexType, List<ColumnInfo>>> ret = new HashMap<>(super.getUniqueIndices());
+        String indexName = "idx_material_ak";
+        Map<String, IndexDef> ret = new HashMap<>(super.getUniqueIndices());
         if (getColumn("Name") != null)
-            ret.put("idx_material_ak", Pair.of(IndexType.Unique, Arrays.asList(getColumn("Name"))));
+            ret.put(indexName, new IndexDef(indexName, IndexType.Unique, Arrays.asList(getColumn("Name")), null));
         else
-            ret.remove("idx_material_ak");
+            ret.remove(indexName);
         return Collections.unmodifiableMap(ret);
     }
 

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -1059,7 +1059,7 @@ public class DomainImpl implements Domain
         Set<ColumnInfo> uniqueIndexCols = new LinkedHashSet<>();
         // Find the uniqueIndexCols so we can use these for selecting items to update the uniqueIds of,
         // but exclude the uniqueId fields themselves.
-        table.getUniqueIndices().values().forEach(def -> def.columns().stream().filter(col -> !col.isUniqueIdField()).forEach(uniqueIndexCols::add));
+        table.getUniqueIndices().forEach(def -> def.columns().stream().filter(col -> !col.isUniqueIdField()).forEach(uniqueIndexCols::add));
 
         DbSequence sequence = DbSequenceManager.get(ContainerManager.getRoot(), STORAGE_UNIQUE_ID_SEQUENCE_PREFIX);
 

--- a/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainImpl.java
@@ -24,15 +24,38 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.labkey.api.audit.AbstractAuditTypeProvider;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.audit.AbstractAuditTypeProvider;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.AuditTypeEvent;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.Sets;
-import org.labkey.api.data.*;
+import org.labkey.api.data.BaseColumnInfo;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.ConditionalFormat;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.data.DbSequence;
+import org.labkey.api.data.DbSequenceManager;
+import org.labkey.api.data.ImportAliasable;
+import org.labkey.api.data.MVDisplayColumnFactory;
+import org.labkey.api.data.Parameter;
+import org.labkey.api.data.ParameterMapStatement;
+import org.labkey.api.data.PropertyStorageSpec;
+import org.labkey.api.data.Results;
+import org.labkey.api.data.RuntimeSQLException;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SchemaTableInfo;
+import org.labkey.api.data.ServerPrimaryKeyLock;
+import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.Table;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
@@ -1036,7 +1059,7 @@ public class DomainImpl implements Domain
         Set<ColumnInfo> uniqueIndexCols = new LinkedHashSet<>();
         // Find the uniqueIndexCols so we can use these for selecting items to update the uniqueIds of,
         // but exclude the uniqueId fields themselves.
-        table.getUniqueIndices().values().forEach(idx -> idx.second.stream().filter(col -> !col.isUniqueIdField()).forEach(uniqueIndexCols::add));
+        table.getUniqueIndices().values().forEach(def -> def.columns().stream().filter(col -> !col.isUniqueIdField()).forEach(uniqueIndexCols::add));
 
         DbSequence sequence = DbSequenceManager.get(ContainerManager.getRoot(), STORAGE_UNIQUE_ID_SEQUENCE_PREFIX);
 

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -690,14 +690,14 @@ public class StorageProvisionerImpl implements StorageProvisioner
 
         @NotNull
         @Override
-        public Map<String, IndexDefinition> getUniqueIndices()
+        public List<IndexDefinition> getUniqueIndices()
         {
             return _inner.getUniqueIndices();
         }
 
         @NotNull
         @Override
-        public Map<String, IndexDefinition> getAllIndices()
+        public List<IndexDefinition> getAllIndices()
         {
             return _inner.getAllIndices();
         }
@@ -924,7 +924,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
             DomainKind<?> kind = domain.getDomainKind();
             if (null == kind)
                 throw new IllegalStateException("Domain kind of " + domain.getName() + " is null!");
-            Map<String, IndexDefinition> existingIndices = schemaTableInfo.getAllIndices();
+            List<IndexDefinition> existingIndices = schemaTableInfo.getAllIndices();
             // Determine the desired indexes. Note that the index lists provided by Domain and DomainKind may overlap,
             // so we need to uniquify. Domain indices never specify "clustered" but DomainKind indices may (e.g.,
             // DatasetDomainKind), so compare using only column names and give preference to DomainKind.
@@ -932,9 +932,8 @@ public class StorageProvisionerImpl implements StorageProvisioner
             newIndices.addAll(domain.getPropertyIndices());
             newIndices.addAll(kind.getPropertyIndices(domain));
             Set<String> toRemove = new HashSet<>();
-            for (String name : existingIndices.keySet())
+            for (IndexDefinition def : existingIndices)
             {
-                IndexDefinition def = existingIndices.get(name);
                 if (def.indexType() == TableInfo.IndexType.Primary)
                     continue;
                 String[] columnNames = def.columns().stream()
@@ -953,7 +952,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
                 }
 
                 if (!foundIt)
-                    toRemove.add(name);
+                    toRemove.add(def.name());
             }
 
             if (!toRemove.isEmpty())

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -52,6 +52,7 @@ import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableChange;
 import org.labkey.api.data.TableChange.ChangeType;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableInfo.IndexDef;
 import org.labkey.api.data.UpdateableTableInfo;
 import org.labkey.api.data.VirtualTable;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -86,7 +87,6 @@ import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.util.logging.LogHelper;
@@ -689,14 +689,14 @@ public class StorageProvisionerImpl implements StorageProvisioner
 
         @NotNull
         @Override
-        public Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
+        public Map<String, IndexDef> getUniqueIndices()
         {
             return _inner.getUniqueIndices();
         }
 
         @NotNull
         @Override
-        public Map<String, Pair<IndexType, List<ColumnInfo>>> getAllIndices()
+        public Map<String, IndexDef> getAllIndices()
         {
             return _inner.getAllIndices();
         }
@@ -923,7 +923,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
             DomainKind<?> kind = domain.getDomainKind();
             if (null == kind)
                 throw new IllegalStateException("Domain kind of " + domain.getName() + " is null!");
-            Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> existingIndices = schemaTableInfo.getAllIndices();
+            Map<String, IndexDef> existingIndices = schemaTableInfo.getAllIndices();
             // Determine the desired indexes. Note that the index lists provided by Domain and DomainKind may overlap,
             // so we need to uniquify. Domain indices never specify "clustered" but DomainKind indices may (e.g.,
             // DatasetDomainKind), so compare using only column names and give preference to DomainKind.
@@ -933,15 +933,13 @@ public class StorageProvisionerImpl implements StorageProvisioner
             Set<String> toRemove = new HashSet<>();
             for (String name : existingIndices.keySet())
             {
-                if (existingIndices.get(name).first == TableInfo.IndexType.Primary)
+                IndexDef def = existingIndices.get(name);
+                if (def.indexType() == TableInfo.IndexType.Primary)
                     continue;
-                Pair<TableInfo.IndexType, List<ColumnInfo>> columnIndex = existingIndices.get(name);
-                String[] columnNames = new String[columnIndex.second.size()];
-                for (int i = 0; i < columnIndex.second.size(); i++)
-                {
-                    columnNames[i] = columnIndex.second.get(i).getColumnName();
-                }
-                Index existingIndex = new Index(columnIndex.first == TableInfo.IndexType.Unique, columnNames);
+                String[] columnNames = def.columns().stream()
+                    .map(ColumnInfo::getColumnName)
+                    .toArray(String[]::new);
+                Index existingIndex = new Index(def.indexType() == TableInfo.IndexType.Unique, columnNames);
                 boolean foundIt = false;
                 for (Index propertyIndex : newIndices)
                 {

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -52,7 +52,7 @@ import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableChange;
 import org.labkey.api.data.TableChange.ChangeType;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableInfo.IndexDef;
+import org.labkey.api.data.TableInfo.IndexDefinition;
 import org.labkey.api.data.UpdateableTableInfo;
 import org.labkey.api.data.VirtualTable;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -689,14 +689,14 @@ public class StorageProvisionerImpl implements StorageProvisioner
 
         @NotNull
         @Override
-        public Map<String, IndexDef> getUniqueIndices()
+        public Map<String, IndexDefinition> getUniqueIndices()
         {
             return _inner.getUniqueIndices();
         }
 
         @NotNull
         @Override
-        public Map<String, IndexDef> getAllIndices()
+        public Map<String, IndexDefinition> getAllIndices()
         {
             return _inner.getAllIndices();
         }
@@ -923,7 +923,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
             DomainKind<?> kind = domain.getDomainKind();
             if (null == kind)
                 throw new IllegalStateException("Domain kind of " + domain.getName() + " is null!");
-            Map<String, IndexDef> existingIndices = schemaTableInfo.getAllIndices();
+            Map<String, IndexDefinition> existingIndices = schemaTableInfo.getAllIndices();
             // Determine the desired indexes. Note that the index lists provided by Domain and DomainKind may overlap,
             // so we need to uniquify. Domain indices never specify "clustered" but DomainKind indices may (e.g.,
             // DatasetDomainKind), so compare using only column names and give preference to DomainKind.
@@ -933,7 +933,7 @@ public class StorageProvisionerImpl implements StorageProvisioner
             Set<String> toRemove = new HashSet<>();
             for (String name : existingIndices.keySet())
             {
-                IndexDef def = existingIndices.get(name);
+                IndexDefinition def = existingIndices.get(name);
                 if (def.indexType() == TableInfo.IndexType.Primary)
                     continue;
                 String[] columnNames = def.columns().stream()

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -293,12 +293,12 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
 
             // table indices
             JSONObject jsonIndices = new JSONObject();
-            for (Map.Entry<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> entry : tinfo.getUniqueIndices().entrySet())
+            for (TableInfo.IndexDef def : tinfo.getUniqueIndices().values())
             {
                 JSONObject jsonIndex = new JSONObject();
-                jsonIndex.put("type", entry.getValue().getKey());
-                jsonIndex.put("columns", entry.getValue().getValue().stream().map(ColumnInfo::getFieldKey).toArray());
-                jsonIndices.put(entry.getKey(), jsonIndex);
+                jsonIndex.put("type", def.indexType());
+                jsonIndex.put("columns", def.columns().stream().map(ColumnInfo::getFieldKey).toArray());
+                jsonIndices.put(def.name(), jsonIndex);
             }
             resp.put("indices", jsonIndices);
 

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -293,7 +293,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
 
             // table indices
             JSONObject jsonIndices = new JSONObject();
-            for (TableInfo.IndexDef def : tinfo.getUniqueIndices().values())
+            for (TableInfo.IndexDefinition def : tinfo.getUniqueIndices().values())
             {
                 JSONObject jsonIndex = new JSONObject();
                 jsonIndex.put("type", def.indexType());

--- a/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
+++ b/query/src/org/labkey/query/controllers/GetQueryDetailsAction.java
@@ -293,7 +293,7 @@ public class GetQueryDetailsAction extends ReadOnlyApiAction<GetQueryDetailsActi
 
             // table indices
             JSONObject jsonIndices = new JSONObject();
-            for (TableInfo.IndexDefinition def : tinfo.getUniqueIndices().values())
+            for (TableInfo.IndexDefinition def : tinfo.getUniqueIndices())
             {
                 JSONObject jsonIndex = new JSONObject();
                 jsonIndex.put("type", def.indexType());

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -95,7 +95,6 @@ import org.labkey.api.util.DemoMode;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.StringExpression;
 import org.labkey.api.view.ActionURL;
 import org.labkey.data.xml.TableType;
@@ -527,16 +526,17 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
 
     @NotNull
     @Override
-    public Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
+    public Map<String, IndexDef> getUniqueIndices()
     {
         // Get indices from underlying storage table
-        Map<String, Pair<IndexType, List<ColumnInfo>>> ret = new HashMap<>(wrapTableIndices(getDatasetDefinition().getStorageTableInfo(false)));
+        Map<String, IndexDef> ret = new HashMap<>(wrapTableIndices(getDatasetDefinition().getStorageTableInfo(false)));
         String subjectColName = StudyService.get().getSubjectColumnName(getContainer());
 
         // Index enforced in code not on actual database for demographic datasets only
         if (getColumn(subjectColName) != null && getDatasetDefinition().isDemographicData())
         {
-            ret.put("uq_dataset_subject", Pair.of(IndexType.Unique, Arrays.asList(getColumn(subjectColName))));
+            String name = "uq_dataset_subject";
+            ret.put(name, new IndexDef(name, IndexType.Unique, Arrays.asList(getColumn(subjectColName)), null));
         }
         return Collections.unmodifiableMap(ret);
     }

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -526,17 +526,17 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
 
     @NotNull
     @Override
-    public Map<String, IndexDef> getUniqueIndices()
+    public Map<String, IndexDefinition> getUniqueIndices()
     {
         // Get indices from underlying storage table
-        Map<String, IndexDef> ret = new HashMap<>(wrapTableIndices(getDatasetDefinition().getStorageTableInfo(false)));
+        Map<String, IndexDefinition> ret = new HashMap<>(wrapTableIndices(getDatasetDefinition().getStorageTableInfo(false)));
         String subjectColName = StudyService.get().getSubjectColumnName(getContainer());
 
         // Index enforced in code not on actual database for demographic datasets only
         if (getColumn(subjectColName) != null && getDatasetDefinition().isDemographicData())
         {
             String name = "uq_dataset_subject";
-            ret.put(name, new IndexDef(name, IndexType.Unique, Arrays.asList(getColumn(subjectColName)), null));
+            ret.put(name, new IndexDefinition(name, IndexType.Unique, Arrays.asList(getColumn(subjectColName)), null));
         }
         return Collections.unmodifiableMap(ret);
     }

--- a/study/src/org/labkey/study/query/DatasetTableImpl.java
+++ b/study/src/org/labkey/study/query/DatasetTableImpl.java
@@ -526,19 +526,18 @@ public class DatasetTableImpl extends BaseStudyTable implements DatasetTable
 
     @NotNull
     @Override
-    public Map<String, IndexDefinition> getUniqueIndices()
+    public List<IndexDefinition> getUniqueIndices()
     {
         // Get indices from underlying storage table
-        Map<String, IndexDefinition> ret = new HashMap<>(wrapTableIndices(getDatasetDefinition().getStorageTableInfo(false)));
+        List<IndexDefinition> ret = new ArrayList<>(wrapTableIndices(getDatasetDefinition().getStorageTableInfo(false)));
         String subjectColName = StudyService.get().getSubjectColumnName(getContainer());
 
         // Index enforced in code not on actual database for demographic datasets only
         if (getColumn(subjectColName) != null && getDatasetDefinition().isDemographicData())
         {
-            String name = "uq_dataset_subject";
-            ret.put(name, new IndexDefinition(name, IndexType.Unique, Arrays.asList(getColumn(subjectColName)), null));
+            ret.add(new IndexDefinition("uq_dataset_subject", IndexType.Unique, Arrays.asList(getColumn(subjectColName)), null));
         }
-        return Collections.unmodifiableMap(ret);
+        return Collections.unmodifiableList(ret);
     }
 
     @Override

--- a/study/src/org/labkey/study/query/QueryDatasetTable.java
+++ b/study/src/org/labkey/study/query/QueryDatasetTable.java
@@ -37,7 +37,7 @@ public class QueryDatasetTable extends DatasetTableImpl
     }
 
     @Override
-    public @NotNull Map<String, IndexDef> getUniqueIndices()
+    public @NotNull Map<String, IndexDefinition> getUniqueIndices()
     {
         return Collections.emptyMap();
     }

--- a/study/src/org/labkey/study/query/QueryDatasetTable.java
+++ b/study/src/org/labkey/study/query/QueryDatasetTable.java
@@ -8,16 +8,16 @@ import org.labkey.study.model.DatasetDefinition;
 import org.labkey.study.model.DatasetDomainKind;
 
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 
 public class QueryDatasetTable extends DatasetTableImpl
 {
     public static final String[] REQUIRED_COLUMNS = new String[]{
-            DatasetDomainKind._KEY,
-            DatasetDomainKind.DATE,
-            DatasetDomainKind.QCSTATE,
-            DatasetDomainKind.LSID,
-            DatasetDomainKind.PARTICIPANTID
+        DatasetDomainKind._KEY,
+        DatasetDomainKind.DATE,
+        DatasetDomainKind.QCSTATE,
+        DatasetDomainKind.LSID,
+        DatasetDomainKind.PARTICIPANTID
     };
 
     QueryDatasetTable(@NotNull StudyQuerySchema schema, ContainerFilter cf, @NotNull DatasetDefinition dsd)
@@ -37,9 +37,9 @@ public class QueryDatasetTable extends DatasetTableImpl
     }
 
     @Override
-    public @NotNull Map<String, IndexDefinition> getUniqueIndices()
+    public @NotNull List<IndexDefinition> getUniqueIndices()
     {
-        return Collections.emptyMap();
+        return Collections.emptyList();
     }
 
     @Override

--- a/study/src/org/labkey/study/query/QueryDatasetTable.java
+++ b/study/src/org/labkey/study/query/QueryDatasetTable.java
@@ -1,16 +1,13 @@
 package org.labkey.study.query;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.query.QueryUpdateService;
-import org.labkey.api.util.Pair;
 import org.labkey.study.model.DatasetDefinition;
 import org.labkey.study.model.DatasetDomainKind;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 public class QueryDatasetTable extends DatasetTableImpl
@@ -40,7 +37,7 @@ public class QueryDatasetTable extends DatasetTableImpl
     }
 
     @Override
-    public @NotNull Map<String, Pair<IndexType, List<ColumnInfo>>> getUniqueIndices()
+    public @NotNull Map<String, IndexDef> getUniqueIndices()
     {
         return Collections.emptyMap();
     }

--- a/study/src/org/labkey/study/writer/DatasetDataWriter.java
+++ b/study/src/org/labkey/study/writer/DatasetDataWriter.java
@@ -404,12 +404,12 @@ public class DatasetDataWriter implements InternalStudyWriter
             return Collections.emptyList();
 
         SchemaTableInfo schemaTableInfo = StorageProvisioner.get().getSchemaTableInfo(tinfo.getDomain());
-        Map<String, IndexDefinition> allIndices = schemaTableInfo.getAllIndices();
+        List<IndexDefinition> allIndices = schemaTableInfo.getAllIndices();
         Collection<IndexInfo> outIndices = new LinkedHashSet<>(allIndices.size());
 
         Set<PropertyStorageSpec.Index> domainKindIndices = tinfo.getDomainKind().getPropertyIndices(tinfo.getDomain());
 
-        for (IndexDefinition index : allIndices.values())
+        for (IndexDefinition index : allIndices)
         {
             List<ColumnInfo> columnInfoList = index.columns();
             if (index.indexType().equals(TableInfo.IndexType.Primary) ||

--- a/study/src/org/labkey/study/writer/DatasetDataWriter.java
+++ b/study/src/org/labkey/study/writer/DatasetDataWriter.java
@@ -40,6 +40,7 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TSVGridWriter;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableInfo.IndexDef;
 import org.labkey.api.data.WrappedColumnInfo;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -54,7 +55,6 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.study.Dataset;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.util.JunitUtil;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.writer.VirtualFile;
 import org.labkey.study.StudySchema;
@@ -404,15 +404,15 @@ public class DatasetDataWriter implements InternalStudyWriter
             return Collections.emptyList();
 
         SchemaTableInfo schemaTableInfo = StorageProvisioner.get().getSchemaTableInfo(tinfo.getDomain());
-        Map<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> allIndices = schemaTableInfo.getAllIndices();
+        Map<String, IndexDef> allIndices = schemaTableInfo.getAllIndices();
         Collection<IndexInfo> outIndices = new LinkedHashSet<>(allIndices.size());
 
         Set<PropertyStorageSpec.Index> domainKindIndices = tinfo.getDomainKind().getPropertyIndices(tinfo.getDomain());
 
-        for (Map.Entry<String, Pair<TableInfo.IndexType, List<ColumnInfo>>> indexEntry : allIndices.entrySet())
+        for (IndexDef index : allIndices.values())
         {
-            List<ColumnInfo> columnInfoList = indexEntry.getValue().getValue();
-            if (indexEntry.getValue().getKey().equals(TableInfo.IndexType.Primary) ||
+            List<ColumnInfo> columnInfoList = index.columns();
+            if (index.indexType().equals(TableInfo.IndexType.Primary) ||
                     columnInfoListMatchesDomainIndex(columnInfoList, domainKindIndices))
             {
                 continue;
@@ -424,7 +424,7 @@ public class DatasetDataWriter implements InternalStudyWriter
                 columnNames.add(columnInfo.getColumnName());
             }
 
-            IndexInfo indexInfo = new IndexInfo(indexEntry.getValue().getKey(), columnNames);
+            IndexInfo indexInfo = new IndexInfo(index.indexType(), columnNames);
             outIndices.add(indexInfo);
         }
         return outIndices;

--- a/study/src/org/labkey/study/writer/DatasetDataWriter.java
+++ b/study/src/org/labkey/study/writer/DatasetDataWriter.java
@@ -40,7 +40,7 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TSVGridWriter;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableInfo.IndexDef;
+import org.labkey.api.data.TableInfo.IndexDefinition;
 import org.labkey.api.data.WrappedColumnInfo;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.exp.api.ExpProtocol;
@@ -404,12 +404,12 @@ public class DatasetDataWriter implements InternalStudyWriter
             return Collections.emptyList();
 
         SchemaTableInfo schemaTableInfo = StorageProvisioner.get().getSchemaTableInfo(tinfo.getDomain());
-        Map<String, IndexDef> allIndices = schemaTableInfo.getAllIndices();
+        Map<String, IndexDefinition> allIndices = schemaTableInfo.getAllIndices();
         Collection<IndexInfo> outIndices = new LinkedHashSet<>(allIndices.size());
 
         Set<PropertyStorageSpec.Index> domainKindIndices = tinfo.getDomainKind().getPropertyIndices(tinfo.getDomain());
 
-        for (IndexDef index : allIndices.values())
+        for (IndexDefinition index : allIndices.values())
         {
             List<ColumnInfo> columnInfoList = index.columns();
             if (index.indexType().equals(TableInfo.IndexType.Primary) ||


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53887

`TableInfo.getUniqueIndices()` and `TableInfo.getAllIndices()` have been returning `Map<String, Pair<IndexType, List<ColumnInfo>>>`, which is both awkward to work with and hard to extend. Returning `List<IndexDefinition>` increases flexibility and readability. 

Reading and stashing each index's filter condition helps improve the detection of overlapping indices. SQL Server JDBC driver does not report filter conditions in the `getIndexInfo()` `ResultSet`; work around that by stashing the results of an explicit query at data source `prepare()` time.

Drop five redundant indices in the `exp` schema.

#### Tasks 📍
- [x] Manual Testing @labkey-jeckels 
- [x] Verify Fix @labkey-jeckels 