### PR TITLE
DataRegion: Watch out for undefined moduleContext

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -16,7 +16,7 @@ if (!LABKEY.DataRegions) {
     var ALL_ROWS_MAX = 5_000;
     var CUSTOM_VIEW_PANELID = '~~customizeView~~';
     var DEFAULT_TIMEOUT = 30_000;
-    const MAX_SELECTION_SIZE = LABKEY.moduleContext.query?.maxQuerySelection ?? 100_000;
+    const MAX_SELECTION_SIZE = LABKEY.moduleContext?.query?.maxQuerySelection ?? 100_000;
     var PARAM_PREFIX = '.param.';
     var SORT_ASC = '+';
     var SORT_DESC = '-';


### PR DESCRIPTION
#### Rationale
There are various situations in which a Data Region can be loaded onto the page before the `LABKEY.moduleContext` is available. Be defensive in this scenario.

#### Related Pull Requests
- #7107

#### Changes
- Check for `LABKEY.moduleContext` not being defined when establishing constant value.