### PR TITLE
Add subquery alias required by PostgreSQL 15

### DIFF
--- a/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
@@ -244,7 +244,7 @@ abstract class PostgreSql92Dialect extends BasePostgreSqlDialect
                     s.relkind = 'S' -- Sequence
                     AND t.relkind IN ('r', 'P') -- Table (regular table or partitioned table)
                     AND d.deptype IN ('a', 'i') -- Automatic dependency for DEFAULT or index-related for PK
-            )
+            ) AS x
             WHERE SchemaName ILIKE ? AND TableName ILIKE ?
             """,
             table.getSchema().getName(),


### PR DESCRIPTION
#### Rationale
Subquery aliases are optional as of PostgreSQL 16... but we're still running PostgreSQL 15 for some deployments 😞 