### PR TITLE
Remove redundant gradle property

### DIFF
--- a/api/gradle.properties
+++ b/api/gradle.properties
@@ -1,1 +1,0 @@
-angusActivationVersion=2.0.2


### PR DESCRIPTION
#### Rationale
`angusActivationVersion` is defined in the root `gradle.properties`. No need to define it here also.

#### Related Pull Requests
- https://github.com/LabKey/server/pull/1200

#### Changes
- Remove redundant gradle property