### PR TITLE
Permission validation for related issues

### DIFF
--- a/issues/src/org/labkey/issue/IssueServiceImpl.java
+++ b/issues/src/org/labkey/issue/IssueServiceImpl.java
@@ -140,7 +140,8 @@ public class IssueServiceImpl implements IssueService
                     for (int curIssueId : prevIssues)
                     {
                         IssueObject relatedIssue = ChangeSummary.relatedIssueCommentHandler(issueObject.getIssueId(), curIssueId, user, true);
-                        IssueManager.saveIssue(getRelatedIssueUser(container, user, relatedIssue), container, relatedIssue);
+                        if (null != relatedIssue)
+                            IssueManager.saveIssue(getRelatedIssueUser(container, user, relatedIssue), container, relatedIssue);
                     }
                 }
 

--- a/issues/src/org/labkey/issue/actions/IssueValidation.java
+++ b/issues/src/org/labkey/issue/actions/IssueValidation.java
@@ -231,13 +231,18 @@ public class IssueValidation
                 }
             }
 
-            // Issue 40178: Related Issues need to be in synch when related issues are deleted
+            // Issue 40178: Related Issues need to be in sync when related issues are deleted
             for (Integer originalRelatedId : originalRelatedIssues)
             {
                 if (!newRelatedIssues.contains(originalRelatedId))
                 {
                     IssueObject related = IssueManager.getIssue(null, user, originalRelatedId);
-                    if (null != related)
+                    if (related == null || !related.lookupContainer().hasPermission(user, ReadPermission.class))
+                    {
+                        errors.reject(SpringActionController.ERROR_MSG, "User does not have Read Permission for related issue '" + originalRelatedId + "'");
+                        return;
+                    }
+                    else
                     {
                       related = ChangeSummary.relatedIssueCommentHandler(originalIssue.getIssueId(), related.getIssueId(), user, true );
                       IssueManager.saveIssue(user, related.lookupContainer(), related);


### PR DESCRIPTION
#### Rationale
[tracking issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53820)

If a user doesn't have permission to see issues in another folder, they can be added (or removed) as related issues from an issue they do have access to. We had checks to prevent adding related issues, but not removing them.

#### Related Pull Requests
https://github.com/LabKey/testAutomation/pull/2739
