### PR TITLE
Test: Use copied implementation of FileUtil.makeLegalName()

### DIFF
--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -1484,7 +1484,7 @@ quickScan:
             os.write(buf,0,r);
     }
 
-
+    // NOTE: Keep in sync with the copied constants in TestFileUtils
     private static final char[] ILLEGAL_CHARS = {'/','\\',':','?','<','>','*','|','"','^', '\n', '\r', '\''};
     public static final String ILLEGAL_CHARS_STRING = new String(ILLEGAL_CHARS);
 
@@ -1499,7 +1499,7 @@ quickScan:
         return !StringUtils.containsAny(name, ILLEGAL_CHARS);
     }
 
-
+    // NOTE: Keep in sync with the copied implementation in TestFileUtils.makeLegalFileName()
     public static String makeLegalName(String name)
     {
         if (name == null)

--- a/api/src/org/labkey/api/util/FileUtil.java
+++ b/api/src/org/labkey/api/util/FileUtil.java
@@ -111,7 +111,6 @@ public class FileUtil
         tempPaths.get().clear();
     }
 
-
     @SuppressWarnings("RedundantOperationOnEmptyContainer")
     public static void stopRequest()
     {


### PR DESCRIPTION
#### Rationale
Tests need to be able to determine/compute the legal file name for a file based on a name. This updates the test implementation to match the server-side implementation.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2716
- https://github.com/LabKey/platform/pull/7089
- https://github.com/LabKey/limsModules/pull/1695

#### Changes
- Add comments about copied implementation