### PR TITLE
Improve plate assay import performance

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -121,6 +121,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 import static org.labkey.api.assay.AssayRunUploadContext.ReImportOption.MERGE_DATA;
@@ -1084,13 +1085,27 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
 
                     if (plateId != null && wellLocation != null)
                     {
-                        Map<String, Long> wellSampleCache = plateWellCache.computeIfAbsent(plateId, (id) -> AssayPlateMetadataService.get().getWellLocationToSampleIdMap(container, user, plateId));
+                        boolean loadMaterialsCache = !plateWellCache.containsKey(plateId);
+                        Map<String, Long> wellSampleCache = plateWellCache.computeIfAbsent(plateId, (id) -> AssayPlateMetadataService.get().getWellLocationToSampleIdMap(plateId));
+
+                        // If we had to load the wellSampleCache we should also preload the ExpMaterials into the
+                        // materialCache, so we don't need to fetch them with individual queries. This has a large
+                        // impact on performance.
+                        if (loadMaterialsCache)
+                        {
+                            Set<Long> samplesToFetch = wellSampleCache.values().stream()
+                                    .filter(id -> !materialCache.containsKey(id))
+                                    .collect(Collectors.toSet());
+
+                            for (ExpMaterial m : exp.getExpMaterials(samplesToFetch))
+                                materialCache.put(m.getRowId(), m);
+                        }
                         sampleId = wellSampleCache.get(wellLocation);
                     }
 
                     if (sampleId != null)
                     {
-                        material = materialCache.computeIfAbsent(sampleId, (id) -> exp.getExpMaterial(id, containerFilter));
+                        material = materialCache.get(sampleId);
                     }
 
                     if (material != null)

--- a/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
+++ b/api/src/org/labkey/api/assay/plate/AssayPlateMetadataService.java
@@ -187,7 +187,7 @@ public interface AssayPlateMetadataService
     /**
      * Returns a Map of Well Location to Sample RowID for a given Plate ID.
      */
-    Map<String, Long> getWellLocationToSampleIdMap(Container container, User user, Long plateId);
+    Map<String, Long> getWellLocationToSampleIdMap(Long plateId);
 
     boolean isWellLookup(ColumnInfo col);
 

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -1518,14 +1518,22 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
         return new PlateSchema(querySchema, contextualRoles);
     }
 
-    @Override
-    public Map<String, Long> getWellLocationToSampleIdMap(Container container, User user, Long plateId)
-    {
-        Map<String, Long> wellLocationToSampleIdMap = new HashMap<>();
-        List<WellData> wellData = PlateManager.get().getWellData(container, user, plateId, true, false);
+    record WellSampleData(Long sampleId, Integer row, Integer col) {}
 
-        for (WellData data : wellData)
-            wellLocationToSampleIdMap.put(data.getPosition(), data.getSampleId());
+    @Override
+    public Map<String, Long> getWellLocationToSampleIdMap(Long plateId)
+    {
+        // Note: this method intentionally does not use PlateManager.get().getWellData, by selecting only the columns
+        // we need there is a small but measurable performance boost when importing plate assay data
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("plateid"), plateId);
+        List<WellSampleData> wells = new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), Set.of("SampleId", "Row", "Col"), filter, null).getArrayList(WellSampleData.class);
+        Map<String, Long> wellLocationToSampleIdMap = new HashMap<>();
+
+        for (WellSampleData well : wells)
+        {
+            PositionImpl pos = new PositionImpl(null, well.row, well.col);
+            wellLocationToSampleIdMap.put(pos.getDescription(), well.sampleId);
+        }
 
         return wellLocationToSampleIdMap;
     }

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -1525,8 +1525,9 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
     {
         // Note: this method intentionally does not use PlateManager.get().getWellData, by selecting only the columns
         // we need there is a small but measurable performance boost when importing plate assay data
-        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("plateid"), plateId);
-        List<WellSampleData> wells = new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), Set.of("SampleId", "Row", "Col"), filter, null).getArrayList(WellSampleData.class);
+        SimpleFilter filter = new SimpleFilter(WellTable.Column.PlateId.fieldKey(), plateId);
+        Set<String> columns = Set.of(WellTable.Column.SampleID.name(), WellTable.Column.Row.name(), WellTable.Column.Col.name());
+        List<WellSampleData> wells = new TableSelector(AssayDbSchema.getInstance().getTableInfoWell(), columns, filter, null).getArrayList(WellSampleData.class);
         Map<String, Long> wellLocationToSampleIdMap = new HashMap<>();
 
         for (WellSampleData well : wells)


### PR DESCRIPTION
#### Rationale
This PR slightly optimizes the way we query for well samples, and preloads all exp materials for a plate into the `materialCache` during import, which improves performance.

Benchmarks from my machine show that on develop import time is approximately 58% slower than 25.10. With the changes in this PR import time is approximately 24% slower.

Assay import time is expected to be slower by some amount, because when marking well samples as Material Inputs we are inserting at least 3x the amount of rows into the database, and we are also making additional queries to the Well table during import (in order to determine what samples to mark as inputs).

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7101

#### Changes
- AssayPlateMetadataServiceImpl.getWellLocationToSampleIdMap: select only the columns we need when querying the well table
- AbstractAssayTsvDataHandler.checkData: preload all exp materials for a plate into the `materialCache`
