### PR TITLE
Support deserialization of NowTimestamp

### DIFF
--- a/api/src/org/labkey/api/data/NowTimestamp.java
+++ b/api/src/org/labkey/api/data/NowTimestamp.java
@@ -1,0 +1,59 @@
+package org.labkey.api.data;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+
+/**
+ * Marker interface to hint that this value may be replaced by CURRENT_TIMESTAMP.
+ */
+@JsonDeserialize(using = NowTimestamp.NowTimestampDeserializer.class)
+public class NowTimestamp extends java.sql.Timestamp
+{
+    public NowTimestamp()
+    {
+        this(System.currentTimeMillis());
+    }
+
+    public NowTimestamp(long ms)
+    {
+        super(ms);
+    }
+
+    public static class NowTimestampDeserializer extends JsonDeserializer<NowTimestamp>
+    {
+        @Override
+        public NowTimestamp deserialize(JsonParser p, DeserializationContext ctx) throws IOException
+        {
+            JsonToken token = p.getCurrentToken();
+
+            if (token == JsonToken.VALUE_STRING)
+            {
+                String text = p.getText().trim();
+
+                try
+                {
+                    Timestamp ts = Timestamp.valueOf(text);
+                    return new NowTimestamp(ts.getTime());
+                }
+                catch (IllegalArgumentException ex)
+                {
+                    throw ctx.weirdStringException(text, NowTimestamp.class, "Expected a valid timestamp string.");
+                }
+            }
+
+            if (token == JsonToken.VALUE_NUMBER_INT)
+            {
+                long milliseconds = p.getLongValue();
+                return new NowTimestamp(milliseconds);
+            }
+
+            throw ctx.wrongTokenException(p, NowTimestamp.class, JsonToken.VALUE_STRING, "Expected timestamp as String or long.");
+        }
+    }
+}

--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -1342,18 +1342,4 @@ public class SQLFragment implements Appendable, CharSequence
 
         return new SQLFragment(sql, params);
     }
-
-    // Marker interface to hint that this value may be replaced by CURRENT_TIMESTAMP
-    public static class NowTimestamp extends java.sql.Timestamp
-    {
-        public NowTimestamp()
-        {
-            this(System.currentTimeMillis());
-        }
-
-        public NowTimestamp(long ms)
-        {
-            super(ms);
-        }
-    }
 }

--- a/api/src/org/labkey/api/data/StatementUtils.java
+++ b/api/src/org/labkey/api/data/StatementUtils.java
@@ -1240,7 +1240,7 @@ public class StatementUtils
             f.append(value.toString());
             return;
         }
-        if (value instanceof SQLFragment.NowTimestamp now)
+        if (value instanceof NowTimestamp now)
         {
             f.appendValue(now);
             return;
@@ -1405,7 +1405,7 @@ public class StatementUtils
             assertEquals(new SQLFragment("1234567890"), actual);
 
             // NowTimestamp
-            var now = new SQLFragment.NowTimestamp(dateLong);
+            var now = new NowTimestamp(dateLong);
             actual = runToLiteral.apply(now);
             assertEquals(new SQLFragment().appendValue(now), actual);
 

--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -705,7 +705,7 @@ public class Table
         return StringUtils.stripEnd(s, "\t\r\n ");
     }
 
-    protected static void _insertSpecialFields(User user, TableInfo table, Map<String, Object> fields, SQLFragment.NowTimestamp now)
+    protected static void _insertSpecialFields(User user, TableInfo table, Map<String, Object> fields, NowTimestamp now)
     {
         ColumnInfo col = table.getColumn(OWNER_COLUMN_NAME);
         if (null != col && null != user)
@@ -741,7 +741,7 @@ public class Table
             _setProperty(returnObject, CREATED_BY_COLUMN_NAME, fields.get(CREATED_BY_COLUMN_NAME));
     }
 
-    protected static void _updateSpecialFields(@Nullable User user, TableInfo table, Map<String, Object> fields, SQLFragment.NowTimestamp now)
+    protected static void _updateSpecialFields(@Nullable User user, TableInfo table, Map<String, Object> fields, NowTimestamp now)
     {
         ColumnInfo colModifiedBy = table.getColumn(MODIFIED_BY_COLUMN_NAME);
         if (null != colModifiedBy && null != user)
@@ -826,7 +826,7 @@ public class Table
         Map<String, Object> fields = fieldsIn instanceof Map ?
                 _getTableData(table, (Map<String, Object>)fieldsIn, true) :
                 _getTableData(table, fieldsIn, true);
-        SQLFragment.NowTimestamp now = new SQLFragment.NowTimestamp();
+        NowTimestamp now = new NowTimestamp();
         _insertSpecialFields(user, table, fields, now);
         _updateSpecialFields(user, table, fields, now);
 
@@ -860,7 +860,7 @@ public class Table
             valueSQL.append(comma);
             if (null == value || value instanceof String s && s.isEmpty())
                 valueSQL.append("NULL");
-            else if (value instanceof SQLFragment.NowTimestamp ts)
+            else if (value instanceof NowTimestamp ts)
                 valueSQL.appendValue(ts);
             else
             {
@@ -1020,7 +1020,7 @@ public class Table
         Map<String, Object> fields = fieldsIn instanceof Map ?
             _getTableData(table, (Map<String,Object>)fieldsIn, true) :
             _getTableData(table, fieldsIn, true);
-        _updateSpecialFields(user, table, fields, new SQLFragment.NowTimestamp());
+        _updateSpecialFields(user, table, fields, new NowTimestamp());
 
         List<ColumnInfo> columns = table.getColumns();
         ColumnInfo colModified = table.getColumn(MODIFIED_COLUMN_NAME);
@@ -1064,7 +1064,7 @@ public class Table
 
             if (null == value || value instanceof String s && s.isEmpty())
                 setSQL.append("NULL");
-            else if (value instanceof SQLFragment.NowTimestamp ts)
+            else if (value instanceof NowTimestamp ts)
                 setSQL.appendValue(ts);
             else
             {

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -48,7 +48,7 @@ import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.LookupResolutionType;
 import org.labkey.api.data.MultiValuedForeignKey;
 import org.labkey.api.data.MvUtil;
-import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.NowTimestamp;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableDescription;
 import org.labkey.api.data.TableInfo;
@@ -59,7 +59,6 @@ import org.labkey.api.exp.MvFieldWrapper;
 import org.labkey.api.exp.PropertyDescriptor;
 import org.labkey.api.exp.PropertyType;
 import org.labkey.api.files.FileContentService;
-import org.labkey.api.gwt.client.model.PropertyValidatorType;
 import org.labkey.api.ontology.Unit;
 import org.labkey.api.query.AbstractQueryUpdateService;
 import org.labkey.api.query.BatchValidationException;
@@ -72,7 +71,6 @@ import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.UpdatePermission;
-import org.labkey.api.settings.OptionalFeatureService;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.IntegerUtils;
 import org.labkey.api.util.JunitUtil;
@@ -1057,7 +1055,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         public Object get()
         {
             if (null == _ts)
-                _ts =  new SQLFragment.NowTimestamp();
+                _ts =  new NowTimestamp();
             return _ts;
         }
     }
@@ -2005,7 +2003,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
         if (c instanceof SimpleConvertColumn scc)
             return scc.convert(_data.getConstantValue(scc.index));
         if (c instanceof TimestampColumn)
-            return new SQLFragment.NowTimestamp();
+            return new NowTimestamp();
         throw new IllegalStateException("shouldn't call this method unless isConstant()==true");
     }
 


### PR DESCRIPTION
#### Rationale
Follow-on work for [Issue 48864](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48864) to add support for deserialization of `NowTimestamp` via Jackson.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7104

#### Changes
- extract `NowTimestamp` into own class definition file
- define `NowTimestampDeserializer`