### PR TITLE
Remove deprecated methods from SQLFragment

### DIFF
--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -1346,13 +1346,4 @@ public class SQLFragment implements Appendable, CharSequence
 
         return new SQLFragment(sql, params);
     }
-
-
-
-    /* REMOVE THIS - These methods are going away, but this allows us to merge w/o doing 100 modules at the same time */
-//    @Deprecated public SQLFragment append(@NotNull Container c) {return appendValue(c);}
-    @Deprecated public SQLFragment append(Integer i) {return appendValue(i);}
-//    @Deprecated public SQLFragment append(java.util.Date date) {return appendValue(date);}
-    @Deprecated public SQLFragment appendStringLiteral(CharSequence s) {return appendValue(s);}
-    /* END OF REMOVE THIS */
 }

--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -17,6 +17,7 @@
 package org.labkey.api.data;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
@@ -207,11 +208,11 @@ public class SQLFragment implements Appendable, CharSequence
             CTE cte = pair.second;
             for (String token : cte.tokens)
             {
-                select = StringUtils.replace(select, token, alias);
+                select = Strings.CS.replace(select, token, alias);
             }
         }
         if (null != self)
-            select = StringUtils.replace(select, "$SELF$", self);
+            select = Strings.CS.replace(select, "$SELF$", self);
         return select;
     }
 
@@ -409,11 +410,6 @@ public class SQLFragment implements Appendable, CharSequence
         return this;
     }
 
-    @Deprecated
-    public SQLFragment append(DatabaseIdentifier id)
-    {
-        return append(id.getSql());
-    }
     public SQLFragment appendIdentifier(DatabaseIdentifier id)
     {
         return append(id.getSql());
@@ -599,12 +595,11 @@ public class SQLFragment implements Appendable, CharSequence
 
         if (N instanceof BigDecimal || N instanceof BigInteger || N instanceof Long)
         {
-            getStringBuilder().append(String.valueOf(N));
+            getStringBuilder().append(N);
         }
         else if (Double.isFinite(N.doubleValue()))
         {
-            // Do we know that default java toString() for all numbers creates a valid SQL literal?
-            getStringBuilder().append(String.valueOf(N));
+            getStringBuilder().append(N);
         }
         else
         {

--- a/query/src/org/labkey/query/sql/SqlBuilder.java
+++ b/query/src/org/labkey/query/sql/SqlBuilder.java
@@ -88,13 +88,6 @@ public class SqlBuilder extends Builder
         return super.appendValue(s, _dialect);
     }
 
-//    @Override
-    @Override
-    public SQLFragment appendStringLiteral(CharSequence s)
-    {
-        return super.appendStringLiteral(s, _dialect);
-    }
-
     @Override
     public SQLFragment appendStringLiteral(CharSequence s, @NotNull SqlDialect d)
     {

--- a/specimen/src/org/labkey/specimen/importer/SpecimenImporter.java
+++ b/specimen/src/org/labkey/specimen/importer/SpecimenImporter.java
@@ -1215,7 +1215,7 @@ public class SpecimenImporter extends SpecimenTableManager
             SQLFragment cols = new SQLFragment();
             for (SpecimenColumn col : getVialCols(availableColumns))
             {
-                cols.append(sep).append(col.getLegalDbColumnName(getSqlDialect()));
+                cols.append(sep).appendIdentifier(col.getLegalDbColumnName(getSqlDialect()));
                 sep = ",\n   ";
             }
             _vialColsSql = cols;
@@ -1246,7 +1246,7 @@ public class SpecimenImporter extends SpecimenTableManager
             SQLFragment cols = new SQLFragment();
             for (SpecimenColumn col : getSpecimenEventCols(availableColumns))
             {
-                cols.append(sep).append(col.getLegalDbColumnName(getSqlDialect()));
+                cols.append(sep).appendIdentifier(col.getLegalDbColumnName(getSqlDialect()));
                 sep = ",\n    ";
             }
             _vialEventColsSql = cols;
@@ -1422,7 +1422,7 @@ public class SpecimenImporter extends SpecimenTableManager
             {
                 if (null != castColumn)
                 {
-                    sql.append(" COUNT(DISTINCT ").append(tempTableName).append(".").append(castColumn.getLegalDbColumnName(getSqlDialect())).append(") = 1 THEN ");
+                    sql.append(" COUNT(DISTINCT ").append(tempTableName).append(".").appendIdentifier(castColumn.getLegalDbColumnName(getSqlDialect())).append(") = 1 THEN ");
                     sql.append("CAST(MIN(").append(selectCol).append(") AS ").append(castColumn.getDbType()).append(")");
                 }
                 else
@@ -1436,9 +1436,9 @@ public class SpecimenImporter extends SpecimenTableManager
         sql.append(" AS ");
 
         if (null != castColumn)
-            sql.append(castColumn.getLegalDbColumnName(getSqlDialect()));
+            sql.appendIdentifier(castColumn.getLegalDbColumnName(getSqlDialect()));
         else
-            sql.append(col.getLegalDbColumnName(getSqlDialect()));
+            sql.appendIdentifier(col.getLegalDbColumnName(getSqlDialect()));
     }
 
 
@@ -1591,7 +1591,7 @@ public class SpecimenImporter extends SpecimenTableManager
             .add(Boolean.TRUE);
 
         for (SpecimenColumn col : getVialCols(info.getAvailableColumns()))
-            insertSelectSql.append(prefix).append("VialList.").append(col.getLegalDbColumnName(getSqlDialect()));
+            insertSelectSql.append(prefix).append("VialList.").appendIdentifier(col.getLegalDbColumnName(getSqlDialect()));
 
         insertSelectSql
             .append(" FROM (").append(getVialListFromTempTableSql(info, false, seenVisitValue))
@@ -2412,10 +2412,10 @@ public class SpecimenImporter extends SpecimenTableManager
         {
             if (col.getFkTable() != null)
             {
-                remapExternalIdsSql.append(sep).append(col.getLegalDbColumnName(getSqlDialect())).append(" = (SELECT RowId FROM ")
+                remapExternalIdsSql.append(sep).appendIdentifier(col.getLegalDbColumnName(getSqlDialect())).append(" = (SELECT RowId FROM ")
                         .append(getTableInfoFromFkTableName(col.getFkTable()).getSelectName()).append(" ").append(col.getFkTableAlias())
                         .append(" WHERE ").append("(").append(tempTable).append(".")
-                        .append(col.getLegalDbColumnName(getSqlDialect())).append(" = ").append(col.getFkTableAlias()).append(".").append(col.getFkColumn())
+                        .appendIdentifier(col.getLegalDbColumnName(getSqlDialect())).append(" = ").append(col.getFkTableAlias()).append(".").append(col.getFkColumn())
                         .append("))");
                 sep = ",\n\t";
             }
@@ -2610,7 +2610,7 @@ public class SpecimenImporter extends SpecimenTableManager
                     conflictResolvingSubselect.append(singletonAggregate);
                     conflictResolvingSubselect.append(" ELSE NULL END");
                 }
-                conflictResolvingSubselect.append(" AS ").append(col.getLegalDbColumnName(getSqlDialect()));
+                conflictResolvingSubselect.append(" AS ").appendIdentifier(col.getLegalDbColumnName(getSqlDialect()));
             }
         }
         conflictResolvingSubselect.append("\nFROM ").append(tempTableName).append("\nGROUP BY GlobalUniqueId");


### PR DESCRIPTION
#### Rationale
Deprecation is good, removal is even better.

#### Changes
- Get rid of `append(Integer)` and `appendStringLiteral(CharSequence)`

#### Tasks 📍
- Manual Testing - N/A
- Needs Automation - N/A
