### PR TITLE
Second issue related to FilePaths being relativized in XAR/ExpRun import

### DIFF
--- a/experiment/src/org/labkey/experiment/DataURLRelativizer.java
+++ b/experiment/src/org/labkey/experiment/DataURLRelativizer.java
@@ -22,6 +22,7 @@ import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.view.ActionURL;
+import org.labkey.experiment.api.ExperimentServiceImpl;
 import org.labkey.experiment.controllers.exp.ExperimentController;
 
 import java.io.IOException;
@@ -75,21 +76,16 @@ public enum DataURLRelativizer
                 @Override
                 public String rewriteURL(Path path, ExpData data, String roleName, ExpRun expRun, User user, String rootFilePath) throws ExperimentException
                 {
-                    try
-                    {
-                        if (path == null)
-                            return null;
+                    if (path == null)
+                        return null;
 
-                        if (expRun == null || expRun.getFilePathRoot() == null)
-                        {
-                            return FileUtil.pathToString(path);
-                        }
-                        return FileUtil.relativizeUnix(expRun.getFilePathRootPath(), path, false);
-                    }
-                    catch (IOException e)
+                    if (expRun == null || expRun.getFilePathRoot() == null)
                     {
-                        throw new ExperimentException(e);
+                        return FileUtil.pathToString(path);
                     }
+
+                    // NOTE: this will only write a relative path if the file is a direct descendant of the root.
+                    return ExperimentServiceImpl.get().generatePathStringRelativeToRootIfUnderRoot(path, expRun.getFilePathRootPath());
                 }
             };
         }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -230,13 +230,13 @@ import org.labkey.api.util.ReentrantLockWithName;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.SubstitutionFormat;
 import org.labkey.api.util.TestContext;
+import org.labkey.api.util.URIUtil;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspTemplate;
 import org.labkey.api.view.JspView;
-import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.api.view.ViewContext;
@@ -244,7 +244,6 @@ import org.labkey.experiment.ExperimentAuditProvider;
 import org.labkey.experiment.FileLinkFileListener;
 import org.labkey.experiment.MissingFilesCheckInfo;
 import org.labkey.experiment.XarExportType;
-import org.labkey.experiment.XarExporter;
 import org.labkey.experiment.XarReader;
 import org.labkey.experiment.api.property.DomainPropertyManager;
 import org.labkey.experiment.controllers.exp.ExperimentController;
@@ -253,13 +252,11 @@ import org.labkey.experiment.pipeline.ExpGeneratorHelper;
 import org.labkey.experiment.pipeline.ExperimentPipelineJob;
 import org.labkey.experiment.pipeline.MoveRunsPipelineJob;
 import org.labkey.experiment.xar.AutoFileLSIDReplacer;
-import org.labkey.experiment.xar.XarExportSelection;
 import org.labkey.vfs.FileLike;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.PessimisticLockingFailureException;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
@@ -778,7 +775,17 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 {
                     path = FileUtil.stringToPath(source.getXarContext().getContainer(),
                             source.getCanonicalDataFileURL(FileUtil.pathToString(path)));
-                    pathStr = FileUtil.relativizeUnix(source.getRootPath(), path, false);
+
+                    // Only convert to a relative path if this is a descendant of the root:
+                    path = path.normalize();
+                    if (URIUtil.isDescendant(source.getRootPath().toUri(), path.toUri()))
+                    {
+                        pathStr = FileUtil.relativizeUnix(source.getRootPath(), path, false);
+                    }
+                    else
+                    {
+                        pathStr = FileUtil.pathToString(path);
+                    }
                 }
                 catch (IOException e)
                 {

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -768,33 +768,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             String[] parts = pathStr.split("/");
             String name = FileUtil.decodeSpaces(parts[parts.length - 1]);
             Path path = FileUtil.getPath(source.getXarContext().getContainer(), uri);
-
             if (path != null)
             {
-                try
-                {
-                    path = FileUtil.stringToPath(source.getXarContext().getContainer(),
-                            source.getCanonicalDataFileURL(FileUtil.pathToString(path)));
-
-                    // Only convert to a relative path if this is a descendant of the root:
-                    path = path.normalize();
-                    if (URIUtil.isDescendant(source.getRootPath().toUri(), path.toUri()))
-                    {
-                        pathStr = FileUtil.relativizeUnix(source.getRootPath(), path, false);
-                    }
-                    else
-                    {
-                        pathStr = FileUtil.pathToString(path);
-                    }
-                }
-                catch (IOException e)
-                {
-                    pathStr = FileUtil.pathToString(path);
-                }
-            }
-            else
-            {
-                pathStr = FileUtil.uriToString(uri);
+                path = FileUtil.stringToPath(source.getXarContext().getContainer(), source.getCanonicalDataFileURL(FileUtil.pathToString(path)));
+                pathStr = generatePathStringRelativeToRootIfUnderRoot(path, source.getRootPath());
             }
 
             Lsid.LsidBuilder lsid = new Lsid.LsidBuilder(LsidUtils.resolveLsidFromTemplate(AutoFileLSIDReplacer.AUTO_FILE_LSID_SUBSTITUTION, source.getXarContext(), "Data", new AutoFileLSIDReplacer(pathStr, source.getXarContext().getContainer(), source)));
@@ -814,6 +791,30 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             data.save(source.getXarContext().getUser());
         }
         return data;
+    }
+
+    public String generatePathStringRelativeToRootIfUnderRoot(@NotNull Path path, @Nullable Path pipeRootPath)
+    {
+        String pathStr;
+        try
+        {
+            // Only convert to a relative path if this is a descendant of the root:
+            path = path.normalize();
+            if (pipeRootPath != null && URIUtil.isDescendant(pipeRootPath.toUri(), path.toUri()))
+            {
+                pathStr = FileUtil.relativizeUnix(pipeRootPath, path, false);
+            }
+            else
+            {
+                pathStr = FileUtil.pathToString(path);
+            }
+        }
+        catch (IOException e)
+        {
+            pathStr = FileUtil.pathToString(path);
+        }
+
+        return pathStr;
     }
 
     @Override


### PR DESCRIPTION
This is related to: https://github.com/LabKey/platform/pull/7261.

More background is listed on that issue. In 25.11, additional checks were added to disallow relative filepaths. The problem is that the XAR/Experiment system creates relative filepaths on data import. PR #7261 addressed one problem. After fixing this, I hit the following. This error happens a few lines after the original error. The gist is that LabKey writes out a XAR file for the run, and this file still contains forced relative URLs, even if not under the container's file root. 

My proposal here is to make the DataFileURL behavior consistent between ExperimentRun creation and XAR writing. The method "generatePathStringRelativeToRootIfUnderRoot" could certainly get a better name. I can add some code comments if you think this is a viable pathway.

The second path that might work is more involved. The ExpDatas being written to XML store their original non-relative DataFileURL. The XAR code could read that and preferentially swap in that original URI. This is less invasive, but also raises the question of what's the point of writing a relative URI to that XML if we're just going to reverse it. 

Here is a stacktrace, from: https://prime-seq.ohsu.edu/Labs/Bimber/1976/pipeline-status-details.view?rowId=602940. 

```
14 Dec 2025 07:58:31,535 ERROR: Path to parent not allowed: ../../../../1973/@files/sequenceOutputPipeline/SequenceOutput_2025-12-07_07-39-02/SingleCell.tca.ctd.PPG_Project2_Tissues_23230_T_NK.seurat.rds
java.nio.file.InvalidPathException: Path to parent not allowed: ../../../../1973/@files/sequenceOutputPipeline/SequenceOutput_2025-12-07_07-39-02/SingleCell.tca.ctd.PPG_Project2_Tissues_23230_T_NK.seurat.rds
	at org.labkey.api.exp.AbstractFileXarSource.canonicalizeDataFileURL(AbstractFileXarSource.java:126)
	at org.labkey.api.exp.XarSource.getCanonicalDataFileURL(XarSource.java:116)
	at org.labkey.experiment.xar.AutoFileLSIDReplacer.getReplacement(AutoFileLSIDReplacer.java:64)
	at org.labkey.api.exp.xar.Replacer$CompoundReplacer.getReplacement(Replacer.java:48)
	at org.labkey.api.exp.xar.LsidUtils.doReplacements(LsidUtils.java:154)
	at org.labkey.api.exp.xar.LsidUtils.resolveStringFromTemplate(LsidUtils.java:131)
	at org.labkey.api.exp.xar.LsidUtils.resolveLsidFromTemplate(LsidUtils.java:95)
	at org.labkey.api.exp.xar.LsidUtils.resolveLsidFromTemplate(LsidUtils.java:206)
	at org.labkey.experiment.XarReader.loadData(XarReader.java:1707)
	at org.labkey.experiment.XarReader.loadDoc(XarReader.java:418)
	at org.labkey.experiment.XarReader.parseAndLoad(XarReader.java:237)
	at org.labkey.experiment.api.ExperimentServiceImpl.importXar(ExperimentServiceImpl.java:2144)
	at org.labkey.experiment.api.ExperimentServiceImpl.importXar(ExperimentServiceImpl.java:2130)
	at org.labkey.experiment.pipeline.XarGeneratorTask.run(XarGeneratorTask.java:177)
	at org.labkey.api.pipeline.PipelineJob.runActiveTask(PipelineJob.java:831)
	at org.labkey.api.pipeline.PipelineJob.run(PipelineJob.java:1079)
	at org.labkey.pipeline.mule.PipelineJobRunner.run(PipelineJobRunner.java:40)
	at jdk.internal.reflect.GeneratedMethodAccessor634.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.mule.impl.model.resolvers.DynamicEntryPoint.invokeMethod(DynamicEntryPoint.java:312)
	at org.mule.impl.model.resolvers.DynamicEntryPoint.invoke(DynamicEntryPoint.java:259)
	at org.mule.impl.DefaultLifecycleAdapter.intercept(DefaultLifecycleAdapter.java:193)
	at org.mule.impl.InterceptorsInvoker.execute(InterceptorsInvoker.java:47)
	at org.mule.impl.model.DefaultMuleProxy.run(DefaultMuleProxy.java:470)
	at org.mule.impl.work.WorkerContext.run(WorkerContext.java:310)
	at edu.emory.mathcs.backport.java.util.concurrent.ThreadPoolExecutor$CallerRunsPolicy.rejectedExecution(ThreadPoolExecutor.java:1486)
	at edu.emory.mathcs.backport.java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:391)
	at edu.emory.mathcs.backport.java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:865)
	at org.mule.impl.work.ScheduleWorkExecutor.doExecute(ScheduleWorkExecutor.java:39)
	at org.mule.impl.work.MuleWorkManager.executeWork(MuleWorkManager.java:277)
	at org.mule.impl.work.MuleWorkManager.scheduleWork(MuleWorkManager.java:244)
	at org.mule.impl.model.seda.SedaComponent.run(SedaComponent.java:483)
	at org.mule.impl.work.WorkerContext.run(WorkerContext.java:310)
	at edu.emory.mathcs.backport.java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:650)
	at edu.emory.mathcs.backport.java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:675)
	at java.base/java.lang.Thread.run(Thread.java:840)

```