### PR TITLE
Avoid leaving connection in bad state after precommit task exception

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.cache.Cache;
 import org.labkey.api.data.ConnectionWrapper.Closer;
@@ -2166,8 +2167,7 @@ public class DbScope
                 }
                 try
                 {
-                    LOG.warn("Forcing close of still-pending transaction object. Current stack is ", new Throwable());
-                    LOG.warn("Forcing close of still-pending transaction object started at ", t._creation);
+                    LOG.warn("Forcing close of still-pending transaction object started at {}. Current stack is ", t._creation, new Throwable());
                     t.close();
                 }
                 catch (ConnectionAlreadyReleasedException ignored)
@@ -2715,16 +2715,17 @@ public class DbScope
                             conn.commit();
                             conn.setAutoCommit(true);
                             LOG.debug("setAutoCommit(true)");
-                            if (null != _closeOnClose)
-                                try { _closeOnClose.close(); } catch (Exception ignore) {}
                         }
                         finally
                         {
+                            if (null != _closeOnClose)
+                                try { _closeOnClose.close(); } catch (Exception ignore) {}
                             if (null != conn)
                                 conn.internalClose();
-                        }
 
-                        popCurrentTransaction();
+                            // Make sure to pop whether we successfully committed or not
+                            popCurrentTransaction();
+                        }
 
                         CommitTaskOption.POSTCOMMIT.run(this);
                     }
@@ -3159,6 +3160,24 @@ public class DbScope
             catch (RuntimeSQLException e)
             {
                 assertTrue("Bad message: " + e.getMessage(), e.getMessage().contains("simulated"));
+            }
+            assertFalse(getLabKeyScope().isTransactionActive());
+            closeAllConnectionsForCurrentThread();
+        }
+
+        @Test
+        public void tesCommitTaskFailure()
+        {
+            String message = "Expected failure";
+            try (Transaction t = getLabKeyScope().ensureTransaction())
+            {
+                t.addCommitTask(() -> { throw new ApiUsageException("Expected failure"); }, CommitTaskOption.PRECOMMIT);
+                t.commit();
+                fail("Shouldn't have gotten here, expected ApiUsageException");
+            }
+            catch (ApiUsageException e)
+            {
+                assertEquals("Bad message", message, e.getMessage());
             }
             assertFalse(getLabKeyScope().isTransactionActive());
             closeAllConnectionsForCurrentThread();


### PR DESCRIPTION
#### Rationale
```
ERROR DbScope                  2025-11-17T15:16:54,463 tps-jsse-nio-443-exec-10 : Failed to force the still-pending transaction object closed on DB scope labkeyDataSource
java.lang.IllegalStateException: SPID=1465 DbScope=labkey No transactions remain, can't decrement!
	at org.labkey.api.data.DbScope.createIllegalStateException(DbScope.java:275)
	at org.labkey.api.data.DbScope$TransactionImpl.isOutermostTransaction(DbScope.java:2803)
	at org.labkey.api.data.DbScope$TransactionImpl.close(DbScope.java:2648)
	at org.labkey.api.data.DbScope.closeAllConnectionsForCurrentThread(DbScope.java:2171)
	at org.labkey.api.data.DbScope.finishedWithThread(DbScope.java:2198)
	at org.labkey.api.data.TransactionFilter.doFilter(TransactionFilter.java:185)
```

#### Related Pull Requests
- https://github.com/LabKey/targetedms/pull/1132

#### Changes
- Ensure `DbScope.Transaction` is closed properly in error scenarios
- Integration test

#### Tasks 📍
- [x] Manual Testing @labkey-danield 
- [x] Needs Automation
