### PR TITLE
CompareType: fix how parseParams parses null values in JSON arrays

### DIFF
--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
@@ -984,7 +985,8 @@ public abstract class CompareType
                     JSONArray array = new JSONArray(value);
                     for (int i = 0; i < array.length(); i++)
                     {
-                        collection.add(Objects.toString(array.get(i), null));
+                        Object jsonVal = array.get(i);
+                        collection.add(JSONObject.NULL.equals(jsonVal) ? null : Objects.toString(jsonVal));
                     }
                 }
                 catch (JSONException ex)

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -222,6 +222,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 void complete(boolean success)
                 {
                     logQueueStatus("addNoop() complete");
+                    commit();
                     super.complete(success);
                 }
             };

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -879,7 +879,17 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
                     _log.debug("indexing docid: " + r.getDocumentId());
             }
 
-            return index(r.getDocumentId(), doc);
+            boolean result = index(r.getDocumentId(), doc);
+
+            if (_log.isDebugEnabled())
+            {
+                if (_log.isTraceEnabled())
+                    _log.trace("finished indexing " + dump(r, doc));
+                else
+                    _log.debug("finished indexing docid: " + r.getDocumentId());
+            }
+
+            return result;
         }
         catch (NoClassDefFoundError err)
         {


### PR DESCRIPTION
#### Rationale
This PR fixes how CompareType handles `null` values when parsing JSON arrays

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/848
- https://github.com/LabKey/platform/pull/7198
- https://github.com/LabKey/limsModules/pull/1788

#### Changes
- CompareType::parseParams - actually allow null values when parsing JSONArray
  - Previous implementation was coercing null values to `"null"`
  - Necessary for us to properly parse the NotebookReferenceCompareType

#### Tasks 📍
- [x] Manual Testing
- [x] Needs Automation
- [x] ~Verify Fix~