### PR TITLE
ListItemDetailsAction: improve parameter resolution

### DIFF
--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -894,8 +894,8 @@ public class ListController extends SpringActionController
 
             if (_list == null)
             {
-                int listId = form.getListId();
-                if (listId > 0)
+                Integer listId = form.getListId();
+                if (listId != null && listId > 0)
                     _list = ListService.get().getList(getContainer(), listId);
             }
 
@@ -906,7 +906,10 @@ public class ListController extends SpringActionController
             String oldRecord = null;
             String newRecord = null;
 
-            int eventRowId = form.getRowId();
+            Integer eventRowId = form.getRowId();
+            if (eventRowId == null || eventRowId <= 0)
+                return HtmlView.of("Unable to resolve event details. An event \"rowId\" must be specified.");
+
             ListAuditProvider.ListAuditEvent event = AuditLogService.get().getAuditEvent(getUser(), ListManager.LIST_AUDIT_EVENT, eventRowId);
 
             if (event != null)


### PR DESCRIPTION
#### Rationale
Avoid NPE when resolving `Integer` parameters. Introduced with #7097 and discovered by link check failures in CI.

#### Related Pull Requests
- #7097

#### Changes
- Resolve as `Integer` and add explicit null/range checks.