### PR TITLE
Handle tricky characters in domain name JavaScript test

### DIFF
--- a/experiment/src/client/test/integration/AssayImportRunAction.ispec.ts
+++ b/experiment/src/client/test/integration/AssayImportRunAction.ispec.ts
@@ -221,9 +221,9 @@ describe('assay-importRun.api', () => {
             const run = await getRunQueryRow(server, ASSAY_A_NAME, runId, topFolderOptions);
             const expectedUrl = `/${encodeURIComponent(PROJECT_NAME)}/core-downloadFileLink.view?propertyId=`;
             const runBatchField = `Batch/${BATCH_FILE_FIELD_NAME}`;
-            expect(run[runBatchField].value.replace('\\', '/')).toEqual(`assaydata/${batchFileName}`);
+            expect(run[runBatchField].value.replaceAll('\\', '/')).toEqual(`assaydata/${batchFileName}`);
             expect(run[runBatchField].url).toContain(expectedUrl);
-            expect(run[RUN_FILE_FIELD_NAME].value.replace('\\', '/')).toEqual(`assaydata/${runFileName}`);
+            expect(run[RUN_FILE_FIELD_NAME].value.replaceAll('\\', '/')).toEqual(`assaydata/${runFileName}`);
             expect(run[RUN_FILE_FIELD_NAME].url).toContain(expectedUrl);
 
             // Verify audit log
@@ -504,9 +504,9 @@ describe('assay-importRun.api', () => {
             const run = await getRunQueryRow(server, ASSAY_A_NAME, runId, topFolderOptions);
             const expectedUrl = `/${encodeURIComponent(PROJECT_NAME)}/core-downloadFileLink.view?propertyId=`;
             const runBatchField = `Batch/${BATCH_FILE_FIELD_TWO_NAME}`;
-            expect(run[runBatchField].value.replace('\\', '/')).toEqual(`assaydata/${batchFileName}`);
+            expect(run[runBatchField].value.replaceAll('\\', '/')).toEqual(`assaydata/${batchFileName}`);
             expect(run[runBatchField].url).toContain(expectedUrl);
-            expect(run[RUN_FILE_FIELD_NAME].value.replace('\\', '/')).toEqual(`assaydata/${runFileName}`);
+            expect(run[RUN_FILE_FIELD_NAME].value.replaceAll('\\', '/')).toEqual(`assaydata/${runFileName}`);
             expect(run[RUN_FILE_FIELD_NAME].url).toContain(expectedUrl);
 
             // Verify audit log

--- a/experiment/src/client/test/integration/AssayImportRunAction.ispec.ts
+++ b/experiment/src/client/test/integration/AssayImportRunAction.ispec.ts
@@ -221,9 +221,9 @@ describe('assay-importRun.api', () => {
             const run = await getRunQueryRow(server, ASSAY_A_NAME, runId, topFolderOptions);
             const expectedUrl = `/${encodeURIComponent(PROJECT_NAME)}/core-downloadFileLink.view?propertyId=`;
             const runBatchField = `Batch/${BATCH_FILE_FIELD_NAME}`;
-            expect(run[runBatchField].value).toEqual(`assaydata/${batchFileName}`);
+            expect(run[runBatchField].value.replace('\\', '/')).toEqual(`assaydata/${batchFileName}`);
             expect(run[runBatchField].url).toContain(expectedUrl);
-            expect(run[RUN_FILE_FIELD_NAME].value).toEqual(`assaydata/${runFileName}`);
+            expect(run[RUN_FILE_FIELD_NAME].value.replace('\\', '/')).toEqual(`assaydata/${runFileName}`);
             expect(run[RUN_FILE_FIELD_NAME].url).toContain(expectedUrl);
 
             // Verify audit log
@@ -504,9 +504,9 @@ describe('assay-importRun.api', () => {
             const run = await getRunQueryRow(server, ASSAY_A_NAME, runId, topFolderOptions);
             const expectedUrl = `/${encodeURIComponent(PROJECT_NAME)}/core-downloadFileLink.view?propertyId=`;
             const runBatchField = `Batch/${BATCH_FILE_FIELD_TWO_NAME}`;
-            expect(run[runBatchField].value).toEqual(`assaydata/${batchFileName}`);
+            expect(run[runBatchField].value.replace('\\', '/')).toEqual(`assaydata/${batchFileName}`);
             expect(run[runBatchField].url).toContain(expectedUrl);
-            expect(run[RUN_FILE_FIELD_NAME].value).toEqual(`assaydata/${runFileName}`);
+            expect(run[RUN_FILE_FIELD_NAME].value.replace('\\', '/')).toEqual(`assaydata/${runFileName}`);
             expect(run[RUN_FILE_FIELD_NAME].url).toContain(expectedUrl);
 
             // Verify audit log

--- a/experiment/src/client/test/integration/utils.ts
+++ b/experiment/src/client/test/integration/utils.ts
@@ -463,7 +463,7 @@ async function verifyDomainCreateFailure(server: IntegrationTestServer, domainTy
     }, {...folderOptions, ...userOptions});
 
     expect(badDomainNameResp['body']['success']).toBeFalsy();
-    expect(badDomainNameResp['body']['exception']).toBe(error.replace('REPLACE', badDomainName));
+    expect(badDomainNameResp['body']['exception']).toBe(error.replace('REPLACE', () => badDomainName));
 }
 
 async function verifyDomainUpdateFailure(server: IntegrationTestServer, domainId: number, domainURI: string, dataTypeRowId/*needed for updating dataclass*/: number, badDomainName: string, error: string, folderOptions: RequestOptions, userOptions: RequestOptions, domainFields?: any[]) {
@@ -488,7 +488,7 @@ async function verifyDomainUpdateFailure(server: IntegrationTestServer, domainId
     const badDomainNameResp = await server.post('property', 'saveDomain', updatedDomainPayload, {...folderOptions, ...userOptions});
 
     expect(badDomainNameResp['body']['success']).toBeFalsy();
-    expect(badDomainNameResp['body']['exception']).toBe(error.replace('REPLACE', badDomainName));
+    expect(badDomainNameResp['body']['exception']).toBe(error.replace('REPLACE', () => badDomainName));
 }
 
 async function verifyDomainCreateSuccess(server: IntegrationTestServer, domainType: string, domainName: string, folderOptions: RequestOptions, userOptions: RequestOptions) {
@@ -519,7 +519,7 @@ export async function checkDomainName(server: IntegrationTestServer, domainType:
         'with\0nullCharacter': `Invalid ${domainType} name 'REPLACE'. ${domainType} name must contain only valid unicode characters.`,
         'with\tnewLines': `Invalid ${domainType} name 'REPLACE'. ${domainType} name may not contain 'tab', 'new line', or 'return' characters.`,
         '.startWithDot': `Invalid ${domainType} name 'REPLACE'. ${domainType} name must start with a letter or a number.`,
-        ['c' + selectRandomN(ILLEGAL_DOMAIN_CHARSET.split(''), 2).join('')]: `Invalid ${domainType} name 'REPLACE'. ${domainType} name may not contain any of these characters: ` + ILLEGAL_DOMAIN_CHARSET,
+        ['c' + selectRandomN(ILLEGAL_DOMAIN_CHARSET.split(''), 2).join('')]: `Invalid DataClass name 'REPLACE'. ${domainType} name may not contain any of these characters: ` + ILLEGAL_DOMAIN_CHARSET,
         'a -b': `Invalid ${domainType} name 'REPLACE'. ${domainType} name may not contain space followed by dash.`
     };
     if (supportNameExpression) {

--- a/experiment/src/client/test/integration/utils.ts
+++ b/experiment/src/client/test/integration/utils.ts
@@ -519,7 +519,7 @@ export async function checkDomainName(server: IntegrationTestServer, domainType:
         'with\0nullCharacter': `Invalid ${domainType} name 'REPLACE'. ${domainType} name must contain only valid unicode characters.`,
         'with\tnewLines': `Invalid ${domainType} name 'REPLACE'. ${domainType} name may not contain 'tab', 'new line', or 'return' characters.`,
         '.startWithDot': `Invalid ${domainType} name 'REPLACE'. ${domainType} name must start with a letter or a number.`,
-        ['c' + selectRandomN(ILLEGAL_DOMAIN_CHARSET.split(''), 2).join('')]: `Invalid DataClass name 'REPLACE'. ${domainType} name may not contain any of these characters: ` + ILLEGAL_DOMAIN_CHARSET,
+        ['c' + selectRandomN(ILLEGAL_DOMAIN_CHARSET.split(''), 2).join('')]: `Invalid ${domainType} name 'REPLACE'. ${domainType} name may not contain any of these characters: ` + ILLEGAL_DOMAIN_CHARSET,
         'a -b': `Invalid ${domainType} name 'REPLACE'. ${domainType} name may not contain space followed by dash.`
     };
     if (supportNameExpression) {

--- a/experiment/src/client/test/integration/utils.ts
+++ b/experiment/src/client/test/integration/utils.ts
@@ -502,6 +502,8 @@ async function verifyDomainCreateSuccess(server: IntegrationTestServer, domainTy
         }
     }, {...folderOptions, ...userOptions}).expect((result) => {
         const domain = JSON.parse(result.text);
+        expect(domain).toHaveProperty('domainId');
+        expect(domain).toHaveProperty('domainURI');
         domainId = domain.domainId;
         domainURI = domain.domainURI;
         return true;
@@ -626,6 +628,8 @@ export async function verifyRequiredLineageInsertUpdate(server: IntegrationTestS
         }
     }, {...topFolderOptions, ...designerReaderOptions}).expect((result) => {
         const domain = JSON.parse(result.text);
+        expect(domain).toHaveProperty('domainId');
+        expect(domain).toHaveProperty('domainURI');
         childDomainId = domain.domainId;
         childDomainURI = domain.domainURI;
         return true;


### PR DESCRIPTION
#### Rationale
JavaScript regex replacement has several [special replacement strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement) that start with `$`. Random domain name generation might stumble into one of them, so we need to use the function replacement instead.
```
FAILED
Error: expect(received).toBe(expected) // Object.is equality
Expected: "Invalid DataClass name 'cInvalid DataClass name ''. DataClass name may not contain any of these characters: <>[]{};,`\"~!@#$%^*=|?\\"
Received: "Invalid DataClass name 'c$`'. DataClass name may not contain any of these characters: <>[]{};,`\"~!@#$%^*=|?\\"
    at verifyDomainCreateFailure (/mnt/teamcity/work/a7b1f3583054d6ed/server/modules/platform/experiment/src/client/test/integration/utils.ts:466:52)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at checkDomainName (/mnt/teamcity/work/a7b1f3583054d6ed/server/modules/platform/experiment/src/client/test/integration/utils.ts:533:9)
    at Object.<anonymous> (/mnt/teamcity/work/a7b1f3583054d6ed/server/modules/platform/experiment/src/client/test/integration/DataClassCrud.ispec.ts:78:9)
```

#### Related Pull Requests
- N/A

#### Changes
- Handle tricky characters in domain name JavaScript test