### PR TITLE
Ignore IllegalStateException when request is already recycled

### DIFF
--- a/api/src/org/labkey/api/data/TransactionFilter.java
+++ b/api/src/org/labkey/api/data/TransactionFilter.java
@@ -117,7 +117,14 @@ public class TransactionFilter implements Filter
                             {
                                 RequestTracker tracker = entry.getValue();
                                 Thread thread = entry.getKey();
-                                Object readOnly = tracker.request.getAttribute(READ_ONLY_ATTRIBUTE_NAME);
+                                
+                                Object readOnly = Boolean.FALSE;
+                                try
+                                {
+                                    readOnly = tracker.request.getAttribute(READ_ONLY_ATTRIBUTE_NAME);
+                                }
+                                catch (IllegalStateException ignored) {} // Ignore when the request has already been recycled
+
                                 if (Boolean.TRUE.equals(readOnly) && tracker.startTime < cutoff)
                                 {
                                     try (DbScope.ConnectionSharingCloseable ignored = DbScope.shareConnections(thread, Thread.currentThread()))


### PR DESCRIPTION
#### Rationale
There's a race condition between a request finishing and when we check to see if it's still pending and needs to yank its DB connections.

```
java.lang.IllegalStateException: The request object has been recycled and is no longer associated with this facade
    at jakarta.servlet.ServletRequestWrapper.getAttribute(ServletRequestWrapper.java:83)
    at org.labkey.api.data.TransactionFilter$1.lambda$moduleStartupComplete$0(TransactionFilter.java:120)
    at java.base/java.lang.Thread.run(Unknown Source)
```

#### Changes
- Suppress the `IllegalStateException`

#### Tasks 📍
- Manual Testing - N/A
- Needs Automation - N/A
