### PR TITLE
Compensate for SQL Server timestamp granularity

### DIFF
--- a/assay/src/org/labkey/assay/AssayIntegrationTestCase.jsp
+++ b/assay/src/org/labkey/assay/AssayIntegrationTestCase.jsp
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+<%@ page import="org.apache.commons.collections.MapUtils" %>
 <%@ page import="org.apache.logging.log4j.LogManager" %>
 <%@ page import="org.apache.logging.log4j.Logger" %>
 <%@ page import="org.hamcrest.MatcherAssert" %>
+<%@ page import="org.jetbrains.annotations.Nullable" %>
 <%@ page import="org.junit.After" %>
 <%@ page import="org.junit.Before" %>
 <%@ page import="org.junit.Test" %>
@@ -47,19 +49,24 @@
 <%@ page import="org.labkey.api.exp.api.ExpMaterial" %>
 <%@ page import="org.labkey.api.exp.api.ExpProtocol" %>
 <%@ page import="org.labkey.api.exp.api.ExpRun" %>
+<%@ page import="org.labkey.api.exp.api.ExpSampleType" %>
 <%@ page import="org.labkey.api.exp.api.ExperimentService" %>
+<%@ page import="org.labkey.api.exp.api.SampleTypeService" %>
 <%@ page import="org.labkey.api.exp.property.Domain" %>
 <%@ page import="org.labkey.api.exp.property.DomainProperty" %>
 <%@ page import="org.labkey.api.exp.property.PropertyService" %>
 <%@ page import="org.labkey.api.exp.query.ExpSchema" %>
+<%@ page import="org.labkey.api.exp.query.SamplesSchema" %>
 <%@ page import="org.labkey.api.files.FileContentService" %>
 <%@ page import="org.labkey.api.files.FilesAdminOptions" %>
 <%@ page import="org.labkey.api.gwt.client.assay.model.GWTProtocol" %>
 <%@ page import="org.labkey.api.gwt.client.model.GWTDomain" %>
 <%@ page import="org.labkey.api.gwt.client.model.GWTPropertyDescriptor" %>
+<%@ page import="org.labkey.api.pipeline.PipeRoot" %>
 <%@ page import="org.labkey.api.pipeline.PipelineService" %>
 <%@ page import="org.labkey.api.query.BatchValidationException" %>
 <%@ page import="org.labkey.api.query.FieldKey" %>
+<%@ page import="org.labkey.api.query.QueryService" %>
 <%@ page import="org.labkey.api.query.QueryUpdateService" %>
 <%@ page import="org.labkey.api.query.ValidationException" %>
 <%@ page import="org.labkey.api.security.User" %>
@@ -71,31 +78,24 @@
 <%@ page import="org.labkey.api.view.ViewContext" %>
 <%@ page import="org.labkey.assay.AssayDomainServiceImpl" %>
 <%@ page import="org.labkey.assay.TsvAssayProvider" %>
+<%@ page import="org.labkey.vfs.FileSystemLike" %>
 <%@ page import="org.springframework.mock.web.MockMultipartHttpServletRequest" %>
 <%@ page import="java.io.File" %>
+<%@ page import="static org.junit.Assert.*" %>
+<%@ page import="static org.labkey.api.files.FileContentService.UPLOADED_FILE" %>
+<%@ page import="static org.hamcrest.CoreMatchers.hasItem" %>
+<%@ page import="static org.hamcrest.CoreMatchers.not" %>
+<%@ page import="java.io.IOException" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
+<%@ page import="static java.util.Collections.emptyList" %>
 <%@ page import="java.nio.file.Files" %>
 <%@ page import="java.util.ArrayList" %>
+<%@ page import="static org.labkey.api.exp.query.SamplesSchema.SCHEMA_SAMPLES" %>
 <%@ page import="java.util.Collections" %>
 <%@ page import="java.util.HashSet" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.Set" %>
-<%@ page import="static org.junit.Assert.*" %>
-<%@ page import="static org.labkey.api.files.FileContentService.UPLOADED_FILE" %>
-<%@ page import="static org.hamcrest.CoreMatchers.hasItem" %>
-<%@ page import="static org.hamcrest.CoreMatchers.not" %>
-<%@ page import="org.labkey.api.exp.api.ExpSampleType" %>
-<%@ page import="org.labkey.api.exp.api.SampleTypeService" %>
-<%@ page import="static java.util.Collections.emptyList" %>
-<%@ page import="org.labkey.api.exp.query.SamplesSchema" %>
-<%@ page import="org.labkey.api.query.QueryService" %>
-<%@ page import="static org.labkey.api.exp.query.SamplesSchema.SCHEMA_SAMPLES" %>
-<%@ page import="org.labkey.api.pipeline.PipeRoot" %>
-<%@ page import="org.jetbrains.annotations.Nullable" %>
-<%@ page import="java.io.IOException" %>
-<%@ page import="org.apache.commons.collections.MapUtils" %>
-<%@ page import="org.labkey.vfs.FileSystemLike" %>
 <%@ page import="static org.junit.Assert.assertEquals" %>
 <%@ page import="static org.junit.Assert.assertNotEquals" %>
 
@@ -580,6 +580,7 @@
         updated.put("ResultProp", 200);
         updated.put("RowId", resultRowId);
         errors = new BatchValidationException();
+        Thread.sleep(5); // SQL Server timestamps aren't granular enough to guarantee different modified time
         resultsQUS.updateRows(user, c, Collections.singletonList(updated), null, errors, null, null);
 
         // verify result created matches run's created in query table, but result modified now differs from run's created


### PR DESCRIPTION
#### Rationale
SQL Server timestamps aren't granular enough (1/300 second) to guarantee that modified times differ.

#### Related Pull Requests
- N/A

#### Changes
- Compensate for SQL Server timestamp granularity