### PR TITLE
Fix primary product resolution when no product explicitly set

### DIFF
--- a/api/src/org/labkey/api/products/ProductRegistry.java
+++ b/api/src/org/labkey/api/products/ProductRegistry.java
@@ -240,7 +240,8 @@ public class ProductRegistry
         List<String> orderedProducts = getProducts(true, false).stream().filter(Product::isEnabled).map(Product::getProductGroupId).toList();
         _logger.debug("Products are {}", _products.keySet());
         _logger.debug("Ordered products are {}", orderedProducts);
-        ProductMenuProvider highestProvider = providers.stream().filter(p -> orderedProducts.contains(p.getProductId())).min(Comparator.comparing(provider -> orderedProducts.indexOf(provider.getProductId()))).orElse(null);
+        ProductMenuProvider highestProvider = providers.stream()
+                .min(Comparator.comparing(provider -> orderedProducts.indexOf(provider.getProductId()))).orElse(null);
         _logger.debug("Highest product menu provider: {}", highestProvider.getProductId());
         // then see if there's a provider that matches the configured product
         Product product = new ProductConfiguration().getCurrentProduct();

--- a/api/src/org/labkey/api/products/ProductRegistry.java
+++ b/api/src/org/labkey/api/products/ProductRegistry.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.products;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -219,7 +220,9 @@ public class ProductRegistry
     public ProductMenuProvider getPrimaryProductMenuForContainer(@NotNull Container container)
     {
         List<String> productIds = getProductIdsForContainer(container);
+        _logger.debug("Product Ids in container '{}' of type '{}' are {}", container.getPath(), container.getFolderType().getName(), StringUtils.join(productIds));
         List<ProductMenuProvider> providers = getRegisteredProducts().stream().filter(provider -> productIds.contains(provider.getProductId())).toList();
+        _logger.debug("Menu providers: {}", providers.stream().map(ProductMenuProvider::getProductId).collect(Collectors.toList()));
         if (providers.isEmpty())
             return null;
 
@@ -229,16 +232,26 @@ public class ProductRegistry
         // see if there's a provider that matches the folder type (need to check this first so if LabKey LIMS or LKB is the configured product you can still show LKSM folders)
         Optional<ProductMenuProvider> optionalProvider = providers.stream().filter(provider -> provider.getFolderTypeName() != null && provider.getFolderTypeName().equals(container.getFolderType().getName())).findFirst();
         if (optionalProvider.isPresent())
+        {
+            _logger.debug("Found product menu provider for folder type '{}'", container.getFolderType().getName());
             return optionalProvider.get();
+        }
 
         List<String> orderedProducts = getProducts(true, false).stream().filter(Product::isEnabled).map(Product::getProductGroupId).toList();
-        ProductMenuProvider highestProvider = providers.stream().min(Comparator.comparing(provider -> orderedProducts.indexOf(provider.getProductId()))).orElse(null);
+        _logger.debug("Products are {}", _products.keySet());
+        _logger.debug("Ordered products are {}", orderedProducts);
+        ProductMenuProvider highestProvider = providers.stream().filter(p -> orderedProducts.contains(p.getProductId())).min(Comparator.comparing(provider -> orderedProducts.indexOf(provider.getProductId()))).orElse(null);
+        _logger.debug("Highest product menu provider: {}", highestProvider.getProductId());
         // then see if there's a provider that matches the configured product
         Product product = new ProductConfiguration().getCurrentProduct();
         if (product == null)
+        {
+            _logger.debug("Using highest product menu provider.");
             return highestProvider;
+        }
 
         optionalProvider = providers.stream().filter(provider -> provider.getProductId().equals(product.getProductGroupId())).findFirst();
+        _logger.debug("Product from product group: {}", optionalProvider.isPresent() ? optionalProvider.get() : "null");
         // if neither of those is true (when can this happen?), use the highest provider
         return optionalProvider.orElseGet(() -> highestProvider);
     }

--- a/api/src/org/labkey/api/settings/ProductConfiguration.java
+++ b/api/src/org/labkey/api/settings/ProductConfiguration.java
@@ -1,11 +1,13 @@
 package org.labkey.api.settings;
 
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.products.Product;
 import org.labkey.api.products.ProductRegistry;
+import org.labkey.api.util.logging.LogHelper;
 
 import java.util.Collection;
 
@@ -13,6 +15,7 @@ public class ProductConfiguration extends AbstractWriteableSettingsGroup impleme
 {
     public static final String SCOPE_PRODUCT_CONFIGURATION = "ProductConfiguration";
     public static final String PROPERTY_NAME = "productKey";
+    private static final Logger _logger = LogHelper.getLogger(ProductConfiguration.class, "Product Configuration properties");
 
     @Override
     protected String getGroupName()
@@ -54,6 +57,7 @@ public class ProductConfiguration extends AbstractWriteableSettingsGroup impleme
     public Product getCurrentProduct()
     {
         String productKey = getCurrentProductKey();
+        _logger.debug("Current product key: {}", productKey);
         if (productKey == null)
             return null;
         return ProductRegistry.getProduct(productKey);


### PR DESCRIPTION
#### Rationale
When a server has no product key explicitly set, we work with the set of modules to determine what the highest product available is in order to construct app URLs and the like. This logic is complicated because the product setting is global for the server but we also want to allow folders from lower products to be shown in a server with a higher product configured.  

Yes, we really should be able to simplify this, but for now this PR and its related one fix the problem with the logic of finding the highest provider and adds some debugging logging in case we have other problems like this.

Repro steps for this issue:
- Set up a Biologics product on a server where a product configuration has not been set
- Create a subfolder (of type Collaboration)
- Create a notebook in the subfolder
- Search for the notebook using the global search
- Click on the link for the search.

Result:
- The URL for the link goes to  `lims-app.view` instead of `biologics-app.view`
- If you then search again from the `lims-app.view` page, the URL will get mangled to attach the `biologics-app.view` URL part at the end.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1804

#### Changes
- Debug logging added for `ProductConfiguration` and `ProductRegistry`


#### Tasks 📍
- [x] Manual Testing @labkey-nicka 
- [ ] ~Needs Automation~ - not including an automated test because this problem scenario relies on a property not being set, and that property may be set by another test and, once set, cannot be unset.
- [ ] ~Verify Fix~
