### PR TITLE
Issue 54025: Issues with search scope when referencing notebooks from a subfolder

### DIFF
--- a/api/src/org/labkey/api/search/NoopSearchService.java
+++ b/api/src/org/labkey/api/search/NoopSearchService.java
@@ -29,6 +29,7 @@ import org.labkey.api.view.WebPartView;
 import org.labkey.api.webdav.WebdavResource;
 
 import java.io.Reader;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -198,6 +199,12 @@ public class NoopSearchService implements SearchService
 
     @Override
     public boolean drainQueue(@NotNull PRIORITY priority, long timeout, @NotNull TimeUnit unit)
+    {
+        return true;
+    }
+
+    @Override
+    public boolean waitForStart(@NotNull Duration timeout)
     {
         return true;
     }

--- a/api/src/org/labkey/api/search/NoopSearchService.java
+++ b/api/src/org/labkey/api/search/NoopSearchService.java
@@ -204,9 +204,8 @@ public class NoopSearchService implements SearchService
     }
 
     @Override
-    public boolean waitForStart(@NotNull Duration timeout)
+    public void addStartupListener(@NotNull SearchStartupListener listener)
     {
-        return true;
     }
 
     @Override

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -55,6 +55,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -125,6 +126,13 @@ public interface SearchService extends SearchMXBean
      * @return true if the task in the queue completed before the timeout
      */
     boolean drainQueue(@NotNull PRIORITY priority, long timeout, @NotNull TimeUnit unit) throws InterruptedException;
+
+    /**
+     * Wait until the search service has initialized its underlying index and is ready for operations.
+     * Returns true if ready before the timeout elapses; false on timeout.
+     * Default implementation returns true to avoid breaking non-Lucene implementations.
+     */
+    boolean waitForStart(@NotNull Duration timeout);
 
     /**
      * From lowest to highest priority

--- a/api/src/org/labkey/api/search/SearchService.java
+++ b/api/src/org/labkey/api/search/SearchService.java
@@ -55,7 +55,6 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -128,11 +127,10 @@ public interface SearchService extends SearchMXBean
     boolean drainQueue(@NotNull PRIORITY priority, long timeout, @NotNull TimeUnit unit) throws InterruptedException;
 
     /**
-     * Wait until the search service has initialized its underlying index and is ready for operations.
-     * Returns true if ready before the timeout elapses; false on timeout.
-     * Default implementation returns true to avoid breaking non-Lucene implementations.
+     * Adds a startup listener that will be notified when the search index startup process is complete.
+     * @param listener The {@link SearchStartupListener} that will handle startup completion events.
      */
-    boolean waitForStart(@NotNull Duration timeout);
+    void addStartupListener(@NotNull SearchStartupListener listener);
 
     /**
      * From lowest to highest priority

--- a/api/src/org/labkey/api/search/SearchStartupListener.java
+++ b/api/src/org/labkey/api/search/SearchStartupListener.java
@@ -1,0 +1,13 @@
+package org.labkey.api.search;
+
+/**
+ * Defines a listener interface for events related to the completion of search indexing startup/initialization.
+ * Implementations of this interface can define specific actions to be executed once the search startup process
+ * is completed during the application's startup or initialization phase.
+ */
+public interface SearchStartupListener
+{
+    String getName();
+
+    void indexStartupComplete();
+}

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -80,9 +80,11 @@ import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.files.FileSystemDirectoryListener;
 import org.labkey.api.files.FileSystemWatchers;
 import org.labkey.api.mbean.SearchMXBean;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.search.SearchService;
+import org.labkey.api.search.SearchStartupListener;
 import org.labkey.api.search.SearchUtils;
 import org.labkey.api.search.SearchUtils.HtmlParseException;
 import org.labkey.api.search.SearchUtils.LuceneMessageParser;
@@ -132,7 +134,6 @@ import java.io.Reader;
 import java.lang.ref.SoftReference;
 import java.nio.ByteBuffer;
 import java.nio.file.FileSystemException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -145,8 +146,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -234,6 +236,9 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         _autoDetectParser = new AutoDetectParser(config);
     }
 
+    private final List<SearchStartupListener> _startupListeners = new CopyOnWriteArrayList<>();
+    private final AtomicBoolean _startupCompleted = new AtomicBoolean(false);
+
     private boolean _initializingIndex = false;
 
     private record IndexLockFileWatch(java.nio.file.Path dir, FileSystemDirectoryListener listener) {}
@@ -319,6 +324,27 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
                     });
 
                     FileSystemWatchers.get().addListener(_lockFileWatch.dir, _lockFileWatch.listener, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+                }
+
+                if (!_startupCompleted.get())
+                {
+                    if (isIndexManagerReady())
+                    {
+                        if (_startupCompleted.compareAndSet(false, true))
+                        {
+                            for (SearchStartupListener listener : _startupListeners)
+                                indexStartupComplete(listener);
+                            _startupListeners.clear();
+                        }
+                        else
+                        {
+                            _log.debug("Search startup listeners already executed by another thread.");
+                        }
+                    }
+                    else
+                    {
+                        _log.warn("Search index manager not yet ready; skipping startup listeners.");
+                    }
                 }
             }
         }
@@ -458,35 +484,31 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         super.start();
     }
 
-    @Override
-    public boolean waitForStart(@NotNull Duration timeout)
+    private void indexStartupComplete(@NotNull SearchStartupListener listener)
     {
-        if (timeout.isZero() || timeout.isNegative())
-            return isIndexManagerReady();
-
-        final long deadline = System.nanoTime() + timeout.toNanos();
-        final long sleepNanos = TimeUnit.MILLISECONDS.toNanos(200);
-
-        while (true)
+        try
         {
-            if (isIndexManagerReady())
-                return true;
-
-            long remaining = deadline - System.nanoTime();
-            if (remaining <= 0)
-                return isIndexManagerReady();
-
-            long toSleep = Math.min(sleepNanos, remaining);
-            try
-            {
-                TimeUnit.NANOSECONDS.sleep(toSleep);
-            }
-            catch (InterruptedException ie)
-            {
-                Thread.currentThread().interrupt();
-                return isIndexManagerReady();
-            }
+            _log.info("Running search startup listener: {}", listener.getName());
+            listener.indexStartupComplete();
         }
+        catch (Throwable t)
+        {
+            _log.error("Search startup listener '{}' failed: ", listener.getName(), t);
+        }
+    }
+
+    @Override
+    public void addStartupListener(@NotNull SearchStartupListener listener)
+    {
+        // If the index is already initialized, then run the listener immediately.
+        if (_startupCompleted.get())
+        {
+            indexStartupComplete(listener);
+            return;
+        }
+
+        // Otherwise, wait until the index is initialized.
+        _startupListeners.add(listener);
     }
 
     private boolean isIndexManagerReady()

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -132,6 +132,7 @@ import java.io.Reader;
 import java.lang.ref.SoftReference;
 import java.nio.ByteBuffer;
 import java.nio.file.FileSystemException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -145,6 +146,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -457,6 +459,43 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
     }
 
     @Override
+    public boolean waitForStart(@NotNull Duration timeout)
+    {
+        if (timeout.isZero() || timeout.isNegative())
+            return isIndexManagerReady();
+
+        final long deadline = System.nanoTime() + timeout.toNanos();
+        final long sleepNanos = TimeUnit.MILLISECONDS.toNanos(200);
+
+        while (true)
+        {
+            if (isIndexManagerReady())
+                return true;
+
+            long remaining = deadline - System.nanoTime();
+            if (remaining <= 0)
+                return isIndexManagerReady();
+
+            long toSleep = Math.min(sleepNanos, remaining);
+            try
+            {
+                TimeUnit.NANOSECONDS.sleep(toSleep);
+            }
+            catch (InterruptedException ie)
+            {
+                Thread.currentThread().interrupt();
+                return isIndexManagerReady();
+            }
+        }
+    }
+
+    private boolean isIndexManagerReady()
+    {
+        WritableIndexManager manager = _indexManager;
+        return manager.isReal() && !manager.isClosed();
+    }
+
+    @Override
     public void startCrawler()
     {
         handleEmptyOrMismatchedIndex();
@@ -557,7 +596,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
     public void deleteIndex(String reason)
     {
         _log.info("Deleting full-text search index and clearing last indexed because: " + reason);
-        if (_indexManager.isReal() && !_indexManager.isClosed())
+        if (isIndexManagerReady())
             closeIndex();
 
         File indexDir = getIndexDirectory();


### PR DESCRIPTION
#### Rationale
As a part of the changes for [Issue 54025](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=54025) we are attempting to run an upgrade script that needs to utilize the search service. The search service, however, is not ready at that time and is subsequently started in a background thread. This PR introduces `SearchService.waitForStart()` to give callers a way to wait for the service to start up. For additional context see https://github.com/LabKey/limsModules/pull/1693#discussion_r2386406935.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1693

#### Changes
- Introduce `SearchService.waitForStart()` to give callers a way to wait for the search service to start