### PR TITLE
GitHub Issue #443: AbstractAssayTsvDataHandler to lookup field values by titleColumn before primaryKey in checkData()

### DIFF
--- a/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
+++ b/api/src/org/labkey/api/assay/AbstractAssayTsvDataHandler.java
@@ -706,7 +706,8 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
         DomainProperty wellLocationPropFinder = null;
         DomainProperty wellLsidPropFinder = null;
 
-        RemapCache cache = new RemapCache();
+        RemapCache cacheWithoutPkLookup = new RemapCache();
+        RemapCache cacheWithPkLookup = new RemapCache();
         Map<DomainProperty, TableInfo> remappableLookup = new HashMap<>();
         Map<Long, ExpMaterial> materialCache = new LongHashMap<>();
         Map<Long, Map<String, Long>> plateWellCache = new LongHashMap<>();
@@ -879,7 +880,12 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                     {
                         String s = o instanceof String ? (String) o : o.toString();
                         TableInfo lookupTable = remappableLookup.get(pd);
-                        Object remapped = cache.remap(lookupTable, s, true);
+
+                        // GitHub Issue #443: similar to LookupResolutionType.alternateThenPrimaryKey, we want to check if the string value remaps using alternate keys (titleColumn) first
+                        Object remapped = cacheWithoutPkLookup.remap(lookupTable, s, false);
+                        if (remapped == null)
+                            remapped = cacheWithPkLookup.remap(lookupTable, s, true);
+
                         if (remapped == null)
                         {
                             if (SAMPLE_CONCEPT_URI.equals(pd.getConceptURI()))
@@ -1026,7 +1032,7 @@ public abstract class AbstractAssayTsvDataHandler extends AbstractExperimentData
                             try
                             {
                                 if (material == null)
-                                    material = exp.findExpMaterial(lookupContainer, user, materialName, byNameSS, cache, materialCache);
+                                    material = exp.findExpMaterial(lookupContainer, user, materialName, byNameSS, cacheWithoutPkLookup, materialCache);
                             }
                             catch (ValidationException ve)
                             {

--- a/study/test/src/org/labkey/test/tests/study/AssayTest.java
+++ b/study/test/src/org/labkey/test/tests/study/AssayTest.java
@@ -1036,7 +1036,10 @@ public class AssayTest extends AbstractAssayTest
         _listHelper.bulkImportData(TestDataUtils.tsvStringFromRowMaps(List.of(
                 Map.of(valueField.getName(), "One"),
                 Map.of(valueField.getName(), "Two"),
-                Map.of(valueField.getName(), "123")
+                Map.of(valueField.getName(), "123"),
+                // GitHub Issue #443: value is the primary key for another row
+                Map.of(valueField.getName(), "5"), // pk = 4
+                Map.of(valueField.getName(), "6") // pk = 5
         ), List.of(valueField.getName()), true));
 
         log("Create an assay with a results lookup field to the list, with lookup validator set");
@@ -1060,6 +1063,24 @@ public class AssayTest extends AbstractAssayTest
                 .setLookupValidatorEnabled(false);
         designerPage.clickFinish();
         verifyAssayImportForLookupValidator(ISSUE_53625_ASSAY, lookupField, "RunWithoutLookupValidator", false);
+
+        log("GitHub Issue #443: Verify that importing a value that is also a primary key maps to the titleColumn value");
+        verifyAssayImportForPKValueThatIsTitleColumn(ISSUE_53625_ASSAY, lookupField, "RunWithPKandTitleColumn");
+    }
+
+    private void verifyAssayImportForPKValueThatIsTitleColumn(String assayName, FieldInfo lookupField, String runName)
+    {
+        String runDataStr = TestDataUtils.tsvStringFromRowMaps(List.of(
+                        Map.of(lookupField.getName(), "4"), // pk 4, value 5
+                        Map.of(lookupField.getName(), "5"), // pk 4, value 5
+                        Map.of(lookupField.getName(), "6")), // pk 5, value 6
+                List.of(lookupField.getName()), true
+        );
+        importAssayData(assayName, runName, runDataStr);
+        clickAndWait(Locator.linkWithText(runName));
+        DataRegionTable dataTable = new DataRegionTable("Data", getDriver());
+        checker().verifyEquals("Incorrect number of results shown.", 3, dataTable.getDataRowCount());
+        checker().fatal().verifyEquals("Lookup values not as expected.", List.of("5", "5", "6"), dataTable.getColumnDataAsText(lookupField.getLabel()));
     }
 
     private void verifyAssayImportForLookupValidator(String assayName, FieldInfo lookupField, String runName, boolean validatorOn)


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/internal-issues/issues/443
Similar to LookupResolutionType.alternateThenPrimaryKey, we want to check if the string value remaps using alternate keys (titleColumn) first in the assay results import data case.

#### Changes
- AbstractAssayTsvDataHandler.checkData() update to first try RemapCache  without PK values for lookup value before trying again with PK lookup enabled

#### Tasks 📍
- [x] Manual Testing
- [x] Needs Automation