### PR TITLE
Fix for AbstractFileUpload

### DIFF
--- a/api/src/org/labkey/api/action/AbstractFileUploadAction.java
+++ b/api/src/org/labkey/api/action/AbstractFileUploadAction.java
@@ -17,6 +17,7 @@ package org.labkey.api.action;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
@@ -24,6 +25,8 @@ import org.labkey.api.util.Pair;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.writer.PrintWriters;
+import org.springframework.beans.MutablePropertyValues;
+import org.springframework.beans.PropertyValues;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.multipart.MultipartFile;
@@ -53,7 +56,7 @@ public abstract class AbstractFileUploadAction<FORM extends AbstractFileUploadAc
 {
     private ModelAndView _successView = null;
 
-    public static class FileUploadForm
+    public static class FileUploadForm implements HasBindParameters
     {
         private String[] _fileName = new String[0];
         private String[] _fileContent  = new String[0];
@@ -91,6 +94,22 @@ public abstract class AbstractFileUploadAction<FORM extends AbstractFileUploadAc
         public void setForceMultipleResults(boolean forceMultipleResults)
         {
             _forceMultipleResults = forceMultipleResults;
+        }
+
+        @Override
+        public @NotNull BindException bindParameters(PropertyValues m)
+        {
+            // We are often posting CSV data here to a String[] array parameter.  We need to avoid conversion when
+            // only one value is posted.
+            var fileContentOrig = m.getPropertyValue("fileContent");
+            if (null != fileContentOrig && fileContentOrig.getValue() instanceof String strOrig)
+            {
+                MutablePropertyValues copy = new MutablePropertyValues(m);
+                copy.removePropertyValue("fileContent");
+                copy.addPropertyValue("fileContent", new String[] {strOrig});
+                m = copy;
+            }
+            return springBindParameters(this, "form", m);
         }
     }
 

--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -712,7 +712,10 @@ public class DataColumn extends DisplayColumn
             {
                 IPropertyValidator textChoiceValidator = PropertyService.get().getValidatorForColumn(_boundColumn, PropertyValidatorType.TextChoice);
                 if (textChoiceValidator != null)
-                    renderTextChoiceFormInput(out, formFieldName, value, List.of(strVal), disabledInput, textChoiceValidator);
+                {
+                    List<String> strVals = StringUtils.isEmpty(strVal) ? List.of() : List.of(strVal);
+                    renderTextChoiceFormInput(out, formFieldName, value, strVals, disabledInput, textChoiceValidator);
+                }
                 else
                     renderTextFormInput(out, formFieldName, value, strVal, disabledInput);
             }

--- a/api/src/org/labkey/api/data/MultiChoice.java
+++ b/api/src/org/labkey/api/data/MultiChoice.java
@@ -103,7 +103,7 @@ public class MultiChoice
             if (textChoiceValidator != null)
             {
                 setInputType("select.multiple");
-                renderTextChoiceFormInput(out, formFieldName+ARRAY_MARKER, array, array, disabledInput, textChoiceValidator);
+                renderTextChoiceFormInput(out, ARRAY_MARKER+formFieldName, array, array, disabledInput, textChoiceValidator);
             }
             else
             {

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -814,16 +814,16 @@ public class TableViewForm extends ViewForm implements HasBindParameters
         }
     }
 
-    /** Handle @ prefix and [] suffix
-     * "@field" indicates that if "field" is missing, it should be treated as "field=0"
-     * "@field[] indicates that value should be treated as an array even if only one value is present
+    /** Handle @ prefix and [] prefix
+     * "@quf_field" indicates that if "field" is missing, it should be treated as "field=0"
+     * "[]quf_field indicates that value should be treated as an array even if only one value is present
      *  <br>
-     *  client _could_ post both "myfield=" and "myfield[]=", but that's a client bug
+     *  client _could_ post both "myfield=" and "[]myfield=", but that's a client bug
      */
     public static PropertyValues preprocessPropertyValues(PropertyValues params)
     {
         // we can usually just return params
-        if (params.stream().noneMatch(e -> e.getName().endsWith(ARRAY_MARKER) || e.getName().startsWith(FIELD_MARKER)))
+        if (params.stream().noneMatch(e -> e.getName().startsWith(ARRAY_MARKER) || e.getName().startsWith(FIELD_MARKER)))
             return params;
 
         Set<String> names = params.stream().map(PropertyValue::getName).collect(Collectors.toSet());
@@ -833,11 +833,11 @@ public class TableViewForm extends ViewForm implements HasBindParameters
             var copy = orig;
             if (orig.getName().startsWith(FIELD_MARKER))
             {
-                if (names.contains(orig.getName().substring(1)))
+                if (names.contains(orig.getName().substring(FIELD_MARKER.length())))
                     continue;
                 copy = new PropertyValue(orig.getName().substring(1), "0");
             }
-            else if (orig.getName().endsWith(ARRAY_MARKER) && orig.getValue()!=null)
+            else if (orig.getName().startsWith(ARRAY_MARKER) && orig.getValue()!=null)
             {
                 var value = orig.getValue();
                 var convertedValue = value;
@@ -850,7 +850,7 @@ public class TableViewForm extends ViewForm implements HasBindParameters
                     convertedValue = Array.newInstance(value.getClass(), 1);
                     Array.set(convertedValue, 0, value);
                 }
-                copy = new PropertyValue(orig.getName().substring(0, orig.getName().length() - 2), convertedValue);
+                copy = new PropertyValue(orig.getName().substring(ARRAY_MARKER.length()), convertedValue);
             }
             ret.addPropertyValue(copy);
         }

--- a/core/src/org/labkey/core/view/TableViewFormTestCase.java
+++ b/core/src/org/labkey/core/view/TableViewFormTestCase.java
@@ -132,7 +132,7 @@ public class TableViewFormTestCase extends Assert
         // this is explicitly an array of size 1, so no parsing
         form = new BeanViewForm<>(BindBean.class, null);
         mpv = new MutablePropertyValues();
-        mpv.add("strArray[]", "Option 1, Option 2");
+        mpv.add("[]strArray", "Option 1, Option 2");
         form.bindParameters(mpv);
         typed = form.getTypedValues();
         assertEquals(1, typed.size());


### PR DESCRIPTION
#### Rationale
AbstractFileUploadAction.FileUploadForm has a String[] array used for posting multiple "files" of CSV data.  So that doesn't work now.  Need to disambiguate the case of posting one CSV string.  

NOTE: An alternative would be to call TableViewForm.preprocessPropertyValues(PropertyValues params) from class ViewActionParameterPropertyValues.  Then the we could use the [] prefix to handle this case without special code here.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
Fix FileUploadForm binding
Also switch ARRAY_FIELD to be a prefix


<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->