### PR TITLE
Remove lower casing of fields in audit details maps

### DIFF
--- a/api/src/org/labkey/api/audit/AuditHandler.java
+++ b/api/src/org/labkey/api/audit/AuditHandler.java
@@ -116,8 +116,6 @@ public interface AuditHandler
                     nameFromAlias = encodedInputColumn;
                 }
             }
-            else
-                nameFromAlias = lcName;
 
             boolean isExtraAuditField = extraFieldsToInclude != null && extraFieldsToInclude.contains(nameFromAlias);
             if (!excludedFromDetailDiff.contains(nameFromAlias) && (row.containsKey(nameFromAlias) || isExpInput))

--- a/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
+++ b/experiment/src/org/labkey/experiment/api/ExpDataClassDataTestCase.jsp
@@ -1257,7 +1257,7 @@ public void testUpdateAuditForLongField() throws Exception
         List<AuditTypeEvent> events = AuditLogService.get().getAuditEvents(c, user, "QueryUpdateAuditEvent", filter, new Sort("-RowId"));
         assertEquals("Number of audit events not as expected", 2, events.size()); // should have one for insert and one for update
         String oldRecordMap = ((DetailedAuditTypeEvent) events.get(0)).getOldRecordMap();
-        assertTrue("Old record map (" + oldRecordMap + ") does not contain expected field", oldRecordMap.contains(encodeURIComponent(fieldName.toLowerCase()) + "=Initial"));
+        assertTrue("Old record map (" + oldRecordMap + ") does not contain expected field", oldRecordMap.contains(encodeURIComponent(fieldName) + "=Initial"));
     }
 }
 %>


### PR DESCRIPTION
#### Rationale
Issue [495](https://github.com/LabKey/internal-issues/issues/495) - We sometimes capitalize the names of types and field names when it is not necessary. This includes, but may not be limited to, the parent type names when adding lineage in an editable grid and the names of fields in audit event details. In addition to that we are lower casing field names in the audit log old data map and new data map, which is also not necessary. This PR removes that lower casing.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1880
- https://github.com/LabKey/labkey-ui-components/pull/1916

#### Changes
- Remove setting of nameFromAlias to lower cased name

