### PR TITLE
Handle digest time ranges within the runnable

### DIFF
--- a/api/src/org/labkey/api/message/digest/MessageDigest.java
+++ b/api/src/org/labkey/api/message/digest/MessageDigest.java
@@ -68,23 +68,24 @@ public abstract class MessageDigest
 
     public void sendMessageDigest() throws Exception
     {
-        Date prev = getLastSuccessful();
-        Date current = new Date();
-
-        // get the start and end times to compute the message digest for
-        Date start = getStartRange(current, prev);
-        Date end = getEndRange(current, prev);
-
         AtomicReference<Exception> ref = new AtomicReference<>();
 
         // Issue 45978: Run in a background thread to better simulate being triggered by a timer
         JobRunner.getDefault().execute(() -> {
             try
             {
+                Date prev = getLastSuccessful();
+                Date current = new Date();
+
+                // get the start and end times to compute the message digest for
+                Date start = getStartRange(current, prev);
+                Date end = getEndRange(current, prev);
+
                 for (Provider provider : _providers)
                 {
                     provider.sendDigestForAllContainers(start, end);
                 }
+                setLastSuccessful(end);
             }
             catch (Exception e)
             {
@@ -98,8 +99,6 @@ public abstract class MessageDigest
         {
             throw ref.get();
         }
-
-        setLastSuccessful(end);
     }
 
     protected Date getStartRange(Date current, Date last)


### PR DESCRIPTION
#### Rationale
A previous [change](https://github.com/LabKey/platform/pull/7286) was resulting in a dataset notification test failure : https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailySuites_DailyEPostgres/3779575

The change pushed the email notification generation into a background thread which created the possibility of a second job starting before the end time was recorded on a previous digest. The test failure indicated that we were picking up changes from datasets in multiple email digests. This change moves the start and end time handling for the digest generation into the `Runnable`.