### PR TITLE
Remove workaround for recently fixed MS SQL JDBC driver issue

### DIFF
--- a/api/src/org/labkey/api/data/CachedResultSets.java
+++ b/api/src/org/labkey/api/data/CachedResultSets.java
@@ -39,7 +39,7 @@ public class CachedResultSets
 
     public static CachedResultSet create(ResultSet rsIn, boolean cacheMetaData, int maxRows, @Nullable StackTraceElement[] stackTrace, QueryLogging queryLogging) throws SQLException
     {
-        try (ResultSet rs = new LoggingResultSetWrapper(rsIn, queryLogging))         // TODO: avoid is we're passed a read-only and empty one??
+        try (ResultSet rs = new LoggingResultSetWrapper(rsIn, queryLogging))         // TODO: avoid if we're passed a read-only and empty one??
         {
             // Snowflake auto-closes metadata after reading the last row, so cache that metadata first
             ResultSetMetaData md = cacheMetaData ? new CachedResultSetMetaData(rs.getMetaData()) : rs.getMetaData();
@@ -56,17 +56,7 @@ public class CachedResultSets
                 list.add(factory.getRowMap(rs));
 
             // If we have another row, then we're not complete
-            boolean isComplete = true;
-
-            // TODO: Remove this try/catch once SQL Server driver fixes getIndexInfo()
-            try
-            {
-                isComplete = !rs.next();
-            }
-            catch (SQLException ignored)
-            {
-                // tolerate this for now
-            }
+            boolean isComplete = !rs.next();
 
             return new CachedResultSet(md, list, isComplete, stackTrace);
         }


### PR DESCRIPTION
#### Rationale
Microsoft fixed [an issue with `DatabaseMetaData.getIndexInfo()`](https://github.com/microsoft/mssql-jdbc/issues/2758) in their latest JDBC driver release, so we can remove our workaround.

https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53885

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7023

#### Tasks 📍
- [x] Verify Fix - Previously failing tests should continue to pass after this change. @labkey-tchad do you remember which tests failed when the issue was introduced?