### PR TITLE
Replace AbstractContainerListener with ContainerListener default

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementContainerListener.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementContainerListener.java
@@ -5,7 +5,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
 
-public class AnnouncementContainerListener extends ContainerManager.AbstractContainerListener
+public class AnnouncementContainerListener implements ContainerManager.ContainerListener
 {
     // Note: Attachments are purged by AttachmentServiceImpl.containerDeleted()
     @Override

--- a/api/src/org/labkey/api/data/Container.java
+++ b/api/src/org/labkey/api/data/Container.java
@@ -186,12 +186,6 @@ public class Container implements Serializable, Comparable<Container>, Securable
             }
 
             @Override
-            public @NotNull Collection<String> canMove(Container c, Container newParent, User user)
-            {
-                return Collections.emptyList();
-            }
-
-            @Override
             public void propertyChange(PropertyChangeEvent evt)
             {
                 REQUIRED_MODULES_CACHE.clear();

--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -380,7 +380,7 @@ public class ContainerManager
                     SecurityManager.setInheritPermissions(c);
             }
 
-            // NOTE parent caches some info about children (e.g. hasWorkbookChildren)
+            // NOTE parent caches some info about children (e.g., hasWorkbookChildren)
             // since mutating cached objects is frowned upon, just uncache parent
             // CONSIDER: we could perhaps only uncache if the child is a workbook, but I think this reasonable
             _removeFromCache(parent, true);
@@ -1165,7 +1165,6 @@ public class ContainerManager
         return map.get(name);
     }
 
-
     public static Container getForURL(@NotNull ActionURL url)
     {
         Container ret = getForPath(url.getExtraPath());
@@ -1173,7 +1172,6 @@ public class ContainerManager
             ret = getForId(StringUtils.strip(url.getExtraPath(), "/"));
         return ret;
     }
-
 
     public static Container getForPath(@NotNull String path)
     {
@@ -1448,7 +1446,7 @@ public class ContainerManager
 
                 NavTree t = new NavTree(name);
 
-                // 34137: Support folder path expansion for containers where label != name
+                // Issue 34137: Support folder path expansion for containers where label != name
                 t.setId(f.getId());
                 if (hasPolicyRead)
                 {
@@ -1464,7 +1462,7 @@ public class ContainerManager
                 }
                 else
                 {
-                    // 32718: If navigation access is not open then hide projects that aren't directly
+                    // Issue 32718: If navigation access is not open then hide projects that aren't directly
                     // accessible in site folder navigation.
 
                     if (f.equals(c) || f.isRoot() || (hasPolicyRead && f.isProject()))
@@ -1689,7 +1687,7 @@ public class ContainerManager
 
             boolean changedProjects = !oldProject.getId().equals(newProject.getId());
 
-            // Synchronize the transaction, but not the listeners -- see #9901
+            // Issue 9901: Synchronize the transaction, but not the listeners
             try (DbScope.Transaction t = ensureTransaction())
             {
                 new SqlExecutor(CORE.getSchema()).execute("UPDATE " + CORE.getTableInfoContainers() + " SET Parent = ? WHERE EntityId = ?", newParent.getId(), c.getId());
@@ -1752,7 +1750,7 @@ public class ContainerManager
             // Rename
             if (isRenaming)
             {
-                // Issue 16221: Don't allow renaming of system reserved folders (e.g. /Shared, home, root, etc).
+                // Issue 16221: Don't allow renaming of system reserved folders (e.g., /Shared, home, root, etc).
                 if (!isRenameable(c))
                     throw new ApiUsageException("This folder may not be renamed as it is reserved by the system.");
 
@@ -1949,8 +1947,7 @@ public class ContainerManager
             if (experimentService != null)
                 experimentService.removeContainerDataTypeExclusions(c.getId());
 
-            // After we've committed the transaction, be sure that we remove this container from the cache
-            // See https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=17015
+            // Issue 17015: After we've committed the transaction, be sure that we remove this container from the cache
             tx.addCommitTask(() ->
             {
                 // Be sure that we've waited until any threads that might be populating the cache have finished
@@ -2141,7 +2138,6 @@ public class ContainerManager
         }
     }
 
-
     /** Recursive, including root node */
     public static Set<Container> getAllChildren(Container root)
     {
@@ -2191,7 +2187,6 @@ public class ContainerManager
                 "WHERE ps.category = '" + AUDIT_SETTINGS_PROPERTY_SET_NAME + "' AND p.name='"+ REQUIRE_USER_COMMENTS_PROPERTY_NAME + "' and p.value='true'");
         return new SqlSelector(CORE.getSchema(), sql).getObject(Long.class);
     }
-
 
     /** Retrieve entire container hierarchy */
     public static MultiValuedMap<Container, Container> getContainerTree()
@@ -2264,7 +2259,6 @@ public class ContainerManager
             .collect(Collectors.toSet());
     }
 
-
     public static SQLFragment getIdsAsCsvList(Set<Container> containers, SqlDialect d)
     {
         if (containers.isEmpty())
@@ -2283,7 +2277,6 @@ public class ContainerManager
         return csvList;
     }
 
-
     public static List<String> getIds(User user, Class<? extends Permission> perm)
     {
         Set<Container> containers = getContainerSet(getContainerTree(), user, perm);
@@ -2296,66 +2289,37 @@ public class ContainerManager
         return ids;
     }
 
-
-    //
-    // ContainerListener
-    //
-
     public interface ContainerListener extends PropertyChangeListener
     {
         enum Order {First, Last}
 
         /** Called after a new container has been created */
-        void containerCreated(Container c, User user);
+        default void containerCreated(Container c, User user) { }
 
         default void containerCreated(Container c, User user, @Nullable String auditMsg)
         {
             containerCreated(c, user);
         }
 
-        /** Called immediately prior to deleting the row from core.containers */
-        void containerDeleted(Container c, User user);
+        /** Called immediately before deleting the row from core.containers */
+        default void containerDeleted(Container c, User user) { }
 
-        /** Called after the container has been moved to its new parent */
-        void containerMoved(Container c, Container oldParent, User user);
+        /** Called after the container has been moved to its new parent (post-commit) */
+        default void containerMoved(Container c, Container oldParent, User user) { }
 
         /**
-         * Called prior to moving a container, to find out if there are any issues that would prevent a successful move
+         * Called before moving a container, to find out if there are any issues that would prevent a successful move
          * @return a list of errors that should prevent the move from happening, if any
          */
         @NotNull
-        Collection<String> canMove(Container c, Container newParent, User user);
-
-        @Override
-        void propertyChange(PropertyChangeEvent evt);
-    }
-
-    public static abstract class AbstractContainerListener implements ContainerListener
-    {
-        @Override
-        public void containerCreated(Container c, User user)
-        {}
-
-        @Override
-        public void containerDeleted(Container c, User user)
-        {}
-
-        @Override
-        public void containerMoved(Container c, Container oldParent, User user)
-        {}
-
-        @NotNull
-        @Override
-        public Collection<String> canMove(Container c, Container newParent, User user)
+        default Collection<String> canMove(Container c, Container newParent, User user)
         {
             return Collections.emptyList();
         }
 
         @Override
-        public void propertyChange(PropertyChangeEvent evt)
-        {}
+        default void propertyChange(PropertyChangeEvent evt) { }
     }
-
 
     public static class ContainerPropertyChangeEvent extends PropertyChangeEvent implements PropertyChange<Property, Object>
     {
@@ -2383,7 +2347,6 @@ public class ContainerManager
         }
     }
 
-
     // Thread-safe list implementation that allows iteration and modifications without external synchronization
     private static final List<ContainerListener> _listeners = new CopyOnWriteArrayList<>();
     private static final List<ContainerListener> _laterListeners = new CopyOnWriteArrayList<>();
@@ -2394,7 +2357,6 @@ public class ContainerManager
         addContainerListener(listener, ContainerListener.Order.First);
     }
 
-
     // Explicitly request "Last" ordering via this method.  "Last" listeners execute after all "First" listeners.
     public static void addContainerListener(ContainerListener listener, ContainerListener.Order order)
     {
@@ -2404,13 +2366,11 @@ public class ContainerManager
             _laterListeners.add(listener);
     }
 
-
     public static void removeContainerListener(ContainerListener listener)
     {
         _listeners.remove(listener);
         _laterListeners.remove(listener);
     }
-
 
     private static List<ContainerListener> getListeners()
     {
@@ -2421,7 +2381,6 @@ public class ContainerManager
         return combined;
     }
 
-
     private static List<ContainerListener> getListenersReversed()
     {
         List<ContainerListener> combined = new LinkedList<>();
@@ -2431,7 +2390,7 @@ public class ContainerManager
         ListIterator<ContainerListener> iter = copy.listIterator(copy.size());
 
         // Iterate in reverse
-        while(iter.hasPrevious())
+        while (iter.hasPrevious())
             combined.add(iter.previous());
 
         // Copy to guarantee consistency between .listIterator() and .size()
@@ -2440,12 +2399,11 @@ public class ContainerManager
         ListIterator<ContainerListener> laterIter = laterCopy.listIterator(laterCopy.size());
 
         // Iterate in reverse
-        while(laterIter.hasPrevious())
+        while (laterIter.hasPrevious())
             combined.add(laterIter.previous());
 
         return combined;
     }
-
 
     protected static void fireCreateContainer(Container c, User user, @Nullable String auditMsg)
     {
@@ -2464,7 +2422,6 @@ public class ContainerManager
         }
     }
 
-
     protected static void fireDeleteContainer(Container c, User user)
     {
         List<ContainerListener> list = getListenersReversed();
@@ -2480,21 +2437,19 @@ public class ContainerManager
             {
                 LOG.error("fireDeleteContainer for " + l.getClass().getName(), e);
 
-                // Fail fast (first Throwable aborts iteration), #17560
+                // Issue 17560: Fail fast (first Throwable aborts iteration)
                 throw e;
             }
         }
     }
 
-
-    protected static void fireRenameContainer(Container c, User user, String oldValue)
+    private static void fireRenameContainer(Container c, User user, String oldValue)
     {
         ContainerPropertyChangeEvent evt = new ContainerPropertyChangeEvent(c, user, Property.Name, oldValue, c.getName());
         firePropertyChangeEvent(evt);
     }
 
-
-    protected static void fireMoveContainer(Container c, Container oldParent, User user)
+    private static void fireMoveContainer(Container c, Container oldParent, User user)
     {
         List<ContainerListener> list = getListeners();
 
@@ -2511,7 +2466,6 @@ public class ContainerManager
         ContainerPropertyChangeEvent evt = new ContainerPropertyChangeEvent(c, user, Property.Parent, oldParent, c.getParent());
         firePropertyChangeEvent(evt);
     }
-
 
     public static void firePropertyChangeEvent(ContainerPropertyChangeEvent evt)
     {
@@ -2986,12 +2940,6 @@ public class ContainerManager
             }
         }
 
-        // ContainerListener
-        @Override
-        public void propertyChange(PropertyChangeEvent evt)
-        {
-        }
-
         @Override
         public void containerCreated(Container c, User user)
         {
@@ -3000,23 +2948,10 @@ public class ContainerManager
             _containers.put(c.getParsedPath(), c);
         }
 
-
         @Override
         public void containerDeleted(Container c, User user)
         {
             _containers.remove(c.getParsedPath());
-        }
-
-        @Override
-        public void containerMoved(Container c, Container oldParent, User user)
-        {
-        }
-
-        @NotNull
-        @Override
-        public Collection<String> canMove(Container c, Container newParent, User user)
-        {
-            return Collections.emptyList();
         }
     }
 

--- a/api/src/org/labkey/api/module/SimpleModuleContainerListener.java
+++ b/api/src/org/labkey/api/module/SimpleModuleContainerListener.java
@@ -36,12 +36,7 @@ import org.labkey.api.security.User;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * User: bimber
- * Date: 3/4/13
- * Time: 10:45 AM
- */
-public class SimpleModuleContainerListener extends ContainerManager.AbstractContainerListener
+public class SimpleModuleContainerListener implements ContainerManager.ContainerListener
 {
     private final Module _owner;
 

--- a/api/src/org/labkey/api/reports/model/ReportPropsManager.java
+++ b/api/src/org/labkey/api/reports/model/ReportPropsManager.java
@@ -51,11 +51,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
-/**
- * User: klum
- * Date: Feb 13, 2012
- */
-public class ReportPropsManager extends ContainerManager.AbstractContainerListener
+public class ReportPropsManager implements ContainerManager.ContainerListener
 {
     private static final Logger _log = LogManager.getLogger(ReportPropsManager.class);
     private static final String PROPERTIES_DOMAIN = "Report Properties";

--- a/api/src/org/labkey/api/reports/model/ViewCategoryManager.java
+++ b/api/src/org/labkey/api/reports/model/ViewCategoryManager.java
@@ -42,12 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-/**
- * User: klum
- * Date: Oct 12, 2011
- * Time: 7:13:20 PM
- */
-public class ViewCategoryManager extends ContainerManager.AbstractContainerListener
+public class ViewCategoryManager implements ContainerManager.ContainerListener
 {
     private static final ViewCategoryManager _instance = new ViewCategoryManager();
     private static final List<ViewCategoryListener> _listeners = new CopyOnWriteArrayList<>();

--- a/api/src/org/labkey/api/security/SecurityManager.java
+++ b/api/src/org/labkey/api/security/SecurityManager.java
@@ -391,7 +391,7 @@ public class SecurityManager
     }
 
     /** Move is handled by direct call from ContainerManager into SecurityManager */
-    private static class SecurityContainerListener extends ContainerManager.AbstractContainerListener
+    private static class SecurityContainerListener implements ContainerManager.ContainerListener
     {
         @Override
         public void containerDeleted(Container c, User user)

--- a/api/src/org/labkey/api/settings/FolderSettingsCache.java
+++ b/api/src/org/labkey/api/settings/FolderSettingsCache.java
@@ -15,17 +15,12 @@
  */
 package org.labkey.api.settings;
 
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.Constants;
 import org.labkey.api.cache.BlockingCache;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
-
-import java.beans.PropertyChangeEvent;
-import java.util.Collection;
-import java.util.Collections;
 
 // Folder settings inherit all the way up the folder tree. All the property sets involved should be cached, but the walk
 // up the tree is a potentially expensive operation just to format a date or number. So, we cache the set of resolved
@@ -116,13 +111,6 @@ public class FolderSettingsCache
     public static class FolderSettingsCacheListener implements ContainerManager.ContainerListener
     {
         @Override
-        public void containerCreated(Container c, User user)
-        {
-            // Don't care... nothing should be cached for a brand new container, and it must be a leaf node (doesn't
-            // affect other folders' settings.
-        }
-
-        @Override
         public void containerDeleted(Container c, User user)
         {
             // Should be sufficient to remove settings for this container only; in a recursive delete, this method
@@ -135,19 +123,6 @@ public class FolderSettingsCache
         {
             // When moving a tree, this is called only for the top node, so we need to clear the entire cache.
             clear();
-        }
-
-        @NotNull
-        @Override
-        public Collection<String> canMove(Container c, Container newParent, User user)
-        {
-            return Collections.emptyList();
-        }
-
-        @Override
-        public void propertyChange(PropertyChangeEvent evt)
-        {
-            // Don't care
         }
     }
 }

--- a/api/src/org/labkey/api/study/DataspaceContainerFilter.java
+++ b/api/src/org/labkey/api/study/DataspaceContainerFilter.java
@@ -217,13 +217,6 @@ public class DataspaceContainerFilter extends ContainerFilter.AllInProject
                     studiesCache.remove(oldParent.getProject().getId());
             }
 
-            @NotNull
-            @Override
-            public Collection<String> canMove(Container c, Container newParent, User user)
-            {
-                return Collections.emptyList();
-            }
-
             @Override
             public void propertyChange(PropertyChangeEvent evt)
             {

--- a/api/src/org/labkey/api/webdav/AbstractWebdavResolver.java
+++ b/api/src/org/labkey/api/webdav/AbstractWebdavResolver.java
@@ -269,7 +269,7 @@ public abstract class AbstractWebdavResolver implements WebdavResolver
         }
     }
 
-    public abstract static class AbstractWebdavListener extends ContainerManager.AbstractContainerListener
+    public abstract static class AbstractWebdavListener implements ContainerManager.ContainerListener
     {
         @Override
         public void containerCreated(Container c, User user)

--- a/assay/src/org/labkey/assay/AssayContainerListener.java
+++ b/assay/src/org/labkey/assay/AssayContainerListener.java
@@ -26,7 +26,6 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.security.User;
 import org.labkey.assay.plate.PlateManager;
 
-import java.beans.PropertyChangeEvent;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -37,27 +36,12 @@ import java.util.Set;
 public class AssayContainerListener implements ContainerListener
 {
     @Override
-    public void containerCreated(Container c, User user)
-    {
-    }
-
-    @Override
     public void containerDeleted(Container c, User user)
     {
         PlateManager.get().deleteAllPlateData(c);
 
         // Changing the container tree can change what assays are in scope
         AssayManager.get().clearProtocolCache();
-    }
-
-    @Override
-    public void propertyChange(PropertyChangeEvent evt)
-    {
-    }
-
-    @Override
-    public void containerMoved(Container c, Container oldParent, User user)
-    {
     }
 
     @NotNull

--- a/core/src/org/labkey/core/CoreContainerListener.java
+++ b/core/src/org/labkey/core/CoreContainerListener.java
@@ -15,9 +15,6 @@
  */
 package org.labkey.core;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.AuditTypeEvent;
@@ -36,14 +33,10 @@ import org.labkey.api.security.User;
 import org.labkey.api.view.Portal;
 
 import java.beans.PropertyChangeEvent;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Objects;
 
 public class CoreContainerListener implements ContainerManager.ContainerListener
 {
-    private static final Logger _log = LogManager.getLogger(CoreContainerListener.class);
-
     @Override
     public void containerCreated(Container c, User user)
     {
@@ -84,13 +77,6 @@ public class CoreContainerListener implements ContainerManager.ContainerListener
         String message = c.getName() + " was moved from " + oldParent.getPath() + " to " + c.getParent().getPath();
         addAuditEvent(user, c, message);
         // re-index is handled when the propertyChange() event fires
-    }
-
-    @NotNull
-    @Override
-    public Collection<String> canMove(Container c, Container newParent, User user)
-    {
-        return Collections.emptyList();
     }
 
     private void addAuditEvent(User user, Container c, String comment)

--- a/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
+++ b/core/src/org/labkey/core/attachment/AttachmentServiceImpl.java
@@ -110,7 +110,6 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.validation.BindException;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.beans.PropertyChangeEvent;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -1000,36 +999,12 @@ public class AttachmentServiceImpl implements AttachmentService, ContainerManage
         }
     }
 
-
-    @Override
-    public void containerCreated(Container c, User user)
-    {
-    }
-
-
-    @Override
-    public void propertyChange(PropertyChangeEvent propertyChangeEvent)
-    {
-    }
-
     @Override
     public void containerDeleted(Container c, User user)
     {
         // TODO: do we need to get each document and remove its security policy?
         ContainerUtil.purgeTable(coreTables().getTableInfoDocuments(), c, null);
         AttachmentCache.removeAttachments(c);
-    }
-
-    @Override
-    public void containerMoved(Container c, Container oldParent, User user)
-    {        
-    }
-
-    @NotNull
-    @Override
-    public Collection<String> canMove(Container c, Container newParent, User user)
-    {
-        return Collections.emptyList();
     }
 
     private void writeDocument(DocumentWriter writer, AttachmentParent parent, String name, @Nullable String alias, boolean asAttachment) throws ServletException, IOException

--- a/core/src/org/labkey/core/notification/EmailPreferenceContainerListener.java
+++ b/core/src/org/labkey/core/notification/EmailPreferenceContainerListener.java
@@ -1,12 +1,12 @@
 package org.labkey.core.notification;
 
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerManager.AbstractContainerListener;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.util.ContainerUtil;
 
-public class EmailPreferenceContainerListener extends AbstractContainerListener
+public class EmailPreferenceContainerListener implements ContainerManager.ContainerListener
 {
     @Override
     public void containerDeleted(Container c, User user)

--- a/core/src/org/labkey/core/notification/NotificationServiceImpl.java
+++ b/core/src/org/labkey/core/notification/NotificationServiceImpl.java
@@ -32,7 +32,6 @@ import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.ContainerManager.AbstractContainerListener;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
@@ -67,11 +66,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-/**
- * User: cnathe
- * Date: 9/14/2015
- */
-public class NotificationServiceImpl extends AbstractContainerListener implements NotificationService
+public class NotificationServiceImpl implements ContainerManager.ContainerListener, NotificationService
 {
     private final static NotificationServiceImpl INSTANCE = new NotificationServiceImpl();
     private final Map<String, String> _typeLabelMap = new ConcurrentHashMap<>();
@@ -397,7 +392,6 @@ public class NotificationServiceImpl extends AbstractContainerListener implement
     {
         return _typeIconMap.getOrDefault(type, "fa-bell");
     }
-
 
     @Override
     public void sendServerEvent(int userId, Class<?> clazz)

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -531,27 +531,26 @@ public class ExperimentModule extends SpringModule
             fileContentService.addFileListener(new TableUpdaterFileListener(ExperimentService.get().getTinfoExperimentRun(), "FilePathRoot", TableUpdaterFileListener.Type.fileRootPath, "RowId"));
             fileContentService.addFileListener(new FileLinkFileListener());
         }
-        ContainerManager.addContainerListener(
-                new ContainerManager.AbstractContainerListener()
+        ContainerManager.addContainerListener(new ContainerManager.ContainerListener()
+        {
+            @Override
+            public void containerDeleted(Container c, User user)
+            {
+                try
                 {
-                    @Override
-                    public void containerDeleted(Container c, User user)
-                    {
-                        try
-                        {
-                        ExperimentService.get().deleteAllExpObjInContainer(c, user);
-                        }
-                        catch (ExperimentException ee)
-                        {
-                        throw new RuntimeException(ee);
-                        }
-                    }
-                },
-                // This is in the Last group because when a container is deleted,
-                // the Experiment listener needs to be called after the Study listener,
-                // because Study needs the metadata held by Experiment to delete properly.
-                // but it should be before the CoreContainerListener
-                ContainerManager.ContainerListener.Order.Last);
+                    ExperimentService.get().deleteAllExpObjInContainer(c, user);
+                }
+                catch (ExperimentException ee)
+                {
+                    throw new RuntimeException(ee);
+                }
+            }
+        },
+        // This is in the Last group because when a container is deleted,
+        // the Experiment listener needs to be called after the Study listener,
+        // because Study needs the metadata held by Experiment to delete properly.
+        // but it should be before the CoreContainerListener
+        ContainerManager.ContainerListener.Order.Last);
 
         if (ModuleLoader.getInstance().shouldInsertData())
             SystemProperty.registerProperties();

--- a/filecontent/src/org/labkey/filecontent/FileContentContainerListener.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentContainerListener.java
@@ -19,12 +19,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
 
-/**
- * User: adam
- * Date: 2/25/12
- * Time: 8:44 PM
- */
-public class FileContentContainerListener extends ContainerManager.AbstractContainerListener
+public class FileContentContainerListener implements ContainerManager.ContainerListener
 {
     @Override
     public void containerDeleted(Container c, User user)

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -904,13 +904,6 @@ public class FileContentServiceImpl implements FileContentService, WarningProvid
             }
         }
 
-        @NotNull
-        @Override
-        public Collection<String> canMove(Container c, Container newParent, User user)
-        {
-            return Collections.emptyList();
-        }
-
         @Override
         public void propertyChange(PropertyChangeEvent propertyChangeEvent)
         {

--- a/issues/src/org/labkey/issue/IssueContainerListener.java
+++ b/issues/src/org/labkey/issue/IssueContainerListener.java
@@ -21,12 +21,7 @@ import org.labkey.api.security.User;
 import org.labkey.issue.model.IssueListDefCache;
 import org.labkey.issue.model.IssueManager;
 
-/**
- * User: adam
- * Date: Nov 5, 2008
- * Time: 3:30:34 PM
- */
-public class IssueContainerListener extends ContainerManager.AbstractContainerListener
+public class IssueContainerListener implements ContainerManager.ContainerListener
 {
     @Override
     public void containerDeleted(Container c, User user)

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -121,7 +121,7 @@ public class MothershipModule extends DefaultModule
     {
         MothershipReport.setShowSelfReportExceptions(true);
 
-        ContainerManager.addContainerListener(new ContainerManager.AbstractContainerListener()
+        ContainerManager.addContainerListener(new ContainerManager.ContainerListener()
         {
             @Override
             public void containerDeleted(Container c, User user)

--- a/pipeline/src/org/labkey/pipeline/PipelineModule.java
+++ b/pipeline/src/org/labkey/pipeline/PipelineModule.java
@@ -95,10 +95,8 @@ import org.labkey.pipeline.xml.ExecTaskType;
 import org.labkey.pipeline.xml.ScriptTaskType;
 
 import javax.management.StandardMBean;
-import java.beans.PropertyChangeEvent;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -295,11 +293,6 @@ public class PipelineModule extends SpringModule implements ContainerManager.Con
     }
 
     @Override
-    public void containerCreated(Container c, User user)
-    {
-    }
-
-    @Override
     public void containerDeleted(Container c, User user)
     {
         try
@@ -313,24 +306,6 @@ public class PipelineModule extends SpringModule implements ContainerManager.Con
 
         PipelineManager.purge(c, user);
     }
-
-    @Override
-    public void containerMoved(Container c, Container oldParent, User user)
-    {        
-    }
-
-    @NotNull
-    @Override
-    public Collection<String> canMove(Container c, Container newParent, User user)
-    {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public void propertyChange(PropertyChangeEvent evt)
-    {
-    }
-
 
     @Override
     public @NotNull Set<Class<?>> getIntegrationTests()

--- a/query/src/org/labkey/query/olap/ServerManager.java
+++ b/query/src/org/labkey/query/olap/ServerManager.java
@@ -126,7 +126,7 @@ public class ServerManager
 
     static
     {
-        ContainerManager.addContainerListener(new ContainerManager.AbstractContainerListener()
+        ContainerManager.addContainerListener(new ContainerManager.ContainerListener()
         {
             @Override
             public void containerDeleted(Container c, User user)

--- a/query/src/org/labkey/query/persist/QueryManager.java
+++ b/query/src/org/labkey/query/persist/QueryManager.java
@@ -611,7 +611,7 @@ public class QueryManager
         return dependents;
     }
 
-    static public final ContainerManager.ContainerListener CONTAINER_LISTENER = new ContainerManager.AbstractContainerListener()
+    static public final ContainerManager.ContainerListener CONTAINER_LISTENER = new ContainerManager.ContainerListener()
     {
         @Override
         public void containerDeleted(Container c, User user)

--- a/query/src/org/labkey/query/reports/ReportServiceImpl.java
+++ b/query/src/org/labkey/query/reports/ReportServiceImpl.java
@@ -34,7 +34,6 @@ import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.collections.MultiSetUtils;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.ContainerManager.AbstractContainerListener;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
@@ -117,7 +116,7 @@ import java.util.stream.Collectors;
 
 import static org.labkey.api.reports.report.ScriptReportDescriptor.REPORT_METADATA_EXTENSION;
 
-public class ReportServiceImpl extends AbstractContainerListener implements ReportService
+public class ReportServiceImpl implements ContainerManager.ContainerListener, ReportService
 {
     private static final Logger _log = LogHelper.getLogger(ReportService.class, "Errors and warnings with reports");
     private static final List<UIProvider> _uiProviders = new CopyOnWriteArrayList<>();

--- a/search/src/org/labkey/search/SearchContainerListener.java
+++ b/search/src/org/labkey/search/SearchContainerListener.java
@@ -25,7 +25,7 @@ import org.labkey.search.model.DavCrawler;
 
 import java.beans.PropertyChangeEvent;
 
-public class SearchContainerListener extends ContainerManager.AbstractContainerListener
+public class SearchContainerListener implements ContainerManager.ContainerListener
 {
     @Override
     public void containerCreated(Container c, User user)

--- a/specimen/src/org/labkey/specimen/SpecimenRequestContainerListener.java
+++ b/specimen/src/org/labkey/specimen/SpecimenRequestContainerListener.java
@@ -1,13 +1,10 @@
 package org.labkey.specimen;
 
-import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
 
 import java.beans.PropertyChangeEvent;
-import java.util.Collection;
-import java.util.Collections;
 
 public class SpecimenRequestContainerListener implements ContainerManager.ContainerListener
 {
@@ -27,13 +24,6 @@ public class SpecimenRequestContainerListener implements ContainerManager.Contai
     public void containerMoved(Container c, Container oldParent, User user)
     {
         SpecimenRequestManager.get().clearCaches(c);
-    }
-
-    @NotNull
-    @Override
-    public Collection<String> canMove(Container c, Container newParent, User user)
-    {
-        return Collections.emptyList();
     }
 
     @Override

--- a/study/src/org/labkey/study/StudyContainerListener.java
+++ b/study/src/org/labkey/study/StudyContainerListener.java
@@ -24,7 +24,7 @@ import org.labkey.study.model.StudyManager;
 
 import java.beans.PropertyChangeEvent;
 
-public class StudyContainerListener extends ContainerManager.AbstractContainerListener
+public class StudyContainerListener implements ContainerManager.ContainerListener
 {
     @Override
     public void containerDeleted(Container c, User user)

--- a/survey/src/org/labkey/survey/SurveyContainerListener.java
+++ b/survey/src/org/labkey/survey/SurveyContainerListener.java
@@ -20,7 +20,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
 
-public class SurveyContainerListener extends ContainerManager.AbstractContainerListener
+public class SurveyContainerListener implements ContainerManager.ContainerListener
 {
     @Override
     public void containerDeleted(Container c, User user)

--- a/wiki/src/org/labkey/wiki/WikiContainerListener.java
+++ b/wiki/src/org/labkey/wiki/WikiContainerListener.java
@@ -19,12 +19,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.security.User;
 
-/**
- * User: adam
- * Date: Nov 5, 2008
- * Time: 10:52:38 AM
- */
-public class WikiContainerListener extends ContainerManager.AbstractContainerListener
+public class WikiContainerListener implements ContainerManager.ContainerListener
 {
     // Note: Attachments are purged by AttachmentServiceImpl.containerDeleted()
     @Override


### PR DESCRIPTION
#### Rationale
Reduce boilerplate and empty methods. Most implementations only override one or two methods.

#### Changes
- Remove `AbstractContainerListener`. Replace with default implementation of methods on `ContainerListener` interface.