### PR TITLE
Don't always fail test for missing sample data

### DIFF
--- a/api/src/org/labkey/api/util/JunitUtil.java
+++ b/api/src/org/labkey/api/util/JunitUtil.java
@@ -233,22 +233,26 @@ public class JunitUtil
                     }
 
                     sampleDataDir = _sampleDataDirectories.get(name);
-
-                    if (sampleDataDir == null)
-                    {
-                        Assert.fail("Sample data directory not found for module: " + name + ". Known directories: " + _sampleDataDirectories);
-                    }
                 }
             }
         }
 
-        File file = FileUtil.appendPath(sampleDataDir, Path.parse(relativePath));
-        if (file.exists())
-            return file;
+        String message;
 
-        String message = "No sample data found at [" + file.getAbsolutePath() + "].";
+        if (sampleDataDir != null)
+        {
+            File file = FileUtil.appendPath(sampleDataDir, Path.parse(relativePath));
+            if (file.exists())
+                return file;
 
-        if (null != module)
+            message = "No sample data found at [" + file.getAbsolutePath() + "].";
+        }
+        else
+        {
+            message = "No sample data found at [" + relativePath + "].";
+        }
+
+        if (module != null)
         {
             if (sampleDataDir == null || !sampleDataDir.exists())
             {


### PR DESCRIPTION
#### Rationale
Server-side JUnit tests should be skipped if they require sampledata from a module but that module's source isn't present.

#### Related Pull Requests
- #7115 

#### Changes
- Don't fail tests when module source isn't present