### PR TITLE
Tone down logging for unknown folder types

### DIFF
--- a/api/src/org/labkey/api/data/ContainerManager.java
+++ b/api/src/org/labkey/api/data/ContainerManager.java
@@ -585,7 +585,8 @@ public class ContainerManager
         return containersMatchingTabs;
     }
 
-    private static final Set<Container> containersWithBadFolderTypes = new ConcurrentHashSet<>();
+    private static final Set<Integer> containersWithBadFolderTypes = new ConcurrentHashSet<>();
+    private static final Set<String> badFolderTypes = new ConcurrentHashSet<>();
 
     @NotNull
     public static FolderType getFolderType(Container c)
@@ -602,10 +603,16 @@ public class ContainerManager
                 // If we're upgrading then folder types won't be defined yet... don't warn in that case.
                 if (!ModuleLoader.getInstance().isUpgradeInProgress() &&
                     !ModuleLoader.getInstance().isUpgradeRequired() &&
-                    !containersWithBadFolderTypes.contains(c))
+                    containersWithBadFolderTypes.add(c.getRowId()))
                 {
-                    LOG.warn("No such folder type " + name + " for folder " + c.toString());
-                    containersWithBadFolderTypes.add(c);
+                    if (badFolderTypes.add(name))
+                    {
+                        LOG.warn("No such folder type {} for container {}. Additional containers of this folder type will be logged at DEBUG level.", name, c.getPath());
+                    }
+                    else
+                    {
+                        LOG.debug("No such folder type {} for container {}.", name, c.getPath());
+                    }
                 }
 
                 folderType = FolderType.NONE;


### PR DESCRIPTION
#### Rationale
We can spam the log file with many redundant complaints about an unknown folder type. Real-world wxamples:

https://app.datadoghq.com/logs?query=%22no%20such%20folder%20type%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1761169394772&to_ts=1762465394772&live=true

#### Changes
- After the first time hitting an unknown folder type, switch to `DEBUG` logging
- Track by RowId instead of `Container`

#### Tasks 📍
- [x] Manual Testing @labkey-tchad 
  - Create two folders with a folder type supplied by a non-critical module, like MS2 or Flow.
  - Remove that module from your deployment directory
  - Start up the server and visit those containers. You should see a single `WARN` message about the folder type
- Needs Automation - N/A
