### PR TITLE
Add webpack protocol to ContentSecurityPolicyFilter

### DIFF
--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -92,10 +92,10 @@ public class ContentSecurityPolicyFilter implements Filter
     static
     {
         // ReactJS hot reload uses localhost port 3001. If in dev mode, allow the browser to access that port for fonts
-        // and connections.
+        // and connections. Also allow webpack: protocol for source map loading by some external packages.
         if (AppProps.getInstance().isDevMode())
         {
-            registerAllowedSources("reactjs.hot.reload", Directive.Connection, "localhost:3001 ws://localhost:3001");
+            registerAllowedSources("reactjs.hot.reload", Directive.Connection, "localhost:3001 ws://localhost:3001 webpack:");
             registerAllowedSources("reactjs.hot.reload", Directive.Font, "localhost:3001");
         }
     }


### PR DESCRIPTION
#### Rationale
Some external React dependencies serve up source maps using the webpack: protocol. This is fully dependent on their webpack configuration and out of our control. Add the webpack protocol to CSP filtering while in dev mode.

#### Changes
- Update ContentSecurityPolicyFilter hot reloading directive
