### PR TITLE
Issue 54095: QC Trend Reports update to not group data by date when x-axis label variable is provided

### DIFF
--- a/core/webapp/vis/src/plot.js
+++ b/core/webapp/vis/src/plot.js
@@ -1754,6 +1754,7 @@ boxPlot.render();
         }
         // default to true
         config.properties.showBoundLines = config.properties.showBoundLines ?? true;
+        config.properties.groupMatchingXTick = config.properties.groupMatchingXTick ?? true;
 
         // get a sorted array of the unique x-axis labels
         var uniqueXAxisKeys = {}, uniqueXAxisLabels = [];
@@ -2129,7 +2130,11 @@ boxPlot.render();
                     }
                 };
 
-                index = uniqueXAxisLabels.indexOf(row[config.properties.xTick]);
+                if (config.properties.groupMatchingXTick) {
+                    index = uniqueXAxisLabels.indexOf(row[config.properties.xTick]);
+                } else {
+                    index++; // Issue 54018
+                }
 
                 // calculate average values for the trend line data (used when grouping x by unique value)
                 addAllValuesToTrendLineData(groupedTrendlineData, index, index, row, hasYRightMetric);
@@ -2181,8 +2186,6 @@ boxPlot.render();
         if (distinctColorValues.length < 2 && config.properties.groupBy === undefined) {
             config.properties.color = undefined;
         }
-
-        config.tickOverlapRotation = 35;
 
         // CUSUM plots can only be linear scale
         var yAxisScaleOverride;


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=54095

#### Related Pull Requests
- https://github.com/LabKey/premiumModules/pull/396

#### Changes
- add groupMatchingXTick property to LABKEY.vis.TrendingLinePlot, default to true to not affect trend reports for Panorama
