### PR TITLE
Constants for many commonly used role names in tests

### DIFF
--- a/mothership/test/src/org/labkey/test/tests/mothership/InProductMessagingTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/InProductMessagingTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
 
 
 @Category({Daily.class})
@@ -61,7 +62,7 @@ public class InProductMessagingTest extends BaseWebDriverTest implements Postgre
     private void doSetup()
     {
         TEST_AUTHOR.create(this)
-                .addPermission("Author", "home");
+                .addPermission(AUTHOR_ROLE, "home");
     }
 
     @Test

--- a/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
+++ b/mothership/test/src/org/labkey/test/tests/mothership/MothershipTest.java
@@ -56,6 +56,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.labkey.test.pages.test.TestActions.ExceptionActions;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 import static org.labkey.test.util.mothership.MothershipHelper.MOTHERSHIP_PROJECT;
 
 @Category({Daily.class})
@@ -99,7 +100,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         _userHelper.createUser(ASSIGNEE2);
         _userHelper.createUser(NON_ASSIGNEE);
         permissionsHelper.createProjectGroup(MOTHERSHIP_GROUP, MOTHERSHIP_PROJECT);
-        permissionsHelper.addMemberToRole(MOTHERSHIP_GROUP, "Editor", MemberType.group, MOTHERSHIP_PROJECT);
+        permissionsHelper.addMemberToRole(MOTHERSHIP_GROUP, EDITOR_ROLE, MemberType.group, MOTHERSHIP_PROJECT);
         permissionsHelper.addUserToProjGroup(ASSIGNEE, MOTHERSHIP_PROJECT, MOTHERSHIP_GROUP);
         permissionsHelper.addUserToProjGroup(ASSIGNEE2, MOTHERSHIP_PROJECT, MOTHERSHIP_GROUP);
         permissionsHelper.addMemberToRole(NON_ASSIGNEE, "Project Admin", MemberType.user, MOTHERSHIP_PROJECT);
@@ -121,7 +122,7 @@ public class MothershipTest extends BaseWebDriverTest implements PostgresOnlyTes
         ApiPermissionsHelper permHelper = new ApiPermissionsHelper(this);
         permHelper.createProjectGroup(ISSUES_GROUP, ISSUES_PROJECT);
         permHelper.addUserToProjGroup(ASSIGNEE, ISSUES_PROJECT, ISSUES_GROUP);
-        permHelper.addMemberToRole(ISSUES_GROUP, "Editor", MemberType.group, ISSUES_PROJECT);
+        permHelper.addMemberToRole(ISSUES_GROUP, EDITOR_ROLE, MemberType.group, ISSUES_PROJECT);
     }
 
     @Before

--- a/query/test/src/org/labkey/test/tests/query/ContainerFilterQueryTest.java
+++ b/query/test/src/org/labkey/test/tests/query/ContainerFilterQueryTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class})
 public class ContainerFilterQueryTest extends BaseWebDriverTest
@@ -158,7 +159,7 @@ public class ContainerFilterQueryTest extends BaseWebDriverTest
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
         _userHelper.createUser(USER);
         apiPermissionsHelper
-            .addMemberToRole(USER, "Reader", PermissionsHelper.MemberType.user, getFolderPath());
+            .addMemberToRole(USER, READER_ROLE, PermissionsHelper.MemberType.user, getFolderPath());
 
         DataRegionTable table = createQuery(getFolderPath(), queryName, "core", sql);
         impersonate(USER);

--- a/study/test/src/org/labkey/test/tests/search/SearchTest.java
+++ b/study/test/src/org/labkey/test/tests/search/SearchTest.java
@@ -58,6 +58,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.labkey.test.TestFileUtils.getFileRowCount;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 import static org.labkey.test.util.PermissionsHelper.MemberType.group;
 import static org.labkey.test.util.SearchHelper.getUnsearchableValue;
 
@@ -543,7 +544,7 @@ public abstract class SearchTest extends StudyBaseTest
     {
         ApiPermissionsHelper apiPermissionsHelper = new ApiPermissionsHelper(this);
         apiPermissionsHelper.createPermissionsGroup(GROUP_NAME, USER1);
-        apiPermissionsHelper.addMemberToRole(GROUP_NAME, "Editor", group, getProjectName());
+        apiPermissionsHelper.addMemberToRole(GROUP_NAME, EDITOR_ROLE, group, getProjectName());
         clickFolder(getFolderName());
 
         IssuesHelper issuesHelper = new IssuesHelper(this);

--- a/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AutoLinkToStudyTest.java
@@ -22,6 +22,8 @@ import org.labkey.test.util.StudyHelper;
 import java.io.File;
 import java.util.List;
 
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
+
 @Category({Daily.class, Assays.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class AutoLinkToStudyTest extends BaseWebDriverTest
@@ -68,7 +70,7 @@ public class AutoLinkToStudyTest extends BaseWebDriverTest
         log("Creating a reader user");
         _userHelper.createUser(READER_USER);
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
-        permissionsHelper.addMemberToRole(READER_USER, "Reader", PermissionsHelper.MemberType.user, STUDY1);
+        permissionsHelper.addMemberToRole(READER_USER, READER_ROLE, PermissionsHelper.MemberType.user, STUDY1);
     }
 
     @Override

--- a/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/SharedStudyTest.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 9)
@@ -480,7 +481,7 @@ public class SharedStudyTest extends BaseWebDriverTest
     @Test
     public void testSharedDatasetSubfolderSecurity()
     {
-        createUserWithPermissions(user, getProjectName(), "Reader");
+        createUserWithPermissions(user, getProjectName(), READER_ROLE);
 
         impersonate(user);
         {
@@ -503,7 +504,7 @@ public class SharedStudyTest extends BaseWebDriverTest
         clickFolder(STUDY1);
         _permissionsHelper.enterPermissionsUI();
         _permissionsHelper.uncheckInheritedPermissions();
-        _permissionsHelper.setUserPermissions(user, "Reader");
+        _permissionsHelper.setUserPermissions(user, READER_ROLE);
         _permissionsHelper.saveAndFinish();
         clickFolder(STUDY2);
         _permissionsHelper.enterPermissionsUI();

--- a/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyPublishTest.java
@@ -69,6 +69,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 30)
@@ -1225,8 +1227,8 @@ public class StudyPublishTest extends StudyPHIExportTest
         _permissionsHelper.enterPermissionsUI();
         _permissionsHelper.uncheckInheritedPermissions();
         _permissionsHelper.savePermissions();
-        _permissionsHelper.setUserPermissions(PUBLISH_FOLDER_ADMIN, "Folder Administrator");
-        _permissionsHelper.setUserPermissions(PUBLISH_SUB_FOLDER_ADMIN, "Reader");
+        _permissionsHelper.setUserPermissions(PUBLISH_FOLDER_ADMIN, FOLDER_ADMIN_ROLE);
+        _permissionsHelper.setUserPermissions(PUBLISH_SUB_FOLDER_ADMIN, READER_ROLE);
         impersonate(PUBLISH_FOLDER_ADMIN);
         goToSchemaBrowser();
         selectQuery("study", "StudySnapshot");
@@ -1251,7 +1253,7 @@ public class StudyPublishTest extends StudyPHIExportTest
         // verify the case where a user has read access to a folder and admin access to a subfolder
         log("verify permissions for a sub level folder admin");
         navigateToFolder(getProjectName(), PUB1_NAME);
-        _permissionsHelper.setUserPermissions(PUBLISH_SUB_FOLDER_ADMIN, "Folder Administrator");
+        _permissionsHelper.setUserPermissions(PUBLISH_SUB_FOLDER_ADMIN, FOLDER_ADMIN_ROLE);
         clickButton("Save and Finish");
         clickFolder(getFolderName());
         goToSchemaBrowser();

--- a/study/test/src/org/labkey/test/tests/study/StudySecurityTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudySecurityTest.java
@@ -38,6 +38,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
+
 @Category({Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
 public class StudySecurityTest extends BaseWebDriverTest
@@ -145,7 +147,7 @@ public class StudySecurityTest extends BaseWebDriverTest
         goToStudyFolder();
 
         // Test dataset security operations as a folder admin to avoid regressions, Issue #50103
-        impersonateRole("Folder Administrator");
+        impersonateRole(FOLDER_ADMIN_ROLE);
 
         StudySecurityPage studySecurityPage = _studyHelper.enterStudySecurity();
 

--- a/study/test/src/org/labkey/test/tests/study/StudyTest.java
+++ b/study/test/src/org/labkey/test/tests/study/StudyTest.java
@@ -72,6 +72,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.labkey.test.util.DataRegionTable.DataRegion;
 import static org.labkey.test.util.PasswordUtil.getUsername;
+import static org.labkey.test.util.PermissionsHelper.AUTHOR_ROLE;
 
 @Category({Specimen.class, Daily.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 15)
@@ -312,7 +313,7 @@ public class StudyTest extends StudyBaseTest
     {
         clickProject(getProjectName());
         _userHelper.createUser(authorUser, true);
-        _permissionsHelper.setUserPermissions(authorUser, "Author");
+        _permissionsHelper.setUserPermissions(authorUser, AUTHOR_ROLE);
         impersonate(authorUser);
         beginAt(specimenUrl);
         clickButton("Request Options", 0);

--- a/study/test/src/org/labkey/test/tests/study/TruncationTest.java
+++ b/study/test/src/org/labkey/test/tests/study/TruncationTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.labkey.test.util.PermissionsHelper.EDITOR_ROLE;
 
 @Category({Daily.class, Specimen.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 6)
@@ -107,7 +108,7 @@ public class TruncationTest extends BaseWebDriverTest
     public void testTruncateVisibility()
     {
         goToProjectHome();
-        impersonateRole("Editor");
+        impersonateRole(EDITOR_ROLE);
         clickAndWait(Locator.linkWithText(LIST_NAME));
         assertTextNotPresent("Delete All Rows");
         stopImpersonating();


### PR DESCRIPTION
#### Rationale
There's an exciting new computer science concept - using constants instead of many copies of hard-code values. Let's give it a try with our most commonly used role names in automated tests.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2703

#### Changes
- Common role names available in PermissionsHelper
- Update tests to use them