### PR TITLE
Issue 54156: Assay XAR with invalid transform script can't be edited

### DIFF
--- a/api/src/org/labkey/api/assay/transform/AnalysisScript.java
+++ b/api/src/org/labkey/api/assay/transform/AnalysisScript.java
@@ -40,13 +40,13 @@ public class AnalysisScript
 
     private AnalysisScript(File script)
     {
-        try
+        if (!script.exists())
         {
-            _script = FileSystemLike.wrapFile(script.getParentFile(), script);
+            _script = new FileSystemLike.Builder(script).build().getRoot();
         }
-        catch (IOException e)
+        else
         {
-            throw UnexpectedException.wrap(e);
+            _script = FileSystemLike.wrapFile(script);
         }
     }
 


### PR DESCRIPTION
#### Rationale
You should still be able to edit an assay design when it's pointing to an invalid transform script file. In fact, that may be the reason you want to edit it.

Teasing out this small change for 25.11 as the larger FileLike PR will be merged to develop, post-branch.

#### Changes
- Use alternate approach for constructing FileLike when the file doesn't exist

#### Tasks 📍
- [x] Manual Testing @cnathe 
- [x] Needs Automation - targeting develop with https://github.com/LabKey/testAutomation/pull/2752
