### PR TITLE
Issue 53367: sample status edit fails

### DIFF
--- a/core/src/org/labkey/core/query/DataStatesTableInfo.java
+++ b/core/src/org/labkey/core/query/DataStatesTableInfo.java
@@ -91,7 +91,7 @@ public class DataStatesTableInfo extends FilteredTable<CoreQuerySchema>
             return _dataState;
         }
 
-        private boolean isDuplicate(String label, Container container)
+        private boolean isDuplicate(String label, Container container, int currentRowId)
         {
             Map<String, DataStateHandler<AbstractManageDataStatesForm>> registeredHandlers = DataStateManager.getInstance().getRegisteredDataHandlers();
             for (DataStateHandler<AbstractManageDataStatesForm> handler : registeredHandlers.values())
@@ -101,7 +101,8 @@ public class DataStatesTableInfo extends FilteredTable<CoreQuerySchema>
                     List<DataState> dataStates = handler.getStates(container);
                     for (DataState dataState : dataStates)
                     {
-                        if (dataState.getLabel().equalsIgnoreCase(label))
+                        boolean isUpdatingCurrent = currentRowId == dataState.getRowId();
+                        if (!isUpdatingCurrent && dataState.getLabel().equalsIgnoreCase(label))
                             return true;
                     }
                 }
@@ -151,7 +152,8 @@ public class DataStatesTableInfo extends FilteredTable<CoreQuerySchema>
             if (!validateLabel(row, true))
                 throw new QueryUpdateServiceException("Label cannot be blank.");
 
-            if (isDuplicate(String.valueOf(row.get("label")), container))
+
+            if (isDuplicate(String.valueOf(row.get("label")), container, (int) row.get("rowId")))
                 throw new QueryUpdateServiceException("Label '" + row.get("label") + "' already exists, perhaps with different capitalization.");
 
             String errorMsg = validateQCStateChangeAllowed(row, container);
@@ -173,7 +175,7 @@ public class DataStatesTableInfo extends FilteredTable<CoreQuerySchema>
         {
             if (!validateLabel(row, false))
                 throw new QueryUpdateServiceException("Label cannot be blank.");
-            if (isDuplicate(String.valueOf(row.get("label")), container))
+            if (isDuplicate(String.valueOf(row.get("label")), container, -1/*new row, no rowId*/))
                 throw new QueryUpdateServiceException("Label '" + row.get("label") + "' already exists, perhaps with different capitalization.");
 
             Map<String, Object> rowToInsert;


### PR DESCRIPTION
#### Rationale
Issue [53367](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53367)
The check of duplicate label for sample status checks a provided label against all existing labels. This works for new labels, but fails for updating an existing label. 

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/831
- https://github.com/LabKey/platform/pull/7111
- https://github.com/LabKey/limsModules/pull/1720

#### Changes
- exclude self when checking duplicate during update sample state details

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->