### PR TITLE
Improve SQL Server migration process

### DIFF
--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -34,16 +34,20 @@ import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.attachments.AttachmentParentType;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.provider.MessageAuditProvider;
+import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.WrappedColumn;
 import org.labkey.api.message.digest.DailyMessageDigest;
 import org.labkey.api.message.settings.MessageConfigService;
 import org.labkey.api.migration.DatabaseMigrationConfiguration;
 import org.labkey.api.migration.DatabaseMigrationService;
 import org.labkey.api.migration.DefaultMigrationSchemaHandler;
+import org.labkey.api.migration.MigrationTableHandler;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.rss.RSSService;
@@ -52,6 +56,7 @@ import org.labkey.api.security.UserManager;
 import org.labkey.api.security.roles.EditorRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
+import org.labkey.api.util.GUID;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.emailTemplate.EmailTemplateService;
 import org.labkey.api.view.AlwaysAvailableWebPartFactory;
@@ -206,6 +211,45 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
                 // It's theoretically possible to deploy Announcement without Wiki, so conditionalize
                 WikiService ws = WikiService.get();
                 return ws != null ? List.of(AnnouncementType.get(), ws.getAttachmentType()) : List.of(AnnouncementType.get());
+            }
+        });
+
+        DatabaseMigrationService.get().registerTableHandler(new MigrationTableHandler()
+        {
+            @Override
+            public TableInfo getTableInfo()
+            {
+                return CommSchema.getInstance().getTableInfoAnnouncements();
+            }
+
+            @Override
+            public ColumnInfo handleColumn(ColumnInfo col)
+            {
+                return "DiscussionSrcIdentifier".equals(col.getName()) ? new GuidMapperColumn(col) : col;
+            }
+
+            // In this column, map any value that exactly matches a GUID to lowercase
+            private static final class GuidMapperColumn extends WrappedColumn
+            {
+                public GuidMapperColumn(ColumnInfo col)
+                {
+                    super(col, col.getName());
+                }
+
+                @Override
+                public SQLFragment getValueSql(String tableAlias)
+                {
+                    SQLFragment columnAlias = super.getValueSql(tableAlias);
+                    //noinspection StringConcatenationInsideStringBufferAppend - SQLFragment flips out about unmatched quotes, so we're forced to use string concatenation
+                    return new SQLFragment("CASE WHEN ")
+                        .append(columnAlias)
+                        .append(" LIKE '" + GUID.SQL_LIKE_GUID_PATTERN + "'")
+                        .append(" THEN LOWER(")
+                        .append(columnAlias)
+                        .append(") ELSE ")
+                        .append(columnAlias)
+                        .append(" END");
+                }
             }
         });
     }

--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -431,6 +431,7 @@ public class ApiModule extends CodeOnlyModule
             SimpleFilter.BetweenClauseTestCase.class,
             SimpleFilter.FilterTestCase.class,
             SimpleFilter.InClauseTestCase.class,
+            SimpleFilter.SqlClauseTestCase.class,
             SqlScanner.TestCase.class,
             StringExpressionFactory.TestCase.class,
             StringUtilsLabKey.TestCase.class,

--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -366,6 +366,7 @@ public class ApiModule extends CodeOnlyModule
             Aggregate.TestCase.class,
             ApiXmlWriter.TestCase.class,
             ArrayListMap.TestCase.class,
+            AssayResultsFileWriter.TestCase.class,
             BaseServerProperties.TestCase.class,
             BooleanFormat.TestCase.class,
             BuilderObjectFactory.TestCase.class,
@@ -399,12 +400,12 @@ public class ApiModule extends CodeOnlyModule
             GenerateUniqueDataIterator.TestCase.class,
             HelpTopic.TestCase.class,
             InlineInClauseGenerator.TestCase.class,
-            JobRunner.TestCase.class,
             JSONDataLoader.HeaderMatchTest.class,
             JSONDataLoader.MetadataTest.class,
             JSONDataLoader.RowTest.class,
             JSoupUtil.TestCase.class,
             JavaVersion.TestCase.class,
+            JobRunner.TestCase.class,
             JsonTest.class,
             JsonUtil.TestCase.class,
             LimitedUser.TestCase.class,
@@ -429,6 +430,7 @@ public class ApiModule extends CodeOnlyModule
             SchemaKey.TestCase.class,
             SessionHelper.TestCase.class,
             SimpleFilter.BetweenClauseTestCase.class,
+            SimpleFilter.ContainsOneOfTestCase.class,
             SimpleFilter.FilterTestCase.class,
             SimpleFilter.InClauseTestCase.class,
             SimpleFilter.SqlClauseTestCase.class,
@@ -441,9 +443,8 @@ public class ApiModule extends CodeOnlyModule
             TSVWriter.TestCase.class,
             TabLoader.HeaderMatchTest.class,
             Table.IsSelectTestCase.class,
-            ValidEmail.TestCase.class,
             URIUtil.TestCase.class,
-            AssayResultsFileWriter.TestCase.class
+            ValidEmail.TestCase.class
         );
     }
 

--- a/api/src/org/labkey/api/data/CompareType.java
+++ b/api/src/org/labkey/api/data/CompareType.java
@@ -2108,7 +2108,7 @@ public abstract class CompareType
         public String getLabKeySQLWhereClause(Map<FieldKey, ? extends ColumnInfo> columnMap)
         {
             String colName = getLabKeySQLColName(_fieldKey);
-            return "LOWER(" + colName + ") LIKE LOWER('%" + escapeLabKeySqlValue(getParamVals()[0], getColumnType(columnMap, JdbcType.VARCHAR), true) + "%') " + sqlEscape();
+            return "LOWER(" + colName + ") LIKE LOWER('%" + escapeLabKeySqlValue(getParamVals()[0], getColumnType(columnMap, JdbcType.VARCHAR), true) + "%')" + sqlEscape();
         }
 
         @Override

--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -313,12 +313,15 @@ public class SQLFragment implements Appendable, CharSequence
         return "SQLFragment@" + System.identityHashCode(this) + "\n" + JdbcUtil.format(this);
     }
 
-
     public String toDebugString()
     {
         return JdbcUtil.format(this);
     }
 
+    public String toDebugString(SqlDialect dialect)
+    {
+        return JdbcUtil.format(this, dialect);
+    }
 
     public List<Object> getParams()
     {

--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -1322,6 +1322,12 @@ public class SQLFragment implements Appendable, CharSequence
         return getSQL().equals(other.getSQL()) && getParams().equals(other.getParams());
     }
 
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getSQL(), getParams());
+    }
+
     /**
      * Joins the SQLFragments in the provided {@code Iterable} into a single SQLFragment. The SQL is joined by string
      * concatenation using the provided separator. The parameters are combined to form the new parameter list.

--- a/api/src/org/labkey/api/data/SQLFragment.java
+++ b/api/src/org/labkey/api/data/SQLFragment.java
@@ -310,12 +310,15 @@ public class SQLFragment implements Appendable, CharSequence
     @NotNull
     public String toString()
     {
-        return "SQLFragment@" + System.identityHashCode(this) + "\n" + JdbcUtil.format(this);
+        return "SQLFragment@" + System.identityHashCode(this) + "\n" + toDebugString();
     }
 
+    // Not recommended -- this uses the LabKey scope to dictate parsing of identifiers and string literals... which
+    // might not be correct for the incoming SQL.
+    @Deprecated // Use the variant below that takes a SqlDialect
     public String toDebugString()
     {
-        return JdbcUtil.format(this);
+        return toDebugString(DbScope.getLabKeyScope().getSqlDialect());
     }
 
     public String toDebugString(SqlDialect dialect)

--- a/api/src/org/labkey/api/data/SimpleFilter.java
+++ b/api/src/org/labkey/api/data/SimpleFilter.java
@@ -413,7 +413,7 @@ public class SimpleFilter implements Filter
     {
         public FalseClause()
         {
-            super("0=1", null);
+            super("0 = 1", null);
         }
     }
 
@@ -574,7 +574,7 @@ public class SimpleFilter implements Filter
         public SQLFragment toSQLFragment(Map<FieldKey, ? extends ColumnInfo> columnMap, SqlDialect dialect)
         {
             SQLFragment sqlFragment = new SQLFragment();
-            sqlFragment.append(" NOT (");
+            sqlFragment.append("NOT (");
             sqlFragment.append(_clause.toSQLFragment(columnMap, dialect));
             sqlFragment.append(")");
             return sqlFragment;
@@ -583,13 +583,21 @@ public class SimpleFilter implements Filter
         @Override
         public String getLabKeySQLWhereClause(Map<FieldKey, ? extends ColumnInfo> columnMap)
         {
-            return " NOT (" + _clause.getLabKeySQLWhereClause(columnMap) + ")";
+            return "NOT (" + _clause.getLabKeySQLWhereClause(columnMap) + ")";
         }
 
         @Override
         protected boolean meetsCriteria(ColumnRenderProperties col, Object value)
         {
             return !_clause.meetsCriteria(col, value);
+        }
+
+        @Override
+        public void appendFilterText(StringBuilder sb, ColumnNameFormatter formatter)
+        {
+            sb.append("NOT (");
+            _clause.appendFilterText(sb, formatter);
+            sb.append(")");
         }
     }
 
@@ -740,14 +748,14 @@ public class SimpleFilter implements Filter
             String alias = getLabKeySQLColName(getFieldKey());
             ColumnInfo col = columnMap != null ? columnMap.get(getFieldKey()) : null;
             Object[] params = getParamVals();
-            StringBuilder in =  new StringBuilder();
+            StringBuilder in = new StringBuilder();
 
             if (params.length == 0)
             {
                 if (isIncludeNull())
-                    in.append(alias).append(" IS ").append(isNegated() ? " NOT " : "").append("NULL");
-                else if (!isNegated())
-                    in.append(alias).append(" IN (NULL)");  // Empty list case; "WHERE column IN (NULL)" should always be false
+                    in.append(alias).append(" IS ").append(isNegated() ? "NOT " : "").append("NULL");
+                else
+                    in.append(isNegated() ? "1 = 1" : "0 = 1");
             }
             else
             {
@@ -794,11 +802,9 @@ public class SimpleFilter implements Filter
         private void handleEmptyParams(DatabaseIdentifier alias, SQLFragment in)
         {
             if (isIncludeNull())
-                in.appendIdentifier(alias).append(" IS ").append(isNegated() ? " NOT " : "").append("NULL");
-            else if (!isNegated())
-                in.appendIdentifier(alias).append(" IN (NULL)");  // Empty list case; "WHERE column IN (NULL)" should always be false
+                in.appendIdentifier(alias).append(" IS ").append(isNegated() ? "NOT " : "").append("NULL");
             else
-                in.append("1=1");
+                in.append(isNegated() ? "1 = 1" : "0 = 1");
         }
 
         @Override
@@ -944,21 +950,21 @@ public class SimpleFilter implements Filter
                 return getContainsClause(col).getLabKeySQLWhereClause(columnMap);
             }
 
-            return col.getName() + (isNegated() ? " NOT IN" : " IN ") + " (NULL)";  // Empty list case; "WHERE column IN (NULL)" should always be false
+            // Empty params list
+            return isNegated() ? "1 = 1" : "0 = 1";
         }
 
         @Override
         public SQLFragment toSQLFragment(Map<FieldKey, ? extends ColumnInfo> columnMap, SqlDialect dialect)
         {
             ColumnInfo colInfo = columnMap != null ? columnMap.get(getFieldKey()) : null;
-            var alias = getAliasForColumnFilter(dialect, colInfo, getFieldKey());
 
             SQLFragment in = new SQLFragment();
             OperationClause oc = getContainsClause(colInfo);
-            if(!oc.getClauses().isEmpty())
+            if (!oc.getClauses().isEmpty())
                 return in.append(oc.toSQLFragment(columnMap, dialect));
 
-            return in.appendIdentifier(alias).append(isNegated() ? " NOT IN " : " IN ").append("(NULL)");  // Empty list case; "WHERE column IN (NULL)" should always be false
+            return in.append(isNegated() ? "1 = 1" : "0 = 1");
         }
 
         private OperationClause getContainsClause(ColumnInfo colInfo)
@@ -1666,9 +1672,10 @@ public class SimpleFilter implements Filter
             assertArrayEquals(new Object[] { "x", "u_u" }, containsOneOf.getParamVals());
             assertEquals("x;u_u", containsOneOf.toURLParam("query").getValue());
             var containsOneOfFrag = containsOneOf.getLabKeySQLWhereClause(Collections.emptyMap());
-            assertEquals("(LOWER(\"Field2\") LIKE LOWER('%x%')  ESCAPE '!')" +
-                        " OR (LOWER(\"Field2\") LIKE LOWER('%u!_u%')  ESCAPE '!')",
-                    containsOneOfFrag);
+            assertEquals(
+                "(LOWER(\"Field2\") LIKE LOWER('%x%') ESCAPE '!') OR (LOWER(\"Field2\") LIKE LOWER('%u!_u%') ESCAPE '!')",
+                containsOneOfFrag
+            );
             filter.addClause(containsOneOf);
 
             // verify filter containing multi-value separator ';' use json encoded filter value
@@ -1686,18 +1693,18 @@ public class SimpleFilter implements Filter
             filter.addClause(containsClause);
 
             assertEquals("query.Field1~eq=1" +
-                    "&query.Field2~containsoneof=x%3Bu_u" +
-                    "&query.Field3~containsoneof=" + PageFlowUtil.encodeURIComponent(containsOneOfJsonValue) +
-                    "&query.Field4~contains=o_O",
-                    filter.toQueryString("query"));
+                "&query.Field2~containsoneof=x%3Bu_u" +
+                "&query.Field3~containsoneof=" + PageFlowUtil.encodeURIComponent(containsOneOfJsonValue) +
+                "&query.Field4~contains=o_O",
+                filter.toQueryString("query"));
             URLHelper url = new URLHelper("http://labkey.com");
 
             filter.applyToURL(url, "query");
             assertEquals("query.Field1~eq=1" +
-                    "&query.Field2~containsoneof=x%3Bu_u" +
-                    "&query.Field3~containsoneof=" + PageFlowUtil.encodeURIComponent(containsOneOfJsonValue) +
-                    "&query.Field4~contains=o_O",
-                    url.getQueryString());
+                "&query.Field2~containsoneof=x%3Bu_u" +
+                "&query.Field3~containsoneof=" + PageFlowUtil.encodeURIComponent(containsOneOfJsonValue) +
+                "&query.Field4~contains=o_O",
+                url.getQueryString());
         }
     }
 
@@ -1705,7 +1712,7 @@ public class SimpleFilter implements Filter
     {
         protected void test(String expectedSQL, String description, FilterClause clause, SqlDialect dialect, Map<FieldKey, ColumnInfo> columnMap)
         {
-            assertEquals("Generated SQL did not match", expectedSQL, SQLFragment.filterDebugString(clause.toSQLFragment(columnMap, dialect).toDebugString()));
+            assertEquals("Generated SQL did not match", expectedSQL, SQLFragment.filterDebugString(clause.toSQLFragment(columnMap, dialect).toDebugString(dialect)));
             StringBuilder sb = new StringBuilder();
             clause.appendFilterText(sb, new ColumnNameFormatter());
             assertEquals("Description did not match", description, sb.toString());
@@ -1726,8 +1733,15 @@ public class SimpleFilter implements Filter
             FieldKey fieldKey = FieldKey.fromParts("Foo");
 
             // Empty parameter list
-            test("Foo IN (NULL)", "Foo never matches", new InClause(fieldKey, Collections.emptySet()), mockDialect);
-            test("1=1", "Foo has any value", new InClause(fieldKey, Collections.emptySet(), true, true), mockDialect);
+            test("0 = 1", "Foo never matches", new InClause(fieldKey, Collections.emptySet()), mockDialect);
+            test("NOT (0 = 1)", "NOT (Foo never matches)", new NotClause(new InClause(fieldKey, Collections.emptySet())), mockDialect);
+            test("1 = 1", "Foo has any value", new InClause(fieldKey, Collections.emptySet(), true, true), mockDialect);
+            test("NOT (1 = 1)", "NOT (Foo has any value)", new NotClause(new InClause(fieldKey, Collections.emptySet(), true, true)), mockDialect);
+            Map<FieldKey, ColumnInfo> map = Map.of(fieldKey, new BaseColumnInfo(fieldKey, JdbcType.VARCHAR));
+            assertEquals("0 = 1", new InClause(fieldKey, List.of()).getLabKeySQLWhereClause(map));
+            assertEquals("NOT (0 = 1)", new NotClause(new InClause(fieldKey, List.of())).getLabKeySQLWhereClause(map));
+            assertEquals("1 = 1", new InClause(fieldKey, List.of(), false, true).getLabKeySQLWhereClause(map));
+            assertEquals("NOT (1 = 1)", new NotClause(new InClause(fieldKey, List.of(), false, true)).getLabKeySQLWhereClause(map));
 
             // Non-null parameters only
             test("(Foo IN (1, 2, 3))", "Foo IS ONE OF (1, 2, 3)", new InClause(fieldKey, PageFlowUtil.set(1, 2, 3)), mockDialect);
@@ -1750,13 +1764,15 @@ public class SimpleFilter implements Filter
             in._needsTypeConversion = true;
             test("((NOT \"FOO\" IN (1, 2)) OR \"FOO\" IS NULL)", "Foo IS NOT ANY OF (1, 2, S-3)", in, mockDialect, columnInfoMap);
 
-            in =  new InClause(fieldKey, PageFlowUtil.set("S-3"));
+            in = new InClause(fieldKey, PageFlowUtil.set("S-3"));
             in._needsTypeConversion = true;
-            test("\"FOO\" IN (NULL)", "Foo IS ONE OF (S-3)", in, mockDialect, columnInfoMap);
+            test("0 = 1", "Foo IS ONE OF (S-3)", in, mockDialect, columnInfoMap);
+            test("NOT (0 = 1)", "NOT (Foo IS ONE OF (S-3))", new NotClause(in), mockDialect, columnInfoMap);
 
             in = new InClause(fieldKey, PageFlowUtil.set("S-3"), true, true);
             in._needsTypeConversion = true;
-            test("1=1", "Foo IS NOT ANY OF (S-3)", in, mockDialect, columnInfoMap);
+            test("1 = 1", "Foo IS NOT ANY OF (S-3)", in, mockDialect, columnInfoMap);
+            test("NOT (1 = 1)", "NOT (Foo IS NOT ANY OF (S-3))", new NotClause(in), mockDialect, columnInfoMap);
         }
 
         @Test
@@ -1970,7 +1986,7 @@ public class SimpleFilter implements Filter
     public static class SqlClauseTestCase extends Assert
     {
         @Test
-        public void testEquals()
+        public void testEqualsAndHashCode()
         {
             SQLClause clause1 = new SQLClause(new SQLFragment("This = That", 1, 2));
             SQLClause clause2 = new SQLClause(new SQLFragment("This = That", 1, 2));
@@ -1982,6 +1998,39 @@ public class SimpleFilter implements Filter
             SQLClause clause4 = new SQLClause(new SQLFragment("This = That", 3, 4));
             assertNotEquals(clause1, clause4);
             assertNotEquals(clause1.hashCode(), clause4.hashCode());
+        }
+    }
+
+    public static class ContainsOneOfTestCase extends ClauseTestCase
+    {
+        @Test
+        public void testContainsOneOf()
+        {
+            SqlDialect dialect = DbScope.getLabKeyScope().getSqlDialect();
+            FieldKey fieldKey = FieldKey.fromParts("Foo");
+            String like = dialect.getCaseInsensitiveLikeOperator();
+            String concat = dialect.isPostgreSQL() ? "||" : "+";
+
+            FilterClause clause = new ContainsOneOfClause(fieldKey, List.of("This", "That"), false);
+            test("(Foo " + like + " '%' " + concat + " 'This' " + concat + " '%' ESCAPE '!') OR (Foo " + like + " '%' " + concat + " 'That' " + concat + " '%' ESCAPE '!')", "Foo CONTAINS ONE OF (This, That)", clause, dialect);
+            test("NOT ((Foo " + like + " '%' " + concat + " 'This' " + concat + " '%' ESCAPE '!') OR (Foo " + like + " '%' " + concat + " 'That' " + concat + " '%' ESCAPE '!'))", "NOT (Foo CONTAINS ONE OF (This, That))", new NotClause(clause), dialect);
+
+            clause = new ContainsOneOfClause(fieldKey, List.of("This", "That"), false, true);
+            test("((Foo IS NULL OR Foo NOT " + like + " '%' " + concat + " 'This' " + concat + " '%' ESCAPE '!')) AND ((Foo IS NULL OR Foo NOT " + like + " '%' " + concat + " 'That' " + concat + " '%' ESCAPE '!'))", "Foo DOES NOT CONTAIN ANY OF (This, That)", clause, dialect);
+            test("NOT (((Foo IS NULL OR Foo NOT " + like + " '%' " + concat + " 'This' " + concat + " '%' ESCAPE '!')) AND ((Foo IS NULL OR Foo NOT " + like + " '%' " + concat + " 'That' " + concat + " '%' ESCAPE '!')))", "NOT (Foo DOES NOT CONTAIN ANY OF (This, That))", new NotClause(clause), dialect);
+
+            Map<FieldKey, ColumnInfo> map = Map.of(fieldKey, new BaseColumnInfo(fieldKey, JdbcType.VARCHAR));
+            clause = new ContainsOneOfClause(fieldKey, List.of(), false);
+            test("0 = 1", "Foo CONTAINS ONE OF (BLANK)", clause, dialect);
+            test("NOT (0 = 1)", "NOT (Foo CONTAINS ONE OF (BLANK))", new NotClause(clause), dialect);
+            assertEquals("0 = 1", clause.getLabKeySQLWhereClause(map));
+            assertEquals("NOT (0 = 1)", new NotClause(clause).getLabKeySQLWhereClause(map));
+
+            clause = new ContainsOneOfClause(fieldKey, List.of(), false, true);
+            test("1 = 1", "Foo DOES NOT CONTAIN ANY OF (BLANK)", clause, dialect);
+            test("NOT (1 = 1)", "NOT (Foo DOES NOT CONTAIN ANY OF (BLANK))", new NotClause(clause), dialect);
+            assertEquals("1 = 1", clause.getLabKeySQLWhereClause(map));
+            assertEquals("NOT (1 = 1)", new NotClause(clause).getLabKeySQLWhereClause(map));
         }
     }
 }

--- a/api/src/org/labkey/api/data/SimpleFilter.java
+++ b/api/src/org/labkey/api/data/SimpleFilter.java
@@ -393,6 +393,20 @@ public class SimpleFilter implements Filter
         {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (o == null || getClass() != o.getClass()) return false;
+            SQLClause sqlClause = (SQLClause) o;
+            return Objects.equals(_fragment, sqlClause._fragment) && Objects.equals(_fieldKeys, sqlClause._fieldKeys);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(_fragment, _fieldKeys);
+        }
     }
 
     public static class FalseClause extends SQLClause
@@ -1701,7 +1715,6 @@ public class SimpleFilter implements Filter
         {
             test(expectedSQL, description, clause, dialect, Collections.emptyMap());
         }
-
     }
 
     public static class InClauseTestCase extends ClauseTestCase
@@ -1951,6 +1964,24 @@ public class SimpleFilter implements Filter
             // verify filter containing multi-value separator ',' use json encoded filter value
             assertEquals(Pair.of("query.Foo~between", "{json:[\"a,b,c\",\"Z\"]}"),
                     new CompareType.BetweenClause(fieldKey, "a,b,c", "Z", false).toURLParam("query."));
+        }
+    }
+
+    public static class SqlClauseTestCase extends Assert
+    {
+        @Test
+        public void testEquals()
+        {
+            SQLClause clause1 = new SQLClause(new SQLFragment("This = That", 1, 2));
+            SQLClause clause2 = new SQLClause(new SQLFragment("This = That", 1, 2));
+            assertEquals(clause1, clause2);
+            assertEquals(clause1.hashCode(), clause2.hashCode());
+            SQLClause clause3 = new SQLClause(new SQLFragment("That = This", 1, 2));
+            assertNotEquals(clause1, clause3);
+            assertNotEquals(clause1.hashCode(), clause3.hashCode());
+            SQLClause clause4 = new SQLClause(new SQLFragment("This = That", 3, 4));
+            assertNotEquals(clause1, clause4);
+            assertNotEquals(clause1.hashCode(), clause4.hashCode());
         }
     }
 }

--- a/api/src/org/labkey/api/data/SimpleFilter.java
+++ b/api/src/org/labkey/api/data/SimpleFilter.java
@@ -413,7 +413,15 @@ public class SimpleFilter implements Filter
     {
         public FalseClause()
         {
-            super("0 = 1", null);
+            super(new SQLFragment("0 = 1"));
+        }
+    }
+
+    public static class TrueClause extends SQLClause
+    {
+        public TrueClause()
+        {
+            super(new SQLFragment("1 = 1"));
         }
     }
 

--- a/api/src/org/labkey/api/data/TableSelectorTestCase.java
+++ b/api/src/org/labkey/api/data/TableSelectorTestCase.java
@@ -20,8 +20,12 @@ import org.apache.logging.log4j.Level;
 import org.junit.Test;
 import org.labkey.api.collections.CsvSet;
 import org.labkey.api.data.Selector.ForEachBlock;
+import org.labkey.api.data.SimpleFilter.FilterClause;
+import org.labkey.api.data.SimpleFilter.InClause;
+import org.labkey.api.data.SimpleFilter.NotClause;
 import org.labkey.api.data.dialect.SqlDialect.ExecutionPlanType;
 import org.labkey.api.module.ModuleContext;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.PageFlowUtil;
@@ -39,6 +43,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -514,5 +519,21 @@ public class TableSelectorTestCase extends AbstractSelectorTestCase<TableSelecto
         assertEquals(rowCount, list.size());
         assertEquals(sortedList.subList(offset, offset + rowCount), list);
         verifyResultSets(selector, rowCount, expectedComplete);
+    }
+
+    @Test
+    public void testInClause()
+    {
+        TableInfo table = CoreSchema.getInstance().getTableInfoContainers();
+        long rowCount = new TableSelector(table).getRowCount();
+
+        Container root = ContainerManager.getRoot();
+        FilterClause rootClause = new InClause(FieldKey.fromParts("RowId"), Set.of(root.getRowId()));
+        assertEquals(1, new TableSelector(table, new SimpleFilter(rootClause), null).getRowCount());
+        assertEquals(rowCount - 1, new TableSelector(table, new SimpleFilter(new NotClause(rootClause)), null).getRowCount());
+
+        FilterClause emptyClause = new InClause(FieldKey.fromParts("RowId"), Set.of());
+        assertEquals(0, new TableSelector(table, new SimpleFilter(emptyClause), null).getRowCount());
+        assertEquals(rowCount, new TableSelector(table, new SimpleFilter(new NotClause(emptyClause)), null).getRowCount());
     }
 }

--- a/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/BasePostgreSqlDialect.java
@@ -16,7 +16,6 @@
 
 package org.labkey.api.data.dialect;
 
-import jakarta.servlet.ServletException;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -27,62 +26,41 @@ import org.labkey.api.collections.Sets;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ConnectionWrapper;
 import org.labkey.api.data.ConnectionWrapper.Closer;
-import org.labkey.api.data.Constraint;
-import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DatabaseIdentifier;
 import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DbScope.LabKeyDataSource;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.MetadataSqlSelector;
 import org.labkey.api.data.PropertyStorageSpec;
-import org.labkey.api.data.PropertyStorageSpec.Index;
 import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.Selector;
-import org.labkey.api.data.Selector.ForEachBlock;
 import org.labkey.api.data.SqlExecutingSelector.ConnectionFactory;
-import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
-import org.labkey.api.data.TableChange;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TempTableTracker;
 import org.labkey.api.data.dialect.LimitRowsSqlGenerator.LimitRowsCustomizer;
 import org.labkey.api.data.dialect.LimitRowsSqlGenerator.StandardLimitRowsCustomizer;
-import org.labkey.api.query.AliasManager;
-import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.template.Warnings;
 import org.labkey.remoteapi.collections.CaseInsensitiveHashMap;
-import org.springframework.jdbc.BadSqlGrammarException;
 
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
-import java.sql.Driver;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
-import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 // Base dialect for PostgreSQL AND Redshift. IMPORTANT: Make sure everything added here applies to Redshift as well;
 // if not, put it in PostgreSql92Dialect.
@@ -92,7 +70,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     public static final String POSTGRES_SCHEMA_NAME = "postgres";
 
     private final Map<String, Integer> _domainScaleMap = new CopyOnWriteHashMap<>();
-    private final AtomicBoolean _arraySortFunctionExists = new AtomicBoolean(false);
 
     private HtmlString _adminWarning = null;
 
@@ -233,21 +210,9 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     }
 
     @Override
-    public String getSQLScriptPath()
-    {
-        return "postgresql";
-    }
-
-    @Override
     public String getDefaultDateTimeDataType()
     {
         return "TIMESTAMP";
-    }
-
-    @Override
-    public String getUniqueIdentType()
-    {
-        return "SERIAL";
     }
 
     @Override
@@ -442,88 +407,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     }
 
     @Override
-    public boolean supportsGroupConcat()
-    {
-        return getServerType().supportsGroupConcat();
-    }
-
-    @Override
-    public boolean supportsSelectConcat()
-    {
-        return true;
-    }
-
-    @Override
-    public SQLFragment getSelectConcat(SQLFragment selectSql, String delimiter)
-    {
-        SQLFragment result = new SQLFragment("array_to_string(array(");
-        result.append(selectSql);
-        result.append("), ");
-        result.append(getStringHandler().quoteStringLiteral(delimiter));
-        result.append(")");
-        return result;
-    }
-
-    @Override
-    public SQLFragment getGroupConcat(SQLFragment sql, boolean distinct, boolean sorted, @NotNull SQLFragment delimiterSQL, boolean includeNulls)
-    {
-        // Sort function might not exist in external datasource; skip that syntax if not
-        boolean useSortFunction = sorted && _arraySortFunctionExists.get();
-        SQLFragment result = new SQLFragment();
-
-        if (useSortFunction)
-        {
-            result.append("array_to_string(");
-            result.append("core.sort(");   // TODO: Switch to use ORDER BY option inside array aggregate instead of our custom function
-            result.append("array_agg(");
-            if (distinct)
-            {
-                result.append("DISTINCT ");
-            }
-
-            if (includeNulls)
-            {
-                result.append("COALESCE(CAST(");
-                result.append(sql);
-                result.append(" AS VARCHAR), '')");
-            }
-            else
-            {
-                result.append(sql);
-            }
-
-            result.append(")"); // array_agg
-            result.append(")"); // core.sort
-        }
-        else
-        {
-            result.append("string_agg(");
-            if (distinct)
-            {
-                result.append("DISTINCT ");
-            }
-
-            if (includeNulls)
-            {
-                result.append("COALESCE(");
-                result.append(sql);
-                result.append("::text, '')");
-            }
-            else
-            {
-                result.append(sql);
-                result.append("::text");
-            }
-        }
-
-        result.append(", ");
-        result.append(delimiterSQL);
-        result.append(")"); // array_to_string | string_agg
-
-        return result;
-    }
-
-    @Override
     protected String getSystemTableNames()
     {
         return "pg_logdir_ls";
@@ -564,12 +447,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     }
 
     @Override
-    public String getBinaryDataType()
-    {
-        return "BYTEA";
-    }
-
-    @Override
     public String getTempTableKeyword()
     {
         return "TEMPORARY";
@@ -582,12 +459,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     }
 
     @Override
-    public String getGlobalTempTablePrefix()
-    {
-        return DbSchema.TEMP_SCHEMA_NAME + ".";
-    }
-
-    @Override
     public boolean isNoDatabaseException(SQLException e)
     {
         return "3D000".equals(e.getSQLState());
@@ -597,38 +468,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     public boolean isSortableDataType(String sqlDataTypeName)
     {
         return !"json".equals(sqlDataTypeName) && !"jsonb".equals(sqlDataTypeName);
-    }
-
-    @Override
-    public String getDropIndexCommand(String tableName, String indexName)
-    {
-        return "DROP INDEX " + indexName;
-    }
-
-    @Override
-    public String getCreateDatabaseSql(String dbName)
-    {
-        // This will handle both mixed case and special characters on PostgreSQL
-        var legal = makeIdentifierFromMetaDataName(dbName);
-        return new SQLFragment("CREATE DATABASE ").appendIdentifier(legal).append(" WITH ENCODING 'UTF8'").getRawSQL();
-    }
-
-    @Override
-    public String getCreateSchemaSql(String schemaName)
-    {
-        if (!isLegalName(schemaName) || isReserved(schemaName))
-            throw new IllegalArgumentException("Not a legal schema name: " + schemaName);
-
-        //Quoted schema names are bad news
-        return "CREATE SCHEMA " + schemaName;
-    }
-
-    @Override
-    public String getTruncateSql(String tableName)
-    {
-        // To be consistent with MS SQL server, always restart the sequence.  Note that the default for postgres
-        // is to continue the sequence but we don't have this option with MS SQL Server
-        return "TRUNCATE TABLE " + tableName + " RESTART IDENTITY";
     }
 
     @Override
@@ -715,49 +554,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     }
 
     @Override
-    public void handleCreateDatabaseException(SQLException e) throws ServletException
-    {
-        if ("55006".equals(e.getSQLState()))
-        {
-            LOG.error("You must close down pgAdmin III and all other applications accessing PostgreSQL.");
-            throw (new ServletException("Close down or disconnect pgAdmin III and all other applications accessing PostgreSQL", e));
-        }
-        else
-        {
-            super.handleCreateDatabaseException(e);
-        }
-    }
-
-
-    @Override
-    public void prepareDriver(Class<Driver> driverClass)
-    {
-        // PostgreSQL driver 42.0.0 added logging via the Java Logging API (java.util.logging). This caused the driver to
-        // start logging SQLExceptions (such as the initial connection failure on bootstrap) to the console... harmless
-        // but annoying. This code suppresses the driver logging.
-        Logger pgjdbcLogger = LogManager.getLogManager().getLogger("org.postgresql");
-
-        if (null != pgjdbcLogger)
-            pgjdbcLogger.setLevel(Level.OFF);
-    }
-
-
-    // Make sure that the PL/pgSQL language is enabled in the associated database. If not, throw. Since 9.0, PostgreSQL has
-    // shipped with PL/pgSQL enabled by default, so the check is no longer critical, but continue to verify just to be safe.
-    @Override
-    public void prepareNewLabKeyDatabase(DbScope scope)
-    {
-        if (new SqlSelector(scope, "SELECT * FROM pg_language WHERE lanname = 'plpgsql'").exists())
-            return;
-
-        String dbName = scope.getDatabaseName();
-        String message = "PL/pgSQL is not enabled in the \"" + dbName + "\" database because it is not enabled in your Template1 master database.";
-        String advice = "Use PostgreSQL's 'createlang' command line utility to enable PL/pgSQL in the \"" + dbName + "\" database then restart Tomcat.";
-
-        throw new ConfigurationException(message, advice);
-    }
-
-    @Override
     public void prepare(LabKeyDataSource dataSource)
     {
         // PostgreSQL JDBC driver introduced caching of PreparedStatements starting with 9.4.1202, with no provision for uncaching.
@@ -774,7 +570,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     {
         initializeUserDefinedTypes(scope);
         determineSettings(scope);
-        determineIfArraySortFunctionExists(scope);
         return super.prepare(scope);
     }
 
@@ -817,7 +612,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
         }
     }
 
-
     private String getDomainKey(String schemaName, String domainName)
     {
         // Domain names are returned from column metadata fully qualified and quoted, so save them that way. See #26149.
@@ -833,21 +627,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
             _standardConformingStrings = "on".equalsIgnoreCase(selector.getObject(String.class));
         }
     }
-
-
-    // Does this datasource include our sort array function? The LabKey datasource should always have it, but external datasources might not
-    private void determineIfArraySortFunctionExists(DbScope scope)
-    {
-        if (getServerType().supportsSpecialMetadataQueries())
-        {
-            Selector selector = new SqlSelector(scope, "SELECT * FROM pg_catalog.pg_namespace n INNER JOIN pg_catalog.pg_proc p ON pronamespace = n.oid WHERE nspname = 'core' AND proname = 'sort'");
-            _arraySortFunctionExists.set(selector.exists());
-        }
-
-        // Array sort function should always exist in LabKey scope (for now)
-        assert !scope.isLabKeyScope() || _arraySortFunctionExists.get();
-    }
-
 
     /**
      * Wrap one or more INSERT statements to allow explicit specification
@@ -895,25 +674,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
         }
     }
 
-    private static final Pattern PROC_PATTERN = Pattern.compile("^\\s*SELECT\\s+core\\.(executeJava(?:Upgrade|Initialization)Code\\s*\\(\\s*'(.+)'\\s*\\))\\s*;\\s*$", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
-
-    @NotNull
-    @Override
-    protected Pattern getSQLScriptProcPattern()
-    {
-        return PROC_PATTERN;
-    }
-
-    @Override
-    protected void checkSqlScript(String lowerNoComments, String lowerNoCommentsNoWhiteSpace, Collection<String> errors)
-    {
-        if (lowerNoCommentsNoWhiteSpace.contains("setsearch_pathto"))
-            errors.add("Do not use \"SET search_path TO <schema>\". Instead, schema-qualify references to all objects.");
-
-        if (!lowerNoCommentsNoWhiteSpace.endsWith(";"))
-            errors.add("Script must end with a semicolon");
-    }
-
     @Override
     public String getJDBCArrayType(Object object)
     {
@@ -929,32 +689,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
         }
         return super.getJDBCArrayType(object);
     }
-
-
-    @Override
-    public boolean canExecuteUpgradeScripts()
-    {
-        return true;
-    }
-
-
-    @Override
-    public String getDefaultDatabaseName()
-    {
-        return "template1";
-    }
-
-
-    /*
-        PostgreSQL example connection URLs we need to parse:
-
-        jdbc:postgresql:database
-        jdbc:postgresql://host/database
-        jdbc:postgresql://host:port/database
-        jdbc:postgresql:database?user=fred&password=secret&ssl=true
-        jdbc:postgresql://host/database?user=fred&password=secret&ssl=true
-        jdbc:postgresql://host:port/database?user=fred&password=secret&ssl=true
-    */
 
     @Override
     protected @Nullable String getDatabaseMaintenanceSql()
@@ -1002,427 +736,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
         return true;
     }
 
-
-    @Override
-    public List<SQLFragment> getChangeStatements(TableChange change)
-    {
-        List<SQLFragment> result = new ArrayList<>();
-        switch (change.getType())
-        {
-            case CreateTable -> result.addAll(getCreateTableStatements(change));
-            case DropTable -> {
-                SQLFragment f = new SQLFragment("DROP TABLE ");
-                f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-                result.add(f);
-            }
-            case AddColumns -> result.addAll(getAddColumnsStatements(change));
-            case DropColumns -> result.add(getDropColumnsStatement(change));
-            case RenameColumns -> result.addAll(getRenameColumnsStatement(change));
-            case DropIndicesByName -> result.addAll(getDropIndexByNameStatements(change));
-            case AddIndices -> result.addAll(getCreateIndexStatements(change));
-            case ResizeColumns, ChangeColumnTypes -> result.addAll(getChangeColumnTypeStatement(change));
-            case DropConstraints -> result.addAll(getDropConstraintsStatement(change));
-            case AddConstraints -> result.addAll(getAddConstraintsStatement(change));
-            default -> throw new IllegalArgumentException("Unsupported change type: " + change.getType());
-        }
-
-        return result;
-    }
-
-    private Collection<? extends SQLFragment> getDropIndexByNameStatements(TableChange change)
-    {
-        List<SQLFragment> statements = new ArrayList<>();
-        for (String indexName : change.getIndicesToBeDroppedByName())
-        {
-            statements.add(getDropIndexCommand(change, indexName));
-        }
-        return statements;
-    }
-
-    private SQLFragment getDropIndexCommand(TableChange change, String indexName)
-    {
-        SQLFragment f = new SQLFragment("DROP INDEX ");
-        f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(indexName);
-        return f;
-    }
-
-
-    /**
-     * Generate the Alter Table statement to change the size or type of the column
-     * <p>
-     * NOTE: expects data size check to be done prior,
-     *       will throw a SQL exception if not able to change size due to existing data
-     */
-    private List<SQLFragment> getChangeColumnTypeStatement(TableChange change)
-    {
-        List<SQLFragment> statements = new ArrayList<>();
-
-        // Postgres allows executing multiple ALTER COLUMN statements under one ALTER TABLE
-        List<SQLFragment> nonDateTimeClauses = new ArrayList<>();
-
-        for (PropertyStorageSpec column : change.getColumns())
-        {
-            DatabaseIdentifier columnIdent = makePropertyIdentifier(column.getName());
-            if (column.getJdbcType().isDateOrTime())
-            {
-                String tempColumnName = column.getName() + "~~temp~~";
-                DatabaseIdentifier tempColumnIdent = makePropertyIdentifier(tempColumnName);
-
-                // 1) ADD temp column
-                SQLFragment addTemp = new SQLFragment("ALTER TABLE ");
-                addTemp.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-                addTemp.append(" ADD COLUMN ").append(getSqlColumnSpec(column, tempColumnName));
-                statements.add(addTemp);
-
-                // 2) UPDATE: copy casted value to temp column
-                SQLFragment update = new SQLFragment("UPDATE ");
-                update.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-                update.append(" SET ").appendIdentifier(tempColumnIdent);
-                update.append(" = CAST(").appendIdentifier(columnIdent).append(" AS ").append(getSqlTypeName(column)).append(")");
-                statements.add(update);
-
-                // 3) DROP original column
-                SQLFragment drop = new SQLFragment("ALTER TABLE ");
-                drop.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-                drop.append(" DROP COLUMN ").appendIdentifier(columnIdent);
-                statements.add(drop);
-
-                // 4) RENAME temp column to original column name
-                SQLFragment rename = new SQLFragment("ALTER TABLE ");
-                rename.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-                rename.append(" RENAME COLUMN ").appendIdentifier(tempColumnIdent).append(" TO ").appendIdentifier(columnIdent);
-                statements.add(rename);
-            }
-            else
-            {
-                String dbType;
-                if (column.getJdbcType().isText())
-                {
-                    // Using the common default max size to make type change to text
-                    dbType = column.getSize() == -1 || column.getSize() > SqlDialect.MAX_VARCHAR_SIZE ?
-                            getSqlTypeName(JdbcType.LONGVARCHAR) :
-                            getSqlTypeName(column.getJdbcType()) + "(" + column.getSize().toString() + ")";
-                }
-                else if (column.getJdbcType().isDecimal())
-                {
-                    dbType = getSqlTypeName(column.getJdbcType()) + DEFAULT_DECIMAL_SCALE_PRECISION;
-                }
-                else
-                {
-                    dbType = getSqlTypeName(column.getJdbcType());
-                }
-
-                SQLFragment clause = new SQLFragment();
-                clause.append("ALTER COLUMN ").appendIdentifier(columnIdent).append(" TYPE ").append(dbType);
-                nonDateTimeClauses.add(clause);
-            }
-        }
-
-        if (!nonDateTimeClauses.isEmpty())
-        {
-            SQLFragment alter = new SQLFragment("ALTER TABLE ");
-            alter.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-            alter.append(" ");
-            String sep = "";
-            for (SQLFragment c : nonDateTimeClauses)
-            {
-                alter.append(sep).append(c);
-                sep = ", ";
-            }
-            statements.add(alter);
-        }
-
-        return statements;
-    }
-
-    private List<SQLFragment> getRenameColumnsStatement(TableChange change)
-    {
-        List<SQLFragment> statements = new ArrayList<>();
-        for (Map.Entry<String, String> oldToNew : change.getColumnRenames().entrySet())
-        {
-            DatabaseIdentifier oldIdentifier = makePropertyIdentifier(oldToNew.getKey());
-            DatabaseIdentifier newIdentifier = makePropertyIdentifier(oldToNew.getValue());
-            if (!oldIdentifier.equals(newIdentifier))
-            {
-                SQLFragment f = new SQLFragment("ALTER TABLE ");
-                f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-                f.append(" RENAME COLUMN ").appendIdentifier(oldIdentifier).append(" TO ").appendIdentifier(newIdentifier);
-                statements.add(f);
-            }
-        }
-
-        // TODO: This loop should not guess the name of the old indices; instead, it should look them up.
-        // TableChange.setIndexedColumns() could set _indexRenames providing the name, and then this code uses that info.
-        // Or maybe schemaTableInfo.getAllIndices() and then use Index.isSameIndex() to find names. Issue 53838.
-        for (Map.Entry<Index, Index> oldToNew : change.getIndexRenames().entrySet())
-        {
-            Index oldIndex = oldToNew.getKey();
-            Index newIndex = oldToNew.getValue();
-            String oldName = nameIndex(change.getTableName(), oldIndex.columnNames); // TODO: Look up name
-            String newName = nameIndex(change.getTableName(), newIndex.columnNames);
-            if (!oldName.equals(newName))
-            {
-                SQLFragment f = new SQLFragment("ALTER INDEX ");
-                f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(oldName);
-                f.append(" RENAME TO ").appendIdentifier(newName);
-                statements.add(f);
-            }
-        }
-
-        return statements;
-    }
-
-    private SQLFragment getDropColumnsStatement(TableChange change)
-    {
-        List<SQLFragment> sqlParts = new ArrayList<>();
-        for (PropertyStorageSpec prop : change.getColumns())
-        {
-            SQLFragment sql = new SQLFragment("DROP COLUMN ");
-            if (prop.getExactName())
-            {
-                sql.append(quoteIdentifier(prop.getName()));
-            }
-            else
-            {
-                sql.appendIdentifier(makePropertyIdentifier(prop.getName()));
-            }
-            sqlParts.add(sql);
-        }
-
-        SQLFragment f = new SQLFragment("ALTER TABLE ");
-        f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-        f.append(" ").append(sqlParts, ", ");
-        return f;
-    }
-
-    // TODO if there are cases where user-defined columns need indices, this method will need to support
-    // creating indices like getCreateTableStatement does.
-
-    private List<SQLFragment> getAddColumnsStatements(TableChange change)
-    {
-        List<SQLFragment> statements = new ArrayList<>();
-        String pkColumn = null;
-        Constraint constraint = null;
-
-        List<SQLFragment> columnSpecs = new ArrayList<>();
-        for (PropertyStorageSpec prop : change.getColumns())
-        {
-            columnSpecs.add(getSqlColumnSpec(prop));
-            if (prop.isPrimaryKey())
-            {
-                assert null == pkColumn : "no more than one primary key defined";
-                pkColumn = prop.getName();
-                constraint = new Constraint(change.getTableName(), Constraint.CONSTRAINT_TYPES.PRIMARYKEY, false, null);
-            }
-        }
-
-        SQLFragment alter = new SQLFragment("ALTER TABLE ");
-        alter.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-        alter.append(" ");
-        String sep = "";
-        for (SQLFragment col : columnSpecs)
-        {
-            alter.append(sep);
-            alter.append("ADD COLUMN ");
-            alter.append(col);
-            sep = ", ";
-        }
-        statements.add(alter);
-        if (null != pkColumn)
-        {
-            SQLFragment addPk = new SQLFragment("ALTER TABLE ");
-            addPk.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-            addPk.append(" ADD CONSTRAINT ").appendIdentifier(constraint.getName())
-                 .append(" ").append(constraint.getType().toString()).append(" (")
-                 .appendIdentifier(makePropertyIdentifier(pkColumn)).append(")");
-            statements.add(addPk);
-        }
-
-        return statements;
-    }
-
-    private List<SQLFragment> getDropConstraintsStatement(TableChange change)
-    {
-        return change.getConstraints().stream().map(constraint -> {
-            SQLFragment f = new SQLFragment("ALTER TABLE ");
-            f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-            f.append(" DROP CONSTRAINT ").appendIdentifier(constraint.getName());
-            return f;
-        }).collect(Collectors.toList());
-    }
-
-    private List<SQLFragment> getAddConstraintsStatement(TableChange change)
-    {
-        List<SQLFragment> statements = new ArrayList<>();
-        Collection<Constraint> constraints = change.getConstraints();
-
-        if (null!=constraints && !constraints.isEmpty())
-        {
-            statements = constraints.stream().map(constraint -> {
-                List<SQLFragment> columns = new ArrayList<>();
-                for (String col : constraint.getColumns())
-                {
-                    columns.add(new SQLFragment().appendIdentifier(col));
-                }
-
-                SQLFragment f = new SQLFragment();
-                f.append("DO $$\nBEGIN\nIF NOT EXISTS\n(SELECT 1 FROM information_schema.constraint_column_usage\nWHERE table_name = ")
-                        .appendStringLiteral(change.getSchemaName() + "." + change.getTableName(), this)
-                        .append(" and constraint_name = ")
-                        .appendStringLiteral(constraint.getName(), this)
-                        .append(") THEN\nALTER TABLE ");
-                f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-                f.append(" ADD CONSTRAINT ").appendIdentifier(constraint.getName()).append(" ")
-                        .append(constraint.getType().toString()).append(" (")
-                        .append(columns, ",")
-                        .append(")").appendEOS().append("\nEND IF)").appendEOS().append("\nEND$$").appendEOS();
-                return f;
-            }).collect(Collectors.toList());
-        }
-
-        return statements;
-    }
-
-    private List<SQLFragment> getCreateTableStatements(TableChange change)
-    {
-        List<SQLFragment> statements = new ArrayList<>();
-        List<SQLFragment> createTableSqlParts = new ArrayList<>();
-        String pkColumn = null;
-        for (PropertyStorageSpec prop : change.getColumns())
-        {
-            createTableSqlParts.add(getSqlColumnSpec(prop));
-            if (prop.isPrimaryKey())
-            {
-                assert null == pkColumn : "no more than one primary key defined";
-                pkColumn = prop.getName();
-            }
-        }
-
-        for (PropertyStorageSpec.ForeignKey foreignKey : change.getForeignKeys())
-        {
-            DbSchema schema = DbSchema.get(foreignKey.getSchemaName(), DbSchemaType.Module);
-            TableInfo tableInfo = foreignKey.isProvisioned() ?
-                    foreignKey.getTableInfoProvisioned() :
-                    schema.getTable(foreignKey.getTableName());
-            String constraintName = "fk_" + foreignKey.getColumnName() + "_" + change.getTableName() + "_" + tableInfo.getName();
-            SQLFragment fkFrag = new SQLFragment("CONSTRAINT ");
-            fkFrag.appendIdentifier(constraintName)
-                  .append(" FOREIGN KEY (")
-                  .appendIdentifier(makePropertyIdentifier(foreignKey.getColumnName()))
-                  .append(") REFERENCES ")
-                  .appendIdentifier(tableInfo.getSchema().getName()).append(".").appendIdentifier(tableInfo.getName())
-                  .append(" (")
-                  .appendIdentifier(makePropertyIdentifier(foreignKey.getForeignColumnName()))
-                  .append(")");
-            createTableSqlParts.add(fkFrag);
-        }
-
-        SQLFragment create = new SQLFragment("CREATE TABLE ");
-        create.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-        create.append(" (").append(createTableSqlParts, ", ").append(")");
-        statements.add(create);
-        if (null != pkColumn)
-        {
-            // Making this just for consistent naming
-            Constraint constraint = new Constraint(change.getTableName(), Constraint.CONSTRAINT_TYPES.PRIMARYKEY, false, null);
-
-            SQLFragment addPk = new SQLFragment("ALTER TABLE ");
-            addPk.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-            addPk.append(" ADD CONSTRAINT ").appendIdentifier(constraint.getName())
-                 .append(" ").append(constraint.getType().toString()).append(" (")
-                 .appendIdentifier(makePropertyIdentifier(pkColumn)).append(")");
-            statements.add(addPk);
-        }
-
-        statements.addAll(getCreateIndexStatements(change));
-        statements.addAll(getAddConstraintsStatement(change));
-        return statements;
-    }
-
-    private List<SQLFragment> getCreateIndexStatements(TableChange change)
-    {
-        List<SQLFragment> statements = new ArrayList<>();
-        for (Index index : change.getIndexedColumns())
-        {
-            String newIndexName = nameIndex(change.getTableName(), index.columnNames);
-            SQLFragment f = new SQLFragment("CREATE ");
-            if (index.isUnique)
-                f.append("UNIQUE ");
-            f.append("INDEX ").appendIdentifier(newIndexName).append(" ON ");
-            f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-            f.append(" (");
-            String separator = "";
-            for (String columnName : index.columnNames)
-            {
-                f.append(separator).appendIdentifier(makePropertyIdentifier(columnName));
-                separator = ", ";
-            }
-            f.append(")");
-            f.appendEOS();
-            statements.add(f);
-
-            if (index.isClustered)
-            {
-                SQLFragment c = new SQLFragment();
-                c.append(PropertyStorageSpec.CLUSTER_TYPE.CLUSTER.toString()).append(" ");
-                c.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
-                c.append(" USING ").appendIdentifier(newIndexName);
-                statements.add(c);
-            }
-        }
-        return statements;
-    }
-
-    @Override
-    public String nameIndex(String tableName, String[] indexedColumns)
-    {
-        return AliasManager.makeLegalName(tableName + '_' + StringUtils.join(indexedColumns, "_"), this);
-    }
-
-    private SQLFragment getSqlColumnSpec(PropertyStorageSpec prop)
-    {
-        return getSqlColumnSpec(prop, prop.getName());
-    }
-
-    private SQLFragment getSqlColumnSpec(PropertyStorageSpec prop, String columnName)
-    {
-        SQLFragment colSpec = new SQLFragment();
-        colSpec.appendIdentifier(makePropertyIdentifier(columnName)).append(" ");
-        colSpec.append(getSqlTypeName(prop));
-
-        // Apply size and precision to varchar and Decimal types
-        if (prop.getJdbcType() == JdbcType.VARCHAR && prop.getSize() != -1 && prop.getSize() <= SqlDialect.MAX_VARCHAR_SIZE)
-        {
-            colSpec.append("(").append(prop.getSize().toString()).append(")");
-        }
-        else if (prop.getJdbcType() == JdbcType.DECIMAL)
-        {
-            colSpec.append(DEFAULT_DECIMAL_SCALE_PRECISION);
-        }
-
-        if (prop.isPrimaryKey() || !prop.isNullable())
-            colSpec.append(" NOT NULL");
-
-        if (null != prop.getDefaultValue())
-        {
-            if (prop.getJdbcType() == JdbcType.BOOLEAN)
-            {
-                colSpec.append(" DEFAULT ");
-                colSpec.append((Boolean)prop.getDefaultValue() ? getBooleanTRUE() : getBooleanFALSE());
-            }
-            else if (prop.getJdbcType() == JdbcType.VARCHAR)
-            {
-                colSpec.append(" DEFAULT ");
-                colSpec.append(getStringHandler().quoteStringLiteral(prop.getDefaultValue().toString()));
-            }
-            else
-            {
-                throw new IllegalArgumentException("Default value on type " + prop.getJdbcType().name() + " is not supported.");
-            }
-        }
-        return colSpec;
-    }
-
     @Override
     public String getSqlTypeName(PropertyStorageSpec prop)
     {
@@ -1456,75 +769,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
         {
             return getSqlTypeName(prop.getJdbcType());
         }
-    }
-
-    /**
-     * We've historically created lower-cased column names in provisioned tables in Postgres. Keep doing that
-     * for consistency, though ideally we'd stop doing this and update all existing provisioned tables.
-     */
-    private DatabaseIdentifier makePropertyIdentifier(String name)
-    {
-        if (isIdentifierTooLong(name))
-            throw new UnsupportedOperationException("Name is too long: " + name);
-        return new _DatabaseIdentifier(name, quoteIdentifier(name.toLowerCase()), this);
-    }
-
-    @Override
-    public void purgeTempSchema(Map<String, TempTableTracker> createdTableNames)
-    {
-        try
-        {
-            trackTempTables(createdTableNames);
-        }
-        catch (SQLException e)
-        {
-            LOG.warn("error cleaning up temp schema", e);
-        }
-
-        DbSchema coreSchema = CoreSchema.getInstance().getSchema();
-        SqlExecutor executor = new SqlExecutor(coreSchema);
-
-        //rs = conn.getMetaData().getFunctions(dbName, tempSchemaName, "%");
-
-        new SqlSelector(coreSchema, "SELECT proname AS SPECIFIC_NAME, CAST(proargtypes AS VARCHAR) FROM pg_proc WHERE pronamespace=(select oid from pg_namespace where nspname = ?)", DbSchema.getTemp().getName()).forEach(
-            new ForEachBlock<>()
-            {
-                private Map<String, String> _types = null;
-
-                @Override
-                public void exec(ResultSet rs) throws SQLException
-                {
-                    if (null == _types)
-                    {
-                        _types = new HashMap<>();
-                        new SqlSelector(coreSchema, "SELECT CAST(oid AS VARCHAR) as oid, typname, (select nspname from pg_namespace where oid = typnamespace) as nspname FROM pg_type").forEach(type ->
-                                _types.put(type.getString(1), quoteIdentifier(type.getString(3)) + "." + quoteIdentifier(type.getString(2))));
-                    }
-
-                    String name = rs.getString(1);
-                    String[] oids = StringUtils.split(rs.getString(2), ' ');
-                    SQLFragment drop = new SQLFragment("DROP FUNCTION temp.").append(name);
-                    drop.append("(");
-                    String comma = "";
-                    for (String oid : oids)
-                    {
-                        drop.append(comma).append(_types.get(oid));
-                        comma = ",";
-                    }
-                    drop.append(")");
-
-                    try
-                    {
-                        executor.execute(drop);
-                    }
-                    catch (BadSqlGrammarException x)
-                    {
-                        LOG.warn("could not clean up postgres function : temp." + name, x);
-                    }
-                }
-            });
-
-        // TODO delete types in temp schema as well! search for "CREATE TYPE" in StatementUtils.java
     }
 
     @Override
@@ -1841,23 +1085,6 @@ public abstract class BasePostgreSqlDialect extends SqlDialect
     {
         return search.replaceAll("_", "\\\\_").replaceAll("%", "\\\\%");
     }
-
-
-    @Override
-    public boolean canShowExecutionPlan(ExecutionPlanType type)
-    {
-        return true;
-    }
-
-    @Override
-    protected Collection<String> getQueryExecutionPlan(Connection conn, DbScope scope, SQLFragment sql, ExecutionPlanType type)
-    {
-        SQLFragment copy = new SQLFragment(sql);
-        copy.insert(0, type == ExecutionPlanType.Estimated ? "EXPLAIN " : "EXPLAIN ANALYZE ");
-
-        return new SqlSelector(scope, conn, copy).getCollection(String.class);
-    }
-
 
     // This list is definitely not exhaustive, can be used for any function where the parameter count and
     // order are exactly the same as the JDBC equivalent

--- a/api/src/org/labkey/api/data/dialect/PostgreSqlServerType.java
+++ b/api/src/org/labkey/api/data/dialect/PostgreSqlServerType.java
@@ -13,7 +13,7 @@ public enum PostgreSqlServerType
         }
 
         @Override
-        boolean supportsGroupConcat()
+        public boolean supportsGroupConcat()
         {
             return true;
         }
@@ -33,7 +33,7 @@ public enum PostgreSqlServerType
         }
 
         @Override
-        boolean supportsGroupConcat()
+        public boolean supportsGroupConcat()
         {
             return false;
         }
@@ -46,7 +46,7 @@ public enum PostgreSqlServerType
     };
 
     abstract boolean shouldTest();
-    abstract boolean supportsGroupConcat();
+    public abstract boolean supportsGroupConcat();
     public abstract boolean supportsSpecialMetadataQueries();
 
     public static PostgreSqlServerType getFromParameterStatuses(Map<String, String> parameterStatuses)

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -923,7 +923,7 @@ public abstract class SqlDialect
     // dialect is just for debugging reference
     protected record _DatabaseIdentifier(String id, SQLFragment sql, SqlDialect dialect) implements DatabaseIdentifier
     {
-        _DatabaseIdentifier(String id, String sql, SqlDialect dialect)
+        public _DatabaseIdentifier(String id, String sql, SqlDialect dialect)
         {
             this(id, new SQLFragment().appendIdentifier(sql), dialect);
             assert null==dialect || dialect.validateIdentifier(this);
@@ -2251,13 +2251,13 @@ public abstract class SqlDialect
         void testLikeOperator()
         {
             String stringLiteralPrefix = d.isSqlServer() ? " N" : " ";
-            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'ABC%' ESCAPE '!'", d.appendCaseInsensitiveStartsWith(new SQLFragment("SELECT * FROM A WHERE Name"), "ABC").toDebugString());
-            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'a!%bc%' ESCAPE '!'", d.appendCaseInsensitiveStartsWith(new SQLFragment("SELECT * FROM A WHERE Name"), "a%bc").toDebugString());
-            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'%ab!_C' ESCAPE '!'", d.appendCaseInsensitiveEndsWith(new SQLFragment("SELECT * FROM A WHERE Name"), "ab_C").toDebugString());
-            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'%a![b]C%' ESCAPE '!'", d.appendCaseInsensitiveLikeClause(new SQLFragment("SELECT * FROM A WHERE Name"), "a[b]C").toDebugString());
-            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'a![b]C_' ESCAPE '!'", d.appendCaseInsensitiveLikeClause(new SQLFragment("SELECT * FROM A WHERE Name"), "a[b]C", null, "_").toDebugString());
-            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'_a!_![b]C%' ESCAPE '!'", d.appendCaseInsensitiveLikeClause(new SQLFragment("SELECT * FROM A WHERE Name"), "a_[b]C", "_", "%").toDebugString());
-            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'_a[_[[b]C!d%' ESCAPE '['", d.appendCaseInsensitiveLikeClause(new SQLFragment("SELECT * FROM A WHERE Name"), "a_[b]C!d", "_", "%", '[').toDebugString());
+            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'ABC%' ESCAPE '!'", d.appendCaseInsensitiveStartsWith(new SQLFragment("SELECT * FROM A WHERE Name"), "ABC").toDebugString(d));
+            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'a!%bc%' ESCAPE '!'", d.appendCaseInsensitiveStartsWith(new SQLFragment("SELECT * FROM A WHERE Name"), "a%bc").toDebugString(d));
+            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'%ab!_C' ESCAPE '!'", d.appendCaseInsensitiveEndsWith(new SQLFragment("SELECT * FROM A WHERE Name"), "ab_C").toDebugString(d));
+            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'%a![b]C%' ESCAPE '!'", d.appendCaseInsensitiveLikeClause(new SQLFragment("SELECT * FROM A WHERE Name"), "a[b]C").toDebugString(d));
+            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'a![b]C_' ESCAPE '!'", d.appendCaseInsensitiveLikeClause(new SQLFragment("SELECT * FROM A WHERE Name"), "a[b]C", null, "_").toDebugString(d));
+            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'_a!_![b]C%' ESCAPE '!'", d.appendCaseInsensitiveLikeClause(new SQLFragment("SELECT * FROM A WHERE Name"), "a_[b]C", "_", "%").toDebugString(d));
+            assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'_a[_[[b]C!d%' ESCAPE '['", d.appendCaseInsensitiveLikeClause(new SQLFragment("SELECT * FROM A WHERE Name"), "a_[b]C!d", "_", "%", '[').toDebugString(d));
         }
 
         @Test

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -32,11 +32,11 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.ConnectionWrapper;
 import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.DatabaseIdentifier;
 import org.labkey.api.data.DatabaseTableType;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.DbScope.LabKeyDataSource;
-import org.labkey.api.data.DatabaseIdentifier;
 import org.labkey.api.data.InClauseGenerator;
 import org.labkey.api.data.JdbcMetaDataSelector.JdbcMetaDataResultSetFactory;
 import org.labkey.api.data.JdbcType;
@@ -2258,6 +2258,16 @@ public abstract class SqlDialect
             assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'a![b]C_' ESCAPE '!'", d.appendCaseInsensitiveLikeClause(new SQLFragment("SELECT * FROM A WHERE Name"), "a[b]C", null, "_").toDebugString());
             assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'_a!_![b]C%' ESCAPE '!'", d.appendCaseInsensitiveLikeClause(new SQLFragment("SELECT * FROM A WHERE Name"), "a_[b]C", "_", "%").toDebugString());
             assertEquals("SELECT * FROM A WHERE Name " + d.getCaseInsensitiveLikeOperator() + stringLiteralPrefix + "'_a[_[[b]C!d%' ESCAPE '['", d.appendCaseInsensitiveLikeClause(new SQLFragment("SELECT * FROM A WHERE Name"), "a_[b]C!d", "_", "%", '[').toDebugString());
+        }
+
+        @Test
+        public void testAutoIncrementQuery()
+        {
+            TableInfo tableInfo = CoreSchema.getInstance().getTableInfoContainers();
+            Collection<Sequence> sequences = DbScope.getLabKeyScope().getSqlDialect().getAutoIncrementSequences(tableInfo);
+            assertEquals(1, sequences.size());
+            Sequence seq = sequences.stream().findFirst().orElseThrow();
+            assertEquals("rowid", seq.columnName().toLowerCase());
         }
     }
 }

--- a/api/src/org/labkey/api/data/dialect/SqlDialectFactory.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialectFactory.java
@@ -27,7 +27,7 @@ public interface SqlDialectFactory
     @Nullable SqlDialect createFromDriverClassName(String driverClassName);
 
     /**
-     * Returns null if this factory is not responsible for the specified database server.  Otherwise, if the version is
+     * Returns null if this factory is not responsible for the specified database server. Otherwise, if the version is
      * supported, returns the matching implementation; if the version is not supported, throws DatabaseNotSupportedException.
      * @param primaryDataSource whether the data source is the primary LabKey Server database, or an external/secondary database
      */

--- a/api/src/org/labkey/api/migration/DatabaseMigrationConfiguration.java
+++ b/api/src/org/labkey/api/migration/DatabaseMigrationConfiguration.java
@@ -10,9 +10,7 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.Pair;
 
-import java.io.PrintWriter;
 import java.util.Set;
-import java.util.function.Predicate;
 
 public interface DatabaseMigrationConfiguration
 {
@@ -21,7 +19,6 @@ public interface DatabaseMigrationConfiguration
     DbScope getSourceScope();
     DbScope getTargetScope();
     @NotNull Set<String> getSkipSchemas();
-    Predicate<String> getColumnNameFilter();
     @Nullable TableSelector getTableSelector(DbSchemaType schemaType, TableInfo sourceTable, TableInfo targetTable, Set<String> selectColumnNames, MigrationSchemaHandler schemaHandler, @Nullable MigrationTableHandler tableHandler);
     default void copyAttachments(DbSchema sourceSchema, DbSchema targetSchema, MigrationSchemaHandler schemaHandler){}
     default @Nullable Pair<FilePathWriter, Set<GUID>> initializeFilePathWriter()

--- a/api/src/org/labkey/api/migration/DatabaseMigrationConfiguration.java
+++ b/api/src/org/labkey/api/migration/DatabaseMigrationConfiguration.java
@@ -20,7 +20,8 @@ public interface DatabaseMigrationConfiguration
     DbScope getTargetScope();
     @NotNull Set<String> getSkipSchemas();
     @Nullable TableSelector getTableSelector(DbSchemaType schemaType, TableInfo sourceTable, TableInfo targetTable, Set<String> selectColumnNames, MigrationSchemaHandler schemaHandler, @Nullable MigrationTableHandler tableHandler);
-    default void copyAttachments(DbSchema sourceSchema, DbSchema targetSchema, MigrationSchemaHandler schemaHandler){}
+    default void copySchemaAttachments(DbSchema sourceSchema, DbSchema targetSchema, MigrationSchemaHandler schemaHandler){}
+    default void afterMigration(){}
     default @Nullable Pair<FilePathWriter, Set<GUID>> initializeFilePathWriter()
     {
         return null;

--- a/api/src/org/labkey/api/migration/DatabaseMigrationService.java
+++ b/api/src/org/labkey/api/migration/DatabaseMigrationService.java
@@ -56,7 +56,8 @@ public interface DatabaseMigrationService
         return null;
     }
 
-    default void copySourceTableToTargetTable(DatabaseMigrationConfiguration configuration, TableInfo sourceTable, TableInfo targetTable, DbSchemaType schemaType, boolean updateSequences, String additionalLogMessage, MigrationSchemaHandler schemaHandler) {}
+    default void copySourceTableToTargetTable(DatabaseMigrationConfiguration configuration, TableInfo sourceTable, TableInfo targetTable, DbSchemaType schemaType, boolean updateSequences, @Nullable String additionalLogMessage, MigrationSchemaHandler schemaHandler) {}
+    default void copyAttachments(DatabaseMigrationConfiguration configuration, @Nullable FilterClause filterClause, @Nullable String additionalLogMessage) {}
     default void updateSequences(TableInfo sourceTable, TableInfo targetTable) {}
 
     // Helper method that parses a data filter then adds it and its container to the provided collections, coalescing

--- a/api/src/org/labkey/api/migration/DefaultDatabaseMigrationConfiguration.java
+++ b/api/src/org/labkey/api/migration/DefaultDatabaseMigrationConfiguration.java
@@ -8,7 +8,6 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 
 import java.util.Set;
-import java.util.function.Predicate;
 
 public class DefaultDatabaseMigrationConfiguration implements DatabaseMigrationConfiguration
 {
@@ -34,12 +33,6 @@ public class DefaultDatabaseMigrationConfiguration implements DatabaseMigrationC
     public @NotNull Set<String> getSkipSchemas()
     {
         return Set.of();
-    }
-
-    @Override
-    public Predicate<String> getColumnNameFilter()
-    {
-        return null;
     }
 
     @Override

--- a/api/src/org/labkey/api/migration/DefaultMigrationSchemaHandler.java
+++ b/api/src/org/labkey/api/migration/DefaultMigrationSchemaHandler.java
@@ -241,8 +241,8 @@ public class DefaultMigrationSchemaHandler implements MigrationSchemaHandler
     @Override
     public Collection<AttachmentParentType> copyAttachments(DatabaseMigrationConfiguration configuration, DbSchema sourceSchema, DbSchema targetSchema, @Nullable Set<GUID> copyContainers)
     {
-        // Now that the target tables in this schema have been populated, copy all associated attachments. By
-        // default, use this handler's attachment types to select from the target tables all EntityIds that might be
+        // Now that the target tables in this schema have been populated, copy all associated attachments. By default,
+        // use this handler's attachment parent types to select from the target tables all EntityIds that might be
         // attachment parents (this avoids re-running potentially expensive queries on the source tables). Use the
         // set of EntityIds to copy those attachments from the core.Documents table in the source database. Override
         // if special behavior is required, for example, AttachmentTypes that use documentNameColumn since that

--- a/api/src/org/labkey/api/migration/DefaultMigrationSchemaHandler.java
+++ b/api/src/org/labkey/api/migration/DefaultMigrationSchemaHandler.java
@@ -3,10 +3,8 @@ package org.labkey.api.migration;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.attachments.AttachmentService;
 import org.labkey.api.attachments.AttachmentParentType;
 import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DatabaseTableType;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
@@ -30,7 +28,6 @@ import org.labkey.api.query.SchemaKey;
 import org.labkey.api.query.TableSorter;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.GUID;
-import org.labkey.api.util.JobRunner;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.logging.LogHelper;
 
@@ -40,9 +37,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class DefaultMigrationSchemaHandler implements MigrationSchemaHandler
@@ -242,7 +239,7 @@ public class DefaultMigrationSchemaHandler implements MigrationSchemaHandler
     }
 
     @Override
-    public void copyAttachments(DatabaseMigrationConfiguration configuration, DbSchema sourceSchema, DbSchema targetSchema, Set<GUID> copyContainers)
+    public Collection<AttachmentParentType> copyAttachments(DatabaseMigrationConfiguration configuration, DbSchema sourceSchema, DbSchema targetSchema, @Nullable Set<GUID> copyContainers)
     {
         // Now that the target tables in this schema have been populated, copy all associated attachments. By
         // default, use this handler's attachment types to select from the target tables all EntityIds that might be
@@ -250,6 +247,8 @@ public class DefaultMigrationSchemaHandler implements MigrationSchemaHandler
         // set of EntityIds to copy those attachments from the core.Documents table in the source database. Override
         // if special behavior is required, for example, AttachmentTypes that use documentNameColumn since that
         // requires querying and re-filtering the source tables instead.
+        Collection<AttachmentParentType> ret = new LinkedList<>();
+
         getAttachmentTypes().forEach(type -> {
             SQLFragment sql = type.getSelectParentEntityIdsSql();
             if (sql != null)
@@ -258,13 +257,15 @@ public class DefaultMigrationSchemaHandler implements MigrationSchemaHandler
                 SQLFragment selectParents = new SQLFragment("Parent");
                 // This query against the source database is likely to contain a large IN clause, so use an alternative InClauseGenerator
                 sourceSchema.getSqlDialect().appendInClauseSqlWithCustomInClauseGenerator(selectParents, entityIds, getTempTableInClauseGenerator(sourceSchema.getScope()));
-                copyAttachments(configuration, sourceSchema, new SQLClause(selectParents), type);
+                ret.addAll(copyAttachments(configuration, new SQLClause(selectParents), type));
             }
             else
             {
                 throw new ConfigurationException("AttachmentType \"" + type.getUniqueName() + "\" is not configured to find parent EntityIds!");
             }
         });
+
+        return ret;
     }
 
     // Creates a TempTableInClauseGenerator that targets the *source* temp schema instead of the default
@@ -274,47 +275,12 @@ public class DefaultMigrationSchemaHandler implements MigrationSchemaHandler
         return new TempTableInClauseGenerator(() -> sourceScope.getSchema("temp", DbSchemaType.Bare));
     }
 
-    private static final Set<AttachmentParentType> SEEN = new HashSet<>();
-    private static final JobRunner ATTACHMENT_JOB_RUNNER = new JobRunner("Attachment JobRunner", 1, () -> "Attachments");
-
     // Copy all core.Documents rows that match the provided filter clause
-    protected final void copyAttachments(DatabaseMigrationConfiguration configuration, DbSchema sourceSchema, FilterClause filterClause, AttachmentParentType... type)
+    protected final Collection<AttachmentParentType> copyAttachments(DatabaseMigrationConfiguration configuration, FilterClause filterClause, AttachmentParentType... type)
     {
-        SEEN.addAll(Arrays.asList(type));
         String additionalMessage = " associated with " + Arrays.stream(type).map(t -> t.getClass().getSimpleName()).collect(Collectors.joining(", "));
-        TableInfo sourceDocumentsTable = sourceSchema.getScope().getSchema("core", DbSchemaType.Migration).getTable("Documents");
-        TableInfo targetDocumentsTable = CoreSchema.getInstance().getTableInfoDocuments();
-
-        // Queue up the core.Documents transfers and let them run in the background
-        ATTACHMENT_JOB_RUNNER.execute(() -> DatabaseMigrationService.get().copySourceTableToTargetTable(configuration, sourceDocumentsTable, targetDocumentsTable, DbSchemaType.Module, false, additionalMessage, new DefaultMigrationSchemaHandler(CoreSchema.getInstance().getSchema())
-        {
-            @Override
-            public FilterClause getTableFilterClause(TableInfo sourceTable, Set<GUID> containers)
-            {
-                return filterClause;
-            }
-        }));
-    }
-
-    // Global (not schema- or configuration-specific) cleanup
-    public static void afterMigration() throws InterruptedException
-    {
-        // Report any unseen attachment types
-        Set<AttachmentParentType> unseen = new HashSet<>(AttachmentService.get().getAttachmentParentTypes());
-        unseen.removeAll(SEEN);
-
-        if (unseen.isEmpty())
-            LOG.info("All AttachmentTypes have been seen");
-        else
-            LOG.error("These AttachmentTypes have not been seen: {}", unseen.stream().map(type -> type.getClass().getSimpleName()).collect(Collectors.joining(", ")));
-
-        // Shut down the attachment JobRunner
-        LOG.info("Waiting for attachments background transfer to complete");
-        ATTACHMENT_JOB_RUNNER.shutdown();
-        if (ATTACHMENT_JOB_RUNNER.awaitTermination(2, TimeUnit.HOURS))
-            LOG.info("Attachments background transfer is complete");
-        else
-            LOG.error("Attachments background transfer did not complete after two hours! Giving up.");
+        DatabaseMigrationService.get().copyAttachments(configuration, filterClause, additionalMessage);
+        return Arrays.asList(type);
     }
 
     @Override

--- a/api/src/org/labkey/api/migration/MigrationSchemaHandler.java
+++ b/api/src/org/labkey/api/migration/MigrationSchemaHandler.java
@@ -12,7 +12,6 @@ import org.labkey.api.migration.DatabaseMigrationService.DataFilter;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.util.GUID;
 
-import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -53,7 +52,7 @@ public interface MigrationSchemaHandler
 
     void afterSchema(DatabaseMigrationConfiguration configuration, DbSchema sourceSchema, DbSchema targetSchema);
 
-    void copyAttachments(DatabaseMigrationConfiguration configuration, DbSchema sourceSchema, DbSchema targetSchema, Set<GUID> copyContainers);
+    Collection<AttachmentParentType> copyAttachments(DatabaseMigrationConfiguration configuration, DbSchema sourceSchema, DbSchema targetSchema, @Nullable Set<GUID> copyContainers);
 
     @NotNull Collection<AttachmentParentType> getAttachmentTypes();
 

--- a/api/src/org/labkey/api/migration/MigrationTableHandler.java
+++ b/api/src/org/labkey/api/migration/MigrationTableHandler.java
@@ -1,5 +1,6 @@
 package org.labkey.api.migration;
 
+import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.util.GUID;
@@ -14,5 +15,11 @@ import java.util.Set;
 public interface MigrationTableHandler
 {
     TableInfo getTableInfo();
-    void adjustFilter(TableInfo sourceTable, SimpleFilter filter, Set<GUID> containers);
+    // This method is invoked during cloning migration
+    default void adjustFilter(TableInfo sourceTable, SimpleFilter filter, Set<GUID> containers){}
+    // This method is invoked during SQL Server migration primarily to map GUID values to lowercase
+    default ColumnInfo handleColumn(ColumnInfo sourceColumn)
+    {
+        return sourceColumn;
+    }
 }

--- a/api/src/org/labkey/api/migration/MigrationTableHandler.java
+++ b/api/src/org/labkey/api/migration/MigrationTableHandler.java
@@ -8,9 +8,14 @@ import org.labkey.api.util.GUID;
 import java.util.Set;
 
 /**
- * Rarely needed, this interface lets a module filter the rows of another module's table. The specific use case: LabBook
- * needs to filter the compliance.SignedSnapshots table of snapshots associated with Notebooks that are excluded by a
- * NotebookFilter.
+ * <p>In the cloning migration case, lets a module filter the rows of another module's table. The specific use case:
+ * LabBook needs to filter the compliance.SignedSnapshots table, removing snapshots associated with Notebooks that are
+ * excluded by a NotebookFilter.
+ * </p>
+ * <p>
+ * In the SQL Server migration case, lets a module replace specific select columns. This is primarily used to translate
+ * GUID values residing in non-GUID columns to lowercase.
+ * </p>
  */
 public interface MigrationTableHandler
 {

--- a/api/src/org/labkey/api/security/GroupManager.java
+++ b/api/src/org/labkey/api/security/GroupManager.java
@@ -16,7 +16,6 @@
 
 package org.labkey.api.security;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -49,6 +48,7 @@ import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.JunitUtil;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.TestContext;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.ViewContext;
 import org.labkey.security.xml.GroupEnumType;
@@ -72,7 +72,7 @@ import java.util.Set;
 
 public class GroupManager
 {
-    private static final Logger _log = LogManager.getLogger(GroupManager.class);
+    private static final Logger _log = LogHelper.getLogger(GroupManager.class, "Security group warnings");
     private static final CoreSchema _core = CoreSchema.getInstance();
 
     public static final String GROUP_AUDIT_EVENT = "GroupAuditEvent";
@@ -101,7 +101,7 @@ public class GroupManager
     {
         int gotUserId;
         if ((gotUserId = createSystemGroup(userId, name, type)) != userId)
-            _log.warn(name + " group exists but has an unexpected UserId (is " + gotUserId + ", should be " + userId + ")");
+            _log.warn("{} group exists but has an unexpected UserId (is {}, should be {})", name, gotUserId, userId);
         GroupCache.uncache(userId);
     }
 

--- a/api/src/org/labkey/api/util/GUID.java
+++ b/api/src/org/labkey/api/util/GUID.java
@@ -80,6 +80,8 @@ public class GUID implements Serializable, Parameter.JdbcParameterValue, SafeToR
     private static long msTimer = System.currentTimeMillis();
     private static int nanoCounter = 0xffffffff;
 
+    // Can be used to match GUID values in SQL
+    public static String SQL_LIKE_GUID_PATTERN = "[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]";
 
     private static String genClockSeqAndReserved()
     {

--- a/api/src/org/labkey/api/util/JdbcUtil.java
+++ b/api/src/org/labkey/api/util/JdbcUtil.java
@@ -17,16 +17,12 @@
 package org.labkey.api.util;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.dialect.DialectStringHandler;
 import org.labkey.api.data.dialect.SqlDialect;
 
 import java.util.Date;
 
-/**
- * User: kevink
- */
 public final class JdbcUtil
 {
     private JdbcUtil() { }
@@ -37,20 +33,10 @@ public final class JdbcUtil
         return format(fragment, dialect.getStringHandler());
     }
 
-
-    // Not recommended -- this uses the LabKey scope to dictate parsing of identifiers and string literals... which
-    // might not be correct for the incoming SQL.
-    public static String format(SQLFragment fragment)
-    {
-        return format(fragment, DbScope.getLabKeyScope().getSqlDialect().getStringHandler());
-    }
-
-
     private static String format(SQLFragment fragment, DialectStringHandler handler)
     {
         return handler.substituteParameters(fragment);
     }
-
 
     // handle equality check for various row version types, LONG, ROWVERSION, TIMESTAMP (date time)
     public static boolean rowVersionEqual(@NotNull Object a, @NotNull Object b)

--- a/core/src/org/labkey/core/CoreMigrationSchemaHandler.java
+++ b/core/src/org/labkey/core/CoreMigrationSchemaHandler.java
@@ -216,7 +216,7 @@ class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler implement
     @Override
     public Collection<AttachmentParentType> copyAttachments(DatabaseMigrationConfiguration configuration, DbSchema sourceSchema, DbSchema targetSchema, @Nullable Set<GUID> copyContainers)
     {
-        // Default handling for core's standard attachment types
+        // Default handling for core's standard attachment parent types
         Collection<AttachmentParentType> ret = new LinkedList<>(super.copyAttachments(configuration, sourceSchema, targetSchema, copyContainers));
 
         // Special handling for LookAndFeelResourceType, which must select from the source database. Keep in sync with

--- a/core/src/org/labkey/core/CoreMigrationSchemaHandler.java
+++ b/core/src/org/labkey/core/CoreMigrationSchemaHandler.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.attachments.AttachmentCache;
 import org.labkey.api.attachments.AttachmentParentType;
 import org.labkey.api.attachments.LookAndFeelResourceType;
+import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.CompareType.CompareClause;
 import org.labkey.api.data.CoreSchema;
@@ -21,11 +22,13 @@ import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TestSchema;
+import org.labkey.api.data.WrappedColumn;
 import org.labkey.api.files.FileSystemAttachmentType;
 import org.labkey.api.migration.DatabaseMigrationConfiguration;
 import org.labkey.api.migration.DatabaseMigrationService;
 import org.labkey.api.migration.DefaultMigrationSchemaHandler;
 import org.labkey.api.migration.MigrationFilter;
+import org.labkey.api.migration.MigrationTableHandler;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.reports.report.ReportType;
@@ -33,8 +36,10 @@ import org.labkey.api.security.AuthenticationLogoType;
 import org.labkey.api.security.AvatarType;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.GUID;
+import org.labkey.api.view.Portal;
 
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -45,6 +50,20 @@ class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler implement
         CoreMigrationSchemaHandler schemaHandler = new CoreMigrationSchemaHandler();
         DatabaseMigrationService.get().registerSchemaHandler(schemaHandler);
         DatabaseMigrationService.get().registerMigrationFilter(schemaHandler);
+        DatabaseMigrationService.get().registerTableHandler(new MigrationTableHandler()
+        {
+            @Override
+            public TableInfo getTableInfo()
+            {
+                return Portal.getTableInfoPortalWebParts();
+            }
+
+            @Override
+            public ColumnInfo handleColumn(ColumnInfo col)
+            {
+                return "Properties".equals(col.getName()) ? new GuidReplacingColumn(col) : col;
+            }
+        });
 
         DatabaseMigrationService.get().registerSchemaHandler(new DefaultMigrationSchemaHandler(PropertySchema.getInstance().getSchema()){
             @Override
@@ -195,21 +214,34 @@ class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler implement
     }
 
     @Override
-    public void copyAttachments(DatabaseMigrationConfiguration configuration, DbSchema sourceSchema, DbSchema targetSchema, Set<GUID> copyContainers)
+    public Collection<AttachmentParentType> copyAttachments(DatabaseMigrationConfiguration configuration, DbSchema sourceSchema, DbSchema targetSchema, @Nullable Set<GUID> copyContainers)
     {
         // Default handling for core's standard attachment types
-        super.copyAttachments(configuration, sourceSchema, targetSchema, copyContainers);
+        Collection<AttachmentParentType> ret = new LinkedList<>(super.copyAttachments(configuration, sourceSchema, targetSchema, copyContainers));
 
         // Special handling for LookAndFeelResourceType, which must select from the source database. Keep in sync with
         // LookAndFeelResourceType.addWhereSql().
-        SQLFragment sql = new SQLFragment()
-            .append("Parent").appendInClause(copyContainers, sourceSchema.getSqlDialect())
-            .append(" AND (DocumentName IN (?, ?) OR ")
+        SQLFragment sql = new SQLFragment("Parent");
+
+        if (copyContainers != null)
+        {
+            // Subset of containers
+            sql.appendInClause(copyContainers, sourceSchema.getSqlDialect());
+        }
+        else
+        {
+            // All containers
+            sql.append(" IN (SELECT EntityId FROM core.Containers)");
+        }
+
+        sql.append(" AND (DocumentName IN (?, ?) OR ")
             .add(AttachmentCache.FAVICON_FILE_NAME)
             .add(AttachmentCache.STYLESHEET_FILE_NAME)
             .append("DocumentName LIKE '" + AttachmentCache.LOGO_FILE_NAME_PREFIX + "%' OR ")
             .append("DocumentName LIKE '" + AttachmentCache.MOBILE_LOGO_FILE_NAME_PREFIX + "%')");
-        copyAttachments(configuration, sourceSchema, new SQLClause(sql), LookAndFeelResourceType.get());
+        ret.addAll(copyAttachments(configuration, new SQLClause(sql), LookAndFeelResourceType.get()));
+
+        return ret;
     }
 
     @Override
@@ -247,5 +279,30 @@ class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler implement
             throw new ConfigurationException("GroupFilter is applied globally; you cannot specify a GUID");
 
         _groupFilterCondition = new SQLFragment(groupFilter);
+    }
+
+    // Replace the first contained GUID in each value with a lowercase version
+    private static final class GuidReplacingColumn extends WrappedColumn
+    {
+        public GuidReplacingColumn(ColumnInfo col)
+        {
+            super(col, col.getName());
+        }
+
+        @Override
+        public SQLFragment getValueSql(String tableAlias)
+        {
+            SQLFragment columnAlias = super.getValueSql(tableAlias);
+
+            // SELECT CASE WHEN idx > 0 THEN SUBSTRING(Properties, 1, idx - 1) + LOWER(SUBSTRING(Properties, idx, 36)) + SUBSTRING(Properties, idx + 36, LEN(Properties) - idx - 35) ELSE Properties END FROM (SELECT CAST(Properties AS VARCHAR(MAX)) AS Properties, PATINDEX(, Properties) AS idx) AS Properties)
+
+            //noinspection StringConcatenationInsideStringBufferAppend - SQLFragment flips out about unmatched quotes, so we're forced to use string concatenation
+            return new SQLFragment("(SELECT CASE WHEN idx > 0 THEN SUBSTRING(Properties, 1, idx - 1) + LOWER(SUBSTRING(Properties, idx, 36)) + SUBSTRING(Properties, idx + 36, LEN(Properties) - idx - 35) ELSE Properties END")
+                .append(" FROM (SELECT CAST(")
+                .append(columnAlias)
+                .append(" AS VARCHAR(MAX)) AS Properties, PATINDEX('%" + GUID.SQL_LIKE_GUID_PATTERN + "%', ")
+                .append(columnAlias)
+                .append(") AS idx) AS Properties)");
+        }
     }
 }

--- a/core/src/org/labkey/core/CoreMigrationSchemaHandler.java
+++ b/core/src/org/labkey/core/CoreMigrationSchemaHandler.java
@@ -294,8 +294,6 @@ class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler implement
         {
             SQLFragment columnAlias = super.getValueSql(tableAlias);
 
-            // SELECT CASE WHEN idx > 0 THEN SUBSTRING(Properties, 1, idx - 1) + LOWER(SUBSTRING(Properties, idx, 36)) + SUBSTRING(Properties, idx + 36, LEN(Properties) - idx - 35) ELSE Properties END FROM (SELECT CAST(Properties AS VARCHAR(MAX)) AS Properties, PATINDEX(, Properties) AS idx) AS Properties)
-
             //noinspection StringConcatenationInsideStringBufferAppend - SQLFragment flips out about unmatched quotes, so we're forced to use string concatenation
             return new SQLFragment("(SELECT CASE WHEN idx > 0 THEN SUBSTRING(Properties, 1, idx - 1) + LOWER(SUBSTRING(Properties, idx, 36)) + SUBSTRING(Properties, idx + 36, LEN(Properties) - idx - 35) ELSE Properties END")
                 .append(" FROM (SELECT CAST(")

--- a/core/src/org/labkey/core/CoreMigrationSchemaHandler.java
+++ b/core/src/org/labkey/core/CoreMigrationSchemaHandler.java
@@ -86,10 +86,12 @@ class CoreMigrationSchemaHandler extends DefaultMigrationSchemaHandler implement
         super.beforeVerification();
 
         // Delete root and shared containers that were needed for bootstrapping
-        TableInfo containers = CoreSchema.getInstance().getTableInfoContainers();
-        Table.delete(containers);
+        Table.delete(CoreSchema.getInstance().getTableInfoContainers());
         DbScope targetScope = DbScope.getLabKeyScope();
         new SqlExecutor(targetScope).execute("ALTER SEQUENCE core.containers_rowid_seq RESTART"); // Reset Containers sequence
+
+        // Delete Guests and Users groups that were needed for bootstrapping
+        Table.delete(CoreSchema.getInstance().getTableInfoPrincipals());
     }
 
     @Override

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -871,12 +871,12 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
 
     private void bootstrap()
     {
+        // Create the initial groups
+        GroupManager.bootstrapGroup(Group.groupUsers, "Users");
+        GroupManager.bootstrapGroup(Group.groupGuests, "Guests");
+
         if (ModuleLoader.getInstance().shouldInsertData())
         {
-            // Create the initial groups
-            GroupManager.bootstrapGroup(Group.groupUsers, "Users");
-            GroupManager.bootstrapGroup(Group.groupGuests, "Guests");
-
             // Other containers inherit permissions from root; admins get all permissions, users & guests none
             Role noPermsRole = RoleManager.getRole(NoPermissionsRole.class);
             Role readerRole = RoleManager.getRole(ReaderRole.class);
@@ -926,7 +926,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
         }
         else
         {
-            // It's very difficult to bootstrap without the root or shared containers in place; create them now and
+            // It's very difficult to bootstrap without the root or shared containers in place; create them now, and
             // we'll delete them later
             Container root = ContainerManager.ensureContainer("/", User.getAdminServiceUser());
             Table.insert(null, CoreSchema.getInstance().getTableInfoContainers(), Map.of("Parent", root.getId(), "Name", "Shared"));

--- a/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
+++ b/core/src/org/labkey/core/dialect/PostgreSql92Dialect.java
@@ -15,31 +15,61 @@
  */
 package org.labkey.core.dialect;
 
+import jakarta.servlet.ServletException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Constraint;
+import org.labkey.api.data.CoreSchema;
+import org.labkey.api.data.DatabaseIdentifier;
+import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.InClauseGenerator;
+import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.ParameterMarkerInClauseGenerator;
+import org.labkey.api.data.PropertyStorageSpec;
 import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.Selector;
+import org.labkey.api.data.Selector.ForEachBlock;
+import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.TableChange;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TempTableInClauseGenerator;
+import org.labkey.api.data.TempTableTracker;
 import org.labkey.api.data.dialect.BasePostgreSqlDialect;
 import org.labkey.api.data.dialect.DialectStringHandler;
 import org.labkey.api.data.dialect.JdbcHelper;
+import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.dialect.StandardJdbcHelper;
+import org.labkey.api.query.AliasManager;
+import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.view.template.Warnings;
 import org.labkey.core.admin.sql.ScriptReorderer;
+import org.springframework.jdbc.BadSqlGrammarException;
 
 import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /*
  * This is the base class defining PostgreSQL-specific (i.e., not Redshift) behavior. PostgreSQL 9.2 is no longer
@@ -53,14 +83,57 @@ abstract class PostgreSql92Dialect extends BasePostgreSqlDialect
     // the future plus servers can be compiled with a different limit, so we query this setting on first connection to
     // each database.
     private int _maxIdentifierByteLength = 63;
-
     private InClauseGenerator _inClauseGenerator;
+
     private final TempTableInClauseGenerator _tempTableInClauseGenerator = new TempTableInClauseGenerator();
+    private final AtomicBoolean _arraySortFunctionExists = new AtomicBoolean(false);
+
+    @Override
+    public void handleCreateDatabaseException(SQLException e) throws ServletException
+    {
+        if ("55006".equals(e.getSQLState()))
+        {
+            LOG.error("You must close down pgAdmin III and all other applications accessing PostgreSQL.");
+            throw (new ServletException("Close down or disconnect pgAdmin III and all other applications accessing PostgreSQL", e));
+        }
+        else
+        {
+            super.handleCreateDatabaseException(e);
+        }
+    }
+
+    @Override
+    public void prepareDriver(Class<Driver> driverClass)
+    {
+        // PostgreSQL driver 42.0.0 added logging via the Java Logging API (java.util.logging). This caused the driver to
+        // start logging SQLExceptions (such as the initial connection failure on bootstrap) to the console... harmless
+        // but annoying. This code suppresses the driver logging.
+        Logger pgjdbcLogger = LogManager.getLogManager().getLogger("org.postgresql");
+
+        if (null != pgjdbcLogger)
+            pgjdbcLogger.setLevel(Level.OFF);
+    }
+
+    // Make sure that the PL/pgSQL language is enabled in the associated database. If not, throw. Since 9.0, PostgreSQL has
+    // shipped with PL/pgSQL enabled by default, so the check is no longer critical, but continue to verify just to be safe.
+    @Override
+    public void prepareNewLabKeyDatabase(DbScope scope)
+    {
+        if (new SqlSelector(scope, "SELECT * FROM pg_language WHERE lanname = 'plpgsql'").exists())
+            return;
+
+        String dbName = scope.getDatabaseName();
+        String message = "PL/pgSQL is not enabled in the \"" + dbName + "\" database because it is not enabled in your Template1 master database.";
+        String advice = "Use PostgreSQL's 'createlang' command line utility to enable PL/pgSQL in the \"" + dbName + "\" database then restart Tomcat.";
+
+        throw new ConfigurationException(message, advice);
+    }
 
     @Override
     public String prepare(DbScope scope)
     {
         initializeInClauseGenerator(scope);
+        determineIfArraySortFunctionExists(scope);
         return super.prepare(scope);
     }
 
@@ -119,10 +192,32 @@ abstract class PostgreSql92Dialect extends BasePostgreSqlDialect
             return new PostgreSqlNonConformingStringHandler();
     }
 
+    /*
+        PostgreSQL example connection URLs we need to parse:
+
+        jdbc:postgresql:database
+        jdbc:postgresql://host/database
+        jdbc:postgresql://host:port/database
+        jdbc:postgresql:database?user=fred&password=secret&ssl=true
+        jdbc:postgresql://host/database?user=fred&password=secret&ssl=true
+        jdbc:postgresql://host:port/database?user=fred&password=secret&ssl=true
+    */
     @Override
     public JdbcHelper getJdbcHelper()
     {
         return new StandardJdbcHelper(PostgreSqlDialectFactory.JDBC_PREFIX);
+    }
+
+    @Override
+    public String getDefaultDatabaseName()
+    {
+        return "template1";
+    }
+
+    @Override
+    public boolean canExecuteUpgradeScripts()
+    {
+        return true;
     }
 
     @Override
@@ -145,15 +240,122 @@ abstract class PostgreSql92Dialect extends BasePostgreSqlDialect
         return warnings;
     }
 
-    private void initializeInClauseGenerator(DbScope scope)
+    @Override
+    public String getSQLScriptPath()
     {
-        _inClauseGenerator = getJdbcVersion(scope) >= 4 ? new ArrayParameterInClauseGenerator(scope) : new ParameterMarkerInClauseGenerator();
+        return "postgresql";
+    }
+
+    @Override
+    public String getUniqueIdentType()
+    {
+        return "SERIAL";
+    }
+
+    @Override
+    public boolean supportsGroupConcat()
+    {
+        return getServerType().supportsGroupConcat();
+    }
+
+    @Override
+    public boolean supportsSelectConcat()
+    {
+        return true;
+    }
+
+    @Override
+    public SQLFragment getSelectConcat(SQLFragment selectSql, String delimiter)
+    {
+        SQLFragment result = new SQLFragment("array_to_string(array(");
+        result.append(selectSql);
+        result.append("), ");
+        result.append(getStringHandler().quoteStringLiteral(delimiter));
+        result.append(")");
+        return result;
+    }
+
+    // Does this datasource include our sort array function? The LabKey datasource should always have it, but external datasources might not
+    private void determineIfArraySortFunctionExists(DbScope scope)
+    {
+        if (getServerType().supportsSpecialMetadataQueries())
+        {
+            Selector selector = new SqlSelector(scope, "SELECT * FROM pg_catalog.pg_namespace n INNER JOIN pg_catalog.pg_proc p ON pronamespace = n.oid WHERE nspname = 'core' AND proname = 'sort'");
+            _arraySortFunctionExists.set(selector.exists());
+        }
+
+        // Array sort function should always exist in LabKey scope (for now)
+        assert !scope.isLabKeyScope() || _arraySortFunctionExists.get();
+    }
+
+    @Override
+    public SQLFragment getGroupConcat(SQLFragment sql, boolean distinct, boolean sorted, @NotNull SQLFragment delimiterSQL, boolean includeNulls)
+    {
+        // Sort function might not exist in external datasource; skip that syntax if not
+        boolean useSortFunction = sorted && _arraySortFunctionExists.get();
+        SQLFragment result = new SQLFragment();
+
+        if (useSortFunction)
+        {
+            result.append("array_to_string(");
+            result.append("core.sort(");   // TODO: Switch to use ORDER BY option inside array aggregate instead of our custom function
+            result.append("array_agg(");
+            if (distinct)
+            {
+                result.append("DISTINCT ");
+            }
+
+            if (includeNulls)
+            {
+                result.append("COALESCE(CAST(");
+                result.append(sql);
+                result.append(" AS VARCHAR), '')");
+            }
+            else
+            {
+                result.append(sql);
+            }
+
+            result.append(")"); // array_agg
+            result.append(")"); // core.sort
+        }
+        else
+        {
+            result.append("string_agg(");
+            if (distinct)
+            {
+                result.append("DISTINCT ");
+            }
+
+            if (includeNulls)
+            {
+                result.append("COALESCE(");
+                result.append(sql);
+                result.append("::text, '')");
+            }
+            else
+            {
+                result.append(sql);
+                result.append("::text");
+            }
+        }
+
+        result.append(", ");
+        result.append(delimiterSQL);
+        result.append(")"); // array_to_string | string_agg
+
+        return result;
     }
 
     @Override
     public SQLFragment getAnalyzeCommandForTable(String tableName)
     {
         return new SQLFragment("ANALYZE ").appendIdentifier(tableName);
+    }
+
+    private void initializeInClauseGenerator(DbScope scope)
+    {
+        _inClauseGenerator = getJdbcVersion(scope) >= 4 ? new ArrayParameterInClauseGenerator(scope) : new ParameterMarkerInClauseGenerator();
     }
 
     @Override
@@ -236,10 +438,44 @@ abstract class PostgreSql92Dialect extends BasePostgreSqlDialect
     }
 
     @Override
+    public boolean canShowExecutionPlan(ExecutionPlanType type)
+    {
+        return true;
+    }
+
+    @Override
+    protected Collection<String> getQueryExecutionPlan(Connection conn, DbScope scope, SQLFragment sql, ExecutionPlanType type)
+    {
+        SQLFragment copy = new SQLFragment(sql);
+        copy.insert(0, type == ExecutionPlanType.Estimated ? "EXPLAIN " : "EXPLAIN ANALYZE ");
+
+        return new SqlSelector(scope, conn, copy).getCollection(String.class);
+    }
+
+    @Override
     // No need to split up PostgreSQL scripts; execute all statements in a single block (unless we have a special stored proc call).
     protected Pattern getSQLScriptSplitPattern()
     {
         return null;
+    }
+
+    private static final Pattern PROC_PATTERN = Pattern.compile("^\\s*SELECT\\s+core\\.(executeJava(?:Upgrade|Initialization)Code\\s*\\(\\s*'(.+)'\\s*\\))\\s*;\\s*$", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+
+    @NotNull
+    @Override
+    protected Pattern getSQLScriptProcPattern()
+    {
+        return PROC_PATTERN;
+    }
+
+    @Override
+    protected void checkSqlScript(String lowerNoComments, String lowerNoCommentsNoWhiteSpace, Collection<String> errors)
+    {
+        if (lowerNoCommentsNoWhiteSpace.contains("setsearch_pathto"))
+            errors.add("Do not use \"SET search_path TO <schema>\". Instead, schema-qualify references to all objects.");
+
+        if (!lowerNoCommentsNoWhiteSpace.endsWith(";"))
+            errors.add("Script must end with a semicolon");
     }
 
     @Override
@@ -281,6 +517,536 @@ abstract class PostgreSql92Dialect extends BasePostgreSqlDialect
         return new SqlSelector(table.getSchema(), sql).getCollection(Sequence.class);
     }
 
+    @Override
+    public String getBinaryDataType()
+    {
+        return "BYTEA";
+    }
+
+    @Override
+    public String getGlobalTempTablePrefix()
+    {
+        return DbSchema.TEMP_SCHEMA_NAME + ".";
+    }
+
+    @Override
+    public String getDropIndexCommand(String tableName, String indexName)
+    {
+        return "DROP INDEX " + indexName;
+    }
+
+    @Override
+    public String getCreateDatabaseSql(String dbName)
+    {
+        // This will handle both mixed case and special characters on PostgreSQL
+        var legal = makeIdentifierFromMetaDataName(dbName);
+        return new SQLFragment("CREATE DATABASE ").appendIdentifier(legal).append(" WITH ENCODING 'UTF8'").getRawSQL();
+    }
+
+    @Override
+    public String getCreateSchemaSql(String schemaName)
+    {
+        if (!isLegalName(schemaName) || isReserved(schemaName))
+            throw new IllegalArgumentException("Not a legal schema name: " + schemaName);
+
+        //Quoted schema names are bad news
+        return "CREATE SCHEMA " + schemaName;
+    }
+
+    @Override
+    public String getTruncateSql(String tableName)
+    {
+        // To be consistent with MS SQL server, always restart the sequence.  Note that the default for postgres
+        // is to continue the sequence but we don't have this option with MS SQL Server
+        return "TRUNCATE TABLE " + tableName + " RESTART IDENTITY";
+    }
+
+    @Override
+    public List<SQLFragment> getChangeStatements(TableChange change)
+    {
+        List<SQLFragment> result = new ArrayList<>();
+        switch (change.getType())
+        {
+            case CreateTable -> result.addAll(getCreateTableStatements(change));
+            case DropTable -> {
+                SQLFragment f = new SQLFragment("DROP TABLE ");
+                f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+                result.add(f);
+            }
+            case AddColumns -> result.addAll(getAddColumnsStatements(change));
+            case DropColumns -> result.add(getDropColumnsStatement(change));
+            case RenameColumns -> result.addAll(getRenameColumnsStatement(change));
+            case DropIndicesByName -> result.addAll(getDropIndexByNameStatements(change));
+            case AddIndices -> result.addAll(getCreateIndexStatements(change));
+            case ResizeColumns, ChangeColumnTypes -> result.addAll(getChangeColumnTypeStatement(change));
+            case DropConstraints -> result.addAll(getDropConstraintsStatement(change));
+            case AddConstraints -> result.addAll(getAddConstraintsStatement(change));
+            default -> throw new IllegalArgumentException("Unsupported change type: " + change.getType());
+        }
+
+        return result;
+    }
+
+    private Collection<? extends SQLFragment> getDropIndexByNameStatements(TableChange change)
+    {
+        List<SQLFragment> statements = new ArrayList<>();
+        for (String indexName : change.getIndicesToBeDroppedByName())
+        {
+            statements.add(getDropIndexCommand(change, indexName));
+        }
+        return statements;
+    }
+
+    private SQLFragment getDropIndexCommand(TableChange change, String indexName)
+    {
+        SQLFragment f = new SQLFragment("DROP INDEX ");
+        f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(indexName);
+        return f;
+    }
+
+    /**
+     * We've historically created lower-cased column names in provisioned tables in Postgres. Keep doing that
+     * for consistency, though ideally we'd stop doing this and update all existing provisioned tables.
+     */
+    private DatabaseIdentifier makePropertyIdentifier(String name)
+    {
+        if (isIdentifierTooLong(name))
+            throw new UnsupportedOperationException("Name is too long: " + name);
+        return new _DatabaseIdentifier(name, quoteIdentifier(name.toLowerCase()), this);
+    }
+
+    /**
+     * Generate the Alter Table statement to change the size or type of the column
+     * <p>
+     * NOTE: expects data size check to be done prior,
+     *       will throw a SQL exception if not able to change size due to existing data
+     */
+    private List<SQLFragment> getChangeColumnTypeStatement(TableChange change)
+    {
+        List<SQLFragment> statements = new ArrayList<>();
+
+        // Postgres allows executing multiple ALTER COLUMN statements under one ALTER TABLE
+        List<SQLFragment> nonDateTimeClauses = new ArrayList<>();
+
+        for (PropertyStorageSpec column : change.getColumns())
+        {
+            DatabaseIdentifier columnIdent = makePropertyIdentifier(column.getName());
+            if (column.getJdbcType().isDateOrTime())
+            {
+                String tempColumnName = column.getName() + "~~temp~~";
+                DatabaseIdentifier tempColumnIdent = makePropertyIdentifier(tempColumnName);
+
+                // 1) ADD temp column
+                SQLFragment addTemp = new SQLFragment("ALTER TABLE ");
+                addTemp.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+                addTemp.append(" ADD COLUMN ").append(getSqlColumnSpec(column, tempColumnName));
+                statements.add(addTemp);
+
+                // 2) UPDATE: copy casted value to temp column
+                SQLFragment update = new SQLFragment("UPDATE ");
+                update.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+                update.append(" SET ").appendIdentifier(tempColumnIdent);
+                update.append(" = CAST(").appendIdentifier(columnIdent).append(" AS ").append(getSqlTypeName(column)).append(")");
+                statements.add(update);
+
+                // 3) DROP original column
+                SQLFragment drop = new SQLFragment("ALTER TABLE ");
+                drop.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+                drop.append(" DROP COLUMN ").appendIdentifier(columnIdent);
+                statements.add(drop);
+
+                // 4) RENAME temp column to original column name
+                SQLFragment rename = new SQLFragment("ALTER TABLE ");
+                rename.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+                rename.append(" RENAME COLUMN ").appendIdentifier(tempColumnIdent).append(" TO ").appendIdentifier(columnIdent);
+                statements.add(rename);
+            }
+            else
+            {
+                String dbType;
+                if (column.getJdbcType().isText())
+                {
+                    // Using the common default max size to make type change to text
+                    dbType = column.getSize() == -1 || column.getSize() > SqlDialect.MAX_VARCHAR_SIZE ?
+                        getSqlTypeName(JdbcType.LONGVARCHAR) :
+                        getSqlTypeName(column.getJdbcType()) + "(" + column.getSize().toString() + ")";
+                }
+                else if (column.getJdbcType().isDecimal())
+                {
+                    dbType = getSqlTypeName(column.getJdbcType()) + DEFAULT_DECIMAL_SCALE_PRECISION;
+                }
+                else
+                {
+                    dbType = getSqlTypeName(column.getJdbcType());
+                }
+
+                SQLFragment clause = new SQLFragment();
+                clause.append("ALTER COLUMN ").appendIdentifier(columnIdent).append(" TYPE ").append(dbType);
+                nonDateTimeClauses.add(clause);
+            }
+        }
+
+        if (!nonDateTimeClauses.isEmpty())
+        {
+            SQLFragment alter = new SQLFragment("ALTER TABLE ");
+            alter.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+            alter.append(" ");
+            String sep = "";
+            for (SQLFragment c : nonDateTimeClauses)
+            {
+                alter.append(sep).append(c);
+                sep = ", ";
+            }
+            statements.add(alter);
+        }
+
+        return statements;
+    }
+
+    private List<SQLFragment> getRenameColumnsStatement(TableChange change)
+    {
+        List<SQLFragment> statements = new ArrayList<>();
+        for (Map.Entry<String, String> oldToNew : change.getColumnRenames().entrySet())
+        {
+            DatabaseIdentifier oldIdentifier = makePropertyIdentifier(oldToNew.getKey());
+            DatabaseIdentifier newIdentifier = makePropertyIdentifier(oldToNew.getValue());
+            if (!oldIdentifier.equals(newIdentifier))
+            {
+                SQLFragment f = new SQLFragment("ALTER TABLE ");
+                f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+                f.append(" RENAME COLUMN ").appendIdentifier(oldIdentifier).append(" TO ").appendIdentifier(newIdentifier);
+                statements.add(f);
+            }
+        }
+
+        // TODO: This loop should not guess the name of the old indices; instead, it should look them up.
+        // TableChange.setIndexedColumns() could set _indexRenames providing the name, and then this code uses that info.
+        // Or maybe schemaTableInfo.getAllIndices() and then use Index.isSameIndex() to find names. Issue 53838.
+        for (Map.Entry<PropertyStorageSpec.Index, PropertyStorageSpec.Index> oldToNew : change.getIndexRenames().entrySet())
+        {
+            PropertyStorageSpec.Index oldIndex = oldToNew.getKey();
+            PropertyStorageSpec.Index newIndex = oldToNew.getValue();
+            String oldName = nameIndex(change.getTableName(), oldIndex.columnNames); // TODO: Look up name
+            String newName = nameIndex(change.getTableName(), newIndex.columnNames);
+            if (!oldName.equals(newName))
+            {
+                SQLFragment f = new SQLFragment("ALTER INDEX ");
+                f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(oldName);
+                f.append(" RENAME TO ").appendIdentifier(newName);
+                statements.add(f);
+            }
+        }
+
+        return statements;
+    }
+
+    private SQLFragment getDropColumnsStatement(TableChange change)
+    {
+        List<SQLFragment> sqlParts = new ArrayList<>();
+        for (PropertyStorageSpec prop : change.getColumns())
+        {
+            SQLFragment sql = new SQLFragment("DROP COLUMN ");
+            if (prop.getExactName())
+            {
+                sql.append(quoteIdentifier(prop.getName()));
+            }
+            else
+            {
+                sql.appendIdentifier(makePropertyIdentifier(prop.getName()));
+            }
+            sqlParts.add(sql);
+        }
+
+        SQLFragment f = new SQLFragment("ALTER TABLE ");
+        f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+        f.append(" ").append(sqlParts, ", ");
+        return f;
+    }
+
+    // TODO if there are cases where user-defined columns need indices, this method will need to support
+    // creating indices like getCreateTableStatement does.
+    private List<SQLFragment> getAddColumnsStatements(TableChange change)
+    {
+        List<SQLFragment> statements = new ArrayList<>();
+        String pkColumn = null;
+        Constraint constraint = null;
+
+        List<SQLFragment> columnSpecs = new ArrayList<>();
+        for (PropertyStorageSpec prop : change.getColumns())
+        {
+            columnSpecs.add(getSqlColumnSpec(prop));
+            if (prop.isPrimaryKey())
+            {
+                assert null == pkColumn : "no more than one primary key defined";
+                pkColumn = prop.getName();
+                constraint = new Constraint(change.getTableName(), Constraint.CONSTRAINT_TYPES.PRIMARYKEY, false, null);
+            }
+        }
+
+        SQLFragment alter = new SQLFragment("ALTER TABLE ");
+        alter.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+        alter.append(" ");
+        String sep = "";
+        for (SQLFragment col : columnSpecs)
+        {
+            alter.append(sep);
+            alter.append("ADD COLUMN ");
+            alter.append(col);
+            sep = ", ";
+        }
+        statements.add(alter);
+        if (null != pkColumn)
+        {
+            SQLFragment addPk = new SQLFragment("ALTER TABLE ");
+            addPk.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+            addPk.append(" ADD CONSTRAINT ").appendIdentifier(constraint.getName())
+                .append(" ").append(constraint.getType().toString()).append(" (")
+                .appendIdentifier(makePropertyIdentifier(pkColumn)).append(")");
+            statements.add(addPk);
+        }
+
+        return statements;
+    }
+
+    private List<SQLFragment> getDropConstraintsStatement(TableChange change)
+    {
+        return change.getConstraints().stream().map(constraint -> {
+            SQLFragment f = new SQLFragment("ALTER TABLE ");
+            f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+            f.append(" DROP CONSTRAINT ").appendIdentifier(constraint.getName());
+            return f;
+        }).collect(Collectors.toList());
+    }
+
+    private List<SQLFragment> getAddConstraintsStatement(TableChange change)
+    {
+        List<SQLFragment> statements = new ArrayList<>();
+        Collection<Constraint> constraints = change.getConstraints();
+
+        if (null!=constraints && !constraints.isEmpty())
+        {
+            statements = constraints.stream().map(constraint -> {
+                List<SQLFragment> columns = new ArrayList<>();
+                for (String col : constraint.getColumns())
+                {
+                    columns.add(new SQLFragment().appendIdentifier(col));
+                }
+
+                SQLFragment f = new SQLFragment();
+                f.append("DO $$\nBEGIN\nIF NOT EXISTS\n(SELECT 1 FROM information_schema.constraint_column_usage\nWHERE table_name = ")
+                    .appendStringLiteral(change.getSchemaName() + "." + change.getTableName(), this)
+                    .append(" and constraint_name = ")
+                    .appendStringLiteral(constraint.getName(), this)
+                    .append(") THEN\nALTER TABLE ");
+                f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+                f.append(" ADD CONSTRAINT ").appendIdentifier(constraint.getName()).append(" ")
+                    .append(constraint.getType().toString()).append(" (")
+                    .append(columns, ",")
+                    .append(")").appendEOS().append("\nEND IF)").appendEOS().append("\nEND$$").appendEOS();
+                return f;
+            }).collect(Collectors.toList());
+        }
+
+        return statements;
+    }
+
+    private List<SQLFragment> getCreateTableStatements(TableChange change)
+    {
+        List<SQLFragment> statements = new ArrayList<>();
+        List<SQLFragment> createTableSqlParts = new ArrayList<>();
+        String pkColumn = null;
+        for (PropertyStorageSpec prop : change.getColumns())
+        {
+            createTableSqlParts.add(getSqlColumnSpec(prop));
+            if (prop.isPrimaryKey())
+            {
+                assert null == pkColumn : "no more than one primary key defined";
+                pkColumn = prop.getName();
+            }
+        }
+
+        for (PropertyStorageSpec.ForeignKey foreignKey : change.getForeignKeys())
+        {
+            DbSchema schema = DbSchema.get(foreignKey.getSchemaName(), DbSchemaType.Module);
+            TableInfo tableInfo = foreignKey.isProvisioned() ?
+                foreignKey.getTableInfoProvisioned() :
+                schema.getTable(foreignKey.getTableName());
+            String constraintName = "fk_" + foreignKey.getColumnName() + "_" + change.getTableName() + "_" + tableInfo.getName();
+            SQLFragment fkFrag = new SQLFragment("CONSTRAINT ");
+            fkFrag.appendIdentifier(constraintName)
+                .append(" FOREIGN KEY (")
+                .appendIdentifier(makePropertyIdentifier(foreignKey.getColumnName()))
+                .append(") REFERENCES ")
+                .appendIdentifier(tableInfo.getSchema().getName()).append(".").appendIdentifier(tableInfo.getName())
+                .append(" (")
+                .appendIdentifier(makePropertyIdentifier(foreignKey.getForeignColumnName()))
+                .append(")");
+            createTableSqlParts.add(fkFrag);
+        }
+
+        SQLFragment create = new SQLFragment("CREATE TABLE ");
+        create.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+        create.append(" (").append(createTableSqlParts, ", ").append(")");
+        statements.add(create);
+        if (null != pkColumn)
+        {
+            // Making this just for consistent naming
+            Constraint constraint = new Constraint(change.getTableName(), Constraint.CONSTRAINT_TYPES.PRIMARYKEY, false, null);
+
+            SQLFragment addPk = new SQLFragment("ALTER TABLE ");
+            addPk.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+            addPk.append(" ADD CONSTRAINT ").appendIdentifier(constraint.getName())
+                .append(" ").append(constraint.getType().toString()).append(" (")
+                .appendIdentifier(makePropertyIdentifier(pkColumn)).append(")");
+            statements.add(addPk);
+        }
+
+        statements.addAll(getCreateIndexStatements(change));
+        statements.addAll(getAddConstraintsStatement(change));
+        return statements;
+    }
+
+    private List<SQLFragment> getCreateIndexStatements(TableChange change)
+    {
+        List<SQLFragment> statements = new ArrayList<>();
+        for (PropertyStorageSpec.Index index : change.getIndexedColumns())
+        {
+            String newIndexName = nameIndex(change.getTableName(), index.columnNames);
+            SQLFragment f = new SQLFragment("CREATE ");
+            if (index.isUnique)
+                f.append("UNIQUE ");
+            f.append("INDEX ").appendIdentifier(newIndexName).append(" ON ");
+            f.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+            f.append(" (");
+            String separator = "";
+            for (String columnName : index.columnNames)
+            {
+                f.append(separator).appendIdentifier(makePropertyIdentifier(columnName));
+                separator = ", ";
+            }
+            f.append(")");
+            f.appendEOS();
+            statements.add(f);
+
+            if (index.isClustered)
+            {
+                SQLFragment c = new SQLFragment();
+                c.append(PropertyStorageSpec.CLUSTER_TYPE.CLUSTER.toString()).append(" ");
+                c.appendIdentifier(change.getSchemaName()).append(".").appendIdentifier(change.getTableName());
+                c.append(" USING ").appendIdentifier(newIndexName);
+                statements.add(c);
+            }
+        }
+        return statements;
+    }
+
+    @Override
+    public String nameIndex(String tableName, String[] indexedColumns)
+    {
+        return AliasManager.makeLegalName(tableName + '_' + StringUtils.join(indexedColumns, "_"), this);
+    }
+
+    private SQLFragment getSqlColumnSpec(PropertyStorageSpec prop)
+    {
+        return getSqlColumnSpec(prop, prop.getName());
+    }
+
+    private SQLFragment getSqlColumnSpec(PropertyStorageSpec prop, String columnName)
+    {
+        SQLFragment colSpec = new SQLFragment();
+        colSpec.appendIdentifier(makePropertyIdentifier(columnName)).append(" ");
+        colSpec.append(getSqlTypeName(prop));
+
+        // Apply size and precision to varchar and Decimal types
+        if (prop.getJdbcType() == JdbcType.VARCHAR && prop.getSize() != -1 && prop.getSize() <= SqlDialect.MAX_VARCHAR_SIZE)
+        {
+            colSpec.append("(").append(prop.getSize().toString()).append(")");
+        }
+        else if (prop.getJdbcType() == JdbcType.DECIMAL)
+        {
+            colSpec.append(DEFAULT_DECIMAL_SCALE_PRECISION);
+        }
+
+        if (prop.isPrimaryKey() || !prop.isNullable())
+            colSpec.append(" NOT NULL");
+
+        if (null != prop.getDefaultValue())
+        {
+            if (prop.getJdbcType() == JdbcType.BOOLEAN)
+            {
+                colSpec.append(" DEFAULT ");
+                colSpec.append((Boolean)prop.getDefaultValue() ? getBooleanTRUE() : getBooleanFALSE());
+            }
+            else if (prop.getJdbcType() == JdbcType.VARCHAR)
+            {
+                colSpec.append(" DEFAULT ");
+                colSpec.append(getStringHandler().quoteStringLiteral(prop.getDefaultValue().toString()));
+            }
+            else
+            {
+                throw new IllegalArgumentException("Default value on type " + prop.getJdbcType().name() + " is not supported.");
+            }
+        }
+        return colSpec;
+    }
+
+    @Override
+    public void purgeTempSchema(Map<String, TempTableTracker> createdTableNames)
+    {
+        try
+        {
+            trackTempTables(createdTableNames);
+        }
+        catch (SQLException e)
+        {
+            LOG.warn("error cleaning up temp schema", e);
+        }
+
+        DbSchema coreSchema = CoreSchema.getInstance().getSchema();
+        SqlExecutor executor = new SqlExecutor(coreSchema);
+
+        //rs = conn.getMetaData().getFunctions(dbName, tempSchemaName, "%");
+
+        new SqlSelector(coreSchema, "SELECT proname AS SPECIFIC_NAME, CAST(proargtypes AS VARCHAR) FROM pg_proc WHERE pronamespace=(select oid from pg_namespace where nspname = ?)", DbSchema.getTemp().getName()).forEach(
+            new ForEachBlock<>()
+            {
+                private Map<String, String> _types = null;
+
+                @Override
+                public void exec(ResultSet rs) throws SQLException
+                {
+                    if (null == _types)
+                    {
+                        _types = new HashMap<>();
+                        new SqlSelector(coreSchema, "SELECT CAST(oid AS VARCHAR) as oid, typname, (select nspname from pg_namespace where oid = typnamespace) as nspname FROM pg_type").forEach(type ->
+                            _types.put(type.getString(1), quoteIdentifier(type.getString(3)) + "." + quoteIdentifier(type.getString(2))));
+                    }
+
+                    String name = rs.getString(1);
+                    String[] oids = StringUtils.split(rs.getString(2), ' ');
+                    SQLFragment drop = new SQLFragment("DROP FUNCTION temp.").append(name);
+                    drop.append("(");
+                    String comma = "";
+                    for (String oid : oids)
+                    {
+                        drop.append(comma).append(_types.get(oid));
+                        comma = ",";
+                    }
+                    drop.append(")");
+
+                    try
+                    {
+                        executor.execute(drop);
+                    }
+                    catch (BadSqlGrammarException x)
+                    {
+                        LOG.warn("could not clean up postgres function : temp." + name, x);
+                    }
+                }
+            });
+
+        // TODO delete types in temp schema as well! search for "CREATE TYPE" in StatementUtils.java
+    }
 
     //
     // ARRAY and SET syntax

--- a/list/src/org/labkey/list/controllers/ListController.java
+++ b/list/src/org/labkey/list/controllers/ListController.java
@@ -19,7 +19,6 @@ package org.labkey.list.controllers;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
@@ -217,8 +216,8 @@ public class ListController extends SpringActionController
             SimpleFilter filter = new SimpleFilter();
 
             SQLFragment sql = new SQLFragment("Category IS NULL OR Category = ")
-                    .appendValue(ListDefinition.Category.PublicPicklist)
-                    .append(" OR CreatedBy = ").appendValue(getUser().getUserId());
+                .appendValue(ListDefinition.Category.PublicPicklist)
+                .append(" OR CreatedBy = ").appendValue(getUser().getUserId());
             filter.addWhereClause(sql, FieldKey.fromParts("Category"), FieldKey.fromParts("CreatedBy"));
             settings.setBaseFilter(filter);
 


### PR DESCRIPTION
[Github epic](https://github.com/LabKey/kanban/issues/1499)

#### Rationale
We need to lowercase all ENTITYIDs during SQL Server migration. We also need to address a few issues and complications introduced by the cloning migration work and other recent changes.

Fix a variety of `SimpleFilter` issues uncovered during the cloning migration work. Add regression tests for these issues.

`IN (NULL)` has been used in various places as a substitute for `FALSE`. This construct is problematic because `NULL` is considered an unknown value in SQL, which means `IN (NULL)` evaluates to FALSE but `NOT IN (NULL)` _also_ evaluates to FALSE, which can lead to surprising results. For example, in LabKey, `new InClause(fk, emptyList)` selects no rows and `new NotClause(new InClause(fk, emptyList))` also selects no rows.

#### SQL Server Migration Changes
- Eliminate `DatabaseMigrationConfiguration.getColumnNameFilter()`; each configuration's `getTableSelector()` method can filter columns, if needed.
- Bootstrap Users and Guests groups during bootstrap. Delete them before migration.
- Rework attachment copying to simplify the SQL Server migration case: all rows are copied with no filtering and no need to enumerate or track `AttachmentParentTypes`. Recognize `Image` data type as a large binary type.
- Provide a mechanism for schemas to map arbitrary GUID values that reside in non-GUID-typed columns to lowercase. Implement for `core.PortalWebparts` (GUID values are embedded in webpart properties) and `comm.Announcements` (GUID values can be used as DiscussionSrcIdentifiers).

#### PostgreSQL Dialect and `SimpleFilter.FilterClause` Changes
- `BasePostgreSqlDialect` is common to Redshift and PostgreSQL; move PostgreSQL-specific methods from BasePostgreSqlDialect to `PostgreSql92Dialect`.
- Fix completely broken `SQLClause.equals()`
- Fix `SqlDialect.testLikeOperator()` when scopes with different dialects are present. All configured scopes are tested, but the debug string used by the test was always generated assuming the LabKey scope.
- Replace use of `IN (NULL)` to represent `FALSE` with `0 = 1`

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->