### PR TITLE
Issue 53567: Improve "Alias" column performance

### DIFF
--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -87,7 +87,7 @@ public interface AuditHandler
             String key = entry.getKey();
             // getDatasetRows() (at least) should return key==column.getName(), expect getColumn(name) to work
             ColumnInfo col = null==table ? null : table.getColumn(key);
-            if (col != null && col.getFk() instanceof MultiValuedForeignKey)
+            if (col != null && (col.isMultiValued() || col.getFk() instanceof MultiValuedForeignKey))
                 isMultiValued = true;
 
             String nameFromAlias = key;
@@ -99,7 +99,7 @@ public interface AuditHandler
 
                 if (aliasColumn != null)
                 {
-                    if (aliasColumn.getFk() != null && aliasColumn.getFk() instanceof MultiValuedForeignKey)
+                    if (aliasColumn.getFk() != null && (aliasColumn.isMultiValued() || aliasColumn.getFk() instanceof MultiValuedForeignKey))
                         isMultiValued = true;
                     nameFromAlias = aliasColumn.getName();
                 }

--- a/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
+++ b/api/src/org/labkey/api/data/AbstractWrappedColumnInfo.java
@@ -842,4 +842,10 @@ public abstract class AbstractWrappedColumnInfo implements ColumnInfo
     {
         return delegate.isScannable();
     }
+
+    @Override
+    public boolean isMultiValued()
+    {
+        return delegate.isMultiValued();
+    }
 }

--- a/api/src/org/labkey/api/data/BaseColumnInfo.java
+++ b/api/src/org/labkey/api/data/BaseColumnInfo.java
@@ -97,6 +97,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     private String _jdbcDefaultValue = null;  // TODO: Merge with defaultValue, see #17646
     private boolean _isAutoIncrement = false;
     private boolean _hasDbSequence = false;
+    private boolean _isMultiValued = false;
     private boolean _isRootDbSequence = false;
     private boolean _isKeyField = false;
     private boolean _isReadOnly = false;
@@ -324,6 +325,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
 
         // and the remaining
         setUserEditable(col.isUserEditable());
+        setIsMultiValued(col.isMultiValued());
         setNullable(col.isNullable());
         setRequired(col.isRequiredSet());
         setAutoIncrement(col.isAutoIncrement());
@@ -445,6 +447,7 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
 
         setDerivationDataScope(col.getDerivationDataScope());
         setScannable(col.isScannable());
+        setIsMultiValued(col.isMultiValued());
     }
 
     /*
@@ -986,6 +989,17 @@ public class BaseColumnInfo extends ColumnRenderPropertiesImpl implements Mutabl
     public void setIsRootDbSequence(boolean isRootDbSequence)
     {
         _isRootDbSequence = isRootDbSequence;
+    }
+
+    public boolean isMultiValued()
+    {
+        return _isMultiValued;
+    }
+
+    public void setIsMultiValued(boolean isMultiValued)
+    {
+        checkLocked();
+        _isMultiValued = isMultiValued;
     }
 
     @Override

--- a/api/src/org/labkey/api/data/ColumnInfo.java
+++ b/api/src/org/labkey/api/data/ColumnInfo.java
@@ -290,6 +290,8 @@ public interface ColumnInfo extends ColumnRenderProperties
      */
     boolean isKeyField();
 
+    boolean isMultiValued();
+
     @Override
     boolean isMvEnabled();
 

--- a/api/src/org/labkey/api/data/MultiValuedLookupColumn.java
+++ b/api/src/org/labkey/api/data/MultiValuedLookupColumn.java
@@ -211,4 +211,10 @@ public class MultiValuedLookupColumn extends LookupColumn
         // Can't sort because we need to make sure that all the multi-value columns come back in the same order
         return getSqlDialect().getGroupConcat(sql, false, false, new SQLFragment().appendStringLiteral(MultiValuedRenderContext.VALUE_DELIMITER, getSqlDialect()), true);
     }
+
+    @Override
+    public boolean isMultiValued()
+    {
+        return true;
+    }
 }

--- a/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
@@ -487,36 +487,37 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     {
         // Sort function might not exist in external datasource; skip that syntax if not
         boolean useSortFunction = sorted && _arraySortFunctionExists.get();
+        SQLFragment result = new SQLFragment();
 
-        // TODO: Use "string_agg()" in place of array_to_string(array_agg())?
-        SQLFragment result = new SQLFragment("array_to_string(");
         if (useSortFunction)
         {
+            result.append("array_to_string(");
             result.append("core.sort(");   // TODO: Switch to use ORDER BY option inside array aggregate instead of our custom function
+            result.append("array_agg(");
         }
-        result.append("array_agg(");
+        else
+        {
+            result.append("string_agg(");
+        }
+
         if (distinct)
         {
             result.append("DISTINCT ");
-        }
-        if (includeNulls)
-        {
-            result.append("COALESCE(CAST(");
         }
         result.append(sql);
 
         if (includeNulls)
         {
-            result.append(" AS VARCHAR), '')");
+            result.append("::text");
         }
-        result.append(")");
         if (useSortFunction)
         {
-            result.append(")");
+            result.append(")"); // array_agg
+            result.append(")"); // core.sort
         }
         result.append(", ");
         result.append(delimiterSQL);
-        result.append(")");
+        result.append(")"); // array_to_string | string_agg
 
         return result;
     }

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -450,7 +450,7 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
         {
             checkAlive(_job);
             List<Map<String, Object>> parents = getRandomSamples(sampleType, Math.min(10, Math.max(quantity, quantity / 100)));
-            numGenerated = generateAliquotsForParents(parents, svc, quantity - totalAliquots, 0, 1, randomInt(1, _config.getMaxGenerations()), sampleStatuses);
+            numGenerated = generateAliquotsForParents(sampleType, parents, svc, quantity - totalAliquots, 0, 1, randomInt(1, _config.getMaxGenerations()), sampleStatuses);
             totalAliquots += numGenerated;
             _log.info("... " + totalAliquots);
             iterations++;
@@ -463,7 +463,7 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
         return totalAliquots;
     }
 
-    private int generateAliquotsForParents(List<Map<String, Object>> parents, QueryUpdateService svc, int quantity, int numGenerated, int generation, int maxGenerations, List<Long> sampleStatuses) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
+    private int generateAliquotsForParents(ExpSampleType sampleType, List<Map<String, Object>> parents, QueryUpdateService svc, int quantity, int numGenerated, int generation, int maxGenerations, List<Long> sampleStatuses) throws SQLException, BatchValidationException, QueryUpdateServiceException, DuplicateKeyException
     {
         int generatedCount = 0;
         List<Map<String, Object>> aliquots = new ArrayList<>();
@@ -492,6 +492,7 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
                 if (randomInt(0, 10) == 5) // set amount for 10%
                 {
                     row.put("StoredAmount", p + (i % 15) * (1.2));
+                    row.put("Units", getUnitsValue(sampleType));
                 }
                 rows.add(row);
             }
@@ -511,7 +512,7 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
         {
             List<Map<String, Object>> nextParents = aliquots.isEmpty() ? parents : aliquots;
             if (!nextParents.isEmpty())
-                generatedCount += generateAliquotsForParents(nextParents.subList(randomInt(0, nextParents.size() / 2), randomInt(nextParents.size() / 2, nextParents.size())), svc, quantity - generatedCount, numGenerated + generatedCount, generation + 1, maxGenerations, sampleStatuses);
+                generatedCount += generateAliquotsForParents(sampleType, nextParents.subList(randomInt(0, nextParents.size() / 2), randomInt(nextParents.size() / 2, nextParents.size())), svc, quantity - generatedCount, numGenerated + generatedCount, generation + 1, maxGenerations, sampleStatuses);
         }
         return generatedCount;
     }
@@ -836,12 +837,10 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
 
     private static String getUnitsValue(ExpSampleType sampleType)
     {
+        Unit sampleTypeUnit = Unit.fromName(sampleType.getMetricUnit());
         String units;
-        if (!StringUtils.isEmpty(sampleType.getMetricUnit()))
-        {
-            Unit unit = Unit.fromName(sampleType.getMetricUnit());
-            units = randomIndex(unit.getKindOfQuantity().getCommonUnits()).name();
-        }
+        if (sampleTypeUnit != null)
+            units = randomIndex(sampleTypeUnit.getKindOfQuantity().getCommonUnits()).name();
         else
             units = randomIndex(UNITS);
 
@@ -854,10 +853,7 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
         if (randomInt(0, 4) < 3) // set amount for 75% - TODO parameterize
         {
             row.put("StoredAmount", randomDouble(0, 100));
-            // add a unit for some percentage
-            String units = getUnitsValue(sampleType);
-            if (units != null)
-                row.put("Units", units);
+            row.put("Units", getUnitsValue(sampleType));
         }
         return row;
     }
@@ -897,11 +893,29 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
     protected List<Map<String, Object>> createSampleRows(int numRows, ExpSampleType sampleType)
     {
         List<Map<String, Object>> rows = new ArrayList<>();
+        int samplesWithAliases = Math.round(numRows * _config.getPctAlias());
         for (int i = 1; i <= numRows; i++)
         {
-            rows.add(createSampleRow(sampleType, i));
+            Map<String, Object> row = createSampleRow(sampleType, i);
+            if (i < samplesWithAliases)
+            {
+                row.put("Alias", randomAlias("alias_"));
+            }
+            rows.add(row);
         }
         return rows;
+    }
+
+    private String randomAlias(String prefix)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= randomInt(1, _config._maxAliases); i++)
+        {
+            if (!sb.isEmpty())
+                sb.append(", ");
+            sb.append(prefix).append(i);
+        }
+        return sb.toString();
     }
 
     public static String randomDate()
@@ -962,6 +976,8 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
         public static final String MIN_DATA_CLASS_PARENT_TYPES_PER_SAMPLE = "minDataClassParentTypesPerSample";
         public static final String MAX_DATA_CLASS_PARENT_TYPES_PER_SAMPLE = "maxDataClassParentTypesPerSample";
         public static final String AUDIT_BEHAVIOR_TYPE = "auditBehaviorType";
+        public static final String PCT_ALIAS = "percentWithAliases";
+        public static final String MAX_ALIAS = "maxAliases";
 
         int _numFolders;
         int _numSampleTypes;
@@ -977,6 +993,8 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
         int _maxChildrenPerParent;
         int _minFields;
         int _maxFields;
+        float _pctAlias;
+        int _maxAliases;
         List<String> _sampleTypeNames;
         List<String> _dataClassParents;
         List<String> _sampleTypeParents;
@@ -1009,6 +1027,9 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
             _maxGenerations = Integer.parseInt(properties.getProperty(MAX_GENERATIONS, "1"));
             _maxAliquotsPerParent = Integer.parseInt(properties.getProperty(MAX_ALIQUOTS_PER_SAMPLE, "0"));
             _maxChildrenPerParent = Integer.parseInt(properties.getProperty(MAX_CHILDREN_PER_PARENT, "1"));
+
+            _pctAlias = Float.parseFloat(properties.getProperty(PCT_ALIAS, "0.0"));
+            _maxAliases = Integer.parseInt(properties.getProperty(MAX_ALIAS, "1"));
 
             _minFields = Integer.parseInt(properties.getProperty(MIN_NUM_FIELDS, "1"));
             _maxFields = Math.max(Integer.parseInt(properties.getProperty(MAX_NUM_FIELDS, "1")), _minFields);
@@ -1234,6 +1255,26 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
         public void setAuditBehaviorType(AuditBehaviorType auditBehaviorType)
         {
             _auditBehaviorType = auditBehaviorType;
+        }
+
+        public float getPctAlias()
+        {
+            return _pctAlias;
+        }
+
+        public void setPctAlias(float pctAlias)
+        {
+            _pctAlias = pctAlias;
+        }
+
+        public int getMaxAliases()
+        {
+            return _maxAliases;
+        }
+
+        public void setMaxAliases(int maxAliases)
+        {
+            _maxAliases = maxAliases;
         }
     }
 

--- a/api/src/org/labkey/api/dataiterator/CoerceDataIterator.java
+++ b/api/src/org/labkey/api/dataiterator/CoerceDataIterator.java
@@ -65,7 +65,7 @@ public class CoerceDataIterator extends SimpleTranslator
                 seen.add(to.getName());
                 if (to.getPropertyType() == PropertyType.ATTACHMENT || to.getPropertyType() == PropertyType.FILE_LINK)
                     addColumn(to, i);
-                else if (to.getFk() instanceof MultiValuedForeignKey)
+                else if (to.isMultiValued() || to.getFk() instanceof MultiValuedForeignKey)
                     addColumn(to.getName(), i); // pass-through multi-value columns -- converting will stringify a collection
                 else
                     addConvertColumn(to.getName(), i, to.getJdbcType(), to.getFk(), RemapMissingBehavior.Error, true);

--- a/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
+++ b/api/src/org/labkey/api/dataiterator/SimpleTranslator.java
@@ -1356,7 +1356,7 @@ public class SimpleTranslator extends AbstractDataIterator implements DataIterat
             c = new RemappingConvertColumn(c, fromIndex, col, missing, true, lookupResolutionType);
         }
 
-        boolean multiValue = fk instanceof MultiValuedForeignKey;
+        boolean multiValue = col.isMultiValued() || fk instanceof MultiValuedForeignKey;
         if (multiValue)
         {
             // convert input into Collection of jdbcType values

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -20,7 +20,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONArray;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -723,9 +722,8 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
             !col.getJavaObjectClass().isInstance(value) &&
             !(value instanceof AttachmentFile) &&
             !(value instanceof MultipartFile) &&
-            !(value instanceof JSONArray) &&
             !(value instanceof String[]) &&
-            !(col.getFk() instanceof MultiValuedForeignKey))
+            !(col.isMultiValued() || col.getFk() instanceof MultiValuedForeignKey))
         {
             try
             {

--- a/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
+++ b/api/src/org/labkey/api/query/AbstractQueryUpdateService.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.json.JSONArray;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -716,6 +717,40 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         return null;
     }
 
+    protected Object coerceTypesValue(ColumnInfo col, Map<String, Object> providedValues, String key, Object value)
+    {
+        if (col != null && value != null &&
+            !col.getJavaObjectClass().isInstance(value) &&
+            !(value instanceof AttachmentFile) &&
+            !(value instanceof MultipartFile) &&
+            !(value instanceof JSONArray) &&
+            !(value instanceof String[]) &&
+            !(col.getFk() instanceof MultiValuedForeignKey))
+        {
+            try
+            {
+                if (PropertyType.FILE_LINK.equals(col.getPropertyType()))
+                    value = ExpDataFileConverter.convert(value);
+                else if (col.getKindOfQuantity() != null)
+                {
+                    providedValues.put(key, value);
+                    value = Quantity.convert(value, col.getKindOfQuantity().getStorageUnit());
+                }
+                else
+                    value = col.getConvertFn().apply(value);
+            }
+            catch (ConvertHelper.FileConversionException e)
+            {
+                throw e;
+            }
+            catch (ConversionException e)
+            {
+                // That's OK, the transformation script may be able to fix up the value before it gets inserted
+            }
+        }
+
+        return value;
+    }
 
     /** Attempt to make the passed in types match the expected types so the script doesn't have to do the conversion */
     @Deprecated
@@ -726,41 +761,12 @@ public abstract class AbstractQueryUpdateService implements QueryUpdateService
         for (Map.Entry<String, Object> entry : row.entrySet())
         {
             ColumnInfo col = columnMap.get(entry.getKey());
-
-            Object value = entry.getValue();
-            if (col != null && value != null &&
-                    !col.getJavaObjectClass().isInstance(value) &&
-                    !(value instanceof AttachmentFile) &&
-                    !(value instanceof MultipartFile) &&
-                    !(value instanceof String[]) &&
-                    !(col.getFk() instanceof MultiValuedForeignKey))
-            {
-                try
-                {
-                    if (PropertyType.FILE_LINK.equals(col.getPropertyType()))
-                        value = ExpDataFileConverter.convert(value);
-                    else if (col.getKindOfQuantity() != null)
-                    {
-                        providedValues.put(entry.getKey(), value);
-                        value = Quantity.convert(value, col.getKindOfQuantity().getStorageUnit());
-                    }
-                    else
-                        value = col.getConvertFn().apply(value);
-                }
-                catch (ConvertHelper.FileConversionException e)
-                {
-                    throw e;
-                }
-                catch (ConversionException e)
-                {
-                    // That's OK, the transformation script may be able to fix up the value before it gets inserted
-                }
-            }
+            Object value = coerceTypesValue(col, providedValues, entry.getKey(), entry.getValue());
             result.put(entry.getKey(), value);
         }
+        
         return result;
     }
-
 
     protected abstract Map<String, Object> updateRow(User user, Container container, Map<String, Object> row, @NotNull Map<String, Object> oldRow, @Nullable Map<Enum, Object> configParameters)
             throws InvalidKeyException, ValidationException, QueryUpdateServiceException, SQLException;

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.70.2-fb-alias-perf-53567.0"
+        "@labkey/components": "6.70.2"
       },
       "devDependencies": {
         "@labkey/build": "8.7.0",
@@ -2525,9 +2525,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.70.2-fb-alias-perf-53567.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.2-fb-alias-perf-53567.0.tgz",
-      "integrity": "sha512-bszf9TMHSsn77udxjpVDklaFK9QenyqMM2R9B+cw/Z6XK71jNBJlm6Lk08JZxCvcTMVsqtCOB6mKmBUQYM0j0g==",
+      "version": "6.70.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.2.tgz",
+      "integrity": "sha512-AlZRJ1TzO8ux2tup/LbHr/Sy6xI51PH0xJo0WK7W5AdTjj1kch+RgfLKJOo7pwfk4bKk5YxpEC4nEBgWOTc7IA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.70.1"
+        "@labkey/components": "6.70.2-fb-alias-perf-53567.0"
       },
       "devDependencies": {
         "@labkey/build": "8.7.0",
@@ -2525,9 +2525,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.70.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.1.tgz",
-      "integrity": "sha512-bBgLy2ZsfOgmv8i3O4Ny7G0yA2Z2BvOeG0CbgGOg8U792iqx81pdyfjMLdSq4orRS5CKMU7yXd52BounXqL1Pg==",
+      "version": "6.70.2-fb-alias-perf-53567.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.2-fb-alias-perf-53567.0.tgz",
+      "integrity": "sha512-bszf9TMHSsn77udxjpVDklaFK9QenyqMM2R9B+cw/Z6XK71jNBJlm6Lk08JZxCvcTMVsqtCOB6mKmBUQYM0j0g==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.70.1"
+    "@labkey/components": "6.70.2-fb-alias-perf-53567.0"
   },
   "devDependencies": {
     "@labkey/build": "8.7.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.70.2-fb-alias-perf-53567.0"
+    "@labkey/components": "6.70.2"
   },
   "devDependencies": {
     "@labkey/build": "8.7.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.70.1",
+        "@labkey/components": "6.70.2-fb-alias-perf-53567.0",
         "@labkey/themes": "1.5.0"
       },
       "devDependencies": {
@@ -3547,9 +3547,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.70.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.1.tgz",
-      "integrity": "sha512-bBgLy2ZsfOgmv8i3O4Ny7G0yA2Z2BvOeG0CbgGOg8U792iqx81pdyfjMLdSq4orRS5CKMU7yXd52BounXqL1Pg==",
+      "version": "6.70.2-fb-alias-perf-53567.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.2-fb-alias-perf-53567.0.tgz",
+      "integrity": "sha512-bszf9TMHSsn77udxjpVDklaFK9QenyqMM2R9B+cw/Z6XK71jNBJlm6Lk08JZxCvcTMVsqtCOB6mKmBUQYM0j0g==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,12 +8,12 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.70.2-fb-alias-perf-53567.0",
+        "@labkey/components": "6.70.2",
         "@labkey/themes": "1.5.0"
       },
       "devDependencies": {
         "@labkey/build": "8.7.0",
-        "@labkey/eslint-config": "1.1.0",
+        "@labkey/eslint-config": "1.1.1",
         "@types/jest": "30.0.0",
         "@types/react": "18.3.26",
         "@types/react-dom": "18.3.7",
@@ -3547,9 +3547,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.70.2-fb-alias-perf-53567.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.2-fb-alias-perf-53567.0.tgz",
-      "integrity": "sha512-bszf9TMHSsn77udxjpVDklaFK9QenyqMM2R9B+cw/Z6XK71jNBJlm6Lk08JZxCvcTMVsqtCOB6mKmBUQYM0j0g==",
+      "version": "6.70.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.2.tgz",
+      "integrity": "sha512-AlZRJ1TzO8ux2tup/LbHr/Sy6xI51PH0xJo0WK7W5AdTjj1kch+RgfLKJOo7pwfk4bKk5YxpEC4nEBgWOTc7IA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
@@ -3579,9 +3579,9 @@
       }
     },
     "node_modules/@labkey/eslint-config": {
-      "version": "1.1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/eslint-config/-/@labkey/eslint-config-1.1.0.tgz",
-      "integrity": "sha512-r7cuwRQg1JJgFROPdUcbRnwrnB3XV70Y0rw+Djgy3xCJyrVeTuV1G7uR+bltnl9R8fSMLyAP8QNTKdhJSDGinA==",
+      "version": "1.1.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/eslint-config/-/@labkey/eslint-config-1.1.1.tgz",
+      "integrity": "sha512-yTd/C0aynL/yoonEGq3/7ivwyWy0oa54iNZ4PP9afXDe9e5bpvQ2pp/dTrjBTH4WL2Re92L27uSnlu5RDL1nsA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.70.1",
+    "@labkey/components": "6.70.2-fb-alias-perf-53567.0",
     "@labkey/themes": "1.5.0"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,12 +53,12 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.70.2-fb-alias-perf-53567.0",
+    "@labkey/components": "6.70.2",
     "@labkey/themes": "1.5.0"
   },
   "devDependencies": {
     "@labkey/build": "8.7.0",
-    "@labkey/eslint-config": "1.1.0",
+    "@labkey/eslint-config": "1.1.1",
     "@types/jest": "30.0.0",
     "@types/react": "18.3.26",
     "@types/react-dom": "18.3.7",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.70.2-fb-alias-perf-53567.0"
+        "@labkey/components": "6.70.2"
       },
       "devDependencies": {
         "@labkey/build": "8.7.0",
@@ -3314,9 +3314,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.70.2-fb-alias-perf-53567.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.2-fb-alias-perf-53567.0.tgz",
-      "integrity": "sha512-bszf9TMHSsn77udxjpVDklaFK9QenyqMM2R9B+cw/Z6XK71jNBJlm6Lk08JZxCvcTMVsqtCOB6mKmBUQYM0j0g==",
+      "version": "6.70.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.2.tgz",
+      "integrity": "sha512-AlZRJ1TzO8ux2tup/LbHr/Sy6xI51PH0xJo0WK7W5AdTjj1kch+RgfLKJOo7pwfk4bKk5YxpEC4nEBgWOTc7IA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.70.1"
+        "@labkey/components": "6.70.2-fb-alias-perf-53567.0"
       },
       "devDependencies": {
         "@labkey/build": "8.7.0",
@@ -3314,9 +3314,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.70.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.1.tgz",
-      "integrity": "sha512-bBgLy2ZsfOgmv8i3O4Ny7G0yA2Z2BvOeG0CbgGOg8U792iqx81pdyfjMLdSq4orRS5CKMU7yXd52BounXqL1Pg==",
+      "version": "6.70.2-fb-alias-perf-53567.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.2-fb-alias-perf-53567.0.tgz",
+      "integrity": "sha512-bszf9TMHSsn77udxjpVDklaFK9QenyqMM2R9B+cw/Z6XK71jNBJlm6Lk08JZxCvcTMVsqtCOB6mKmBUQYM0j0g==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.70.2-fb-alias-perf-53567.0"
+    "@labkey/components": "6.70.2"
   },
   "devDependencies": {
     "@labkey/build": "8.7.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.70.1"
+    "@labkey/components": "6.70.2-fb-alias-perf-53567.0"
   },
   "devDependencies": {
     "@labkey/build": "8.7.0",

--- a/experiment/src/org/labkey/experiment/api/AliasDisplayColumnFactory.java
+++ b/experiment/src/org/labkey/experiment/api/AliasDisplayColumnFactory.java
@@ -6,6 +6,7 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.MultiValuedDisplayColumn;
 import org.labkey.api.data.RenderContext;
+import org.labkey.api.util.PageFlowUtil;
 
 import java.util.List;
 
@@ -24,7 +25,7 @@ class AliasDisplayColumnFactory implements DisplayColumnFactory
             {
                 Object value = super.getInputValue(ctx);
                 if (value instanceof List)
-                    return String.join(", ", (List) value);
+                    return PageFlowUtil.joinValuesToStringForExport((List<String>) value);
                 return "";
             }
         };

--- a/experiment/src/org/labkey/experiment/api/AliasDisplayColumnFactory.java
+++ b/experiment/src/org/labkey/experiment/api/AliasDisplayColumnFactory.java
@@ -6,10 +6,7 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.MultiValuedDisplayColumn;
 import org.labkey.api.data.RenderContext;
-import org.labkey.api.data.TableSelector;
-import org.labkey.api.exp.api.ExperimentService;
 
-import java.util.Collections;
 import java.util.List;
 
 class AliasDisplayColumnFactory implements DisplayColumnFactory
@@ -17,32 +14,18 @@ class AliasDisplayColumnFactory implements DisplayColumnFactory
     @Override
     public DisplayColumn createRenderer(ColumnInfo colInfo)
     {
-        DataColumn dataColumn = new DataColumn(colInfo);
+        DataColumn dataColumn = new DataColumn(colInfo, false);
         dataColumn.setInputType("text");
 
-        return new MultiValuedDisplayColumn(dataColumn, true)
+        return new MultiValuedDisplayColumn(dataColumn)
         {
             @Override
             public Object getInputValue(RenderContext ctx)
             {
                 Object value = super.getInputValue(ctx);
-                StringBuilder sb = new StringBuilder();
                 if (value instanceof List)
-                {
-                    String delim = "";
-                    for (Object item : (List) value)
-                    {
-                        if (item != null)
-                        {
-                            String name = new TableSelector(ExperimentService.get().getTinfoAlias(), Collections.singleton("Name")).getObject(item, String.class);
-
-                            sb.append(delim);
-                            sb.append(name);
-                            delim = ", ";
-                        }
-                    }
-                }
-                return sb.toString();
+                    return String.join(", ", (List) value);
+                return "";
             }
         };
     }

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
@@ -482,15 +482,15 @@ private void verifyAliasesViaSelectRows(String schemaName, String queryName, lon
         //        "value": "JUNIT-5-50", "url": "..."
         //    },
         //    "Alias": [{
-        //        "displayValue": "a", "value": 4
+        //        "value": "a"
         //    },{
-        //        "displayValue": "c", "value": 6
+        //        "value": "b"
         //    },{
-        //        "displayValue": "b", "value": 989
+        //        "value": "c"
         //    }]
         //}
         List<Map<String, Object>> row0aliases = (List<Map<String, Object>>)row0data.get(ExpDataTable.Column.Alias.name());
-        Set<String> aliases = row0aliases.stream().map(m -> (String)m.get("displayValue")).collect(Collectors.toSet());
+        Set<String> aliases = row0aliases.stream().map(m -> (String)m.get("value")).collect(Collectors.toSet());
         assertEquals(aliases, expectedAliases);
     }
 }
@@ -1107,7 +1107,7 @@ public void testInsertOptionUpdate() throws Exception
 
     ts = new TableSelector(table, columnNames, null, new Sort("Name"));
     ts.setForDisplay(true);
-    String aliasAlias = "alias$alias$name";
+    String aliasAlias = "alias";
     String flagAlias = "flag$";
 
     List<Map<String,Object>> rows = Arrays.asList(ts.getMapArray());

--- a/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
@@ -21,6 +21,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ForeignKey;
 import org.labkey.api.data.MultiValuedRenderContext;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.ParameterMapStatement;
@@ -90,6 +91,13 @@ public abstract class ExpRunItemTableImpl<C extends Enum> extends ExpTableImpl<C
         MutableColumnInfo aliasCol = new AliasedColumn(this, alias, lsidCol)
         {
             @Override
+            public ForeignKey getFk()
+            {
+                // Do not traverse lookup
+                return null;
+            }
+
+            @Override
             public SQLFragment getValueSql(String tableAlias)
             {
                 return new SQLFragment("(SELECT ")
@@ -99,6 +107,12 @@ public abstract class ExpRunItemTableImpl<C extends Enum> extends ExpTableImpl<C
                     .append(" ON AA.rowId = MM.alias")
                     .append(" WHERE MM.lsid = ").append(lsidCol.getValueSql(tableAlias))
                     .append(")");
+            }
+
+            @Override
+            public boolean isMultiValued()
+            {
+                return true;
             }
         };
 

--- a/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
@@ -21,10 +21,7 @@ import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ForeignKey;
-import org.labkey.api.data.LookupColumn;
-import org.labkey.api.data.MultiValuedForeignKey;
-import org.labkey.api.data.MultiValuedLookupColumn;
+import org.labkey.api.data.MultiValuedRenderContext;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.ParameterMapStatement;
 import org.labkey.api.data.SQLFragment;
@@ -36,6 +33,7 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.exp.query.ExpMaterialInputTable;
 import org.labkey.api.exp.query.ExpSchema;
+import org.labkey.api.query.AliasedColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.LookupForeignKey;
@@ -88,30 +86,23 @@ public abstract class ExpRunItemTableImpl<C extends Enum> extends ExpTableImpl<C
 
     protected MutableColumnInfo createAliasColumn(String alias, Supplier<TableInfo> aliasMapTable)
     {
-        var aliasCol = wrapColumn("Alias", getRealTable().getColumn("LSID"));
-        aliasCol.setDescription("Contains the list of aliases for this data object");
-        aliasCol.setFk(new MultiValuedForeignKey(new LookupForeignKey("LSID")
+        ColumnInfo lsidCol = getRealTable().getColumn("LSID");
+        MutableColumnInfo aliasCol = new AliasedColumn(this, alias, lsidCol)
         {
             @Override
-            public TableInfo getLookupTableInfo()
+            public SQLFragment getValueSql(String tableAlias)
             {
-                return aliasMapTable.get();
+                return new SQLFragment("(SELECT ")
+                    .append(getSqlDialect().getGroupConcat(new SQLFragment("AA.name"), false, false, new SQLFragment().appendStringLiteral(MultiValuedRenderContext.VALUE_DELIMITER, getSqlDialect()), true))
+                    .append(" FROM ").append(ExperimentServiceImpl.get().getTinfoAlias(), "AA")
+                    .append(" INNER JOIN ").append(aliasMapTable.get(), "MM")
+                    .append(" ON AA.rowId = MM.alias")
+                    .append(" WHERE MM.lsid = ").append(lsidCol.getValueSql(tableAlias))
+                    .append(")");
             }
-        }, "Alias")
-        {
-            @Override
-            protected MultiValuedLookupColumn createMultiValuedLookupColumn(ColumnInfo lookupColumn, ColumnInfo parent, ColumnInfo childKey, ColumnInfo junctionKey, ForeignKey fk)
-            {
-                ((LookupColumn)lookupColumn)._joinType = LookupColumn.JoinType.inner;
-                return super.createMultiValuedLookupColumn(lookupColumn, parent, childKey, junctionKey, fk);
-            }
+        };
 
-            @Override
-            public boolean isMultiSelectInput()
-            {
-                return false;
-            }
-        });
+        aliasCol.setDescription("Contains the list of aliases for this data object");
         aliasCol.setCalculated(false);
         aliasCol.setNullable(true);
         aliasCol.setRequired(false);

--- a/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
@@ -19,8 +19,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ForeignKey;
+import org.labkey.api.data.LookupColumn;
 import org.labkey.api.data.MultiValuedForeignKey;
+import org.labkey.api.data.MultiValuedLookupColumn;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.ParameterMapStatement;
 import org.labkey.api.data.SQLFragment;
@@ -95,6 +99,13 @@ public abstract class ExpRunItemTableImpl<C extends Enum> extends ExpTableImpl<C
             }
         }, "Alias")
         {
+            @Override
+            protected MultiValuedLookupColumn createMultiValuedLookupColumn(ColumnInfo lookupColumn, ColumnInfo parent, ColumnInfo childKey, ColumnInfo junctionKey, ForeignKey fk)
+            {
+                ((LookupColumn)lookupColumn)._joinType = LookupColumn.JoinType.inner;
+                return super.createMultiValuedLookupColumn(lookupColumn, parent, childKey, junctionKey, fk);
+            }
+
             @Override
             public boolean isMultiSelectInput()
             {

--- a/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpRunItemTableImpl.java
@@ -22,6 +22,7 @@ import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ForeignKey;
+import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MultiValuedRenderContext;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.ParameterMapStatement;
@@ -116,6 +117,7 @@ public abstract class ExpRunItemTableImpl<C extends Enum> extends ExpTableImpl<C
             }
         };
 
+        aliasCol.setSqlTypeName(getSqlDialect().getSqlTypeName(JdbcType.VARCHAR));
         aliasCol.setDescription("Contains the list of aliases for this data object");
         aliasCol.setCalculated(false);
         aliasCol.setNullable(true);

--- a/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpSampleTypeTestCase.jsp
@@ -25,7 +25,6 @@
 <%@ page import="org.labkey.api.data.CompareType" %>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.ContainerManager" %>
-<%@ page import="org.labkey.api.data.DbScope" %>
 <%@ page import="org.labkey.api.data.JdbcType" %>
 <%@ page import="org.labkey.api.data.SQLFragment" %>
 <%@ page import="org.labkey.api.data.SimpleFilter" %>
@@ -70,9 +69,7 @@
 <%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.util.TestContext" %>
 <%@ page import="org.labkey.experiment.api.ExpProvisionedTableTestHelper" %>
-<%@ page import="org.labkey.experiment.api.ExpSampleTypeImpl" %>
 <%@ page import="org.labkey.experiment.api.ExperimentServiceImpl" %>
-<%@ page import="org.labkey.experiment.api.SampleTypeServiceImpl" %>
 <%@ page import="java.io.StringBufferInputStream" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.Arrays" %>
@@ -91,6 +88,13 @@
 <%@ page import="org.labkey.api.dataiterator.MapDataIterator" %>
 <%@ page import="static org.labkey.api.exp.api.ExperimentService.asInteger" %>
 <%@ page import="static org.labkey.api.exp.api.ExperimentService.asLong" %>
+<%@ page import="static java.util.Collections.emptyList" %>
+<%@ page import="org.jetbrains.annotations.Nullable" %>
+<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.api.query.QueryParam" %>
+<%@ page import="org.labkey.api.view.ViewServlet" %>
+<%@ page import="org.labkey.api.util.JsonUtil" %>
+<%@ page import="org.labkey.api.settings.LookAndFeelProperties" %>
 <%@ page extends="org.labkey.api.jsp.JspTest.BVT" %>
 
 <%!
@@ -128,16 +132,12 @@ private void assertExpectedName(ExpSampleType st, String expectedName)
 @Test
 public void nameNotNull() throws Exception
 {
-    final User user = TestContext.get().getUser();
-
     try
     {
         List<GWTPropertyDescriptor> props = new ArrayList<>();
         props.add(new GWTPropertyDescriptor("name", "string"));
 
-        final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
-                null, null, props, Collections.emptyList(),
-                -1, -1, -1, -1, null, null);
+        createSampleType(null, props, null);
     }
     catch (ApiUsageException ee)
     {
@@ -148,16 +148,12 @@ public void nameNotNull() throws Exception
 @Test // Issue 51321
 public void reservedNameFirst() throws Exception
 {
-    final User user = TestContext.get().getUser();
-
     try
     {
         List<GWTPropertyDescriptor> props = new ArrayList<>();
         props.add(new GWTPropertyDescriptor("name", "string"));
 
-        final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
-                "First", null, props, Collections.emptyList(),
-                -1, -1, -1, -1, null, null);
+        createSampleType("First", props, null);
     }
     catch (ApiUsageException ee)
     {
@@ -168,16 +164,12 @@ public void reservedNameFirst() throws Exception
 @Test // Issue 51321
 public void reservedNameAll() throws Exception
 {
-    final User user = TestContext.get().getUser();
-
     try
     {
         List<GWTPropertyDescriptor> props = new ArrayList<>();
         props.add(new GWTPropertyDescriptor("name", "string"));
 
-        final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
-                "All", null, props, Collections.emptyList(),
-                -1, -1, -1, -1, null, null);
+        createSampleType("All", props, null);
     }
     catch (ApiUsageException ee)
     {
@@ -189,18 +181,12 @@ public void reservedNameAll() throws Exception
 @Test
 public void nameScale() throws Exception
 {
-    final User user = TestContext.get().getUser();
-
     try
     {
         List<GWTPropertyDescriptor> props = new ArrayList<>();
         props.add(new GWTPropertyDescriptor("name", "string"));
 
-        String name = StringUtils.repeat("a", 1000);
-
-        final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
-                name, null, props, Collections.emptyList(),
-                -1, -1, -1, -1, null, null);
+        createSampleType(StringUtils.repeat("a", 1000), props, null);
     }
     catch (ApiUsageException ee)
     {
@@ -212,8 +198,6 @@ public void nameScale() throws Exception
 @Test
 public void nameExpressionScale() throws Exception
 {
-    final User user = TestContext.get().getUser();
-
     try
     {
         List<GWTPropertyDescriptor> props = new ArrayList<>();
@@ -221,11 +205,7 @@ public void nameExpressionScale() throws Exception
         props.add(new GWTPropertyDescriptor("prop", "string"));
         props.add(new GWTPropertyDescriptor("age", "int"));
 
-        String nameExpression = StringUtils.repeat("a", 1000);
-
-        final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
-                "Samples", null, props, Collections.emptyList(),
-                -1, -1, -1, -1, nameExpression, null);
+        createSampleType("Samples", props, StringUtils.repeat("a", 1000));
     }
     catch (ApiUsageException ee)
     {
@@ -237,17 +217,13 @@ public void nameExpressionScale() throws Exception
 @Test
 public void idColsUnset_nameExpressionNull_noNameProperty() throws Exception
 {
-    final User user = TestContext.get().getUser();
-
     try
     {
         List<GWTPropertyDescriptor> props = new ArrayList<>();
         props.add(new GWTPropertyDescriptor("notName", "string"));
         props.add(new GWTPropertyDescriptor("age", "int"));
 
-        final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
-                "Samples", null, props, Collections.emptyList(),
-                -1, -1, -1, -1, null, null);
+        createSampleType("Samples", props, null);
         fail("Expected exception");
     }
     catch (ApiUsageException ee)
@@ -260,15 +236,11 @@ public void idColsUnset_nameExpressionNull_noNameProperty() throws Exception
 @Test
 public void idColsUnset_nameExpressionNull_hasNameProperty() throws Exception
 {
-    final User user = TestContext.get().getUser();
-
     List<GWTPropertyDescriptor> props = new ArrayList<>();
     props.add(new GWTPropertyDescriptor("name", "string"));
     props.add(new GWTPropertyDescriptor("age", "int"));
 
-    final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
-            "Samples", null, props, Collections.emptyList(),
-            -1, -1, -1, -1, null, null);
+    final ExpSampleType st = createSampleType("Samples", props, null);
 
     ExpMaterial sample = st.getSample(c, "bob");
     assertNull(sample);
@@ -285,18 +257,12 @@ public void idColsUnset_nameExpressionNull_hasNameProperty() throws Exception
 @Test
 public void idColsUnset_nameExpression_hasNameProperty() throws Exception
 {
-    final User user = TestContext.get().getUser();
-
     List<GWTPropertyDescriptor> props = new ArrayList<>();
     props.add(new GWTPropertyDescriptor("name", "string"));
     props.add(new GWTPropertyDescriptor("prop", "string"));
     props.add(new GWTPropertyDescriptor("age", "int"));
 
-    final String nameExpression = "S-${prop}.${age}";
-
-    final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
-            "Samples", null, props, Collections.emptyList(),
-            -1, -1, -1, -1, nameExpression, null);
+    createSampleType("Samples", props, "S-${prop}.${age}");
 }
 
 // idCols not null, nameExpression null, no 'name' property -- ok
@@ -364,9 +330,7 @@ public void idColsSet_nameExpressionNull_hasNameProperty() throws Exception
     props.add(new GWTPropertyDescriptor("prop", "string"));
     props.add(new GWTPropertyDescriptor("age", "int"));
 
-    final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
-            "Samples", null, props, Collections.emptyList(),
-            0, -1, -1, -1, null, null);
+    final ExpSampleType st = createSampleType("Samples", props, null);
 
     final String expectedName1 = "bob";
     ExpMaterial sample1 = st.getSample(c, expectedName1);
@@ -428,11 +392,7 @@ public void testNameExpression() throws Exception
     props.add(new GWTPropertyDescriptor("age", "int"));
 
     final String sampleTypeName = "Samples";
-    final String nameExpression = "S-${prop}.${age}.${genId:number('000')}";
-
-    final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
-            sampleTypeName, null, props, Collections.emptyList(),
-            -1, -1, -1, -1, nameExpression, null);
+    final ExpSampleType st = createSampleType(sampleTypeName, props, "S-${prop}.${age}.${genId:number('000')}");
 
     final String expectedName1 = "bob";
     final String expectedName2 = "S-red.11.002";
@@ -547,16 +507,12 @@ public void testNameExpression() throws Exception
 @Test
 public void testAliases() throws Exception
 {
-    final User user = TestContext.get().getUser();
-
     // setup
     List<GWTPropertyDescriptor> props = new ArrayList<>();
     props.add(new GWTPropertyDescriptor("name", "string"));
     props.add(new GWTPropertyDescriptor("age", "int"));
 
-    final ExpSampleType st = SampleTypeService.get().createSampleType(c, user,
-            "Samples", null, props, Collections.emptyList(),
-            -1, -1, -1, -1, null, null);
+    final ExpSampleType st = createSampleType("Samples", props, null);
 
     List<Map<String, Object>> rows = new ArrayList<>();
     Map<String, Object> row = new CaseInsensitiveHashMap<>();
@@ -584,11 +540,7 @@ public void testBlankRows() throws Exception
     props.add(new GWTPropertyDescriptor("name", "string"));
     props.add(new GWTPropertyDescriptor("age", "int"));
 
-    final String nameExpression = "S-${now:date}-${dailySampleCount}";
-
-    final ExpSampleTypeImpl st = SampleTypeServiceImpl.get().createSampleType(c, user,
-            "Samples", null, props, Collections.emptyList(),
-            -1, -1, -1, -1, nameExpression, null);
+    final ExpSampleType st = createSampleType("Samples", props, "S-${now:date}-${dailySampleCount}");
 
     List<? extends ExpMaterial> allSamples = st.getSamples(c);
     assertTrue("Expected no samples", allSamples.isEmpty());
@@ -685,18 +637,9 @@ public void testUpdateSomeParents() throws Exception
     List<GWTPropertyDescriptor> props = new ArrayList<>();
     props.add(new GWTPropertyDescriptor("name", "string"));
     props.add(new GWTPropertyDescriptor("age", "int"));
-    final ExpSampleTypeImpl childType = SampleTypeServiceImpl.get().createSampleType(c, user,
-            "ChildSamples", null, props, Collections.emptyList(),
-            -1, -1, -1, -1, null, null);
-
-    final ExpSampleTypeImpl parent1Type = SampleTypeServiceImpl.get().createSampleType(c, user,
-            "Parent1Samples", null, props, Collections.emptyList(),
-            -1, -1, -1, -1, null, null);
-
-    final ExpSampleTypeImpl parent2Type = SampleTypeServiceImpl.get().createSampleType(c, user,
-            "Parent2Samples", null, props, Collections.emptyList(),
-            -1, -1, -1, -1, null, null);
-
+    final ExpSampleType childType = createSampleType("ChildSamples", props, null);
+    final ExpSampleType parent1Type = createSampleType("Parent1Samples", props, null);
+    final ExpSampleType parent2Type = createSampleType("Parent2Samples", props, null);
 
     UserSchema schema = QueryService.get().getUserSchema(user, c, SchemaKey.fromParts("Samples"));
     List<Map<String, Object>> rows = new ArrayList<>();
@@ -827,13 +770,12 @@ public void testParentColAndDataInputDerivation() throws Exception
     props.add(new GWTPropertyDescriptor("data", "int"));
     props.add(new GWTPropertyDescriptor("parent", "string"));
 
-    final ExpSampleTypeImpl st = SampleTypeServiceImpl.get().createSampleType(c, user,
-            "Samples", null, props, Collections.emptyList(),
-            0, -1, -1, 2, null, null);
+    String sampleTypeName = "Samples";
+    final ExpSampleType st = createSampleType(sampleTypeName, props, null);
 
     // insert and derive with both 'parent' column and 'DataInputs/Samples'
-    UserSchema schema = QueryService.get().getUserSchema(user, c, SchemaKey.fromParts("Samples"));
-    TableInfo table = schema.getTable("Samples");
+    UserSchema schema = QueryService.get().getUserSchema(user, c, SamplesSchema.SCHEMA_SAMPLES);
+    TableInfo table = schema.getTable(sampleTypeName);
     QueryUpdateService svc = table.getUpdateService();
 
     List<Map<String, Object>> rows = new ArrayList<>();
@@ -955,6 +897,48 @@ public void testParentColAndDataInputDerivation() throws Exception
     assertFalse(oldDerivationRun.getMaterialInputs().containsKey(E));
     assertFalse(oldDerivationRun.getMaterialOutputs().contains(D));
     assertTrue(oldDerivationRun.getMaterialOutputs().contains(E));
+
+    // Issue 43241: Display of dates from Input/Output columns for sample types does not use the project date format
+    {
+        var folderProps = LookAndFeelProperties.getWriteableInstance(c);
+        folderProps.setDefaultDateTimeFormat("'kevink' dd-MM-yyyy");
+        folderProps.save();
+
+        var multiValueColumn = "Outputs/Materials/" + sampleTypeName + "/Created";
+        var url = new ActionURL("query", "selectRows", c);
+        url.addParameter(QueryParam.schemaName, schema.getName());
+        url.addParameter("query." + QueryParam.queryName, sampleTypeName);
+        url.addParameter("query." + QueryParam.columns, "Name, " + multiValueColumn);
+        url.addFilter("query", FieldKey.fromParts("Name"), CompareType.EQUAL, "A");
+        url.addParameter("includeMetadata", false);
+        url.addParameter("apiVersion", "17.1");
+
+        var response = ViewServlet.GET(url, user, null);
+        assertEquals(200, response.getStatus());
+
+        var json = JsonUtil.DEFAULT_MAPPER.readTree(response.getContentAsString());
+        var resultRows = json.get("rows");
+        assertEquals(1, resultRows.size());
+
+        var createdValues = resultRows.get(0).get("data").get(multiValueColumn);
+        assertEquals(4, createdValues.size());
+
+        for (var data : createdValues)
+        {
+            var value = data.get("value").asText();
+            assertNotNull(value);
+
+            // Formatted with container date format
+            var formattedValue = data.get("formattedValue").asText();
+            assertTrue("Expected date format not applied", formattedValue.startsWith("kevink "));
+
+            // Do not care what the JSON format looks like, as long as it is different
+            assertNotEquals(value, formattedValue);
+        }
+
+        folderProps.clearDefaultDateTimeFormat();
+        folderProps.save();
+    }
 }
 
 @Test
@@ -971,12 +955,8 @@ public void testSampleTypeWithVocabularyProperties() throws Exception
     Domain mockDomain = helper.createVocabularyTestDomain(user, c);
     Map<String, String> vocabularyPropertyURIs = helper.getVocabularyPropertyURIS(mockDomain);
 
-    //create sample type
-    ExpSampleTypeImpl st = SampleTypeServiceImpl.get().createSampleType(c, user,
-            sampleName, null, List.of(new GWTPropertyDescriptor("name", "string")), Collections.emptyList(),
-            -1, -1, -1, -1, null, null);
-
-    assertNotNull(st);
+    // create a sample type
+    createSampleType(sampleName, List.of(new GWTPropertyDescriptor("name", "string")), null);
 
     UserSchema schema = QueryService.get().getUserSchema(user, c, SchemaKey.fromParts("Samples"));
 
@@ -1038,9 +1018,7 @@ public void testDetailedAuditLog() throws Exception
     props.add(new GWTPropertyDescriptor("Name", "string"));
     props.add(new GWTPropertyDescriptor("Measure", "string"));
     props.add(new GWTPropertyDescriptor("Value", "float"));
-    final ExpSampleTypeImpl st = SampleTypeServiceImpl.get().createSampleType(c, user,
-            "SamplesDAL", null, props, Collections.emptyList(),
-            -1, -1, -1, -1, null, null);
+    final ExpSampleType st = createSampleType("SamplesDAL", props, null);
 
     QuerySchema samplesSchema = DefaultSchema.get(user, c, "samples");
     assertNotNull(samplesSchema);
@@ -1130,10 +1108,8 @@ public void testExpMaterialPermissions() throws Exception
     User user = TestContext.get().getUser();
     var schema = QueryService.get().getUserSchema(user, c, ExpSchema.SCHEMA_EXP);
 
-    // create sample type
-    ExpSampleTypeImpl st = SampleTypeServiceImpl.get().createSampleType(c, user,
-            "MySamples", null, List.of(new GWTPropertyDescriptor("name", "string")), Collections.emptyList(),
-            -1, -1, -1, -1, null, null);
+    // create a sample type
+    ExpSampleType st = createSampleType("MySamples", List.of(new GWTPropertyDescriptor("name", "string")), null);
 
     // insert a sample
     var errors = new BatchValidationException();
@@ -1214,7 +1190,7 @@ public void testInsertOptionUpdate() throws Exception
     props.add(new GWTPropertyDescriptor(longFieldName, "string"));
 
     final String sampleTypeName = "TestSamplesWithRequired";
-    ExpSampleType sampleType = SampleTypeService.get().createSampleType(c, user, sampleTypeName, null, props, Collections.emptyList(), -1, -1, -1, -1, null);
+    ExpSampleType sampleType = createSampleType(sampleTypeName, props, null);
 
     TableInfo table = getSampleTypeTable(sampleTypeName);
     QueryUpdateService qus = table.getUpdateService();
@@ -1351,6 +1327,11 @@ public void testInsertOptionUpdate() throws Exception
     assertNull(rows.get(0).get("AliquotedFromLSID"));
     assertEquals(aliquotedFromLSID, rows.get(1).get("AliquotedFromLSID"));
     assertNull(rows.get(2).get("AliquotedFromLSID"));
+}
+
+private ExpSampleType createSampleType(String sampleTypeName, List<GWTPropertyDescriptor> props, @Nullable String nameExpression) throws Exception
+{
+    return SampleTypeService.get().createSampleType(c, TestContext.get().getUser(), sampleTypeName, null, props, emptyList(), -1, -1, -1, -1, nameExpression, null);
 }
 
 private @NotNull TableInfo getSampleTypeTable(String sampleType)

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -4739,7 +4739,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         Container container,
         Collection<Long> selectedMaterialIds,
         boolean deleteRunsUsingMaterials,
-        @Nullable ExpSampleTypeImpl stDeleteFrom,
+        @Nullable ExpSampleType stDeleteFrom,
         boolean ignoreStatus,
         boolean truncateContainer
     )
@@ -4763,7 +4763,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         SQLFragment materialFilterSQL,
         boolean deleteRunsUsingMaterials,
         boolean deleteFromAllSampleTypes,
-        @Nullable ExpSampleTypeImpl stDeleteFrom,
+        @Nullable ExpSampleType stDeleteFrom,
         boolean ignoreStatus,
         boolean truncateContainer
     )
@@ -4777,7 +4777,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         {
             Map<ExpSampleType, Set<Long>> sampleTypeAliquotRoots = new HashMap<>();
 
-            Map<String, ExpSampleTypeImpl> sampleTypes = new HashMap<>();
+            Map<String, ExpSampleType> sampleTypes = new HashMap<>();
             if (null != stDeleteFrom)
                 sampleTypes.put(stDeleteFrom.getLSID(), stDeleteFrom);
 
@@ -4934,13 +4934,13 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
             try (Timing ignored = MiniProfiler.step("expsampletype materialized tables"))
             {
-                for (ExpSampleTypeImpl st : sampleTypes.values())
+                for (ExpSampleType st : sampleTypes.values())
                 {
                     // Material may have been orphaned from its SampleType
                     if (st == null)
                         continue;
 
-                    TableInfo dbTinfo = st.getTinfo();
+                    TableInfo dbTinfo = ((ExpSampleTypeImpl) st).getTinfo();
                     // NOTE: study specimens don't have a domain for their samples, so no table
                     if (null != dbTinfo)
                     {

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayFileWriter;
-import org.labkey.api.attachments.AttachmentFile;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
@@ -42,10 +41,8 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ConversionExceptionWithMessage;
-import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DbSequence;
-import org.labkey.api.data.ExpDataFileConverter;
 import org.labkey.api.data.Filter;
 import org.labkey.api.data.ForeignKey;
 import org.labkey.api.data.ImportAliasable;
@@ -118,7 +115,6 @@ import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.experiment.ExpDataIterators;
 import org.labkey.experiment.SampleTypeAuditProvider;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -1944,7 +1940,7 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
                         else
                             addColumn(to, i);
                     }
-                    else if (to.getFk() instanceof MultiValuedForeignKey)
+                    else if (to.isMultiValued() || to.getFk() instanceof MultiValuedForeignKey)
                     {
                         // pass-through multi-value columns -- converting will stringify a collection
                         if (isScopedField)

--- a/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeUpdateServiceDI.java
@@ -657,7 +657,6 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             providedValues.put(PROVIDED_DATA_PREFIX + StoredAmount.label(),  amountVal + unitsStr);
         }
 
-
         Unit baseUnit = _sampleType != null ? _sampleType.getBaseUnit() : null;
 
         for (Map.Entry<String, Object> entry : row.entrySet())
@@ -673,34 +672,11 @@ public class SampleTypeUpdateServiceDI extends DefaultQueryUpdateService
             {
                 value = _SamplesCoerceDataIterator.SampleAmountConvertColumn.getValue(amountVal, unitsCol != null, unitsVal, baseUnit, _sampleType == null ? null : _sampleType.getName());
             }
-            else if (col != null && value != null &&
-                    !col.getJavaObjectClass().isInstance(value) &&
-                    !(value instanceof AttachmentFile) &&
-                    !(value instanceof MultipartFile) &&
-                    !(value instanceof String[]) &&
-                    !(col.getFk() instanceof MultiValuedForeignKey))
+            else
             {
-                try
-                {
-                    if (PropertyType.FILE_LINK.equals(col.getPropertyType()))
-                        value = ExpDataFileConverter.convert(value);
-                    else if (col.getKindOfQuantity() != null)
-                    {
-                        providedValues.put(entry.getKey(), value);
-                        value = Quantity.convert(value, col.getKindOfQuantity().getStorageUnit());
-                    }
-                    else
-                        value = col.getConvertFn().apply(value);
-                }
-                catch (ConvertHelper.FileConversionException e)
-                {
-                    throw e;
-                }
-                catch (ConversionException e)
-                {
-                    // That's OK, the transformation script may be able to fix up the value before it gets inserted
-                }
+                value = coerceTypesValue(col, providedValues, entry.getKey(), value);
             }
+
             result.put(entry.getKey(), value);
         }
         return result;

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.70.1"
+        "@labkey/components": "6.70.2-fb-alias-perf-53567.0"
       },
       "devDependencies": {
         "@labkey/build": "8.7.0",
@@ -2759,9 +2759,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.70.1",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.1.tgz",
-      "integrity": "sha512-bBgLy2ZsfOgmv8i3O4Ny7G0yA2Z2BvOeG0CbgGOg8U792iqx81pdyfjMLdSq4orRS5CKMU7yXd52BounXqL1Pg==",
+      "version": "6.70.2-fb-alias-perf-53567.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.2-fb-alias-perf-53567.0.tgz",
+      "integrity": "sha512-bszf9TMHSsn77udxjpVDklaFK9QenyqMM2R9B+cw/Z6XK71jNBJlm6Lk08JZxCvcTMVsqtCOB6mKmBUQYM0j0g==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,11 +8,11 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.70.2-fb-alias-perf-53567.0"
+        "@labkey/components": "6.70.2"
       },
       "devDependencies": {
         "@labkey/build": "8.7.0",
-        "@labkey/eslint-config": "1.1.0",
+        "@labkey/eslint-config": "1.1.1",
         "@types/jest": "30.0.0",
         "@types/react": "18.3.26",
         "@types/react-dom": "18.3.7"
@@ -2759,9 +2759,9 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.70.2-fb-alias-perf-53567.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.2-fb-alias-perf-53567.0.tgz",
-      "integrity": "sha512-bszf9TMHSsn77udxjpVDklaFK9QenyqMM2R9B+cw/Z6XK71jNBJlm6Lk08JZxCvcTMVsqtCOB6mKmBUQYM0j0g==",
+      "version": "6.70.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.70.2.tgz",
+      "integrity": "sha512-AlZRJ1TzO8ux2tup/LbHr/Sy6xI51PH0xJo0WK7W5AdTjj1kch+RgfLKJOo7pwfk4bKk5YxpEC4nEBgWOTc7IA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
@@ -2791,9 +2791,9 @@
       }
     },
     "node_modules/@labkey/eslint-config": {
-      "version": "1.1.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/eslint-config/-/@labkey/eslint-config-1.1.0.tgz",
-      "integrity": "sha512-r7cuwRQg1JJgFROPdUcbRnwrnB3XV70Y0rw+Djgy3xCJyrVeTuV1G7uR+bltnl9R8fSMLyAP8QNTKdhJSDGinA==",
+      "version": "1.1.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/eslint-config/-/@labkey/eslint-config-1.1.1.tgz",
+      "integrity": "sha512-yTd/C0aynL/yoonEGq3/7ivwyWy0oa54iNZ4PP9afXDe9e5bpvQ2pp/dTrjBTH4WL2Re92L27uSnlu5RDL1nsA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,11 +14,11 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.70.2-fb-alias-perf-53567.0"
+    "@labkey/components": "6.70.2"
   },
   "devDependencies": {
     "@labkey/build": "8.7.0",
-    "@labkey/eslint-config": "1.1.0",
+    "@labkey/eslint-config": "1.1.1",
     "@types/jest": "30.0.0",
     "@types/react": "18.3.26",
     "@types/react-dom": "18.3.7"

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.70.1"
+    "@labkey/components": "6.70.2-fb-alias-perf-53567.0"
   },
   "devDependencies": {
     "@labkey/build": "8.7.0",

--- a/query/src/org/labkey/query/MultiValueTest.jsp
+++ b/query/src/org/labkey/query/MultiValueTest.jsp
@@ -1,5 +1,4 @@
 <%@ page import="com.fasterxml.jackson.databind.JsonNode" %>
-<%@ page import="com.fasterxml.jackson.databind.ObjectMapper" %>
 <%@ page import="com.fasterxml.jackson.databind.node.ArrayNode" %>
 <%@ page import="com.fasterxml.jackson.databind.node.ObjectNode" %>
 <%@ page import="com.google.common.collect.ImmutableList" %>
@@ -16,7 +15,6 @@
 <%@ page import="org.labkey.api.data.TableInfo" %>
 <%@ page import="org.labkey.api.exp.api.ExpMaterial" %>
 <%@ page import="org.labkey.api.exp.api.ExperimentService" %>
-<%@ page import="org.labkey.api.exp.query.ExpMaterialTable" %>
 <%@ page import="org.labkey.api.module.Module" %>
 <%@ page import="org.labkey.api.module.ModuleLoader" %>
 <%@ page import="org.labkey.api.query.BatchValidationException" %>
@@ -37,17 +35,8 @@
 <%@ page import="java.util.Map" %>
 <%@ page import="static org.hamcrest.CoreMatchers.hasItems" %>
 <%@ page import="static org.junit.Assert.assertThat" %>
-<%@ page import="static org.junit.Assert.assertEquals" %>
 <%@ page import="java.util.Set" %>
-<%@ page import="static org.labkey.api.exp.query.ExpMaterialTable.Column.Alias" %>
-<%@ page import="static org.labkey.api.exp.query.ExpMaterialTable.Column.Name" %>
-<%@ page import="com.fasterxml.jackson.core.JsonPointer" %>
-<%@ page import="org.labkey.api.study.MasterPatientIndexService" %>
-<%@ page import="org.labkey.api.settings.FolderSettingsCache" %>
 <%@ page import="org.labkey.api.settings.LookAndFeelProperties" %>
-<%@ page import="org.labkey.api.settings.AppProps" %>
-<%@ page import="static org.junit.Assert.assertNotNull" %>
-<%@ page import="static org.junit.Assert.assertTrue" %>
 <%@ page import="org.labkey.api.util.JsonUtil" %>
 <%@ page import="static org.labkey.api.exp.api.ExperimentService.asInteger" %>
 <%@ page import="static org.labkey.api.exp.api.ExperimentService.asLong" %>

--- a/query/src/org/labkey/query/MultiValueTest.jsp
+++ b/query/src/org/labkey/query/MultiValueTest.jsp
@@ -13,7 +13,6 @@
 <%@ page import="org.labkey.api.data.SimpleFilter" %>
 <%@ page import="org.labkey.api.data.Table" %>
 <%@ page import="org.labkey.api.data.TableInfo" %>
-<%@ page import="org.labkey.api.exp.api.ExpMaterial" %>
 <%@ page import="org.labkey.api.exp.api.ExperimentService" %>
 <%@ page import="org.labkey.api.module.Module" %>
 <%@ page import="org.labkey.api.module.ModuleLoader" %>
@@ -24,7 +23,6 @@
 <%@ page import="org.labkey.api.security.Group" %>
 <%@ page import="org.labkey.api.security.SecurityManager" %>
 <%@ page import="org.labkey.api.security.User" %>
-<%@ page import="org.labkey.api.util.GUID" %>
 <%@ page import="org.labkey.api.util.TestContext" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.ViewServlet" %>
@@ -33,10 +31,7 @@
 <%@ page import="java.util.HashSet" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="static org.hamcrest.CoreMatchers.hasItems" %>
-<%@ page import="static org.junit.Assert.assertThat" %>
 <%@ page import="java.util.Set" %>
-<%@ page import="org.labkey.api.settings.LookAndFeelProperties" %>
 <%@ page import="org.labkey.api.util.JsonUtil" %>
 <%@ page import="static org.labkey.api.exp.api.ExperimentService.asInteger" %>
 <%@ page import="static org.labkey.api.exp.api.ExperimentService.asLong" %>
@@ -238,89 +233,6 @@
         Assert.assertEquals(speciesId4, verifySpecies4);
     }
 
-    // Issue 43241: SM: Display of dates from Input columns for sample types does not use project date format
-    @Test
-    public void testSampleAlias() throws Exception
-    {
-        //
-        // SETUP - create a Sample with >1 alias
-        //
-
-        // set a date format
-        var props = LookAndFeelProperties.getWriteableInstance(c);
-        props.setDefaultDateTimeFormat("'kevink' dd-MM-yyyy");
-        props.save();
-
-        String materialLsid = ExperimentService.get().generateLSID(c, ExpMaterial.class, "TestMaterial");
-        var material = ExperimentService.get().createExpMaterial(c, materialLsid, "TestMaterial");
-        material.save(getUser());
-
-        // insert some aliases
-        var alias1 = Table.insert(getUser(), ExperimentService.get().getTinfoAlias(), CaseInsensitiveHashMap.of("name", aliasPrefix + "1-" + new GUID()));
-        var alias2 = Table.insert(getUser(), ExperimentService.get().getTinfoAlias(), CaseInsensitiveHashMap.of("name", aliasPrefix + "2-" + new GUID()));
-
-        // insert sample -> alias junction entries
-        ExperimentService.get().getTinfoMaterialAliasMap();
-        Table.insert(getUser(), ExperimentService.get().getTinfoMaterialAliasMap(), CaseInsensitiveHashMap.of(
-                "container", c.getEntityId(),
-                "alias", alias1.get("rowId"),
-                "lsid", materialLsid
-        ));
-        Table.insert(getUser(), ExperimentService.get().getTinfoMaterialAliasMap(), CaseInsensitiveHashMap.of(
-                "container", c.getEntityId(),
-                "alias", alias2.get("rowId"),
-                "lsid", materialLsid
-        ));
-
-        // verify we have set up correctly
-        var aliases = material.getAliases();
-        assertThat(aliases, hasItems(alias1.get("name"), alias2.get("name")));
-
-        //
-        // VERIFY - query the aliases and verify the date is formatted correctly
-        //
-
-        ActionURL selectUrl = new ActionURL(QueryController.SelectRowsAction.class, c);
-        selectUrl.addParameter(QueryParam.schemaName, "exp");
-        selectUrl.addParameter(QueryParam.queryName, "Materials");
-        selectUrl.addParameter("query." + QueryParam.columns, "Alias/Created");
-        selectUrl.addFilter("query", FieldKey.fromParts("rowId"), CompareType.EQUAL, material.getRowId());
-        selectUrl.addParameter("includeMetadata", false);
-        // enable the multi-value array response and "formattedValue"
-        selectUrl.addParameter("apiVersion", "17.1");
-
-        MockHttpServletResponse resp = ViewServlet.GET(selectUrl, getUser(), null);
-        Assert.assertEquals(200, resp.getStatus());
-        String content = resp.getContentAsString();
-        //System.out.println("query response:\n" + content);
-
-        ObjectNode n = JsonUtil.DEFAULT_MAPPER.readValue(content, ObjectNode.class);
-        Assert.assertEquals("Expected only one row", 1, n.get("rowCount").asInt());
-        ArrayNode rows = n.withArray("rows");
-
-        JsonNode row0 = rows.get(0);
-        // JSON Pointer uses "~1" to encode "/" in "Alias/Created"
-        ArrayNode row0aliases = (ArrayNode)row0.at("/data/Alias~1Created");
-        Assert.assertEquals("Expected two aliases, got:\n" + row0aliases,
-                2, row0aliases.size());
-
-        for (var row0alias : row0aliases)
-        {
-            // JSON formatted date value
-            String value = row0alias.get("value").asText();
-            Assert.assertNotNull(value);
-
-            // formatted with container date format
-            String formattedValue = row0alias.get("formattedValue").asText();
-            Assert.assertTrue("Expected date format to be applied, got: " + formattedValue,
-                    formattedValue.startsWith("kevink "));
-
-            // don't care what the json format looks like, as long as it is different
-            Assert.assertNotEquals(value, formattedValue);
-        }
-
-    }
-
     private void throwErrors(BatchValidationException errors) throws BatchValidationException
     {
         if (errors.hasErrors())
@@ -328,5 +240,4 @@
             throw errors;
         }
     }
-
 %>


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53567](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53567) by refactoring the "Alias" column for data classes and sample types away from the traditional multi-value foreign key (MVFK) to an inline join on the values.

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-components/pull/1875
- https://github.com/LabKey/platform/pull/7152
- https://github.com/LabKey/limsModules/pull/1759

#### Changes
- Alias column is now an array of string values.
- Alias is no longer a lookup column.
- Introduce `ColumnInfo.isMultiValued()` to allow columns to declare they are multi-value. Formerly, everything needed to be an instance of `MultiValueForeignKey`.
- Refactor group concat sql generation for postgres to use `string_agg()` and `::text`. Reduces per item processing.
- Consolidate duplicated logic for coercing type values in query update services.
- Migrate regression test for [Issue 43241](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=43241).