### PR TITLE
GitHub Issue 751: Assay import with transform script conversion error for numeric Sample IDs

### DIFF
--- a/api/src/org/labkey/api/qc/TsvDataSerializer.java
+++ b/api/src/org/labkey/api/qc/TsvDataSerializer.java
@@ -150,6 +150,7 @@ public class TsvDataSerializer implements DataExchangeHandler.DataSerializer
         Domain dataDomain = provider.getResultsDomain(protocol);
         DataLoaderSettings loaderSettings = new DataLoaderSettings();
         loaderSettings.setAllowUnexpectedColumns(true);
+        loaderSettings.setBestEffortConversion(true); // GitHub Issue 751: setBestEffortConversion to match TsvDataExchangeHandler._writeRunData
 
         return context -> {
             FileLike fo = new FileSystemLike.Builder(runData.toURI()).readonly().root();


### PR DESCRIPTION
#### Rationale
[#751](https://github.com/LabKey/internal-issues/issues/751) Assay incorrectly looking for RowIDs when Sample IDs look numeric (with Transform script)

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7316
- https://github.com/LabKey/limsModules/pull/1902

#### Changes
- DataLoaderSettings to setBestEffortConversion(true) for post transform script data parsing, to match pre transform data parsing