### PR TITLE
Remove unused User parameters from service methods

### DIFF
--- a/api/src/org/labkey/api/audit/AuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AuditTypeProvider.java
@@ -28,16 +28,14 @@ import java.util.Map;
 public interface AuditTypeProvider
 {
     /**
-     * The audit event name associated with this audit provider. Must be
-     * unique within the system.
+     * The audit event name associated with this audit provider. Must be unique within the system.
      */
     String getEventName();
     String getLabel();
     String getDescription();
 
     /**
-     * Perform any initialization of the provider at registration time such as
-     * domain creation.
+     * Perform any initialization of the provider at registration time such as domain creation.
      * @param user User used when saving the backing Domain.
      */
     void initializeProvider(User user);

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -859,7 +859,7 @@ public class NameGenerator
                 return false;
         }
 
-        return ExperimentService.get().getDataClass(container, user, dataType) != null;
+        return ExperimentService.get().getDataClass(container, dataType, true) != null;
     }
 
     private Object getParentLookupTokenPreview(String currentDataType, FieldKey fkTok, String inputPrefix, @Nullable String inputDataType, @Nullable NameExpressionAncestorPartOption ancestorPartOption, String lookupField, User user, Map<String, String> dataClassNames, Map<String, String> sampleTypeNames)
@@ -924,12 +924,12 @@ public class NameGenerator
         {
             if (!StringUtils.isEmpty(inputDataType))
             {
-                ExpDataClass dataClass = ExperimentService.get().getDataClass(_container, user, inputDataType);
+                ExpDataClass dataClass = ExperimentService.get().getDataClass(_container, inputDataType, true);
                 if (dataClass != null)
                     dataTypes.add(dataClass);
             }
             else
-                dataTypes.addAll(ExperimentService.get().getDataClasses(_container, user, true));
+                dataTypes.addAll(ExperimentService.get().getDataClasses(_container, true));
         }
 
         boolean isCurrentDataType = inputDataType != null && inputDataType.equals(currentDataType);
@@ -1114,7 +1114,7 @@ public class NameGenerator
 
         if (_container != null)
         {
-            for (ExpDataClass dataClass : ExperimentService.get().getDataClasses(_container, user, true))
+            for (ExpDataClass dataClass : ExperimentService.get().getDataClasses(_container, true))
             {
                 dataClassLSIDs.put(dataClass.getName(), dataClass.getLSID());
                 dataClassNames.put(dataClass.getLSID(), dataClass.getName());

--- a/api/src/org/labkey/api/data/NameGenerator.java
+++ b/api/src/org/labkey/api/data/NameGenerator.java
@@ -852,7 +852,7 @@ public class NameGenerator
 
         if (isMaterial || isInput)
         {
-            if (SampleTypeService.get().getSampleType(container, user, dataType) != null)
+            if (SampleTypeService.get().getSampleType(container, dataType, true) != null)
                 return true;
 
             if (isMaterial)
@@ -913,7 +913,7 @@ public class NameGenerator
         {
             if (!StringUtils.isEmpty(inputDataType))
             {
-                ExpSampleType sampleType = SampleTypeService.get().getSampleType(_container, user, inputDataType);
+                ExpSampleType sampleType = SampleTypeService.get().getSampleType(_container, inputDataType, true);
                 if (sampleType != null)
                     dataTypes.add(sampleType);
             }

--- a/api/src/org/labkey/api/data/NameGeneratorState.java
+++ b/api/src/org/labkey/api/data/NameGeneratorState.java
@@ -540,7 +540,7 @@ public class NameGeneratorState implements AutoCloseable
         Map<String, ExpDataClass> dataClasses = getDataClasses();
         ExpObject parentObjectType = isMaterialParent ?
                 sampleTypes.computeIfAbsent(parentTypeName, (name) -> SampleTypeService.get().getSampleType(_container, _user, name))
-                : dataClasses.computeIfAbsent(parentTypeName, (name) -> ExperimentService.get().getDataClass(_container, _user, name));
+                : dataClasses.computeIfAbsent(parentTypeName, (name) -> ExperimentService.get().getDataClass(_container, name, true));
         if (parentObjectType == null)
             throw new RuntimeValidationException("Invalid parent type: " + parentTypeName);
 

--- a/api/src/org/labkey/api/data/NameGeneratorState.java
+++ b/api/src/org/labkey/api/data/NameGeneratorState.java
@@ -539,7 +539,7 @@ public class NameGeneratorState implements AutoCloseable
         Map<String, ExpSampleType> sampleTypes = getSampleTypes();
         Map<String, ExpDataClass> dataClasses = getDataClasses();
         ExpObject parentObjectType = isMaterialParent ?
-                sampleTypes.computeIfAbsent(parentTypeName, (name) -> SampleTypeService.get().getSampleType(_container, _user, name))
+                sampleTypes.computeIfAbsent(parentTypeName, (name) -> SampleTypeService.get().getSampleType(_container, name, true))
                 : dataClasses.computeIfAbsent(parentTypeName, (name) -> ExperimentService.get().getDataClass(_container, name, true));
         if (parentObjectType == null)
             throw new RuntimeValidationException("Invalid parent type: " + parentTypeName);

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -349,7 +349,7 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
         List<String> dataClassParents = new ArrayList<>(config.getDataClassParents());
         // Default to using all types in the container
         if (dataClassParents.isEmpty())
-            dataClassParents.addAll(ExperimentService.get().getDataClasses(getContainer(), getUser(), false).stream().map(ExpDataClass::getName).toList());
+            dataClassParents.addAll(ExperimentService.get().getDataClasses(getContainer(), false).stream().map(ExpDataClass::getName).toList());
         for (ExpSampleType sampleType : getSampleTypes(_config.getSampleTypeNames()))
         {
             _log.info(String.format("Generating %d samples for sample type '%s'.", numSamples, sampleType.getName()));
@@ -702,7 +702,7 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
         {
             parentInput = "DataInputs";
             parentQueryNames.forEach(parentQueryName -> {
-                ExpObject parentObject = ExperimentService.get().getDataClass(_container, _user, parentQueryName);
+                ExpObject parentObject = ExperimentService.get().getDataClass(_container, parentQueryName, true);
                 if (parentObject != null)
                     parentObjects.add(parentObject);
             });

--- a/api/src/org/labkey/api/data/generator/DataGenerator.java
+++ b/api/src/org/labkey/api/data/generator/DataGenerator.java
@@ -222,7 +222,7 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
             {
                 for (String typeName : sampleTypeNames)
                 {
-                    ExpSampleType sampleType = service.getSampleType(getContainer(), getUser(), typeName);
+                    ExpSampleType sampleType = service.getSampleType(getContainer(), typeName, true);
                     if (sampleType == null)
                         _log.warn(String.format("Unable to resolve sample type by name '%s'.", typeName));
                     else
@@ -302,7 +302,7 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
                 typeIndex++;
                 sampleTypeName = namePrefix + typeIndex;
             }
-            while (service.getSampleType(_container, _user, sampleTypeName) != null);
+            while (service.getSampleType(_container, sampleTypeName, true) != null);
             String prefixWithIndex = namingPatternPrefix + typeIndex + "_";
             String namingPattern = prefixWithIndex + "${genId}";
             ExpSampleType sampleType = generateSampleType(sampleTypeName, namingPattern, numFields);
@@ -711,7 +711,7 @@ public class DataGenerator<T extends DataGenerator.Config> implements ContainerU
         {
             parentInput = "MaterialInputs";
             parentQueryNames.forEach(parentQueryName -> {
-                ExpObject parentObject = SampleTypeService.get().getSampleType(_container, _user, parentQueryName);
+                ExpObject parentObject = SampleTypeService.get().getSampleType(_container, parentQueryName, true);
                 if (parentObject != null)
                     parentObjects.add(parentObject);
             });

--- a/api/src/org/labkey/api/exp/api/DefaultExperimentSaveHandler.java
+++ b/api/src/org/labkey/api/exp/api/DefaultExperimentSaveHandler.java
@@ -505,7 +505,7 @@ public class DefaultExperimentSaveHandler implements ExperimentSaveHandler
                 else if (sampleTypeJson.has(ExperimentJSONConverter.NAME))
                 {
                     String sampleTypeName = sampleTypeJson.getString(ExperimentJSONConverter.NAME);
-                    sampleType = SampleTypeService.get().getSampleType(context.getContainer(), context.getUser(), sampleTypeName);
+                    sampleType = SampleTypeService.get().getSampleType(context.getContainer(), sampleTypeName, true);
                     if (sampleType == null)
                         throw new NotFoundException("A sample type named '" + sampleTypeName + "' doesn't exist.");
                 }

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -303,7 +303,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     ExpDataClass getDataClass(@NotNull Container definitionContainer, @NotNull String dataClassName);
 
     /**
-     * Get a DataClass by name within scope -- current plus (if <code>includeOtherContainers</code> is true), project and shared
+     * Get a DataClass by name within scope -- current plus, if <code>includeOtherContainers</code> is true, project and shared
      */
     ExpDataClass getDataClass(@NotNull Container scope, @NotNull String dataClassName, boolean includeProjectAndShared);
 
@@ -313,7 +313,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     ExpDataClass getDataClass(@NotNull Container definitionContainer, long rowId);
 
     /**
-     * Get a DataClass by rowId within scope -- current plus (if <code>includeOtherContainers</code> is true), project and shared
+     * Get a DataClass by rowId within scope -- current plus, if <code>includeOtherContainers</code> is true, project and shared
      */
     ExpDataClass getDataClass(@NotNull Container scope, long rowId, boolean includeProjectAndShared);
 

--- a/api/src/org/labkey/api/exp/api/ExperimentService.java
+++ b/api/src/org/labkey/api/exp/api/ExperimentService.java
@@ -251,7 +251,7 @@ public interface ExperimentService extends ExperimentRunTypeSource
     ExpData getEffectiveData(@NotNull ExpDataClass dataClass, String name, @NotNull Date effectiveDate, @NotNull Container container, @Nullable ContainerFilter cf);
 
     /**
-     * Create a data object.  The object will be unsaved, and will have a name which is a GUID.
+     * Create a data object. The object will be unsaved, and will have a name which is a GUID.
      */
     ExpData createData(Container container, @NotNull DataType type);
 
@@ -293,65 +293,51 @@ public interface ExperimentService extends ExperimentRunTypeSource
     void validateDataClassName(@NotNull Container c, @NotNull User u, String name, boolean skipExisting);
 
     /**
-     * Get all DataClass definitions in the container.  If <code>includeOtherContainers</code> is true,
-     * a user must be provided to check for read permission of the containers in scope.
+     * Get all DataClass definitions in the container
      */
-    // TODO: Remove user parameter (not used)
-    List<? extends ExpDataClass> getDataClasses(@NotNull Container container, @Nullable User user, boolean includeOtherContainers);
+    List<? extends ExpDataClass> getDataClasses(@NotNull Container container, boolean includeOtherContainers);
 
     /**
-     * Get a DataClass by name within the definition container.
+     * Get a DataClass by name within the definition container
      */
     ExpDataClass getDataClass(@NotNull Container definitionContainer, @NotNull String dataClassName);
 
     /**
-     * Get a DataClass by name within scope -- current, project, and shared.
-     * Requires a user to check for container read permission.
+     * Get a DataClass by name within scope -- current plus (if <code>includeOtherContainers</code> is true), project and shared
      */
-    // TODO: Remove user parameter (not used)
-    ExpDataClass getDataClass(@NotNull Container scope, @NotNull User user, @NotNull String dataClassName);
+    ExpDataClass getDataClass(@NotNull Container scope, @NotNull String dataClassName, boolean includeProjectAndShared);
 
     /**
-     * Get a DataClass by rowId within the definition container.
+     * Get a DataClass by rowId within the definition container
      */
     ExpDataClass getDataClass(@NotNull Container definitionContainer, long rowId);
 
     /**
-     * Get a DataClass by rowId within scope -- current, project, and shared.
-     * Requires a user to check for container read permission.
+     * Get a DataClass by rowId within scope -- current plus (if <code>includeOtherContainers</code> is true), project and shared
      */
-    // TODO: Remove user parameter (not used)
-    ExpDataClass getDataClass(@NotNull Container scope, @NotNull User user, long rowId);
+    ExpDataClass getDataClass(@NotNull Container scope, long rowId, boolean includeProjectAndShared);
 
     /**
      * Get a DataClass by LSID.
-     * NOTE: Prefer using one of the getDataClass methods that accept a Container and User for permission checking.
+     * NOTE: Prefer using one of the getDataClass methods that accept a Container
      */
     @Nullable ExpDataClass getDataClass(@NotNull String lsid);
 
     /**
      * Get a DataClass by RowId
-     * NOTE: Prefer using one of the getDataClass methods that accept a Container and User for permission checking.
+     * NOTE: Prefer using one of the getDataClass methods that accept a Container
      */
     ExpDataClass getDataClass(long rowId);
 
     /**
      * Get a DataClass with name at a specific time.
      */
-    // TODO: Remove user parameter (not used)
     @Nullable ExpDataClass getEffectiveDataClass(
         @NotNull Container definitionContainer,
-        @NotNull User user,
         @NotNull String dataClassName,
         @NotNull Date effectiveDate,
         @Nullable ContainerFilter cf
     );
-
-    /**
-     * Get a ExpProtocol with name at a specific time.
-     */
-    // TODO: Delete?
-    ExpProtocol getEffectiveProtocol(Container container, User user, String schemaName, Date effectiveDate, ContainerFilter dataTypeCF);
 
     /**
      * Get materials by rowId in this, project, or shared container and within the provided sample type.
@@ -622,9 +608,10 @@ public interface ExperimentService extends ExperimentRunTypeSource
      * ignoring any sample children derived from ExpData children.
      */
     Set<ExpMaterial> getRelatedChildSamples(Container c, User user, ExpData start);
+
     /**
-     * Get the lineage for the seed Identifiable object.  Typically, the seed object is a ExpMaterial,
-     * a ExpData (in a DataClass), or an ExpRun.
+     * Get the lineage for the seed Identifiable object. Typically, the seed object is an ExpMaterial,
+     * an ExpData (in a DataClass), or an ExpRun.
      */
     @NotNull
     ExpLineage getLineage(Container c, User user, @NotNull Identifiable start, @NotNull ExpLineageOptions options);

--- a/api/src/org/labkey/api/exp/api/SampleTypeService.java
+++ b/api/src/org/labkey/api/exp/api/SampleTypeService.java
@@ -172,23 +172,15 @@ public interface SampleTypeService
      */
     List<? extends ExpSampleType> getSampleTypes(@NotNull Container container, boolean includeOtherContainers);
 
-    @Deprecated // Temporary just to keep code compiling during migration to new method
-    default List<? extends ExpSampleType> getSampleTypes(@NotNull Container container, User user, boolean includeOtherContainers)
-    {
-        return getSampleTypes(container, includeOtherContainers);
-    }
-
     /**
      * Get a SampleType by name within the definition container.
      */
     ExpSampleType getSampleType(@NotNull Container definitionContainer, @NotNull String sampleTypeName);
 
     /**
-     * Get a SampleType by name within scope -- current, project, and shared.
-     * Requires a user to check for container read permission.
+     * Get a SampleType by name within scope -- current plus, if <code>includeOtherContainers</code> is true, project and shared
      */
-    // TODO: Remove user parameter (not used)
-    ExpSampleType getSampleType(@NotNull Container scope, @NotNull User user, @NotNull String sampleTypeName);
+    ExpSampleType getSampleType(@NotNull Container scope, @NotNull String sampleTypeName, boolean includeOtherContainers);
 
     /** Get the sample type with name at a specific time */
     @Nullable
@@ -205,11 +197,9 @@ public interface SampleTypeService
     ExpSampleType getSampleType(@NotNull Container definitionContainer, long rowId);
 
     /**
-     * Get a SampleType by rowId within scope -- current, project, and shared.
-     * Requires a user to check for container read permission.
+     * Get a SampleType by rowId within scope -- current plus, if <code>includeOtherContainers</code> is true, project and shared
      */
-    // TODO: Remove user parameter (not used)
-    ExpSampleType getSampleType(@NotNull Container scope, @NotNull User user, long rowId);
+    ExpSampleType getSampleType(@NotNull Container scope, long rowId, boolean includeOtherContainers);
 
     Lsid getSampleTypeLsid(String name, Container container);
 

--- a/api/src/org/labkey/api/exp/query/DataClassUserSchema.java
+++ b/api/src/org/labkey/api/exp/query/DataClassUserSchema.java
@@ -48,11 +48,11 @@ public class DataClassUserSchema extends AbstractExpSchema
 
     private Map<String, ExpDataClass> _map;
 
-    static private Map<String, ExpDataClass> getDataClassMap(Container container, User user)
+    static private Map<String, ExpDataClass> getDataClassMap(Container container)
     {
         Map<String, ExpDataClass> map = new CaseInsensitiveTreeMap<>();
         // User can be null if we're running in a background thread, such as doing a study export.
-        for (ExpDataClass dataClass : ExperimentService.get().getDataClasses(container, user, true))
+        for (ExpDataClass dataClass : ExperimentService.get().getDataClasses(container, true))
         {
             map.put(dataClass.getName(), dataClass);
         }
@@ -73,7 +73,7 @@ public class DataClassUserSchema extends AbstractExpSchema
     private Map<String, ExpDataClass> getDataClasses()
     {
         if (_map == null)
-            _map = getDataClassMap(getContainer(), getUser());
+            _map = getDataClassMap(getContainer());
         return _map;
     }
 

--- a/assay/api-src/org/labkey/api/assay/matrix/AbstractMatrixDataHandler.java
+++ b/assay/api-src/org/labkey/api/assay/matrix/AbstractMatrixDataHandler.java
@@ -259,7 +259,7 @@ public abstract class AbstractMatrixDataHandler extends AbstractExperimentDataHa
     // If none exist, a new SampleType named "Samples" is created.
     private static @NotNull ExpSampleType ensureSampleType(Container c, User user) throws ExperimentException
     {
-        List<? extends ExpSampleType> sampleTypes = SampleTypeService.get().getSampleTypes(c, user, true);
+        List<? extends ExpSampleType> sampleTypes = SampleTypeService.get().getSampleTypes(c, true);
         if (sampleTypes.isEmpty())
         {
             return createSampleType(c, user);

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -1976,7 +1976,7 @@ public class ExpDataIterators
                         if (skipExistingAliquotParents)
                             continue;
 
-                        ExpDataClass dataClass = dataClasses.computeIfAbsent(namePart, (name) -> ExperimentService.get().getDataClass(c, user, name));
+                        ExpDataClass dataClass = dataClasses.computeIfAbsent(namePart, (name) -> ExperimentService.get().getDataClass(c, name, true));
                         if (dataClass == null)
                             throw new ValidationException(String.format("Invalid import alias: parent DataClass [%1$s] does not exist or may have been deleted", namePart));
 
@@ -2008,7 +2008,7 @@ public class ExpDataIterators
                 }
                 else if (ExpData.DATA_OUTPUT_CHILD.equalsIgnoreCase(aliasPrefix))
                 {
-                    ExpDataClass dataClass = dataClasses.computeIfAbsent(namePart, (name) -> ExperimentService.get().getDataClass(c, user, name));
+                    ExpDataClass dataClass = dataClasses.computeIfAbsent(namePart, (name) -> ExperimentService.get().getDataClass(c, name, true));
                     if (dataClass == null)
                         throw new ValidationException(String.format("Invalid import alias: child DataClass [%1$s] does not exist or may have been deleted", namePart));
 

--- a/experiment/src/org/labkey/experiment/ExpDataIterators.java
+++ b/experiment/src/org/labkey/experiment/ExpDataIterators.java
@@ -1835,7 +1835,7 @@ public class ExpDataIterators
 
         if (isAliquot && !updateOnly)
         {
-            ExpSampleType sampleType = sampleTypes.computeIfAbsent(dataType, (name) -> SampleTypeService.get().getSampleType(c, user, name));
+            ExpSampleType sampleType = sampleTypes.computeIfAbsent(dataType, (name) -> SampleTypeService.get().getSampleType(c, name, true));
             if (sampleType == null)
                 throw new ValidationException("Invalid sample type: " + dataType);
 
@@ -1910,7 +1910,7 @@ public class ExpDataIterators
                         if (skipExistingAliquotParents)
                             continue;
 
-                        ExpSampleType sampleType = sampleTypes.computeIfAbsent(namePart, (name) -> SampleTypeService.get().getSampleType(c, user, name));
+                        ExpSampleType sampleType = sampleTypes.computeIfAbsent(namePart, (name) -> SampleTypeService.get().getSampleType(c, name, true));
                         if (sampleType == null)
                             throw new ValidationException(String.format("Invalid import alias: parent SampleType [%1$s] does not exist or may have been deleted", namePart));
 
@@ -1937,7 +1937,7 @@ public class ExpDataIterators
                 }
                 else if (ExpMaterial.MATERIAL_OUTPUT_CHILD.equalsIgnoreCase(aliasPrefix))
                 {
-                    ExpSampleType sampleType = sampleTypes.computeIfAbsent(namePart, (name) -> SampleTypeService.get().getSampleType(c, user, name));
+                    ExpSampleType sampleType = sampleTypes.computeIfAbsent(namePart, (name) -> SampleTypeService.get().getSampleType(c, name, true));
                     if (sampleType == null)
                         throw new ValidationException(String.format("Invalid import alias: child SampleType [%1$s] does not exist or may have been deleted", namePart));
 
@@ -2954,7 +2954,7 @@ public class ExpDataIterators
                     {
                         if (_isSamples)
                         {
-                            ExpSampleTypeImpl sampleType = _typeColIndex != null ? (ExpSampleTypeImpl) SampleTypeService.get().getSampleType(targetContainer, _user, typeName) : (ExpSampleTypeImpl) _dataType;
+                            ExpSampleTypeImpl sampleType = _typeColIndex != null ? (ExpSampleTypeImpl) SampleTypeService.get().getSampleType(targetContainer, typeName, true) : (ExpSampleTypeImpl) _dataType;
                             if (sampleType == null)
                                 _context.getErrors().addRowError(new ValidationException(_typeColName + " '" + typeName + "' not found.") );
                             else

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -966,7 +966,7 @@ public class ExperimentModule extends SpringModule
                 list.add(runCount + " runs of type " + runType.getDescription());
         }
 
-        int dataClassCount = ExperimentService.get().getDataClasses(c, null, false).size();
+        int dataClassCount = ExperimentService.get().getDataClasses(c, false).size();
         if (dataClassCount > 0)
             list.add(dataClassCount + " Data Class" + (dataClassCount > 1 ? "es" : ""));
 
@@ -993,7 +993,7 @@ public class ExperimentModule extends SpringModule
             summaries.add(new Summary(runGroupCount, "Assay run"));
 
         // Number of Data Classes
-        List<? extends ExpDataClass> dataClasses = ExperimentService.get().getDataClasses(c, user, false);
+        List<? extends ExpDataClass> dataClasses = ExperimentService.get().getDataClasses(c, false);
         int dataClassCount = dataClasses.size();
         if (dataClassCount > 0)
             summaries.add(new Summary(dataClassCount, "Data Class"));

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -323,7 +323,7 @@ public class ExperimentUpgradeCode implements UpgradeCode
                             .append(" SET Units = ?, StoredAmount = ?, AliquotUnit = ?, AliquotVolume = ?, AvailableAliquotVolume = ? WHERE RowId = ?")
                             .addAll(units, amount, aliquotUnits, aliquotAmount, availableAliquotAmount, rowId), null);
 
-            for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(container, user, false))
+            for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(container, false))
             {
                 LOG.debug("** Starting upgrade for sample type {} in folder {}", sampleType.getName(), container.getPath());
                 Map<String, Integer> sampleCounts = new HashMap<>();
@@ -335,9 +335,9 @@ public class ExperimentUpgradeCode implements UpgradeCode
                 AtomicInteger batchCount = new AtomicInteger();
                 List<AuditTypeEvent> auditEvents = new ArrayList<>();
                 SQLFragment sql = new SQLFragment("SELECT m.RowId, m.Name, m.StoredAmount, m.Units, m.AliquotVolume, m.AliquotUnit, m.AvailableAliquotVolume, m.container FROM ")
-                        .append(tInfo, "m")
-                        .append(" WHERE cpastype = ?").add(sampleType.getLSID())
-                        .append(" AND (m.StoredAmount IS NOT NULL OR m.Units IS NOT NULL OR m.AliquotVolume IS NOT NULL OR m.AliquotUnit IS NOT NULL OR m.AvailableAliquotVolume IS NOT NULL)");
+                    .append(tInfo, "m")
+                    .append(" WHERE cpastype = ?").add(sampleType.getLSID())
+                    .append(" AND (m.StoredAmount IS NOT NULL OR m.Units IS NOT NULL OR m.AliquotVolume IS NOT NULL OR m.AliquotUnit IS NOT NULL OR m.AvailableAliquotVolume IS NOT NULL)");
                 SqlSelector selector = new SqlSelector(scope, sql);
 
                 selector.mapStream().forEach(sampleMap -> {

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -2409,7 +2409,7 @@ public class XarReader extends AbstractXarImporter
         ExpDataClass dc = null;
         if (dataClassName != null)
         {
-            dc = ExperimentService.get().getDataClass(getContainer(), getUser(), dataClassName);
+            dc = ExperimentService.get().getDataClass(getContainer(), dataClassName, true);
             if (dc == null)
                 logErrorAndThrow("DataClass '" + dataClassName + "' not found for protocol input '" + name + "'");
         }

--- a/experiment/src/org/labkey/experiment/XarReader.java
+++ b/experiment/src/org/labkey/experiment/XarReader.java
@@ -696,7 +696,7 @@ public class XarReader extends AbstractXarImporter
 
         if (dataClassType.getSampleType() != null)
         {
-            ExpSampleType sampleType = SampleTypeService.get().getSampleType(getContainer(), getUser(), dataClassType.getSampleType());
+            ExpSampleType sampleType = SampleTypeService.get().getSampleType(getContainer(), dataClassType.getSampleType(), true);
             if (sampleType != null)
                 dataClass.setSampleType(sampleType.getRowId());
             else
@@ -2444,7 +2444,7 @@ public class XarReader extends AbstractXarImporter
         ExpSampleType sampleType = null;
         if (sampleTypeName != null)
         {
-            sampleType = SampleTypeService.get().getSampleType(getContainer(), getUser(), sampleTypeName);
+            sampleType = SampleTypeService.get().getSampleType(getContainer(), sampleTypeName, true);
             if (sampleType == null)
                 logErrorAndThrow("SampleSet '" + sampleTypeName + "' not found for protocol input '" + name + "'");
         }

--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -380,7 +380,7 @@ public class ClosureQueryHelper
             container -> {
                 int totalRows = 0;
                 logger.info("Adding rows to exp.materialAncestors from sample types in container " + container.getPath());
-                for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(container, null, false))
+                for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(container, false))
                 {
                     logger.debug("   Adding rows from samples in sampleType " + sampleType.getName());
                     SQLFragment from = new SQLFragment(" FROM exp.material WHERE materialSourceId = ?").add(sampleType.getRowId());
@@ -653,15 +653,15 @@ public class ClosureQueryHelper
                     Collection<? extends ExpObject> getInstances(Container c, User u)
                     {
                         return SampleTypeServiceImpl.get()
-                                .getSampleTypes(c, u,true)
-                                .stream()
-                                .filter(this::isInstance)
-                                .collect(Collectors.toList());
+                            .getSampleTypes(c,true)
+                            .stream()
+                            .filter(this::isInstance)
+                            .collect(Collectors.toList());
                     }
                     @Override
                     ExpObject getInstance(Container c, User u, String name)
                     {
-                        return SampleTypeServiceImpl.get().getSampleType(c, u, name);
+                        return SampleTypeServiceImpl.get().getSampleType(c, name, true);
                     }
                     @Override
                     boolean isInstance(ExpObject expObject)
@@ -718,15 +718,15 @@ public class ClosureQueryHelper
                     Collection<? extends ExpObject> getInstances(Container c, User u)
                     {
                         return SampleTypeServiceImpl.get()
-                                .getSampleTypes(c, u,true)
-                                .stream()
-                                .filter(this::isInstance)
-                                .collect(Collectors.toList());
+                            .getSampleTypes(c,true)
+                            .stream()
+                            .filter(this::isInstance)
+                            .collect(Collectors.toList());
                     }
                     @Override
                     ExpObject getInstance(Container c, User u, String name)
                     {
-                        return SampleTypeServiceImpl.get().getSampleType(c, u, name);
+                        return SampleTypeServiceImpl.get().getSampleType(c, name, true);
                     }
                     @Override
                     boolean isInstance(ExpObject expObject)

--- a/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
+++ b/experiment/src/org/labkey/experiment/api/ClosureQueryHelper.java
@@ -403,7 +403,7 @@ public class ClosureQueryHelper
             container -> {
                 int totalRows = 0;
                 logger.info("Adding rows to exp.dataAncestors from data classes in container " + container.getPath());
-                for (ExpDataClass dataClass : ExperimentService.get().getDataClasses(container, null, false))
+                for (ExpDataClass dataClass : ExperimentService.get().getDataClasses(container, false))
                 {
                     logger.debug("   Adding rows to exp.dataAncestors from data class " + dataClass.getName());
                     SQLFragment from = new SQLFragment(" FROM exp.data WHERE classId = ?").add(dataClass.getRowId());
@@ -674,7 +674,7 @@ public class ClosureQueryHelper
                     @Override
                     Collection<? extends ExpObject> getInstances(Container c, User u)
                     {
-                        return ExperimentServiceImpl.get().getDataClasses(c, u,true)
+                        return ExperimentServiceImpl.get().getDataClasses(c, true)
                                 .stream()
                                 .filter(this::isInstance)
                                 .collect(Collectors.toList());
@@ -682,7 +682,7 @@ public class ClosureQueryHelper
                     @Override
                     ExpObject getInstance(Container c, User u, String name)
                     {
-                        return ExperimentServiceImpl.get().getDataClass(c, u, name);
+                        return ExperimentServiceImpl.get().getDataClass(c, name, true);
                     }
                     @Override
                     boolean isInstance(ExpObject expObject)
@@ -696,7 +696,7 @@ public class ClosureQueryHelper
                     Collection<? extends ExpObject> getInstances(Container c, User u)
                     {
                         return ExperimentServiceImpl.get()
-                                .getDataClasses(c, u,true)
+                                .getDataClasses(c, true)
                                 .stream()
                                 .filter(this::isInstance)
                                 .collect(Collectors.toList());
@@ -704,7 +704,7 @@ public class ClosureQueryHelper
                     @Override
                     ExpObject getInstance(Container c, User u, String name)
                     {
-                        return ExperimentServiceImpl.get().getDataClass(c, u, name);
+                        return ExperimentServiceImpl.get().getDataClass(c, name, true);
                     }
                     @Override
                     boolean isInstance(ExpObject expObject)
@@ -740,7 +740,7 @@ public class ClosureQueryHelper
                     Collection<? extends ExpObject> getInstances(Container c, User u)
                     {
                         return ExperimentServiceImpl.get()
-                                .getDataClasses(c, u,true)
+                                .getDataClasses(c, true)
                                 .stream()
                                 .filter(this::isInstance)
                                 .collect(Collectors.toList());
@@ -748,7 +748,7 @@ public class ClosureQueryHelper
                     @Override
                     ExpObject getInstance(Container c, User u, String name)
                     {
-                        return ExperimentServiceImpl.get().getDataClass(c, u, name);
+                        return ExperimentServiceImpl.get().getDataClass(c, name, true);
                     }
                     @Override
                     boolean isInstance(ExpObject expObject)

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -146,7 +146,7 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
         // if "sampleSet" is the Name string, look it up and switch the argument map to use the RowId
         if (arguments.containsKey("sampleSet") && !StringUtils.isNumeric(arguments.get("sampleSet").toString()))
         {
-            ExpSampleType sampleType = SampleTypeService.get().getSampleType(container, user, (String)arguments.get("sampleSet"));
+            ExpSampleType sampleType = SampleTypeService.get().getSampleType(container, (String)arguments.get("sampleSet"), true);
             if (sampleType != null)
                 updatedArguments.put("sampleSet", sampleType.getRowId());
         }

--- a/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataImpl.java
@@ -432,7 +432,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
             if (user == null)
                 return ExperimentServiceImpl.get().getDataClass(getContainer(), _object.getClassId());
             else
-                return ExperimentServiceImpl.get().getDataClass(getContainer(), user, _object.getClassId());
+                return ExperimentServiceImpl.get().getDataClass(getContainer(), _object.getClassId(), true);
         }
 
         return null;
@@ -836,7 +836,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
                 ViewContext ctx = HttpView.currentContext();
                 String dataclass = ctx.getActionURL().getParameter(PROPERTY);
                 if (dataclass != null)
-                    return ExperimentService.get().getDataClass(ctx.getContainer(), ctx.getUser(), dataclass);
+                    return ExperimentService.get().getDataClass(ctx.getContainer(), dataclass, true);
             }
             return null;
         }
@@ -905,7 +905,7 @@ public class ExpDataImpl extends AbstractRunItemImpl<Data> implements ExpData
                 html.append("<div class=\"labkey-search-filter\">");
 
                 appendParam(html, null, dataclass, "All", false, url);
-                for (ExpDataClass dc : ExperimentService.get().getDataClasses(ctx.getContainer(), ctx.getUser(), true))
+                for (ExpDataClass dc : ExperimentService.get().getDataClasses(ctx.getContainer(), true))
                 {
                     appendParam(html, dc.getName(), dataclass, dc.getName(), true, url);
                 }

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -859,7 +859,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public List<ExpMaterialImpl> getExpMaterialsByName(@NotNull Collection<String> names, @NotNull String sampleTypeName, @NotNull Container container, User user)
     {
-        ExpSampleType sampleType = SampleTypeService.get().getSampleType(container, user, sampleTypeName);
+        ExpSampleType sampleType = SampleTypeService.get().getSampleType(container, sampleTypeName, true);
         if (sampleType == null)
             return Collections.emptyList();
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts(ExpMaterialTable.Column.Name.name()), names, IN);
@@ -8083,7 +8083,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         if (options.getSampleType() != null)
         {
-            ExpSampleType st = SampleTypeService.get().getSampleType(c, u, options.getSampleType());
+            ExpSampleType st = SampleTypeService.get().getSampleType(c, options.getSampleType(), true);
             if (st == null)
                 throw new ApiUsageException("SampleType '" + options.getSampleType() + "' not found.");
 
@@ -9421,7 +9421,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
                 String parentCpas = null;
                 if (isParentSamples)
                 {
-                    ExpSampleType sampleTypeParent = SampleTypeService.get().getSampleType(c, u, dataTypeName);
+                    ExpSampleType sampleTypeParent = SampleTypeService.get().getSampleType(c, dataTypeName, true);
                     if (sampleTypeParent != null)
                         parentCpas = sampleTypeParent.getLSID();
                 }
@@ -10012,7 +10012,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             return null;
 
         Container c = lookup.getContainer() != null ? lookup.getContainer() : container;
-        return SampleTypeService.get().getSampleType(c, user, lookup.getQueryName());
+        return SampleTypeService.get().getSampleType(c, lookup.getQueryName(), true);
     }
 
     @Override

--- a/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExperimentServiceImpl.java
@@ -1713,7 +1713,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public List<ExpDataClassImpl> getDataClasses(@NotNull Container container, User user, boolean includeProjectAndShared)
+    public List<ExpDataClassImpl> getDataClasses(@NotNull Container container, boolean includeProjectAndShared)
     {
         SortedSet<DataClass> classes = new TreeSet<>();
         List<String> containerIds = createContainerList(container, includeProjectAndShared);
@@ -1730,7 +1730,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     @Override
     public ExpDataClassImpl getDataClass(@NotNull Container c, @NotNull String dataClassName)
     {
-        return getDataClass(c, false, dataClassName);
+        return getDataClass(c, dataClassName, false);
     }
 
     public ExpDataClassImpl getDataClassByObjectId(Long objectId)
@@ -1743,24 +1743,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public ExpProtocol getEffectiveProtocol(Container definitionContainer, User user, String schemaName, Date effectiveDate, ContainerFilter cf)
-    {
-        Long legacyObjectId = getObjectIdWithLegacyName(schemaName, ExperimentServiceImpl.getNamespacePrefix(ExpProtocol.class), effectiveDate, definitionContainer, cf);
-        if (legacyObjectId != null)
-            return getExpProtocol(legacyObjectId);
-
-        ExpProtocol protocol = getExpProtocol(definitionContainer, schemaName, cf);
-
-        if (protocol != null && protocol.getCreated().compareTo(effectiveDate) <= 0)
-            return protocol;
-
-        return null;
-    }
-
-    @Override
     public @Nullable ExpDataClass getEffectiveDataClass(
         @NotNull Container definitionContainer,
-        @NotNull User user,
         @NotNull String dataClassName,
         @NotNull Date effectiveDate,
         @Nullable ContainerFilter cf
@@ -1771,7 +1755,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             return getDataClassByObjectId(legacyObjectId);
 
         boolean includeProjectAndShared = cf != null && cf.getType() != ContainerFilter.Type.Current;
-        ExpDataClassImpl dataClass = getDataClass(definitionContainer, includeProjectAndShared, dataClassName);
+        ExpDataClassImpl dataClass = getDataClass(definitionContainer, dataClassName, includeProjectAndShared);
         if (dataClass != null && dataClass.getCreated().compareTo(effectiveDate) <= 0)
             return dataClass;
 
@@ -1779,12 +1763,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public ExpDataClassImpl getDataClass(@NotNull Container c, @NotNull User user, @NotNull String dataClassName)
-    {
-        return getDataClass(c, true, dataClassName);
-    }
-
-    private ExpDataClassImpl getDataClass(@NotNull Container c, boolean includeProjectAndShared, String dataClassName)
+    public ExpDataClassImpl getDataClass(@NotNull Container c, @NotNull String dataClassName, boolean includeProjectAndShared)
     {
         return getDataClass(c, includeProjectAndShared, (dataClass -> dataClass.getName().equalsIgnoreCase(dataClassName)));
     }
@@ -1796,12 +1775,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     }
 
     @Override
-    public ExpDataClassImpl getDataClass(@NotNull Container c, @NotNull User user, long rowId)
-    {
-        return getDataClass(c, rowId, true);
-    }
-
-    private ExpDataClassImpl getDataClass(@NotNull Container c, long rowId, boolean includeProjectAndShared)
+    public ExpDataClassImpl getDataClass(@NotNull Container c, long rowId, boolean includeProjectAndShared)
     {
         return getDataClass(c, includeProjectAndShared, (dataClass -> dataClass.getRowId() == rowId));
     }
@@ -5486,7 +5460,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         List<ExpExperimentImpl> exps = getExperiments(c, false, true, true);
         List<ExpSampleTypeImpl> sampleTypes = ((SampleTypeServiceImpl) SampleTypeService.get()).getSampleTypes(c, false);
-        List<ExpDataClassImpl> dataClasses = getDataClasses(c, user, false);
+        List<ExpDataClassImpl> dataClasses = getDataClasses(c, false);
 
         sql = "SELECT RowId FROM " + getTinfoProtocol() + " WHERE Container = ?";
         long[] protIds = ArrayUtils.toPrimitive(new SqlSelector(getExpSchema(), sql, c).getArray(Long.class));
@@ -7872,9 +7846,9 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
         {
             domain.setDisabledSystemFields(kind.getDisabledSystemFields(disabledSystemField));
             lowerReservedNames = kind.getReservedPropertyNames(domain, u)
-                    .stream()
-                    .map(String::toLowerCase)
-                    .collect(toSet());
+                .stream()
+                .map(String::toLowerCase)
+                .collect(toSet());
         }
         else
             lowerReservedNames = emptySet();
@@ -8082,7 +8056,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         if (!skipExisting)
         {
-            ExpDataClass existing = getDataClass(c, u, name);
+            ExpDataClass existing = getDataClass(c, name, true);
             if (existing != null)
                 throw new ApiUsageException("DataClass '" + existing.getName() + "' already exists.");
         }
@@ -9212,12 +9186,12 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
     private Pair<Long, Long> getParentAliasMetrics(TableInfo tableInfo, String aliasField)
     {
         SQLFragment sql = new SQLFragment("SELECT ")
-                .append(aliasField)
-                .append(" FROM ")
-                .append(tableInfo)
-                .append(" WHERE ")
-                .append(aliasField)
-                .append(" IS NOT NULL");
+            .append(aliasField)
+            .append(" FROM ")
+            .append(tableInfo)
+            .append(" WHERE ")
+            .append(aliasField)
+            .append(" IS NOT NULL");
         List<String> aliases = new SqlSelector(ExperimentService.get().getSchema(), sql).getArrayList(String.class);
 
         Long requiredSampleParentCount = 0L;
@@ -9370,7 +9344,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             {
             }
         }
-        for (ExpDataClassImpl dataClass : getDataClasses(container, user, true))
+        for (ExpDataClassImpl dataClass : getDataClasses(container, true))
         {
             try
             {
@@ -9395,8 +9369,8 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         SQLFragment totalSql = new SQLFragment("SELECT COUNT(cur.rowId) FROM ");
         totalSql.append(dataTableInfo, "cur")
-                .append("\nWHERE cpastype = ? ")
-                .add(childCpasType);
+            .append("\nWHERE cpastype = ? ")
+            .add(childCpasType);
 
         if (isSampleChild)
         {
@@ -9410,20 +9384,20 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         SQLFragment sql = new SQLFragment("SELECT COUNT(DISTINCT cur.rowId) FROM ");
         sql.append(dataTableInfo, "cur")
-                .append(" LEFT OUTER JOIN ")
-                .append(protocolAppTableInfo, "pa")
-                .append(" ON cur.sourceapplicationid = pa.rowId\n")
-                .append("JOIN ")
-                .append(parentInputTableInfo, "ip")
-                .append(" ON pa.rowId = ip.targetapplicationid\n")
-                .append("JOIN ")
-                .append(parentDataTableInfo, "p")
-                .append(" ON p.rowId = ip.")
-                .append(inputFieldName)
-                .append("\nWHERE cur.cpastype = ? ")
-                .add(childCpasType)
-                .append(" AND p.cpastype = ? ")
-                .add(parentCpasType);
+            .append(" LEFT OUTER JOIN ")
+            .append(protocolAppTableInfo, "pa")
+            .append(" ON cur.sourceapplicationid = pa.rowId\n")
+            .append("JOIN ")
+            .append(parentInputTableInfo, "ip")
+            .append(" ON pa.rowId = ip.targetapplicationid\n")
+            .append("JOIN ")
+            .append(parentDataTableInfo, "p")
+            .append(" ON p.rowId = ip.")
+            .append(inputFieldName)
+            .append("\nWHERE cur.cpastype = ? ")
+            .add(childCpasType)
+            .append(" AND p.cpastype = ? ")
+            .add(parentCpasType);
         if (isSampleChild)
         {
             sql.append(" AND cur.rowId = cur.rootmaterialrowid"); // exclude aliquots
@@ -9488,20 +9462,20 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             return null;
 
         SQLFragment currentFolderCountSql = new SQLFragment()
-                .append(" SELECT COUNT(*) FROM ")
-                .append(tableInfo, "t")
-                .append("\nWHERE Container = ? ")
-                .add(container.getId())
-                .append("\nAND RowId ");
+            .append(" SELECT COUNT(*) FROM ")
+            .append(tableInfo, "t")
+            .append("\nWHERE Container = ? ")
+            .add(container.getId())
+            .append("\nAND RowId ");
         dialect.appendInClauseSql(currentFolderCountSql, rowIds);
         int currentFolderSelectionCount = new SqlSelector(expSchema, currentFolderCountSql).getArrayList(Integer.class).get(0);
 
         SQLFragment crossFolderCountSql = new SQLFragment()
-                .append(" SELECT COUNT(*) FROM ")
-                .append(tableInfo, "t")
-                .append("\nWHERE Container <> ? ")
-                .add(container.getId())
-                .append("\nAND RowId ");
+            .append(" SELECT COUNT(*) FROM ")
+            .append(tableInfo, "t")
+            .append("\nWHERE Container <> ? ")
+            .add(container.getId())
+            .append("\nAND RowId ");
         dialect.appendInClauseSql(crossFolderCountSql, rowIds);
         int crossFolderSelectionCount = new SqlSelector(expSchema, crossFolderCountSql).getArrayList(Integer.class).get(0);
 
@@ -9516,7 +9490,7 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
 
         TableInfo objectTable = OntologyManager.getTinfoObject();
         SQLFragment objectUpdate = new SQLFragment("UPDATE ").append(objectTable).append(" SET container = ").appendValue(targetContainer.getEntityId())
-                .append(" WHERE objectid IN (SELECT objectid FROM ").append(tableInfo).append(" WHERE rowid ");
+            .append(" WHERE objectid IN (SELECT objectid FROM ").append(tableInfo).append(" WHERE rowid ");
         objectTable.getSchema().getSqlDialect().appendInClauseSql(objectUpdate, rowIds);
         objectUpdate.append(")");
         return new SqlExecutor(objectTable.getSchema()).execute(objectUpdate);
@@ -9870,15 +9844,15 @@ public class ExperimentServiceImpl implements ExperimentService, ObjectReference
             if (!targetFile.getParentFile().mkdirs())
             {
                 LOG.warn(String.format("Creation of target directory '%s' to move file '%s' to, for '%s' assay run '%s' (field: '%s') failed.",
-                        targetFile.getParent(),
-                        sourceFile.getAbsolutePath(),
-                        assayName,
-                        runName,
-                        fieldName));
+                    targetFile.getParent(),
+                    sourceFile.getAbsolutePath(),
+                    assayName,
+                    runName,
+                    fieldName
+                ));
                 return false;
             }
         }
-
 
         String changeDetail = String.format("assay '%s' run '%s'", assayName, runName);
         return moveFileLinkFile(sourceFile, targetFile, sourceContainer, user, changeDetail, txAuditEvent, fieldName);

--- a/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
+++ b/experiment/src/org/labkey/experiment/api/SampleTypeServiceImpl.java
@@ -172,7 +172,6 @@ import static org.labkey.api.exp.query.ExpMaterialTable.Column.RawAmount;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.RawUnits;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.StoredAmount;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.Units;
-import static org.labkey.api.exp.query.ExpSchema.NestedSchemas.materials;
 
 
 public class SampleTypeServiceImpl extends AbstractAuditHandler implements SampleTypeService
@@ -454,7 +453,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             return getSampleTypeByObjectId(legacyObjectId);
 
         boolean includeOtherContainers = cf != null && cf.getType() != ContainerFilter.Type.Current;
-        ExpSampleTypeImpl sampleType = getSampleType(definitionContainer, includeOtherContainers, sampleTypeName);
+        ExpSampleTypeImpl sampleType = getSampleType(definitionContainer, sampleTypeName, includeOtherContainers);
         if (sampleType != null && sampleType.getCreated().compareTo(effectiveDate) <= 0)
             return sampleType;
 
@@ -482,17 +481,11 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     @Override
     public ExpSampleTypeImpl getSampleType(@NotNull Container c, @NotNull String sampleTypeName)
     {
-        return getSampleType(c, false, sampleTypeName);
+        return getSampleType(c, sampleTypeName, false);
     }
 
-    // NOTE: This method used to not take a user or check permissions
     @Override
-    public ExpSampleTypeImpl getSampleType(@NotNull Container c, @NotNull User user, @NotNull String sampleTypeName)
-    {
-        return getSampleType(c, true, sampleTypeName);
-    }
-
-    private ExpSampleTypeImpl getSampleType(@NotNull Container c, boolean includeOtherContainers, String sampleTypeName)
+    public ExpSampleTypeImpl getSampleType(@NotNull Container c, @NotNull String sampleTypeName, boolean includeOtherContainers)
     {
         return getSampleType(c, includeOtherContainers, (materialSource -> materialSource.getName().equalsIgnoreCase(sampleTypeName)));
     }
@@ -504,29 +497,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     }
 
     @Override
-    public ExpSampleTypeImpl getSampleType(@NotNull Container c, @NotNull User user, long rowId)
-    {
-        return getSampleType(c, rowId, true);
-    }
-
-    @Override
-    public ExpSampleTypeImpl getSampleTypeByType(@NotNull String lsid, Container hint)
-    {
-        Container c = hint;
-        String id = sampleTypeCache.get(lsid);
-        if (null != id && (null == hint || !id.equals(hint.getId())))
-            c = ContainerManager.getForId(id);
-        ExpSampleTypeImpl st = null;
-        if (null != c)
-            st = getSampleType(c, false, ms -> lsid.equals(ms.getLSID()) );
-        if (null == st)
-            st = _getSampleType(lsid);
-        if (null != st && null==id)
-            sampleTypeCache.put(lsid,st.getContainer().getId());
-        return st;
-    }
-
-    private ExpSampleTypeImpl getSampleType(@NotNull Container c, long rowId, boolean includeOtherContainers)
+    public ExpSampleTypeImpl getSampleType(@NotNull Container c, long rowId, boolean includeOtherContainers)
     {
         return getSampleType(c, includeOtherContainers, (materialSource -> materialSource.getRowId() == rowId));
     }
@@ -564,6 +535,23 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
     public ExpSampleTypeImpl getSampleType(String lsid)
     {
         return getSampleTypeByType(lsid, null);
+    }
+
+    @Override
+    public ExpSampleTypeImpl getSampleTypeByType(@NotNull String lsid, Container hint)
+    {
+        Container c = hint;
+        String id = sampleTypeCache.get(lsid);
+        if (null != id && (null == hint || !id.equals(hint.getId())))
+            c = ContainerManager.getForId(id);
+        ExpSampleTypeImpl st = null;
+        if (null != c)
+            st = getSampleType(c, false, ms -> lsid.equals(ms.getLSID()) );
+        if (null == st)
+            st = _getSampleType(lsid);
+        if (null != st && null==id)
+            sampleTypeCache.put(lsid,st.getContainer().getId());
+        return st;
     }
 
     @Nullable
@@ -651,7 +639,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
         CPUTimer timer = new CPUTimer("delete sample type");
         timer.start();
 
-        ExpSampleTypeImpl source = getSampleType(c, user, rowId);
+        ExpSampleTypeImpl source = getSampleType(c, rowId, true);
         if (null == source)
             throw new IllegalArgumentException("Can't find SampleType with rowId " + rowId);
         if (!source.getContainer().equals(c))
@@ -1049,7 +1037,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
 
         if (!skipExistingCheck)
         {
-            if (getSampleType(container, user, name) != null)
+            if (getSampleType(container, name, true) != null)
                 throw new ApiUsageException("A Sample Type with name '" + name + "' already exists.");
         }
 
@@ -1306,7 +1294,7 @@ public class SampleTypeServiceImpl extends AbstractAuditHandler implements Sampl
             UserSchema schema = tInfo.getUserSchema();
             if (schema != null)
             {
-                ExpSampleType sampleType = getSampleType(c, schema.getUser(), tInfo.getName());
+                ExpSampleType sampleType = getSampleType(c, tInfo.getName(), true);
                 if (sampleType != null)
                 {
                     event.setSampleType(sampleType.getName());

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -892,7 +892,7 @@ public class ExperimentController extends SpringActionController
         @Override
         public ModelAndView getView(ExpObjectForm form, BindException errors)
         {
-            _sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), getUser(), form.getRowId());
+            _sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), form.getRowId(), true);
             if (_sampleType == null && form.getLsid() != null)
             {
                 if (form.getLsid().equalsIgnoreCase("Material") || form.getLsid().equalsIgnoreCase("Sample"))
@@ -909,7 +909,7 @@ public class ExperimentController extends SpringActionController
                 throw new NotFoundException("No matching sample type found");
             }
 
-            List<ExpSampleTypeImpl> allScopedSampleTypes = (List<ExpSampleTypeImpl>) SampleTypeService.get().getSampleTypes(getContainer(), getUser(), true);
+            List<ExpSampleTypeImpl> allScopedSampleTypes = (List<ExpSampleTypeImpl>) SampleTypeService.get().getSampleTypes(getContainer(), true);
             if (!allScopedSampleTypes.contains(_sampleType))
             {
                 ensureCorrectContainer(getContainer(), _sampleType, getViewContext());
@@ -1626,7 +1626,7 @@ public class ExperimentController extends SpringActionController
                 if (template.getOptions().containsKey("sampleSet"))
                 {
                     String sampleTypeName = template.getOptions().get("sampleSet").toString();
-                    ExpSampleType sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), getUser(), sampleTypeName);
+                    ExpSampleType sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), sampleTypeName, true);
                     if (sampleType == null)
                         errors.reject(ERROR_MSG, "Unable to find a sample type in this container with name: " + sampleTypeName + ".");
                 }
@@ -4116,7 +4116,7 @@ public class ExperimentController extends SpringActionController
             List<ExpSampleType> sources = new ArrayList<>();
             for (long rowId : deleteForm.getIds(false))
             {
-                ExpSampleType sampleType = SampleTypeService.get().getSampleType(getContainer(), getUser(), rowId);
+                ExpSampleType sampleType = SampleTypeService.get().getSampleType(getContainer(), rowId, true);
                 if (sampleType != null)
                 {
                     sources.add(sampleType);
@@ -4368,7 +4368,7 @@ public class ExperimentController extends SpringActionController
             {
                 if (!_isCrossTypeImport)
                 {
-                    _sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), getUser(), queryForm.getQueryName());
+                    _sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), queryForm.getQueryName(), true);
                     if (_sampleType == null)
                     {
                         errors.reject(ERROR_GENERIC, "Sample type '" + queryForm.getQueryName() + " not found.");
@@ -4422,7 +4422,7 @@ public class ExperimentController extends SpringActionController
             }
             else
             {
-                ExpSampleTypeImpl sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), getUser(), _form.getQueryName());
+                ExpSampleTypeImpl sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), _form.getQueryName(), true);
                 aliases.addAll(sampleType.getImportAliases().keySet());
             }
             return aliases;
@@ -5112,7 +5112,7 @@ public class ExperimentController extends SpringActionController
             {
                 throw new NotFoundException("No sampleTypeId parameter specified");
             }
-            ExpSampleType sampleType = SampleTypeService.get().getSampleType(getContainer(), getUser(), rowId.intValue());
+            ExpSampleType sampleType = SampleTypeService.get().getSampleType(getContainer(), rowId.intValue(), true);
             if (sampleType == null)
             {
                 throw new NotFoundException("No such sample type with RowId " + rowId);
@@ -5587,7 +5587,7 @@ public class ExperimentController extends SpringActionController
     private List<ExpSampleType> getUploadableSampleTypes()
     {
         // Make a copy so we can modify it
-        List<ExpSampleType> sampleTypes = new ArrayList<>(SampleTypeService.get().getSampleTypes(getContainer(), getUser(), true));
+        List<ExpSampleType> sampleTypes = new ArrayList<>(SampleTypeService.get().getSampleTypes(getContainer(), true));
         sampleTypes.removeIf(sampleType -> !sampleType.canImportMoreSamples());
         return sampleTypes;
     }
@@ -5618,7 +5618,7 @@ public class ExperimentController extends SpringActionController
             if (form.getTargetSampleTypeId() == 0)
                 throw new NotFoundException("Target sample type required for the derived samples");
 
-            ExpSampleTypeImpl sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), getUser(), form.getTargetSampleTypeId());
+            ExpSampleTypeImpl sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), form.getTargetSampleTypeId(), true);
             if (sampleType == null)
                 throw new NotFoundException("Could not find sample type with rowId " + form.getTargetSampleTypeId());
 
@@ -5707,7 +5707,7 @@ public class ExperimentController extends SpringActionController
         @Override
         public boolean handlePost(DeriveMaterialForm form, BindException errors)
         {
-            ExpSampleTypeImpl sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), getUser(), form.getTargetSampleTypeId());
+            ExpSampleTypeImpl sampleType = SampleTypeServiceImpl.get().getSampleType(getContainer(), form.getTargetSampleTypeId(), true);
 
             DerivedSamplePropertyHelper helper = new DerivedSamplePropertyHelper(sampleType, form.getOutputCount(), getContainer(), getUser());
 
@@ -8206,10 +8206,9 @@ public class ExperimentController extends SpringActionController
             try (var ignore = SpringActionController.ignoreSqlUpdates())
             {
                 Container container = getContainer();
-                User user = getUser();
 
                 List<? extends ExpSampleType> sampleTypes = SampleTypeService.get()
-                        .getSampleTypes(container, user, true);
+                    .getSampleTypes(container, true);
 
                 HtmlStringBuilder builder = HtmlStringBuilder.of();
                 builder.unsafeAppend("<table class=\"DataRegion\"><tr><th>Sample Type</th><th>#Recomputed</th></tr>");
@@ -8222,10 +8221,10 @@ public class ExperimentController extends SpringActionController
                     // we could check "if (0 < updatedCount) refresh(rollup)", but since this is a "manual" usage lets just always refresh
                     SampleTypeServiceImpl.get().refreshSampleTypeMaterializedView(sampleType, update);
                     builder.unsafeAppend("<tr><td>")
-                            .append(sampleType.getName())
-                            .unsafeAppend("</td><td>")
-                            .append(updatedCount)
-                            .unsafeAppend("</td></tr>");
+                        .append(sampleType.getName())
+                        .unsafeAppend("</td><td>")
+                        .append(updatedCount)
+                        .unsafeAppend("</td></tr>");
                 }
 
                 builder.unsafeAppend("</table>");

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -1320,13 +1320,13 @@ public class ExperimentController extends SpringActionController
 
             if (getName() != null)
             {
-                dataClass = ExperimentServiceImpl.get().getDataClass(getContainer(), getUser(), getName());
+                dataClass = ExperimentServiceImpl.get().getDataClass(getContainer(), getName(), true);
                 if (dataClass == null)
                     throw new NotFoundException("No data class found for name '" + getName() + "'.");
             }
             else if (getRowId() > 0)
             {
-                dataClass = ExperimentServiceImpl.get().getDataClass(getContainer(), getUser(), getRowId());
+                dataClass = ExperimentServiceImpl.get().getDataClass(getContainer(), getRowId(), true);
             }
 
             if (dataClass == null)
@@ -1517,7 +1517,7 @@ public class ExperimentController extends SpringActionController
             List<ExpDataClass> dataClasses = new ArrayList<>();
             for (long rowId : deleteForm.getIds(false))
             {
-                ExpDataClass dataClass = ExperimentServiceImpl.get().getDataClass(getContainer(), getUser(), rowId);
+                ExpDataClass dataClass = ExperimentServiceImpl.get().getDataClass(getContainer(), rowId, true);
                 if (dataClass != null)
                 {
                     dataClasses.add(dataClass);
@@ -1634,7 +1634,7 @@ public class ExperimentController extends SpringActionController
 
             if (StringUtils.isBlank(name))
                 errors.reject(ERROR_MSG, "DataClass template selection is required.");
-            else if (ExperimentService.get().getDataClass(getContainer(), getUser(), name) != null)
+            else if (ExperimentService.get().getDataClass(getContainer(), name, true) != null)
                 errors.reject(ERROR_MSG, "DataClass '" + name + "' already exists.");
 
         }
@@ -4555,7 +4555,7 @@ public class ExperimentController extends SpringActionController
         @Override
         protected Set<String> getLineageImportAliases() throws IOException
         {
-            ExpDataClass dataClass = ExperimentServiceImpl.get().getDataClass(getContainer(), getUser(), _form.getQueryName());
+            ExpDataClass dataClass = ExperimentServiceImpl.get().getDataClass(getContainer(), _form.getQueryName(), true);
             return new CaseInsensitiveHashSet(dataClass.getImportAliases().keySet());
         }
 
@@ -4623,7 +4623,7 @@ public class ExperimentController extends SpringActionController
                 errors.reject(ERROR_REQUIRED, "Data class name is required");
             else
             {
-                ExpDataClass dataClass = ExperimentService.get().getDataClass(getContainer(), getUser(), queryForm.getQueryName());
+                ExpDataClass dataClass = ExperimentService.get().getDataClass(getContainer(), queryForm.getQueryName(), true);
                 if (dataClass == null)
                 {
                     errors.reject(ERROR_GENERIC, "Data class '" + queryForm.getQueryName() + " not found.");
@@ -7400,7 +7400,7 @@ public class ExperimentController extends SpringActionController
         {
             List<Map<String, Object>> notInIndex = new ArrayList<>(100);
 
-            List<? extends ExpDataClass> list = ExperimentService.get().getDataClasses(getContainer(), getUser(), false);
+            List<? extends ExpDataClass> list = ExperimentService.get().getDataClasses(getContainer(), false);
             for (ExpDataClass dc : list)
             {
                 for (ExpData d : dc.getDatas())

--- a/experiment/src/org/labkey/experiment/lineage/LineageForeignKey.java
+++ b/experiment/src/org/labkey/experiment/lineage/LineageForeignKey.java
@@ -110,7 +110,7 @@ public class LineageForeignKey extends AbstractForeignKey
             @Override
             List<? extends ExpObject> getItems(UserSchema s)
             {
-                return ExperimentService.get().getDataClasses(s.getContainer(), s.getUser(), true);
+                return ExperimentService.get().getDataClasses(s.getContainer(), true);
             }
         },
         Material("Materials", ExpLineageOptions.LineageExpType.Material)

--- a/experiment/src/org/labkey/experiment/lineage/LineageForeignKey.java
+++ b/experiment/src/org/labkey/experiment/lineage/LineageForeignKey.java
@@ -118,7 +118,7 @@ public class LineageForeignKey extends AbstractForeignKey
             @Override
             List<? extends ExpObject> getItems(UserSchema s)
             {
-                return SampleTypeService.get().getSampleTypes(s.getContainer(), s.getUser(), true);
+                return SampleTypeService.get().getSampleTypes(s.getContainer(), true);
             }
         },
         ExperimentRun("Runs", ExpLineageOptions.LineageExpType.ExperimentRun)

--- a/experiment/src/org/labkey/experiment/pipeline/SampleReloadTask.java
+++ b/experiment/src/org/labkey/experiment/pipeline/SampleReloadTask.java
@@ -117,7 +117,7 @@ public class SampleReloadTask extends PipelineJob.Task<SampleReloadTask.Factory>
         if (params.containsKey(SAMPLE_NAME_KEY))
         {
             sampleName = params.get(SAMPLE_NAME_KEY);
-            sampleType = SampleTypeService.get().getSampleType(job.getContainer(), job.getUser(), sampleName);
+            sampleType = SampleTypeService.get().getSampleType(job.getContainer(), sampleName, true);
             if (sampleType != null)
                 log.info("Sample Type matching the 'name' capture group was resolved : " + sampleName);
             else
@@ -144,7 +144,7 @@ public class SampleReloadTask extends PipelineJob.Task<SampleReloadTask.Factory>
             // if we aren't trying a named capture group resolution, see if there is a match of an existing sample type
             // by file name
             if (!params.containsKey(SAMPLE_NAME_KEY))
-                sampleType = SampleTypeService.get().getSampleType(job.getContainer(), job.getUser(), sampleName);
+                sampleType = SampleTypeService.get().getSampleType(job.getContainer(), sampleName, true);
 
             // still no resolution to an existing sample type, create a new one inferring the schema from the data file
             if (sampleType == null)

--- a/experiment/src/org/labkey/experiment/samples/DataClassFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/DataClassFolderWriter.java
@@ -68,7 +68,7 @@ public abstract class DataClassFolderWriter extends AbstractExpFolderWriter
         if (exportContext.isDataClassXarCreated())
             return;
 
-        for (ExpDataClass dataClass : ExperimentService.get().getDataClasses(c, ctx.getUser(), false))
+        for (ExpDataClass dataClass : ExperimentService.get().getDataClasses(c, false))
         {
             // ignore data classes that are filtered out
             if (EXCLUDED_TYPES.contains(dataClass.getName()))

--- a/experiment/src/org/labkey/experiment/samples/SampleStatusFolderImporter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleStatusFolderImporter.java
@@ -88,7 +88,7 @@ public class SampleStatusFolderImporter extends SampleTypeFolderImporter
                     XarReader typesReader = getXarReader(job, ctx, root, typesXarFile);
                     XarContext xarContext = typesReader.getXarSource().getXarContext();
                     List<String> sampleTypeNames = typesReader.getSampleTypeNames();
-                    List<ExpSampleType> sampleTypes = SampleTypeService.get().getSampleTypes(ctx.getContainer(), ctx.getUser(), false)
+                    List<ExpSampleType> sampleTypes = SampleTypeService.get().getSampleTypes(ctx.getContainer(), false)
                             .stream().filter(sampleType -> sampleTypeNames.contains(sampleType.getName())).collect(Collectors.toList());
 
                     // process any sample status data files

--- a/experiment/src/org/labkey/experiment/samples/SampleTypeFolderWriter.java
+++ b/experiment/src/org/labkey/experiment/samples/SampleTypeFolderWriter.java
@@ -80,7 +80,7 @@ public abstract class SampleTypeFolderWriter extends AbstractExpFolderWriter
             return;
 
         Lsid sampleTypeLsid = new Lsid(ExperimentService.get().generateLSID(c, ExpSampleType.class, "export"));
-        for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(c, ctx.getUser(), true))
+        for (ExpSampleType sampleType : SampleTypeService.get().getSampleTypes(c, true))
         {
             // ignore the magic sample type that is used for the specimen repository, it is managed by the specimen importer
             StudyService ss = StudyService.get();

--- a/study/src/org/labkey/study/controllers/publish/PublishController.java
+++ b/study/src/org/labkey/study/controllers/publish/PublishController.java
@@ -170,7 +170,7 @@ public class PublishController extends SpringActionController
             if (rowId == -1)
                 throw new NotFoundException("rowId required");
 
-            ExpSampleType st = SampleTypeService.get().getSampleType(scope, user, rowId);
+            ExpSampleType st = SampleTypeService.get().getSampleType(scope, rowId, true);
             if (st == null)
                 throw new NotFoundException("SampleType not found: " + rowId);
 

--- a/study/src/org/labkey/study/controllers/publish/SampleTypePublishConfirmAction.java
+++ b/study/src/org/labkey/study/controllers/publish/SampleTypePublishConfirmAction.java
@@ -55,7 +55,7 @@ public class SampleTypePublishConfirmAction extends AbstractPublishConfirmAction
             if (_sampleType == null)
             {
                 if (getRowId() != null)
-                    _sampleType = SampleTypeService.get().getSampleType(getContainer(), getUser(), getRowId());
+                    _sampleType = SampleTypeService.get().getSampleType(getContainer(), getRowId(), true);
                 else
                     throw new NotFoundException("Sample Type ID not specified.");
 

--- a/study/src/org/labkey/study/controllers/publish/SampleTypePublishStartAction.java
+++ b/study/src/org/labkey/study/controllers/publish/SampleTypePublishStartAction.java
@@ -119,7 +119,7 @@ public class SampleTypePublishStartAction extends AbstractPublishStartAction<Sam
         if (_ids.isEmpty() && !form.isSampleTypeIds() && null != form.getRowId())
         {
             _ids = getCheckboxIds(getViewContext());
-            _sampleType = SampleTypeService.get().getSampleType(form.getContainer(), form.getUser(), form.getRowId());
+            _sampleType = SampleTypeService.get().getSampleType(form.getContainer(), form.getRowId(), true);
             form.setAutoLinkEnabled(_sampleType != null && _sampleType.getAutoLinkCategory() != null);
         }
         return _ids;


### PR DESCRIPTION
#### Rationale
Some `ExperimentService` and `SampleTypeService` methods take a `User` parameter but ignore it, as of the related PR below. Remove this parameter from those signatures (and callers).

There should be no functional changes here. I recommend relying on existing automated tests; no need for manual testing or additional automated tests.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6947