### PR TITLE
GitHub Issue 731: LABKEY.vis.GenericChartHelper selectRows for chart data to use POST method

### DIFF
--- a/visualization/resources/web/vis/genericChart/genericChartHelper.js
+++ b/visualization/resources/web/vis/genericChart/genericChartHelper.js
@@ -1847,6 +1847,7 @@ LABKEY.vis.GenericChartHelper = new function(){
 
     var queryChartData = function(renderTo, queryConfig, chartConfig, callback) {
         queryConfig.containerPath = LABKEY.container.path;
+        queryConfig.method = 'POST'; // GitHub Issue 731
 
         if (queryConfig.filterArray && queryConfig.filterArray.length > 0) {
             var filters = [];


### PR DESCRIPTION
#### Rationale
[#731](https://github.com/LabKey/internal-issues/issues/731) Chart doesn't load for data accessed from Source/Assays tab with lots of derived samples

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1862

#### Changes
- LABKEY.vis.GenericChartHelper selectRows for chart data to use POST method
