### PR TITLE
Bump some search queue logging down to TRACE

### DIFF
--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -733,7 +733,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
 
     private void logQueueStatus(String message)
     {
-        _log.debug("{}; _runQueue.size() = {}, _itemQueue.size() = {}", message, _runQueue.size(), _itemQueue.size());
+        _log.trace("{}; _runQueue.size() = {}, _itemQueue.size() = {}", message, _runQueue.size(), _itemQueue.size());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We recently wrote a lot of log output when trying to identify which files were causing problems during indexing.

#### Changes
- Push queue size info to `TRACE` logging

#### Tasks 📍
- Manual Testing - N/A
- Needs Automation - N/A
