### PR TITLE
Update PostgreSQL version support

### DIFF
--- a/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
@@ -48,7 +48,6 @@ import java.util.regex.Pattern;
 abstract class PostgreSql92Dialect extends BasePostgreSqlDialect
 {
     public static final String PRODUCT_NAME = "PostgreSQL";
-    public static final String RECOMMENDED = PRODUCT_NAME + " 17.x is the recommended version.";
 
     // This has been the standard PostgreSQL identifier max byte length for many years. However, this could change in
     // the future plus servers can be compiled with a different limit, so we query this setting on first connection to

--- a/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlDialectFactory.java
@@ -17,6 +17,7 @@
 package org.labkey.core.dialect;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -65,7 +66,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
     @Override
     public @Nullable SqlDialect createFromMetadata(DatabaseMetaData md, boolean logWarnings, boolean primaryDataSource) throws SQLException, DatabaseNotSupportedException
     {
-        if (!(StringUtils.startsWithIgnoreCase(md.getURL(), JDBC_PREFIX)))
+        if (!(Strings.CI.startsWith(md.getURL(), JDBC_PREFIX)))
             return null;
 
         String databaseProductVersion = md.getDatabaseProductVersion();
@@ -115,7 +116,7 @@ public class PostgreSqlDialectFactory implements SqlDialectFactory
 
     public static String getStandardWarningMessage(String warning, String databaseProductVersion)
     {
-        return "LabKey Server " + warning + " " + PostgreSql92Dialect.PRODUCT_NAME + " version " + databaseProductVersion + ". " + PostgreSql92Dialect.RECOMMENDED;
+        return "LabKey Server " + warning + " " + PostgreSql92Dialect.PRODUCT_NAME + " version " + databaseProductVersion + ". " + PostgreSqlVersion.RECOMMENDED;
     }
 
     @Override

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -16,12 +16,12 @@ import java.util.stream.Collectors;
 public enum PostgreSqlVersion
 {
     POSTGRESQL_UNSUPPORTED(-1, true, false, null),
-    POSTGRESQL_13(130, false, true, PostgreSql_13_Dialect::new),
+    POSTGRESQL_13(130, true, true, PostgreSql_13_Dialect::new),
     POSTGRESQL_14(140, false, true, PostgreSql_14_Dialect::new),
     POSTGRESQL_15(150, false, true, PostgreSql_15_Dialect::new),
     POSTGRESQL_16(160, false, true, PostgreSql_16_Dialect::new),
     POSTGRESQL_17(170, false, true, PostgreSql_17_Dialect::new),
-    POSTGRESQL_18(180, false, false, PostgreSql_18_Dialect::new),
+    POSTGRESQL_18(180, false, true, PostgreSql_18_Dialect::new),
     POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_18_Dialect::new);
 
     private final int _version;

--- a/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
+++ b/core/src/org/labkey/core/dialect/PostgreSqlVersion.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.labkey.core.dialect.PostgreSql92Dialect.PRODUCT_NAME;
+
 /**
  * Enum that specifies the versions of PostgreSQL that LabKey supports plus their properties
  */
@@ -23,6 +25,8 @@ public enum PostgreSqlVersion
     POSTGRESQL_17(170, false, true, PostgreSql_17_Dialect::new),
     POSTGRESQL_18(180, false, true, PostgreSql_18_Dialect::new),
     POSTGRESQL_FUTURE(Integer.MAX_VALUE, true, false, PostgreSql_18_Dialect::new);
+
+    public static final String RECOMMENDED = PRODUCT_NAME + " 18.x is the recommended version.";
 
     private final int _version;
     private final boolean _deprecated;


### PR DESCRIPTION
#### Rationale
Update code to reflect our decisions to deprecate PostgreSQL 13.x and recommend 18.x

#### Tasks 📍
- [x] Manual Testing / Verify Fix @labkey-jeckels 
- [x] Needs Automation - No