### PR TITLE
GitHub Issue 717: Reserve fields from ExpDataTable in DataClassDomainKind

### DIFF
--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -48,6 +48,7 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.query.DataClassUserSchema;
 import org.labkey.api.exp.query.ExpDataClassDataTable;
+import org.labkey.api.exp.query.ExpDataClassTable;
 import org.labkey.api.exp.query.ExpDataTable;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.gwt.client.model.GWTDomain;
@@ -110,6 +111,7 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
         names.add("Container");
         // GitHub Issue 717
         names.addAll(Arrays.stream(ExpDataTable.Column.values()).map(ExpDataTable.Column::name).toList());
+        names.addAll(Arrays.stream(ExpDataClassTable.Column.values()).map(ExpDataClassTable.Column::name).toList());
 
         RESERVED_NAMES = DomainUtil.getNamesAndLabels(names);
 

--- a/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
+++ b/experiment/src/org/labkey/experiment/api/DataClassDomainKind.java
@@ -48,6 +48,7 @@ import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.query.DataClassUserSchema;
 import org.labkey.api.exp.query.ExpDataClassDataTable;
+import org.labkey.api.exp.query.ExpDataTable;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.gwt.client.model.GWTDomain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
@@ -107,6 +108,8 @@ public class DataClassDomainKind extends AbstractDomainKind<DataClassDomainKindP
         names.addAll(Arrays.stream(ExpDataClassDataTable.Column.values()).map(ExpDataClassDataTable.Column::name).toList());
         names.add("RunId"); // Issue 50461
         names.add("Container");
+        // GitHub Issue 717
+        names.addAll(Arrays.stream(ExpDataTable.Column.values()).map(ExpDataTable.Column::name).toList());
 
         RESERVED_NAMES = DomainUtil.getNamesAndLabels(names);
 


### PR DESCRIPTION
#### Rationale
Issue [717](https://github.com/LabKey/internal-issues/issues/717) The data class domain kind does not reserve fields from the ExpDataTable, in contrast to the corresponding domain kind and table for samples. This PR fixes that.

#### Related Pull Requests
- https://github.com/LabKey/testAutomation/pull/2836

#### Changes
- Add `ExpDataTable.Column`s as reserved fields for data classes.
