### PR TITLE
Drop unique constraint on study.uploadLog filePath field

### DIFF
--- a/study/resources/schemas/dbscripts/postgresql/study-25.004-25.005.sql
+++ b/study/resources/schemas/dbscripts/postgresql/study-25.004-25.005.sql
@@ -1,0 +1,1 @@
+ALTER TABLE study.uploadlog DROP CONSTRAINT UQ_UploadLog_FilePath;

--- a/study/resources/schemas/dbscripts/sqlserver/study-25.004-25.005.sql
+++ b/study/resources/schemas/dbscripts/sqlserver/study-25.004-25.005.sql
@@ -1,0 +1,1 @@
+ALTER TABLE study.uploadlog DROP CONSTRAINT UQ_UploadLog_FilePath;

--- a/study/src/org/labkey/study/StudyModule.java
+++ b/study/src/org/labkey/study/StudyModule.java
@@ -226,7 +226,7 @@ public class StudyModule extends SpringModule implements SearchService.DocumentP
     @Override
     public Double getSchemaVersion()
     {
-        return 25.004;
+        return 25.005;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We stopped saving dataset bulk imported data to the file system with this [PR](https://github.com/LabKey/platform/pull/7248), but kept the database field : `study.uploadLog.filePath` even though we no longer will populate it.

This drops the unique constraint on that field.