### PR TITLE
Only inspect fields for isKeyField when the Reader is using the default idProperty

### DIFF
--- a/api/webapp/clientapi/ext4/data/Proxy.js
+++ b/api/webapp/clientapi/ext4/data/Proxy.js
@@ -220,13 +220,15 @@ Ext4.define('LABKEY.ext4.data.AjaxProxy', {
                 }
 
                 oldKeys[this.reader.getIdProperty()] = id;
-                oldKeys['_internalId'] = record.internalId;  //NOTE: also include internalId for records that do not have a server-assigned PK yet
+                oldKeys[LABKEY.ext4.data.JsonReader.DEFAULT_ID_PROPERTY] = record.internalId;  //NOTE: also include internalId for records that do not have a server-assigned PK yet
 
-                // NOTE: if the 'id' property of the ApiQueryResponse is null, which will occur if there is more than 1 PK (see ApiQueryResponse.getMetaData()),
-                // then we need to ensure the original values of keyFields are still included in oldKeys. The check against record.modified should ensure we send the original value
-                this.reader?.metaData?.fields?.filter(f => f.isKeyField).map(f => f.name).forEach(keyFieldName => {
-                    oldKeys[keyFieldName] = record.modified?.hasOwnProperty(keyFieldName) ? record.modified[keyFieldName] : record.get(keyFieldName);
-                })
+                // NOTE: this will apply if a table has more than one PK. If that is true, the 'id' property of the ApiQueryResponse is will be null (see ApiQueryResponse.getMetaData()).
+                // If this happens, we iterate the fields, find PKs, and include them in oldKeys. As above, check record.modified to ensure we send the original value, in case it was modified on the client.
+                if (this.reader.getIdProperty() === LABKEY.ext4.data.JsonReader.DEFAULT_ID_PROPERTY) {
+                    this.reader?.metaData?.fields.filter(f => f.isKeyField).map(f => f.name).forEach(keyFieldName => {
+                        oldKeys[keyFieldName] = record.modified?.hasOwnProperty(keyFieldName) ? record.modified[keyFieldName] : record.get(keyFieldName);
+                    })
+                }
 
                 if (command.command == 'delete'){
                     command.rows.push(this.getRowData(record));

--- a/api/webapp/clientapi/ext4/data/Proxy.js
+++ b/api/webapp/clientapi/ext4/data/Proxy.js
@@ -225,7 +225,7 @@ Ext4.define('LABKEY.ext4.data.AjaxProxy', {
                 // NOTE: this will apply if a table has more than one PK. If that is true, the 'id' property of the ApiQueryResponse is will be null (see ApiQueryResponse.getMetaData()).
                 // If this happens, we iterate the fields, find PKs, and include them in oldKeys. As above, check record.modified to ensure we send the original value, in case it was modified on the client.
                 if (this.reader.getIdProperty() === LABKEY.ext4.data.JsonReader.DEFAULT_ID_PROPERTY) {
-                    this.reader?.metaData?.fields.filter(f => f.isKeyField).map(f => f.name).forEach(keyFieldName => {
+                    this.reader?.metaData?.fields?.filter(f => f.isKeyField).map(f => f.name).forEach(keyFieldName => {
                         oldKeys[keyFieldName] = record.modified?.hasOwnProperty(keyFieldName) ? record.modified[keyFieldName] : record.get(keyFieldName);
                     })
                 }

--- a/api/webapp/clientapi/ext4/data/Reader.js
+++ b/api/webapp/clientapi/ext4/data/Reader.js
@@ -21,6 +21,9 @@ Ext4.define('LABKEY.ext4.data.JsonReader', {
     mixins: {
         observable: 'Ext.util.Observable'
     },
+    statics: {
+        DEFAULT_ID_PROPERTY: '_internalId'
+    },
     constructor: function(){
         this.callParent(arguments);
         this.addEvents('dataload');
@@ -29,7 +32,7 @@ Ext4.define('LABKEY.ext4.data.JsonReader', {
         if (data.metaData){
             // NOTE: normalize which field holds the PK.  this is a little unfortunate b/c ext will automatically create this field if it doesnt exist,
             // such as a query w/o a PK.  therefore we fall back to a standard name, which we can ignore when drawing grids
-            this.idProperty = data.metaData.id || this.idProperty || '_internalId';
+            this.idProperty = data.metaData.id || this.idProperty || LABKEY.ext4.data.JsonReader.DEFAULT_ID_PROPERTY;
             this.totalProperty = data.metaData.totalProperty; //NOTE: normalize which field holds total rows.
             if (this.model){
                 this.model.prototype.idProperty = this.idProperty;


### PR DESCRIPTION
@labkey-martyp, I'm pretty sure the existing PR was perfectly fine and safe; however, if you want to be extra conservative this check narrows the scope a little. 

I'm trying to protect against the condition where the data has multiple PKs. Currently, the server API and client Reader handle this poorly and end up using '_internalId' as the client idProperty. This results in updates failing. While I believe the prior proposal works fine, this PR will only perform that check when idProperty === '_internalId'. This means it will only change behavior over this one condition.