### PR TITLE
Fixes for Windows failures after FileLike refactor

### DIFF
--- a/api/src/org/labkey/api/exp/AbstractFileXarSource.java
+++ b/api/src/org/labkey/api/exp/AbstractFileXarSource.java
@@ -111,6 +111,7 @@ public abstract class AbstractFileXarSource extends XarSource
     @Override
     public String canonicalizeDataFileURL(String dataFileURL)
     {
+        dataFileURL = dataFileURL.replace("\\", "/");
         Path xarDirectory = getRootPath();
         URI uri = FileUtil.createUri(dataFileURL);
         if (!uri.isAbsolute())

--- a/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
+++ b/assay/src/org/labkey/assay/actions/ImportRunApiAction.java
@@ -36,17 +36,13 @@ import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayRunUploadContext;
 import org.labkey.api.assay.AssayUrls;
 import org.labkey.api.assay.DefaultAssayRunCreator;
-import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.TransactionAuditProvider;
-import org.labkey.api.audit.provider.FileSystemAuditProvider;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.TSVMapWriter;
 import org.labkey.api.dataiterator.MapDataIterator;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.AssayJSONConverter;
-import org.labkey.api.exp.api.DataType;
-import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpExperiment;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.exp.api.ExpRun;
@@ -66,7 +62,6 @@ import org.labkey.api.security.ActionNames;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
-import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.NetworkDrive;
 import org.labkey.api.util.PageFlowUtil;
@@ -74,7 +69,6 @@ import org.labkey.api.util.Pair;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
-import org.labkey.assay.FileBasedModuleDataHandler;
 import org.labkey.vfs.FileLike;
 import org.labkey.vfs.FileSystemLike;
 import org.springframework.beans.MutablePropertyValues;
@@ -84,19 +78,16 @@ import org.springframework.validation.BindException;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
-import java.io.IOException;
+import java.nio.file.InvalidPathException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static org.labkey.api.assay.AssayDataCollector.PRIMARY_FILE;
 import static org.labkey.api.assay.AssayFileWriter.createFile;
-import static org.labkey.api.util.FileUtil.toFileForWrite;
 
 @ActionNames("importRun")
 @RequiresPermission(InsertPermission.class)
@@ -236,23 +227,31 @@ public class ImportRunApiAction extends MutatingApiAction<ImportRunApiAction.Imp
             }
             else
             {
-                // Resolve file under pipeline root
-                PipeRoot root = PipelineService.get().findPipelineRoot(getContainer());
-                if (root == null)
-                    throw new NotFoundException("Pipeline root not configured");
+                try
+                {
+                    // Resolve file under pipeline root
+                    PipeRoot root = PipelineService.get().findPipelineRoot(getContainer());
+                    if (root == null)
+                        throw new NotFoundException("Pipeline root not configured");
 
-                if (!root.hasPermission(getContainer(), getUser(), ReadPermission.class))
-                    throw new UnauthorizedException();
+                    if (!root.hasPermission(getContainer(), getUser(), ReadPermission.class))
+                        throw new UnauthorizedException();
 
-                // Attempt absolute path first, then relative path from pipeline root
-                File f = new File(runFilePath);
-                if (!root.isUnderRoot(f))
-                    f = root.resolvePath(runFilePath);
+                    // Attempt absolute path first, then relative path from pipeline root
+                    File f = new File(runFilePath);
+                    if (!root.isUnderRoot(f))
+                        f = root.resolvePath(runFilePath);
 
-                if (!NetworkDrive.exists(f) || !root.isUnderRoot(f))
+                    if (!NetworkDrive.exists(f) || !root.isUnderRoot(f))
+                        throw new NotFoundException("File not found: " + runFilePath);
+
+                    file = f;
+                }
+                catch (InvalidPathException e)
+                {
+                    LOG.info("Invalid path: " + runFilePath, e);
                     throw new NotFoundException("File not found: " + runFilePath);
-
-                file = f;
+                }
             }
         }
 


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/LabKey_2511Release_Premium_CommunitySqlserver_DailyASqlserver/3728152

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2780

#### Changes
- Handle exception for bad paths
- Use `/` instead of `\` when resolving paths

#### Tasks 📍
- Manual Testing - N/A
- Needs Automation - N/A
