### PR TITLE
Remove unused legacyNameMap() method

### DIFF
--- a/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AbstractAuditTypeProvider.java
@@ -276,12 +276,6 @@ public abstract class AbstractAuditTypeProvider implements AuditTypeProvider
         return null;
     }
 
-    @Override
-    public Map<FieldKey, String> legacyNameMap()
-    {
-        return new LinkedHashMap<>();
-    }
-
     public static Container getDomainContainer()
     {
         return ContainerManager.getSharedContainer();

--- a/api/src/org/labkey/api/audit/AuditTypeProvider.java
+++ b/api/src/org/labkey/api/audit/AuditTypeProvider.java
@@ -48,9 +48,6 @@ public interface AuditTypeProvider
 
     <K extends AuditTypeEvent> Class<K> getEventClass();
 
-    @Deprecated // Not used anymore - remove
-    Map<FieldKey, String> legacyNameMap();
-
     ActionURL getAuditUrl();
 
     /**


### PR DESCRIPTION
#### Rationale
Previous PR removed the callers of `legacyNameMap()` and overrides in `platform`, but didn't clean up overrides in other repos. This set of PRs eliminates the remaining overrides plus the interface method.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7230