### PR TITLE
Issue 53831: check the true assay name length since we append onto the name when creating the assay domains (ex. "<assay name> Batch Fields")

### DIFF
--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -1018,12 +1018,6 @@ public class DomainUtil
                 return prefix + invalidPattenError;
         }
 
-        // Issue 53831: add a specific check for assay name length since we append onto the name when creating the assay domains (ex. "<assay nam> Batch Fields")
-        // which makes that actual max less than the DB size of 200
-        int assayNameLengthMax = 150;
-        if ("Assay Design".equalsIgnoreCase(kindName) && domainName.length() > assayNameLengthMax)
-            return "Value is too long for assay design name, a maximum length of " + assayNameLengthMax + " is allowed. The supplied value, '" + StringUtils.abbreviateMiddle(domainName, "...", 50) + "', was " + domainName.length() + " characters long.";
-
         return null;
     }
 

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -1018,6 +1018,11 @@ public class DomainUtil
                 return prefix + invalidPattenError;
         }
 
+        // Issue 53831: check the true assay name length since we append onto the name when creating the assay domains (ex. "<assay nam> Batch Fields")
+        int actualAssayNameLengthMax = 186;
+        if ("Assay Design".equalsIgnoreCase(kindName) && domainName.length() > actualAssayNameLengthMax)
+            return "Value is too long for assay design name, a maximum length of " + actualAssayNameLengthMax + " is allowed. The supplied value, '" + StringUtils.abbreviateMiddle(domainName, "...", 50) + "', was " + domainName.length() + " characters long.";
+
         return null;
     }
 

--- a/api/src/org/labkey/api/exp/property/DomainUtil.java
+++ b/api/src/org/labkey/api/exp/property/DomainUtil.java
@@ -1018,10 +1018,11 @@ public class DomainUtil
                 return prefix + invalidPattenError;
         }
 
-        // Issue 53831: check the true assay name length since we append onto the name when creating the assay domains (ex. "<assay nam> Batch Fields")
-        int actualAssayNameLengthMax = 186;
-        if ("Assay Design".equalsIgnoreCase(kindName) && domainName.length() > actualAssayNameLengthMax)
-            return "Value is too long for assay design name, a maximum length of " + actualAssayNameLengthMax + " is allowed. The supplied value, '" + StringUtils.abbreviateMiddle(domainName, "...", 50) + "', was " + domainName.length() + " characters long.";
+        // Issue 53831: add a specific check for assay name length since we append onto the name when creating the assay domains (ex. "<assay nam> Batch Fields")
+        // which makes that actual max less than the DB size of 200
+        int assayNameLengthMax = 150;
+        if ("Assay Design".equalsIgnoreCase(kindName) && domainName.length() > assayNameLengthMax)
+            return "Value is too long for assay design name, a maximum length of " + assayNameLengthMax + " is allowed. The supplied value, '" + StringUtils.abbreviateMiddle(domainName, "...", 50) + "', was " + domainName.length() + " characters long.";
 
         return null;
     }

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -430,7 +430,7 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                 if (nameError != null)
                     throw new ValidationException(nameError);
 
-                // Issue 53831: add a specific check for assay name length since we append onto the name when creating the assay domains (ex. "<assay nam> Batch Fields")
+                // Issue 53831: add a specific check for assay name length since we append onto the name when creating the assay domains (ex. "<assay name> Batch Fields")
                 // which makes that actual max less than the DB size of 200
                 int assayNameLengthMax = 150;
                 if (assay.getName().length() > assayNameLengthMax)

--- a/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
+++ b/assay/src/org/labkey/assay/AssayDomainServiceImpl.java
@@ -430,6 +430,12 @@ public class AssayDomainServiceImpl extends BaseRemoteService implements AssayDo
                 if (nameError != null)
                     throw new ValidationException(nameError);
 
+                // Issue 53831: add a specific check for assay name length since we append onto the name when creating the assay domains (ex. "<assay nam> Batch Fields")
+                // which makes that actual max less than the DB size of 200
+                int assayNameLengthMax = 150;
+                if (assay.getName().length() > assayNameLengthMax)
+                    throw new ValidationException("Value is too long for assay design name, a maximum length of " + assayNameLengthMax + " is allowed. The supplied value, '" + StringUtils.abbreviateMiddle(assay.getName(), "...", 50) + "', was " + assay.getName().length() + " characters long.");
+
                 if (isNew)
                 {
                     // check for existing assay protocol with the given name before creating


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53831

This PR doesn't fix or update anything on the server side to actually allow for assay names of the full 200 characters. This instead adds a check for what is currently the "true assay name max length" at assay creation time.

Note that this definitely feels like a stop gap. If we really want to allow assay names that are 200 characters and not this arbitrary length, we should put that on the backlog and figure out an approach that works for assays but probably applies to all data types so they all have the same name max length.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7150
- https://github.com/LabKey/testAutomation/pull/2764

#### Changes
- add assay name specific length check in AssayDomainServiceImpl

#### Tasks 📍
- [x] Manual Testing @labkey-tchad 
- [x] Needs Automation
- [x] Verify Fix