### PR TITLE
Fix BiologicsReportTest - don't offer files with no content

### DIFF
--- a/api/src/org/labkey/api/reports/report/r/ParamReplacementSvc.java
+++ b/api/src/org/labkey/api/reports/report/r/ParamReplacementSvc.java
@@ -659,7 +659,7 @@ public class ParamReplacementSvc
          }
      }
 
-     public Collection<ParamReplacement> fromFile(FileLike file) throws Exception
+     public Collection<ParamReplacement> fromFile(FileLike file) throws IOException
      {
          Map<String, ParamReplacement> outputSubstMap = new HashMap<>();
          if (file.exists())

--- a/api/src/org/labkey/api/reports/report/r/view/DownloadOutputView.java
+++ b/api/src/org/labkey/api/reports/report/r/view/DownloadOutputView.java
@@ -86,7 +86,7 @@ public abstract class DownloadOutputView extends ROutputView
                 return;
 
             out.write("<table class=\"labkey-output\">");
-            renderTitle(model, out);
+            renderTitle(out);
             if (isCollapse())
                 out.write("<tr style=\"display:none\"><td>");
             else

--- a/api/src/org/labkey/api/reports/report/r/view/HtmlOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/HtmlOutput.java
@@ -98,7 +98,7 @@ public class HtmlOutput extends AbstractParamReplacement
         @Override
         protected String renderInternalAsString(FileLike file) throws Exception
         {
-            if (file.exists())
+            if (existsWithContent(file))
                 return PageFlowUtil.addScriptNonces(PageFlowUtil.getStreamContentsAsString(file.openInputStream()));
 
             return null;
@@ -113,7 +113,7 @@ public class HtmlOutput extends AbstractParamReplacement
                 if (null != html)
                 {
                     out.write("<table class=\"labkey-output\">");
-                    renderTitle(model, out);
+                    renderTitle(out);
                     if (isCollapse())
                         out.write("<tr style=\"display:none\"><td>");
                     else

--- a/api/src/org/labkey/api/reports/report/r/view/ImageOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/ImageOutput.java
@@ -123,7 +123,7 @@ public class ImageOutput extends AbstractParamReplacement
         {
             String imgUrl = null;
 
-            if (file.exists())
+            if (existsWithContent(file))
             {
                 FileLike imgFile;
                 if (!_deleteFile)
@@ -157,7 +157,7 @@ public class ImageOutput extends AbstractParamReplacement
                 if (null != imgUrl)
                 {
                     out.write("<table class=\"labkey-output\">");
-                    renderTitle(model, out);
+                    renderTitle(out);
                     if (isCollapse())
                         out.write("<tr style=\"display:none\"><td>");
                     else

--- a/api/src/org/labkey/api/reports/report/r/view/JsonOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/JsonOutput.java
@@ -57,7 +57,7 @@ public class JsonOutput extends AbstractParamReplacement
     }
 
     @Override
-    public HttpView getView(ViewContext context)
+    public HttpView<?> getView(ViewContext context)
     {
         return new JsonOutputView(this);
     }
@@ -85,7 +85,7 @@ public class JsonOutput extends AbstractParamReplacement
         @Override
         protected String renderInternalAsString(FileLike file) throws IOException
         {
-            if (file.exists())
+            if (existsWithContent(file))
                 return PageFlowUtil.getStreamContentsAsString(file.openInputStream());
 
             return null;
@@ -101,7 +101,7 @@ public class JsonOutput extends AbstractParamReplacement
                 if (null != rawValue)
                 {
                     out.write("<table class=\"labkey-output\">");
-                    renderTitle(model, out);
+                    renderTitle(out);
                     if (isCollapse())
                         out.write("<tr style=\"display:none\"><td><pre>");
                     else

--- a/api/src/org/labkey/api/reports/report/r/view/ROutputView.java
+++ b/api/src/org/labkey/api/reports/report/r/view/ROutputView.java
@@ -29,11 +29,8 @@ import org.labkey.api.view.HttpView;
 import org.labkey.vfs.FileLike;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -128,7 +125,7 @@ public class ROutputView extends HttpView<Object>
         return null;
     }
 
-    protected void renderTitle(Object model, PrintWriter out)
+    protected void renderTitle(PrintWriter out)
     {
         StringBuilder sb = new StringBuilder();
 
@@ -164,7 +161,7 @@ public class ROutputView extends HttpView<Object>
         return null;
     }
 
-    protected boolean exists(File file)
+    protected boolean existsWithContent(FileLike file)
     {
         long size = 0;
 
@@ -181,11 +178,7 @@ public class ROutputView extends HttpView<Object>
             if (ALLOW_REMOTE_FILESIZE_BYPASS && _isRemote)
                 return true;
 
-            try
-            {
-                size = Files.size(Paths.get(file.getAbsolutePath()));
-            }
-            catch(IOException ignore){}
+            size = file.getSize();
         }
 
         return (size > 0);
@@ -199,16 +192,12 @@ public class ROutputView extends HttpView<Object>
 
         if (tempDir.exists())
         {
-            File[] filesToDelete = tempDir.listFiles(new FileFilter(){
-                @Override
-                public boolean accept(File file)
+            File[] filesToDelete = tempDir.listFiles(file -> {
+                if (!file.isDirectory() && file.getName().startsWith(PREFIX))
                 {
-                    if (!file.isDirectory() && file.getName().startsWith(PREFIX))
-                    {
-                        return file.lastModified() < cutoff;
-                    }
-                    return false;
+                    return file.lastModified() < cutoff;
                 }
+                return false;
             });
             
             for (File file : filesToDelete)

--- a/api/src/org/labkey/api/reports/report/r/view/TextOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/TextOutput.java
@@ -85,7 +85,7 @@ public class TextOutput extends AbstractParamReplacement
         @Override
         protected String renderInternalAsString(FileLike file) throws IOException
         {
-            if (file.exists())
+            if (existsWithContent(file))
                 return PageFlowUtil.getStreamContentsAsString(file.openInputStream());
 
             return null;
@@ -101,7 +101,7 @@ public class TextOutput extends AbstractParamReplacement
                 if (null != rawValue)
                 {
                     out.write("<table class=\"labkey-output\">");
-                    renderTitle(model, out);
+                    renderTitle(out);
                     if (isCollapse())
                         out.write("<tr style=\"display:none\"><td><pre>");
                     else

--- a/api/src/org/labkey/api/reports/report/r/view/TsvOutput.java
+++ b/api/src/org/labkey/api/reports/report/r/view/TsvOutput.java
@@ -112,7 +112,7 @@ public class TsvOutput extends AbstractParamReplacement
         @Override
         protected String renderInternalAsString(FileLike file) throws IOException
         {
-            if (file.exists())
+            if (existsWithContent(file))
                 return PageFlowUtil.getStreamContentsAsString(file.openInputStream());
 
             return null;
@@ -126,104 +126,111 @@ public class TsvOutput extends AbstractParamReplacement
                 TabLoader tabLoader = createTabLoader(file);
                 if (tabLoader != null)
                 {
-                    ColumnDescriptor[] cols = tabLoader.getColumns();
-                    List<Map<String, Object>> data = tabLoader.load();
-
-                    List<ColumnDescriptor> display = new ArrayList<>();
-                    HashMap<String, ColumnDescriptor> hrefs = new HashMap<>(tabLoader.getColumns().length * 2);
-                    HashMap<String, ColumnDescriptor> styles = new HashMap<>(tabLoader.getColumns().length * 2);
-
-                    for (ColumnDescriptor col : cols)
-                        hrefs.put(col.name, null);
-
-                    for (ColumnDescriptor col : cols)
+                    try
                     {
-                        if (col.name.endsWith(".href") || col.name.endsWith("_href"))
+                        ColumnDescriptor[] cols = tabLoader.getColumns();
+                        List<Map<String, Object>> data = tabLoader.load();
+
+                        List<ColumnDescriptor> display = new ArrayList<>();
+                        HashMap<String, ColumnDescriptor> hrefs = new HashMap<>(tabLoader.getColumns().length * 2);
+                        HashMap<String, ColumnDescriptor> styles = new HashMap<>(tabLoader.getColumns().length * 2);
+
+                        for (ColumnDescriptor col : cols)
+                            hrefs.put(col.name, null);
+
+                        for (ColumnDescriptor col : cols)
                         {
-                            String name = col.name.substring(0,col.name.length()-".href".length());
-                            if (hrefs.containsKey(name))
+                            if (col.name.endsWith(".href") || col.name.endsWith("_href"))
                             {
-                                hrefs.put(name,col);
-                                continue;
+                                String name = col.name.substring(0, col.name.length() - ".href".length());
+                                if (hrefs.containsKey(name))
+                                {
+                                    hrefs.put(name, col);
+                                    continue;
+                                }
                             }
-                        }
-                        if (col.name.endsWith(".style") || col.name.endsWith("_style"))
-                        {
-                            String name = col.name.substring(0,col.name.length()-".style".length());
-                            if (hrefs.containsKey(name))
+                            if (col.name.endsWith(".style") || col.name.endsWith("_style"))
                             {
-                                styles.put(name,col);
-                                continue;
+                                String name = col.name.substring(0, col.name.length() - ".style".length());
+                                if (hrefs.containsKey(name))
+                                {
+                                    styles.put(name, col);
+                                    continue;
+                                }
                             }
+                            display.add(col);
                         }
-                        display.add(col);
-                    }
 
-                    int row = 0;
-                    out.write("<table class=\"labkey-data-region-legacy labkey-show-borders\">");
-                    renderTitle(model, out);
-                    if (isCollapse())
-                        out.write("<tr style=\"display:none\"><td><table>");
-                    else
-                        out.write("<tr><td><table class=\"labkey-r-tsvout\">");
-                    out.write("<tr>");
-                    for (ColumnDescriptor col : display)
-                    {
-                        if (Number.class.isAssignableFrom(col.getDataClass()))
-                            out.write("<td class=\"labkey-column-header\" align=\"right\">");
+                        int row = 0;
+                        out.write("<table class=\"labkey-data-region-legacy labkey-show-borders\">");
+                        renderTitle(out);
+                        if (isCollapse())
+                            out.write("<tr style=\"display:none\"><td><table>");
                         else
-                            out.write("<td class=\"labkey-column-header\">");
-                        out.write(PageFlowUtil.filter(col.name, true, true));
-                        out.write("</td>");
-                        row++;
-                    }
-                    out.write("</tr>");
-
-                    for (Map<String, Object> m : data)
-                    {
-                        if (row % 2 == 0)
-                            out.write("<tr class=\"labkey-row\">");
-                        else
-                            out.write("<tr class=\"labkey-alternate-row\">");
+                            out.write("<tr><td><table class=\"labkey-r-tsvout\">");
+                        out.write("<tr>");
                         for (ColumnDescriptor col : display)
                         {
-                            Object colVal = m.get(col.name);
-                            if ("NA".equals(colVal))
-                                colVal = null;
-                            ColumnDescriptor hrefCol = hrefs.get(col.name);
-                            String href = hrefCol == null ? null : ConvertUtils.convert((m.get(hrefCol.name)));
-                            ColumnDescriptor styleCol = styles.get(col.name);
-                            String style = styleCol == null ? null : ConvertUtils.convert((m.get(styleCol.name)));
-
-                            out.write("<td");
-                            if (Number.class.isAssignableFrom(col.clazz))
-                                out.write(" align=\"right\"");
-                            if (null != style)
-                            {
-                                out.write(" style=\"");
-                                out.write(PageFlowUtil.filter(style));
-                                out.write("\"");
-                            }
-                            out.write(">");
-                            if (null != href)
-                            {
-                                out.write("<a href=\"");
-                                out.write(PageFlowUtil.filter(href));
-                                out.write("\">");
-                            }
-                            if (null == colVal)
-                                out.write("&nbsp;");
+                            if (Number.class.isAssignableFrom(col.getDataClass()))
+                                out.write("<td class=\"labkey-column-header\" align=\"right\">");
                             else
-                                out.write(PageFlowUtil.filter(ConvertUtils.convert(colVal), true, true));
-                            if (null != href)
-                                out.write("</a>");
+                                out.write("<td class=\"labkey-column-header\">");
+                            out.write(PageFlowUtil.filter(col.name, true, true));
                             out.write("</td>");
+                            row++;
                         }
                         out.write("</tr>");
-                        row++;
+
+                        for (Map<String, Object> m : data)
+                        {
+                            if (row % 2 == 0)
+                                out.write("<tr class=\"labkey-row\">");
+                            else
+                                out.write("<tr class=\"labkey-alternate-row\">");
+                            for (ColumnDescriptor col : display)
+                            {
+                                Object colVal = m.get(col.name);
+                                if ("NA".equals(colVal))
+                                    colVal = null;
+                                ColumnDescriptor hrefCol = hrefs.get(col.name);
+                                String href = hrefCol == null ? null : ConvertUtils.convert((m.get(hrefCol.name)));
+                                ColumnDescriptor styleCol = styles.get(col.name);
+                                String style = styleCol == null ? null : ConvertUtils.convert((m.get(styleCol.name)));
+
+                                out.write("<td");
+                                if (Number.class.isAssignableFrom(col.clazz))
+                                    out.write(" align=\"right\"");
+                                if (null != style)
+                                {
+                                    out.write(" style=\"");
+                                    out.write(PageFlowUtil.filter(style));
+                                    out.write("\"");
+                                }
+                                out.write(">");
+                                if (null != href)
+                                {
+                                    out.write("<a href=\"");
+                                    out.write(PageFlowUtil.filter(href));
+                                    out.write("\">");
+                                }
+                                if (null == colVal)
+                                    out.write("&nbsp;");
+                                else
+                                    out.write(PageFlowUtil.filter(ConvertUtils.convert(colVal), true, true));
+                                if (null != href)
+                                    out.write("</a>");
+                                out.write("</td>");
+                            }
+                            out.write("</tr>");
+                            row++;
+                        }
+                        out.write("</table></td></tr>");
+                        out.write("</table>");
                     }
-                    out.write("</table></td></tr>");
-                    out.write("</table>");
+                    finally
+                    {
+                        tabLoader.close();
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Rationale
The recent FileLike refactor broke the BiologicsReportTest by offering up R output files that didn't actually get generated. We've been creating 0 byte output files and then opt not to serve them to the client. This restores that behavior. As a followup, we might avoid creating these files in the first place.

#### Changes
- Restore check that sees if file exists and has content
- Misc code cleanup

#### Tasks 📍
- Manual Testing - N/A
- [x] Needs Automation - verification run: https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_ProductSuites_Biologics_BiologicsPostgres/3762227
