### PR TITLE
Handle multiple special chars in plate based assay measure field

### DIFF
--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -705,11 +705,11 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 
         private @Nullable String getPrefixedValue(String annotation, String prefix)
         {
-            if (annotation != null && annotation.trim().toLowerCase().startsWith(prefix + ":"))
+            if (annotation != null)
             {
                 // Issue 52782: measure name may contain a colon
                 String[] parts = annotation.split(":", 2);
-                if (parts.length == 2)
+                if (parts.length == 2 && parts[0].trim().equalsIgnoreCase(prefix))
                 {
                     return parts[1].trim();
                 }

--- a/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
+++ b/assay/src/org/labkey/assay/plate/AssayPlateMetadataServiceImpl.java
@@ -96,7 +96,6 @@ import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.assay.TSVProtocolSchema;
-import org.labkey.assay.plate.data.WellData;
 import org.labkey.assay.plate.model.WellBean;
 import org.labkey.assay.plate.query.PlateSchema;
 import org.labkey.assay.plate.query.PlateTable;
@@ -706,13 +705,13 @@ public class AssayPlateMetadataServiceImpl implements AssayPlateMetadataService
 
         private @Nullable String getPrefixedValue(String annotation, String prefix)
         {
-            if (annotation != null && annotation.trim().toLowerCase().startsWith(prefix))
+            if (annotation != null && annotation.trim().toLowerCase().startsWith(prefix + ":"))
             {
-                String[] parts = annotation.split(":");
-                if (parts.length > 1)
+                // Issue 52782: measure name may contain a colon
+                String[] parts = annotation.split(":", 2);
+                if (parts.length == 2)
                 {
-                    // Issue 52782: measure name may contain a colon, so we need to join the rest of the parts
-                    return StringUtils.join(parts, ":", 1, parts.length).trim();
+                    return parts[1].trim();
                 }
             }
             return null;


### PR DESCRIPTION
#### Rationale
This has been failing intermittently on TeamCity. If the randomly generated measure field name ends with a '`:`' the data does not import.

```
java.lang.AssertionError: Expect graphical measures to be as imported for Decimal: Meas.ure+@}👾],^안< ;]И%и=안};?$/&}~,. %()=+-[] |*`'":;\<>?!@#^и И안はΠ⋯∑(|-],`/?~`(は$/&}~,. %()=+-[] |*`'":;\<>?!@#^и И안はΠ⋯∑. '?}%'@?: expected:<[0.1, 0.11, 0.12, 0.13, , 0.21, 0.22, 0.23, 0.3, 0.31, 0.32, 0.33, 0.1, 0.11, 0.12, 0.13, , 0.21, 0.22, 0.23, 0.3, 0.31, 0.32, 0.33]> but was:<[, , , , , , , , , , , , , , , , , , , , , , , ]>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:120)
        at org.labkey.test.util.DeferredErrorCollector.lambda$5(DeferredErrorCollector.java:248)
        at org.labkey.test.util.DeferredErrorCollector.wrapAssertion(DeferredErrorCollector.java:188)
        at org.labkey.test.util.DeferredErrorCollector.verifyEquals(DeferredErrorCollector.java:248)
        at org.labkey.test.tests.biologics.plates.PlateAssayImportTest.testVerifyGraphicalVsTabularImport(PlateAssayImportTest.java:197)
```

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6545

#### Changes
- Handle multiple special chars in plate based assay measure field