### PR TITLE
Issues 53975, 53955, 53961, 53963: misc messaging issues

### DIFF
--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -119,7 +119,7 @@ public interface SampleTypeService
     List<Unit> getSupportedUnits();
 
     @Nullable
-    Unit getValidatedUnit(@Nullable Object rawUnits, @Nullable Unit defaultUnits);
+    Unit getValidatedUnit(@Nullable Object rawUnits, @Nullable Unit defaultUnits, @Nullable String sampleTypeName);
 
     Map<String, ExpSampleType> getSampleTypesForRoles(Container container, ContainerFilter filter, ExpProtocol.ApplicationType type);
 

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -55,8 +55,8 @@ import java.util.function.Function;
 
 public interface SampleTypeService
 {
-    String MISSING_COLUMN_ERROR_MESSAGE_PATTERN = "When adding or updating samples, the %s column must be provided when the %s column is.";
-    String MISSING_COLUMN_VALUE_ERROR_MESSAGE_PATTERN = "When adding or updating samples, a %s value must be provided when there is a value for %s.";
+    String MISSING_AMOUNT_ERROR_MESSAGE = "An Amount value must be provided when Units are provided.";
+    String MISSING_UNITS_ERROR_MESSAGE = "A Units value must be provided when Amounts are provided.";
     String UNPROVIDED_VALUE_ERROR_MESSAGE_PATTERN = "No %s value provided for %s %s.";
     String NEW_SAMPLE_TYPE_ALIAS_VALUE = "{{this_sample_set}}";
     String MATERIAL_INPUTS_PREFIX = "MaterialInputs/";

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -30,6 +30,7 @@ import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTIndex;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.lists.permissions.ManagePicklistsPermission;
+import org.labkey.api.ontology.Unit;
 import org.labkey.api.qc.DataState;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.ValidationException;
@@ -113,6 +114,12 @@ public interface SampleTypeService
     {
         ServiceRegistry.get().registerService(SampleTypeService.class, impl);
     }
+
+    @NotNull
+    List<Unit> getSupportedUnits();
+
+    @Nullable
+    Unit getValidatedUnit(@Nullable Object rawUnits, @Nullable Unit defaultUnits);
 
     Map<String, ExpSampleType> getSampleTypesForRoles(Container container, ContainerFilter filter, ExpProtocol.ApplicationType type);
 

--- a/api/src/org/labkey/api/ontology/KindOfQuantity.java
+++ b/api/src/org/labkey/api/ontology/KindOfQuantity.java
@@ -20,7 +20,7 @@ public enum KindOfQuantity
         @Override
         public List<Unit> getCommonUnits()
         {
-            return List.of(Unit.L, Unit.mL, Unit.uL);
+            return List.of(Unit.kL, Unit.L, Unit.mL, Unit.uL);
         }
     },
 

--- a/api/src/org/labkey/api/ontology/Unit.java
+++ b/api/src/org/labkey/api/ontology/Unit.java
@@ -218,9 +218,9 @@ public enum Unit
             rawUnitsString = rawUnitsString.trim();
 
             Unit mUnit = Unit.fromName(rawUnitsString);
-            if (mUnit == null)
+            List<Unit> commonUnits = KindOfQuantity.getSupportedUnits();
+            if (mUnit == null || !commonUnits.contains(mUnit))
             {
-                List<Unit> commonUnits = KindOfQuantity.getSupportedUnits();
                 throw new ConversionExceptionWithMessage("Unsupported Units value (" + rawUnitsString + ").  Supported values are: " + StringUtils.join(commonUnits, ", ") + ".");
             }
             if (defaultUnits != null && mUnit.kindOfQuantity != defaultUnits.kindOfQuantity)

--- a/api/src/org/labkey/api/ontology/Unit.java
+++ b/api/src/org/labkey/api/ontology/Unit.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.labkey.api.data.ConversionExceptionWithMessage;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.function.Function;
 
 public enum Unit
@@ -75,8 +74,6 @@ public enum Unit
     pg(KindOfQuantity.Mass, g, 1e-12, 3, "pg",
             Quantity.Mass_pg.class,
             "picogram", "picograms");
-
-    private static final String CONVERSION_EXCEPTION_MESSAGE ="Units value (%s) is not compatible with the display units (%s).";
 
     @Getter
     final @NotNull KindOfQuantity kindOfQuantity;
@@ -198,38 +195,6 @@ public enum Unit
         return Quantity.convert(value, this);
     }
 
-    public static Unit getValidatedUnit(@Nullable Object rawUnits, @Nullable Unit defaultUnits)
-    {
-        if (rawUnits == null)
-            return null;
-        if (rawUnits instanceof Unit u)
-        {
-            if (defaultUnits == null)
-                return u;
-            else if (u.kindOfQuantity != defaultUnits.kindOfQuantity)
-                throw new ConversionExceptionWithMessage(String.format(CONVERSION_EXCEPTION_MESSAGE, rawUnits, defaultUnits));
-            else
-                return u;
-        }
-        if (!(rawUnits instanceof String rawUnitsString))
-            throw new ConversionExceptionWithMessage(String.format(CONVERSION_EXCEPTION_MESSAGE, rawUnits, defaultUnits));
-        if (!StringUtils.isBlank(rawUnitsString))
-        {
-            rawUnitsString = rawUnitsString.trim();
-
-            Unit mUnit = Unit.fromName(rawUnitsString);
-            List<Unit> commonUnits = KindOfQuantity.getSupportedUnits();
-            if (mUnit == null || !commonUnits.contains(mUnit))
-            {
-                throw new ConversionExceptionWithMessage("Unsupported Units value (" + rawUnitsString + ").  Supported values are: " + StringUtils.join(commonUnits, ", ") + ".");
-            }
-            if (defaultUnits != null && mUnit.kindOfQuantity != defaultUnits.kindOfQuantity)
-                throw new ConversionExceptionWithMessage(String.format(CONVERSION_EXCEPTION_MESSAGE, rawUnits, defaultUnits));
-            return mUnit;
-        }
-        return null;
-    }
-
     public static class TestCase extends Assert
     {
         @Test
@@ -330,9 +295,9 @@ public enum Unit
         {
             try
             {
-                Unit.getValidatedUnit("g", Unit.mg);
-                Unit.getValidatedUnit("g ", Unit.mg);
-                Unit.getValidatedUnit(" g ", Unit.mg);
+                SampleTypeServiceImpl.getValidatedUnit("g", Unit.mg);
+                SampleTypeServiceImpl.getValidatedUnit("g ", Unit.mg);
+                SampleTypeServiceImpl.getValidatedUnit(" g ", Unit.mg);
             }
             catch (ConversionExceptionWithMessage e)
             {
@@ -340,7 +305,7 @@ public enum Unit
             }
             try
             {
-                assertNull(Unit.getValidatedUnit(null, Unit.unit));
+                assertNull(SampleTypeServiceImpl.getValidatedUnit(null, Unit.unit));
             }
             catch (ConversionExceptionWithMessage e)
             {
@@ -348,7 +313,7 @@ public enum Unit
             }
             try
             {
-                assertNull(Unit.getValidatedUnit("", Unit.unit));
+                assertNull(SampleTypeServiceImpl.getValidatedUnit("", Unit.unit));
             }
             catch (ConversionExceptionWithMessage e)
             {
@@ -356,7 +321,7 @@ public enum Unit
             }
             try
             {
-                Unit.getValidatedUnit("g", Unit.unit);
+                SampleTypeServiceImpl.getValidatedUnit("g", Unit.unit);
                 fail("Units that are not comparable should throw exception.");
             }
             catch (ConversionExceptionWithMessage ignore)
@@ -366,7 +331,7 @@ public enum Unit
 
             try
             {
-                Unit.getValidatedUnit("nonesuch", Unit.unit);
+                SampleTypeServiceImpl.getValidatedUnit("nonesuch", Unit.unit);
                 fail("Invalid units should throw exception.");
             }
             catch (ConversionExceptionWithMessage ignore)

--- a/api/src/org/labkey/api/ontology/Unit.java
+++ b/api/src/org/labkey/api/ontology/Unit.java
@@ -290,56 +290,5 @@ public enum Unit
             assertNull(Unit.fromName(""));
         }
 
-        @Test
-        public void testGetValidatedUnit()
-        {
-            try
-            {
-                SampleTypeServiceImpl.getValidatedUnit("g", Unit.mg);
-                SampleTypeServiceImpl.getValidatedUnit("g ", Unit.mg);
-                SampleTypeServiceImpl.getValidatedUnit(" g ", Unit.mg);
-            }
-            catch (ConversionExceptionWithMessage e)
-            {
-                fail("Compatible unit should not throw exception.");
-            }
-            try
-            {
-                assertNull(SampleTypeServiceImpl.getValidatedUnit(null, Unit.unit));
-            }
-            catch (ConversionExceptionWithMessage e)
-            {
-                fail("null units should be null");
-            }
-            try
-            {
-                assertNull(SampleTypeServiceImpl.getValidatedUnit("", Unit.unit));
-            }
-            catch (ConversionExceptionWithMessage e)
-            {
-                fail("empty units should be null");
-            }
-            try
-            {
-                SampleTypeServiceImpl.getValidatedUnit("g", Unit.unit);
-                fail("Units that are not comparable should throw exception.");
-            }
-            catch (ConversionExceptionWithMessage ignore)
-            {
-
-            }
-
-            try
-            {
-                SampleTypeServiceImpl.getValidatedUnit("nonesuch", Unit.unit);
-                fail("Invalid units should throw exception.");
-            }
-            catch (ConversionExceptionWithMessage ignore)
-            {
-
-            }
-
-        }
-
     }
 }

--- a/experiment/resources/schemas/exp.xml
+++ b/experiment/resources/schemas/exp.xml
@@ -223,7 +223,7 @@
           <column columnName="Name" >
               <!--
                 Resolve lists by "name" instead of "listId" as "name" will resolve cross-folder
-                where as "listId"s are only unique within a folder.
+                whereas "listId"s are only unique within a folder.
               -->
               <url>/list/grid.view?name=${Name}</url>
           </column>

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -1039,6 +1039,7 @@ public class ExperimentModule extends SpringModule
             LineageTest.class,
             OntologyManager.TestCase.class,
             PropertyServiceImpl.TestCase.class,
+            SampleTypeServiceImpl.TestCase.class,
             StorageNameGenerator.TestCase.class,
             StorageProvisionerImpl.TestCase.class,
             UniqueValueCounterTestCase.class

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeImpl.java
@@ -557,11 +557,11 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         {
             // Failed to generate a name due to some part of the expression not in the row
             if (hasNameExpression())
-                throw new ExperimentException("Failed to generate name for sample on row " + e.getRowNumber(), e);
+                throw new ExperimentException("Failed to generate name for sample.", e);
             else if (hasNameAsIdCol())
-                throw new ExperimentException("SampleID or Name is required for sample on row " + e.getRowNumber(), e);
+                throw new ExperimentException("SampleID or Name is required for sample.", e);
             else
-                throw new ExperimentException("All id columns are required for sample on row " + e.getRowNumber(), e);
+                throw new ExperimentException("All id columns are required for sample.", e);
         }
     }
 
@@ -609,7 +609,7 @@ public class ExpSampleTypeImpl extends ExpIdentifiableEntityImpl<MaterialSource>
         }
         catch (NameGenerator.NameGenerationException e)
         {
-            throw new ExperimentException("Failed to generate name for Sample", e);
+            throw new ExperimentException("Failed to generate name for sample.", e);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTableImpl.java
@@ -64,11 +64,16 @@ public class ExpSampleTypeTableImpl extends ExpTableImpl<ExpSampleTypeTable.Colu
             case MaterialLSIDPrefix:
             case Name:
             case LabelColor:
-            case MetricUnit:
             case AutoLinkTargetContainer:
             case AutoLinkCategory:
             case RowId:
                 return wrapColumn(alias, _rootTable.getColumn(column.toString()));
+            case MetricUnit:
+            {
+                var columnInfo = wrapColumn(alias, _rootTable.getColumn(column.toString()));
+                columnInfo.setLabel("Display Units");
+                return columnInfo;
+            }
             case Created:
                 return wrapColumn(alias, _rootTable.getColumn("Created"));
             case CreatedBy:

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
@@ -390,7 +390,7 @@ public void idColsSet_nameExpressionNull_hasNameProperty() throws Exception
     errors = new BatchValidationException();
     svc.insertRows(user, c, rows, errors, null, null);
     assertTrue(errors.hasErrors());
-    assertTrue(errors.getMessage().contains("SampleID or Name is required for sample on row 1"));
+    assertTrue(errors.getMessage().contains("SampleID or Name is required for sample"));
 }
 
 // idCols not null, nameExpression not null, 'name' property (not used) -- fail

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -106,7 +106,6 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.MetadataUnavailableException;
 import org.labkey.api.query.QueryChangeListener;
-import org.labkey.api.query.QueryKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.SimpleValidationError;
@@ -145,7 +144,6 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
@@ -180,7 +178,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     public static final String ROOT_SAMPLE_COUNT_SEQ_NAME = "org.labkey.api.exp.api.ExpMaterial:rootSampleCount";
 
     public static final List<Unit> SUPPORTED_UNITS = new ArrayList<>();
-    public static final String CONVERSION_EXCEPTION_MESSAGE ="Units value (%s) is not compatible with the display units (%s).";
+    public static final String CONVERSION_EXCEPTION_MESSAGE ="Units value (%s) is not compatible with the %s display units (%s).";
 
     static
     {
@@ -223,15 +221,14 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         return materialSourceCache;
     }
 
-
-    @Override
+    @Override @NotNull
     public List<Unit> getSupportedUnits()
     {
         return SUPPORTED_UNITS;
     }
 
     @Nullable @Override
-    public Unit getValidatedUnit(@Nullable Object rawUnits, @Nullable Unit defaultUnits)
+    public Unit getValidatedUnit(@Nullable Object rawUnits, @Nullable Unit defaultUnits, String sampleTypeName)
     {
         if (rawUnits == null)
             return null;
@@ -240,12 +237,12 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             if (defaultUnits == null)
                 return u;
             else if (u.getKindOfQuantity() != defaultUnits.getKindOfQuantity())
-                throw new ConversionExceptionWithMessage(String.format(CONVERSION_EXCEPTION_MESSAGE, rawUnits, defaultUnits));
+                throw new ConversionExceptionWithMessage(String.format(CONVERSION_EXCEPTION_MESSAGE, rawUnits, sampleTypeName == null ? "" : sampleTypeName, defaultUnits));
             else
                 return u;
         }
         if (!(rawUnits instanceof String rawUnitsString))
-            throw new ConversionExceptionWithMessage(String.format(CONVERSION_EXCEPTION_MESSAGE, rawUnits, defaultUnits));
+            throw new ConversionExceptionWithMessage(String.format(CONVERSION_EXCEPTION_MESSAGE, rawUnits, sampleTypeName == null ? "" : sampleTypeName, defaultUnits));
         if (!StringUtils.isBlank(rawUnitsString))
         {
             rawUnitsString = rawUnitsString.trim();
@@ -257,7 +254,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
                 throw new ConversionExceptionWithMessage("Unsupported Units value (" + rawUnitsString + ").  Supported values are: " + StringUtils.join(commonUnits, ", ") + ".");
             }
             if (defaultUnits != null && mUnit.getKindOfQuantity() != defaultUnits.getKindOfQuantity())
-                throw new ConversionExceptionWithMessage(String.format(CONVERSION_EXCEPTION_MESSAGE, rawUnits, defaultUnits));
+                throw new ConversionExceptionWithMessage(String.format(CONVERSION_EXCEPTION_MESSAGE, rawUnits, sampleTypeName == null ? "" : sampleTypeName, defaultUnits));
             return mUnit;
         }
         return null;
@@ -2329,9 +2326,9 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             SampleTypeService service = SampleTypeService.get();
             try
             {
-                service.getValidatedUnit("g", Unit.mg);
-                service.getValidatedUnit("g ", Unit.mg);
-                service.getValidatedUnit(" g ", Unit.mg);
+                service.getValidatedUnit("g", Unit.mg, "Sample Type");
+                service.getValidatedUnit("g ", Unit.mg, "Sample Type");
+                service.getValidatedUnit(" g ", Unit.mg, "Sample Type");
             }
             catch (ConversionExceptionWithMessage e)
             {
@@ -2339,7 +2336,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             }
             try
             {
-                assertNull(service.getValidatedUnit(null, Unit.unit));
+                assertNull(service.getValidatedUnit(null, Unit.unit, "Sample Type"));
             }
             catch (ConversionExceptionWithMessage e)
             {
@@ -2347,7 +2344,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             }
             try
             {
-                assertNull(service.getValidatedUnit("", Unit.unit));
+                assertNull(service.getValidatedUnit("", Unit.unit, "Sample Type"));
             }
             catch (ConversionExceptionWithMessage e)
             {
@@ -2355,7 +2352,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             }
             try
             {
-                service.getValidatedUnit("g", Unit.unit);
+                service.getValidatedUnit("g", Unit.unit, "Sample Type");
                 fail("Units that are not comparable should throw exception.");
             }
             catch (ConversionExceptionWithMessage ignore)
@@ -2365,7 +2362,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
             try
             {
-                service.getValidatedUnit("nonesuch", Unit.unit);
+                service.getValidatedUnit("nonesuch", Unit.unit, "Sample Type");
                 fail("Invalid units should throw exception.");
             }
             catch (ConversionExceptionWithMessage ignore)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -23,6 +23,8 @@ import org.apache.commons.math3.util.Precision;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+import org.junit.Test;
 import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.audit.AbstractAuditHandler;
 import org.labkey.api.audit.AbstractAuditTypeProvider;
@@ -42,6 +44,7 @@ import org.labkey.api.data.AuditConfigurable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.ConversionExceptionWithMessage;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DbSequence;
@@ -93,6 +96,7 @@ import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.inventory.InventoryService;
 import org.labkey.api.miniprofiler.MiniProfiler;
 import org.labkey.api.miniprofiler.Timing;
+import org.labkey.api.ontology.KindOfQuantity;
 import org.labkey.api.ontology.Quantity;
 import org.labkey.api.ontology.Unit;
 import org.labkey.api.qc.DataState;
@@ -175,6 +179,16 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     public static final String SAMPLE_COUNT_SEQ_NAME = "org.labkey.api.exp.api.ExpMaterial:sampleCount";
     public static final String ROOT_SAMPLE_COUNT_SEQ_NAME = "org.labkey.api.exp.api.ExpMaterial:rootSampleCount";
 
+    public static final List<Unit> SUPPORTED_UNITS = new ArrayList<>();
+    public static final String CONVERSION_EXCEPTION_MESSAGE ="Units value (%s) is not compatible with the display units (%s).";
+
+    static
+    {
+        SUPPORTED_UNITS.addAll(KindOfQuantity.Volume.getCommonUnits());
+        SUPPORTED_UNITS.addAll(KindOfQuantity.Mass.getCommonUnits());
+        SUPPORTED_UNITS.addAll(KindOfQuantity.Count.getCommonUnits());
+    }
+
     // columns that may appear in a row when only the sample status is updating.
     public static final Set<String> statusUpdateColumns = Set.of(
             ExpMaterialTable.Column.Modified.name().toLowerCase(),
@@ -203,11 +217,51 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         return Collections.unmodifiableSortedSet(new TreeSet<>(new TableSelector(getTinfoMaterialSource(), filter, null).getCollection(MaterialSource.class)));
     });
 
+
     Cache<String, SortedSet<MaterialSource>> getMaterialSourceCache()
     {
         return materialSourceCache;
     }
 
+
+    @Override
+    public List<Unit> getSupportedUnits()
+    {
+        return SUPPORTED_UNITS;
+    }
+
+    @Nullable @Override
+    public Unit getValidatedUnit(@Nullable Object rawUnits, @Nullable Unit defaultUnits)
+    {
+        if (rawUnits == null)
+            return null;
+        if (rawUnits instanceof Unit u)
+        {
+            if (defaultUnits == null)
+                return u;
+            else if (u.getKindOfQuantity() != defaultUnits.getKindOfQuantity())
+                throw new ConversionExceptionWithMessage(String.format(CONVERSION_EXCEPTION_MESSAGE, rawUnits, defaultUnits));
+            else
+                return u;
+        }
+        if (!(rawUnits instanceof String rawUnitsString))
+            throw new ConversionExceptionWithMessage(String.format(CONVERSION_EXCEPTION_MESSAGE, rawUnits, defaultUnits));
+        if (!StringUtils.isBlank(rawUnitsString))
+        {
+            rawUnitsString = rawUnitsString.trim();
+
+            Unit mUnit = Unit.fromName(rawUnitsString);
+            List<Unit> commonUnits = getSupportedUnits();
+            if (mUnit == null || !commonUnits.contains(mUnit))
+            {
+                throw new ConversionExceptionWithMessage("Unsupported Units value (" + rawUnitsString + ").  Supported values are: " + StringUtils.join(commonUnits, ", ") + ".");
+            }
+            if (defaultUnits != null && mUnit.getKindOfQuantity() != defaultUnits.getKindOfQuantity())
+                throw new ConversionExceptionWithMessage(String.format(CONVERSION_EXCEPTION_MESSAGE, rawUnits, defaultUnits));
+            return mUnit;
+        }
+        return null;
+    }
 
     public void clearMaterialSourceCache(@Nullable Container c)
     {
@@ -2264,5 +2318,61 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     public void refreshSampleTypeMaterializedView(@NotNull ExpSampleType st, SampleChangeType reason)
     {
         ExpMaterialTableImpl.refreshMaterializedView(st.getLSID(), reason);
+    }
+
+
+    public static class TestCase extends Assert
+    {
+        @Test
+        public void testGetValidatedUnit()
+        {
+            SampleTypeService service = SampleTypeService.get();
+            try
+            {
+                service.getValidatedUnit("g", Unit.mg);
+                service.getValidatedUnit("g ", Unit.mg);
+                service.getValidatedUnit(" g ", Unit.mg);
+            }
+            catch (ConversionExceptionWithMessage e)
+            {
+                fail("Compatible unit should not throw exception.");
+            }
+            try
+            {
+                assertNull(service.getValidatedUnit(null, Unit.unit));
+            }
+            catch (ConversionExceptionWithMessage e)
+            {
+                fail("null units should be null");
+            }
+            try
+            {
+                assertNull(service.getValidatedUnit("", Unit.unit));
+            }
+            catch (ConversionExceptionWithMessage e)
+            {
+                fail("empty units should be null");
+            }
+            try
+            {
+                service.getValidatedUnit("g", Unit.unit);
+                fail("Units that are not comparable should throw exception.");
+            }
+            catch (ConversionExceptionWithMessage ignore)
+            {
+
+            }
+
+            try
+            {
+                service.getValidatedUnit("nonesuch", Unit.unit);
+                fail("Invalid units should throw exception.");
+            }
+            catch (ConversionExceptionWithMessage ignore)
+            {
+
+            }
+
+        }
     }
 }

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -148,8 +148,8 @@ import static org.labkey.api.exp.api.ExperimentService.QueryOptions.SkipBulkRema
 import static org.labkey.api.exp.api.SampleTypeDomainKind.ALIQUOT_ROLLUP_FIELD_LABELS;
 import static org.labkey.api.exp.api.SampleTypeService.ConfigParameters.SkipAliquotRollup;
 import static org.labkey.api.exp.api.SampleTypeService.ConfigParameters.SkipMaxSampleCounterFunction;
-import static org.labkey.api.exp.api.SampleTypeService.MISSING_COLUMN_ERROR_MESSAGE_PATTERN;
-import static org.labkey.api.exp.api.SampleTypeService.MISSING_COLUMN_VALUE_ERROR_MESSAGE_PATTERN;
+import static org.labkey.api.exp.api.SampleTypeService.MISSING_AMOUNT_ERROR_MESSAGE;
+import static org.labkey.api.exp.api.SampleTypeService.MISSING_UNITS_ERROR_MESSAGE;
 import static org.labkey.api.exp.api.SampleTypeService.UNPROVIDED_VALUE_ERROR_MESSAGE_PATTERN;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.AliquotCount;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.AliquotVolume;
@@ -534,9 +534,9 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         if (hasUnits == hasAmount)
             return; // both columns are present or neither is
         if (!hasAmount)
-            throw new ConversionExceptionWithMessage(String.format(MISSING_COLUMN_ERROR_MESSAGE_PATTERN, StoredAmount.label(), Units.name()));
+            throw new ConversionExceptionWithMessage(MISSING_AMOUNT_ERROR_MESSAGE);
 
-        throw new ConversionExceptionWithMessage(String.format(MISSING_COLUMN_ERROR_MESSAGE_PATTERN, Units.name(), StoredAmount.label()));
+        throw new ConversionExceptionWithMessage(MISSING_UNITS_ERROR_MESSAGE);
     }
 
     @Override
@@ -2046,7 +2046,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
                 // when there's a units value but no amount column, this is an error
                 if (!haveAmountCol)
-                    throw new ConversionExceptionWithMessage(String.format(MISSING_COLUMN_VALUE_ERROR_MESSAGE_PATTERN, StoredAmount.label(), Units.name()));
+                    throw new ConversionExceptionWithMessage(MISSING_AMOUNT_ERROR_MESSAGE);
 
                 // When an amount column is present but no amount value is provided, this is an error
                 if (amountObj == null || ((amountObj instanceof String) && ((String) amountObj).isEmpty()))
@@ -2083,7 +2083,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
                 // When there is an amount value, if there isn't a units column, this is an error.
                 if (!hasUnitsCol)
-                    throw new ConversionExceptionWithMessage(String.format(MISSING_COLUMN_VALUE_ERROR_MESSAGE_PATTERN, Units.name(), StoredAmount.label()));
+                    throw new ConversionExceptionWithMessage(MISSING_UNITS_ERROR_MESSAGE);
 
                 // Have a units column, but no units value
                 if (unitsObj == null || ((unitsObj instanceof String) && ((String) unitsObj).trim().isEmpty()))

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -665,11 +665,11 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             Object value = entry.getValue();
             if (col != null && col == unitsCol)
             {
-                value = _SamplesCoerceDataIterator.SampleUnitsConvertColumn.getValue(unitsVal, amountVal, amountCol != null, baseUnit);
+                value = _SamplesCoerceDataIterator.SampleUnitsConvertColumn.getValue(unitsVal, amountVal, amountCol != null, baseUnit, _sampleType == null ? null : _sampleType.getName());
             }
             else if (col != null && col == amountCol)
             {
-                value = _SamplesCoerceDataIterator.SampleAmountConvertColumn.getValue(amountVal, unitsCol != null, unitsVal, baseUnit);
+                value = _SamplesCoerceDataIterator.SampleAmountConvertColumn.getValue(amountVal, unitsCol != null, unitsVal, baseUnit, _sampleType == null ? null : _sampleType.getName());
             }
             else if (col != null && value != null &&
                     !col.getJavaObjectClass().isInstance(value) &&
@@ -875,8 +875,8 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
 
             if (row.containsKey(StoredAmount.name()) || row.containsKey(Units.name()))
             {
-                Unit oldRowUnits = stService.getValidatedUnit(oldRow.get(Units.name()), _sampleType.getBaseUnit());
-                Unit rowUnits = stService.getValidatedUnit(row.get(Units.name()), _sampleType.getBaseUnit());
+                Unit oldRowUnits = stService.getValidatedUnit(oldRow.get(Units.name()), _sampleType.getBaseUnit(), _sampleType.getName());
+                Unit rowUnits = stService.getValidatedUnit(row.get(Units.name()), _sampleType.getBaseUnit(), _sampleType.getName());
                 Quantity oldQuantity = null;
                 Quantity newQuantity = null;
                 if (oldRowUnits != null && oldRow.get(StoredAmount.name()) != null)
@@ -2037,7 +2037,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             }
 
             // This should return the base unit if we have one for the sample type since we are storing all data in the base unit
-            public static Object getValue(Object o, Object amountObj, boolean haveAmountCol, Unit baseUnit)
+            public static Object getValue(Object o, Object amountObj, boolean haveAmountCol, Unit baseUnit, String sampleTypeName)
             {
                 if (o == null || ((o instanceof String) && ((String) o).isEmpty()))
                 {
@@ -2053,7 +2053,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                     throw new ConversionExceptionWithMessage(String.format(UNPROVIDED_VALUE_ERROR_MESSAGE_PATTERN,  StoredAmount.label(), Units.name(), o));
 
 
-                Unit validatedUnit = SampleTypeService.get().getValidatedUnit(o, baseUnit);
+                Unit validatedUnit = SampleTypeService.get().getValidatedUnit(o, baseUnit, sampleTypeName);
                 // if there's a base unit, return the base unit name otherwise return the name of the given unit
                 return validatedUnit == null ? null : baseUnit != null ? baseUnit.name() : validatedUnit.name();
             }
@@ -2061,7 +2061,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             @Override
             protected Object convert(Object o)
             {
-                return getValue(o, _storedAmountColInd == -1 ? null : _data.get(_storedAmountColInd), _storedAmountColInd != -1, _sampleTypeBaseUnit);
+                return getValue(o, _storedAmountColInd == -1 ? null : _data.get(_storedAmountColInd), _storedAmountColInd != -1, _sampleTypeBaseUnit, _sampleType.getName());
             }
         }
 
@@ -2076,7 +2076,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             }
 
             // This should return a Number in the base units of the sample type.
-            public static Object getValue(Object amountObj, boolean hasUnitsCol, Object unitsObj, Unit displayUnit)
+            public static Object getValue(Object amountObj, boolean hasUnitsCol, Object unitsObj, Unit displayUnit, @Nullable String sampleTypeName)
             {
                 if (amountObj == null || ((amountObj instanceof String) && ((String) amountObj).trim().isEmpty()))
                     return null;
@@ -2093,7 +2093,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                     throw new ConversionExceptionWithMessage(String.format(UNPROVIDED_VALUE_ERROR_MESSAGE_PATTERN , Units.name(), StoredAmount.label(), amountObj));
                 }
 
-                Unit unit = SampleTypeService.get().getValidatedUnit(unitsObj, displayUnit);
+                Unit unit = SampleTypeService.get().getValidatedUnit(unitsObj, displayUnit, sampleTypeName);
 
                 // Should always be non-null at this point.
                 if (unit != null && displayUnit != null)
@@ -2118,7 +2118,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             @Override
             protected Object convert(Object amountObj)
             {
-                return getValue(amountObj, _unitsColInd != -1, _unitsColInd == -1 ? null : _data.get(_unitsColInd), _sampleTypeBaseUnit);
+                return getValue(amountObj, _unitsColInd != -1, _unitsColInd == -1 ? null : _data.get(_unitsColInd), _sampleTypeBaseUnit, _sampleType.getName());
             }
         }
 

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -868,15 +868,15 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
         boolean isAliquot = !StringUtils.isEmpty(oldAliquotedFromLSID);
 
         Integer aliquotRollupRoot = null;
-
+        SampleTypeService stService = SampleTypeService.get();
         if (!_sampleType.isMedia() && isAliquot)
         {
             Integer aliquotRoot = (Integer) oldRow.get(RootMaterialRowId.name());
 
             if (row.containsKey(StoredAmount.name()) || row.containsKey(Units.name()))
             {
-                Unit oldRowUnits = Unit.getValidatedUnit(oldRow.get(Units.name()), _sampleType.getBaseUnit());
-                Unit rowUnits = Unit.getValidatedUnit(row.get(Units.name()), _sampleType.getBaseUnit());
+                Unit oldRowUnits = stService.getValidatedUnit(oldRow.get(Units.name()), _sampleType.getBaseUnit());
+                Unit rowUnits = stService.getValidatedUnit(row.get(Units.name()), _sampleType.getBaseUnit());
                 Quantity oldQuantity = null;
                 Quantity newQuantity = null;
                 if (oldRowUnits != null && oldRow.get(StoredAmount.name()) != null)
@@ -1828,14 +1828,15 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             catch (NameGenerator.NameGenerationException e)
             {
                 // Failed to generate a name due to some part of the expression not in the row
+                String rowText = _context.isCrossFolderImport() || _context.isCrossTypeImport() ? "" : " on row " + e.getRowNumber();
                 if (isAliquot)
-                    addRowError("Failed to generate name for aliquot on row " + e.getRowNumber() + " using aliquot naming pattern " + _sampleType.getAliquotNameExpression() + ". Check the syntax of the aliquot naming pattern and the data values for the aliquot.");
+                    addRowError("Failed to generate name for aliquot " + rowText + " using aliquot naming pattern " + _sampleType.getAliquotNameExpression() + ". Check the syntax of the aliquot naming pattern and the data values for the aliquot.");
                 else if (_sampleType.hasNameExpression())
-                    addRowError("Failed to generate name for sample on row " + e.getRowNumber() + " using naming pattern " + _sampleType.getNameExpression() + ". Check the syntax of the naming pattern and the data values for the sample.");
+                    addRowError("Failed to generate name for sample " + rowText + " using naming pattern " + _sampleType.getNameExpression() + ". Check the syntax of the naming pattern and the data values for the sample.");
                 else if (_sampleType.hasNameAsIdCol())
-                    addRowError("SampleID or Name is required for sample on row " + e.getRowNumber());
+                    addRowError("SampleID or Name is required for sample " + rowText + ".");
                 else
-                    addRowError("All id columns are required for sample on row " + e.getRowNumber());
+                    addRowError("All id columns are required for sample " + rowText + ".");
             }
         }
 
@@ -2052,7 +2053,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                     throw new ConversionExceptionWithMessage(String.format(UNPROVIDED_VALUE_ERROR_MESSAGE_PATTERN,  StoredAmount.label(), Units.name(), o));
 
 
-                Unit validatedUnit = Unit.getValidatedUnit(o, baseUnit);
+                Unit validatedUnit = SampleTypeService.get().getValidatedUnit(o, baseUnit);
                 // if there's a base unit, return the base unit name otherwise return the name of the given unit
                 return validatedUnit == null ? null : baseUnit != null ? baseUnit.name() : validatedUnit.name();
             }
@@ -2092,7 +2093,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                     throw new ConversionExceptionWithMessage(String.format(UNPROVIDED_VALUE_ERROR_MESSAGE_PATTERN , Units.name(), StoredAmount.label(), amountObj));
                 }
 
-                Unit unit = Unit.getValidatedUnit(unitsObj, displayUnit);
+                Unit unit = SampleTypeService.get().getValidatedUnit(unitsObj, displayUnit);
 
                 // Should always be non-null at this point.
                 if (unit != null && displayUnit != null)


### PR DESCRIPTION
#### Rationale
- [Issue 53975: Edit in bulk messaging for Amounts & Units improvement](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53975)
- [Issue 53963: Cross-sample-type import gives incorrect row number in message for name expression problems](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53963)
- [Issue 53955: Error message for invalid units value omits "ug"](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53955)
- [Issue 53961: Inconsistent name: Metric Unit/Amount Display Units](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53961)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/823
- https://github.com/LabKey/testAutomation/pull/2705

#### Changes
- Consolidate to a single error message for missing amount or units values or fields
- Move `getSupportedUnits` and `getValidatedUnit` to `SampleTypeService` and update validated unit logic
- Update error messaging related to name expression problems to exclude row numbers
- Add label for `ExpSampleType.MetricUnit` column
