### PR TITLE
Issue 54218: Escape special characters in form field names

### DIFF
--- a/api/src/org/labkey/api/assay/AssayFileWriter.java
+++ b/api/src/org/labkey/api/assay/AssayFileWriter.java
@@ -24,6 +24,7 @@ import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.provider.FileSystemAuditProvider;
 import org.labkey.api.collections.CollectionUtils;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.TableViewForm;
 import org.labkey.api.exp.ExperimentException;
 import org.labkey.api.exp.api.ExpProtocol;
 import org.labkey.api.pipeline.PipeRoot;
@@ -40,9 +41,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -229,72 +232,84 @@ public class AssayFileWriter<ContextType extends AssayRunUploadContext<? extends
 
     public Map<String, FileLike> savePostedFiles(ContextType context, @NotNull Set<String> parameterNames, boolean allowMultiple, boolean ensureExpData) throws ExperimentException, IOException
     {
+        if (!(context.getRequest() instanceof MultipartHttpServletRequest multipartRequest))
+            return Collections.emptyMap();
+
         Map<String, FileLike> files = CollectionUtils.enforceValueClass(new TreeMap<>(), FileLike.class);
         Set<String> originalFileNames = new HashSet<>();
-        if (context.getRequest() instanceof MultipartHttpServletRequest multipartRequest)
+        Map<String, String> encodedParameterNames = new HashMap<>();
+        for (String parameterName : parameterNames)
+            encodedParameterNames.put(TableViewForm.getMultiPartFormFieldNameForColumn(parameterName), parameterName);
+
+        Deque<FileLike> overflowFiles = new ArrayDeque<>();  // using a deque for easy removal of single elements
+        Set<String> unusedParameterNames = new HashSet<>(parameterNames);
+        List<FileSystemAuditProvider.FileSystemAuditEvent> auditEvents = new ArrayList<>();
+
+        for (Map.Entry<String, List<MultipartFile>> entry : multipartRequest.getMultiFileMap().entrySet())
         {
-            Iterator<Map.Entry<String, List<MultipartFile>>> iter = multipartRequest.getMultiFileMap().entrySet().iterator();
-            Deque<FileLike> overflowFiles = new ArrayDeque<>();  // using a deque for easy removal of single elements
-            Set<String> unusedParameterNames = new HashSet<>(parameterNames);
-            while (iter.hasNext())
-            {
-                Map.Entry<String, List<MultipartFile>> entry = iter.next();
-                if (parameterNames.contains(entry.getKey()))
-                {
-                    List<MultipartFile> multipartFiles = entry.getValue();
-                    boolean isAfterFirstFile = false;
-                    for (MultipartFile multipartFile : multipartFiles)
-                    {
-                        String fileName = getFileName(multipartFile);
-                        if (!fileName.isEmpty() && !originalFileNames.add(fileName))
-                        {
-                            throw new ExperimentException("The file '" + fileName + " ' was uploaded twice - all files must be unique");
-                        }
-                        if (!multipartFile.isEmpty())
-                        {
-                            FileLike dir = getFileTargetDir(context);
-                            FileLike file = FileUtil.findUniqueFileName(fileName, dir);
-                            multipartFile.transferTo(toFileForWrite(file));
-                            if (!dir.toURI().getPath().contains(TEMP_DIR_NAME))
-                            {
-                                FileSystemAuditProvider.FileSystemAuditEvent event = new FileSystemAuditProvider.FileSystemAuditEvent(context.getContainer(), allowMultiple ? "File field provided for assay import" : "Primary file provided for assay import");
-                                event.setProvidedFileName(fileName);
-                                event.setFile(file.getName());
-                                event.setDirectory(dir.toURI().getPath());
-                                AuditLogService.get().addEvent(context.getUser(), event);
-                            }
-                            if (!isAfterFirstFile)  // first file gets stored with multipartFile's name
-                            {
-                                files.put(multipartFile.getName(), file);
-                                isAfterFirstFile = true;
-                                unusedParameterNames.remove(multipartFile.getName());
-                            }
-                            else  // other files get stored in leftover keys later to store only one file per key (bit of a hack)
-                            {
-                                overflowFiles.add(file);
-                            }
+            if (!(encodedParameterNames.containsKey(entry.getKey()) || parameterNames.contains(entry.getKey())))
+                continue;
 
-                            if (ensureExpData)
-                                AbstractQueryUpdateService.ensureExpData(context.getUser(), context.getContainer(), toFileForWrite(file));
-                        }
-                    }
-                }
-            }
-            // now process overflow files, if any
-            for (String unusedParameterName : unusedParameterNames)
+            boolean isAfterFirstFile = false;
+            for (MultipartFile multipartFile : entry.getValue())
             {
-                if (overflowFiles.isEmpty())
-                    break;  // we're done
-                else
-                {
-                    files.put(unusedParameterName, overflowFiles.remove());
-                }
-            }
+                String fileName = getFileName(multipartFile);
+                if (!fileName.isEmpty() && !originalFileNames.add(fileName))
+                    throw new ExperimentException("The file '" + fileName + " ' was uploaded twice - all files must be unique");
 
-            if (!overflowFiles.isEmpty() && !allowMultiple)  // too many files; shouldn't happen, but if it does, throw an error
-                throw new ExperimentException("Tried to save too many files: number of keys is " + parameterNames.size() +
-                        ", but " + overflowFiles.size() + " extra file(s) were found.");
+                if (multipartFile.isEmpty())
+                    continue;
+
+                FileLike dir = getFileTargetDir(context);
+                FileLike file = FileUtil.findUniqueFileName(fileName, dir);
+                multipartFile.transferTo(toFileForWrite(file));
+                if (!dir.toURI().getPath().contains(TEMP_DIR_NAME))
+                {
+                    FileSystemAuditProvider.FileSystemAuditEvent event = new FileSystemAuditProvider.FileSystemAuditEvent(context.getContainer(), allowMultiple ? "File field provided for assay import" : "Primary file provided for assay import");
+                    event.setProvidedFileName(fileName);
+                    event.setFile(file.getName());
+                    event.setDirectory(dir.toURI().getPath());
+                    auditEvents.add(event);
+                }
+                if (!isAfterFirstFile)  // first file gets stored with multipartFile's name
+                {
+                    String name = multipartFile.getName();
+                    String param = encodedParameterNames.get(name);
+                    if (param == null && parameterNames.contains(name))
+                        param = name;
+                    if (param == null)
+                        throw new ExperimentException("No parameter name found for multipart file '" + name + "'");
+
+                    files.put(param, file);
+                    isAfterFirstFile = true;
+                    unusedParameterNames.remove(param);
+                }
+                else  // other files get stored in leftover keys later to store only one file per key (bit of a hack)
+                {
+                    overflowFiles.add(file);
+                }
+
+                if (ensureExpData)
+                    AbstractQueryUpdateService.ensureExpData(context.getUser(), context.getContainer(), toFileForWrite(file));
+            }
         }
+
+        if (!auditEvents.isEmpty())
+            AuditLogService.get().addEvents(context.getUser(), auditEvents);
+
+        // now process overflow files, if any
+        for (String unusedParameterName : unusedParameterNames)
+        {
+            if (overflowFiles.isEmpty())
+                break;  // we're done
+
+            files.put(unusedParameterName, overflowFiles.remove());
+        }
+
+        if (!overflowFiles.isEmpty() && !allowMultiple)  // too many files; shouldn't happen, but if it does, throw an error
+            throw new ExperimentException("Tried to save too many files: number of keys is " + parameterNames.size() +
+                    ", but " + overflowFiles.size() + " extra file(s) were found.");
+
         return files;
     }
 

--- a/api/src/org/labkey/api/assay/AssayRunDatabaseContext.java
+++ b/api/src/org/labkey/api/assay/AssayRunDatabaseContext.java
@@ -48,8 +48,6 @@ import java.util.Map;
 
 /**
  * Information about an assay run that has already been imported into the database.
- * User: jeckels
- * Date: Oct 7, 2011
  */
 public class AssayRunDatabaseContext<ProviderType extends AssayProvider> implements AssayRunUploadContext<ProviderType>
 {
@@ -193,14 +191,6 @@ public class AssayRunDatabaseContext<ProviderType extends AssayProvider> impleme
             }
         }
         return null;
-    }
-
-    @NotNull
-    @Override
-    public Map<Object, String> getInputDatas()
-    {
-        // CONSIDER: get the run's input datas
-        return Collections.emptyMap();
     }
 
     @Override

--- a/api/src/org/labkey/api/assay/AssayRunUploadContext.java
+++ b/api/src/org/labkey/api/assay/AssayRunUploadContext.java
@@ -36,7 +36,6 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.vfs.FileLike;
 
-import java.io.File;
 import java.util.Map;
 import java.util.Set;
 
@@ -113,7 +112,10 @@ public interface AssayRunUploadContext<ProviderType extends AssayProvider> exten
      * NOTE: These files will not be parsed or imported by the assay's DataHandler -- use {@link #getUploadedData()} instead.
      */
     @NotNull
-    Map<?, String> getInputDatas();
+    default Map<?, String> getInputDatas()
+    {
+        return emptyMap();
+    }
 
     @NotNull
     default Map<?, String> getOutputDatas()
@@ -181,16 +183,19 @@ public interface AssayRunUploadContext<ProviderType extends AssayProvider> exten
 
     void uploadComplete(ExpRun run) throws ExperimentException;
 
+    @Nullable
     default String getJobDescription()
     {
         return null;
     }
 
+    @Nullable
     default String getJobNotificationProvider()
     {
         return null;
     }
 
+    @Nullable
     default String getPipelineJobGUID()
     {
         return null;

--- a/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
+++ b/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
@@ -21,6 +21,7 @@ import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AbstractAssayProvider;
@@ -122,7 +123,7 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
     public Map<DomainProperty, String> getRunProperties() throws ExperimentException
     {
         if (_runProperties == null)
-            _runProperties = Collections.unmodifiableMap(getPropertyMapFromRequest(getProvider().getRunDomain(getProtocol())));
+            _runProperties = Collections.unmodifiableMap(getPropertyMapFromRequest(getProvider().getRunDomain(getProtocol()), true));
 
         return _runProperties;
     }
@@ -131,52 +132,61 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
     public Map<DomainProperty, String> getBatchProperties() throws ExperimentException
     {
         if (_batchProperties == null)
-            _batchProperties = Collections.unmodifiableMap(getPropertyMapFromRequest(getProvider().getBatchDomain(getProtocol())));
+            _batchProperties = Collections.unmodifiableMap(getPropertyMapFromRequest(getProvider().getBatchDomain(getProtocol()), false));
 
         return _batchProperties;
     }
 
-    protected Map<DomainProperty, String> getPropertyMapFromRequest(Domain domain) throws ExperimentException
+    protected Map<DomainProperty, String> getPropertyMapFromRequest(Domain domain, boolean isRunDomain) throws ExperimentException
     {
         List<? extends DomainProperty> columns = domain.getProperties();
         Map<DomainProperty, String> properties = new LinkedHashMap<>();
         Map<DomainProperty, FileLike> additionalFiles = getAdditionalPostedFiles(domain, columns);
         Map<DomainProperty, Object> defaults = getDefaultValues(domain, false);
+        boolean isMultiPartRequest = getRequest() instanceof MultipartHttpServletRequest;
 
         for (DomainProperty pd : columns)
         {
-            String propName = UploadWizardAction.getInputName(pd);
-            String value = StringUtils.trimToNull(getRequest().getParameter(propName));
-            if (pd.getPropertyDescriptor().getPropertyType() == PropertyType.BOOLEAN && (value == null || value.isEmpty()))
+            String propName = isMultiPartRequest ? UploadWizardAction.getMultiPartInputName(pd) : UploadWizardAction.getInputName(pd);
+            String rawValue = getRequest().getParameter(propName);
+            String value = StringUtils.trimToNull(rawValue);
+
+            if (PropertyType.BOOLEAN == pd.getPropertyDescriptor().getPropertyType() && value == null)
                 value = Boolean.FALSE.toString();
 
             if (AbstractAssayProvider.PARTICIPANT_VISIT_RESOLVER_PROPERTY_NAME.equalsIgnoreCase(pd.getName()) && value != null)
                 value = ParticipantVisitResolverType.Serializer.encode(value, getRequest());
 
-            if (additionalFiles.containsKey(pd))
-            {
-                if (BLANK_FILE.equals(additionalFiles.get(pd))) // file has been removed
-                    properties.put(pd, null);
-                else
-                    properties.put(pd, additionalFiles.get(pd).toNioPathForRead().toString());
-            }
-            else
-                properties.put(pd, value);
-
-            // Issue 54112: Retain previous file values when reimporting a run
             if (PropertyType.FILE_LINK == pd.getPropertyDescriptor().getPropertyType())
             {
-                boolean postedNewFile = additionalFiles.containsKey(pd);
-                String current = properties.get(pd);
-                boolean hasValue = current != null && !current.isEmpty();
-
-                if (!postedNewFile && !hasValue)
+                if (additionalFiles.containsKey(pd))
                 {
+                    // The file was explicitly removed
+                    if (BLANK_FILE.equals(additionalFiles.get(pd)))
+                    {
+                        // When this is a batch domain we set to Strings.EMPTY to
+                        // allow round-tripping removed values through the run step.
+                        properties.put(pd, isRunDomain ? null : Strings.EMPTY);
+                    }
+                    else
+                        properties.put(pd, additionalFiles.get(pd).toNioPathForRead().toString());
+                }
+                else if (Strings.EMPTY.equals(rawValue))
+                {
+                    // The file was previously removed
+                    properties.put(pd, null);
+                }
+                else if (StringUtils.trimToNull(properties.get(pd)) == null)
+                {
+                    // Issue 54112: Retain previous file values when reimporting a run
                     Object prior = defaults.get(pd);
                     if (prior != null)
                         properties.put(pd, prior.toString());
                 }
             }
+
+            if (!properties.containsKey(pd))
+                properties.put(pd, value);
         }
 
         return properties;
@@ -339,15 +349,20 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
         if (_additionalFiles == null)
             _additionalFiles = new HashMap<>();
 
+        // Additional files have already been computed for this domain
         if (_additionalFiles.containsKey(domain.getTypeURI()))
             return _additionalFiles.get(domain.getTypeURI());
+
+        // This is not a multipart request, so no files have been posted
+        if (!(getRequest() instanceof MultipartHttpServletRequest request))
+            return setAdditionalFilesEntry(domain, emptyMap());
 
         Map<String, DomainProperty> fileParameters = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
         for (DomainProperty pd : pds)
         {
             if (pd.getPropertyDescriptor().getPropertyType() == PropertyType.FILE_LINK)
-                fileParameters.put(UploadWizardAction.getInputName(pd), pd);
+                fileParameters.put(pd.getName(), pd);
         }
 
         if (fileParameters.isEmpty())
@@ -358,13 +373,9 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
 
         try
         {
-            // Initialize member variable so we know that we've already tried to save the posted files in case of error
             Map<String, FileLike> postedFiles = writer.savePostedFiles(this, fileParameters.keySet(), false, false);
             for (Map.Entry<String, FileLike> entry : postedFiles.entrySet())
                 additionalFiles.put(fileParameters.get(entry.getKey()), entry.getValue());
-
-            if (!(getViewContext().getRequest() instanceof MultipartHttpServletRequest request))
-                return setAdditionalFilesEntry(domain, additionalFiles);
 
             File assayDirectory = getAssayDirectory(getContainer(), null);
             Map<String, MultipartFile> requestFiles = request.getFileMap();
@@ -372,7 +383,7 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
             // Hidden values in form containing previously uploaded files if the previous upload resulted in error
             for (Map.Entry<String, DomainProperty> entry : fileParameters.entrySet())
             {
-                String fileParam = entry.getKey();
+                String fileParam = UploadWizardAction.getMultiPartInputName(entry.getValue());
                 DomainProperty domainProperty = entry.getValue();
                 MultipartFile multiFile = requestFiles.get(fileParam);
 

--- a/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
+++ b/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
@@ -83,6 +83,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
 
 public class AssayRunUploadForm<ProviderType extends AssayProvider> extends ProtocolIdForm implements AssayRunUploadContext<ProviderType>
 {
@@ -99,7 +100,7 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
     private Map<String, FileLike> _uploadedData;
     private boolean _successfulUploadComplete;
     private String _uploadAttemptID = GUID.makeGUID();
-    private Map<DomainProperty, FileLike> _additionalFiles;
+    private Map<String, Map<DomainProperty, FileLike>> _additionalFiles;
     private Long _batchId;
     private Long _reRunId;
     private String _severityLevel;
@@ -121,25 +122,25 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
     public Map<DomainProperty, String> getRunProperties() throws ExperimentException
     {
         if (_runProperties == null)
-            _runProperties = getPropertyMapFromRequest(getProvider().getRunDomain(getProtocol()));
+            _runProperties = Collections.unmodifiableMap(getPropertyMapFromRequest(getProvider().getRunDomain(getProtocol())));
 
-        return Collections.unmodifiableMap(_runProperties);
+        return _runProperties;
     }
 
     @Override
     public Map<DomainProperty, String> getBatchProperties() throws ExperimentException
     {
         if (_batchProperties == null)
-            _batchProperties = getPropertyMapFromRequest(getProvider().getBatchDomain(getProtocol()));
+            _batchProperties = Collections.unmodifiableMap(getPropertyMapFromRequest(getProvider().getBatchDomain(getProtocol())));
 
-        return Collections.unmodifiableMap(_batchProperties);
+        return _batchProperties;
     }
 
     protected Map<DomainProperty, String> getPropertyMapFromRequest(Domain domain) throws ExperimentException
     {
         List<? extends DomainProperty> columns = domain.getProperties();
         Map<DomainProperty, String> properties = new LinkedHashMap<>();
-        Map<DomainProperty, FileLike> additionalFiles = getAdditionalPostedFiles(columns);
+        Map<DomainProperty, FileLike> additionalFiles = getAdditionalPostedFiles(domain, columns);
         Map<DomainProperty, Object> defaults = getDefaultValues(domain, false);
 
         for (DomainProperty pd : columns)
@@ -282,7 +283,7 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
     public void init() throws ExperimentException
     {
         AssayDataCollector collector = getSelectedDataCollector();
-        if(null != collector)
+        if (null != collector)
         {
             collector.initDir(this);
         }
@@ -312,9 +313,17 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
         return _uploadedData;
     }
 
-    public Map<DomainProperty, FileLike> getAdditionalFiles()
+    public Map<DomainProperty, FileLike> getAdditionalFiles(@NotNull Domain domain)
     {
-        return _additionalFiles;
+        return _additionalFiles.get(domain.getTypeURI());
+    }
+
+    private Map<DomainProperty, FileLike> setAdditionalFilesEntry(@NotNull Domain domain, Map<DomainProperty, FileLike> files)
+    {
+        var _files = unmodifiableMap(files);
+        _additionalFiles.put(domain.getTypeURI(), _files);
+
+        return _files;
     }
 
     public static File getAssayDirectory(Container c, File root)
@@ -325,10 +334,13 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
             return new File(PipelineService.get().findPipelineRoot(c).getRootPath().getAbsolutePath(), AssayFileWriter.DIR_NAME);
     }
 
-    public Map<DomainProperty, FileLike> getAdditionalPostedFiles(List<? extends DomainProperty> pds) throws ExperimentException
+    private Map<DomainProperty, FileLike> getAdditionalPostedFiles(Domain domain, List<? extends DomainProperty> pds) throws ExperimentException
     {
-        if (_additionalFiles != null)
-            return _additionalFiles;
+        if (_additionalFiles == null)
+            _additionalFiles = new HashMap<>();
+
+        if (_additionalFiles.containsKey(domain.getTypeURI()))
+            return _additionalFiles.get(domain.getTypeURI());
 
         Map<String, DomainProperty> fileParameters = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         List<String> filePdNames = new ArrayList<>();
@@ -343,32 +355,34 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
         }
 
         if (fileParameters.isEmpty())
-            return _additionalFiles = emptyMap();
+            return setAdditionalFilesEntry(domain, emptyMap());
 
         AssayFileWriter<AssayRunUploadForm<ProviderType>> writer = new AssayFileWriter<>();
+        Map<DomainProperty, FileLike> additionalFiles = new HashMap<>();
+
         try
         {
             // Initialize member variable so we know that we've already tried to save the posted files in case of error
-            _additionalFiles = new HashMap<>();
             Map<String, FileLike> postedFiles = writer.savePostedFiles(this, fileParameters.keySet(), false, false);
             for (Map.Entry<String, FileLike> entry : postedFiles.entrySet())
-                _additionalFiles.put(fileParameters.get(entry.getKey()), entry.getValue());
+                additionalFiles.put(fileParameters.get(entry.getKey()), entry.getValue());
 
             if (!(getViewContext().getRequest() instanceof MultipartHttpServletRequest request))
-                return _additionalFiles;
+                return setAdditionalFilesEntry(domain, additionalFiles);
 
             File assayDirectory = getAssayDirectory(getContainer(), null);
+            Map<String, MultipartFile> requestFiles = request.getFileMap();
 
             // Hidden values in form containing previously uploaded files if the previous upload resulted in error
             for (String fileParam : filePdNames)
             {
                 DomainProperty domainProperty = fileParameters.get(fileParam);
-                MultipartFile multiFile = request.getFileMap().get(fileParam);
+                MultipartFile multiFile = requestFiles.get(fileParam);
 
                 // If the file is removed from form after error, override hidden file name with an empty file
-                if (null != multiFile && multiFile.getOriginalFilename().isEmpty())
+                if (null != multiFile && StringUtils.trimToNull(multiFile.getOriginalFilename()) == null)
                 {
-                    _additionalFiles.put(domainProperty, BLANK_FILE);
+                    additionalFiles.put(domainProperty, BLANK_FILE);
                     continue;
                 }
 
@@ -379,8 +393,8 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
                 // Only add a hidden file parameter if it is a valid file in the pipeline root directory and
                 // a new file hasn't been uploaded for that parameter
                 File previousFile = FileUtil.appendName(assayDirectory, previousFileName);
-                if (previousFile.isFile() && FileUtils.directoryContains(assayDirectory, previousFile) && !_additionalFiles.containsKey(domainProperty))
-                    _additionalFiles.put(domainProperty, FileSystemLike.wrapFile(previousFile));
+                if (previousFile.isFile() && FileUtils.directoryContains(assayDirectory, previousFile) && !additionalFiles.containsKey(domainProperty))
+                    additionalFiles.put(domainProperty, FileSystemLike.wrapFile(previousFile));
             }
         }
         catch (IOException e)
@@ -388,14 +402,7 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
             throw new RuntimeException(e);
         }
 
-        return _additionalFiles;
-    }
-
-    @NotNull
-    @Override
-    public Map<?, String> getInputDatas()
-    {
-        return emptyMap();
+        return setAdditionalFilesEntry(domain, additionalFiles);
     }
 
     @Override

--- a/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
+++ b/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
@@ -404,12 +404,9 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
                 // Only add a hidden file parameter if it is a valid file in the pipeline root directory and
                 // a new file hasn't been uploaded for that parameter
                 Path path = FileUtil.stringToPath(getContainer(), previousFilePath, false);
-                if (FileUtil.isFileAndExists(path))
-                {
-                    File previousFile = path.toFile();
-                    if (previousFile.isFile() && FileUtils.directoryContains(assayDirectory, previousFile))
-                        additionalFiles.put(domainProperty, FileSystemLike.wrapFile(previousFile));
-                }
+                File previousFile = FileUtil.appendName(assayDirectory, path.getFileName().toString());
+                if (previousFile.isFile() && FileUtils.directoryContains(assayDirectory, previousFile))
+                    additionalFiles.put(domainProperty, FileSystemLike.wrapFile(previousFile));
             }
         }
         catch (IOException e)

--- a/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
+++ b/api/src/org/labkey/api/assay/actions/AssayRunUploadForm.java
@@ -72,7 +72,7 @@ import org.springframework.web.multipart.MultipartHttpServletRequest;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -343,15 +343,11 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
             return _additionalFiles.get(domain.getTypeURI());
 
         Map<String, DomainProperty> fileParameters = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-        List<String> filePdNames = new ArrayList<>();
 
         for (DomainProperty pd : pds)
         {
             if (pd.getPropertyDescriptor().getPropertyType() == PropertyType.FILE_LINK)
-            {
                 fileParameters.put(UploadWizardAction.getInputName(pd), pd);
-                filePdNames.add(pd.getName());
-            }
         }
 
         if (fileParameters.isEmpty())
@@ -374,9 +370,10 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
             Map<String, MultipartFile> requestFiles = request.getFileMap();
 
             // Hidden values in form containing previously uploaded files if the previous upload resulted in error
-            for (String fileParam : filePdNames)
+            for (Map.Entry<String, DomainProperty> entry : fileParameters.entrySet())
             {
-                DomainProperty domainProperty = fileParameters.get(fileParam);
+                String fileParam = entry.getKey();
+                DomainProperty domainProperty = entry.getValue();
                 MultipartFile multiFile = requestFiles.get(fileParam);
 
                 // If the file is removed from form after error, override hidden file name with an empty file
@@ -386,15 +383,22 @@ public class AssayRunUploadForm<ProviderType extends AssayProvider> extends Prot
                     continue;
                 }
 
-                String previousFileName = request.getParameter(fileParam);
-                if (previousFileName == null)
+                if (additionalFiles.containsKey(domainProperty))
+                    continue;
+
+                String previousFilePath = StringUtils.trimToNull(request.getParameter(fileParam));
+                if (previousFilePath == null)
                     continue;
 
                 // Only add a hidden file parameter if it is a valid file in the pipeline root directory and
                 // a new file hasn't been uploaded for that parameter
-                File previousFile = FileUtil.appendName(assayDirectory, previousFileName);
-                if (previousFile.isFile() && FileUtils.directoryContains(assayDirectory, previousFile) && !additionalFiles.containsKey(domainProperty))
-                    additionalFiles.put(domainProperty, FileSystemLike.wrapFile(previousFile));
+                Path path = FileUtil.stringToPath(getContainer(), previousFilePath, false);
+                if (FileUtil.isFileAndExists(path))
+                {
+                    File previousFile = path.toFile();
+                    if (previousFile.isFile() && FileUtils.directoryContains(assayDirectory, previousFile))
+                        additionalFiles.put(domainProperty, FileSystemLike.wrapFile(previousFile));
+                }
             }
         }
         catch (IOException e)

--- a/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
+++ b/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
@@ -408,7 +408,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
             // Add unique name of uploaded files as hidden parameters
             Map<DomainProperty, String> fileProps = new HashMap<>();
             for (Map.Entry<DomainProperty, FileLike> entry : form.getAdditionalFiles(domain).entrySet())
-                fileProps.put(entry.getKey(), entry.getValue().getName());
+                fileProps.put(entry.getKey(), entry.getValue().toString());
 
             addHiddenProperties(fileProps, view);
         }

--- a/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
+++ b/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
@@ -767,9 +767,14 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
     public static String getInputName(DomainProperty property, @Nullable String disambiguationId)
     {
         if (disambiguationId != null)
-            return TableViewForm.getMultiPartFormFieldNameForColumn(disambiguationId + "_" + property.getName());
+            return TableViewForm.getFormFieldNameForColumn(disambiguationId + "_" + property.getName());
         else
-            return TableViewForm.getMultiPartFormFieldNameForColumn(property.getName());
+            return TableViewForm.getFormFieldNameForColumn(property.getName());
+    }
+
+    public static String getMultiPartInputName(DomainProperty property)
+    {
+        return TableViewForm.getMultiPartFormFieldNameForColumn(property.getName());
     }
 
     public static String getInputName(DomainProperty property)

--- a/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
+++ b/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
@@ -220,14 +220,12 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
 
                 return new HtmlView(msg);
             } //pipe root does not exist
-            else if (isCloudAndUnsupported(pipeRoot, _protocol))
+            else if (isCloudAndUnsupported(pipeRoot))
             {
                 return HtmlView.err("The pipeline provider for this assay does not support using cloud-based storage. Please contact your administrator.");
             }
-            else
-            {
-                return getBatchPropertiesView(form, false, errors);
-            }
+
+            return getBatchPropertiesView(form, false, errors);
         }
         else
         {
@@ -291,7 +289,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         return handler.getSuccessUrl(form);
     }
 
-    private boolean isCloudAndUnsupported(@NotNull PipeRoot pipeRoot, ExpProtocol protocol)
+    private boolean isCloudAndUnsupported(@NotNull PipeRoot pipeRoot)
     {
         return (pipeRoot.isCloudRoot() &&
                 null != _provider &&
@@ -340,7 +338,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
                 parameterValueMap.put(dp.getName(), runProperties.get(dp));
             }
         }
-        catch(ExperimentException e)
+        catch (ExperimentException e)
         {
             errors.addError(new ObjectError("main", null, null, e.getMessage()));
         }
@@ -378,7 +376,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
             view.setInitialValues(inputNameToValue);
         }
 
-        // issue 19090: add hidden form field for properties with default value that are hidden from insert view
+        // Issue 19090: add a hidden form field for properties with default value that are hidden from the insert view
         for (DomainProperty prop : properties)
         {
             String inputName = getInputName(prop);
@@ -507,11 +505,11 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
     }
 
     /**
-     * Decide whether or not to show the batch properties step in the wizard.
+     * Decide whether to show the batch properties step in the wizard.
      * @param form the form with posted values
      * @param batchDomain domain for the batch fields
      */
-    protected boolean showBatchStep(FormType form, Domain batchDomain) throws ServletException
+    protected boolean showBatchStep(FormType form, Domain batchDomain)
     {
         return batchDomain != null && !batchDomain.getProperties().isEmpty();
     }
@@ -666,12 +664,12 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
 
         VBox vbox = new VBox();
 
-        JspView<AssayRunUploadForm> warningsView = new JspView<>("/org/labkey/api/assay/actions/newUploadWarnings.jsp", newRunForm);
+        JspView<AssayRunUploadForm<?>> warningsView = new JspView<>("/org/labkey/api/assay/actions/newUploadWarnings.jsp", newRunForm);
         if (newRunForm.getTransformResult().getWarnings() != null)
             warningsView.setTitle("Transform Warnings");
         vbox.addView(warningsView);
 
-        JspView<AssayRunUploadForm> assayPropsView = new JspView<>("/org/labkey/assay/view/newUploadAssayProperties.jsp", newRunForm);
+        JspView<AssayRunUploadForm<?>> assayPropsView = new JspView<>("/org/labkey/assay/view/newUploadAssayProperties.jsp", newRunForm);
         assayPropsView.setTitle("Assay Properties");
         vbox.addView(assayPropsView);
 
@@ -687,7 +685,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
             AssayWellExclusionService svc = AssayWellExclusionService.getProvider(_protocol);
             if (svc != null)
             {
-                HttpView exclusionWarning = svc.getAssayReImportWarningView(getContainer(), newRunForm.getReRun());
+                HttpView<?> exclusionWarning = svc.getAssayReImportWarningView(getContainer(), newRunForm.getReRun());
                 if (exclusionWarning != null)
                 {
                     vbox.addView(exclusionWarning);
@@ -695,7 +693,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
             }
 
             AssayQCService qcService = AssayQCService.getProvider();
-            HttpView qcWarning = qcService.getAssayReImportWarningView(getContainer(), newRunForm.getReRun());
+            HttpView<?> qcWarning = qcService.getAssayReImportWarningView(getContainer(), newRunForm.getReRun());
             if (qcWarning != null)
             {
                 vbox.addView(qcWarning);
@@ -769,9 +767,9 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
     public static String getInputName(DomainProperty property, String disambiguationId)
     {
         if (disambiguationId != null)
-            return disambiguationId + "_" + property.getName();
+            return TableViewForm.getMultiPartFormFieldNameForColumn(disambiguationId + "_" + property.getName());
         else
-            return property.getName();
+            return TableViewForm.getMultiPartFormFieldNameForColumn(property.getName());
     }
 
     public static String getInputName(DomainProperty property)
@@ -835,14 +833,14 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
     }
 
     @Override
-    @Nullable
     public void addNavTrail(NavTree root)
     {
         if (null != _protocol)
         {
-            ActionURL helper = PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), _protocol);
-            root.addChild("Assay List", PageFlowUtil.urlProvider(AssayUrls.class).getAssayListURL(getContainer()));
-            root.addChild(_protocol.getName(), PageFlowUtil.urlProvider(AssayUrls.class).getAssayRunsURL(getContainer(), _protocol));
+            AssayUrls urlProvider = PageFlowUtil.urlProvider(AssayUrls.class);
+            ActionURL helper = urlProvider.getAssayRunsURL(getContainer(), _protocol);
+            root.addChild("Assay List", urlProvider.getAssayListURL(getContainer()));
+            root.addChild(_protocol.getName(), urlProvider.getAssayRunsURL(getContainer(), _protocol));
             String finalChild = "Data Import";
             if (_stepDescription != null)
             {
@@ -951,14 +949,14 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         }
 
         @Override
-        public boolean executeStep(FormType form, BindException errors) throws ServletException, SQLException, ExperimentException
+        public boolean executeStep(FormType form, BindException errors)
         {
             // nothing to handle but need to show the run step handler
             return false;
         }
 
         @Override
-        public ModelAndView getNextStep(FormType form, BindException errors) throws ServletException, SQLException, ExperimentException
+        public ModelAndView getNextStep(FormType form, BindException errors) throws ServletException, ExperimentException
         {
             if ((form.isResetDefaultValues() || errors.hasErrors()) && showBatchStep(form, form.getProvider().getBatchDomain(form.getProtocol())))
                 return getBatchPropertiesView(form, !form.isResetDefaultValues(), errors);
@@ -1068,8 +1066,8 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
             {
                 for (ValidationError error : e.getErrors())
                 {
-                    if (error instanceof PropertyValidationError)
-                        errors.addError(new FieldError("AssayUploadForm", ((PropertyValidationError)error).getProperty(), null, false,
+                    if (error instanceof PropertyValidationError pve)
+                        errors.addError(new FieldError("AssayUploadForm", pve.getProperty(), null, false,
                                 new String[]{ERROR_MSG}, new Object[0], error.getMessage() == null ? error.toString() : error.getMessage()));
                     else
                         errors.reject(ERROR_MSG, error.getMessage() == null ? error.toString() : error.getMessage());

--- a/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
+++ b/api/src/org/labkey/api/assay/actions/UploadWizardAction.java
@@ -95,6 +95,7 @@ import org.labkey.api.view.ViewServlet;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.writer.ContainerUser;
 import org.labkey.api.writer.HtmlWriter;
+import org.labkey.vfs.FileLike;
 import org.springframework.context.MessageSourceResolvable;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
@@ -127,9 +128,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
     protected ExpProtocol _protocol;
     protected AssayProtocolSchema _protocolSchema;
     protected ExpRun _run;
-
     private final Map<String, StepHandler<FormType>> _stepHandlers = new HashMap<>();
-
     protected String _stepDescription;
 
     public UploadWizardAction()
@@ -404,13 +403,14 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         view.getDataRegion().addHiddenFormField("uploadAttemptID", form.getUploadAttemptID());
         if (form.isAllowCrossRunFileInputs())
             view.getDataRegion().addHiddenFormField("allowCrossRunFileInputs", "true");
-        if (errorReshow)
+        if (errorReshow && domain != null)
         {
             // Add unique name of uploaded files as hidden parameters
-            for (DomainProperty dp : form.getAdditionalFiles().keySet())
-            {
-                view.getDataRegion().addHiddenFormField(dp.getName(), form.getAdditionalFiles().get(dp).getName());
-            }
+            Map<DomainProperty, String> fileProps = new HashMap<>();
+            for (Map.Entry<DomainProperty, FileLike> entry : form.getAdditionalFiles(domain).entrySet())
+                fileProps.put(entry.getKey(), entry.getValue().getName());
+
+            addHiddenProperties(fileProps, view);
         }
         if (form.getReRunId() != null)
         {
@@ -457,7 +457,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
             inputNameToValue.put(propName, propValue);
     }
 
-    private ModelAndView getBatchPropertiesView(FormType runForm, boolean errorReshow, BindException errors) throws ServletException, ExperimentException
+    private ModelAndView getBatchPropertiesView(FormType runForm, boolean errorReshow, BindException errors) throws ExperimentException
     {
         // Check if the user is trying to replace a run that's already been replaced
         if (runForm.getReRun() != null)
@@ -764,7 +764,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         addHiddenProperties(newRunForm.getRunProperties(), insertView);
     }
 
-    public static String getInputName(DomainProperty property, String disambiguationId)
+    public static String getInputName(DomainProperty property, @Nullable String disambiguationId)
     {
         if (disambiguationId != null)
             return TableViewForm.getMultiPartFormFieldNameForColumn(disambiguationId + "_" + property.getName());
@@ -779,21 +779,15 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
 
     protected void addHiddenProperties(Map<DomainProperty, String> properties, InsertView insertView)
     {
-        for (Map.Entry<DomainProperty, String> entry : properties.entrySet())
-        {
-            String name = entry.getKey().getName();
-            String value = entry.getValue();
-            insertView.getDataRegion().addHiddenFormField(name, value);
-        }
+        addHiddenProperties(properties, insertView, null);
     }
 
-    protected void addHiddenProperties(Map<DomainProperty, String> properties, InsertView insertView, String disambiguationId)
+    protected void addHiddenProperties(Map<DomainProperty, String> properties, InsertView insertView, @Nullable String disambiguationId)
     {
         for (Map.Entry<DomainProperty, String> entry : properties.entrySet())
         {
             String name = getInputName(entry.getKey(), disambiguationId);
-            String value = entry.getValue();
-            insertView.getDataRegion().addHiddenFormField(name, value);
+            insertView.getDataRegion().addHiddenFormField(name, entry.getValue());
         }
     }
 
@@ -956,7 +950,7 @@ public class UploadWizardAction<FormType extends AssayRunUploadForm<ProviderType
         }
 
         @Override
-        public ModelAndView getNextStep(FormType form, BindException errors) throws ServletException, ExperimentException
+        public ModelAndView getNextStep(FormType form, BindException errors) throws ExperimentException
         {
             if ((form.isResetDefaultValues() || errors.hasErrors()) && showBatchStep(form, form.getProvider().getBatchDomain(form.getProtocol())))
                 return getBatchPropertiesView(form, !form.isResetDefaultValues(), errors);

--- a/api/src/org/labkey/api/assay/pipeline/AssayRunAsyncContext.java
+++ b/api/src/org/labkey/api/assay/pipeline/AssayRunAsyncContext.java
@@ -343,13 +343,6 @@ public class AssayRunAsyncContext<ProviderType extends AssayProvider> implements
         return _uploadedData;
     }
 
-    @NotNull
-    @Override
-    public Map<Object, String> getInputDatas()
-    {
-        return Collections.emptyMap();
-    }
-
     @Override
     public boolean isAllowCrossRunFileInputs()
     {

--- a/api/src/org/labkey/api/data/AbstractFileDisplayColumn.java
+++ b/api/src/org/labkey/api/data/AbstractFileDisplayColumn.java
@@ -286,7 +286,7 @@ public abstract class AbstractFileDisplayColumn extends DataColumn
             if (null != filename)
             {
                 // Existing value, so tell the user the file name, allow the file to be removed, and a new file uploaded
-                renderThumbnailAndRemoveLink(out, ctx, formFieldName, filename, value, input);
+                renderThumbnailAndRemoveLink(out, ctx, getBoundColumn(), filename, value, input);
             }
             else
             {
@@ -307,14 +307,14 @@ public abstract class AbstractFileDisplayColumn extends DataColumn
         return "Previous file " + filename + " will be removed.";
     }
 
-    private void renderThumbnailAndRemoveLink(HtmlWriter out, RenderContext ctx, String fieldName, String filename, Object value, InputBuilder<?> filePicker)
+    private void renderThumbnailAndRemoveLink(HtmlWriter out, RenderContext ctx, ColumnInfo column, String filename, Object value, InputBuilder<?> filePicker)
     {
         String divId = GUID.makeGUID();
         String linkId = "remove" + divId;
 
         DIV(
             id(divId)
-                .data("fieldName", fieldName)
+                .data("fieldName", column.getName())
                 .cl("lk-remove-file"),
             (Renderable) ret -> {
                 renderIconAndFilename(ctx, out, value instanceof String s ? s : filename, false, false);

--- a/api/src/org/labkey/api/data/AbstractFileDisplayColumn.java
+++ b/api/src/org/labkey/api/data/AbstractFileDisplayColumn.java
@@ -286,7 +286,7 @@ public abstract class AbstractFileDisplayColumn extends DataColumn
             if (null != filename)
             {
                 // Existing value, so tell the user the file name, allow the file to be removed, and a new file uploaded
-                renderThumbnailAndRemoveLink(out, ctx, formFieldName, filename, input);
+                renderThumbnailAndRemoveLink(out, ctx, formFieldName, filename, value, input);
             }
             else
             {
@@ -307,7 +307,7 @@ public abstract class AbstractFileDisplayColumn extends DataColumn
         return "Previous file " + filename + " will be removed.";
     }
 
-    private void renderThumbnailAndRemoveLink(HtmlWriter out, RenderContext ctx, String fieldName, String filename, InputBuilder<?> filePicker)
+    private void renderThumbnailAndRemoveLink(HtmlWriter out, RenderContext ctx, String fieldName, String filename, Object value, InputBuilder<?> filePicker)
     {
         String divId = GUID.makeGUID();
         String linkId = "remove" + divId;
@@ -317,7 +317,7 @@ public abstract class AbstractFileDisplayColumn extends DataColumn
                 .data("fieldName", fieldName)
                 .cl("lk-remove-file"),
             (Renderable) ret -> {
-                renderIconAndFilename(ctx, out, filename, false, false);
+                renderIconAndFilename(ctx, out, value instanceof String s ? s : filename, false, false);
                 out.write(HtmlString.NBSP);
                 out.write("[");
                 out.write(LinkBuilder.simpleLink("remove", "#").id(linkId));

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -591,7 +591,7 @@ public class TableViewForm extends ViewForm implements HasBindParameters
             }
             else if (getRequest() instanceof MultipartHttpServletRequest request)
             {
-                String fieldName = getFormFieldName(column);
+                String fieldName = getMultiPartFormFieldName(column);
                 Object typedValue = _getTypedValues().get(fieldName);
 
                 if (typedValue != null)
@@ -760,7 +760,7 @@ public class TableViewForm extends ViewForm implements HasBindParameters
     private static final char BACKSLASH = '\\';
     private static final String SPECIAL_CHARS = BACKSLASH + "\";=,";
 
-    private static String getFormFieldNameForColumn(@NotNull String columnName)
+    public static String getFormFieldNameForColumn(@NotNull String columnName)
     {
         StringBuilder sb = new StringBuilder();
         for (char c : columnName.toCharArray())
@@ -775,12 +775,17 @@ public class TableViewForm extends ViewForm implements HasBindParameters
 
     public String getFormFieldName(@NotNull ColumnInfo column)
     {
-        return DataIteratorUtil.MatchType.multiPartFormData.getMatchedName(getFormFieldNameForColumn(column.getName()));
+        return getFormFieldNameForColumn(column.getName());
     }
 
     public static String getMultiPartFormFieldNameForColumn(@NotNull String columnName)
     {
         return DataIteratorUtil.MatchType.multiPartFormData.getMatchedName(getFormFieldNameForColumn(columnName));
+    }
+
+    public String getMultiPartFormFieldName(@NotNull ColumnInfo column)
+    {
+        return getMultiPartFormFieldNameForColumn(column.getName());
     }
 
     @Nullable

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -591,7 +591,7 @@ public class TableViewForm extends ViewForm implements HasBindParameters
             }
             else if (getRequest() instanceof MultipartHttpServletRequest request)
             {
-                String fieldName = getMultiPartFormFieldName(column);
+                String fieldName = getFormFieldName(column);
                 Object typedValue = _getTypedValues().get(fieldName);
 
                 if (typedValue != null)
@@ -707,7 +707,6 @@ public class TableViewForm extends ViewForm implements HasBindParameters
         _values = null;
     }
 
-
     public void validateBind(BindException errors)
     {
         populateValues(errors);
@@ -718,12 +717,10 @@ public class TableViewForm extends ViewForm implements HasBindParameters
         return _oldValues;
     }
 
-
     public void setOldValues(Object oldValues)
     {
         _oldValues = oldValues;
     }
-
 
     public void forceReselect()
     {
@@ -733,7 +730,6 @@ public class TableViewForm extends ViewForm implements HasBindParameters
         setPkVals(pk);
         setDataLoaded(false);
     }
-
 
     protected Class<?> getTruePropType(String propName)
     {
@@ -764,7 +760,7 @@ public class TableViewForm extends ViewForm implements HasBindParameters
     private static final char BACKSLASH = '\\';
     private static final String SPECIAL_CHARS = BACKSLASH + "\";=,";
 
-    public static String getFormFieldNameForColumn(@NotNull String columnName)
+    private static String getFormFieldNameForColumn(@NotNull String columnName)
     {
         StringBuilder sb = new StringBuilder();
         for (char c : columnName.toCharArray())
@@ -779,17 +775,12 @@ public class TableViewForm extends ViewForm implements HasBindParameters
 
     public String getFormFieldName(@NotNull ColumnInfo column)
     {
-        return getFormFieldNameForColumn(column.getName());
+        return DataIteratorUtil.MatchType.multiPartFormData.getMatchedName(getFormFieldNameForColumn(column.getName()));
     }
 
     public static String getMultiPartFormFieldNameForColumn(@NotNull String columnName)
     {
         return DataIteratorUtil.MatchType.multiPartFormData.getMatchedName(getFormFieldNameForColumn(columnName));
-    }
-
-    public String getMultiPartFormFieldName(@NotNull ColumnInfo column)
-    {
-        return getMultiPartFormFieldNameForColumn(column.getName());
     }
 
     @Nullable

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -756,7 +756,7 @@ public class TableViewForm extends ViewForm implements HasBindParameters
         return null==column ? propName : column.getLabel();
     }
 
-    // RFC 2616 / RFC 7230: Escape characters inside the field name
+    // Issue 54218: RFC 2616 / RFC 7230: Escape characters inside the field name
     private static final char BACKSLASH = '\\';
     private static final String SPECIAL_CHARS = BACKSLASH + "\";=,";
 

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -31,6 +31,7 @@ import org.labkey.api.action.HasBindParameters;
 import org.labkey.api.action.NullSafeBindException;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.dataiterator.DataIteratorUtil;
 import org.labkey.api.ontology.Quantity;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
@@ -759,20 +760,64 @@ public class TableViewForm extends ViewForm implements HasBindParameters
         return null==column ? propName : column.getLabel();
     }
 
+    // RFC 2616 / RFC 7230: Escape characters inside the field name
+    private static final char BACKSLASH = '\\';
+    private static final String SPECIAL_CHARS = BACKSLASH + "\";=,";
+
+    public static String getFormFieldNameForColumn(@NotNull String columnName)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (char c : columnName.toCharArray())
+        {
+            if (SPECIAL_CHARS.indexOf(c) >= 0)
+                sb.append(BACKSLASH);
+            sb.append(c);
+        }
+
+        return sb.toString();
+    }
+
     public String getFormFieldName(@NotNull ColumnInfo column)
     {
-        return column.getName();
+        return getFormFieldNameForColumn(column.getName());
+    }
+
+    public static String getMultiPartFormFieldNameForColumn(@NotNull String columnName)
+    {
+        return DataIteratorUtil.MatchType.multiPartFormData.getMatchedName(getFormFieldNameForColumn(columnName));
     }
 
     public String getMultiPartFormFieldName(@NotNull ColumnInfo column)
     {
-        return getFormFieldName(column);
+        return getMultiPartFormFieldNameForColumn(column.getName());
     }
 
     @Nullable
-    public ColumnInfo getColumnByFormFieldName(@NotNull String name)
+    public ColumnInfo getColumnByFormFieldName(@NotNull String fieldName)
     {
-        return null == getTable() ? null : getTable().getColumn(name);
+        if (null == getTable())
+            return null;
+
+        StringBuilder sb = new StringBuilder(fieldName.length());
+        boolean escaping = false;
+        for (char c : fieldName.toCharArray())
+        {
+            if (escaping)
+            {
+                sb.append(c);
+                escaping = false;
+            }
+            else if (c == BACKSLASH)
+                escaping = true;
+            else
+                sb.append(c);
+        }
+
+        // Issue 54094: Ensure it works when backslash is the last character
+        if (escaping)
+            sb.append(BACKSLASH);
+
+        return getTable().getColumn(sb.toString());
     }
 
     @Override

--- a/api/src/org/labkey/api/data/TableViewForm.java
+++ b/api/src/org/labkey/api/data/TableViewForm.java
@@ -785,7 +785,7 @@ public class TableViewForm extends ViewForm implements HasBindParameters
 
     public String getMultiPartFormFieldName(@NotNull ColumnInfo column)
     {
-        return getMultiPartFormFieldNameForColumn(column.getName());
+        return DataIteratorUtil.MatchType.multiPartFormData.getMatchedName(getFormFieldName(column));
     }
 
     @Nullable

--- a/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
+++ b/api/src/org/labkey/api/qc/TsvDataExchangeHandler.java
@@ -1351,13 +1351,6 @@ public class TsvDataExchangeHandler implements DataExchangeHandler
             return emptyMap();
         }
 
-        @NotNull
-        @Override
-        public Map<Object, String> getInputDatas()
-        {
-            return emptyMap();
-        }
-
         @Override
         public AssayProvider getProvider()
         {

--- a/api/src/org/labkey/api/query/QueryUpdateForm.java
+++ b/api/src/org/labkey/api/query/QueryUpdateForm.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableViewForm;
-import org.labkey.api.dataiterator.DataIteratorUtil;
 import org.labkey.api.view.ViewContext;
 import org.springframework.validation.BindException;
 
@@ -68,10 +67,6 @@ public class QueryUpdateForm extends TableViewForm
         }
     }
 
-    // RFC 2616 / RFC 7230: Escape characters inside the field name
-    private static final char BACKSLASH = '\\';
-    private static final String SPECIAL_CHARS = BACKSLASH + "\";=,";
-
     @Override
     @Nullable
     public ColumnInfo getColumnByFormFieldName(@NotNull String fieldName)
@@ -81,47 +76,13 @@ public class QueryUpdateForm extends TableViewForm
 
         var columnName = _ignorePrefix ? fieldName : fieldName.substring(PREFIX.length());
 
-        StringBuilder sb = new StringBuilder(columnName.length());
-        boolean escaping = false;
-        for (char c : columnName.toCharArray())
-        {
-            if (escaping)
-            {
-                sb.append(c);
-                escaping = false;
-            }
-            else if (c == BACKSLASH)
-                escaping = true;
-            else
-                sb.append(c);
-        }
-
-        // Issue 54094: Ensure it works when backslash is the last character
-        if (escaping)
-            sb.append(BACKSLASH);
-
-        return getTable().getColumn(sb.toString());
+        return super.getColumnByFormFieldName(columnName);
     }
 
     @Override
     public String getFormFieldName(@NotNull ColumnInfo column)
     {
-        String columnName = column.getName();
-        StringBuilder sb = new StringBuilder();
-        for (char c : columnName.toCharArray())
-        {
-            if (SPECIAL_CHARS.indexOf(c) >= 0)
-                sb.append(BACKSLASH);
-            sb.append(c);
-        }
-
-        String fieldName = sb.toString();
+        String fieldName = super.getFormFieldName(column);
         return _ignorePrefix ? fieldName : PREFIX + fieldName;
-    }
-
-    @Override
-    public String getMultiPartFormFieldName(@NotNull ColumnInfo column)
-    {
-        return DataIteratorUtil.MatchType.multiPartFormData.getMatchedName(getFormFieldName(column));
     }
 }

--- a/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultUpdateService.java
@@ -478,12 +478,6 @@ public class AssayResultUpdateService extends DefaultQueryUpdateService
         }
 
         @Override
-        public @NotNull Map<?, String> getInputDatas()
-        {
-            return Collections.emptyMap();
-        }
-
-        @Override
         public AssayProvider getProvider()
         {
             return _provider;

--- a/assay/test/src/org/labkey/test/tests/assay/AssayReimportIndexTest.java
+++ b/assay/test/src/org/labkey/test/tests/assay/AssayReimportIndexTest.java
@@ -166,8 +166,8 @@ public class AssayReimportIndexTest extends BaseWebDriverTest
         var row = new AssayRunsPage(getDriver())
             .getTable()
             .getRowDataAsMap("Name", runName);
-        reimportBatchFileValue = StringUtils.trimToNull(row.get("Batch/" + BATCH_FILE_FIELD.getName()));
-        reimportRunFileValue = StringUtils.trimToNull(row.get(RUN_FILE_FIELD.getName()));
+        reimportBatchFileValue = StringUtils.trimToNull(row.get("Batch/" + BATCH_FILE_FIELD.getFieldKey()));
+        reimportRunFileValue = StringUtils.trimToNull(row.get(RUN_FILE_FIELD.getFieldKey().toString()));
 
         checker().verifyEquals("Expected batch file to appear in data", batchFile.getName(), reimportBatchFileValue);
         checker().verifyEquals("Expected run file to appear in data", runFile.getName(), reimportRunFileValue);

--- a/assay/test/src/org/labkey/test/tests/assay/AssayReimportIndexTest.java
+++ b/assay/test/src/org/labkey/test/tests/assay/AssayReimportIndexTest.java
@@ -29,9 +29,8 @@ import java.util.List;
 public class AssayReimportIndexTest extends BaseWebDriverTest
 {
     private static final String ASSAY_NAME = DomainKind.Assay.randomName("test+assay");
-    // TODO: Replace each of the following with DomainKind.Assay.randomField(<fieldName>, ColumnType.File) once Issue 54218 is fixed.
-    private static final FieldInfo BATCH_FILE_FIELD = new FieldInfo("batchFile", ColumnType.File);
-    private static final FieldInfo RUN_FILE_FIELD = new FieldInfo("runFile", ColumnType.File);
+    private static final FieldInfo BATCH_FILE_FIELD = DomainKind.Assay.randomField("batchFile", ColumnType.File);
+    private static final FieldInfo RUN_FILE_FIELD = DomainKind.Assay.randomField("runFile", ColumnType.File);
 
     @BeforeClass
     public static void setupProject() throws Exception

--- a/assay/test/src/org/labkey/test/tests/assay/AssayReimportIndexTest.java
+++ b/assay/test/src/org/labkey/test/tests/assay/AssayReimportIndexTest.java
@@ -29,7 +29,9 @@ import java.util.List;
 public class AssayReimportIndexTest extends BaseWebDriverTest
 {
     private static final String ASSAY_NAME = DomainKind.Assay.randomName("test+assay");
+    private static final FieldInfo BATCH_FIELD = DomainKind.Assay.randomField("batchData", ColumnType.String);
     private static final FieldInfo BATCH_FILE_FIELD = DomainKind.Assay.randomField("batchFile", ColumnType.File);
+    private static final FieldInfo RUN_FIELD = DomainKind.Assay.randomField("runString", ColumnType.String);
     private static final FieldInfo RUN_FILE_FIELD = DomainKind.Assay.randomField("runFile", ColumnType.File);
 
     @BeforeClass
@@ -44,15 +46,8 @@ public class AssayReimportIndexTest extends BaseWebDriverTest
         _containerHelper.createProject(getProjectName(), "Assay");
         goToProjectHome();
 
-        List<PropertyDescriptor> batchFields = List.of(
-            DomainKind.Assay.randomField("batchData", ColumnType.String).getFieldDefinition(),
-            BATCH_FILE_FIELD.getFieldDefinition()
-        );
-
-        List<PropertyDescriptor> runFields = List.of(
-            DomainKind.Assay.randomField("runString", ColumnType.String).getFieldDefinition(),
-            RUN_FILE_FIELD.getFieldDefinition()
-        );
+        List<PropertyDescriptor> batchFields = List.of(BATCH_FIELD.getFieldDefinition(), BATCH_FILE_FIELD.getFieldDefinition());
+        List<PropertyDescriptor> runFields = List.of(RUN_FIELD.getFieldDefinition(), RUN_FILE_FIELD.getFieldDefinition());
 
         new GeneralAssayDesign(ASSAY_NAME)
                 .setBatchFields(batchFields, true)
@@ -133,44 +128,105 @@ public class AssayReimportIndexTest extends BaseWebDriverTest
                         searchResultPage3.hasResultLocatedBy(Locator.linkWithText("Assay Run - " + secondRun)));
     }
 
-    @Test // Issue 54112
+    @Test // Issue 54112, Issue 54218
     public void testFileFieldValuesRetainedRunReimport()
     {
         String runName = TestDataGenerator.randomString(TestDataGenerator.randomInt(10, 50));
+        String batchFieldValue = TestDataGenerator.randomString(TestDataGenerator.randomInt(10, 50));
+        String runFieldValue = TestDataGenerator.randomString(TestDataGenerator.randomInt(10, 50));
         File batchFile = TestFileUtils.getSampleData("dataLoading/excel/fruits.tsv");
         File runFile = TestFileUtils.getSampleData("dataLoading/excel/ClientAPITestList.xls");
         File dataFile = TestFileUtils.getSampleData("assay/GPAT_Run1.tsv");
 
         // import the initial run
         importNewRun()
+            .setNamedInputText(BATCH_FIELD.getName(), batchFieldValue)
             .setFileField(BATCH_FILE_FIELD.getName(), batchFile)
             .clickNext()
             .setNamedInputText("Name", runName)
+            .setNamedInputText(RUN_FIELD.getName(), runFieldValue)
             .setFileField(RUN_FILE_FIELD.getName(), runFile)
             .setDataFile(dataFile)
             .clickSaveAndFinish();
 
-        // Reimport the run and verify expected file field values
+        // Verify batch values during reimport
         var importPage = reimportRun(runName);
-        var reimportBatchFileValue = importPage.getFileFieldValue(BATCH_FILE_FIELD.getName());
-        checker().withScreenshot("reimport-run-batch-field-value")
-                .verifyEquals("Expected batch file name", batchFile.getName(), reimportBatchFileValue);
+        String actualBatchValue = importPage.getFieldValue(BATCH_FIELD.getName());
+        checker().withScreenshot("reimport-batch-field-value")
+                .verifyEquals("Unexpected batch field value", batchFieldValue, actualBatchValue);
+        actualBatchValue = importPage.getFileFieldValue(BATCH_FILE_FIELD.getName());
+        checker().withScreenshot("reimport-batch-file-field-value")
+                .verifyEquals("Unexpected batch file name", batchFile.getName(), actualBatchValue);
+
+        // Verify run values during reimport
         importPage = importPage.clickNext();
-        var reimportRunFileValue = importPage.getFileFieldValue(RUN_FILE_FIELD.getName());
-        checker().withScreenshot("reimport-run-run-field-value")
-                .verifyEquals("Expected run file name", runFile.getName(), reimportRunFileValue);
+        String actualRunValue = importPage.getFieldValue(RUN_FIELD.getName());
+        checker().withScreenshot("reimport-batch-field-value")
+                .verifyEquals("Unexpected run field value", runFieldValue, actualRunValue);
+        actualRunValue = importPage.getFileFieldValue(RUN_FILE_FIELD.getName());
+        checker().withScreenshot("reimport-run-file-field-value")
+                .verifyEquals("Unexpected run file name", runFile.getName(), actualRunValue);
         importPage.selectUploadFileRadioButton()
             .clickSaveAndFinish();
 
-        // Verify that the reimport retained the file values
+        // Verify that the reimport retained the values
         var row = new AssayRunsPage(getDriver())
             .getTable()
             .getRowDataAsMap("Name", runName);
-        reimportBatchFileValue = StringUtils.trimToNull(row.get("Batch/" + BATCH_FILE_FIELD.getFieldKey()));
-        reimportRunFileValue = StringUtils.trimToNull(row.get(RUN_FILE_FIELD.getFieldKey().toString()));
+        actualBatchValue = StringUtils.trimToNull(row.get("Batch/" + BATCH_FIELD.getFieldKey()));
+        actualRunValue = StringUtils.trimToNull(row.get(RUN_FIELD.getFieldKey().toString()));
+        checker().verifyEquals("Unexpected batch field value in grid", batchFieldValue, actualBatchValue);
+        checker().verifyEquals("Unexpected run field value in grid", runFieldValue, actualRunValue);
 
-        checker().verifyEquals("Expected batch file to appear in data", batchFile.getName(), reimportBatchFileValue);
-        checker().verifyEquals("Expected run file to appear in data", runFile.getName(), reimportRunFileValue);
+        actualBatchValue = StringUtils.trimToNull(row.get("Batch/" + BATCH_FILE_FIELD.getFieldKey()));
+        actualRunValue = StringUtils.trimToNull(row.get(RUN_FILE_FIELD.getFieldKey().toString()));
+        checker().verifyEquals("Unexpected batch file in grid", batchFile.getName(), actualBatchValue);
+        checker().verifyEquals("Unexpected run file in grid", runFile.getName(), actualRunValue);
+
+        // Verify deleting batch file value is respected
+        reimportRun(runName)
+            .removeFileValue(BATCH_FILE_FIELD.getName())
+            .clickNext()
+            .selectUploadFileRadioButton()
+            .clickSaveAndFinish();
+
+        row = new AssayRunsPage(getDriver())
+            .getTable()
+            .getRowDataAsMap("Name", runName);
+        actualBatchValue = StringUtils.trimToNull(row.get("Batch/" + BATCH_FILE_FIELD.getFieldKey()));
+        actualRunValue = StringUtils.trimToNull(row.get(RUN_FILE_FIELD.getFieldKey().toString()));
+        checker().verifyNull("Unexpected batch field value in grid", actualBatchValue);
+        checker().verifyEquals("Unexpected run field value in grid", runFile.getName(), actualRunValue);
+
+        // Verify other values remain unchanged
+        actualBatchValue = StringUtils.trimToNull(row.get("Batch/" + BATCH_FIELD.getFieldKey()));
+        actualRunValue = StringUtils.trimToNull(row.get(RUN_FIELD.getFieldKey().toString()));
+        checker().verifyEquals("Unexpected batch field value in grid", batchFieldValue, actualBatchValue);
+        checker().verifyEquals("Unexpected run field value in grid", runFieldValue, actualRunValue);
+
+        // Verify deleting run file value is respected
+        batchFile = TestFileUtils.getSampleData("dataLoading/excel/fruits.xls");
+        runFieldValue = TestDataGenerator.randomString(TestDataGenerator.randomInt(10, 50));
+        reimportRun(runName)
+            .setFileField(BATCH_FILE_FIELD.getName(), batchFile)
+            .clickNext()
+            .removeFileValue(RUN_FILE_FIELD.getName())
+            .setNamedInputText(RUN_FIELD.getName(), runFieldValue)
+            .selectUploadFileRadioButton()
+            .clickSaveAndFinish();
+
+        row = new AssayRunsPage(getDriver())
+            .getTable()
+            .getRowDataAsMap("Name", runName);
+        actualBatchValue = StringUtils.trimToNull(row.get("Batch/" + BATCH_FIELD.getFieldKey()));
+        actualRunValue = StringUtils.trimToNull(row.get(RUN_FIELD.getFieldKey().toString()));
+        checker().verifyEquals("Unexpected batch field value in grid", batchFieldValue, actualBatchValue);
+        checker().verifyEquals("Unexpected run field value in grid", runFieldValue, actualRunValue);
+
+        actualBatchValue = StringUtils.trimToNull(row.get("Batch/" + BATCH_FILE_FIELD.getFieldKey()));
+        actualRunValue = StringUtils.trimToNull(row.get(RUN_FILE_FIELD.getFieldKey().toString()));
+        checker().verifyEquals("Unexpected batch file in grid", batchFile.getName(), actualBatchValue);
+        checker().verifyNull("Unexpected run file in grid", actualRunValue);
     }
 
     private AssayImportPage importNewRun()

--- a/assay/test/src/org/labkey/test/tests/assay/AssayReimportTest.java
+++ b/assay/test/src/org/labkey/test/tests/assay/AssayReimportTest.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Category({Daily.class, Assays.class})
-public class AssayReimportIndexTest extends BaseWebDriverTest
+public class AssayReimportTest extends BaseWebDriverTest
 {
     private static final String ASSAY_NAME = DomainKind.Assay.randomName("test+assay");
     private static final FieldInfo BATCH_FIELD = DomainKind.Assay.randomField("batchData", ColumnType.String);
@@ -37,7 +37,7 @@ public class AssayReimportIndexTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject() throws Exception
     {
-        AssayReimportIndexTest init = getCurrentTest();
+        AssayReimportTest init = getCurrentTest();
         init.doSetup();
     }
 


### PR DESCRIPTION
#### Rationale
This addresses [Issue 54218](https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=54218) by escaping special characters in `TableViewForm` input names. This concept was first introduced with #7033 specifically for `QueryUpdateForm`.

#### Related Pull Requests
- #7033
- https://github.com/LabKey/testAutomation/pull/2783

#### Changes
- Hoist escaping special characters from `QueryUpdateForm` to `TableViewForm`.
- Resolve escaped input names in `AssayFileWriter` when resolving properties in the file map.

#### Tasks
- [ ] Manual Testing @labkey-klum 
- [x] Needs Automation