### PR TITLE
GitHub Issue 563: Assay results default view to include Run/Name

### DIFF
--- a/assay/api-src/org/labkey/api/assay/AssayResultTable.java
+++ b/assay/api-src/org/labkey/api/assay/AssayResultTable.java
@@ -244,6 +244,7 @@ public class AssayResultTable extends FilteredTable<AssayProtocolSchema> impleme
             for (FieldKey calculatedFieldKey : calculatedFieldKeys)
                 visibleColumns.add(FieldKey.fromParts("Run", calculatedFieldKey.getName()));
         }
+        visibleColumns.add(FieldKey.fromParts("Run", "Name"));
 
         for (DomainProperty prop : _provider.getBatchDomain(_protocol).getProperties())
         {


### PR DESCRIPTION
#### Rationale
[#563](https://github.com/LabKey/internal-issues/issues/563) Improve navigation between assay runs and workflow tasks (LabKey Issue: 53642)

#### Related Pull Requests
- https://github.com/LabKey/labkey-ui-premium/pull/865

#### Changes
- Assay results default view to include Run/Name

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->