### PR TITLE
GitHub Issue 712: Add "core" to default module set for DefaultFolderType

### DIFF
--- a/api/src/org/labkey/api/module/DefaultFolderType.java
+++ b/api/src/org/labkey/api/module/DefaultFolderType.java
@@ -425,6 +425,7 @@ public class DefaultFolderType implements FolderType
         if (null == s_defaultModules)
         {
             Set<Module> defaultModules = new HashSet<>();
+            defaultModules.add(getModule("core")); // GitHub Issue 712
             if (ModuleLoader.getInstance().hasModule("Announcements"))
                 defaultModules.add(getModule("Announcements"));
             if (ModuleLoader.getInstance().hasModule("FileContent"))


### PR DESCRIPTION
#### Rationale
[#712](https://github.com/LabKey/internal-issues/issues/712): Unselecting Portal module in a Sample Manager folder/project will lead to an uncaught exception and break the page

Folder management page will not disable the ability to uncheck the "Portal" module.
<img width="1276" height="377" alt="Screenshot 2025-12-09 at 4 44 52 PM" src="https://github.com/user-attachments/assets/a29bd18d-9e5c-4902-b954-66be88baec83" />

#### Changes
- Add "core" to default module set for DefaultFolderType
