### PR TITLE
Defer filter handling and move registration to startup()

### DIFF
--- a/api/src/org/labkey/api/data/DatabaseMigrationService.java
+++ b/api/src/org/labkey/api/data/DatabaseMigrationService.java
@@ -57,13 +57,7 @@ public interface DatabaseMigrationService
     // By default, no-op implementations
     default void registerSchemaHandler(MigrationSchemaHandler schemaHandler) {}
     default void registerTableHandler(MigrationTableHandler tableHandler) {}
-
-    Map<String, MigrationFilter> _migrationFilters = new CopyOnWriteCaseInsensitiveHashMap<>();
-
-    default void registerMigrationFilter(MigrationFilter filter)
-    {
-        _migrationFilters.put(filter.getName(), filter);
-    }
+    default void registerMigrationFilter(MigrationFilter filter) {}
 
     default @Nullable MigrationFilter getMigrationFilter(String propertyName)
     {

--- a/core/src/org/labkey/core/CoreMigrationSchemaHandler.java
+++ b/core/src/org/labkey/core/CoreMigrationSchemaHandler.java
@@ -1,0 +1,185 @@
+package org.labkey.core;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.CompareType;
+import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.DatabaseMigrationService;
+import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbSchemaType;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.data.PropertySchema;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.Table;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TestSchema;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.ConfigurationException;
+import org.labkey.api.util.GUID;
+
+import java.util.List;
+import java.util.Set;
+
+class CoreMigrationSchemaHandler extends DatabaseMigrationService.DefaultMigrationSchemaHandler implements DatabaseMigrationService.MigrationFilter
+{
+    static void register()
+    {
+        CoreMigrationSchemaHandler schemaHandler = new CoreMigrationSchemaHandler();
+        DatabaseMigrationService.get().registerSchemaHandler(schemaHandler);
+        DatabaseMigrationService.get().registerMigrationFilter(schemaHandler);
+
+        DatabaseMigrationService.get().registerSchemaHandler(new DatabaseMigrationService.DefaultMigrationSchemaHandler(PropertySchema.getInstance().getSchema()){
+            @Override
+            public @Nullable FieldKey getContainerFieldKey(TableInfo sourceTable)
+            {
+                return sourceTable.getName().equals("PropertySets") ? FieldKey.fromParts("ObjectId") : super.getContainerFieldKey(sourceTable);
+            }
+        });
+
+        DatabaseMigrationService.get().registerSchemaHandler(new DatabaseMigrationService.DefaultMigrationSchemaHandler(TestSchema.getInstance().getSchema()){
+            @Override
+            public List<TableInfo> getTablesToCopy()
+            {
+                return List.of(); // Skip all test tables
+            }
+        });
+
+        // TODO: Temporary, until "clone" migration type copies schemas with a registered handler only
+        if (ModuleLoader.getInstance().getModule(DbScope.getLabKeyScope(), "vehicle") != null)
+        {
+            DatabaseMigrationService.get().registerSchemaHandler(new DatabaseMigrationService.DefaultMigrationSchemaHandler(DbSchema.get("vehicle", DbSchemaType.Module))
+            {
+                @Override
+                public List<TableInfo> getTablesToCopy()
+                {
+                    return List.of(); // Skip all vehicle tables
+                }
+            });
+        }
+    }
+
+    private CoreMigrationSchemaHandler()
+    {
+        super(CoreSchema.getInstance().getSchema());
+    }
+
+    @Override
+    public void beforeVerification()
+    {
+        super.beforeVerification();
+
+        // Delete root and shared containers that were needed for bootstrapping
+        TableInfo containers = CoreSchema.getInstance().getTableInfoContainers();
+        Table.delete(containers);
+        DbScope targetScope = DbScope.getLabKeyScope();
+        new SqlExecutor(targetScope).execute("ALTER SEQUENCE core.containers_rowid_seq RESTART"); // Reset Containers sequence
+    }
+
+    @Override
+    public void beforeSchema()
+    {
+        new SqlExecutor(getSchema()).execute("ALTER TABLE core.Containers DROP CONSTRAINT FK_Containers_Containers");
+        new SqlExecutor(getSchema()).execute("ALTER TABLE core.ViewCategory DROP CONSTRAINT FK_ViewCategory_Parent");
+    }
+
+    @Override
+    public List<TableInfo> getTablesToCopy()
+    {
+        List<TableInfo> tablesToCopy = super.getTablesToCopy();
+        tablesToCopy.remove(CoreSchema.getInstance().getTableInfoModules());
+        tablesToCopy.remove(CoreSchema.getInstance().getTableInfoSqlScripts());
+        tablesToCopy.remove(CoreSchema.getInstance().getTableInfoUpgradeSteps());
+
+        return tablesToCopy;
+    }
+
+    @Override
+    public @Nullable FieldKey getContainerFieldKey(TableInfo sourceTable)
+    {
+        return switch (sourceTable.getName())
+        {
+            case "ContainerAliases" -> FieldKey.fromParts("ContainerRowId", "EntityId");
+            case "Containers" -> FieldKey.fromParts("EntityId");
+            case "Report" -> FieldKey.fromParts("ContainerId");
+            // Note: DataStates is not really site-wide, but there seem to be exp.Materials referencing DataStates with conflicting containers
+            case "APIKeys", "AuthenticationConfigurations", "DataStates", "EmailOptions", "Logins", "ReportEngines",
+                 "ShortURL", "UsersData" -> SITE_WIDE_TABLE;
+            default -> super.getContainerFieldKey(sourceTable);
+        };
+    }
+
+    @Override
+    public SimpleFilter.FilterClause getContainerClause(TableInfo sourceTable, FieldKey containerFieldKey, Set<GUID> containers)
+    {
+        SimpleFilter.FilterClause containerClause = super.getContainerClause(sourceTable, containerFieldKey, containers);
+        String tableName = sourceTable.getName();
+
+        // Users and root groups have container == null, so add that as an OR clause
+        if ("Principals".equals(tableName) || "Members".equals(tableName))
+        {
+            SimpleFilter.OrClause orClause = new SimpleFilter.OrClause();
+            orClause.addClause(containerClause);
+            orClause.addClause(new CompareType.CompareClause(containerFieldKey, CompareType.ISBLANK, null));
+            containerClause = orClause;
+
+            if (_groupFilterCondition != null)
+            {
+                SQLFragment groupFilterFragment = new SQLFragment();
+
+                if ("Principals".equals(tableName))
+                {
+                    groupFilterFragment
+                        .append("Type <> 'g' OR (type = 'g' AND UserId ")
+                        .append(_groupFilterCondition)
+                        .append(")");
+                }
+                else
+                {
+                    groupFilterFragment
+                        .append("GroupId ")
+                        .append(_groupFilterCondition);
+                }
+
+                containerClause = new SimpleFilter.AndClause(containerClause, new SimpleFilter.SQLClause(groupFilterFragment));
+            }
+        }
+
+        if ("RoleAssignments".equals(tableName) && _groupFilterCondition != null)
+        {
+            SQLFragment groupFilterFragment = new SQLFragment("UserId IN (SELECT UserId FROM core.Principals WHERE Type <> 'g' OR (type = 'g' AND UserId ")
+                .append(_groupFilterCondition)
+                .append("))");
+            containerClause = new SimpleFilter.AndClause(containerClause, new SimpleFilter.SQLClause(groupFilterFragment));
+        }
+
+        return containerClause;
+    }
+
+    @Override
+    public void afterSchema()
+    {
+        new SqlExecutor(getSchema()).execute("ALTER TABLE core.Containers ADD CONSTRAINT FK_Containers_Containers FOREIGN KEY (Parent) REFERENCES core.Containers(EntityId)");
+        new SqlExecutor(getSchema()).execute("ALTER TABLE core.ViewCategory ADD CONSTRAINT FK_ViewCategory_Parent FOREIGN KEY (Parent) REFERENCES core.ViewCategory(RowId)");
+    }
+
+    // MigrationFilter implementation below
+
+    private SQLFragment _groupFilterCondition = null;
+
+    @Override
+    public String getName()
+    {
+        return "GroupFilter";
+    }
+
+    @Override
+    public void saveFilter(@Nullable GUID guid, String groupFilter)
+    {
+        if (guid != null)
+            throw new ConfigurationException("GUID should not be provided to GroupFilter");
+
+        _groupFilterCondition = new SQLFragment(groupFilter);
+    }
+}

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -48,8 +48,6 @@ import org.labkey.api.audit.provider.FileSystemAuditProvider;
 import org.labkey.api.audit.provider.GroupAuditProvider;
 import org.labkey.api.audit.provider.ModulePropertiesAuditProvider;
 import org.labkey.api.cache.CacheManager;
-import org.labkey.api.data.CompareType;
-import org.labkey.api.data.CompareType.CompareClause;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
@@ -61,7 +59,6 @@ import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.DatabaseMigrationService;
 import org.labkey.api.data.DatabaseMigrationService.DefaultMigrationSchemaHandler;
-import org.labkey.api.data.DatabaseMigrationService.MigrationFilter;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
@@ -72,10 +69,6 @@ import org.labkey.api.data.OutOfRangeDisplayColumn;
 import org.labkey.api.data.PropertySchema;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SchemaTableInfoFactory;
-import org.labkey.api.data.SimpleFilter.AndClause;
-import org.labkey.api.data.SimpleFilter.FilterClause;
-import org.labkey.api.data.SimpleFilter.OrClause;
-import org.labkey.api.data.SimpleFilter.SQLClause;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TSVWriter;
@@ -178,7 +171,6 @@ import org.labkey.api.study.StudyService;
 import org.labkey.api.thumbnail.ThumbnailService;
 import org.labkey.api.usageMetrics.SimpleMetricsService;
 import org.labkey.api.usageMetrics.UsageMetricsService;
-import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.ContextListener;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileUtil;
@@ -1283,165 +1275,8 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         ContainerManager.addContainerListener(new EmailPreferenceContainerListener());
         UserManager.addUserListener(new EmailPreferenceUserListener());
 
-        CoreMigrationSchemaHandler schemaHandler = new CoreMigrationSchemaHandler();
-        DatabaseMigrationService.get().registerSchemaHandler(schemaHandler);
-        DatabaseMigrationService.get().registerMigrationFilter(schemaHandler);
-
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(PropertySchema.getInstance().getSchema()){
-            @Override
-            public @Nullable FieldKey getContainerFieldKey(TableInfo sourceTable)
-            {
-                return sourceTable.getName().equals("PropertySets") ? FieldKey.fromParts("ObjectId") : super.getContainerFieldKey(sourceTable);
-            }
-        });
-
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(TestSchema.getInstance().getSchema()){
-            @Override
-            public List<TableInfo> getTablesToCopy()
-            {
-                return List.of(); // Skip all test tables
-            }
-        });
-
-        // TODO: Temporary, until "clone" migration type copies schemas with a registered handler only
-        if (ModuleLoader.getInstance().getModule(DbScope.getLabKeyScope(), "vehicle") != null)
-        {
-            DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(DbSchema.get("vehicle", DbSchemaType.Module))
-            {
-                @Override
-                public List<TableInfo> getTablesToCopy()
-                {
-                    return List.of(); // Skip all vehicle tables
-                }
-            });
-        }
-
+        CoreMigrationSchemaHandler.register();
         Encryption.checkMigration();
-    }
-
-    private static class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler implements MigrationFilter
-    {
-        public CoreMigrationSchemaHandler()
-        {
-            super(CoreSchema.getInstance().getSchema());
-        }
-
-        @Override
-        public void beforeVerification()
-        {
-            super.beforeVerification();
-
-            // Delete root and shared containers that were needed for bootstrapping
-            TableInfo containers = CoreSchema.getInstance().getTableInfoContainers();
-            Table.delete(containers);
-            DbScope targetScope = DbScope.getLabKeyScope();
-            new SqlExecutor(targetScope).execute("ALTER SEQUENCE core.containers_rowid_seq RESTART"); // Reset Containers sequence
-        }
-
-        @Override
-        public void beforeSchema()
-        {
-            new SqlExecutor(getSchema()).execute("ALTER TABLE core.Containers DROP CONSTRAINT FK_Containers_Containers");
-            new SqlExecutor(getSchema()).execute("ALTER TABLE core.ViewCategory DROP CONSTRAINT FK_ViewCategory_Parent");
-        }
-
-        @Override
-        public List<TableInfo> getTablesToCopy()
-        {
-            List<TableInfo> tablesToCopy = super.getTablesToCopy();
-            tablesToCopy.remove(CoreSchema.getInstance().getTableInfoModules());
-            tablesToCopy.remove(CoreSchema.getInstance().getTableInfoSqlScripts());
-            tablesToCopy.remove(CoreSchema.getInstance().getTableInfoUpgradeSteps());
-
-            return tablesToCopy;
-        }
-
-        @Override
-        public @Nullable FieldKey getContainerFieldKey(TableInfo sourceTable)
-        {
-            return switch (sourceTable.getName())
-            {
-                case "ContainerAliases" -> FieldKey.fromParts("ContainerRowId", "EntityId");
-                case "Containers" -> FieldKey.fromParts("EntityId");
-                case "Report" -> FieldKey.fromParts("ContainerId");
-                // Note: DataStates is not really site-wide, but there seem to be exp.Materials referencing DataStates with conflicting containers
-                case "APIKeys", "AuthenticationConfigurations", "DataStates", "EmailOptions", "Logins", "ReportEngines", "ShortURL", "UsersData" -> SITE_WIDE_TABLE;
-                default -> super.getContainerFieldKey(sourceTable);
-            };
-        }
-
-        @Override
-        public FilterClause getContainerClause(TableInfo sourceTable, FieldKey containerFieldKey, Set<GUID> containers)
-        {
-            FilterClause containerClause = super.getContainerClause(sourceTable, containerFieldKey, containers);
-            String tableName = sourceTable.getName();
-
-            // Users and root groups have container == null, so add that as an OR clause
-            if ("Principals".equals(tableName) || "Members".equals(tableName))
-            {
-                OrClause orClause = new OrClause();
-                orClause.addClause(containerClause);
-                orClause.addClause(new CompareClause(containerFieldKey, CompareType.ISBLANK, null));
-                containerClause = orClause;
-
-                if (_groupFilterCondition != null)
-                {
-                    SQLFragment groupFilterFragment = new SQLFragment();
-
-                    if ("Principals".equals(tableName))
-                    {
-                        groupFilterFragment
-                            .append("Type <> 'g' OR (type = 'g' AND UserId ")
-                            .append(_groupFilterCondition)
-                            .append(")");
-                    }
-                    else
-                    {
-                        groupFilterFragment
-                            .append("GroupId ")
-                            .append(_groupFilterCondition);
-                    }
-
-                    containerClause = new AndClause(containerClause, new SQLClause(groupFilterFragment));
-                }
-            }
-
-            if ("RoleAssignments".equals(tableName) && _groupFilterCondition != null)
-            {
-                SQLFragment groupFilterFragment = new SQLFragment("UserId IN (SELECT UserId FROM core.Principals WHERE Type <> 'g' OR (type = 'g' AND UserId ")
-                    .append(_groupFilterCondition)
-                    .append("))");
-                containerClause = new AndClause(containerClause, new SQLClause(groupFilterFragment));
-            }
-
-            return containerClause;
-        }
-
-        @Override
-        public void afterSchema()
-        {
-            new SqlExecutor(getSchema()).execute("ALTER TABLE core.Containers ADD CONSTRAINT FK_Containers_Containers FOREIGN KEY (Parent) REFERENCES core.Containers(EntityId)");
-            new SqlExecutor(getSchema()).execute("ALTER TABLE core.ViewCategory ADD CONSTRAINT FK_ViewCategory_Parent FOREIGN KEY (Parent) REFERENCES core.ViewCategory(RowId)");
-        }
-
-        // MigrationFilter implementation below
-
-        private SQLFragment _groupFilterCondition = null;
-
-        @Override
-        public String getName()
-        {
-            return "GroupFilter";
-        }
-
-        @Override
-        public void saveFilter(@Nullable GUID guid, String groupFilter)
-        {
-            if (guid != null)
-                throw new ConfigurationException("GUID should not be provided to GroupFilter");
-
-            _groupFilterCondition = new SQLFragment(groupFilter);
-        }
     }
 
     // Issue 7527: Auto-detect missing SQL views and attempt to recreate

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -413,30 +413,6 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
     private CoreWarningProvider _warningProvider;
     private ServletRegistration.Dynamic _webdavServletDynamic;
 
-    private SQLFragment _groupFilterCondition = null;
-
-    public CoreModule()
-    {
-        // Must be registered very early
-        DatabaseMigrationService.get().registerMigrationFilter(new MigrationFilter()
-        {
-            @Override
-            public String getName()
-            {
-                return "GroupFilter";
-            }
-
-            @Override
-            public void saveFilter(@Nullable GUID guid, String groupFilter)
-            {
-                if (guid != null)
-                    throw new ConfigurationException("GUID should not be provided to GroupFilter");
-
-                _groupFilterCondition = new SQLFragment(groupFilter);
-            }
-        });
-    }
-
     @Override
     public boolean hasScripts()
     {
@@ -1307,7 +1283,9 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         ContainerManager.addContainerListener(new EmailPreferenceContainerListener());
         UserManager.addUserListener(new EmailPreferenceUserListener());
 
-        DatabaseMigrationService.get().registerSchemaHandler(new CoreMigrationSchemaHandler());
+        CoreMigrationSchemaHandler schemaHandler = new CoreMigrationSchemaHandler();
+        DatabaseMigrationService.get().registerSchemaHandler(schemaHandler);
+        DatabaseMigrationService.get().registerMigrationFilter(schemaHandler);
 
         DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(PropertySchema.getInstance().getSchema()){
             @Override
@@ -1341,7 +1319,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         Encryption.checkMigration();
     }
 
-    private class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler
+    private static class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler implements MigrationFilter
     {
         public CoreMigrationSchemaHandler()
         {
@@ -1444,6 +1422,25 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         {
             new SqlExecutor(getSchema()).execute("ALTER TABLE core.Containers ADD CONSTRAINT FK_Containers_Containers FOREIGN KEY (Parent) REFERENCES core.Containers(EntityId)");
             new SqlExecutor(getSchema()).execute("ALTER TABLE core.ViewCategory ADD CONSTRAINT FK_ViewCategory_Parent FOREIGN KEY (Parent) REFERENCES core.ViewCategory(RowId)");
+        }
+
+        // MigrationFilter implementation below
+
+        private SQLFragment _groupFilterCondition = null;
+
+        @Override
+        public String getName()
+        {
+            return "GroupFilter";
+        }
+
+        @Override
+        public void saveFilter(@Nullable GUID guid, String groupFilter)
+        {
+            if (guid != null)
+                throw new ConfigurationException("GUID should not be provided to GroupFilter");
+
+            _groupFilterCondition = new SQLFragment(groupFilter);
         }
     }
 

--- a/experiment/src/org/labkey/experiment/ExperimentMigrationSchemaHandler.java
+++ b/experiment/src/org/labkey/experiment/ExperimentMigrationSchemaHandler.java
@@ -75,6 +75,14 @@ class ExperimentMigrationSchemaHandler extends DatabaseMigrationService.DefaultM
                     new InClause(FieldKey.fromParts("MaterialId", "RunId", "Container"), containers)
                 )
             );
+            case "MaterialAncestors" -> new AndClause(
+                // Effectively matches the "Material" conditions above since MaterialAncestors has an FK to Material
+                new InClause(FieldKey.fromParts("RowId", "Container"), containers),
+                new OrClause(
+                    new CompareClause(FieldKey.fromParts("RowId", "RunId"), CompareType.ISBLANK, null),
+                    new InClause(FieldKey.fromParts("RowId", "RunId", "Container"), containers)
+                )
+            );
             case "Edge" -> new AndClause(
                 new InClause(FieldKey.fromParts("FromObjectId", "Container"), containers),
                 new InClause(FieldKey.fromParts("ToObjectId", "Container"), containers)

--- a/experiment/src/org/labkey/experiment/ExperimentMigrationSchemaHandler.java
+++ b/experiment/src/org/labkey/experiment/ExperimentMigrationSchemaHandler.java
@@ -59,15 +59,20 @@ class ExperimentMigrationSchemaHandler extends DatabaseMigrationService.DefaultM
                 new InClause(FieldKey.fromParts("DataId", "Container"), containers),
                 new InClause(FieldKey.fromParts("TargetApplicationId", "RunId", "Container"), containers)
             );
-            case "MaterialInput" -> new AndClause(
-                new InClause(FieldKey.fromParts("MaterialId", "Container"), containers),
-                new InClause(FieldKey.fromParts("TargetApplicationId", "RunId", "Container"), containers)
-            );
             case "Material" -> new AndClause(
                 new InClause(FieldKey.fromParts("Container"), containers),
                 new OrClause(
                     new CompareClause(FieldKey.fromParts("RunId"), CompareType.ISBLANK, null),
                     new InClause(FieldKey.fromParts("RunId", "Container"), containers)
+                )
+            );
+            case "MaterialInput" -> new AndClause(
+                new InClause(FieldKey.fromParts("TargetApplicationId", "RunId", "Container"), containers),
+                // The below effectively matches the "Material" conditions above, since MaterialInput has an FK to Material
+                new InClause(FieldKey.fromParts("MaterialId", "Container"), containers),
+                new OrClause(
+                    new CompareClause(FieldKey.fromParts("MaterialId", "RunId"), CompareType.ISBLANK, null),
+                    new InClause(FieldKey.fromParts("MaterialId", "RunId", "Container"), containers)
                 )
             );
             case "Edge" -> new AndClause(

--- a/experiment/src/org/labkey/experiment/ExperimentMigrationSchemaHandler.java
+++ b/experiment/src/org/labkey/experiment/ExperimentMigrationSchemaHandler.java
@@ -1,0 +1,100 @@
+package org.labkey.experiment;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.CompareType;
+import org.labkey.api.data.CompareType.CompareClause;
+import org.labkey.api.data.DatabaseMigrationService;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SimpleFilter.AndClause;
+import org.labkey.api.data.SimpleFilter.FilterClause;
+import org.labkey.api.data.SimpleFilter.InClause;
+import org.labkey.api.data.SimpleFilter.OrClause;
+import org.labkey.api.data.SimpleFilter.SQLClause;
+import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.exp.OntologyManager;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.GUID;
+
+import java.util.Set;
+
+class ExperimentMigrationSchemaHandler extends DatabaseMigrationService.DefaultMigrationSchemaHandler
+{
+    public ExperimentMigrationSchemaHandler()
+    {
+        super(OntologyManager.getExpSchema());
+    }
+
+    @Override
+    public void beforeSchema()
+    {
+        // Work around foreign key cycle between ExperimentRun <-> ProtocolApplication by temporarily dropping FK_Run_WorfklowTask.
+        // Yes, the FK name is misspelled
+        new SqlExecutor(getSchema()).execute("ALTER TABLE exp.ExperimentRun DROP CONSTRAINT FK_Run_WorfklowTask");
+        new SqlExecutor(getSchema()).execute("ALTER TABLE exp.Object DROP CONSTRAINT FK_Object_Object");
+
+        // Need to drop self FK until all rows are populated because replaced runs will be inserted before their replacements
+        new SqlExecutor(getSchema()).execute("ALTER TABLE exp.ExperimentRun DROP CONSTRAINT FK_ExperimentRun_ReplacedByRunId");
+    }
+
+    @Override
+    public @Nullable FieldKey getContainerFieldKey(TableInfo table)
+    {
+        return switch (table.getName())
+        {
+            case "Alias", "ObjectLegacyNames" -> FieldKey.fromParts("DUMMY"); // Unused dummy value -- see override below
+            case "DataTypeExclusion" -> FieldKey.fromParts("ExcludedContainer");
+            case "PropertyDomain" -> FieldKey.fromParts("DomainId", "Container");
+            case "ProtocolApplication" -> FieldKey.fromParts("RunId", "Container");
+            default -> super.getContainerFieldKey(table);
+        };
+    }
+
+    @Override
+    public FilterClause getContainerClause(TableInfo sourceTable, FieldKey containerFieldKey, Set<GUID> containers)
+    {
+        return switch (sourceTable.getName())
+        {
+            case "DataInput" -> new AndClause(
+                new InClause(FieldKey.fromParts("DataId", "Container"), containers),
+                new InClause(FieldKey.fromParts("TargetApplicationId", "RunId", "Container"), containers)
+            );
+            case "MaterialInput" -> new AndClause(
+                new InClause(FieldKey.fromParts("MaterialId", "Container"), containers),
+                new InClause(FieldKey.fromParts("TargetApplicationId", "RunId", "Container"), containers)
+            );
+            case "Material" -> new AndClause(
+                new InClause(FieldKey.fromParts("Container"), containers),
+                new OrClause(
+                    new CompareClause(FieldKey.fromParts("RunId"), CompareType.ISBLANK, null),
+                    new InClause(FieldKey.fromParts("RunId", "Container"), containers)
+                )
+            );
+            case "Edge" -> new AndClause(
+                new InClause(FieldKey.fromParts("FromObjectId", "Container"), containers),
+                new InClause(FieldKey.fromParts("ToObjectId", "Container"), containers)
+            );
+            case "Alias" -> new SQLClause(
+                new SQLFragment("RowId IN (SELECT Alias FROM exp.MaterialAliasMap WHERE Container")
+                    .appendInClause(containers, sourceTable.getSqlDialect())
+                    .append(" UNION SELECT Alias FROM exp.DataAliasMap WHERE Container")
+                    .appendInClause(containers, sourceTable.getSqlDialect())
+                    .append(")")
+            );
+            case "ObjectLegacyNames" -> new SQLClause(
+                new SQLFragment("ObjectId IN (SELECT ObjectId FROM exp.Object WHERE Container")
+                    .appendInClause(containers, sourceTable.getSqlDialect())
+                    .append(")")
+            );
+            default -> super.getContainerClause(sourceTable, containerFieldKey, containers);
+        };
+    }
+
+    @Override
+    public void afterSchema()
+    {
+        new SqlExecutor(getSchema()).execute("ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId) MATCH SIMPLE ON DELETE SET NULL");
+        new SqlExecutor(getSchema()).execute("ALTER TABLE exp.Object ADD CONSTRAINT FK_Object_Object FOREIGN KEY (OwnerObjectId) REFERENCES exp.Object (ObjectId)");
+        new SqlExecutor(getSchema()).execute("ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_ExperimentRun_ReplacedByRunId FOREIGN KEY (ReplacedByRunId) REFERENCES exp.ExperimentRun (RowId)");
+    }
+}

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -39,11 +39,9 @@ import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.NameGenerator;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
-import org.labkey.api.data.SimpleFilter.AndClause;
-import org.labkey.api.data.SimpleFilter.InClause;
+import org.labkey.api.data.SimpleFilter.FilterClause;
 import org.labkey.api.data.SimpleFilter.OrClause;
 import org.labkey.api.data.SimpleFilter.SQLClause;
-import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -886,74 +884,7 @@ public class ExperimentModule extends SpringModule
             });
         }
 
-        DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(OntologyManager.getExpSchema())
-        {
-            @Override
-            public void beforeSchema()
-            {
-                // Work around foreign key cycle between ExperimentRun <-> ProtocolApplication by temporarily dropping FK_Run_WorfklowTask.
-                // Yes, the FK name is misspelled
-                new SqlExecutor(getSchema()).execute("ALTER TABLE exp.ExperimentRun DROP CONSTRAINT FK_Run_WorfklowTask");
-                new SqlExecutor(getSchema()).execute("ALTER TABLE exp.Object DROP CONSTRAINT FK_Object_Object");
-
-                // Need to drop self FK until all rows are populated because replaced runs will be inserted before their replacements
-                new SqlExecutor(getSchema()).execute("ALTER TABLE exp.ExperimentRun DROP CONSTRAINT FK_ExperimentRun_ReplacedByRunId");
-            }
-
-            @Override
-            public @Nullable FieldKey getContainerFieldKey(TableInfo table)
-            {
-                return switch (table.getName())
-                {
-                    case "Alias", "ObjectLegacyNames" -> FieldKey.fromParts("DUMMY"); // Unused dummy value -- see override below
-                    case "DataTypeExclusion" -> FieldKey.fromParts("ExcludedContainer");
-                    case "PropertyDomain" -> FieldKey.fromParts("DomainId", "Container");
-                    case "ProtocolApplication" -> FieldKey.fromParts("RunId", "Container");
-                    default -> super.getContainerFieldKey(table);
-                };
-            }
-
-            @Override
-            public SimpleFilter.FilterClause getContainerClause(TableInfo sourceTable, FieldKey containerFieldKey, Set<GUID> containers)
-            {
-                return switch (sourceTable.getName())
-                {
-                    case "DataInput" -> new AndClause(
-                        new InClause(FieldKey.fromParts("DataId", "Container"), containers),
-                        new InClause(FieldKey.fromParts("TargetApplicationId", "RunId", "Container"), containers)
-                    );
-                    case "MaterialInput" -> new AndClause(
-                        new InClause(FieldKey.fromParts("MaterialId", "Container"), containers),
-                        new InClause(FieldKey.fromParts("TargetApplicationId", "RunId", "Container"), containers)
-                    );
-                    case "Edge" -> new AndClause(
-                        new InClause(FieldKey.fromParts("FromObjectId", "Container"), containers),
-                        new InClause(FieldKey.fromParts("ToObjectId", "Container"), containers)
-                    );
-                    case "Alias" -> new SQLClause(
-                        new SQLFragment("RowId IN (SELECT Alias FROM exp.MaterialAliasMap WHERE Container")
-                            .appendInClause(containers, sourceTable.getSqlDialect())
-                            .append(" UNION SELECT Alias FROM exp.DataAliasMap WHERE Container")
-                            .appendInClause(containers, sourceTable.getSqlDialect())
-                            .append(")")
-                    );
-                    case "ObjectLegacyNames" -> new SQLClause(
-                        new SQLFragment("ObjectId IN (SELECT ObjectId FROM exp.Object WHERE Container")
-                            .appendInClause(containers, sourceTable.getSqlDialect())
-                            .append(")")
-                    );
-                    default -> super.getContainerClause(sourceTable, containerFieldKey, containers);
-                };
-            }
-
-            @Override
-            public void afterSchema()
-            {
-                new SqlExecutor(getSchema()).execute("ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_Run_WorfklowTask FOREIGN KEY (WorkflowTask) REFERENCES exp.ProtocolApplication (RowId) MATCH SIMPLE ON DELETE SET NULL");
-                new SqlExecutor(getSchema()).execute("ALTER TABLE exp.Object ADD CONSTRAINT FK_Object_Object FOREIGN KEY (OwnerObjectId) REFERENCES exp.Object (ObjectId)");
-                new SqlExecutor(getSchema()).execute("ALTER TABLE exp.ExperimentRun ADD CONSTRAINT FK_ExperimentRun_ReplacedByRunId FOREIGN KEY (ReplacedByRunId) REFERENCES exp.ExperimentRun (RowId)");
-            }
-        });
+        DatabaseMigrationService.get().registerSchemaHandler(new ExperimentMigrationSchemaHandler());
 
         // Sample set materialized tables join on RowId to exp.Material. They also have a built-in Flag field.
         DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(SampleTypeDomainKind.getSchema()) {
@@ -964,7 +895,7 @@ public class ExperimentModule extends SpringModule
             }
 
             @Override
-            public SimpleFilter.FilterClause getContainerClause(TableInfo sourceTable, FieldKey containerFieldKey, Set<GUID> containers)
+            public FilterClause getContainerClause(TableInfo sourceTable, FieldKey containerFieldKey, Set<GUID> containers)
             {
                 return new SQLClause(
                     new SQLFragment("RowId IN (SELECT RowId FROM exp.Material WHERE Container")

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -93,12 +93,13 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
 
     private static final Set<String> FORCE_ENABLED_SYSTEM_FIELDS;
 
-    static {
+    static
+    {
         BASE_PROPERTIES = Collections.unmodifiableSet(Sets.newLinkedHashSet(Arrays.asList(
-                new PropertyStorageSpec("genId", JdbcType.INTEGER),
-                new PropertyStorageSpec("lsid", JdbcType.VARCHAR, 300).setNullable(false),
-                new PropertyStorageSpec("name", JdbcType.VARCHAR, 200),
-                new PropertyStorageSpec("classid", JdbcType.INTEGER)
+            new PropertyStorageSpec("genId", JdbcType.INTEGER),
+            new PropertyStorageSpec("lsid", JdbcType.VARCHAR, 300).setNullable(false),
+            new PropertyStorageSpec("name", JdbcType.VARCHAR, 200),
+            new PropertyStorageSpec("classid", JdbcType.INTEGER)
         )));
 
         Set<String> names = new HashSet<>();


### PR DESCRIPTION
#### Rationale
Registering a MigrationFilter in the Module constructor and stashing migration state in the module is icky. It also may be causing memory leaks.