### PR TITLE
Drop columns that supported object-level discussions

### DIFF
--- a/announcements/resources/schemas/comm.xml
+++ b/announcements/resources/schemas/comm.xml
@@ -121,9 +121,6 @@
       <column columnName="DiscussionSrcEntityType">
           <description>A string representing the entity type of the discussion source.</description>
       </column>
-      <column columnName="DiscussionSrcURL">
-          <description>URL to the display the object to which this message is attached. Always null for rows that are part of the default forum for the container</description>
-      </column>
       <column columnName="LastIndexed">
           <isReadOnly>true</isReadOnly>
           <isUserEditable>false</isUserEditable>
@@ -518,7 +515,6 @@
       </column>
       <column columnName="LatestId"/>
       <column columnName="discussionsrcidentifier"/>
-      <column columnName="discussionsrcurl"/>
       <column columnName="ResponseCount"/>
         <column columnName="Modified">
           <columnTitle>Modified</columnTitle>

--- a/announcements/resources/schemas/dbscripts/postgresql/comm-25.002-25.003.sql
+++ b/announcements/resources/schemas/dbscripts/postgresql/comm-25.002-25.003.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comm.Announcements DROP COLUMN DiscussionSrcURL;

--- a/announcements/resources/schemas/dbscripts/postgresql/comm-create.sql
+++ b/announcements/resources/schemas/dbscripts/postgresql/comm-create.sql
@@ -19,7 +19,7 @@
 CREATE VIEW comm.Threads AS
     SELECT threads.*, props.Title, props.AssignedTo, props.Status, props.Expires, props.CreatedBy AS ResponseCreatedBy, props.Created AS ResponseCreated FROM
     (
-        SELECT parents.RowId, parents.EntityId, parents.Container, parents.Body, parents.RendererType, parents.DiscussionSrcIdentifier, parents.DiscussionSrcURL,
+        SELECT parents.RowId, parents.EntityId, parents.Container, parents.Body, parents.RendererType, parents.DiscussionSrcIdentifier,
             parents.CreatedBy, parents.Created, parents.Modified, parents.LastIndexed, COALESCE(LastResponseId, RowId) AS LatestId, COALESCE(ResponseCount, 0) AS ResponseCount
         FROM comm.Announcements parents LEFT OUTER JOIN
         (

--- a/announcements/resources/schemas/dbscripts/sqlserver/comm-25.002-25.003.sql
+++ b/announcements/resources/schemas/dbscripts/sqlserver/comm-25.002-25.003.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comm.Announcements DROP COLUMN DiscussionSrcURL;

--- a/announcements/resources/schemas/dbscripts/sqlserver/comm-create.sql
+++ b/announcements/resources/schemas/dbscripts/sqlserver/comm-create.sql
@@ -19,7 +19,7 @@
 CREATE VIEW comm.Threads AS
     SELECT threads.*, props.Title, props.AssignedTo, props.Status, props.Expires, props.CreatedBy AS ResponseCreatedBy, props.Created AS ResponseCreated FROM
     (
-        SELECT parents.RowId, parents.EntityId, parents.Container, parents.Body, parents.RendererType, parents.DiscussionSrcIdentifier, parents.DiscussionSrcURL,
+        SELECT parents.RowId, parents.EntityId, parents.Container, parents.Body, parents.RendererType, parents.DiscussionSrcIdentifier,
             parents.CreatedBy, parents.Created, parents.Modified, parents.LastIndexed, COALESCE(LastResponseId, RowId) AS LatestId, COALESCE(ResponseCount, 0) AS ResponseCount
         FROM comm.Announcements parents LEFT OUTER JOIN
         (

--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -93,7 +93,7 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 25.002;
+        return 25.003;
     }
 
     @Override

--- a/announcements/src/org/labkey/announcements/query/ThreadsTable.java
+++ b/announcements/src/org/labkey/announcements/query/ThreadsTable.java
@@ -33,7 +33,6 @@ public class ThreadsTable extends FilteredTable<AnnouncementSchema>
         removeColumn(getColumn("Body"));
         removeColumn(getColumn("RendererType"));
         removeColumn(getColumn("DiscussionSrcIdentifier"));
-        removeColumn(getColumn("DiscussionSrcUrl"));
         removeColumn(getColumn("Container"));
         var folderColumn = wrapColumn("Folder", getRealTable().getColumn("Container"));
         folderColumn.setFk(new ContainerForeignKey(userSchema));

--- a/experiment/resources/schemas/dbscripts/postgresql/exp-25.015-25.016.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-25.015-25.016.sql
@@ -1,0 +1,1 @@
+ALTER TABLE exp.List DROP COLUMN DiscussionSetting;

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-25.015-25.016.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-25.015-25.016.sql
@@ -1,0 +1,2 @@
+EXEC core.fn_dropifexists 'List', 'exp', 'DEFAULT', 'DiscussionSetting';
+ALTER TABLE exp.List DROP COLUMN DiscussionSetting;

--- a/experiment/resources/schemas/exp.xml
+++ b/experiment/resources/schemas/exp.xml
@@ -233,7 +233,6 @@
           <column columnName="TitleColumn" />
           <column columnName="Description" />
           <column columnName="Category"/>
-          <column columnName="DiscussionSetting" />
           <column columnName="AllowDelete" />
           <column columnName="AllowUpload" />
           <column columnName="AllowExport" />

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -202,7 +202,7 @@ public class ExperimentModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 25.015;
+        return 25.016;
     }
 
     @Nullable


### PR DESCRIPTION
#### Rationale
The "object-level discussions" feature was removed in the related PR. This cleans up the remaining, unused database columns.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7092