### PR TITLE
Parameter to bypass CSP log deduplication

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -11965,8 +11965,12 @@ public class AdminController extends SpringActionController
                     String urlString = cspReport.optString("document-uri", null);
                     if (urlString != null)
                     {
-                        String path = new URLHelper(urlString).deleteParameters().getURIString();
-                        if (null == reports.put(path, Boolean.TRUE) || _log.isDebugEnabled())
+                        URLHelper urlHelper = new URLHelper(urlString);
+                        // URL parameter that tells us to bypass suppression of redundant logging
+                        // Used to make sure that tests of CSP logging are deterministic and convenient
+                        boolean bypassCspDedupe = "true".equals(urlHelper.getParameter("bypassCspDedupe"));
+                        String path = urlHelper.deleteParameters().getURIString();
+                        if (null == reports.put(path, Boolean.TRUE) || _log.isDebugEnabled() || bypassCspDedupe)
                         {
                             // Don't modify forwarded reports; they already have user, ip, user-agent, etc. from the forwarding server.
                             boolean forwarded = jsonObj.optBoolean("forwarded", false);


### PR DESCRIPTION
#### Rationale
We're adding testing/monitoring for coverage for CSP logging on production servers. We need a reliable way to make sure they log when they're poked.

#### Changes
- URLs with `bypassCspDedupe=true` will always log and forward the report, even if it's a repeat

#### Tasks 📍
- [x] Manual Testing @labkey-adam 
- [x] Needs Automation
