### PR TITLE
Add the list of webparts for the container. 

### DIFF
--- a/api/src/org/labkey/api/data/ContainerTable.java
+++ b/api/src/org/labkey/api/data/ContainerTable.java
@@ -16,7 +16,6 @@
 
 package org.labkey.api.data;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
@@ -39,6 +38,7 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.SimpleNamedObject;
 import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.Portal;
 import org.labkey.api.webdav.WebdavResource;
 import org.labkey.api.webdav.WebdavService;
 
@@ -174,14 +174,23 @@ public class ContainerTable extends FilteredTable<UserSchema>
         var title = getMutableColumn("Title");
         title.setURL(detailsURL);
 
+        // everything except activeModules and webParts
+        setDefaultVisibleColumns(getDefaultVisibleColumns());
+
         var activeModules = new AliasedColumn("ActiveModules", getColumn("RowId"));
         activeModules.setDisplayColumnFactory(ActiveModulesDisplayColumn::new);
         activeModules.setReadOnly(true);
-        activeModules.setHidden(true);
         addColumn(activeModules);
 
+        SQLFragment webpartNamesSQL = new SQLFragment("(SELECT ")
+                .append(getSqlDialect().getGroupConcat(new SQLFragment("PWP.name"), true, true, ", "))
+                .append(" FROM ").append(Portal.getTableInfoPortalWebParts(), "PWP")
+                .append(" WHERE PWP.container = " + ExprColumn.STR_TABLE_ALIAS + ".entityId)");
+        ExprColumn webpartColumn = new ExprColumn(this, "WebParts", webpartNamesSQL, JdbcType.VARCHAR);
+        webpartColumn.setReadOnly(true);
+        addColumn(webpartColumn);
+
         setTitleColumn("DisplayName");
-        
         setImportURL(LINK_DISABLER);
     }
 
@@ -205,6 +214,9 @@ public class ContainerTable extends FilteredTable<UserSchema>
         public ActiveModulesDisplayColumn(ColumnInfo rowIdCol)
         {
             super(rowIdCol, String.class);
+            // VARCHAR rendering
+            _textAlign = "left";
+            _nowrap = false;
         }
 
         @Override

--- a/api/src/org/labkey/api/data/ContainerTable.java
+++ b/api/src/org/labkey/api/data/ContainerTable.java
@@ -220,6 +220,18 @@ public class ContainerTable extends FilteredTable<UserSchema>
         }
 
         @Override
+        public boolean isSortable()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isFilterable()
+        {
+            return false;
+        }
+
+        @Override
         protected String transformValue(Integer rawValue)
         {
             if (rawValue == null)

--- a/core/src/org/labkey/core/query/ModulesTableInfo.java
+++ b/core/src/org/labkey/core/query/ModulesTableInfo.java
@@ -19,13 +19,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnDecorator;
 import org.labkey.api.data.DisplayColumnFactory;
-import org.labkey.api.data.ExpandableTextDisplayColumnFactory;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
@@ -39,11 +36,7 @@ import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.writer.HtmlWriter;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * User: kevink
@@ -101,7 +94,6 @@ public class ModulesTableInfo extends SimpleUserSchema.SimpleTable<CoreQuerySche
         var licenseCol = addTextColumn("License");
         licenseCol.setURL(StringExpressionFactory.createURL("${LicenseURL}"));
         licenseCol.setURLTarget("_blank");
-        addTextColumn("ActiveFolders").setDisplayColumnFactory(new ExpandableTextDisplayColumnFactory());
         addTextColumn("LicenseURL").setHidden(true);
         addTextColumn("VcsRevision");
         addTextColumn("VcsURL");
@@ -117,8 +109,7 @@ public class ModulesTableInfo extends SimpleUserSchema.SimpleTable<CoreQuerySche
             FieldKey.fromParts("SchemaVersion"),
             FieldKey.fromParts("Label"),
             FieldKey.fromParts("Organization"),
-            FieldKey.fromParts("License"),
-            FieldKey.fromParts("ActiveFolders")
+            FieldKey.fromParts("License")
         ));
     }
 
@@ -192,7 +183,6 @@ public class ModulesTableInfo extends SimpleUserSchema.SimpleTable<CoreQuerySche
         cte.append("VALUES ");
         String sep = "";
 
-        Map<Module, List<String>> moduleContainers = getContainersForModule();
         for (Module module : ModuleLoader.getInstance().getModules())
         {
             cte.append(sep);
@@ -214,7 +204,6 @@ public class ModulesTableInfo extends SimpleUserSchema.SimpleTable<CoreQuerySche
             appendStringLiteral(h, cte,",",module.getSourcePath());
             appendStringLiteral(h, cte,",",StringUtils.join(module.getModuleDependenciesAsSet(), ", "));
             appendStringLiteral(h, cte,",",module.getSupportedDatabasesSet().toString());
-            appendStringLiteral(h, cte,",", StringUtils.join(moduleContainers.getOrDefault(module, Collections.emptyList()), "\n"));
             cte.append(")");
         }
         cte.append(") AS T (");
@@ -231,7 +220,6 @@ public class ModulesTableInfo extends SimpleUserSchema.SimpleTable<CoreQuerySche
         cte.append(",VcsRevision, VcsURL");
         cte.append(",SourcePath");
         cte.append(",Dependencies, SupportedDatabases");
-        cte.append(",ActiveFolders");
         cte.append(")\n");
 
         String tableName = getSqlDialect().truncate(alias + "$m", 0);
@@ -250,22 +238,6 @@ public class ModulesTableInfo extends SimpleUserSchema.SimpleTable<CoreQuerySche
         ret.append("\n").append(filterFrag).append(") ").appendIdentifier(alias);
 
         return ret;
-    }
-
-    private Map<Module, List<String>> getContainersForModule()
-    {
-        Map<Module, List<String>> moduleFolders = new HashMap<>();
-
-        for (Container container : ContainerManager.getAllChildren(ContainerManager.getRoot()))
-        {
-            if (container != null)
-                container.getActiveModules().forEach(m -> moduleFolders.computeIfAbsent(m, k -> new ArrayList<>()).add(container.getPath()));
-        }
-
-        for (List<String> folders : moduleFolders.values())
-            Collections.sort(folders);
-
-        return moduleFolders;
     }
 
     // Format SchemaVersion column using the standard ModuleContext formatting rules: force three-decimal places for >= 20.000,


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/internal-issues/issues/685

This adds a `WebParts` column to the `core.containers` table to track webparts per container. Additionally we are removing the recently added `ActiveFolders` column from `core.modules`. The equivalent information was already available as `ActiveModules` in `core.containers` but went largely unnoticed because it was hidden.

Both `WebParts` and `ActiveModules` are not hidden but will not be included in the default view.