### PR TITLE
Experiment: Fix filter for deleting data/material input

### DIFF
--- a/api/src/org/labkey/api/exp/api/ExpLineage.java
+++ b/api/src/org/labkey/api/exp/api/ExpLineage.java
@@ -384,7 +384,7 @@ public class ExpLineage
                 }
                 else // ExpMaterial or generic Identifiable
                 {
-                    if (!seen.contains(target))
+                    if (!seen.contains(target) && target != null)
                     {
                         stack.add(target);
                         seen.add(target);

--- a/experiment/src/org/labkey/experiment/api/ExpProtocolApplicationImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpProtocolApplicationImpl.java
@@ -397,7 +397,7 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
         OntologyManager.deleteOntologyObjects(svc.getSchema(), new SQLFragment("SELECT " +
             dialect.concatenate("'" + DataInput.lsidPrefix() + "'",
                     "CAST(dataId AS VARCHAR)", "'.'", "CAST(targetApplicationId AS VARCHAR)") +
-            " FROM " + svc.getTinfoDataInput() + " WHERE TargetApplicationId IN (SELECT RowId FROM exp.ProtocolApplication WHERE RunId = " + getRowId() + ")"), getContainer());
+            " FROM " + svc.getTinfoDataInput() + " WHERE TargetApplicationId = ?", getRowId()), getContainer());
 
         return Table.delete(ExperimentServiceImpl.get().getTinfoDataInput(), new SimpleFilter(FieldKey.fromParts("TargetApplicationId"), getRowId()));
     }
@@ -413,7 +413,7 @@ public class ExpProtocolApplicationImpl extends ExpIdentifiableBaseImpl<Protocol
         OntologyManager.deleteOntologyObjects(svc.getSchema(), new SQLFragment("SELECT " +
             dialect.concatenate("'" + MaterialInput.lsidPrefix() + "'",
                     "CAST(materialId AS VARCHAR)", "'.'", "CAST(targetApplicationId AS VARCHAR)") +
-            " FROM " + svc.getTinfoMaterialInput() + " WHERE TargetApplicationId IN (SELECT RowId FROM exp.ProtocolApplication WHERE RunId = " + getRowId() + ")"), getContainer());
+            " FROM " + svc.getTinfoMaterialInput() + " WHERE TargetApplicationId = ?", getRowId()), getContainer());
 
         return Table.delete(ExperimentServiceImpl.get().getTinfoMaterialInput(), new SimpleFilter(FieldKey.fromParts("TargetApplicationId"), getRowId()));
     }


### PR DESCRIPTION
#### Rationale
This addresses [#759](https://github.com/LabKey/internal-issues/issues/759) by fixing the scope of the clause for which ontology objects to delete when removing data/material inputs for experiment protocol applications.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1903

#### Changes
- Fix filter for data/material input