### PR TITLE
Clear up more code scan warnings

### DIFF
--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -1251,7 +1251,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
 
     protected File computeResourceDirectory()
     {
-        // We load resources from the module's source directory if all of the following conditions are true:
+        // We load resources from the module's source directory if all the following conditions are true:
         //
         // - devmode = true
         // - The module's source path is a directory that exists on the web server

--- a/api/src/org/labkey/api/module/ModuleLoader.java
+++ b/api/src/org/labkey/api/module/ModuleLoader.java
@@ -1346,7 +1346,7 @@ public class ModuleLoader implements MemTrackerListener, ShutdownListener
     public @Nullable String loadEnlistmentId(File directory)
     {
         String enlistmentId = null;
-        File file = new File(directory, "enlistment.properties");
+        File file = FileUtil.appendName(directory, "enlistment.properties");
 
         if (file.exists())
         {

--- a/assay/src/org/labkey/assay/plate/view/plateList.jsp
+++ b/assay/src/org/labkey/assay/plate/view/plateList.jsp
@@ -91,8 +91,7 @@
         createPlateTemplate = function(){
 
             let template = document.querySelector('#plate_template');
-            // Ensure it's a relative URL before redirecting
-            if (template && template.value.startsWith("/")){
+            if (template) {
                 window.location = template.value;
             }
         };
@@ -228,7 +227,7 @@
         index++;
     }
 
-    if (plates == null || plates.isEmpty())
+    if (plates.isEmpty())
     {
 %>
         <tr><td colspan="2" style="padding: 3px;">No plates available.</td></tr>

--- a/assay/src/org/labkey/assay/plate/view/plateList.jsp
+++ b/assay/src/org/labkey/assay/plate/view/plateList.jsp
@@ -36,6 +36,7 @@
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="org.json.JSONArray" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 
@@ -88,11 +89,10 @@
             });
         };
 
-        createPlateTemplate = function(){
-
+        createPlateTemplate = function() {
             let template = document.querySelector('#plate_template');
-            if (template) {
-                window.location = template.value;
+            if (template && templateUrls[template.value]) {
+                window.location = templateUrls[template.value];
             }
         };
 
@@ -107,6 +107,7 @@
 <%
     if (isAssayDesigner || c.hasPermission(getUser(), InsertPermission.class))
     {
+        JSONArray urls = new JSONArray();
         List<Option> options = new ArrayList<>();
         for (PlateManager.PlateLayout layout : PlateManager.get().getPlateLayouts())
         {
@@ -120,8 +121,9 @@
 
             options.add(new OptionBuilder()
                     .label("new " + layout.description() + " template")
-                    .value(designerURL.toString())
+                    .value(urls.length())
                     .build());
+            urls.put(designerURL.toString());
         }
 %>
 <h4>Create New Plate</h4>
@@ -136,6 +138,10 @@
     %>
     <labkey:button text="create" submit="false" onclick="createPlateTemplate();" id="create-btn"/>
 </labkey:form>
+
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    const templateUrls = <%= urls %>;
+</script>
 <%
     }
 %>

--- a/core/src/org/labkey/core/admin/logger/manage.jsp
+++ b/core/src/org/labkey/core/admin/logger/manage.jsp
@@ -194,7 +194,7 @@
 
         return "<tr class='logger-row' " + (visible ? "" : " style='display:none;'") +
                 "data-name='" + LABKEY.Utils.encodeHtml(logger.name) + "' data-level='" + LABKEY.Utils.encodeHtml(logger.level) + "' data-inherited='" + logger.inherited + "' data-parent='" + LABKEY.Utils.encodeHtml(logger.parent) + "' data-notes='" + LABKEY.Utils.encodeHtml(logger.notes) + "'>" +
-                "<td class='" + (inherited ? 'level-inherited' : 'level-configured') + " level-" + logger.level + "'>" +
+                "<td class='" + (inherited ? 'level-inherited' : 'level-configured') + " level-" + LABKEY.Utils.encodeHtml(logger.level) + "'>" +
                 logger.level +
                 "</td>" +
                 "<td>" + (logger.name === 'null' ? '&lt;root&gt;' : LABKEY.Utils.encodeHtml(logger.name)) + "</td>" +

--- a/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/DomainPropertyImpl.java
@@ -862,7 +862,8 @@ public class DomainPropertyImpl implements DomainProperty
                     StorageProvisionerImpl.get().changePropertyType(this.getDomain(), this);
                     if (_pdOld.getJdbcType() == JdbcType.BOOLEAN && _pd.getJdbcType().isText())
                     {
-                        updateBooleanValue(_domain.getDomainKind().getStorageSchemaName() + "." + _domain.getStorageTableName(),
+                        updateBooleanValue(
+                                new SQLFragment().appendIdentifier(_domain.getDomainKind().getStorageSchemaName()).append(".").appendIdentifier(_domain.getStorageTableName()),
                                 _pd.getLegalSelectName(dialect), _pdOld.getFormat(), null); // GH Issue 755
                     }
                 }
@@ -917,7 +918,7 @@ public class DomainPropertyImpl implements DomainProperty
 
             if (changedType && _pdOld.getJdbcType() == JdbcType.BOOLEAN && _pd.getJdbcType().isText())
             {
-                updateBooleanValue(OntologyManager.getTinfoObjectProperty().getSelectName(), dialect.makeDatabaseIdentifier("StringValue"), _pdOld.getFormat(), new SQLFragment("PropertyId = ?", _pdOld.getPropertyId()));
+                updateBooleanValue(OntologyManager.getTinfoObjectProperty().getSQLName(), dialect.makeDatabaseIdentifier("StringValue"), _pdOld.getFormat(), new SQLFragment("PropertyId = ?", _pdOld.getPropertyId()));
             }
         }
         else
@@ -945,7 +946,7 @@ public class DomainPropertyImpl implements DomainProperty
      * Postgres will now have 'true' and 'false', and SQLServer will have '0' and '1'. Use the format string to use the
      * preferred format, and standardize on 'true' and 'false' in the absence of an explicitly configured format.
      */
-    private void updateBooleanValue(String schemaTable, DatabaseIdentifier column, String formatString, @Nullable SQLFragment whereClause)
+    private void updateBooleanValue(SQLFragment schemaTable, DatabaseIdentifier column, String formatString, @Nullable SQLFragment whereClause)
     {
         BooleanFormat f = BooleanFormat.getInstance(formatString);
         String trueValue = StringUtils.trimToNull(f.format(true));


### PR DESCRIPTION
#### Rationale
Handle known safe values in a way that doesn't need to assume they're safe when building HTML and SQL.

#### Changes
- Additional encoding and escaping
- Don't pass the redirect URL for plate templates directly through the DOM

#### Tasks 📍
- [x] Manual Testing
  - [x] Admin Console->Loggers. Make sure you can filter the list by name. Make sure that editing a log level sticks
  - [x] Create a Nab assay design. In the assay designer, click the Configure Templates link. Select a template and click Create. Be sure you're sent to the right place for that template (testing blank vs 96-well vs 384-well is good)