### PR TITLE
Return Set<Class<?>> from Module "get test" methods

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -200,8 +200,7 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             AnnouncementManager.TestCase.class
@@ -227,7 +226,6 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
 
         return list;
     }
-
 
     @Override
     public void enumerateDocuments(SearchService.TaskIndexingQueue queue, final Date modifiedSince)

--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -361,7 +361,7 @@ public class ApiModule extends CodeOnlyModule
     }
 
     @Override
-    public @NotNull Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             Aggregate.TestCase.class,
@@ -458,7 +458,7 @@ public class ApiModule extends CodeOnlyModule
     }
 
     @Override
-    public @NotNull Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             AbstractAuditDomainKind.TestCase.class,

--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -85,12 +85,6 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
 
     private final AbstractAuditDomainKind _domainKind;
 
-    @Deprecated // Call the other constructor and stop overriding getDomainKind()
-    public AbstractAuditTypeProvider()
-    {
-        this(null);
-    }
-
     public AbstractAuditTypeProvider(@NotNull AbstractAuditDomainKind domainKind)
     {
         // TODO: consolidate domain kind initialization to this constructor and stop overriding getDomainKind()
@@ -99,7 +93,7 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
         PropertyService.get().registerDomainKind(getDomainKind());
     }
 
-    protected AbstractAuditDomainKind getDomainKind()
+    protected final AbstractAuditDomainKind getDomainKind()
     {
         if (_domainKind == null)
             throw new IllegalStateException(String.format("The audit type : \"%s\" has a null domain kind", getLabel()));

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -43,7 +43,6 @@ import org.labkey.api.query.QueryKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
-import org.labkey.api.reader.TabLoader;
 import org.labkey.api.security.User;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.JunitUtil;
@@ -919,7 +918,7 @@ public class NameGenerator
                     dataTypes.add(sampleType);
             }
             else
-                dataTypes.addAll(SampleTypeService.get().getSampleTypes(_container, user, true));
+                dataTypes.addAll(SampleTypeService.get().getSampleTypes(_container, true));
         }
         if (isData)
         {
@@ -1122,7 +1121,7 @@ public class NameGenerator
             }
 
 
-            for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(_container, user, true))
+            for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(_container, true))
             {
                 sampleTypeLSIDs.put(sampleType.getName(), sampleType.getLSID());
                 sampleTypeNames.put(sampleType.getLSID(), sampleType.getName());

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -217,7 +217,7 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
         {
             SampleTypeService service = SampleTypeService.get();
             if (sampleTypeNames.isEmpty())
-                _sampleTypes.addAll(service.getSampleTypes(getContainer(), getUser(), false));
+                _sampleTypes.addAll(service.getSampleTypes(getContainer(), false));
             else
             {
                 for (String typeName : sampleTypeNames)
@@ -345,7 +345,7 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
         boolean hasParentTypes = !parentTypes.isEmpty();
         // Default to using all types in the container
         if (!hasParentTypes)
-            parentTypes.addAll(SampleTypeService.get().getSampleTypes(getContainer(), getUser(), false).stream().map(ExpSampleType::getName).toList());
+            parentTypes.addAll(SampleTypeService.get().getSampleTypes(getContainer(), false).stream().map(ExpSampleType::getName).toList());
         List<String> dataClassParents = new ArrayList<>(config.getDataClassParents());
         // Default to using all types in the container
         if (dataClassParents.isEmpty())

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -939,7 +939,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     List<ObjectReferencer> getObjectReferencers();
 
     @NotNull
-    String getObjectReferenceDescription(Class referencedClass);
+    String getObjectReferenceDescription(Class<?> referencedClass);
 
     @Nullable ProtocolImplementation getProtocolImplementation(String name);
 

--- a/api/src/org/labkey/api/exp/api/ObjectReferencer.java
+++ b/api/src/org/labkey/api/exp/api/ObjectReferencer.java
@@ -15,5 +15,5 @@ public interface ObjectReferencer
     @NotNull Collection<Long> getItemsWithReferences(Collection<Long> referencedRowIds, @NotNull String referencedSchemaName, @Nullable String referencedQueryName);
 
     @Nullable
-    String getObjectReferenceDescription(Class referencedClass);
+    String getObjectReferenceDescription(Class<?> referencedClass);
 }

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -165,34 +165,33 @@ public interface SampleTypeService
     @Nullable
     DataState getSampleState(Container container, Long stateRowId);
 
-    void removeAutoLinkedStudy(@NotNull Container studyContainer, @Nullable User user);
+    void removeAutoLinkedStudy(@NotNull Container studyContainer);
 
     /**
      * @param includeOtherContainers whether sample types from the shared container or the container's project should be included
      */
-    // TODO: Remove user parameter (not used)
-    List<? extends ExpSampleType> getSampleTypes(@NotNull Container container, @Nullable User user, boolean includeOtherContainers);
+    List<? extends ExpSampleType> getSampleTypes(@NotNull Container container, boolean includeOtherContainers);
 
     /**
      * Get a SampleType by name within the definition container.
      */
     ExpSampleType getSampleType(@NotNull Container definitionContainer, @NotNull String sampleTypeName);
 
+    /**
+     * Get a SampleType by name within scope -- current, project, and shared.
+     * Requires a user to check for container read permission.
+     */
+    // TODO: Remove user parameter (not used)
+    ExpSampleType getSampleType(@NotNull Container scope, @NotNull User user, @NotNull String sampleTypeName);
+
     /** Get the sample type with name at a specific time */
     @Nullable
-    // TODO: Remove user parameter (not used)
-    ExpSampleType getEffectiveSampleType(@NotNull Container definitionContainer, @NotNull User user, @NotNull String sampleTypeName, @NotNull Date effectDate, @Nullable ContainerFilter cf);
+    ExpSampleType getEffectiveSampleType(@NotNull Container definitionContainer, @NotNull String sampleTypeName, @NotNull Date effectDate, @Nullable ContainerFilter cf);
 
     /**
      * Return the sample type for this LSID, optionally pass Container hint for performance
      */
     ExpSampleType getSampleTypeByType(@NotNull String lsid, Container hint);
-
-    /**
-     * Get a SampleType by name within scope -- current, project, and shared.
-     * Requires a user to check for container read permission.
-     */
-    ExpSampleType getSampleType(@NotNull Container scope, @NotNull User user, @NotNull String sampleTypeName);
 
     /**
      * Get a SampleType by rowId within the definition container.

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -172,6 +172,12 @@ public interface SampleTypeService
      */
     List<? extends ExpSampleType> getSampleTypes(@NotNull Container container, boolean includeOtherContainers);
 
+    @Deprecated // Temporary just to keep code compiling during migration to new method
+    default List<? extends ExpSampleType> getSampleTypes(@NotNull Container container, User user, boolean includeOtherContainers)
+    {
+        return getSampleTypes(container, includeOtherContainers);
+    }
+
     /**
      * Get a SampleType by name within the definition container.
      */

--- a/api/src/org/labkey/api/exp/query/SamplesSchema.java
+++ b/api/src/org/labkey/api/exp/query/SamplesSchema.java
@@ -77,7 +77,7 @@ public class SamplesSchema extends AbstractExpSchema implements UserSchema.HasCo
     {
         Map<String, ExpSampleType> map = new CaseInsensitiveTreeMap<>();
         // User can be null if we're running in a background thread, such as doing a study export
-        for (ExpSampleType st : SampleTypeService.get().getSampleTypes(container, user, user != null))
+        for (ExpSampleType st : SampleTypeService.get().getSampleTypes(container, user != null))
         {
             map.put(st.getName(), st);
         }

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -494,15 +494,13 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Collections.emptySet();
     }
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Collections.emptySet();
     }

--- a/api/src/org/labkey/api/module/MockModule.java
+++ b/api/src/org/labkey/api/module/MockModule.java
@@ -232,15 +232,13 @@ public class MockModule implements Module
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Collections.emptySet();
     }
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Collections.emptySet();
     }

--- a/api/src/org/labkey/api/module/Module.java
+++ b/api/src/org/labkey/api/module/Module.java
@@ -236,11 +236,12 @@ public interface Module
      * Modules can provide JUnit tests that must be run inside the server
      * VM. These tests will be executed as part of the DRT. These are not true unit tests, and may rely on external
      * resources such as a database connection or services provided by other modules.
+     *
      * @return the integration tests that this module provides
      */
-    @NotNull
     @JsonIgnore
-    Set<Class> getIntegrationTests();
+    @NotNull
+    Set<Class<?>> getIntegrationTests();
 
     /**
      * Modules can provide JUnit tests that must be run inside the server
@@ -258,11 +259,12 @@ public interface Module
     /**
      * Modules can provide JUnit tests that can be run independent of the server VM. Satisfies the requirements for a
      * traditional unit test.
+     *
      * @return the unit tests that this module provides
      */
-    @NotNull
     @JsonIgnore
-    Set<Class> getUnitTests();
+    @NotNull
+    Set<Class<?>> getUnitTests();
 
     /**
      * Returns a set of schemas that the module wants tested. The DbSchema junit test calls this and ensures that the

--- a/api/src/org/labkey/api/module/SimpleWebPartFactory.java
+++ b/api/src/org/labkey/api/module/SimpleWebPartFactory.java
@@ -183,7 +183,7 @@ public class SimpleWebPartFactory extends BaseWebPartFactory
 
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart) throws WebPartConfigurationException
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart) throws WebPartConfigurationException
     {
         if (null != _loadException)
             throw new WebPartConfigurationException(this, "Error thrown during load", _loadException);
@@ -191,7 +191,7 @@ public class SimpleWebPartFactory extends BaseWebPartFactory
         if (null == getViewName())
             throw new WebPartConfigurationException(this, "No view name specified for the module web part defined in " + _resourceName);
 
-        WebPartView ret = ModuleHtmlView.get(getModule(), ModuleHtmlView.getStandardPath(getViewName()), webPart);
+        WebPartView<?> ret = ModuleHtmlView.get(getModule(), ModuleHtmlView.getStandardPath(getViewName()), webPart);
         if (null != _webPartDef && null != _webPartDef.getView())
         {
             if (null != _webPartDef.getView().getFrame())

--- a/api/src/org/labkey/api/study/security/SecurityEscalationAuditProvider.java
+++ b/api/src/org/labkey/api/study/security/SecurityEscalationAuditProvider.java
@@ -50,11 +50,6 @@ import java.util.Set;
  */
 public abstract class SecurityEscalationAuditProvider extends AbstractAuditTypeProvider implements AuditTypeProvider
 {
-    protected SecurityEscalationAuditProvider()
-    {
-        super();
-    }
-
     protected SecurityEscalationAuditProvider(AbstractAuditDomainKind dk)
     {
         super(dk);

--- a/api/src/org/labkey/api/study/security/StudySecurityEscalationAuditProvider.java
+++ b/api/src/org/labkey/api/study/security/StudySecurityEscalationAuditProvider.java
@@ -25,6 +25,11 @@ public class StudySecurityEscalationAuditProvider extends SecurityEscalationAudi
     public static String EVENT_TYPE = StudySecurityEscalationEvent.class.getSimpleName();
     public static String AUDIT_LOG_TITLE = "Study Security Escalations";
 
+    public StudySecurityEscalationAuditProvider()
+    {
+        super(new StudySecurityEscalationDomainKind());
+    }
+
     @Override
     public String getDescription() {
         return "This audits all uses of the Study Security Escalation";
@@ -43,11 +48,6 @@ public class StudySecurityEscalationAuditProvider extends SecurityEscalationAudi
     @Override
     public String getAuditLogTitle() {
         return AUDIT_LOG_TITLE;
-    }
-
-    public StudySecurityEscalationAuditProvider()
-    {
-        super(new StudySecurityEscalationDomainKind());
     }
 
     public static class StudySecurityEscalationEvent extends SecurityEscalationEvent

--- a/api/src/org/labkey/api/view/DefaultWebPartFactory.java
+++ b/api/src/org/labkey/api/view/DefaultWebPartFactory.java
@@ -43,7 +43,7 @@ public class DefaultWebPartFactory extends BaseWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         if (!portalCtx.hasPermission(ReadPermission.class))
             return new HtmlView("Not Authorized", HtmlString.of(portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data"));

--- a/api/src/org/labkey/api/view/SimpleWebPartFactory.java
+++ b/api/src/org/labkey/api/view/SimpleWebPartFactory.java
@@ -131,7 +131,7 @@ public class SimpleWebPartFactory extends BaseWebPartFactory
 
     
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         Object form = null;
         BindException errors = null;
@@ -154,7 +154,7 @@ public class SimpleWebPartFactory extends BaseWebPartFactory
         if (view instanceof HttpView && _formClass != null)
             ((HttpView)view).setModelBean(form);
         if (view instanceof WebPartView)
-            return (WebPartView)view;
+            return (WebPartView<?>)view;
         VBox v = new VBox(view);
         v.setTitle(getName());
         return v;

--- a/assay/src/org/labkey/assay/AssayModule.java
+++ b/assay/src/org/labkey/assay/AssayModule.java
@@ -327,7 +327,7 @@ public class AssayModule extends SpringModule
     }
 
     @Override
-    public @NotNull Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             ModuleAssayCache.TestCase.class,
@@ -345,7 +345,7 @@ public class AssayModule extends SpringModule
     }
 
     @Override
-    public @NotNull Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             TsvAssayProvider.TestCase.class,

--- a/assay/src/org/labkey/assay/view/AssayBaseWebPartFactory.java
+++ b/assay/src/org/labkey/assay/view/AssayBaseWebPartFactory.java
@@ -87,7 +87,7 @@ public abstract class AssayBaseWebPartFactory extends BaseWebPartFactory
 //    }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         Long protocolId = getProtocolId(webPart);
         ProtocolIdForm protocolIdForm = new ProtocolIdForm();
@@ -97,7 +97,7 @@ public abstract class AssayBaseWebPartFactory extends BaseWebPartFactory
 
         boolean showButtons = Boolean.parseBoolean(webPart.getPropertyMap().get(SHOW_BUTTONS_KEY));
         ExpProtocol protocol;
-        WebPartView view;
+        WebPartView<?> view;
         try
         {
             protocol = protocolIdForm.getProtocol(true);
@@ -113,7 +113,7 @@ public abstract class AssayBaseWebPartFactory extends BaseWebPartFactory
         return view;
     }
 
-    public abstract WebPartView getWebPartView(ViewContext portalCtx, Portal.WebPart webPart, ExpProtocol protocol, boolean showButtons);
+    public abstract WebPartView<?> getWebPartView(ViewContext portalCtx, Portal.WebPart webPart, ExpProtocol protocol, boolean showButtons);
 
     public abstract String getDescription();
 
@@ -124,7 +124,7 @@ public abstract class AssayBaseWebPartFactory extends BaseWebPartFactory
     }
 
     @Override
-    public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+    public HttpView<?> getEditView(Portal.WebPart webPart, ViewContext context)
     {
         EditViewBean bean = new EditViewBean();
         bean.description = getDescription();

--- a/assay/src/org/labkey/assay/view/AssayListWebPartFactory.java
+++ b/assay/src/org/labkey/assay/view/AssayListWebPartFactory.java
@@ -37,9 +37,9 @@ public class AssayListWebPartFactory extends BaseWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
-        WebPartView listView = AssayService.get().createAssayListView(portalCtx, true, null);
+        WebPartView<?> listView = AssayService.get().createAssayListView(portalCtx, true, null);
         ActionURL url = PageFlowUtil.urlProvider(AssayUrls.class).getBeginURL(portalCtx.getContainer());
         listView.setTitle("Assay List");
         listView.setTitleHref(url);

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1516,11 +1516,10 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         // Must be mutable since we add the dialect tests below
-        Set<Class> testClasses = Sets.newHashSet
+        Set<Class<?>> testClasses = Sets.newHashSet
         (
             AdminController.SchemaVersionTestCase.class,
             AdminController.SerializationTest.class,
@@ -1561,9 +1560,8 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         return testClasses;
     }
 
-    @NotNull
     @Override
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             ApiJsonWriter.TestCase.class,

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -932,7 +932,7 @@ public class ExperimentModule extends SpringModule
         if (dataClassCount > 0)
             list.add(dataClassCount + " Data Class" + (dataClassCount > 1 ? "es" : ""));
 
-        int sampleTypeCount = SampleTypeService.get().getSampleTypes(c, null, false).size();
+        int sampleTypeCount = SampleTypeService.get().getSampleTypes(c, false).size();
         if (sampleTypeCount > 0)
             list.add(sampleTypeCount + " Sample Type" + (sampleTypeCount > 1 ? "s" : ""));
 
@@ -986,7 +986,7 @@ public class ExperimentModule extends SpringModule
         }
 
         // Sample Types
-        int sampleTypeCount = SampleTypeService.get().getSampleTypes(c, null, false).size();
+        int sampleTypeCount = SampleTypeService.get().getSampleTypes(c, false).size();
         if (sampleTypeCount > 0)
             summaries.add(new Summary(sampleTypeCount, "Sample Type"));
 
@@ -1023,8 +1023,7 @@ public class ExperimentModule extends SpringModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             DomainImpl.TestCase.class,
@@ -1055,9 +1054,8 @@ public class ExperimentModule extends SpringModule
         return list;
     }
 
-    @NotNull
     @Override
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             GraphAlgorithms.TestCase.class,

--- a/experiment/src/org/labkey/experiment/ExperimentRunWebPartFactory.java
+++ b/experiment/src/org/labkey/experiment/ExperimentRunWebPartFactory.java
@@ -76,14 +76,14 @@ public class ExperimentRunWebPartFactory extends BaseWebPartFactory
     }
 
     @Override
-    public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+    public HttpView<?> getEditView(Portal.WebPart webPart, ViewContext context)
     {
         Set<ExperimentRunType> types = ExperimentService.get().getExperimentRunTypes(context.getContainer());
         return new JspView<>("/org/labkey/experiment/customizeRunWebPart.jsp", new Bean(types, getConfiguredRunFilterName(webPart)));
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         String selectedTypeName = getConfiguredRunFilterName(webPart);
         Set<ExperimentRunType> types = ExperimentService.get().getExperimentRunTypes(portalCtx.getContainer());

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1670,7 +1670,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public Pair<String, String> generateLSIDWithDBSeq(@NotNull Container container, DataType type)
+    public Pair<String, String> generateLSIDWithDBSeq(@NotNull Container container, @NotNull DataType type)
     {
         return generateLSIDWithDBSeq(container, type.getNamespacePrefix());
     }
@@ -3200,7 +3200,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public @NotNull String getObjectReferenceDescription(Class referencedClass)
+    public @NotNull String getObjectReferenceDescription(Class<?> referencedClass)
     {
         if (referencedClass != ExpRun.class)
             return "derived data or sample dependencies";
@@ -5519,7 +5519,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         int[] runIds = ArrayUtils.toPrimitive(new SqlSelector(getExpSchema(), sql, c).getArray(Integer.class));
 
         List<ExpExperimentImpl> exps = getExperiments(c, false, true, true);
-        List<ExpSampleTypeImpl> sampleTypes = ((SampleTypeServiceImpl) SampleTypeService.get()).getSampleTypes(c, user, false);
+        List<ExpSampleTypeImpl> sampleTypes = ((SampleTypeServiceImpl) SampleTypeService.get()).getSampleTypes(c, false);
         List<ExpDataClassImpl> dataClasses = getDataClasses(c, user, false);
 
         sql = "SELECT RowId FROM " + getTinfoProtocol() + " WHERE Container = ?";
@@ -9393,7 +9393,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             return new Pair<>(sampleTypes, dataClasses);
 
         String targetInputType = (isSampleParent ? MATERIAL_INPUTS_ALIAS_PREFIX : DATA_INPUTS_ALIAS_PREFIX) + parentDataTypeName;
-        for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(container, user, true))
+        for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(container, true))
         {
             try
             {
@@ -9941,7 +9941,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         DbSchema dbSchema = ExperimentService.get().getSchema();
         SqlDialect dialect = dbSchema.getSqlDialect();
         UserSchema samplesUserSchema = QueryService.get().getUserSchema(user, container, SamplesSchema.SCHEMA_NAME);
-        List<ExpSampleTypeImpl> sampleTypes = SampleTypeServiceImpl.get().getSampleTypes(container, user, true);
+        List<ExpSampleTypeImpl> sampleTypes = SampleTypeServiceImpl.get().getSampleTypes(container, true);
 
         String unionAll = "";
         SQLFragment query = new SQLFragment();

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -420,7 +420,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     }
 
     @Override
-    public void removeAutoLinkedStudy(@NotNull Container studyContainer, @Nullable User user)
+    public void removeAutoLinkedStudy(@NotNull Container studyContainer)
     {
         SQLFragment sql = new SQLFragment("UPDATE ").append(getTinfoMaterialSource())
                 .append(" SET autolinkTargetContainer = NULL WHERE autolinkTargetContainer = ?")
@@ -440,7 +440,6 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     @Override
     public @Nullable ExpSampleType getEffectiveSampleType(
         @NotNull Container definitionContainer,
-        @NotNull User user,
         @NotNull String sampleTypeName,
         @NotNull Date effectiveDate,
         @Nullable ContainerFilter cf
@@ -459,7 +458,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     }
 
     @Override
-    public List<ExpSampleTypeImpl> getSampleTypes(@NotNull Container container, @Nullable User user, boolean includeOtherContainers)
+    public List<ExpSampleTypeImpl> getSampleTypes(@NotNull Container container, boolean includeOtherContainers)
     {
         List<String> containerIds = ExperimentServiceImpl.get().createContainerList(container, includeOtherContainers);
 

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -4429,7 +4429,7 @@ public class ExperimentController extends SpringActionController
             // file is loaded.
             if (crossTypeImport)
             {
-                List<ExpSampleTypeImpl> sampleTypes = SampleTypeServiceImpl.get().getSampleTypes(getContainer(), getUser(), true);
+                List<ExpSampleTypeImpl> sampleTypes = SampleTypeServiceImpl.get().getSampleTypes(getContainer(), true);
                 for (ExpSampleTypeImpl sampleType : sampleTypes)
                     aliases.addAll(sampleType.getImportAliases().keySet());
             }

--- a/experiment/src/org/labkey/experiment/samplesAndAnalytes.jsp
+++ b/experiment/src/org/labkey/experiment/samplesAndAnalytes.jsp
@@ -33,7 +33,7 @@
     }
     else
     {
-        List<ExpSampleTypeImpl> sampleTypes = SampleTypeServiceImpl.get().getSampleTypes(getContainer(), getUser(), true);
+        List<ExpSampleTypeImpl> sampleTypes = SampleTypeServiceImpl.get().getSampleTypes(getContainer(), true);
 
         int i = 0;
     %> <table style="width:50px;margin-right:1em" ><tr><td style="vertical-align:top;white-space:nowrap;margin:1em"> <%

--- a/filecontent/src/org/labkey/filecontent/FileContentModule.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentModule.java
@@ -211,8 +211,7 @@ public class FileContentModule extends DefaultModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             FileContentController.TestCase.class,

--- a/issues/src/org/labkey/issue/IssuesModule.java
+++ b/issues/src/org/labkey/issue/IssuesModule.java
@@ -187,8 +187,7 @@ public class IssuesModule extends DefaultModule implements SearchService.Documen
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Collections.singleton(org.labkey.issue.model.IssueManager.TestCase.class);
     }

--- a/list/src/org/labkey/list/ListModule.java
+++ b/list/src/org/labkey/list/ListModule.java
@@ -212,9 +212,8 @@ public class ListModule extends SpringModule
         return PageFlowUtil.set(ListSchema.getInstance().getSchemaName());
     }
 
-    @NotNull
     @Override
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             ListManager.TestCase.class,

--- a/list/src/org/labkey/list/view/SingleListWebPartFactory.java
+++ b/list/src/org/labkey/list/view/SingleListWebPartFactory.java
@@ -48,7 +48,7 @@ public class SingleListWebPartFactory extends AlwaysAvailableWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         Map<String, String> props = webPart.getPropertyMap();
 
@@ -89,7 +89,7 @@ public class SingleListWebPartFactory extends AlwaysAvailableWebPartFactory
     }
 
     @Override
-    public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+    public HttpView<?> getEditView(Portal.WebPart webPart, ViewContext context)
     {
         return new JspView<>("/org/labkey/list/view/customizeSingleListWebPart.jsp", webPart);
     }

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -111,8 +111,7 @@ public class MothershipModule extends DefaultModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return PageFlowUtil.set(ExceptionStackTrace.TestCase.class);
     }

--- a/pipeline/src/org/labkey/pipeline/PipelineModule.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineModule.java
@@ -333,8 +333,7 @@ public class PipelineModule extends SpringModule implements ContainerManager.Con
 
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             PipelineController.TestCase.class,
@@ -347,8 +346,7 @@ public class PipelineModule extends SpringModule implements ContainerManager.Con
     }
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             CommandLineTokenizer.TestCase.class,

--- a/query/src/org/labkey/query/DataViewsWebPartFactory.java
+++ b/query/src/org/labkey/query/DataViewsWebPartFactory.java
@@ -56,7 +56,7 @@ public class DataViewsWebPartFactory extends BaseWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         JspView<Portal.WebPart> view = new JspView<>("/org/labkey/query/reports/view/dataViews.jsp", webPart);
         view.setTitle("Data Views");
@@ -99,7 +99,6 @@ public class DataViewsWebPartFactory extends BaseWebPartFactory
             for (ReportService.DesignerInfo info : chartDesigners)
                 menu.addChild(getItem(info, "Add "));
         }
-
 
         // We display the edit button for everyone with insert (Author, Editor, Admin). Other components are admin-only.
         if (portalCtx.hasPermission(InsertPermission.class))

--- a/query/src/org/labkey/query/QueryBrowserWebPartFactory.java
+++ b/query/src/org/labkey/query/QueryBrowserWebPartFactory.java
@@ -32,9 +32,9 @@ public class QueryBrowserWebPartFactory extends BaseWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
-        JspView view = new JspView<>("/org/labkey/query/view/browse.jsp");
+        JspView<?> view = new JspView<>("/org/labkey/query/view/browse.jsp");
         view.setTitle(NAME);
         view.setFrame(WebPartView.FrameType.PORTAL);
         return view;

--- a/query/src/org/labkey/query/QueryModule.java
+++ b/query/src/org/labkey/query/QueryModule.java
@@ -344,8 +344,7 @@ public class QueryModule extends DefaultModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             ModuleReportCache.TestCase.class,
@@ -375,8 +374,7 @@ public class QueryModule extends DefaultModule
 
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             AggregateQueryDataTransform.TestCase.class,

--- a/query/src/org/labkey/query/reports/ReportsWebPartFactory.java
+++ b/query/src/org/labkey/query/reports/ReportsWebPartFactory.java
@@ -45,7 +45,7 @@ public class ReportsWebPartFactory extends AlwaysAvailableWebPartFactory
     }
     
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         ReportsWebPart wp = new ReportsWebPart(portalCtx, webPart);
         populateProperties(wp, webPart.getPropertyMap());
@@ -54,7 +54,7 @@ public class ReportsWebPartFactory extends AlwaysAvailableWebPartFactory
     }
 
     @Override
-    public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+    public HttpView<?> getEditView(Portal.WebPart webPart, ViewContext context)
     {
         return new ReportsWebPartConfig(webPart);
     }

--- a/query/src/org/labkey/query/view/QueryWebPartFactory.java
+++ b/query/src/org/labkey/query/view/QueryWebPartFactory.java
@@ -33,7 +33,7 @@ public class QueryWebPartFactory extends AlwaysAvailableWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         QueryWebPart ret = new QueryWebPart(portalCtx, webPart);
         populateProperties(ret, webPart.getPropertyMap());
@@ -41,7 +41,7 @@ public class QueryWebPartFactory extends AlwaysAvailableWebPartFactory
     }
 
     @Override
-    public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+    public HttpView<?> getEditView(Portal.WebPart webPart, ViewContext context)
     {
         return new JspView<>("/org/labkey/query/view/editQueryWebPart.jsp", webPart);
     }

--- a/search/src/org/labkey/search/SearchModule.java
+++ b/search/src/org/labkey/search/SearchModule.java
@@ -246,9 +246,8 @@ public class SearchModule extends DefaultModule
         }
     }
 
-    @NotNull
     @Override
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of
         (

--- a/search/src/org/labkey/search/view/SearchWebPartFactory.java
+++ b/search/src/org/labkey/search/view/SearchWebPartFactory.java
@@ -41,7 +41,7 @@ public class SearchWebPartFactory extends AlwaysAvailableWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         boolean includeSubfolders = includeSubfolders(webPart);
 
@@ -57,7 +57,7 @@ public class SearchWebPartFactory extends AlwaysAvailableWebPartFactory
 
 
     @Override
-    public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+    public HttpView<?> getEditView(Portal.WebPart webPart, ViewContext context)
     {
         return new JspView<>("/org/labkey/search/view/customizeSearchWebPart.jsp", webPart);
     }

--- a/specimen/src/org/labkey/specimen/SpecimenModule.java
+++ b/specimen/src/org/labkey/specimen/SpecimenModule.java
@@ -315,8 +315,7 @@ public class SpecimenModule extends SpringModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             SpecimenWriter.TestCase.class
@@ -330,7 +329,7 @@ public class SpecimenModule extends SpringModule
     }
 
     @Override
-    public @NotNull Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             SpecimenImporter.TestCase.class

--- a/specimen/src/org/labkey/specimen/view/SpecimenReportWebPartFactory.java
+++ b/specimen/src/org/labkey/specimen/view/SpecimenReportWebPartFactory.java
@@ -67,7 +67,7 @@ public class SpecimenReportWebPartFactory extends BaseWebPartFactory
     }
 
     @Override
-    public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+    public HttpView<?> getEditView(Portal.WebPart webPart, ViewContext context)
     {
         return new JspView<>("/org/labkey/specimen/view/customizeSpecimenReportWebPart.jsp", webPart);
     }

--- a/specimen/src/org/labkey/specimen/view/SpecimenSearchWebPartFactory.java
+++ b/specimen/src/org/labkey/specimen/view/SpecimenSearchWebPartFactory.java
@@ -19,7 +19,7 @@ public class SpecimenSearchWebPartFactory extends DefaultWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         if (!portalCtx.hasPermission(ReadPermission.class))
             return new HtmlView("Specimens", HtmlString.of(portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data"));

--- a/specimen/src/org/labkey/specimen/view/SpecimenWebPartFactory.java
+++ b/specimen/src/org/labkey/specimen/view/SpecimenWebPartFactory.java
@@ -22,7 +22,7 @@ public class SpecimenWebPartFactory extends DefaultWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         if (!portalCtx.hasPermission(ReadPermission.class))
             return new HtmlView("Specimens", HtmlString.of(portalCtx.getUser().isGuest() ? "Please log in to see this data." : "You do not have permission to see this data"));

--- a/study/api-src/org/labkey/api/study/view/ToolsWebPartFactory.java
+++ b/study/api-src/org/labkey/api/study/view/ToolsWebPartFactory.java
@@ -41,7 +41,7 @@ public abstract class ToolsWebPartFactory extends BaseWebPartFactory
     protected abstract String getTitle();
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         return new StudyToolsWebPart(getTitle(), webPart.getLocation().equals(HttpView.BODY), getItems(portalCtx));
     }

--- a/study/src/org/labkey/study/StudyContainerListener.java
+++ b/study/src/org/labkey/study/StudyContainerListener.java
@@ -36,7 +36,7 @@ public class StudyContainerListener extends ContainerManager.AbstractContainerLi
             publishedStudy.setSourceStudyContainerId(null);
             StudyManager.getInstance().updateStudy(user, publishedStudy);
         }
-        SampleTypeService.get().removeAutoLinkedStudy(c, user);
+        SampleTypeService.get().removeAutoLinkedStudy(c);
     }
 
     @Override

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -731,19 +731,19 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
-                DatasetDefinition.TestCleanupOrphanedDatasetDomains.class,
-                ParticipantGroupManager.ParticipantGroupTestCase.class,
-                StudyImpl.ProtocolDocumentTestCase.class,
-                StudyManager.StudySnapshotTestCase.class,
-                StudyManager.VisitCreationTestCase.class,
-                StudyModule.TestCase.class,
-                VisitImpl.TestCase.class,
-                DatasetUpdateService.TestCase.class,
-        DatasetLsidImportHelper.TestCase.class);
+            DatasetDefinition.TestCleanupOrphanedDatasetDomains.class,
+            ParticipantGroupManager.ParticipantGroupTestCase.class,
+            StudyImpl.ProtocolDocumentTestCase.class,
+            StudyManager.StudySnapshotTestCase.class,
+            StudyManager.VisitCreationTestCase.class,
+            StudyModule.TestCase.class,
+            VisitImpl.TestCase.class,
+            DatasetUpdateService.TestCase.class,
+            DatasetLsidImportHelper.TestCase.class
+        );
     }
 
     @Override
@@ -755,8 +755,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     }
 
     @Override
-    @NotNull
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             DatasetDataWriter.TestCase.class,

--- a/study/src/org/labkey/study/controllers/SharedStudyController.java
+++ b/study/src/org/labkey/study/controllers/SharedStudyController.java
@@ -107,7 +107,7 @@ public class SharedStudyController extends BaseStudyController
         }
 
         @Override
-        public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+        public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
         {
             JspView<Object> view = new StudyFilterWebPart();
             view.setTitle(getName());

--- a/study/src/org/labkey/study/view/StudyListWebPartFactory.java
+++ b/study/src/org/labkey/study/view/StudyListWebPartFactory.java
@@ -39,9 +39,9 @@ public class StudyListWebPartFactory extends AlwaysAvailableWebPartFactory
 
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
-        WebPartView view;
+        WebPartView<?> view;
 
         if (webPart.getLocation().equals(HttpView.BODY))
         {
@@ -57,7 +57,7 @@ public class StudyListWebPartFactory extends AlwaysAvailableWebPartFactory
     }
 
     @Override
-    public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+    public HttpView<?> getEditView(Portal.WebPart webPart, ViewContext context)
     {
         return new JspView<>("/org/labkey/study/view/customizeStudyList.jsp", webPart);
     }

--- a/study/src/org/labkey/study/view/StudySummaryWebPartFactory.java
+++ b/study/src/org/labkey/study/view/StudySummaryWebPartFactory.java
@@ -135,13 +135,13 @@ public class StudySummaryWebPartFactory extends BaseWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         if (!portalCtx.hasPermission(ReadPermission.class))
             return new HtmlView(NAME, HtmlString.of(portalCtx.getUser().isGuest() ? "Please log in to see this data" : "You do not have permission to see this data"));
 
         BindException errors = (BindException) portalCtx.getRequest().getAttribute("errors");
-        WebPartView v = new JspView<>("/org/labkey/study/view/studySummary.jsp", new StudySummaryBean(portalCtx), errors);
+        WebPartView<?> v = new JspView<>("/org/labkey/study/view/studySummary.jsp", new StudySummaryBean(portalCtx), errors);
         v.setTitle(NAME);
 
         if(portalCtx.getContainer().hasPermission(portalCtx.getUser(), AdminPermission.class))

--- a/study/src/org/labkey/study/view/SubjectDetailsWebPartFactory.java
+++ b/study/src/org/labkey/study/view/SubjectDetailsWebPartFactory.java
@@ -110,7 +110,7 @@ public class SubjectDetailsWebPartFactory extends BaseWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         String participantId = webPart.getPropertyMap().get(PARTICIPANT_ID_KEY);
         String currentUrl = webPart.getPropertyMap().get(CURRENT_URL_KEY);

--- a/studydesign/src/org/labkey/studydesign/StudyDesignModule.java
+++ b/studydesign/src/org/labkey/studydesign/StudyDesignModule.java
@@ -34,9 +34,9 @@ public class StudyDesignModule extends SpringModule
     protected Collection<WebPartFactory> createWebPartFactories()
     {
         return List.of(
-                new AssayScheduleWebpartFactory(),
-                new ImmunizationScheduleWebpartFactory(),
-                new VaccineDesignWebpartFactory()
+            new AssayScheduleWebpartFactory(),
+            new ImmunizationScheduleWebpartFactory(),
+            new VaccineDesignWebpartFactory()
         );
     }
 
@@ -72,12 +72,11 @@ public class StudyDesignModule extends SpringModule
     }
 
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
-                TreatmentManager.TreatmentDataTestCase.class,
-                TreatmentManager.AssayScheduleTestCase.class
+            TreatmentManager.TreatmentDataTestCase.class,
+            TreatmentManager.AssayScheduleTestCase.class
         );
     }
 }

--- a/studydesign/src/org/labkey/studydesign/view/AssayScheduleWebpartFactory.java
+++ b/studydesign/src/org/labkey/studydesign/view/AssayScheduleWebpartFactory.java
@@ -43,7 +43,7 @@ public class AssayScheduleWebpartFactory extends StudyDesignWebpartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         if (!canShow(portalCtx.getContainer()))
             return null;

--- a/studydesign/src/org/labkey/studydesign/view/ImmunizationScheduleWebpartFactory.java
+++ b/studydesign/src/org/labkey/studydesign/view/ImmunizationScheduleWebpartFactory.java
@@ -43,7 +43,7 @@ public class ImmunizationScheduleWebpartFactory extends StudyDesignWebpartFactor
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         if (!canShow(portalCtx.getContainer()))
             return null;

--- a/studydesign/src/org/labkey/studydesign/view/VaccineDesignWebpartFactory.java
+++ b/studydesign/src/org/labkey/studydesign/view/VaccineDesignWebpartFactory.java
@@ -35,7 +35,7 @@ public class VaccineDesignWebpartFactory extends StudyDesignWebpartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         if (!canShow(portalCtx.getContainer()))
             return null;

--- a/survey/src/org/labkey/survey/SurveyModule.java
+++ b/survey/src/org/labkey/survey/SurveyModule.java
@@ -208,13 +208,13 @@ public class SurveyModule extends DefaultModule
         }
 
         @Override
-        public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+        public HttpView<?> getEditView(Portal.WebPart webPart, ViewContext context)
         {
             return new JspView<>("/org/labkey/survey/view/customizeSurveysWebPart.jsp", webPart);
         }
 
         @Override
-        public WebPartView getWebPartView(@NotNull ViewContext context, @NotNull Portal.WebPart webPart)
+        public WebPartView<?> getWebPartView(@NotNull ViewContext context, @NotNull Portal.WebPart webPart)
         {
             if (!context.hasPermission(ReadPermission.class) || context.getUser().isGuest())
                 return new HtmlView("Surveys", HtmlString.of("You do not have permission to see this data"));
@@ -262,9 +262,8 @@ public class SurveyModule extends DefaultModule
         }
     }
 
-    @NotNull
     @Override
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
         return Set.of(
             SurveyManager.TestCase.class

--- a/visualization/src/org/labkey/visualization/VisualizationModule.java
+++ b/visualization/src/org/labkey/visualization/VisualizationModule.java
@@ -63,15 +63,14 @@ public class VisualizationModule extends CodeOnlyModule
         return Collections.emptyList();
     }
 
-
-    @NotNull
     @Override
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
-        Set<Class> set = new LinkedHashSet<>();
+        Set<Class<?>> set = new LinkedHashSet<>();
         set.add(VisualizationController.TestCase.class);
         set.add(VisualizationSQLGenerator.GetDataTestCase.class);
         set.add(VisualizationCDSGenerator.TestCase.class);
+
         return set;
     }
 
@@ -93,7 +92,6 @@ public class VisualizationModule extends CodeOnlyModule
             }
         });
 
-
         addController(VisualizationController.NAME, VisualizationController.class);
         ReportService.get().registerDescriptor(new TimeChartReportDescriptor());
         ReportService.get().registerDescriptor(new GenericChartReportDescriptor());
@@ -106,7 +104,6 @@ public class VisualizationModule extends CodeOnlyModule
 
         VisualizationService.setInstance(new VisualizationServiceImpl());
     }
-
 
     @Override
     public void doStartup(ModuleContext moduleContext)

--- a/wiki/src/org/labkey/wiki/MenuWikiWebPartFactory.java
+++ b/wiki/src/org/labkey/wiki/MenuWikiWebPartFactory.java
@@ -36,7 +36,7 @@ public class MenuWikiWebPartFactory extends WikiWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         Map<String, String> props = new HashMap<>(webPart.getPropertyMap());
         if (null == props.get("webPartContainer"))

--- a/wiki/src/org/labkey/wiki/WikiModule.java
+++ b/wiki/src/org/labkey/wiki/WikiModule.java
@@ -223,16 +223,13 @@ public class WikiModule extends CodeOnlyModule implements SearchService.Document
         }
     }
 
-
     @Override
-    @NotNull
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
             WikiManager.TestCase.class
         );
     }
-
 
     @Override
     public void enumerateDocuments(SearchService.TaskIndexingQueue queue, @Nullable Date modifiedSince)
@@ -241,13 +238,11 @@ public class WikiModule extends CodeOnlyModule implements SearchService.Document
                 getWikiManager().indexWikis(q, modifiedSince, null));
     }
 
-
     @Override
     public void indexDeleted()
     {
         new SqlExecutor(CommSchema.getInstance().getSchema()).execute("UPDATE comm.pages SET lastIndexed=NULL");
     }
-
 
     private WikiManager getWikiManager()
     {

--- a/wiki/src/org/labkey/wiki/WikiTOCFactory.java
+++ b/wiki/src/org/labkey/wiki/WikiTOCFactory.java
@@ -45,16 +45,16 @@ public class WikiTOCFactory extends BaseWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
-        WebPartView v = new WikiTOC(portalCtx, webPart);
+        WebPartView<?> v = new WikiTOC(portalCtx, webPart);
         //TODO: Should just use setters
         populateProperties(v, webPart.getPropertyMap());
         return v;
     }
 
     @Override
-    public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+    public HttpView<?> getEditView(Portal.WebPart webPart, ViewContext context)
     {
         return new JspView<>("/org/labkey/wiki/view/customizeWikiToc.jsp", webPart);
     }

--- a/wiki/src/org/labkey/wiki/WikiWebPartFactory.java
+++ b/wiki/src/org/labkey/wiki/WikiWebPartFactory.java
@@ -50,14 +50,14 @@ public class WikiWebPartFactory extends AlwaysAvailableWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
     {
         Map<String, String> props = webPart.getPropertyMap();
         return new WikiWebPart(webPart.getRowId(), props);
     }
 
     @Override
-    public HttpView getEditView(Portal.WebPart webPart, ViewContext context)
+    public HttpView<?> getEditView(Portal.WebPart webPart, ViewContext context)
     {
         return new WikiController.CustomizeWikiPartView(webPart);
     }


### PR DESCRIPTION
#### Rationale
Eliminate IntelliJ warnings caused by `Module` methods `getUnitTests()` and `getIntegrationTests()` returning raw `Set<Class>`; they now return `Set<Class<?>>`.

Also, eliminate use of the deprecated `AbstractAuditTypeProvider()` constructor and overrides of `getDomainKind()` in its subclasses; we now always call the constructor that passes in a `DomainKind`.

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->