### PR TITLE
Allow site admins to see all views (private and shared) from the hidden query-manageViews page

### DIFF
--- a/query/src/org/labkey/query/controllers/InternalViewForm.java
+++ b/query/src/org/labkey/query/controllers/InternalViewForm.java
@@ -69,7 +69,8 @@ public class InternalViewForm extends ViewForm
         }
         else
         {
-            if (view.getCustomViewOwner().intValue() != context.getUser().getUserId())
+            // must be owner or site admin
+            if (!context.getUser().hasSiteAdminPermission() && view.getCustomViewOwner().intValue() != context.getUser().getUserId())
             {
                 throw new UnauthorizedException();
             }

--- a/query/src/org/labkey/query/view/manageViews.jsp
+++ b/query/src/org/labkey/query/view/manageViews.jsp
@@ -59,14 +59,16 @@
     QueryManager mgr = QueryManager.get();
     List<CstmView> views = new ArrayList<>();
 
-    if (getViewContext().hasPermission(UpdatePermission.class))
+    if (getViewContext().getUser().hasSiteAdminPermission())
     {
-        views.addAll(mgr.getCstmViews(c, schemaName, queryName, null, null, false, true));
+        views.addAll(mgr.getCstmViews(c, schemaName, queryName, null, null, false, false));
     }
-
-    if (!user.isGuest())
+    else
     {
-        views.addAll(mgr.getCstmViews(c, schemaName, queryName, null, user, false, false));
+        if (getViewContext().hasPermission(UpdatePermission.class))
+            views.addAll(mgr.getCstmViews(c, schemaName, queryName, null, null, false, true));
+        if (!user.isGuest())
+            views.addAll(mgr.getCstmViews(c, schemaName, queryName, null, user, false, false));
     }
 
     // UNDONE: Requires queryName and schemaName for now.  We need a method to get all session views in a container.

--- a/query/src/org/labkey/query/view/manageViews.jsp
+++ b/query/src/org/labkey/query/view/manageViews.jsp
@@ -109,22 +109,25 @@
 <% } %>
 </p>
 
-<table>
+<table class="labkey-data-region-legacy labkey-show-borders">
     <tr>
-        <th>Schema</th>
-        <th>Query</th>
-        <th>View Name</th>
-        <th>Flags</th>
-        <th>Owner</th>
-        <th>Created</th>
-        <th>Created&nbsp;By</th>
-        <th>Modified</th>
-        <th>Modified&nbsp;By</th>
+        <td class="labkey-column-header">Schema</td>
+        <td class="labkey-column-header">Query</td>
+        <td class="labkey-column-header">View Name</td>
+        <td class="labkey-column-header">Flags</td>
+        <td class="labkey-column-header">Owner</td>
+        <td class="labkey-column-header">Created</td>
+        <td class="labkey-column-header">Created By</td>
+        <td class="labkey-column-header">Modified</td>
+        <td class="labkey-column-header">Modified By</td>
+        <td class="labkey-column-header"></td>
     </tr>
     <% if (getViewContext().hasPermission(UpdatePermission.class))
     {
+        int count = 1;
         for (CstmView view : views)
         {
+            count++;
             List<String> flags = new ArrayList<>();
             if (view.getCustomViewId() == 0)
                 flags.add("<em>session</em>");
@@ -135,7 +138,7 @@
             if (mgr.isSnapshot(view.getFlags()))
                 flags.add("shapshot");
     %>
-    <tr>
+    <tr class="<%=getShadeRowClass(count)%>">
         <td><%=h(view.getSchema())%>
         </td>
         <td><%=h(view.getQueryName())%>


### PR DESCRIPTION
#### Rationale
[#729](https://github.com/LabKey/internal-issues/issues/729) Allow site admins to see all grid views (including others' private ones) on the query-manageViews admin page

There is a hidden action (query-manageViews.view) that exists to help troubleshoot custom grid views (to allow for editing and deleting errant views). Currently this shows all public/shared views along with private views for the current user. However, it is often the case that site admins use this action to help clean up or fix views for other users (including deactivated ones). It is a pain to have to impersonate each user individually in order to delete/fix their private views. This PR updates that hidden action to show all views for the container in the site admin case.

#### Changes
- allow site admin to see all container custom views from query-manageViews action
- set table css classes to make the static table more readable
