### PR TITLE
Issue 53449: resolve lineage items from container path

### DIFF
--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.67.0"
+        "@labkey/components": "6.67.2-fb-lineage-53449.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2415,9 +2415,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.43.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.0.tgz",
-      "integrity": "sha512-4hOQz+pM/QaCey6ooJEmEbElnR9+TDEzWG+8caFfeIX1iAg1335NXW3+/Xzs6a+L9ysRKds8bNgFPu2sxjPzfg==",
+      "version": "1.43.1-fb-lineage-53449.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1-fb-lineage-53449.0.tgz",
+      "integrity": "sha512-+XxtdM9muhAf2IuAhg4TGQnEOSkYiZGLfDhaEhaUJ1X6fSmcSuy1Czd+xGK1ufmkvTsCKQaUjq7D8i4MpOZtAg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2458,13 +2458,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.67.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.0.tgz",
-      "integrity": "sha512-7YA6aJB3rEMqIXzGBrQZ5J9+Bdz/nkivaBnCrVNSH+4+qs1UvPM7yrvlEBJKE3LxbfSVTh6rIxInztMf274J3Q==",
+      "version": "6.67.2-fb-lineage-53449.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.2-fb-lineage-53449.0.tgz",
+      "integrity": "sha512-zQ2/eOLxCOKlP+aYa0X34WgmJt5xByaxKih9lMZeg5I5bFVeD9Bzq9xt5x7dIGVga9WsKfMgzdOumW9KL4XamA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.43.0",
+        "@labkey/api": "1.43.1-fb-lineage-53449.0",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",

--- a/assay/package-lock.json
+++ b/assay/package-lock.json
@@ -8,7 +8,7 @@
       "name": "assay",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.67.2-fb-lineage-53449.0"
+        "@labkey/components": "6.67.2"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2415,9 +2415,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.43.1-fb-lineage-53449.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1-fb-lineage-53449.0.tgz",
-      "integrity": "sha512-+XxtdM9muhAf2IuAhg4TGQnEOSkYiZGLfDhaEhaUJ1X6fSmcSuy1Czd+xGK1ufmkvTsCKQaUjq7D8i4MpOZtAg==",
+      "version": "1.43.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1.tgz",
+      "integrity": "sha512-PkbI+OlnljpSLO7PkwfRRw/AH76pRRZbF8929ygxVZsrBXVFDSR+lSsSbJREiuMWkBTVcAOycwftwZB/O4QGHw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2458,13 +2458,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.67.2-fb-lineage-53449.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.2-fb-lineage-53449.0.tgz",
-      "integrity": "sha512-zQ2/eOLxCOKlP+aYa0X34WgmJt5xByaxKih9lMZeg5I5bFVeD9Bzq9xt5x7dIGVga9WsKfMgzdOumW9KL4XamA==",
+      "version": "6.67.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.2.tgz",
+      "integrity": "sha512-VZrlfp5wYyb20rZIRMp1TAvIpJOwwpZPriVVO9c5RFhvATKUGA8L56eeNg19Xf3S2DsahXiX3iZ3kKIc1+P8MA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.43.1-fb-lineage-53449.0",
+        "@labkey/api": "1.43.1",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.67.2-fb-lineage-53449.0"
+    "@labkey/components": "6.67.2"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/assay/package.json
+++ b/assay/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf resources/web/assay/gen && rimraf resources/views/gen && rimraf resources/web/gen"
   },
   "dependencies": {
-    "@labkey/components": "6.67.0"
+    "@labkey/components": "6.67.2-fb-lineage-53449.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.67.2-fb-lineage-53449.0",
+        "@labkey/components": "6.67.2",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3461,9 +3461,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.43.1-fb-lineage-53449.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1-fb-lineage-53449.0.tgz",
-      "integrity": "sha512-+XxtdM9muhAf2IuAhg4TGQnEOSkYiZGLfDhaEhaUJ1X6fSmcSuy1Czd+xGK1ufmkvTsCKQaUjq7D8i4MpOZtAg==",
+      "version": "1.43.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1.tgz",
+      "integrity": "sha512-PkbI+OlnljpSLO7PkwfRRw/AH76pRRZbF8929ygxVZsrBXVFDSR+lSsSbJREiuMWkBTVcAOycwftwZB/O4QGHw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3504,13 +3504,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.67.2-fb-lineage-53449.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.2-fb-lineage-53449.0.tgz",
-      "integrity": "sha512-zQ2/eOLxCOKlP+aYa0X34WgmJt5xByaxKih9lMZeg5I5bFVeD9Bzq9xt5x7dIGVga9WsKfMgzdOumW9KL4XamA==",
+      "version": "6.67.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.2.tgz",
+      "integrity": "sha512-VZrlfp5wYyb20rZIRMp1TAvIpJOwwpZPriVVO9c5RFhvATKUGA8L56eeNg19Xf3S2DsahXiX3iZ3kKIc1+P8MA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.43.1-fb-lineage-53449.0",
+        "@labkey/api": "1.43.1",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",

--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -8,7 +8,7 @@
       "name": "labkey-core",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.67.0",
+        "@labkey/components": "6.67.2-fb-lineage-53449.0",
         "@labkey/themes": "1.4.2"
       },
       "devDependencies": {
@@ -3461,9 +3461,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.43.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.0.tgz",
-      "integrity": "sha512-4hOQz+pM/QaCey6ooJEmEbElnR9+TDEzWG+8caFfeIX1iAg1335NXW3+/Xzs6a+L9ysRKds8bNgFPu2sxjPzfg==",
+      "version": "1.43.1-fb-lineage-53449.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1-fb-lineage-53449.0.tgz",
+      "integrity": "sha512-+XxtdM9muhAf2IuAhg4TGQnEOSkYiZGLfDhaEhaUJ1X6fSmcSuy1Czd+xGK1ufmkvTsCKQaUjq7D8i4MpOZtAg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3504,13 +3504,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.67.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.0.tgz",
-      "integrity": "sha512-7YA6aJB3rEMqIXzGBrQZ5J9+Bdz/nkivaBnCrVNSH+4+qs1UvPM7yrvlEBJKE3LxbfSVTh6rIxInztMf274J3Q==",
+      "version": "6.67.2-fb-lineage-53449.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.2-fb-lineage-53449.0.tgz",
+      "integrity": "sha512-zQ2/eOLxCOKlP+aYa0X34WgmJt5xByaxKih9lMZeg5I5bFVeD9Bzq9xt5x7dIGVga9WsKfMgzdOumW9KL4XamA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.43.0",
+        "@labkey/api": "1.43.1-fb-lineage-53449.0",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.67.0",
+    "@labkey/components": "6.67.2-fb-lineage-53449.0",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@labkey/components": "6.67.2-fb-lineage-53449.0",
+    "@labkey/components": "6.67.2",
     "@labkey/themes": "1.4.2"
   },
   "devDependencies": {

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.67.2-fb-lineage-53449.0"
+        "@labkey/components": "6.67.2"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -3204,9 +3204,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.43.1-fb-lineage-53449.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1-fb-lineage-53449.0.tgz",
-      "integrity": "sha512-+XxtdM9muhAf2IuAhg4TGQnEOSkYiZGLfDhaEhaUJ1X6fSmcSuy1Czd+xGK1ufmkvTsCKQaUjq7D8i4MpOZtAg==",
+      "version": "1.43.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1.tgz",
+      "integrity": "sha512-PkbI+OlnljpSLO7PkwfRRw/AH76pRRZbF8929ygxVZsrBXVFDSR+lSsSbJREiuMWkBTVcAOycwftwZB/O4QGHw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3247,13 +3247,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.67.2-fb-lineage-53449.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.2-fb-lineage-53449.0.tgz",
-      "integrity": "sha512-zQ2/eOLxCOKlP+aYa0X34WgmJt5xByaxKih9lMZeg5I5bFVeD9Bzq9xt5x7dIGVga9WsKfMgzdOumW9KL4XamA==",
+      "version": "6.67.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.2.tgz",
+      "integrity": "sha512-VZrlfp5wYyb20rZIRMp1TAvIpJOwwpZPriVVO9c5RFhvATKUGA8L56eeNg19Xf3S2DsahXiX3iZ3kKIc1+P8MA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.43.1-fb-lineage-53449.0",
+        "@labkey/api": "1.43.1",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",

--- a/experiment/package-lock.json
+++ b/experiment/package-lock.json
@@ -8,7 +8,7 @@
       "name": "experiment",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.67.0"
+        "@labkey/components": "6.67.2-fb-lineage-53449.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -3204,9 +3204,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.43.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.0.tgz",
-      "integrity": "sha512-4hOQz+pM/QaCey6ooJEmEbElnR9+TDEzWG+8caFfeIX1iAg1335NXW3+/Xzs6a+L9ysRKds8bNgFPu2sxjPzfg==",
+      "version": "1.43.1-fb-lineage-53449.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1-fb-lineage-53449.0.tgz",
+      "integrity": "sha512-+XxtdM9muhAf2IuAhg4TGQnEOSkYiZGLfDhaEhaUJ1X6fSmcSuy1Czd+xGK1ufmkvTsCKQaUjq7D8i4MpOZtAg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -3247,13 +3247,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.67.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.0.tgz",
-      "integrity": "sha512-7YA6aJB3rEMqIXzGBrQZ5J9+Bdz/nkivaBnCrVNSH+4+qs1UvPM7yrvlEBJKE3LxbfSVTh6rIxInztMf274J3Q==",
+      "version": "6.67.2-fb-lineage-53449.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.2-fb-lineage-53449.0.tgz",
+      "integrity": "sha512-zQ2/eOLxCOKlP+aYa0X34WgmJt5xByaxKih9lMZeg5I5bFVeD9Bzq9xt5x7dIGVga9WsKfMgzdOumW9KL4XamA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.43.0",
+        "@labkey/api": "1.43.1-fb-lineage-53449.0",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.67.0"
+    "@labkey/components": "6.67.2-fb-lineage-53449.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/experiment/package.json
+++ b/experiment/package.json
@@ -13,7 +13,7 @@
     "test-integration": "cross-env NODE_ENV=test jest --ci --runInBand -c test/js/jest.config.integration.js"
   },
   "dependencies": {
-    "@labkey/components": "6.67.2-fb-lineage-53449.0"
+    "@labkey/components": "6.67.2"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.67.0"
+        "@labkey/components": "6.67.2-fb-lineage-53449.0"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2673,9 +2673,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.43.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.0.tgz",
-      "integrity": "sha512-4hOQz+pM/QaCey6ooJEmEbElnR9+TDEzWG+8caFfeIX1iAg1335NXW3+/Xzs6a+L9ysRKds8bNgFPu2sxjPzfg==",
+      "version": "1.43.1-fb-lineage-53449.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1-fb-lineage-53449.0.tgz",
+      "integrity": "sha512-+XxtdM9muhAf2IuAhg4TGQnEOSkYiZGLfDhaEhaUJ1X6fSmcSuy1Czd+xGK1ufmkvTsCKQaUjq7D8i4MpOZtAg==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2716,13 +2716,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.67.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.0.tgz",
-      "integrity": "sha512-7YA6aJB3rEMqIXzGBrQZ5J9+Bdz/nkivaBnCrVNSH+4+qs1UvPM7yrvlEBJKE3LxbfSVTh6rIxInztMf274J3Q==",
+      "version": "6.67.2-fb-lineage-53449.0",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.2-fb-lineage-53449.0.tgz",
+      "integrity": "sha512-zQ2/eOLxCOKlP+aYa0X34WgmJt5xByaxKih9lMZeg5I5bFVeD9Bzq9xt5x7dIGVga9WsKfMgzdOumW9KL4XamA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.43.0",
+        "@labkey/api": "1.43.1-fb-lineage-53449.0",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pipeline",
       "version": "0.0.0",
       "dependencies": {
-        "@labkey/components": "6.67.2-fb-lineage-53449.0"
+        "@labkey/components": "6.67.2"
       },
       "devDependencies": {
         "@labkey/build": "8.6.0",
@@ -2673,9 +2673,9 @@
       }
     },
     "node_modules/@labkey/api": {
-      "version": "1.43.1-fb-lineage-53449.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1-fb-lineage-53449.0.tgz",
-      "integrity": "sha512-+XxtdM9muhAf2IuAhg4TGQnEOSkYiZGLfDhaEhaUJ1X6fSmcSuy1Czd+xGK1ufmkvTsCKQaUjq7D8i4MpOZtAg==",
+      "version": "1.43.1",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/api/-/@labkey/api-1.43.1.tgz",
+      "integrity": "sha512-PkbI+OlnljpSLO7PkwfRRw/AH76pRRZbF8929ygxVZsrBXVFDSR+lSsSbJREiuMWkBTVcAOycwftwZB/O4QGHw==",
       "license": "Apache-2.0"
     },
     "node_modules/@labkey/build": {
@@ -2716,13 +2716,13 @@
       }
     },
     "node_modules/@labkey/components": {
-      "version": "6.67.2-fb-lineage-53449.0",
-      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.2-fb-lineage-53449.0.tgz",
-      "integrity": "sha512-zQ2/eOLxCOKlP+aYa0X34WgmJt5xByaxKih9lMZeg5I5bFVeD9Bzq9xt5x7dIGVga9WsKfMgzdOumW9KL4XamA==",
+      "version": "6.67.2",
+      "resolved": "https://labkey.jfrog.io/artifactory/api/npm/libs-client/@labkey/components/-/@labkey/components-6.67.2.tgz",
+      "integrity": "sha512-VZrlfp5wYyb20rZIRMp1TAvIpJOwwpZPriVVO9c5RFhvATKUGA8L56eeNg19Xf3S2DsahXiX3iZ3kKIc1+P8MA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@labkey/api": "1.43.1-fb-lineage-53449.0",
+        "@labkey/api": "1.43.1",
         "@testing-library/dom": "~10.4.0",
         "@testing-library/jest-dom": "~6.6.3",
         "@testing-library/react": "~16.3.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.67.2-fb-lineage-53449.0"
+    "@labkey/components": "6.67.2"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -14,7 +14,7 @@
     "build-prod": "npm run clean && cross-env NODE_ENV=production PROD_SOURCE_MAP=source-map webpack --config node_modules/@labkey/build/webpack/prod.config.js --color --progress --profile"
   },
   "dependencies": {
-    "@labkey/components": "6.67.0"
+    "@labkey/components": "6.67.2-fb-lineage-53449.0"
   },
   "devDependencies": {
     "@labkey/build": "8.6.0",


### PR DESCRIPTION
#### Rationale
This addresses [Issue 53449](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=53449) by updating the lineage UI to resolve lineage items by `containerPath` rather than `container` (entityId). With this the container filter is resolved correctly based on application configuration so that lookup values in lineage details display as expected.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-js/pull/201
- https://github.com/LabKey/labkey-ui-components/pull/1880
- https://github.com/LabKey/platform/pull/7166
- https://github.com/LabKey/limsModules/pull/1769

#### Changes
- Bump `@labkey/components`.