### PR TITLE
Survey : don't clear all form fields that may be hidden

### DIFF
--- a/survey/webapp/survey/BaseSurveyPanel.js
+++ b/survey/webapp/survey/BaseSurveyPanel.js
@@ -902,7 +902,7 @@ Ext4.define('LABKEY.ext4.BaseSurveyPanel', {
     },
 
     clearHiddenFieldValues : function(cmp) {
-        if (cmp.isHidden())
+        if (cmp.isHidden() && cmp.getXType() !== 'hiddenfield')
         {
             // the component can either be a form field itself or a container that has multiple fields
             if (cmp.isFormField)


### PR DESCRIPTION
#### Rationale
We are currently clearing all hidden form elements in a survey panel. I don't remember the exact reason for this behavior but I can imagine with some skip logic where we hide/show elements we don't want those values posted, although I thought ExtJS forms prevented that automatically although maybe this is just for disabled elements.

This came up recently while trying to help a client where they needed a value posted without rendering a visible element in the form. The exact scenario is there is a value that needs to be dynamically calculated based on other behavior, so a listener is attached and the value of the hidden form field is updated on parent element changes.