### PR TITLE
GridColumn to only apply displayWidth to multiLine columns

### DIFF
--- a/api/src/org/labkey/api/data/JsonWriter.java
+++ b/api/src/org/labkey/api/data/JsonWriter.java
@@ -180,7 +180,9 @@ public class JsonWriter
 
         props.put("wrappedColumnName", cinfo == null ? null : cinfo.getWrappedColumnName());
         props.put("valueExpression", cinfo == null ? null : cinfo.getValueExpression());
-        props.put("displayWidth", cinfo == null ? null : cinfo.getDisplayWidth());
+
+        if (cinfo != null && cinfo.getDisplayWidth() != null && !cinfo.getDisplayWidth().isEmpty())
+            props.put("displayWidth", cinfo.getDisplayWidth());
 
         ColumnInfo displayField = dc.getDisplayColumnInfo();
         if (displayField != null && displayField != cinfo)


### PR DESCRIPTION
#### Rationale
The previous PR started passing the displayWidth column prop via JsonWriter.getMetaData(). However, it was not checking for empty string values, which ended up affecting the client side default GridColumn width.

#### Related Pull Requests
- Previous: https://github.com/LabKey/platform/pull/7192
- https://github.com/LabKey/labkey-ui-components/pull/1900

#### Changes
- JsonWriter.getMetaData to check for null and empty displayWidth String