### PR TITLE
Issue 53896: 'Last Modified' column in fileContent module appears empty

### DIFF
--- a/core/src/org/labkey/core/webdav/DavController.java
+++ b/core/src/org/labkey/core/webdav/DavController.java
@@ -2697,7 +2697,7 @@ public class DavController extends SpringActionController
 
             long created = resource.getCreated();
             if (Long.MIN_VALUE != created)
-                json.key("creationdate").value(new Date(created));
+                json.key("creationdate").value(getISOCreationDate(created));
             User createdby = resource.getCreatedBy();
             if (null != createdby)
                 json.key("createdby").value(UserManager.getDisplayName(createdby.getUserId(), getUser()));
@@ -2709,7 +2709,7 @@ public class DavController extends SpringActionController
             {
                 long lastModified = resource.getLastModified();
                 if (Long.MIN_VALUE != lastModified)
-                    json.key("lastmodified").value(new Date(lastModified));
+                    json.key("lastmodified").value(getISOCreationDate(lastModified));
                 long length = resource.getContentLength();
                 json.key("contentlength").value(length);
                 if (length >= 0)


### PR DESCRIPTION
#### Rational
Issue [53896](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53896)

When querying for file webdav properties, created/modified date values are not formatted explicitly and hence get formatted to RFC_1123_DATE_TIME by default. This value is then used on the client to construct new Date() using javascript. This is not working for all timezones, for example, BST timezones. 

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Format iso date

#### Tasks 📍
- [x] Manual Testing: set tomcat timezone to BST @labkey-danield 📍 
- [ ] ~Needs Automation~ Automation will require changing TC to move the server to BST. Currently we only move the browser. This would require more investigation and work than I could do in the next few days.
- [ ] Code review @labkey-susanh 