### PR TITLE
ObjectFactory fails to map reserved field names

### DIFF
--- a/api/src/org/labkey/api/data/BeanObjectFactory.java
+++ b/api/src/org/labkey/api/data/BeanObjectFactory.java
@@ -256,6 +256,14 @@ public class BeanObjectFactory<K> implements ObjectFactory<K> // implements Resu
             String prop = propMap.get(label); //Map to correct casing...
             if (null != prop)
                 properties[i] = prop;
+            else if (label.endsWith("_"))
+            {
+                // Try stripping trailing underscore (added by some databases for reserved words)
+                // For example "File" is a reserved word in SQL Server, but it's used by FileSystemAuditDomainKind/FileSystemAuditEvent
+                prop = propMap.get(label.substring(0, label.length() - 1));
+                if (null != prop)
+                    properties[i] = prop;
+            }
         }
 
         ArrayList<K> list = new ArrayList<>();

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -35,6 +35,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ContainerService;
+import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.NameGenerator;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.PropertyStorageSpec;
@@ -1484,6 +1485,9 @@ public class DomainUtil
                     continue;
                 }
             }
+
+            if (CoreSchema.getInstance().getSqlDialect().isReserved(name))
+                LOG.warn("Field name '" + name + "' is a reserved word in the current SQL dialect.");
 
             if (namePropertyIdMap.containsKey(name))
             {

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -35,7 +35,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ContainerService;
-import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.NameGenerator;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.PropertyStorageSpec;
@@ -1485,9 +1484,6 @@ public class DomainUtil
                     continue;
                 }
             }
-
-            if (CoreSchema.getInstance().getSqlDialect().isReserved(name))
-                LOG.warn("Field name '" + name + "' is a reserved word in the current SQL dialect.");
 
             if (namePropertyIdMap.containsKey(name))
             {

--- a/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
+++ b/experiment/src/org/labkey/experiment/api/property/StorageProvisionerImpl.java
@@ -384,6 +384,10 @@ public class StorageProvisionerImpl implements StorageProvisioner
                 log.warn("StorageProvisioner ignored property with name of built-in column: " + prop.getPropertyURI());
                 continue;
             }
+
+            if (CoreSchema.getInstance().getSqlDialect().isReserved(prop.getName()))
+                log.warn("Property name '" + prop.getName() + "' is a reserved word in the current SQL dialect.");
+
             PropertyStorageSpec spec = kind.getPropertySpec(prop.getPropertyDescriptor(), domain);
             if (null != spec)
             {


### PR DESCRIPTION
#### Rationale
A recent change to how file fields are displayed in Sample Timeline revealed a flaw in our audit log query utils. Specifically, AuditLogService.getAuditEvents fails to populate the event beans if any of the event field name happens to be in the sql dialect's reservedWordSet. For example, "File" is a reserved word for SQL Server, but not for postgresDB. When a column is a reserved word, it's alias to "col_", "col_1"... in the select sql. The ResultSet uses "col_" as the column name, and has no knowledge of its original name, which results in bean property mapping failure. 

This PR adds a workaround to allow mapping ignoring trailing "_". It also logs warning about reserved word being added to domain. 

Something to consider for future work: the set of reserved word is large, and contains words like "case", "primary" that seems harmless to use as domain fields, so it's not practical to disallow them in user domains. 

[SMSampleTimelineBasicTest](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_SmFeatures_BvtSampleManagerSqlserver/3695275?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests.samplemanagement.timeline&class=SMSampleTimelineBasicTest).[testFileFields](https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_SampleManager_SmFeatures_BvtSampleManagerSqlserver/3695275?buildTab=tests&status=failed&expandedTest=build%3A%28id%3A3695275%29%2Cid%3A2000000007) (MSSQL)
NPE when loading sample timeline with file field changes

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1643

#### Changes
- attempt to resolve bean field mapping by stripping trailing "_"
- add warning about use of reserved word for domain

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->