### PR TITLE
Convert NowTimestamp to Timestamp

### DIFF
--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -736,7 +736,7 @@ public class Table
         if (fields.containsKey(OWNER_COLUMN_NAME))
             _setProperty(returnObject, OWNER_COLUMN_NAME, fields.get(OWNER_COLUMN_NAME));
         if (fields.containsKey(CREATED_COLUMN_NAME))
-            _setTimestampProperty(returnObject, CREATED_COLUMN_NAME, fields.get(CREATED_COLUMN_NAME));
+            _setProperty(returnObject, CREATED_COLUMN_NAME, fields.get(CREATED_COLUMN_NAME));
         if (fields.containsKey(CREATED_BY_COLUMN_NAME))
             _setProperty(returnObject, CREATED_BY_COLUMN_NAME, fields.get(CREATED_BY_COLUMN_NAME));
     }
@@ -765,24 +765,20 @@ public class Table
             _setProperty(returnObject, MODIFIED_BY_COLUMN_NAME, fields.get(MODIFIED_BY_COLUMN_NAME));
 
         if (fields.containsKey(MODIFIED_COLUMN_NAME))
-            _setTimestampProperty(returnObject, MODIFIED_COLUMN_NAME, fields.get(MODIFIED_COLUMN_NAME));
+            _setProperty(returnObject, MODIFIED_COLUMN_NAME, fields.get(MODIFIED_COLUMN_NAME));
 
         ColumnInfo colModified = table.getColumn(MODIFIED_COLUMN_NAME);
         ColumnInfo colVersion = table.getVersionColumn();
         if (null != colVersion && colVersion != colModified && colVersion.getJdbcType() == JdbcType.TIMESTAMP)
-            _setTimestampProperty(returnObject, colVersion.getName(), fields.get(colVersion.getName()));
-    }
-
-    static private void _setTimestampProperty(Object fields, String propName, Object value)
-    {
-        // Replace marker NowTimestamp instances with Timestamp for default serialization
-        if (value instanceof NowTimestamp now)
-            value = new java.sql.Timestamp(now.getTime());
-        _setProperty(fields, propName, value);
+            _setProperty(returnObject, colVersion.getName(), fields.get(colVersion.getName()));
     }
 
     static private void _setProperty(Object fields, String propName, Object value)
     {
+        // Replace marker NowTimestamp instances with Timestamp for default serialization
+        if (value instanceof NowTimestamp now)
+            value = new java.sql.Timestamp(now.getTime());
+
         if (fields instanceof Map)
         {
             ((Map<String, Object>) fields).put(propName, value);

--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -736,7 +736,7 @@ public class Table
         if (fields.containsKey(OWNER_COLUMN_NAME))
             _setProperty(returnObject, OWNER_COLUMN_NAME, fields.get(OWNER_COLUMN_NAME));
         if (fields.containsKey(CREATED_COLUMN_NAME))
-            _setProperty(returnObject, CREATED_COLUMN_NAME, fields.get(CREATED_COLUMN_NAME));
+            _setTimestampProperty(returnObject, CREATED_COLUMN_NAME, fields.get(CREATED_COLUMN_NAME));
         if (fields.containsKey(CREATED_BY_COLUMN_NAME))
             _setProperty(returnObject, CREATED_BY_COLUMN_NAME, fields.get(CREATED_BY_COLUMN_NAME));
     }
@@ -765,14 +765,21 @@ public class Table
             _setProperty(returnObject, MODIFIED_BY_COLUMN_NAME, fields.get(MODIFIED_BY_COLUMN_NAME));
 
         if (fields.containsKey(MODIFIED_COLUMN_NAME))
-            _setProperty(returnObject, MODIFIED_COLUMN_NAME, fields.get(MODIFIED_COLUMN_NAME));
+            _setTimestampProperty(returnObject, MODIFIED_COLUMN_NAME, fields.get(MODIFIED_COLUMN_NAME));
 
         ColumnInfo colModified = table.getColumn(MODIFIED_COLUMN_NAME);
         ColumnInfo colVersion = table.getVersionColumn();
         if (null != colVersion && colVersion != colModified && colVersion.getJdbcType() == JdbcType.TIMESTAMP)
-            _setProperty(returnObject, colVersion.getName(), fields.get(colVersion.getName()));
+            _setTimestampProperty(returnObject, colVersion.getName(), fields.get(colVersion.getName()));
     }
 
+    static private void _setTimestampProperty(Object fields, String propName, Object value)
+    {
+        // Replace marker NowTimestamp instances with Timestamp for default serialization
+        if (value instanceof NowTimestamp now)
+            value = new java.sql.Timestamp(now.getTime());
+        _setProperty(fields, propName, value);
+    }
 
     static private void _setProperty(Object fields, String propName, Object value)
     {


### PR DESCRIPTION
#### Rationale
Serialization of `NowTimestamp` is not resolved in the same way as `java.sql.Timestamp` even though it extends `java.sql.Timestamp`. Rather than looking for `NowTimestamp` everywhere and hooking up custom converters I've elected to just convert back all `NowTimestamp` to `Timestamp` immediately when setting the property values in `Table`.

#### Related Pull Requests
- #7104

#### Changes
- Check for `NowTimestamp` instances and convert to `Timestamp` before setting property.