### PR TITLE
Issue 54112: Retain previous file values when reimporting a run

### DIFF
--- a/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
+++ b/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
@@ -529,6 +529,7 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
                 }
             }
         }
+
         return value;
     }
 
@@ -578,7 +579,6 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
     {
         _batchId = batchId;
     }
-
 
     public void clearDefaultValues(Domain domain)
     {

--- a/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
+++ b/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
@@ -86,7 +86,7 @@ import static java.util.Collections.emptyMap;
 
 public class AssayRunUploadForm<ProviderType extends AssayProvider> extends ProtocolIdForm implements AssayRunUploadContext<ProviderType>
 {
-    protected Map<DomainProperty, String> _uploadSetProperties = null;
+    protected Map<DomainProperty, String> _batchProperties = null;
     protected Map<DomainProperty, String> _runProperties = null;
     private String _comments;
     private String _name;
@@ -129,10 +129,10 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
     @Override
     public Map<DomainProperty, String> getBatchProperties() throws ExperimentException
     {
-        if (_uploadSetProperties == null)
-            _uploadSetProperties = getPropertyMapFromRequest(getProvider().getBatchDomain(getProtocol()));
+        if (_batchProperties == null)
+            _batchProperties = getPropertyMapFromRequest(getProvider().getBatchDomain(getProtocol()));
 
-        return Collections.unmodifiableMap(_uploadSetProperties);
+        return Collections.unmodifiableMap(_batchProperties);
     }
 
     protected Map<DomainProperty, String> getPropertyMapFromRequest(Domain domain) throws ExperimentException

--- a/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
+++ b/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
@@ -70,7 +70,6 @@ import org.springframework.validation.BindException;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -85,11 +84,6 @@ import java.util.TreeMap;
 
 import static java.util.Collections.emptyMap;
 
-/**
- * User: brittp
-* Date: Jul 11, 2007
-* Time: 2:52:54 PM
-*/
 public class AssayRunUploadForm<ProviderType extends AssayProvider> extends ProtocolIdForm implements AssayRunUploadContext<ProviderType>
 {
     protected Map<DomainProperty, String> _uploadSetProperties = null;
@@ -129,8 +123,7 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
         if (_runProperties == null)
         {
             Domain domain = getProvider().getRunDomain(getProtocol());
-            List<? extends DomainProperty> properties = domain.getProperties();
-            _runProperties = getPropertyMapFromRequest(properties);
+            _runProperties = getPropertyMapFromRequest(domain.getProperties());
         }
         return Collections.unmodifiableMap(_runProperties);
     }
@@ -325,70 +318,67 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
 
     public Map<DomainProperty, FileLike> getAdditionalPostedFiles(List<? extends DomainProperty> pds) throws ExperimentException
     {
-        if (_additionalFiles == null)
+        if (_additionalFiles != null)
+            return _additionalFiles;
+
+        Map<String, DomainProperty> fileParameters = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        List<String> filePdNames = new ArrayList<>();
+
+        for (DomainProperty pd : pds)
         {
-            Map<String, DomainProperty> fileParameters = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-            List<String> filePdNames = new ArrayList<>();
-
-            for (DomainProperty pd : pds)
+            if (pd.getPropertyDescriptor().getPropertyType() == PropertyType.FILE_LINK)
             {
-                if (pd.getPropertyDescriptor().getPropertyType() == PropertyType.FILE_LINK)
-                {
-                    fileParameters.put(UploadWizardAction.getInputName(pd), pd);
-                    filePdNames.add(pd.getName());
-                }
+                fileParameters.put(UploadWizardAction.getInputName(pd), pd);
+                filePdNames.add(pd.getName());
             }
-
-            if (!fileParameters.isEmpty())
-            {
-                AssayFileWriter<AssayRunUploadForm<ProviderType>> writer = new AssayFileWriter<>();
-                try
-                {
-                    // Initialize member variable so we know that we've already tried to save the posted files in case of error
-                    _additionalFiles = new HashMap<>();
-                    Map<String, FileLike> postedFiles = writer.savePostedFiles(this, fileParameters.keySet(), false, false);
-                    for (Map.Entry<String, FileLike> entry : postedFiles.entrySet())
-                        _additionalFiles.put(fileParameters.get(entry.getKey()), entry.getValue());
-
-                    File previousFile;
-                    HttpServletRequest request = getViewContext().getRequest();
-
-                    // Hidden values in form containing previously uploaded files if previous upload resulted in error
-                    for (String fileParam : filePdNames)
-                    {
-                        if (request instanceof MultipartHttpServletRequest mhsr && null != request.getParameter(fileParam))
-                        {
-                            String previousFileName = request.getParameter(fileParam);
-                            if (null != previousFileName)
-                            {
-                                previousFile = FileUtil.appendName(getAssayDirectory(getContainer(), null), previousFileName);
-
-                                MultipartFile multiFile = mhsr.getFileMap().get(UploadWizardAction.getInputName(fileParameters.get(fileParam)));
-
-                                // If file is removed from form after error, override hidden file name with empty file
-                                if (null != multiFile && multiFile.getOriginalFilename().isEmpty())
-                                    _additionalFiles.put(fileParameters.get(fileParam), BLANK_FILE);
-
-                                // Only add hidden file parameter if it is a valid file in the pipeline root directory and
-                                // a new file hasn't been uploaded for that parameter
-                                if (previousFile.isFile()
-                                        && FileUtils.directoryContains(getAssayDirectory(getContainer(), null), previousFile)
-                                        && !_additionalFiles.containsKey(fileParameters.get(fileParam)))
-                                {
-                                    _additionalFiles.put(fileParameters.get(fileParam), FileSystemLike.wrapFile(previousFile));
-                                }
-                            }
-                        }
-                    }
-                }
-                catch (IOException e)
-                {
-                    throw new RuntimeException(e);
-                }
-            }
-            else
-                _additionalFiles = emptyMap();
         }
+
+        if (fileParameters.isEmpty())
+            return _additionalFiles = emptyMap();
+
+        AssayFileWriter<AssayRunUploadForm<ProviderType>> writer = new AssayFileWriter<>();
+        try
+        {
+            // Initialize member variable so we know that we've already tried to save the posted files in case of error
+            _additionalFiles = new HashMap<>();
+            Map<String, FileLike> postedFiles = writer.savePostedFiles(this, fileParameters.keySet(), false, false);
+            for (Map.Entry<String, FileLike> entry : postedFiles.entrySet())
+                _additionalFiles.put(fileParameters.get(entry.getKey()), entry.getValue());
+
+            if (!(getViewContext().getRequest() instanceof MultipartHttpServletRequest request))
+                return _additionalFiles;
+
+            File assayDirectory = getAssayDirectory(getContainer(), null);
+
+            // Hidden values in form containing previously uploaded files if the previous upload resulted in error
+            for (String fileParam : filePdNames)
+            {
+                String previousFileName = request.getParameter(fileParam);
+                if (previousFileName == null)
+                    continue;
+
+                DomainProperty domainProperty = fileParameters.get(fileParam);
+                MultipartFile multiFile = request.getFileMap().get(fileParam);
+
+                // If the file is removed from form after error, override hidden file name with an empty file
+                if (null != multiFile && multiFile.getOriginalFilename().isEmpty())
+                {
+                    _additionalFiles.put(domainProperty, BLANK_FILE);
+                    continue;
+                }
+
+                // Only add a hidden file parameter if it is a valid file in the pipeline root directory and
+                // a new file hasn't been uploaded for that parameter
+                File previousFile = FileUtil.appendName(assayDirectory, previousFileName);
+                if (previousFile.isFile() && FileUtils.directoryContains(assayDirectory, previousFile) && !_additionalFiles.containsKey(domainProperty))
+                    _additionalFiles.put(domainProperty, FileSystemLike.wrapFile(previousFile));
+            }
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+
         return _additionalFiles;
     }
 

--- a/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
+++ b/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
@@ -121,53 +121,63 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
     public Map<DomainProperty, String> getRunProperties() throws ExperimentException
     {
         if (_runProperties == null)
-        {
-            Domain domain = getProvider().getRunDomain(getProtocol());
-            _runProperties = getPropertyMapFromRequest(domain.getProperties());
-        }
+            _runProperties = getPropertyMapFromRequest(getProvider().getRunDomain(getProtocol()));
+
         return Collections.unmodifiableMap(_runProperties);
     }
 
-    /** @return property descriptor to value */
     @Override
     public Map<DomainProperty, String> getBatchProperties() throws ExperimentException
     {
         if (_uploadSetProperties == null)
-        {
-            Domain domain = getProvider().getBatchDomain(getProtocol());
-            _uploadSetProperties = getPropertyMapFromRequest(domain.getProperties());
-        }
+            _uploadSetProperties = getPropertyMapFromRequest(getProvider().getBatchDomain(getProtocol()));
+
         return Collections.unmodifiableMap(_uploadSetProperties);
     }
 
-    protected Map<DomainProperty, String> getPropertyMapFromRequest(List<? extends DomainProperty> columns) throws ExperimentException
+    protected Map<DomainProperty, String> getPropertyMapFromRequest(Domain domain) throws ExperimentException
     {
+        List<? extends DomainProperty> columns = domain.getProperties();
         Map<DomainProperty, String> properties = new LinkedHashMap<>();
         Map<DomainProperty, FileLike> additionalFiles = getAdditionalPostedFiles(columns);
+        Map<DomainProperty, Object> defaults = getDefaultValues(domain, false);
+
         for (DomainProperty pd : columns)
         {
             String propName = UploadWizardAction.getInputName(pd);
-            String value = getRequest().getParameter(propName);
-            if (pd.getPropertyDescriptor().getPropertyType() == PropertyType.BOOLEAN &&
-                    (value == null || value.isEmpty()))
+            String value = StringUtils.trimToNull(getRequest().getParameter(propName));
+            if (pd.getPropertyDescriptor().getPropertyType() == PropertyType.BOOLEAN && (value == null || value.isEmpty()))
                 value = Boolean.FALSE.toString();
-            value = StringUtils.trimToNull(value);
 
-            if (pd.getName().equals(AbstractAssayProvider.PARTICIPANT_VISIT_RESOLVER_PROPERTY_NAME) && value != null)
-            {
+            if (AbstractAssayProvider.PARTICIPANT_VISIT_RESOLVER_PROPERTY_NAME.equalsIgnoreCase(pd.getName()) && value != null)
                 value = ParticipantVisitResolverType.Serializer.encode(value, getRequest());
-            }
 
             if (additionalFiles.containsKey(pd))
             {
-                if (additionalFiles.get(pd).equals(BLANK_FILE)) // file has been removed
+                if (BLANK_FILE.equals(additionalFiles.get(pd))) // file has been removed
                     properties.put(pd, null);
                 else
                     properties.put(pd, additionalFiles.get(pd).toNioPathForRead().toString());
             }
             else
                 properties.put(pd, value);
+
+            // Issue 54112: Retain previous file values when reimporting a run
+            if (PropertyType.FILE_LINK == pd.getPropertyDescriptor().getPropertyType())
+            {
+                boolean postedNewFile = additionalFiles.containsKey(pd);
+                String current = properties.get(pd);
+                boolean hasValue = current != null && !current.isEmpty();
+
+                if (!postedNewFile && !hasValue)
+                {
+                    Object prior = defaults.get(pd);
+                    if (prior != null)
+                        properties.put(pd, prior.toString());
+                }
+            }
         }
+
         return properties;
     }
 
@@ -309,11 +319,10 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
 
     public static File getAssayDirectory(Container c, File root)
     {
-        if(null != root)
+        if (null != root)
             return new File(root.getAbsolutePath(), AssayFileWriter.DIR_NAME);
         else
             return new File(PipelineService.get().findPipelineRoot(c).getRootPath().getAbsolutePath(), AssayFileWriter.DIR_NAME);
-
     }
 
     public Map<DomainProperty, FileLike> getAdditionalPostedFiles(List<? extends DomainProperty> pds) throws ExperimentException
@@ -353,10 +362,6 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
             // Hidden values in form containing previously uploaded files if the previous upload resulted in error
             for (String fileParam : filePdNames)
             {
-                String previousFileName = request.getParameter(fileParam);
-                if (previousFileName == null)
-                    continue;
-
                 DomainProperty domainProperty = fileParameters.get(fileParam);
                 MultipartFile multiFile = request.getFileMap().get(fileParam);
 
@@ -366,6 +371,10 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
                     _additionalFiles.put(domainProperty, BLANK_FILE);
                     continue;
                 }
+
+                String previousFileName = request.getParameter(fileParam);
+                if (previousFileName == null)
+                    continue;
 
                 // Only add a hidden file parameter if it is a valid file in the pipeline root directory and
                 // a new file hasn't been uploaded for that parameter
@@ -620,6 +629,11 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
 
     public Map<DomainProperty, Object> getDefaultValues(Domain domain) throws ExperimentException
     {
+        return getDefaultValues(domain, true);
+    }
+
+    private Map<DomainProperty, Object> getDefaultValues(Domain domain, boolean includeNameAndComment) throws ExperimentException
+    {
         ExpRun reRun = getReRun();
         if (reRun != null)
         {
@@ -651,15 +665,18 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
                 // repopulated just like the rest of the domain properties, but they aren't actually part of the
                 // domain- they're hard columns on the ExperimentRun table.  Since the DomainProperty objects are
                 // just used to calculate the input form element names, this hack works to pre-populate the values.
-                DomainProperty nameProperty = domain.addProperty();
-                nameProperty.setName("Name");
-                ret.put(nameProperty, reRun.getName());
-                nameProperty.delete();
+                if (includeNameAndComment)
+                {
+                    DomainProperty nameProperty = domain.addProperty();
+                    nameProperty.setName("Name");
+                    ret.put(nameProperty, reRun.getName());
+                    nameProperty.delete();
 
-                DomainProperty commentsProperty = domain.addProperty();
-                commentsProperty.setName("Comments");
-                ret.put(commentsProperty, reRun.getComments());
-                commentsProperty.delete();
+                    DomainProperty commentsProperty = domain.addProperty();
+                    commentsProperty.setName("Comments");
+                    ret.put(commentsProperty, reRun.getComments());
+                    commentsProperty.delete();
+                }
             }
             return ret;
         }

--- a/api/src/org/labkey/api/data/AbstractFileDisplayColumn.java
+++ b/api/src/org/labkey/api/data/AbstractFileDisplayColumn.java
@@ -286,7 +286,7 @@ public abstract class AbstractFileDisplayColumn extends DataColumn
             if (null != filename)
             {
                 // Existing value, so tell the user the file name, allow the file to be removed, and a new file uploaded
-                renderThumbnailAndRemoveLink(out, ctx, filename, input);
+                renderThumbnailAndRemoveLink(out, ctx, formFieldName, filename, input);
             }
             else
             {
@@ -307,13 +307,15 @@ public abstract class AbstractFileDisplayColumn extends DataColumn
         return "Previous file " + filename + " will be removed.";
     }
 
-    private void renderThumbnailAndRemoveLink(HtmlWriter out, RenderContext ctx, String filename, InputBuilder<?> filePicker)
+    private void renderThumbnailAndRemoveLink(HtmlWriter out, RenderContext ctx, String fieldName, String filename, InputBuilder<?> filePicker)
     {
         String divId = GUID.makeGUID();
         String linkId = "remove" + divId;
 
         DIV(
-            id(divId),
+            id(divId)
+                .data("fieldName", fieldName)
+                .cl("lk-remove-file"),
             (Renderable) ret -> {
                 renderIconAndFilename(ctx, out, filename, false, false);
                 out.write(HtmlString.NBSP);

--- a/api/src/org/labkey/api/data/DataColumn.java
+++ b/api/src/org/labkey/api/data/DataColumn.java
@@ -58,7 +58,6 @@ import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.writer.HtmlWriter;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -153,7 +152,6 @@ public class DataColumn extends DisplayColumn
         _textAlign = _displayColumn.getTextAlign();
     }
 
-
     boolean analyticsProviderInitialized = false;
 
     @Override
@@ -177,7 +175,6 @@ public class DataColumn extends DisplayColumn
         return super.getAnalyticsProviders();
     }
 
-
     @Override
     public @NotNull Set<ClientDependency> getClientDependencies()
     {
@@ -186,7 +183,6 @@ public class DataColumn extends DisplayColumn
         return super.getClientDependencies();
     }
 
-
     protected ColumnInfo getDisplayField(@NotNull ColumnInfo col, boolean withLookups)
     {
         if (!withLookups)
@@ -194,7 +190,6 @@ public class DataColumn extends DisplayColumn
         ColumnInfo display = col.getDisplayField();
         return null==display ? col : display;
     }
-
 
     @Override
     public String toString()
@@ -737,7 +732,6 @@ public class DataColumn extends DisplayColumn
 
         return ctx.getForm() == null || col == null ? HtmlString.EMPTY_STRING : ctx.getErrors(col);
     }
-
 
     private void renderSelectFormInput(HtmlWriter out, String formFieldName, Object value, List<String> strValues, boolean disabledInput, NamedObjectList entryList)
     {

--- a/assay/test/src/org/labkey/test/tests/assay/AssayReimportIndexTest.java
+++ b/assay/test/src/org/labkey/test/tests/assay/AssayReimportIndexTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 public class AssayReimportIndexTest extends BaseWebDriverTest
 {
     private static final String ASSAY_NAME = DomainKind.Assay.randomName("test+assay");
-    // TODO: Replace each of the following with DomainKind.Assay.randomField(<fieldName>, ColumnType.File) once Issue 54112 is fixed.
+    // TODO: Replace each of the following with DomainKind.Assay.randomField(<fieldName>, ColumnType.File) once Issue 54218 is fixed.
     private static final FieldInfo BATCH_FILE_FIELD = new FieldInfo("batchFile", ColumnType.File);
     private static final FieldInfo RUN_FILE_FIELD = new FieldInfo("runFile", ColumnType.File);
 

--- a/assay/test/src/org/labkey/test/tests/assay/AssayReimportIndexTest.java
+++ b/assay/test/src/org/labkey/test/tests/assay/AssayReimportIndexTest.java
@@ -1,41 +1,41 @@
 package org.labkey.test.tests.assay;
 
+import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.domain.PropertyDescriptor;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.TestFileUtils;
 import org.labkey.test.categories.Assays;
 import org.labkey.test.categories.Daily;
-import org.labkey.test.components.assay.AssayConstants;
 import org.labkey.test.pages.assay.AssayImportPage;
 import org.labkey.test.pages.assay.AssayRunsPage;
-import org.labkey.test.params.FieldDefinition;
+import org.labkey.test.params.FieldDefinition.ColumnType;
+import org.labkey.test.params.FieldInfo;
 import org.labkey.test.params.assay.GeneralAssayDesign;
+import org.labkey.test.util.DomainUtils.DomainKind;
+import org.labkey.test.util.TestDataGenerator;
 import org.labkey.test.util.search.SearchAdminAPIHelper;
 
+import java.io.File;
 import java.time.Duration;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 @Category({Daily.class, Assays.class})
 public class AssayReimportIndexTest extends BaseWebDriverTest
 {
-    public static String ASSAY_NAME = "test_assay";
-    public static String STRING_FIELD_NAME = "string_field" + TRICKY_CHARACTERS_NO_QUOTES;
-
-    @Override
-    protected void doCleanup(boolean afterTest)
-    {
-        _containerHelper.deleteProject(getProjectName(), afterTest);
-    }
+    private static final String ASSAY_NAME = DomainKind.Assay.randomName("test+assay");
+    private static final FieldInfo BATCH_FILE_FIELD = new FieldInfo("batchFile", ColumnType.File); // TODO: DomainKind.Assay.randomField("batchFile", ColumnType.File);
+    private static final FieldInfo RUN_FILE_FIELD = new FieldInfo("runFile", ColumnType.File); // TODO: DomainKind.Assay.randomField("runFile", ColumnType.File);
 
     @BeforeClass
     public static void setupProject() throws Exception
     {
         AssayReimportIndexTest init = getCurrentTest();
-
         init.doSetup();
     }
 
@@ -44,9 +44,19 @@ public class AssayReimportIndexTest extends BaseWebDriverTest
         _containerHelper.createProject(getProjectName(), "Assay");
         goToProjectHome();
 
+        List<PropertyDescriptor> batchFields = List.of(
+            DomainKind.Assay.randomField("batchData", ColumnType.String).getFieldDefinition(),
+            BATCH_FILE_FIELD.getFieldDefinition()
+        );
+
+        List<PropertyDescriptor> runFields = List.of(
+            DomainKind.Assay.randomField("runString", ColumnType.String).getFieldDefinition(),
+            RUN_FILE_FIELD.getFieldDefinition()
+        );
+
         new GeneralAssayDesign(ASSAY_NAME)
-                .setBatchFields(List.of(new FieldDefinition("batchData", FieldDefinition.ColumnType.String)), true)
-                .setRunFields(List.of(new FieldDefinition(STRING_FIELD_NAME, FieldDefinition.ColumnType.String)), true)
+                .setBatchFields(batchFields, true)
+                .setRunFields(runFields, true)
                 .createAssay(getProjectName(), createDefaultConnection());
     }
 
@@ -67,15 +77,12 @@ public class AssayReimportIndexTest extends BaseWebDriverTest
                 2	2	1	11/12/2024	whee
                 """;
 
-        // import the first run
-        goToProjectHome();
-        clickAndWait(Locator.linkWithText(ASSAY_NAME));
-        clickButton("Import Data");
-        clickButton("Next");
-        AssayImportPage importPage = new AssayImportPage(getDriver());
-        importPage.setNamedInputText("Name", firstRun);
-        importPage.setNamedTextAreaValue(AssayConstants.TEXT_AREA_DATA_COLLECTOR_TEXT_AREA_NAME, firstRunData);
-        importPage.clickSaveAndFinish();
+        // import a run
+        importNewRun()
+            .clickNext()
+            .setNamedInputText("Name", firstRun)
+            .setDataText(firstRunData)
+            .clickSaveAndFinish();
         SearchAdminAPIHelper.waitForIndexer();
 
         // verify it can be searched
@@ -85,16 +92,12 @@ public class AssayReimportIndexTest extends BaseWebDriverTest
                         .as("expect to find assay run")
                         .isTrue());
 
-        // re-import with secondRunData, call the run version 2
-        goToProjectHome();
-        clickAndWait(Locator.linkWithText(ASSAY_NAME));
-        clickAndWait(Locator.linkWithText(firstRun));
-        clickButton("Re-import run");
-        clickButton("Next");
-        AssayImportPage importPage2 = new AssayImportPage(getDriver());
-        importPage2.setNamedInputText("Name", secondRun);
-        importPage2.setNamedTextAreaValue(AssayConstants.TEXT_AREA_DATA_COLLECTOR_TEXT_AREA_NAME, secondRunData);
-        importPage2.clickSaveAndFinish();
+        // re-import the run with a different name and data
+        reimportRun(firstRun)
+            .clickNext()
+            .setNamedInputText("Name", secondRun)
+            .setDataText(secondRunData)
+            .clickSaveAndFinish();
         SearchAdminAPIHelper.waitForIndexer();
 
         // verify it can be searched
@@ -103,7 +106,7 @@ public class AssayReimportIndexTest extends BaseWebDriverTest
                 ()-> Assertions.assertThat(searchResultPage2.hasResultLocatedBy(Locator.linkWithText("Assay Run - " + secondRun)))
                         .as("expect to find second assay run after re-import")
                         .isTrue());
-        // verify first run cannot be searched
+        // verify the first run cannot be searched
         searchResultPage2.searchForm().searchFor(firstRun);
         checker().withScreenshot("first_run_unexpectedly_found_after_reimport").awaiting(Duration.ofSeconds(2),
                 ()-> Assertions.assertThat(searchResultPage2.hasResultLocatedBy(Locator.linkWithText("Assay Run - " + firstRun)))
@@ -118,16 +121,75 @@ public class AssayReimportIndexTest extends BaseWebDriverTest
         runsPage.getTable().deleteSelectedRows();
         SearchAdminAPIHelper.waitForIndexer();
 
-        // verify second run cannot be searched
+        // verify the second run cannot be searched
         var searchResultPage3 = navBar().search(firstRun);
         checker().withScreenshot("first_run_not_found_after_de-indexing_second_run")
                 .verifyTrue("expect to find first assay run",
                         searchResultPage3.hasResultLocatedBy(Locator.linkWithText("Assay Run - " + firstRun)));
-        // verify first run cannot be searched post-delete
+        // verify the first run cannot be searched post-delete
         searchResultPage3.searchForm().searchFor(secondRun);
         checker().withScreenshot("second_run_found_after_delete")
                 .verifyFalse("expect not to find second assay run after deletion",
                         searchResultPage3.hasResultLocatedBy(Locator.linkWithText("Assay Run - " + secondRun)));
+    }
+
+    @Test // Issue 54112
+    public void testFileFieldValuesRetainedRunReimport()
+    {
+        String runName = TestDataGenerator.randomString(TestDataGenerator.randomInt(10, 50));
+        File batchFile = TestFileUtils.getSampleData("dataLoading/excel/fruits.tsv");
+        File runFile = TestFileUtils.getSampleData("dataLoading/excel/ClientAPITestList.xls");
+        File dataFile = TestFileUtils.getSampleData("assay/GPAT_Run1.tsv");
+
+        // import the initial run
+        importNewRun()
+            .setFileField(BATCH_FILE_FIELD.getName(), batchFile)
+            .clickNext()
+            .setNamedInputText("Name", runName)
+            .setFileField(RUN_FILE_FIELD.getName(), runFile)
+            .setDataFile(dataFile)
+            .clickSaveAndFinish();
+
+        // Reimport the run and verify expected file field values
+        var importPage = reimportRun(runName);
+        var reimportBatchFileValue = importPage.getFileFieldValue(BATCH_FILE_FIELD.getName());
+        checker().withScreenshot("reimport-run-batch-field-value")
+                .verifyEquals("Expected batch file name", batchFile.getName(), reimportBatchFileValue);
+        importPage = importPage.clickNext();
+        var reimportRunFileValue = importPage.getFileFieldValue(RUN_FILE_FIELD.getName());
+        checker().withScreenshot("reimport-run-run-field-value")
+                .verifyEquals("Expected run file name", runFile.getName(), reimportRunFileValue);
+        importPage.selectUploadFileRadioButton()
+            .clickSaveAndFinish();
+
+        // Verify that the reimport retained the file values
+        var row = new AssayRunsPage(getDriver())
+            .getTable()
+            .getRowDataAsMap("Name", runName);
+        reimportBatchFileValue = StringUtils.trimToNull(row.get("Batch/" + BATCH_FILE_FIELD.getName()));
+        reimportRunFileValue = StringUtils.trimToNull(row.get(RUN_FILE_FIELD.getName()));
+
+        checker().verifyEquals("Expected batch file to appear in data", batchFile.getName(), reimportBatchFileValue);
+        checker().verifyEquals("Expected run file to appear in data", runFile.getName(), reimportRunFileValue);
+    }
+
+    private AssayImportPage importNewRun()
+    {
+        goToProjectHome();
+        clickAndWait(Locator.linkWithText(ASSAY_NAME));
+        clickButton("Import Data");
+
+        return new AssayImportPage(getDriver());
+    }
+
+    private AssayImportPage reimportRun(String runName)
+    {
+        goToProjectHome();
+        clickAndWait(Locator.linkWithText(ASSAY_NAME));
+        clickAndWait(Locator.linkWithText(runName));
+        clickButton("Re-import run");
+
+        return new AssayImportPage(getDriver());
     }
 
     @Override
@@ -139,6 +201,6 @@ public class AssayReimportIndexTest extends BaseWebDriverTest
     @Override
     public List<String> getAssociatedModules()
     {
-        return Arrays.asList();
+        return Collections.emptyList();
     }
 }

--- a/assay/test/src/org/labkey/test/tests/assay/AssayReimportIndexTest.java
+++ b/assay/test/src/org/labkey/test/tests/assay/AssayReimportIndexTest.java
@@ -29,8 +29,9 @@ import java.util.List;
 public class AssayReimportIndexTest extends BaseWebDriverTest
 {
     private static final String ASSAY_NAME = DomainKind.Assay.randomName("test+assay");
-    private static final FieldInfo BATCH_FILE_FIELD = new FieldInfo("batchFile", ColumnType.File); // TODO: DomainKind.Assay.randomField("batchFile", ColumnType.File);
-    private static final FieldInfo RUN_FILE_FIELD = new FieldInfo("runFile", ColumnType.File); // TODO: DomainKind.Assay.randomField("runFile", ColumnType.File);
+    // TODO: Replace each of the following with DomainKind.Assay.randomField(<fieldName>, ColumnType.File) once Issue 54112 is fixed.
+    private static final FieldInfo BATCH_FILE_FIELD = new FieldInfo("batchFile", ColumnType.File);
+    private static final FieldInfo RUN_FILE_FIELD = new FieldInfo("runFile", ColumnType.File);
 
     @BeforeClass
     public static void setupProject() throws Exception


### PR DESCRIPTION
#### Rationale
This addresses [Issue 54112](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=54112) by supporting round-trip of file field values for both batch and run properties through assay reimport.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2781

#### Changes
- Resolve previous file value from default values when reimporting assay runs
- Update file thumbnail/field renderer to apply CSS class `lk-remove-file` and a `data-fieldname` so tests can more easily capture the value.
- Add regression tests

#### Tasks
- [x] Manual Testing @labkey-danield 
- [x] Needs Automation