### PR TITLE
Show Plate Samples on Sample Assays Page

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -1076,7 +1076,20 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 // Wire up well samples as materials inputs
                 if (resolvePlateSamples)
                 {
-                    Long plateId = (Long) map.get(platePD.getName());
+                    Long _plateId;
+
+                    try
+                    {
+                        _plateId = (Long) map.get(platePD.getName());
+                    }
+                    catch (ClassCastException e)
+                    {
+                        // File import can cause ClassCastException to be thrown, so we manually convert from integer.
+                        Integer plateIdInt = (Integer) map.get(platePD.getName());
+                        _plateId = plateIdInt.longValue();
+                    }
+
+                    Long plateId = _plateId; // Re-assign so it's final
                     String wellLocation = (String) map.get(wellLocationPD.getName());
                     Long sampleId = null;
                     ExpMaterial material = null;

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -517,7 +517,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             }
             Map<ExpMaterial, String> rowBasedInputMaterials = new LinkedHashMap<>();
 
-            DataIterator fileData = checkData(container, user, dataTable, dataDomain, iter, settings, resolver, protocolInputMaterials, cf, rowBasedInputMaterials);
+            DataIterator fileData = checkData(container, user, protocol, dataTable, dataDomain, iter, settings, resolver, protocolInputMaterials, cf, rowBasedInputMaterials);
             fileData = convertPropertyNamesToURIs(fileData, dataDomain);
 
             OntologyManager.RowCallback rowCallback = NO_OP_ROW_CALLBACK;
@@ -682,16 +682,17 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
      * @param rowBasedInputMaterials the map of materials that are inputs to this run based on the data rows
      */
     private DataIterator checkData(
-        Container container,
-        User user,
-        TableInfo dataTable,
-        Domain dataDomain,
-        DataIterator rawData,
-        DataLoaderSettings settings,
-        ParticipantVisitResolver resolver,
-        Map<String, ExpMaterial> inputMaterials,
-        ContainerFilter containerFilter,
-        Map<ExpMaterial, String> rowBasedInputMaterials
+            Container container,
+            User user,
+            ExpProtocol protocol,
+            TableInfo dataTable,
+            Domain dataDomain,
+            DataIterator rawData,
+            DataLoaderSettings settings,
+            ParticipantVisitResolver resolver,
+            Map<String, ExpMaterial> inputMaterials,
+            ContainerFilter containerFilter,
+            Map<ExpMaterial, String> rowBasedInputMaterials
     ) throws BatchValidationException
     {
         final ExperimentService exp = ExperimentService.get();
@@ -705,10 +706,14 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         DomainProperty visitPropFinder = null;
         DomainProperty datePropFinder = null;
         DomainProperty targetStudyPropFinder = null;
+        DomainProperty platePropFinder = null;
+        DomainProperty wellLocationPropFinder = null;
+        DomainProperty wellLsidPropFinder = null;
 
         RemapCache cache = new RemapCache();
         Map<DomainProperty, TableInfo> remappableLookup = new HashMap<>();
         Map<Long, ExpMaterial> materialCache = new LongHashMap<>();
+        Map<Long, Map<String, Long>> plateWellCache = new LongHashMap<>();
 
         Map<DomainProperty, ExpSampleType> lookupToSampleTypeByName = new HashMap<>();
         Map<DomainProperty, ExpSampleType> lookupToSampleTypeById = new HashMap<>();
@@ -748,6 +753,19 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             {
                 targetStudyPropFinder = pd;
             }
+            else if (pd.getName().equalsIgnoreCase("WellLocation") && pd.getPropertyDescriptor().getPropertyType() == PropertyType.STRING)
+            {
+                wellLocationPropFinder = pd;
+            }
+            else if (pd.getName().equalsIgnoreCase("WellLsid") && pd.getPropertyDescriptor().getPropertyType() == PropertyType.STRING)
+            {
+                wellLsidPropFinder = pd;
+            }
+            else if (pd.getName().equalsIgnoreCase("Plate") && pd.getPropertyDescriptor().isLookup())
+            {
+                platePropFinder = pd;
+            }
+
             else
             {
                 var sampleLookup = AssaySampleLookupContext.checkSampleLookup(container, user, pd);
@@ -794,6 +812,13 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         DomainProperty visitPD = visitPropFinder;
         DomainProperty datePD = datePropFinder;
         DomainProperty targetStudyPD = targetStudyPropFinder;
+        DomainProperty platePD = platePropFinder;
+        DomainProperty wellLocationPD = wellLocationPropFinder;
+        DomainProperty wellLsidPD = wellLsidPropFinder;
+
+        AssayProvider provider = AssayService.get().getProvider(protocol);
+        boolean isPlateMetadataEnabled = provider != null && provider.isPlateMetadataEnabled(protocol);
+        boolean resolvePlateSamples = isPlateMetadataEnabled && platePD != null && wellLocationPD != null && wellLsidPD != null;
 
         return DataIteratorUtil.mapTransformer(rawData, inputCols ->
         {
@@ -1039,6 +1064,34 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                                     errors.add(new PropertyValidationError(error, pd.getName()));
                             }
                         }
+                    }
+                }
+
+                // Wire up well samples as materials inputs
+                if (resolvePlateSamples)
+                {
+                    Long plateId = (Long) map.get(platePD.getName());
+                    String wellLocation = (String) map.get(wellLocationPD.getName());
+                    Long sampleId = null;
+                    ExpMaterial material = null;
+
+                    if (plateId != null && wellLocation != null)
+                    {
+                        Map<String, Long> wellSampleCache = plateWellCache.computeIfAbsent(plateId, (id) -> AssayPlateMetadataService.get().getWellLocationToSampleIdMap(plateId));
+                        sampleId = wellSampleCache.get(wellLocation);
+                    }
+
+                    if (sampleId != null)
+                    {
+                        material = materialCache.computeIfAbsent(sampleId, (id) -> exp.getExpMaterial(id, containerFilter));
+                    }
+
+                    if (material != null)
+                    {
+                        // Note: we have to use the wellLsidPD as the Property Input Lineage Role because we resolve
+                        // the material inputs for a plate assay based on WellLsid during delete.
+                        rowBasedInputMaterials.putIfAbsent(material, AssayService.get().getPropertyInputLineageRole(wellLsidPD));
+                        rowInputLSIDs.add(material.getLSID());
                     }
                 }
 

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -93,6 +93,7 @@ import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.study.assay.ParticipantVisitResolver;
 import org.labkey.api.study.publish.StudyPublishService;
+import org.labkey.api.util.IntegerUtils;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.util.UnexpectedException;
@@ -1076,20 +1077,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                 // Wire up well samples as materials inputs
                 if (resolvePlateSamples)
                 {
-                    Long _plateId;
-
-                    try
-                    {
-                        _plateId = (Long) map.get(platePD.getName());
-                    }
-                    catch (ClassCastException e)
-                    {
-                        // File import can cause ClassCastException to be thrown, so we manually convert from integer.
-                        Integer plateIdInt = (Integer) map.get(platePD.getName());
-                        _plateId = plateIdInt.longValue();
-                    }
-
-                    Long plateId = _plateId; // Re-assign so it's final
+                    Long plateId = IntegerUtils.asLong(map.get(platePD.getName()));
                     String wellLocation = (String) map.get(wellLocationPD.getName());
                     Long sampleId = null;
                     ExpMaterial material = null;

--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -517,7 +517,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             }
             Map<ExpMaterial, String> rowBasedInputMaterials = new LinkedHashMap<>();
 
-            DataIterator fileData = checkData(container, user, protocol, dataTable, dataDomain, iter, settings, resolver, protocolInputMaterials, cf, rowBasedInputMaterials);
+            DataIterator fileData = checkData(container, user, provider, protocol, dataTable, dataDomain, iter, settings, resolver, protocolInputMaterials, cf, rowBasedInputMaterials);
             fileData = convertPropertyNamesToURIs(fileData, dataDomain);
 
             OntologyManager.RowCallback rowCallback = NO_OP_ROW_CALLBACK;
@@ -684,6 +684,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
     private DataIterator checkData(
             Container container,
             User user,
+            AssayProvider provider,
             ExpProtocol protocol,
             TableInfo dataTable,
             Domain dataDomain,
@@ -722,6 +723,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
         List<? extends DomainProperty> columns = dataDomain.getProperties();
         Map<DomainProperty, List<ColumnValidator>> validatorMap = new HashMap<>();
+        boolean isPlateMetadataEnabled = provider.isPlateMetadataEnabled(protocol);
 
         for (DomainProperty pd : columns)
         {
@@ -753,15 +755,21 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
             {
                 targetStudyPropFinder = pd;
             }
-            else if (pd.getName().equalsIgnoreCase("WellLocation") && pd.getPropertyDescriptor().getPropertyType() == PropertyType.STRING)
+            else if (isPlateMetadataEnabled &&
+                    pd.getName().equalsIgnoreCase("WellLocation") &&
+                    pd.getPropertyDescriptor().getPropertyType() == PropertyType.STRING)
             {
                 wellLocationPropFinder = pd;
             }
-            else if (pd.getName().equalsIgnoreCase("WellLsid") && pd.getPropertyDescriptor().getPropertyType() == PropertyType.STRING)
+            else if (isPlateMetadataEnabled &&
+                    pd.getName().equalsIgnoreCase("WellLsid") &&
+                    pd.getPropertyDescriptor().getPropertyType() == PropertyType.STRING)
             {
                 wellLsidPropFinder = pd;
             }
-            else if (pd.getName().equalsIgnoreCase("Plate") && pd.getPropertyDescriptor().isLookup())
+            else if (isPlateMetadataEnabled &&
+                    pd.getName().equalsIgnoreCase("Plate") &&
+                    pd.getPropertyDescriptor().isLookup())
             {
                 platePropFinder = pd;
             }
@@ -816,8 +824,6 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         DomainProperty wellLocationPD = wellLocationPropFinder;
         DomainProperty wellLsidPD = wellLsidPropFinder;
 
-        AssayProvider provider = AssayService.get().getProvider(protocol);
-        boolean isPlateMetadataEnabled = provider != null && provider.isPlateMetadataEnabled(protocol);
         boolean resolvePlateSamples = isPlateMetadataEnabled && platePD != null && wellLocationPD != null && wellLsidPD != null;
 
         return DataIteratorUtil.mapTransformer(rawData, inputCols ->
@@ -1077,7 +1083,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
                     if (plateId != null && wellLocation != null)
                     {
-                        Map<String, Long> wellSampleCache = plateWellCache.computeIfAbsent(plateId, (id) -> AssayPlateMetadataService.get().getWellLocationToSampleIdMap(plateId));
+                        Map<String, Long> wellSampleCache = plateWellCache.computeIfAbsent(plateId, (id) -> AssayPlateMetadataService.get().getWellLocationToSampleIdMap(container, user, plateId));
                         sampleId = wellSampleCache.get(wellLocation);
                     }
 

--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayRunUploadContext;
+import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.TableInfo;
@@ -182,6 +183,13 @@ public interface AssayPlateMetadataService
         TableInfo resultsTable,
         List<Long> runIds
     ) throws ValidationException;
+
+    /**
+     * Returns a Map of Well Location to Sample RowID for a given Plate ID.
+     */
+    Map<String, Long> getWellLocationToSampleIdMap(Long plateId);
+
+    boolean isWellLookup(ColumnInfo col);
 
     /**
      * Should only be used to get a local instance of a plate schema where a contextual role might be involved. Schemas created this way are not cached,

--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -187,7 +187,7 @@ public interface AssayPlateMetadataService
     /**
      * Returns a Map of Well Location to Sample RowID for a given Plate ID.
      */
-    Map<String, Long> getWellLocationToSampleIdMap(Long plateId);
+    Map<String, Long> getWellLocationToSampleIdMap(Container container, User user, Long plateId);
 
     boolean isWellLookup(ColumnInfo col);
 

--- a/api/src/org/labkey/api/assay/sample/AssaySampleLookupContext.java
+++ b/api/src/org/labkey/api/assay/sample/AssaySampleLookupContext.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
+import org.labkey.api.assay.plate.AssayPlateMetadataService;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
@@ -11,6 +12,7 @@ import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpProtocolApplication;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExpSampleType;
@@ -94,6 +96,31 @@ public class AssaySampleLookupContext
     }
 
     /**
+     * Keeps track of experiment runs for assays that have columns with a sample lookup, including plate metadata
+     * enabled assays. Useful in data updates of assay run/result domains where sample lookups are subsequently
+     * reflected as material inputs to  an experiment run.
+     * @param container Container from which to resolve sample lookup information.
+     * @param user User to utilize to resolve sample lookup information.
+     * @param table The table to utilize to resole sample lookup information.
+     * @param protocol The experiment protocol associated with the run.
+     * @param run The experiment run to track.
+     */
+    public void trackSampleLookupChange(Container container, User user, TableInfo table, ExpProtocol protocol, ExpRun run)
+    {
+        if (table.getDomain() == null) return;
+
+        AssayProvider provider = AssayService.get().getProvider(protocol);
+
+        if (provider != null && provider.isPlateMetadataEnabled(protocol))
+        {
+            _runIds.add(run.getRowId());
+        }
+
+        for (DomainProperty dp : table.getDomain().getNonBaseProperties())
+            trackSampleLookupChange(container, user, table, table.getColumn(dp.getName()), run);
+    }
+
+    /**
      * Check if a domain property is considered a valid sample lookup.
      * @param container Container from which to resolve sample lookup information.
      * @param user User to utilize to resolve sample lookup information.
@@ -112,8 +139,9 @@ public class AssaySampleLookupContext
 
         ExpSampleType sampleType = ExperimentService.get().getLookupSampleType(dp, container, user);
         boolean isSampleLookup = sampleType != null || ExperimentService.get().isLookupToMaterials(dp);
+        boolean isWellLookup = dp.getName().equalsIgnoreCase("WellLsid") && col != null && AssayPlateMetadataService.get().isWellLookup(col);
 
-        return new SampleLookup(isSampleLookup, col, dp, sampleType);
+        return new SampleLookup(isSampleLookup || isWellLookup, col, dp, sampleType);
     }
 
     private SampleLookup checkSampleLookup(Container container, User user, TableInfo table, ColumnInfo col)
@@ -384,7 +412,18 @@ public class AssaySampleLookupContext
         var role = AssayService.get().getPropertyInputLineageRole(sampleLookup.domainProperty);
         var sql = new SQLFragment();
 
-        if (column.getJdbcType().isInteger())
+        if (AssayPlateMetadataService.get().isWellLookup(column))
+        {
+            // tableSql selects all the Well LSIDs for the given runId, we then select all the SampleIds from the
+            // assay.well table that match those Well LSIDs.
+            tableSql = QueryService.get().getSelectBuilder(table)
+                    .columns(Set.of(column))
+                    .filter(tableFilter)
+                    .buildSqlFragment();
+            sql.append("SELECT WS.SampleId as MaterialRowId, ").appendValue(role).append(" AS MaterialInputRole\n");
+            sql.append("FROM assay.well WS WHERE LSID IN (").append(tableSql).append(")");
+        }
+        else if (column.getJdbcType().isInteger())
         {
             sql.append("SELECT DA.").appendIdentifier(column.getAlias()).append(" AS MaterialRowId");
             sql.append(", ?").add(role).append(" AS MaterialInputRole\n");

--- a/api/src/org/labkey/api/assay/sample/AssaySampleLookupContext.java
+++ b/api/src/org/labkey/api/assay/sample/AssaySampleLookupContext.java
@@ -2,6 +2,7 @@ package org.labkey.api.assay.sample;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.assay.AssayProtocolSchema;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.assay.plate.AssayPlateMetadataService;
@@ -102,22 +103,24 @@ public class AssaySampleLookupContext
      * @param container Container from which to resolve sample lookup information.
      * @param user User to utilize to resolve sample lookup information.
      * @param table The table to utilize to resole sample lookup information.
-     * @param protocol The experiment protocol associated with the run.
+     * @param schema The AssayProtocolSchema associated with the run.
      * @param run The experiment run to track.
      */
-    public void trackSampleLookupChange(Container container, User user, TableInfo table, ExpProtocol protocol, ExpRun run)
+    public void trackSampleLookupChange(Container container, User user, TableInfo table, AssayProtocolSchema schema, ExpRun run)
     {
         if (table.getDomain() == null) return;
 
-        AssayProvider provider = AssayService.get().getProvider(protocol);
-
-        if (provider != null && provider.isPlateMetadataEnabled(protocol))
-        {
-            _runIds.add(run.getRowId());
-        }
-
         for (DomainProperty dp : table.getDomain().getNonBaseProperties())
             trackSampleLookupChange(container, user, table, table.getColumn(dp.getName()), run);
+
+        if (_runIds.contains(run.getRowId()))
+            return;
+
+        AssayProvider provider = schema.getProvider();
+        ExpProtocol protocol = schema.getProtocol();
+
+        if (provider.isPlateMetadataEnabled(protocol))
+            _runIds.add(run.getRowId());
     }
 
     /**

--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -368,11 +368,7 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
         }
 
         // Issue 51126: need to track and resync run/sample lineage on delete in the same way we do for update
-        if (datatableInfo.getDomain() != null)
-        {
-            for (DomainProperty dp : datatableInfo.getDomain().getNonBaseProperties())
-                _assaySampleLookupContext.trackSampleLookupChange(container, user, datatableInfo, datatableInfo.getColumn(dp.getName()), run);
-        }
+        _assaySampleLookupContext.trackSampleLookupChange(container, user, datatableInfo, _schema.getProtocol(), run);
 
         return result;
     }

--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -368,7 +368,7 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
         }
 
         // Issue 51126: need to track and resync run/sample lineage on delete in the same way we do for update
-        _assaySampleLookupContext.trackSampleLookupChange(container, user, datatableInfo, _schema.getProtocol(), run);
+        _assaySampleLookupContext.trackSampleLookupChange(container, user, datatableInfo, _schema, run);
 
         return result;
     }

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0"
+        "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2458,9 +2458,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.62.8-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.62.8-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-2cM1esIbHmPha4KP8T09GKgBo8K7EKrqPTAFU8ymTDByH9amQ2Xc+l0k3u5sVq0C0acfnXkZzLvGVjUdBdVh3A==",
+      "version": "6.63.0-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.0-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-4g6/2lZOJ2yXwwp9wAw/IgG0Vp8r5uUDXc3MBvowYwjJXUSHz8Yz+YiA1KpQXDKGCTpaSTpp07e0Y1EKBNnkzQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0"
+        "@labkey/components": "6.64.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2458,9 +2458,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.2-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.2-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-9ppFdKfxfdH+0Rzhz6i2Q981Z3eApqNy9jblwG2jl6uvCmaGaiTewUonAHrj7D7ihCj027gI3WCTKiYywHpp6A==",
+      "version": "6.64.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.64.0.tgz",
+      "integrity": "sha512-PvaxxI03mJ64L/F0FFWrtHDFwrFiyYm+/w/uyCTjFv/RZ/A+CIjkb5+v4iaQyAzJPUr1HzVPUfDlNxWkd3r2OQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0"
+        "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2458,9 +2458,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.0-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.0-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-4g6/2lZOJ2yXwwp9wAw/IgG0Vp8r5uUDXc3MBvowYwjJXUSHz8Yz+YiA1KpQXDKGCTpaSTpp07e0Y1EKBNnkzQ==",
+      "version": "6.63.1-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.1-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-Nt7bqWozrXMbSqTSbbLxLCj4sQ+YFJQ/0ukZeYXdGTpuZjYIhYpQ4cpqWmGjI/C8CcekwlMuiduXqjLkIeBmCQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0"
+        "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2458,9 +2458,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.1-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.1-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-Nt7bqWozrXMbSqTSbbLxLCj4sQ+YFJQ/0ukZeYXdGTpuZjYIhYpQ4cpqWmGjI/C8CcekwlMuiduXqjLkIeBmCQ==",
+      "version": "6.63.2-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.2-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-9ppFdKfxfdH+0Rzhz6i2Q981Z3eApqNy9jblwG2jl6uvCmaGaiTewUonAHrj7D7ihCj027gI3WCTKiYywHpp6A==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.1"
+        "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2458,9 +2458,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.1.tgz",
-      "integrity": "sha512-HHniE4AIh1y4g/k5acx1XtdVPck/MpRpA3e6nacjedhVPS811DgRYwPuqrWu4dRYLWFKpG5ddGqTbyU1QYMxpA==",
+      "version": "6.62.8-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.62.8-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-2cM1esIbHmPha4KP8T09GKgBo8K7EKrqPTAFU8ymTDByH9amQ2Xc+l0k3u5sVq0C0acfnXkZzLvGVjUdBdVh3A==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0"
+    "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0"
+    "@labkey/components": "6.64.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0"
+    "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0"
+    "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.63.1"
+    "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -1517,6 +1517,38 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         return new PlateSchema(querySchema, contextualRoles);
     }
 
+    record WellSampleData(Long sampleId, Integer row, Integer col) {}
+
+    @Override
+    public Map<String, Long> getWellLocationToSampleIdMap(Long plateId)
+    {
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("plateid"), plateId);
+        List<WellSampleData> wells = new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), Set.of("SampleId", "Row", "Col"), filter, null).getArrayList(WellSampleData.class);
+        Map<String, Long> wellLocationToSampleIdMap = new HashMap<>();
+
+        for (WellSampleData well : wells)
+        {
+            PositionImpl pos = new PositionImpl(null, well.row, well.col);
+            wellLocationToSampleIdMap.put(pos.getDescription(), well.sampleId);
+        }
+
+        return wellLocationToSampleIdMap;
+    }
+
+    @Override
+    public boolean isWellLookup(ColumnInfo col)
+    {
+        if (col == null) return false;
+
+        if (!col.isLookup()) return false;
+
+        var wellTable = AssayDbSchema.getInstance().getTableInfoWell();
+        var lookupTable = col.getFkTableInfo();
+
+        return lookupTable.getSchema().getName().equalsIgnoreCase(wellTable.getSchema().getName())
+                && lookupTable.getName().equalsIgnoreCase(wellTable.getName());
+    }
+
     private static class PlateMetadataImportHelper extends SimpleAssayDataImportHelper
     {
         private final Map<Long, Map<Position, Lsid>> _wellPositionMap;       // map of plate position to well table

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -96,6 +96,7 @@ import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.assay.TSVProtocolSchema;
+import org.labkey.assay.plate.data.WellData;
 import org.labkey.assay.plate.model.WellBean;
 import org.labkey.assay.plate.query.PlateSchema;
 import org.labkey.assay.plate.query.PlateTable;
@@ -1517,20 +1518,14 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         return new PlateSchema(querySchema, contextualRoles);
     }
 
-    record WellSampleData(Long sampleId, Integer row, Integer col) {}
-
     @Override
-    public Map<String, Long> getWellLocationToSampleIdMap(Long plateId)
+    public Map<String, Long> getWellLocationToSampleIdMap(Container container, User user, Long plateId)
     {
-        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("plateid"), plateId);
-        List<WellSampleData> wells = new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), Set.of("SampleId", "Row", "Col"), filter, null).getArrayList(WellSampleData.class);
         Map<String, Long> wellLocationToSampleIdMap = new HashMap<>();
+        List<WellData> wellData = PlateManager.get().getWellData(container, user, plateId, true, false);
 
-        for (WellSampleData well : wells)
-        {
-            PositionImpl pos = new PositionImpl(null, well.row, well.col);
-            wellLocationToSampleIdMap.put(pos.getDescription(), well.sampleId);
-        }
+        for (WellData data : wellData)
+            wellLocationToSampleIdMap.put(data.getPosition(), data.getSampleId());
 
         return wellLocationToSampleIdMap;
     }

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0",
+        "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3504,9 +3504,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.0-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.0-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-4g6/2lZOJ2yXwwp9wAw/IgG0Vp8r5uUDXc3MBvowYwjJXUSHz8Yz+YiA1KpQXDKGCTpaSTpp07e0Y1EKBNnkzQ==",
+      "version": "6.63.1-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.1-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-Nt7bqWozrXMbSqTSbbLxLCj4sQ+YFJQ/0ukZeYXdGTpuZjYIhYpQ4cpqWmGjI/C8CcekwlMuiduXqjLkIeBmCQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.1",
+        "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3504,9 +3504,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.1.tgz",
-      "integrity": "sha512-HHniE4AIh1y4g/k5acx1XtdVPck/MpRpA3e6nacjedhVPS811DgRYwPuqrWu4dRYLWFKpG5ddGqTbyU1QYMxpA==",
+      "version": "6.62.8-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.62.8-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-2cM1esIbHmPha4KP8T09GKgBo8K7EKrqPTAFU8ymTDByH9amQ2Xc+l0k3u5sVq0C0acfnXkZzLvGVjUdBdVh3A==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0",
+        "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3504,9 +3504,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.1-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.1-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-Nt7bqWozrXMbSqTSbbLxLCj4sQ+YFJQ/0ukZeYXdGTpuZjYIhYpQ4cpqWmGjI/C8CcekwlMuiduXqjLkIeBmCQ==",
+      "version": "6.63.2-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.2-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-9ppFdKfxfdH+0Rzhz6i2Q981Z3eApqNy9jblwG2jl6uvCmaGaiTewUonAHrj7D7ihCj027gI3WCTKiYywHpp6A==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0",
+        "@labkey/components": "6.64.0",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3504,9 +3504,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.2-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.2-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-9ppFdKfxfdH+0Rzhz6i2Q981Z3eApqNy9jblwG2jl6uvCmaGaiTewUonAHrj7D7ihCj027gI3WCTKiYywHpp6A==",
+      "version": "6.64.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.64.0.tgz",
+      "integrity": "sha512-PvaxxI03mJ64L/F0FFWrtHDFwrFiyYm+/w/uyCTjFv/RZ/A+CIjkb5+v4iaQyAzJPUr1HzVPUfDlNxWkd3r2OQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0",
+        "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3504,9 +3504,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.62.8-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.62.8-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-2cM1esIbHmPha4KP8T09GKgBo8K7EKrqPTAFU8ymTDByH9amQ2Xc+l0k3u5sVq0C0acfnXkZzLvGVjUdBdVh3A==",
+      "version": "6.63.0-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.0-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-4g6/2lZOJ2yXwwp9wAw/IgG0Vp8r5uUDXc3MBvowYwjJXUSHz8Yz+YiA1KpQXDKGCTpaSTpp07e0Y1EKBNnkzQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0",
+    "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0",
+    "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0",
+    "@labkey/components": "6.64.0",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.63.1",
+    "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0",
+    "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.1"
+        "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -3247,9 +3247,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.1.tgz",
-      "integrity": "sha512-HHniE4AIh1y4g/k5acx1XtdVPck/MpRpA3e6nacjedhVPS811DgRYwPuqrWu4dRYLWFKpG5ddGqTbyU1QYMxpA==",
+      "version": "6.62.8-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.62.8-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-2cM1esIbHmPha4KP8T09GKgBo8K7EKrqPTAFU8ymTDByH9amQ2Xc+l0k3u5sVq0C0acfnXkZzLvGVjUdBdVh3A==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0"
+        "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -3247,9 +3247,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.1-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.1-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-Nt7bqWozrXMbSqTSbbLxLCj4sQ+YFJQ/0ukZeYXdGTpuZjYIhYpQ4cpqWmGjI/C8CcekwlMuiduXqjLkIeBmCQ==",
+      "version": "6.63.2-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.2-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-9ppFdKfxfdH+0Rzhz6i2Q981Z3eApqNy9jblwG2jl6uvCmaGaiTewUonAHrj7D7ihCj027gI3WCTKiYywHpp6A==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0"
+        "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -3247,9 +3247,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.0-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.0-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-4g6/2lZOJ2yXwwp9wAw/IgG0Vp8r5uUDXc3MBvowYwjJXUSHz8Yz+YiA1KpQXDKGCTpaSTpp07e0Y1EKBNnkzQ==",
+      "version": "6.63.1-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.1-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-Nt7bqWozrXMbSqTSbbLxLCj4sQ+YFJQ/0ukZeYXdGTpuZjYIhYpQ4cpqWmGjI/C8CcekwlMuiduXqjLkIeBmCQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0"
+        "@labkey/components": "6.64.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -3247,9 +3247,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.2-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.2-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-9ppFdKfxfdH+0Rzhz6i2Q981Z3eApqNy9jblwG2jl6uvCmaGaiTewUonAHrj7D7ihCj027gI3WCTKiYywHpp6A==",
+      "version": "6.64.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.64.0.tgz",
+      "integrity": "sha512-PvaxxI03mJ64L/F0FFWrtHDFwrFiyYm+/w/uyCTjFv/RZ/A+CIjkb5+v4iaQyAzJPUr1HzVPUfDlNxWkd3r2OQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0"
+        "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -3247,9 +3247,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.62.8-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.62.8-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-2cM1esIbHmPha4KP8T09GKgBo8K7EKrqPTAFU8ymTDByH9amQ2Xc+l0k3u5sVq0C0acfnXkZzLvGVjUdBdVh3A==",
+      "version": "6.63.0-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.0-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-4g6/2lZOJ2yXwwp9wAw/IgG0Vp8r5uUDXc3MBvowYwjJXUSHz8Yz+YiA1KpQXDKGCTpaSTpp07e0Y1EKBNnkzQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0"
+    "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0"
+    "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0"
+    "@labkey/components": "6.64.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.63.1"
+    "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0"
+    "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0"
+        "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.62.8-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.62.8-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-2cM1esIbHmPha4KP8T09GKgBo8K7EKrqPTAFU8ymTDByH9amQ2Xc+l0k3u5sVq0C0acfnXkZzLvGVjUdBdVh3A==",
+      "version": "6.63.0-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.0-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-4g6/2lZOJ2yXwwp9wAw/IgG0Vp8r5uUDXc3MBvowYwjJXUSHz8Yz+YiA1KpQXDKGCTpaSTpp07e0Y1EKBNnkzQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0"
+        "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.1-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.1-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-Nt7bqWozrXMbSqTSbbLxLCj4sQ+YFJQ/0ukZeYXdGTpuZjYIhYpQ4cpqWmGjI/C8CcekwlMuiduXqjLkIeBmCQ==",
+      "version": "6.63.2-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.2-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-9ppFdKfxfdH+0Rzhz6i2Q981Z3eApqNy9jblwG2jl6uvCmaGaiTewUonAHrj7D7ihCj027gI3WCTKiYywHpp6A==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0"
+        "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.0-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.0-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-4g6/2lZOJ2yXwwp9wAw/IgG0Vp8r5uUDXc3MBvowYwjJXUSHz8Yz+YiA1KpQXDKGCTpaSTpp07e0Y1EKBNnkzQ==",
+      "version": "6.63.1-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.1-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-Nt7bqWozrXMbSqTSbbLxLCj4sQ+YFJQ/0ukZeYXdGTpuZjYIhYpQ4cpqWmGjI/C8CcekwlMuiduXqjLkIeBmCQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.1"
+        "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.1.tgz",
-      "integrity": "sha512-HHniE4AIh1y4g/k5acx1XtdVPck/MpRpA3e6nacjedhVPS811DgRYwPuqrWu4dRYLWFKpG5ddGqTbyU1QYMxpA==",
+      "version": "6.62.8-fb-plate-assay-material-inputs.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.62.8-fb-plate-assay-material-inputs.0.tgz",
+      "integrity": "sha512-2cM1esIbHmPha4KP8T09GKgBo8K7EKrqPTAFU8ymTDByH9amQ2Xc+l0k3u5sVq0C0acfnXkZzLvGVjUdBdVh3A==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0"
+        "@labkey/components": "6.64.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.63.2-fb-plate-assay-material-inputs.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.63.2-fb-plate-assay-material-inputs.0.tgz",
-      "integrity": "sha512-9ppFdKfxfdH+0Rzhz6i2Q981Z3eApqNy9jblwG2jl6uvCmaGaiTewUonAHrj7D7ihCj027gI3WCTKiYywHpp6A==",
+      "version": "6.64.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.64.0.tgz",
+      "integrity": "sha512-PvaxxI03mJ64L/F0FFWrtHDFwrFiyYm+/w/uyCTjFv/RZ/A+CIjkb5+v4iaQyAzJPUr1HzVPUfDlNxWkd3r2OQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0"
+    "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.63.2-fb-plate-assay-material-inputs.0"
+    "@labkey/components": "6.64.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0"
+    "@labkey/components": "6.63.1-fb-plate-assay-material-inputs.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.63.1"
+    "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.62.8-fb-plate-assay-material-inputs.0"
+    "@labkey/components": "6.63.0-fb-plate-assay-material-inputs.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",


### PR DESCRIPTION
#### Rationale
This PR updates our server side code to mark samples on Plate Wells as MaterialInputs when importing assay data for plate enabled assays. This allows us to show plate assay data for samples on the Sample details page in our apps.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1860
- https://github.com/LabKey/labkey-ui-premium/pull/828
- https://github.com/LabKey/platform/pull/7101
- https://github.com/LabKey/limsModules/pull/1705

#### Changes
- AbstractAssayTsvDataHandler: Mark plate well samples as assay run materials inputs during checkData
- AssaySampleLookupContext: Clean up the material inputs during assay data row delete
- AssayPlateMetadataService
    - Add getWellLocationToSampleIdMap
    - Add isWellLookup
- Bump ui-components

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->