### PR TITLE
LOV combo fix

### DIFF
--- a/core/webapp/Ext.ux.form.LovCombo.js
+++ b/core/webapp/Ext.ux.form.LovCombo.js
@@ -292,12 +292,10 @@ Ext.ux.form.LovCombo = Ext.extend(Ext.form.ComboBox, {
 			if(this.valueField && this.store.getCount()) {
                 this.store.suspendEvents(true);
 				this.store.clearFilter();
-				this.store.each(function(r) {
+				this.store.each(function (r) {
 					var checked = !(!v.match(
-						 '(^|' + this.separator + ')' + RegExp.escape(r.get(this.valueField))
-						+'(' + this.separator + '|$)'))
-					;
-
+							'(^|' + this.separator + ')' + RegExp.escape(JSON.stringify(r.get(this.valueField)))
+							+ '(' + this.separator + '|$)'));
 					r.set(this.checkField, checked);
 				}, this);
                 this.store.resumeEvents();


### PR DESCRIPTION
#### Rationale
tracking [issue](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=54149)

Newer browsers fully support `RegExp.escape` but this version requires a `String` argument. The default version at the top of this class would ignore non-string values.