### PR TITLE
Second fix to filepaths outside the folder root with the XAR system, plus testing

### DIFF
--- a/experiment/src/org/labkey/experiment/DataURLRelativizer.java
+++ b/experiment/src/org/labkey/experiment/DataURLRelativizer.java
@@ -22,6 +22,7 @@ import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.view.ActionURL;
+import org.labkey.experiment.api.ExperimentServiceImpl;
 import org.labkey.experiment.controllers.exp.ExperimentController;
 
 import java.io.IOException;
@@ -75,21 +76,16 @@ public enum DataURLRelativizer
                 @Override
                 public String rewriteURL(Path path, ExpData data, String roleName, ExpRun expRun, User user, String rootFilePath) throws ExperimentException
                 {
-                    try
-                    {
-                        if (path == null)
-                            return null;
+                    if (path == null)
+                        return null;
 
-                        if (expRun == null || expRun.getFilePathRoot() == null)
-                        {
-                            return FileUtil.pathToString(path);
-                        }
-                        return FileUtil.relativizeUnix(expRun.getFilePathRootPath(), path, false);
-                    }
-                    catch (IOException e)
+                    if (expRun == null || expRun.getFilePathRoot() == null)
                     {
-                        throw new ExperimentException(e);
+                        return FileUtil.pathToString(path);
                     }
+
+                    // NOTE: this will only write a relative path if the file is a direct descendant of the root.
+                    return ExperimentServiceImpl.get().generatePathStringRelativeToRootIfUnderRoot(path, expRun.getFilePathRootPath());
                 }
             };
         }

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -152,6 +152,7 @@ import org.labkey.experiment.defaults.DefaultValueServiceImpl;
 import org.labkey.experiment.lineage.ExpLineageServiceImpl;
 import org.labkey.experiment.lineage.LineagePerfTest;
 import org.labkey.experiment.pipeline.ExperimentPipelineProvider;
+import org.labkey.experiment.pipeline.XarTestPipelineJob;
 import org.labkey.experiment.samples.DataClassFolderImporter;
 import org.labkey.experiment.samples.DataClassFolderWriter;
 import org.labkey.experiment.samples.SampleStatusFolderImporter;
@@ -1071,7 +1072,8 @@ public class ExperimentModule extends SpringModule
             SampleTypeServiceImpl.TestCase.class,
             StorageNameGenerator.TestCase.class,
             StorageProvisionerImpl.TestCase.class,
-            UniqueValueCounterTestCase.class
+            UniqueValueCounterTestCase.class,
+            XarTestPipelineJob.TestCase.class
         );
     }
 

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -768,33 +768,10 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             String[] parts = pathStr.split("/");
             String name = FileUtil.decodeSpaces(parts[parts.length - 1]);
             Path path = FileUtil.getPath(source.getXarContext().getContainer(), uri);
-
             if (path != null)
             {
-                try
-                {
-                    path = FileUtil.stringToPath(source.getXarContext().getContainer(),
-                            source.getCanonicalDataFileURL(FileUtil.pathToString(path)));
-
-                    // Only convert to a relative path if this is a descendant of the root:
-                    path = path.normalize();
-                    if (URIUtil.isDescendant(source.getRootPath().toUri(), path.toUri()))
-                    {
-                        pathStr = FileUtil.relativizeUnix(source.getRootPath(), path, false);
-                    }
-                    else
-                    {
-                        pathStr = FileUtil.pathToString(path);
-                    }
-                }
-                catch (IOException e)
-                {
-                    pathStr = FileUtil.pathToString(path);
-                }
-            }
-            else
-            {
-                pathStr = FileUtil.uriToString(uri);
+                path = FileUtil.stringToPath(source.getXarContext().getContainer(), source.getCanonicalDataFileURL(FileUtil.pathToString(path)));
+                pathStr = generatePathStringRelativeToRootIfUnderRoot(path, source.getRootPath());
             }
 
             Lsid.LsidBuilder lsid = new Lsid.LsidBuilder(LsidUtils.resolveLsidFromTemplate(AutoFileLSIDReplacer.AUTO_FILE_LSID_SUBSTITUTION, source.getXarContext(), "Data", new AutoFileLSIDReplacer(pathStr, source.getXarContext().getContainer(), source)));
@@ -814,6 +791,30 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             data.save(source.getXarContext().getUser());
         }
         return data;
+    }
+
+    public String generatePathStringRelativeToRootIfUnderRoot(@NotNull Path path, @Nullable Path pipeRootPath)
+    {
+        String pathStr;
+        try
+        {
+            // Only convert to a relative path if this is a descendant of the root:
+            path = path.normalize();
+            if (pipeRootPath != null && URIUtil.isDescendant(pipeRootPath.toUri(), path.toUri()))
+            {
+                pathStr = FileUtil.relativizeUnix(pipeRootPath, path, false);
+            }
+            else
+            {
+                pathStr = FileUtil.pathToString(path);
+            }
+        }
+        catch (IOException e)
+        {
+            pathStr = FileUtil.pathToString(path);
+        }
+
+        return pathStr;
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/pipeline/XarTestPipelineJob.java
+++ b/experiment/src/org/labkey/experiment/pipeline/XarTestPipelineJob.java
@@ -24,11 +24,9 @@ import org.labkey.api.pipeline.AbstractTaskFactorySettings;
 import org.labkey.api.pipeline.ParamParser;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineJob;
-import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.PipelineJobService;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.PipelineStatusFile;
-import org.labkey.api.pipeline.PipelineValidationException;
 import org.labkey.api.pipeline.RecordedAction;
 import org.labkey.api.pipeline.RecordedActionSet;
 import org.labkey.api.pipeline.TaskFactory;
@@ -47,6 +45,7 @@ import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.experiment.ExperimentModule;
 import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -77,15 +76,15 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
 
     private String _jobName;
     private FileLike _webserverJobDir;
-    private List<File> _inputFiles;
-    private List<File> _outputFiles;
+    private List<FileLike> _inputFiles;
+    private List<FileLike> _outputFiles;
 
     // Default constructor for serialization
     protected XarTestPipelineJob()
     {
     }
 
-    private XarTestPipelineJob(Container c, User user, PipeRoot pipeRoot, String jobName, List<File> inputFiles, List<File> outputFiles)
+    private XarTestPipelineJob(Container c, User user, PipeRoot pipeRoot, String jobName, List<FileLike> inputFiles, List<FileLike> outputFiles)
     {
         super(PROVIDER_NAME, new ViewBackgroundInfo(c, user, null), pipeRoot);
 
@@ -100,8 +99,7 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
 
     private static Path getOrCreateLogFile(Container c, String jobName)
     {
-        // TODO: There must be a more convenient way to work with FileLike...
-        return(FileUtil.appendPath(getOrCreateBaseDir(c, jobName), new org.labkey.api.util.Path(FileUtil.makeLegalName(jobName) + ".log")).toNioPathForWrite());
+        return getOrCreateBaseDir(c, jobName).resolveChild(FileUtil.makeLegalName(jobName) + ".log").toNioPathForWrite();
     }
 
     private static FileLike getOrCreateBaseDir(Container c, String jobName)
@@ -112,7 +110,7 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
             throw new IllegalStateException("Pipeline root not found for: " + c.getPath());
         }
 
-        FileLike baseDir = FileUtil.appendPath(pipeRoot.getRootFileLike(), new org.labkey.api.util.Path(FileUtil.makeLegalName(jobName)));
+        FileLike baseDir = pipeRoot.resolvePathToFileLike(FileUtil.makeLegalName(jobName));
         if (!baseDir.exists())
         {
             try
@@ -128,7 +126,7 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
         return baseDir;
     }
 
-    public static XarTestPipelineJob createJob(Container c, User user, String jobName, List<File> inputFiles, List<File> outputFiles) throws PipelineValidationException
+    public static XarTestPipelineJob createJob(Container c, User user, String jobName, List<FileLike> inputFiles, List<FileLike> outputFiles)
     {
         PipeRoot pipelineRoot = PipelineService.get().getPipelineRootSetting(c);
 
@@ -232,20 +230,16 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
             {
                 @NotNull
                 @Override
-                public RecordedActionSet run() throws PipelineJobException
+                public RecordedActionSet run()
                 {
                     // The purpose of this is to specify files outside the LK folder root:
                     RecordedAction action = new RecordedAction(XarTestTaskFactory.class.getName());
 
                     if (getJob() instanceof XarTestPipelineJob xj)
                     {
-                        xj._inputFiles.forEach(x -> {
-                            action.addInput(x.toURI(), INPUT_ROLE);
-                        });
+                        xj._inputFiles.forEach(x -> action.addInput(x.toURI(), INPUT_ROLE));
 
-                        xj._outputFiles.forEach(x -> {
-                            action.addOutput(x.toURI(), OUTPUT_ROLE, false);
-                        });
+                        xj._outputFiles.forEach(x -> action.addOutput(x.toURI(), OUTPUT_ROLE, false));
                     }
 
                     return new RecordedActionSet(action);
@@ -353,13 +347,13 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
     @Override
     public @Nullable File getJobInfoFile()
     {
-        return FileUtil.appendName(_webserverJobDir.toNioPathForWrite().toFile(), FileUtil.makeLegalName(_jobName) + ".job.json");
+        return _webserverJobDir.resolveChild(FileUtil.makeLegalName(_jobName) + ".job.json").toNioPathForWrite().toFile();
     }
 
     @Override
     public List<File> getInputFiles()
     {
-        return _inputFiles;
+        return _inputFiles.stream().map(FileLike::toNioPathForRead).map(Path::toFile).toList();
     }
 
     @Override
@@ -373,7 +367,7 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
         private static final String PROJECT_NAME = "XarPipelineTestProject";
 
         @BeforeClass
-        public static void initialSetUp() throws Exception
+        public static void initialSetUp()
         {
             //pre-clean
             cleanup();
@@ -414,10 +408,12 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
         @Test
         public void xarTest() throws Exception
         {
+            // For testing, intentionally use the real file system room to test relative paths
+            File root = new File("/");
             doXarTest(
                     "XarTestJob1",
-                    Arrays.asList(new File("/arbitrary/path/outside/lkRoot/myFile.txt")),
-                    Arrays.asList(new File("/another/arbitrary/path/outside/lkRoot/myFile.txt"))
+                    Arrays.asList(FileSystemLike.wrapFile(root, new File("/arbitrary/path/outside/lkRoot/myFile.txt"))),
+                    Arrays.asList(FileSystemLike.wrapFile(root, new File("/another/arbitrary/path/outside/lkRoot/myFile.txt")))
             );
 
             Container project = ContainerManager.getForPath(PROJECT_NAME);
@@ -432,12 +428,12 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
             doXarTest(
                     "XarTestJob_UsingShared",
                     Arrays.asList(
-                            FileUtil.appendPath(projectRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myFileInJobFolder.txt")).toNioPathForWrite().toFile(),
-                            FileUtil.appendPath(sharedRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myFileInSharedFolder.txt")).toNioPathForWrite().toFile()
+                            projectRoot.resolvePathToFileLike("myFileInJobFolder.txt"),
+                            sharedRoot.resolvePathToFileLike("myFileInSharedFolder.txt")
                     ),
                     Arrays.asList(
-                            FileUtil.appendPath(projectRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myOutputFileInJobFolder.txt")).toNioPathForWrite().toFile(),
-                            FileUtil.appendPath(sharedRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myOutputFileInSharedFolder.txt")).toNioPathForWrite().toFile()
+                            projectRoot.resolvePathToFileLike("myOutputFileInJobFolder.txt"),
+                            sharedRoot.resolvePathToFileLike("myOutputFileInSharedFolder.txt")
                     )
             );
 
@@ -454,16 +450,16 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
             doXarTest(
                     "XarTestJob_AcrossWorkbooks",
                     Arrays.asList(
-                            FileUtil.appendPath(projectRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myFileInJobFolder.txt")).toNioPathForWrite().toFile(),
-                            FileUtil.appendPath(sharedRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myFileInSharedFolder.txt")).toNioPathForWrite().toFile(),
-                            FileUtil.appendPath(wb1Root.getRootFileLike(), org.labkey.api.util.Path.parse("myFileInWB1Folder.txt")).toNioPathForWrite().toFile(),
-                            FileUtil.appendPath(wb2Root.getRootFileLike(), org.labkey.api.util.Path.parse("myFileInWB2Folder.txt")).toNioPathForWrite().toFile()
+                            projectRoot.resolvePathToFileLike("myFileInJobFolder.txt"),
+                            sharedRoot.resolvePathToFileLike("myFileInSharedFolder.txt"),
+                            wb1Root.resolvePathToFileLike("myFileInWB1Folder.txt"),
+                            wb2Root.resolvePathToFileLike("myFileInWB2Folder.txt")
                     ),
                     Arrays.asList(
-                            FileUtil.appendPath(projectRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myOutputFileInJobFolder.txt")).toNioPathForWrite().toFile(),
-                            FileUtil.appendPath(sharedRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myOutputFileInSharedFolder.txt")).toNioPathForWrite().toFile(),
-                            FileUtil.appendPath(wb1Root.getRootFileLike(), org.labkey.api.util.Path.parse("myOutputFileInWB1Folder.txt")).toNioPathForWrite().toFile(),
-                            FileUtil.appendPath(wb2Root.getRootFileLike(), org.labkey.api.util.Path.parse("myOutputFileInWB2Folder.txt")).toNioPathForWrite().toFile()
+                            projectRoot.resolvePathToFileLike("myOutputFileInJobFolder.txt"),
+                            sharedRoot.resolvePathToFileLike("myOutputFileInSharedFolder.txt"),
+                            wb1Root.resolvePathToFileLike("myOutputFileInWB1Folder.txt"),
+                            wb2Root.resolvePathToFileLike("myOutputFileInWB2Folder.txt")
                     ),
                     wb2
             );
@@ -472,22 +468,24 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
         @Test
         public void xarTestRelativePaths() throws Exception
         {
+            // For testing, intentionally use the real file system room to test relative paths
+            File root = new File("/");
             // NOTE: these will get converted to absolute paths by the pipeline code when they are saved, so this passes right now:
             //Assert.assertThrows("Maybe LabKey shouldn't allow this", Exception.class, () -> {
                 doXarTest(
                         "XarTestJob_QuestionablePaths",
-                        Arrays.asList(new File("../../../root/myFile.txt")),
-                        Arrays.asList(new File("../../../users/root/anotherFile.txt"))
+                        Arrays.asList(FileSystemLike.wrapFile(root, new File("../../../root/myFile.txt"))),
+                        Arrays.asList(FileSystemLike.wrapFile(root, new File("../../../users/root/anotherFile.txt")))
                 );
             //});
         }
 
-        private void doXarTest(String jobName, List<File> inputFiles, List<File> outputFiles) throws Exception
+        private void doXarTest(String jobName, List<FileLike> inputFiles, List<FileLike> outputFiles) throws Exception
         {
             doXarTest(jobName, inputFiles, outputFiles, ContainerManager.getForPath(PROJECT_NAME));
         }
 
-        private void doXarTest(String jobName, List<File> inputFiles, List<File> outputFiles, Container c) throws Exception
+        private void doXarTest(String jobName, List<FileLike> inputFiles, List<FileLike> outputFiles, Container c) throws Exception
         {
             PipelineJob job1 = XarTestPipelineJob.createJob(c, TestContext.get().getUser(), jobName, inputFiles, outputFiles);
             PipelineService.get().queueJob(job1);

--- a/experiment/src/org/labkey/experiment/pipeline/XarTestPipelineJob.java
+++ b/experiment/src/org/labkey/experiment/pipeline/XarTestPipelineJob.java
@@ -12,10 +12,11 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
+import org.labkey.api.data.WorkbookContainerType;
 import org.labkey.api.exp.api.ExpData;
 import org.labkey.api.exp.api.ExpRun;
 import org.labkey.api.exp.api.ExperimentService;
-import org.labkey.api.exp.pipeline.XarGeneratorFactorySettings;
+import org.labkey.api.exp.pipeline.XarGeneratorId;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.AbstractTaskFactory;
@@ -174,7 +175,7 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
         return new TaskId(XarTestTaskFactory.class, location);
     }
 
-    public static TaskId registerTaskPipeline(String location) throws CloneNotSupportedException
+    public static void registerTaskPipeline(String location) throws CloneNotSupportedException
     {
         //first register TaskFactory
         TaskId taskFactoryId = getTaskFactoryId(location);
@@ -182,12 +183,16 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
 
         //then TaskPipeline
         TaskId taskPipelineId = getTaskIdForEngine(location);
+        TaskFactory<?> xarFact = PipelineJobService.get().getTaskFactory(new TaskId(XarGeneratorId.class));
+        if (xarFact == null)
+        {
+            throw new IllegalStateException("Unable to find TaskFactory for XarGeneratorId.class");
+        }
+
         TaskPipelineSettings settings = new TaskPipelineSettings(taskPipelineId);
-        settings.setTaskProgressionSpec(new Object[]{taskFactoryId, getXarGenerator().getId()});
+        settings.setTaskProgressionSpec(new Object[]{taskFactoryId, xarFact.getId()});
         settings.setDeclaringModule(ModuleLoader.getInstance().getModule(ExperimentModule.class));
         PipelineJobService.get().addTaskPipeline(settings);
-
-        return taskPipelineId;
     }
 
     @Override
@@ -271,20 +276,6 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
         {
             return false;
         }
-    }
-
-    protected static XarGeneratorFactorySettings getXarGenerator() throws CloneNotSupportedException
-    {
-        XarGeneratorFactorySettings settings = new XarGeneratorFactorySettings("xarGeneratorJoin");
-        settings.setJoin(true);
-
-        TaskFactory<?> factory = PipelineJobService.get().getTaskFactory(settings.getCloneId());
-        if (factory == null)
-        {
-            PipelineJobService.get().addTaskFactory(settings);
-        }
-
-        return settings;
     }
 
     @Override
@@ -428,22 +419,76 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
                     Arrays.asList(new File("/arbitrary/path/outside/lkRoot/myFile.txt")),
                     Arrays.asList(new File("/another/arbitrary/path/outside/lkRoot/myFile.txt"))
             );
+
+            Container project = ContainerManager.getForPath(PROJECT_NAME);
+            PipeRoot projectRoot = PipelineService.get().getPipelineRootSetting(project);
+            Assert.assertNotNull(PROJECT_NAME + " pipeline root is null", projectRoot);
+
+            // We expect /Shared to be an allowable output location:
+            PipeRoot sharedRoot = PipelineService.get().getPipelineRootSetting(ContainerManager.getSharedContainer());
+            Assert.assertNotNull("Shared pipeline root is null", sharedRoot);
+
+            // A pipeline job submitted to a project/folder should be able to access files in /Shared
+            doXarTest(
+                    "XarTestJob_UsingShared",
+                    Arrays.asList(
+                            FileUtil.appendPath(projectRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myFileInJobFolder.txt")).toNioPathForWrite().toFile(),
+                            FileUtil.appendPath(sharedRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myFileInSharedFolder.txt")).toNioPathForWrite().toFile()
+                    ),
+                    Arrays.asList(
+                            FileUtil.appendPath(projectRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myOutputFileInJobFolder.txt")).toNioPathForWrite().toFile(),
+                            FileUtil.appendPath(sharedRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myOutputFileInSharedFolder.txt")).toNioPathForWrite().toFile()
+                    )
+            );
+
+            // Now create workbooks in this folder:
+            Container wb1 = ContainerManager.createContainer(project, null, "WB1", null, WorkbookContainerType.NAME, TestContext.get().getUser());
+            Container wb2 = ContainerManager.createContainer(project, null, "WB2", null, WorkbookContainerType.NAME, TestContext.get().getUser());
+
+            PipeRoot wb1Root = PipelineService.get().getPipelineRootSetting(wb1);
+            Assert.assertNotNull("wb1Root is null", wb1Root);
+            PipeRoot wb2Root = PipelineService.get().getPipelineRootSetting(wb2);
+            Assert.assertNotNull("wb2Root is null", wb2Root);
+
+            // A pipeline job submitted to a workbook should be able to reference files in /Shared, the parent folder, or sibling workbooks:
+            doXarTest(
+                    "XarTestJob_AcrossWorkbooks",
+                    Arrays.asList(
+                            FileUtil.appendPath(projectRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myFileInJobFolder.txt")).toNioPathForWrite().toFile(),
+                            FileUtil.appendPath(sharedRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myFileInSharedFolder.txt")).toNioPathForWrite().toFile(),
+                            FileUtil.appendPath(wb1Root.getRootFileLike(), org.labkey.api.util.Path.parse("myFileInWB1Folder.txt")).toNioPathForWrite().toFile(),
+                            FileUtil.appendPath(wb2Root.getRootFileLike(), org.labkey.api.util.Path.parse("myFileInWB2Folder.txt")).toNioPathForWrite().toFile()
+                    ),
+                    Arrays.asList(
+                            FileUtil.appendPath(projectRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myOutputFileInJobFolder.txt")).toNioPathForWrite().toFile(),
+                            FileUtil.appendPath(sharedRoot.getRootFileLike(), org.labkey.api.util.Path.parse("myOutputFileInSharedFolder.txt")).toNioPathForWrite().toFile(),
+                            FileUtil.appendPath(wb1Root.getRootFileLike(), org.labkey.api.util.Path.parse("myOutputFileInWB1Folder.txt")).toNioPathForWrite().toFile(),
+                            FileUtil.appendPath(wb2Root.getRootFileLike(), org.labkey.api.util.Path.parse("myOutputFileInWB2Folder.txt")).toNioPathForWrite().toFile()
+                    ),
+                    wb2
+            );
         }
 
         @Test
         public void xarTestRelativePaths() throws Exception
         {
-            // NOTE: these will get converted to absolute paths by the pipeline code when they are saved:
-            doXarTest(
-                    "XarTestJob_QuestionablePaths",
-                    Arrays.asList(new File("../../../root/myFile.txt")),
-                    Arrays.asList(new File("../../../users/root/anotherFile.txt"))
-            );
+            // NOTE: these will get converted to absolute paths by the pipeline code when they are saved, so this passes right now:
+            //Assert.assertThrows("Maybe LabKey shouldn't allow this", Exception.class, () -> {
+                doXarTest(
+                        "XarTestJob_QuestionablePaths",
+                        Arrays.asList(new File("../../../root/myFile.txt")),
+                        Arrays.asList(new File("../../../users/root/anotherFile.txt"))
+                );
+            //});
         }
 
         private void doXarTest(String jobName, List<File> inputFiles, List<File> outputFiles) throws Exception
         {
-            Container c = ContainerManager.getForPath(PROJECT_NAME);
+            doXarTest(jobName, inputFiles, outputFiles, ContainerManager.getForPath(PROJECT_NAME));
+        }
+
+        private void doXarTest(String jobName, List<File> inputFiles, List<File> outputFiles, Container c) throws Exception
+        {
             PipelineJob job1 = XarTestPipelineJob.createJob(c, TestContext.get().getUser(), jobName, inputFiles, outputFiles);
             PipelineService.get().queueJob(job1);
             long start = System.currentTimeMillis();

--- a/experiment/src/org/labkey/experiment/pipeline/XarTestPipelineJob.java
+++ b/experiment/src/org/labkey/experiment/pipeline/XarTestPipelineJob.java
@@ -72,7 +72,6 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
 {
     public static final String PROVIDER_NAME = "XarTestPipelineJob Provider";
 
-    private final String _location = PipelineJobService.LocationType.WebServer.name();
     private TaskId _taskPipelineId;
 
     private String _jobName;
@@ -89,7 +88,7 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
     {
         super(PROVIDER_NAME, new ViewBackgroundInfo(c, user, null), pipeRoot);
 
-        _taskPipelineId = getTaskIdForEngine(PipelineJobService.LocationType.WebServer.name());
+        _taskPipelineId = getTaskIdForEngine();
         _webserverJobDir = getOrCreateBaseDir(c, jobName);
         setLogFile(getOrCreateLogFile(c, jobName));
 
@@ -142,19 +141,19 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
         //ensure this TaskFactory is registered:
         try
         {
-            TaskId taskFactoryId = getTaskFactoryId(_location);
+            TaskId taskFactoryId = getTaskFactoryId();
             try
             {
                 if (PipelineJobService.get().getTaskFactory(taskFactoryId) == null)
                 {
-                    registerTaskPipeline(_location);
+                    registerTaskPipeline();
                 }
             }
             catch (NullPointerException e)
             {
                 //this indicates the TaskFactory has not been registered yet
                 getLogger().error("A NullPointerException was thrown in XarTestPipelineJob", e);
-                registerTaskPipeline(_location);
+                registerTaskPipeline();
             }
         }
         catch (CloneNotSupportedException e)
@@ -165,24 +164,24 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
         return super.getActiveTaskId();
     }
 
-    private static TaskId getTaskIdForEngine(String location)
+    private static TaskId getTaskIdForEngine()
     {
-        return new TaskId(XarTestPipelineJob.class, location);
+        return new TaskId(XarTestPipelineJob.class, PipelineJobService.LocationType.WebServer.name());
     }
 
-    private static TaskId getTaskFactoryId(String location)
+    private static TaskId getTaskFactoryId()
     {
-        return new TaskId(XarTestTaskFactory.class, location);
+        return new TaskId(XarTestTaskFactory.class, PipelineJobService.LocationType.WebServer.name());
     }
 
-    public static void registerTaskPipeline(String location) throws CloneNotSupportedException
+    public static void registerTaskPipeline() throws CloneNotSupportedException
     {
         //first register TaskFactory
-        TaskId taskFactoryId = getTaskFactoryId(location);
-        PipelineJobService.get().addTaskFactory(new XarTestTaskFactory(taskFactoryId, location));
+        TaskId taskFactoryId = getTaskFactoryId();
+        PipelineJobService.get().addTaskFactory(new XarTestTaskFactory(taskFactoryId));
 
         //then TaskPipeline
-        TaskId taskPipelineId = getTaskIdForEngine(location);
+        TaskId taskPipelineId = getTaskIdForEngine();
         TaskFactory<?> xarFact = PipelineJobService.get().getTaskFactory(new TaskId(XarGeneratorId.class));
         if (xarFact == null)
         {
@@ -218,11 +217,11 @@ public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSu
 
     private static class XarTestTaskFactory extends AbstractTaskFactory<AbstractTaskFactorySettings, XarTestTaskFactory>
     {
-        public XarTestTaskFactory(TaskId id, String location)
+        public XarTestTaskFactory(TaskId id)
         {
             super(id);
 
-            setLocation(location);
+            setLocation(PipelineJobService.LocationType.WebServer.name());
         }
 
         @Override

--- a/experiment/src/org/labkey/experiment/pipeline/XarTestPipelineJob.java
+++ b/experiment/src/org/labkey/experiment/pipeline/XarTestPipelineJob.java
@@ -1,0 +1,513 @@
+package org.labkey.experiment.pipeline;
+
+import org.apache.commons.io.FileUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.exp.api.ExpData;
+import org.labkey.api.exp.api.ExpRun;
+import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.exp.pipeline.XarGeneratorFactorySettings;
+import org.labkey.api.module.Module;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.pipeline.AbstractTaskFactory;
+import org.labkey.api.pipeline.AbstractTaskFactorySettings;
+import org.labkey.api.pipeline.ParamParser;
+import org.labkey.api.pipeline.PipeRoot;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.pipeline.PipelineJobException;
+import org.labkey.api.pipeline.PipelineJobService;
+import org.labkey.api.pipeline.PipelineService;
+import org.labkey.api.pipeline.PipelineStatusFile;
+import org.labkey.api.pipeline.PipelineValidationException;
+import org.labkey.api.pipeline.RecordedAction;
+import org.labkey.api.pipeline.RecordedActionSet;
+import org.labkey.api.pipeline.TaskFactory;
+import org.labkey.api.pipeline.TaskId;
+import org.labkey.api.pipeline.TaskPipeline;
+import org.labkey.api.pipeline.TaskPipelineSettings;
+import org.labkey.api.pipeline.file.AbstractFileAnalysisJob;
+import org.labkey.api.pipeline.file.FileAnalysisJobSupport;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.reader.Readers;
+import org.labkey.api.security.User;
+import org.labkey.api.util.FileType;
+import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.TestContext;
+import org.labkey.api.util.URLHelper;
+import org.labkey.api.view.ViewBackgroundInfo;
+import org.labkey.experiment.ExperimentModule;
+import org.labkey.vfs.FileLike;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The goal is this class is to provide a "minimal" test case to exercise the Pipeline/XarGenerator code.
+ * As filesystem-related permissions are tightened, this can be extended to include more test cases, such as:
+ *
+ * - PipelineJob in Container1 referencing a file in /Shared
+ * - PipelineJob in a workbook that references a file in the parent container
+ * - PipelineJob in a workbook that references a file in a sibling workbook
+ * - Check that inappropriate cross-folder access is disallowed
+ * - If LK implements a scheme to determine allowable locations outside the LK root, test that here.
+ */
+public class XarTestPipelineJob extends PipelineJob implements FileAnalysisJobSupport
+{
+    public static final String PROVIDER_NAME = "XarTestPipelineJob Provider";
+
+    private final String _location = PipelineJobService.LocationType.WebServer.name();
+    private TaskId _taskPipelineId;
+
+    private String _jobName;
+    private FileLike _webserverJobDir;
+    private List<File> _inputFiles;
+    private List<File> _outputFiles;
+
+    // Default constructor for serialization
+    protected XarTestPipelineJob()
+    {
+    }
+
+    private XarTestPipelineJob(Container c, User user, PipeRoot pipeRoot, String jobName, List<File> inputFiles, List<File> outputFiles)
+    {
+        super(PROVIDER_NAME, new ViewBackgroundInfo(c, user, null), pipeRoot);
+
+        _taskPipelineId = getTaskIdForEngine(PipelineJobService.LocationType.WebServer.name());
+        _webserverJobDir = getOrCreateBaseDir(c, jobName);
+        setLogFile(getOrCreateLogFile(c, jobName));
+
+        _jobName = jobName;
+        _inputFiles = inputFiles;
+        _outputFiles = outputFiles;
+    }
+
+    private static Path getOrCreateLogFile(Container c, String jobName)
+    {
+        // TODO: There must be a more convenient way to work with FileLike...
+        return(FileUtil.appendPath(getOrCreateBaseDir(c, jobName), new org.labkey.api.util.Path(FileUtil.makeLegalName(jobName) + ".log")).toNioPathForWrite());
+    }
+
+    private static FileLike getOrCreateBaseDir(Container c, String jobName)
+    {
+        PipeRoot pipeRoot = PipelineService.get().findPipelineRoot(c);
+        if (pipeRoot == null)
+        {
+            throw new IllegalStateException("Pipeline root not found for: " + c.getPath());
+        }
+
+        FileLike baseDir = FileUtil.appendPath(pipeRoot.getRootFileLike(), new org.labkey.api.util.Path(FileUtil.makeLegalName(jobName)));
+        if (!baseDir.exists())
+        {
+            try
+            {
+                baseDir.mkdirs();
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException("Unable to create baseDir: " + c.getPath(), e);
+            }
+        }
+
+        return baseDir;
+    }
+
+    public static XarTestPipelineJob createJob(Container c, User user, String jobName, List<File> inputFiles, List<File> outputFiles) throws PipelineValidationException
+    {
+        PipeRoot pipelineRoot = PipelineService.get().getPipelineRootSetting(c);
+
+        return new XarTestPipelineJob(c, user, pipelineRoot, jobName, inputFiles, outputFiles);
+    }
+
+    @Nullable
+    @Override
+    public TaskId getActiveTaskId()
+    {
+        //ensure this TaskFactory is registered:
+        try
+        {
+            TaskId taskFactoryId = getTaskFactoryId(_location);
+            try
+            {
+                if (PipelineJobService.get().getTaskFactory(taskFactoryId) == null)
+                {
+                    registerTaskPipeline(_location);
+                }
+            }
+            catch (NullPointerException e)
+            {
+                //this indicates the TaskFactory has not been registered yet
+                getLogger().error("A NullPointerException was thrown in XarTestPipelineJob", e);
+                registerTaskPipeline(_location);
+            }
+        }
+        catch (CloneNotSupportedException e)
+        {
+            getLogger().error(e.getMessage(), e);
+        }
+
+        return super.getActiveTaskId();
+    }
+
+    private static TaskId getTaskIdForEngine(String location)
+    {
+        return new TaskId(XarTestPipelineJob.class, location);
+    }
+
+    private static TaskId getTaskFactoryId(String location)
+    {
+        return new TaskId(XarTestTaskFactory.class, location);
+    }
+
+    public static TaskId registerTaskPipeline(String location) throws CloneNotSupportedException
+    {
+        //first register TaskFactory
+        TaskId taskFactoryId = getTaskFactoryId(location);
+        PipelineJobService.get().addTaskFactory(new XarTestTaskFactory(taskFactoryId, location));
+
+        //then TaskPipeline
+        TaskId taskPipelineId = getTaskIdForEngine(location);
+        TaskPipelineSettings settings = new TaskPipelineSettings(taskPipelineId);
+        settings.setTaskProgressionSpec(new Object[]{taskFactoryId, getXarGenerator().getId()});
+        settings.setDeclaringModule(ModuleLoader.getInstance().getModule(ExperimentModule.class));
+        PipelineJobService.get().addTaskPipeline(settings);
+
+        return taskPipelineId;
+    }
+
+    @Override
+    public TaskPipeline<?> getTaskPipeline()
+    {
+        return PipelineJobService.get().getTaskPipeline(_taskPipelineId);
+    }
+
+    @Override
+    public URLHelper getStatusHref()
+    {
+        return null;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return _jobName;
+    }
+
+    private static final String INPUT_ROLE = "Input File";
+    private static final String OUTPUT_ROLE = "Output File";
+
+    private static class XarTestTaskFactory extends AbstractTaskFactory<AbstractTaskFactorySettings, XarTestTaskFactory>
+    {
+        public XarTestTaskFactory(TaskId id, String location)
+        {
+            super(id);
+
+            setLocation(location);
+        }
+
+        @Override
+        public Task<XarTestTaskFactory> createTask(PipelineJob job)
+        {
+            return new Task<>(this, job)
+            {
+                @NotNull
+                @Override
+                public RecordedActionSet run() throws PipelineJobException
+                {
+                    // The purpose of this is to specify files outside the LK folder root:
+                    RecordedAction action = new RecordedAction(XarTestTaskFactory.class.getName());
+
+                    if (getJob() instanceof XarTestPipelineJob xj)
+                    {
+                        xj._inputFiles.forEach(x -> {
+                            action.addInput(x.toURI(), INPUT_ROLE);
+                        });
+
+                        xj._outputFiles.forEach(x -> {
+                            action.addOutput(x.toURI(), OUTPUT_ROLE, false);
+                        });
+                    }
+
+                    return new RecordedActionSet(action);
+                }
+            };
+        }
+
+        @Override
+        public List<FileType> getInputTypes()
+        {
+            return null;
+        }
+
+        @Override
+        public List<String> getProtocolActionNames()
+        {
+            return Arrays.asList(XarTestTaskFactory.class.getName());
+        }
+
+        @Override
+        public String getStatusName()
+        {
+            return "RUNNING";
+        }
+
+        @Override
+        public boolean isJobComplete(PipelineJob job)
+        {
+            return false;
+        }
+    }
+
+    protected static XarGeneratorFactorySettings getXarGenerator() throws CloneNotSupportedException
+    {
+        XarGeneratorFactorySettings settings = new XarGeneratorFactorySettings("xarGeneratorJoin");
+        settings.setJoin(true);
+
+        TaskFactory<?> factory = PipelineJobService.get().getTaskFactory(settings.getCloneId());
+        if (factory == null)
+        {
+            PipelineJobService.get().addTaskFactory(settings);
+        }
+
+        return settings;
+    }
+
+    @Override
+    public String getProtocolName()
+    {
+        return _jobName;
+    }
+
+    @Override
+    public String getJoinedBaseName()
+    {
+        throw new IllegalArgumentException("not implemented");
+    }
+
+    @Override
+    public List<String> getSplitBaseNames()
+    {
+        throw new IllegalArgumentException("not implemented");
+    }
+
+    @Override
+    public String getBaseName()
+    {
+        return getAnalysisDirectory().getName();
+    }
+
+    @Override
+    public String getBaseNameForFileType(FileType fileType)
+    {
+        return getBaseName();
+    }
+
+    @Override
+    public File getDataDirectory()
+    {
+        return _webserverJobDir.toNioPathForWrite().toFile();
+    }
+
+    @Override
+    public File getAnalysisDirectory()
+    {
+        return _webserverJobDir.toNioPathForWrite().toFile();
+    }
+
+    @Override
+    public File findInputFile(String name)
+    {
+        return FileUtil.appendName(getAnalysisDirectory(), name);
+    }
+
+    @Override
+    public File findOutputFile(String name)
+    {
+        return FileUtil.appendName(getAnalysisDirectory(), name);
+    }
+
+    @Override
+    public File findOutputFile(@NotNull String outputDir, @NotNull String fileName)
+    {
+        return AbstractFileAnalysisJob.getOutputFile(outputDir, fileName, getPipeRoot(), getLogger(), getAnalysisDirectory());
+    }
+
+    @Override
+    public ParamParser createParamParser()
+    {
+        return PipelineJobService.get().createParamParser();
+    }
+
+    @Override
+    public @Nullable File getParametersFile()
+    {
+        return null;
+    }
+
+    @Override
+    public @Nullable File getJobInfoFile()
+    {
+        return FileUtil.appendName(_webserverJobDir.toNioPathForWrite().toFile(), FileUtil.makeLegalName(_jobName) + ".job.json");
+    }
+
+    @Override
+    public List<File> getInputFiles()
+    {
+        return _inputFiles;
+    }
+
+    @Override
+    public FileType.gzSupportLevel getGZPreference()
+    {
+        return FileType.gzSupportLevel.PREFER_GZ;
+    }
+
+    public static class TestCase extends Assert
+    {
+        private static final String PROJECT_NAME = "XarPipelineTestProject";
+
+        @BeforeClass
+        public static void initialSetUp() throws Exception
+        {
+            //pre-clean
+            cleanup();
+
+            Container project = ContainerManager.getForPath(PROJECT_NAME);
+            if (project == null)
+            {
+                project = ContainerManager.createContainer(ContainerManager.getRoot(), PROJECT_NAME, TestContext.get().getUser());
+                Set<Module> modules = new HashSet<>(project.getActiveModules());
+                modules.add(ModuleLoader.getInstance().getModule(ExperimentModule.class));
+                project.setActiveModules(modules);
+            }
+        }
+
+        @AfterClass
+        public static void cleanup()
+        {
+            Container project = ContainerManager.getForPath(PROJECT_NAME);
+            if (project != null)
+            {
+                File pipelineRoot = PipelineService.get().getPipelineRootSetting(project).getRootPath();
+                try
+                {
+                    if (pipelineRoot.exists())
+                    {
+                        FileUtils.deleteDirectory(pipelineRoot);
+                    }
+                }
+                catch (IOException e)
+                {
+                    throw new RuntimeException(e);
+                }
+
+                ContainerManager.deleteAll(project, TestContext.get().getUser());
+            }
+        }
+
+        @Test
+        public void xarTest() throws Exception
+        {
+            doXarTest(
+                    "XarTestJob1",
+                    Arrays.asList(new File("/arbitrary/path/outside/lkRoot/myFile.txt")),
+                    Arrays.asList(new File("/another/arbitrary/path/outside/lkRoot/myFile.txt"))
+            );
+        }
+
+        @Test
+        public void xarTestRelativePaths() throws Exception
+        {
+            // NOTE: these will get converted to absolute paths by the pipeline code when they are saved:
+            doXarTest(
+                    "XarTestJob_QuestionablePaths",
+                    Arrays.asList(new File("../../../root/myFile.txt")),
+                    Arrays.asList(new File("../../../users/root/anotherFile.txt"))
+            );
+        }
+
+        private void doXarTest(String jobName, List<File> inputFiles, List<File> outputFiles) throws Exception
+        {
+            Container c = ContainerManager.getForPath(PROJECT_NAME);
+            PipelineJob job1 = XarTestPipelineJob.createJob(c, TestContext.get().getUser(), jobName, inputFiles, outputFiles);
+            PipelineService.get().queueJob(job1);
+            long start = System.currentTimeMillis();
+            long timeout = 10 * 1000; //10 secs
+            while (!isJobDone(job1))
+            {
+                Thread.sleep(1000);
+
+                long duration = System.currentTimeMillis() - start;
+                if (duration > timeout)
+                {
+                    //NOTE: it's possible a job could time out on a busy cluster.  rather than fail, continue in case there's a second engine to test
+                    _log.warn("timed out waiting for job: " + job1.getDescription());
+                    break;
+                }
+            }
+
+            PipelineStatusFile sf = PipelineService.get().getStatusFile(job1.getJobGUID());
+            Assert.assertNotNull("Missing status file", sf);
+
+            List<? extends ExpRun> runs = ExperimentService.get().getExpRunsForJobId(sf.getRowId());
+            Assert.assertEquals("Wrong run number", 1, runs.size());
+
+            ExpRun run = runs.get(0);
+            List<? extends ExpData> inputs = run.getInputDatas(INPUT_ROLE, null);
+            Assert.assertEquals("Wrong input number", inputFiles.size(), inputs.size());
+
+            List<? extends ExpData> outputs = run.getOutputDatas(null);
+            Assert.assertEquals("Wrong output number", outputFiles.size(), outputs.size());
+        }
+
+        private static boolean isJobDone (PipelineJob job) throws Exception
+        {
+            TableInfo ti = PipelineService.get().getJobsTable(job.getUser(), job.getContainer());
+            TableSelector ts = new TableSelector(ti, new SimpleFilter(FieldKey.fromString("job"), job.getJobGUID()), null);
+            Map<String, Object> map = ts.getMap();
+
+            if (PipelineJob.TaskStatus.complete.matches((String) map.get("status")))
+                return true;
+
+            //look for errors
+            boolean error = PipelineJob.TaskStatus.error.matches((String) map.get("status"));
+            if (error)
+            {
+                StringBuilder sb = new StringBuilder();
+                try (BufferedReader reader = Readers.getReader(job.getLogFile()))
+                {
+                    sb.append("*******************\n");
+                    sb.append("Error running XarTestPipelineJob.TestCase.  Pipeline log:\n");
+                    String line;
+                    while ((line = reader.readLine()) != null)
+                    {
+                        sb.append(line).append('\n');
+                    }
+
+                    sb.append("*******************\n");
+                }
+
+                _log.error(sb.toString());
+
+                throw new Exception("There was an error running job: " + job.getDescription());
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
This is related to: https://github.com/LabKey/platform/pull/7261.

More background is listed on that issue. In 25.11, additional checks were added to disallow relative filepaths. The problem is that the XAR/Experiment system creates relative filepaths on data import. PR #7261 addressed one problem. After fixing this, I hit the following. This error happens a few lines after the original error. The gist is that LabKey writes out a XAR file for the run, and this file still contains forced relative URLs, even if not under the container's file root. 

My proposal here is to make the DataFileURL behavior consistent between ExperimentRun creation and XAR writing. The method "generatePathStringRelativeToRootIfUnderRoot" could certainly get a better name. I can add some code comments if you think this is a viable pathway.

If you dont like this, there's a second more involved option. The ExpDatas being written to XML store their original non-relative DataFileURL. The XAR code could read that and preferentially swap in that original URI. This is less invasive, but also raises the question of what's the point of writing a relative URI to that XML if we're just going to reverse it. 

In addition to this fix, I created a contained test case that exercises the XarGenerator codepath. This can be used to illustrate this problem, and should be very easy to extend in the future as permissions are tightened. At the moment it exercises the situation of filepaths outside of the LK root; however, all the cross-folder situations I mentioned on #7261 would be easy to include.

Here is a stacktrace, from: https://prime-seq.ohsu.edu/Labs/Bimber/1976/pipeline-status-details.view?rowId=602940. 

```
14 Dec 2025 07:58:31,535 ERROR: Path to parent not allowed: ../../../../1973/@files/sequenceOutputPipeline/SequenceOutput_2025-12-07_07-39-02/SingleCell.tca.ctd.PPG_Project2_Tissues_23230_T_NK.seurat.rds
java.nio.file.InvalidPathException: Path to parent not allowed: ../../../../1973/@files/sequenceOutputPipeline/SequenceOutput_2025-12-07_07-39-02/SingleCell.tca.ctd.PPG_Project2_Tissues_23230_T_NK.seurat.rds
	at org.labkey.api.exp.AbstractFileXarSource.canonicalizeDataFileURL(AbstractFileXarSource.java:126)
	at org.labkey.api.exp.XarSource.getCanonicalDataFileURL(XarSource.java:116)
	at org.labkey.experiment.xar.AutoFileLSIDReplacer.getReplacement(AutoFileLSIDReplacer.java:64)
	at org.labkey.api.exp.xar.Replacer$CompoundReplacer.getReplacement(Replacer.java:48)
	at org.labkey.api.exp.xar.LsidUtils.doReplacements(LsidUtils.java:154)
	at org.labkey.api.exp.xar.LsidUtils.resolveStringFromTemplate(LsidUtils.java:131)
	at org.labkey.api.exp.xar.LsidUtils.resolveLsidFromTemplate(LsidUtils.java:95)
	at org.labkey.api.exp.xar.LsidUtils.resolveLsidFromTemplate(LsidUtils.java:206)
	at org.labkey.experiment.XarReader.loadData(XarReader.java:1707)
	at org.labkey.experiment.XarReader.loadDoc(XarReader.java:418)
	at org.labkey.experiment.XarReader.parseAndLoad(XarReader.java:237)
	at org.labkey.experiment.api.ExperimentServiceImpl.importXar(ExperimentServiceImpl.java:2144)
	at org.labkey.experiment.api.ExperimentServiceImpl.importXar(ExperimentServiceImpl.java:2130)
	at org.labkey.experiment.pipeline.XarGeneratorTask.run(XarGeneratorTask.java:177)
	at org.labkey.api.pipeline.PipelineJob.runActiveTask(PipelineJob.java:831)
	at org.labkey.api.pipeline.PipelineJob.run(PipelineJob.java:1079)
	at org.labkey.pipeline.mule.PipelineJobRunner.run(PipelineJobRunner.java:40)
	at jdk.internal.reflect.GeneratedMethodAccessor634.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.mule.impl.model.resolvers.DynamicEntryPoint.invokeMethod(DynamicEntryPoint.java:312)
	at org.mule.impl.model.resolvers.DynamicEntryPoint.invoke(DynamicEntryPoint.java:259)
	at org.mule.impl.DefaultLifecycleAdapter.intercept(DefaultLifecycleAdapter.java:193)
	at org.mule.impl.InterceptorsInvoker.execute(InterceptorsInvoker.java:47)
	at org.mule.impl.model.DefaultMuleProxy.run(DefaultMuleProxy.java:470)
	at org.mule.impl.work.WorkerContext.run(WorkerContext.java:310)
	at edu.emory.mathcs.backport.java.util.concurrent.ThreadPoolExecutor$CallerRunsPolicy.rejectedExecution(ThreadPoolExecutor.java:1486)
	at edu.emory.mathcs.backport.java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:391)
	at edu.emory.mathcs.backport.java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:865)
	at org.mule.impl.work.ScheduleWorkExecutor.doExecute(ScheduleWorkExecutor.java:39)
	at org.mule.impl.work.MuleWorkManager.executeWork(MuleWorkManager.java:277)
	at org.mule.impl.work.MuleWorkManager.scheduleWork(MuleWorkManager.java:244)
	at org.mule.impl.model.seda.SedaComponent.run(SedaComponent.java:483)
	at org.mule.impl.work.WorkerContext.run(WorkerContext.java:310)
	at edu.emory.mathcs.backport.java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:650)
	at edu.emory.mathcs.backport.java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:675)
	at java.base/java.lang.Thread.run(Thread.java:840)

```