### PR TITLE
Issue 54094: escape form field names ending with "\"

### DIFF
--- a/api/src/org/labkey/api/query/QueryUpdateForm.java
+++ b/api/src/org/labkey/api/query/QueryUpdateForm.java
@@ -97,8 +97,9 @@ public class QueryUpdateForm extends TableViewForm
                 sb.append(c);
         }
 
+        // Issue 54094: Ensure it works when backslash is the last character
         if (escaping)
-            throw new IllegalArgumentException("Invalid escape at end of encoded name: " + columnName);
+            sb.append(BACKSLASH);
 
         return getTable().getColumn(sb.toString());
     }


### PR DESCRIPTION
#### Rationale
This addresses [Issue 54094](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=54094) by appending backslash when it is the last character.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2743

#### Changes
- Append backslash rather than throwing an exception

#### Tasks
- [x] Manual Testing @labkey-tchad 
- [x] Needs Automation