### PR TITLE
Table.updateContainer: use NowTimestamp

### DIFF
--- a/api/src/org/labkey/api/data/Table.java
+++ b/api/src/org/labkey/api/data/Table.java
@@ -1171,7 +1171,7 @@ public class Table
             {
                 dataUpdate.append(", ").appendIdentifier(colModified.getSelectIdentifier())
                         .append(" = ")
-                        .appendValue(new java.sql.Timestamp(System.currentTimeMillis()));
+                        .appendNowTimestamp();
             }
 
             ColumnInfo colModifiedBy = table.getColumn(MODIFIED_BY_COLUMN_NAME);


### PR DESCRIPTION
#### Rationale
I've recently done work for [Issue 48864](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=48864) to use `CURRENT_TIMESTAMP` when inserting/updating timestamps. This coincided with work to support moving list rows which introduced a usage of timestamp generation which should be updated.

#### Related Pull Requests
- #7097
- #7104 

#### Changes
- Use `NowTimestamp` for generating modified timestamp for move operations.

#### Tasks
- [x] ~~Manual Testing~~
- [x] Needs Automation