### PR TITLE
Fix race condition with encryption upgrade/migration

### DIFF
--- a/api/src/org/labkey/api/security/Encryption.java
+++ b/api/src/org/labkey/api/security/Encryption.java
@@ -572,6 +572,10 @@ public class Encryption
 
             if (migrationNeeded)
             {
+                // Reset to zero to ignore problems that might have been encountered early in startup, prior to
+                // starting the migration process
+                DECRYPTION_EXCEPTIONS.set(0);
+
                 final AESConfig migrationConfig = oldConfig;
                 final String message = keySource;
                 final String passPhrase = oldPassPhrase != null ? oldPassPhrase : getEncryptionPassPhrase();


### PR DESCRIPTION
#### Rationale
We want to count the errors in decrypting during the migration even, not ones from trying to use the old key or algorithm earlier.

#### Changes
- Reset the count, letting the migration proceed

Example run that logged problems with encryption settings but then succeeded with the migration and subsequent tests:

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Internal_Upgrade_UpgradeValidation257/3715335?buildTab=overview#%2F_serverLogs.tar.gz;%2F_serverLogs.tar.gz