### PR TITLE
GitHub Issue 726: Fix typo in URLDisplayColumn img style width and height semicolon location

### DIFF
--- a/api/src/org/labkey/api/data/URLDisplayColumn.java
+++ b/api/src/org/labkey/api/data/URLDisplayColumn.java
@@ -182,7 +182,7 @@ public class URLDisplayColumn extends AbstractFileDisplayColumn
                 String thumbnailUrl = _fileIconUrl != null ? ensureAbsoluteUrl(_ctx, _fileIconUrl) : ensureAbsoluteUrl(_ctx, _url);
 
                 return IMG(at(
-                    style, "display:block; vertical-align:middle;" + (renderSize ? (_thumbnailWidth != null ? " width:" + _thumbnailWidth : " max-width:32px" + "; ") + (_thumbnailHeight != null ? " height:" + _thumbnailHeight : " height:auto" + ";") : ""),
+                    style, "display:block; vertical-align:middle;" + (renderSize ? (_thumbnailWidth != null ? " width:" + _thumbnailWidth : " max-width:32px") + "; " + (_thumbnailHeight != null ? " height:" + _thumbnailHeight : " height:auto") + ";" : ""),
                     src, thumbnailUrl, title, _displayName
                 ));
             }


### PR DESCRIPTION
#### Rationale
[#726](https://github.com/LabKey/internal-issues/issues/726) thumbnailImageWidth and thumbnailImageHeight stopped working in 25.7 URLDisplayColumn

A misplaced semicolon is causing the thumbnail width and height values set via query xml to not be applied in the URLDisplayColumn output.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6682/files#diff-65fc0360994f4816a3d246d60401a885e16b777cf5cb8176c009ab86d532032bR185

#### Changes
- make sure semicolon is added after img style width and height

