### PR TITLE
Fix file watcher test for Java 25

### DIFF
--- a/api/src/org/labkey/api/annotations/JavaRuntimeVersion.java
+++ b/api/src/org/labkey/api/annotations/JavaRuntimeVersion.java
@@ -19,8 +19,6 @@ package org.labkey.api.annotations;
   Used to mark code that is specific to a particular Java runtime version, for example, hacks that work around problems
   in the runtime or links to the Java documentation. Re-evaluate these when Java versions are released or deprecated.
   Search for text "@JavaRuntimeVersion" to find all usages.
-  User: adam
-  Date: 9/11/13
  */
 
 import java.lang.annotation.Retention;

--- a/api/src/org/labkey/api/files/FileSystemWatcherImpl.java
+++ b/api/src/org/labkey/api/files/FileSystemWatcherImpl.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.annotations.JavaRuntimeVersion;
 import org.labkey.api.cloud.CloudWatchService;
 import org.labkey.api.cloud.CloudWatcherConfig;
 import org.labkey.api.collections.ConcurrentHashSet;
@@ -61,16 +62,20 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
 
 /**
- * Wraps the low-level Java WatchService API with a simple listener-based interface. Unlike WatchService, which is limited to one
- * registration per file system directory, a single instance of this class should be sufficient to handle all file system listener
- * needs of the entire server.
- *
- * Callers register a FileSystemDirectoryListener on a directory Path, specifying the desired WatchEvent.Kinds (CREATE, DELETE,
- * and/or MODIFY); whenever an event occurs on any file or child directory in that directory, the appropriate method is invoked
- * on all listeners registered on that directory that have requested notification of that event.
- *
- * This class is thread-safe, for both listener registration and event invocation. Implementations of FileSystemDirectoryListener
- * must be thread-safe. Listener methods must return quickly since they are all invoked by a single thread.
+ * <p>Wraps the low-level Java WatchService API with a simple listener-based interface. Unlike WatchService, which is
+ * limited to one registration per file system directory, a single instance of this class should be sufficient to handle
+ * all file system listener needs of the entire server.
+ * </p>
+ * <p>
+ * Callers register a FileSystemDirectoryListener on a directory Path, specifying the desired WatchEvent.Kinds (CREATE,
+ * DELETE, and/or MODIFY); whenever an event occurs on any file or child directory in that directory, the appropriate
+ * method is invoked on all listeners registered on that directory that have requested notification of that event.
+ * </p>
+ * <p>
+ * This class is thread-safe, for both listener registration and event invocation. Implementations of
+ * FileSystemDirectoryListener must be thread-safe. Listener methods must return quickly since they are all invoked by a
+ * single thread.
+ * </p>
  */
 public class FileSystemWatcherImpl implements FileSystemWatcher
 {
@@ -586,8 +591,10 @@ public class FileSystemWatcherImpl implements FileSystemWatcher
 
             assertEquals(3, created.size());
             assertTrue(created.containsAll(Set.of("a", "b", "c")));
-            // Note: Modified events occur on delete on Windows, but not Linux
-            Set<String> expectedModified = SystemUtils.IS_OS_WINDOWS ? Set.of("a", "b", "c") : Set.of("a", "c");
+            // Note: In Java 17 on Windows, modified events occur on delete. This has never been the case on Linux and
+            // is no longer the case in Java 25. TODO: Delete this check once we require Java 25
+            @JavaRuntimeVersion
+            Set<String> expectedModified = SystemUtils.IS_OS_WINDOWS && SystemUtils.IS_JAVA_17 ? Set.of("a", "b", "c") : Set.of("a", "c");
             assertEquals(expectedModified.size(), modified.size());
             assertTrue(created.containsAll(expectedModified));
             int deletedCount = deleted.size();
@@ -613,9 +620,9 @@ public class FileSystemWatcherImpl implements FileSystemWatcher
                 i++;
             }
 
-            LOG.info("Waiting for file watcher events took " + StringUtilsLabKey.pluralize(i, "second"));
+            LOG.info("Waiting for file watcher events took {}", StringUtilsLabKey.pluralize(i, "second"));
 
-            LOG.info("Actual event count: " + events.get() + " vs. target: " + targetCount);
+            LOG.info("Actual event count: {} vs. target: {}", events.get(), targetCount);
             //assertEquals(expectedEventCount, events.get());
         }
     }

--- a/api/src/org/labkey/api/jsp/JspLoader.java
+++ b/api/src/org/labkey/api/jsp/JspLoader.java
@@ -66,7 +66,7 @@ public class JspLoader
      * Create a new JSP page.
      *
      * @param jspFile Full path to the JSP page, starting with "/"
-     * @return inited page
+     * @return initialized page
      */
     public static HttpJspPage createPage(String jspFile)
     {
@@ -84,7 +84,7 @@ public class JspLoader
         }
     }
 
-    public static Class loadClass(String jspFile)
+    public static Class<?> loadClass(String jspFile)
     {
         try
         {

--- a/api/src/org/labkey/api/jsp/RecompilingJspClassLoader.java
+++ b/api/src/org/labkey/api/jsp/RecompilingJspClassLoader.java
@@ -63,7 +63,7 @@ public class RecompilingJspClassLoader extends JspClassLoader
     private static final String DB_SCRIPT_PATH = "/schemas/dbscripts";
 
     @Override
-    public Class loadClass(ServletContext context, String jspFilename) throws ClassNotFoundException
+    public Class<?> loadClass(ServletContext context, String jspFilename) throws ClassNotFoundException
     {
         String compiledJspPath = getCompiledJspPath(jspFilename);
         Collection<ResourceFinder> finders = ModuleLoader.getInstance().getResourceFindersForPath(compiledJspPath);
@@ -86,7 +86,7 @@ public class RecompilingJspClassLoader extends JspClassLoader
 
 
     @JavaRuntimeVersion  // Change CompilerTargetVM and CompilerSourceVM settings below
-    private Class getCompiledClassFile(File classFile, File jspJavaFileBuildDirectory, File jspClassesFileBuildDir, ResourceFinder finder, String jspFileName)
+    private Class<?> getCompiledClassFile(File classFile, File jspJavaFileBuildDirectory, File jspClassesFileBuildDir, ResourceFinder finder, String jspFileName)
     {
         String relativePath = getSourceJspPath(jspFileName);
         // Create File object for JSP source


### PR DESCRIPTION
#### Rationale
When deleting a watched file on Windows + Java 17, `WatchService` would send an `ENTRY_MODIFY` watch event in addition to an `ENTRY_DELETE` watch event. On Java 25, this appears to no longer be the case. Adjust the test to accommodate this change.

Address miscellaneous warnings.

No need to manually test this test fix.