### PR TITLE
File watcher configuration change

### DIFF
--- a/api/src/org/labkey/api/pipeline/PipelineJobService.java
+++ b/api/src/org/labkey/api/pipeline/PipelineJobService.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.formSchema.FormSchema;
 import org.labkey.api.pipeline.file.PathMapper;
+import org.labkey.api.security.User;
 import org.labkey.api.util.QuietCloser;
 
 import java.io.FileNotFoundException;
@@ -192,7 +193,7 @@ public interface PipelineJobService extends TaskPipelineRegistry
         RemoteExecutionEngine
     }
 
-    FormSchema getFormSchema(Container container);
+    FormSchema getFormSchema(Container container, User user);
 
     /** @return true if the current instance is the web server, which has access to more resources including the
      * primary database, or false if we're on a remote server

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -702,8 +702,6 @@ public class PipelineJobServiceImpl implements PipelineJobService
         List<Option<String>> userOptions = new ArrayList<>(SecurityManager.getUsersWithPermissions(container, Set.of(InsertPermission.class)).stream()
                 .map(u -> new Option<>(u.getDisplayName(user), u.getDisplayName(user)))
                 .toList());
-        // allow empty selection
-        userOptions.add(new Option<>("", ""));
 
         String usernameHelpText = "The file watcher will run as this user in the pipeline. Users in this list have insert permissions for the folder. Some tasks may require this user to have admin permissions.";
         String assayProviderHelpText = "Use this provider for running assay import runs. This will be the name of the assay type eg : General or " +
@@ -717,7 +715,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
                 new TextareaField("description", "Description", null, false, ""),
                 new SelectField<>("type", "Type", null, true, typeDefaultValue, typeOptions),
                 new SelectField<>("pipelineId", "Pipeline Task", "Select a Pipeline Task", true, null, taskOptions),
-                new SelectField("username", "Run as Username", null, false, "", userOptions, usernameHelpText, usernameHref),
+                new SelectField("username", "Run as Username", null, true, null, userOptions, usernameHelpText, usernameHref),
                 new TextField("assay provider", "Assay Provider", "General", false, null, assayProviderHelpText, assayProviderHref),
                 new CheckboxField("enabled", "Enable this Trigger", false, true)
         );

--- a/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
+++ b/pipeline/src/org/labkey/pipeline/api/PipelineJobServiceImpl.java
@@ -65,6 +65,9 @@ import org.labkey.api.pipeline.file.PathMapperImpl;
 import org.labkey.api.pipeline.trigger.PipelineTriggerRegistry;
 import org.labkey.api.pipeline.trigger.PipelineTriggerType;
 import org.labkey.api.reports.report.r.RReport;
+import org.labkey.api.security.SecurityManager;
+import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.MemTracker;
@@ -672,7 +675,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
     }
 
     @Override
-    public FormSchema getFormSchema(Container container)
+    public FormSchema getFormSchema(Container container, User user)
     {
         List<Option<String>> typeOptions = new ArrayList<>();
         for (PipelineTriggerType<?> pipelineTriggerType : PipelineTriggerRegistry.get().getTypes())
@@ -696,7 +699,13 @@ public class PipelineJobServiceImpl implements PipelineJobService
         for (FileAnalysisTaskPipeline task : tasks)
             taskOptions.add(new Option<>(task.getId().toString(), task.getDescription()));
 
-        String usernameHelpText = "The file watcher will run as this user in the pipeline. Some tasks may require this user to have admin permissions.";
+        List<Option<String>> userOptions = new ArrayList<>(SecurityManager.getUsersWithPermissions(container, Set.of(InsertPermission.class)).stream()
+                .map(u -> new Option<>(u.getDisplayName(user), u.getDisplayName(user)))
+                .toList());
+        // allow empty selection
+        userOptions.add(new Option<>("", ""));
+
+        String usernameHelpText = "The file watcher will run as this user in the pipeline. Users in this list have insert permissions for the folder. Some tasks may require this user to have admin permissions.";
         String assayProviderHelpText = "Use this provider for running assay import runs. This will be the name of the assay type eg : General or " +
                 "the name of a module based assay.";
         String baseHref = "https://www.labkey.org/Documentation/wiki-page.view?name=fileWatchCreate#";
@@ -708,7 +717,7 @@ public class PipelineJobServiceImpl implements PipelineJobService
                 new TextareaField("description", "Description", null, false, ""),
                 new SelectField<>("type", "Type", null, true, typeDefaultValue, typeOptions),
                 new SelectField<>("pipelineId", "Pipeline Task", "Select a Pipeline Task", true, null, taskOptions),
-                new TextField("username", "Run as Username", null, false, null, usernameHelpText, usernameHref),
+                new SelectField("username", "Run as Username", null, false, "", userOptions, usernameHelpText, usernameHref),
                 new TextField("assay provider", "Assay Provider", "General", false, null, assayProviderHelpText, assayProviderHref),
                 new CheckboxField("enabled", "Enable this Trigger", false, true)
         );

--- a/pipeline/src/org/labkey/pipeline/createPipelineTrigger.jsp
+++ b/pipeline/src/org/labkey/pipeline/createPipelineTrigger.jsp
@@ -59,7 +59,7 @@
 
     String uniqueId = "" + UniqueID.getServerSessionScopedUID();
     String appId = "create-pipeline-trigger-" + uniqueId;
-    FormSchema detailsFormSchema = PipelineJobService.get().getFormSchema(getContainer());
+    FormSchema detailsFormSchema = PipelineJobService.get().getFormSchema(getContainer(), getUser());
     Map<String, FormSchema> taskFormSchemas = new HashMap<>();
     Map<String, FormSchema> customFieldFormSchemas = new HashMap<>();
     Map<String, String> tasksHelpText = new HashMap<>();


### PR DESCRIPTION
#### Rationale
Previously, we rendered the `run as username` field for file watcher configurations as a text field and the user had to enter a display name. This change will render that field as a dropdown populated by users with insert permissions to the current folder.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7254
- https://github.com/LabKey/testAutomation/pull/2810

#### Tasks 📍
- [x] Manual Testing
- [x] Verify Fix
