### PR TITLE
Fix includeNulls logic for generation of string_agg()

### DIFF
--- a/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
@@ -494,27 +494,46 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
             result.append("array_to_string(");
             result.append("core.sort(");   // TODO: Switch to use ORDER BY option inside array aggregate instead of our custom function
             result.append("array_agg(");
+            if (distinct)
+            {
+                result.append("DISTINCT ");
+            }
+
+            if (includeNulls)
+            {
+                result.append("COALESCE(CAST(");
+                result.append(sql);
+                result.append(" AS VARCHAR), '')");
+            }
+            else
+            {
+                result.append(sql);
+            }
+
+            result.append(")"); // array_agg
+            result.append(")"); // core.sort
         }
         else
         {
             result.append("string_agg(");
+            if (distinct)
+            {
+                result.append("DISTINCT ");
+            }
+
+            if (includeNulls)
+            {
+                result.append("COALESCE(");
+                result.append(sql);
+                result.append("::text, '')");
+            }
+            else
+            {
+                result.append(sql);
+                result.append("::text");
+            }
         }
 
-        if (distinct)
-        {
-            result.append("DISTINCT ");
-        }
-        result.append(sql);
-
-        if (includeNulls)
-        {
-            result.append("::text");
-        }
-        if (useSortFunction)
-        {
-            result.append(")"); // array_agg
-            result.append(")"); // core.sort
-        }
         result.append(", ");
         result.append(delimiterSQL);
         result.append(")"); // array_to_string | string_agg


### PR DESCRIPTION
#### Rationale
With #7152 I introduced use of `string_agg()` into the generated group concatenation SQL on PostgreSQL. There are a [couple of test failures](https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyCPostgres/3728521) that indicated I had not properly accounted for handling of null values. This fixes that by doing coalescing as empty string.

#### Related Pull Requests
- #7152

#### Changes
- More explicitly separate the `array_to_string(array_agg())` path from the `string_agg()` path.