### PR TITLE
Expose EntityId columns wiki queries

### DIFF
--- a/announcements/resources/schemas/comm.xml
+++ b/announcements/resources/schemas/comm.xml
@@ -405,6 +405,7 @@
         <formatString>DateTime</formatString>
       </column>
       <column columnName="Body"/>
+      <column columnName="EntityId"/>
     </columns>
   </table>
   <table tableName="AllWikiVersions" tableDbType="VIEW" useColumnOrder="true">
@@ -450,6 +451,7 @@
         <formatString>DateTime</formatString>
       </column>
       <column columnName="Body"/>
+      <column columnName="EntityId"/>
     </columns>
   </table>
   <table tableName="UserList" tableDbType="TABLE">

--- a/announcements/resources/schemas/dbscripts/postgresql/comm-create.sql
+++ b/announcements/resources/schemas/dbscripts/postgresql/comm-create.sql
@@ -73,11 +73,11 @@ CREATE VIEW comm.PagePaths AS
 
 -- View that joins each wiki with its current version (one row per wiki)
 CREATE VIEW comm.CurrentWikiVersions AS
-    SELECT pv.RowId, p.Container, p.Name, p.Path, p.PathParts, p.Depth, pv.Title, pv.Version, pv.Body, pv.RendererType, p.CreatedBy, p.Created, p.ModifiedBy, p.Modified
+    SELECT pv.RowId, p.EntityId, p.Container, p.Name, p.Path, p.PathParts, p.Depth, pv.Title, pv.Version, pv.Body, pv.RendererType, p.CreatedBy, p.Created, p.ModifiedBy, p.Modified
         FROM comm.PagePaths p INNER JOIN comm.PageVersions pv ON p.PageVersionId = pv.RowId;
 
 -- View that joins every wiki version with its parent (one row per wiki version). Report the wiki's Created & CreatedBy,
 -- but map the version's Created & CreatedBy to Modified & ModifiedBy, because that seems like the most useful mapping.
 CREATE VIEW comm.AllWikiVersions AS
-    SELECT pv.RowId, p.Container, p.Name, p.Path, p.PathParts, p.Depth, pv.Title, pv.Version, pv.Body, pv.RendererType, p.CreatedBy, p.Created, pv.CreatedBy AS ModifiedBy, pv.Created AS Modified
+    SELECT pv.RowId, p.EntityId, p.Container, p.Name, p.Path, p.PathParts, p.Depth, pv.Title, pv.Version, pv.Body, pv.RendererType, p.CreatedBy, p.Created, pv.CreatedBy AS ModifiedBy, pv.Created AS Modified
         FROM comm.PageVersions pv INNER JOIN comm.PagePaths p ON pv.PageEntityId = p.EntityId;

--- a/announcements/resources/schemas/dbscripts/sqlserver/comm-create.sql
+++ b/announcements/resources/schemas/dbscripts/sqlserver/comm-create.sql
@@ -76,7 +76,7 @@ GO
 
 -- View that joins each wiki with its current version (one row per wiki)
 CREATE VIEW comm.CurrentWikiVersions AS
-    SELECT pv.RowId, p.Container, p.Name, p.Path, p.PathParts, p.Depth, pv.Title, pv.Version, pv.Body, pv.RendererType, p.CreatedBy, p.Created, p.ModifiedBy, p.Modified
+    SELECT pv.RowId, p.EntityId, p.Container, p.Name, p.Path, p.PathParts, p.Depth, pv.Title, pv.Version, pv.Body, pv.RendererType, p.CreatedBy, p.Created, p.ModifiedBy, p.Modified
         FROM comm.PagePaths p INNER JOIN comm.PageVersions pv ON p.PageVersionId = pv.RowId;
 
 GO
@@ -84,7 +84,7 @@ GO
 -- View that joins every wiki version with its parent (one row per wiki version). Report the wiki's Created & CreatedBy,
 -- but map the version's Created & CreatedBy to Modified & ModifiedBy, because that seems like the most useful mapping.
 CREATE VIEW comm.AllWikiVersions AS
-    SELECT pv.RowId, p.Container, p.Name, p.Path, p.PathParts, p.Depth, pv.Title, pv.Version, pv.Body, pv.RendererType, p.CreatedBy, p.Created, pv.CreatedBy AS ModifiedBy, pv.Created AS Modified
+    SELECT pv.RowId, p.EntityId, p.Container, p.Name, p.Path, p.PathParts, p.Depth, pv.Title, pv.Version, pv.Body, pv.RendererType, p.CreatedBy, p.Created, pv.CreatedBy AS ModifiedBy, pv.Created AS Modified
         FROM comm.PageVersions pv INNER JOIN comm.PagePaths p ON pv.PageEntityId = p.EntityId;
 
 GO

--- a/announcements/src/org/labkey/announcements/AnnouncementModule.java
+++ b/announcements/src/org/labkey/announcements/AnnouncementModule.java
@@ -98,7 +98,7 @@ public class AnnouncementModule extends DefaultModule implements SearchService.D
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 26.000;
+        return 26.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
We don't have a way to get the EntityId for a wiki via LabKey SQL, but it can be useful to correlate with attachments.

#### Changes
- Add `EntityId` to `wiki.AllWikiVersions` and `wiki.CurrentWikiVersions`
