### PR TITLE
Remote stream test fix

### DIFF
--- a/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -195,28 +195,13 @@ public class SelectRowsStreamHack
                 DataIteratorContext dic = new DataIteratorContext();
 
                 DataIterator di = dib.getDataIterator(dic);
-
-                // This should create the file (allow a short delay on Windows filesystems):
-                Set<String> actualTempFiles = getMatchingTempFileNames();
-                int expectedSize = preexistingTempFiles.size() + 1;
-                if (actualTempFiles.size() < expectedSize)
-                {
-                    long start = System.currentTimeMillis();
-                    // Retry for up to 2 seconds to account for eventual directory listing visibility on some systems
-                    while (System.currentTimeMillis() - start < 2000 && actualTempFiles.size() < expectedSize)
-                    {
-                        try { Thread.sleep(50); } catch (InterruptedException ignore) {}
-                        actualTempFiles = getMatchingTempFileNames();
-                    }
-                }
-                assertEquals("Temp file not created", expectedSize, actualTempFiles.size());
-
+                
                 // This should iterate and close the stream:
                 long actualCount = di.stream().count();
                 assertEquals("Incorrect row count", expectedRows, actualCount);
 
                 // The file should be deleted now:
-                actualTempFiles = getMatchingTempFileNames();
+                Set<String> actualTempFiles = getMatchingTempFileNames();
                 actualTempFiles.removeAll(preexistingTempFiles);
                 assertEquals("Temp files were not deleted, found: " + actualTempFiles.size(), 0, actualTempFiles.size());
 

--- a/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
+++ b/query/api-src/org/labkey/remoteapi/SelectRowsStreamHack.java
@@ -196,9 +196,20 @@ public class SelectRowsStreamHack
 
                 DataIterator di = dib.getDataIterator(dic);
 
-                // This should create the file:
+                // This should create the file (allow a short delay on Windows filesystems):
                 Set<String> actualTempFiles = getMatchingTempFileNames();
-                assertEquals("Temp file not created", preexistingTempFiles.size() + 1, actualTempFiles.size());
+                int expectedSize = preexistingTempFiles.size() + 1;
+                if (actualTempFiles.size() < expectedSize)
+                {
+                    long start = System.currentTimeMillis();
+                    // Retry for up to 2 seconds to account for eventual directory listing visibility on some systems
+                    while (System.currentTimeMillis() - start < 2000 && actualTempFiles.size() < expectedSize)
+                    {
+                        try { Thread.sleep(50); } catch (InterruptedException ignore) {}
+                        actualTempFiles = getMatchingTempFileNames();
+                    }
+                }
+                assertEquals("Temp file not created", expectedSize, actualTempFiles.size());
 
                 // This should iterate and close the stream:
                 long actualCount = di.stream().count();


### PR DESCRIPTION
#### Rationale
Remove temp file assert as temp file visibility is not consistent across OSes. Test fails frequently on Windows.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/7059

#### Changes
- Remove assert checking for temp file