### PR TITLE
GitHub Issue 778: Track selection loading state on DataRegion so we can disable buttons and prevent another click

### DIFF
--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -4505,14 +4505,17 @@ if (!LABKEY.DataRegions) {
             }
 
             // NOTE: ignore maxRows, showRows, and offset
+        } else {
+            params = LABKEY.ActionURL.getParameters(config.url);
+            config.url = LABKEY.ActionURL.buildURL('query', 'selectAll.api', config.containerPath);
         }
 
         LABKEY.Ajax.request({
             url: config.url,
             method: 'POST',
-            params: params,
-            success: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnSuccess(config), config.scope),
-            failure: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnFailure(config), config.scope, true)
+            jsonData: params,
+            success: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnSuccess(config), region),
+            failure: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnFailure(config), region, true)
         });
     };
 

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -3051,23 +3051,7 @@ if (!LABKEY.DataRegions) {
 
     var _chainSelectionCountCallback = function(region, config) {
 
-        var success = LABKEY.Utils.getOnSuccess(config);
-
-        // On success, update the current selectedCount on this DataRegion and fire the 'selectchange' event
-        config.success = function(data) {
-            region.removeMessage('selection');
-            region.selectionModified = true;
-            region.selectionLoading = false;
-            region.selectedCount = data.count;
-            _onSelectionChange(region);
-
-            // Chain updateSelected with the user-provided success callback
-            if ($.isFunction(success)) {
-                success.call(config.scope, data);
-            }
-        };
-
-        var failure = LABKEY.Utils.getOnFailure(config);
+        const failure = LABKEY.Utils.getOnFailure(config);
         config.failure = function(error) {
             region.selectionLoading = false;
 
@@ -3079,6 +3063,35 @@ if (!LABKEY.DataRegions) {
                 failure.call(config.scope, error);
             }
         }
+
+        // On success, update the current selectedCount on this DataRegion and fire the 'selectchange' event
+        const success = LABKEY.Utils.getOnSuccess(config);
+        config.success = function(data, response) {
+
+            // Workaround for GitHub Issue 778 where the response payload is JSON but the response has been
+            // configured by the server as non-JSON.
+            if (!data && response?.responseText) {
+                try {
+                    data = JSON.parse(response.responseText);
+                } catch (e) {
+                    const msg = 'failed to parse response';
+                    console.error(msg, e, response);
+                    config.failure.call(config.scope, { exception: msg });
+                    return;
+                }
+            }
+
+            region.removeMessage('selection');
+            region.selectionModified = true;
+            region.selectionLoading = false;
+            region.selectedCount = data.count;
+            _onSelectionChange(region);
+
+            // Chain updateSelected with the user-provided success callback
+            if ($.isFunction(success)) {
+                success.call(config.scope, data);
+            }
+        };
 
         return config;
     };
@@ -4505,15 +4518,12 @@ if (!LABKEY.DataRegions) {
             }
 
             // NOTE: ignore maxRows, showRows, and offset
-        } else {
-            params = LABKEY.ActionURL.getParameters(config.url);
-            config.url = LABKEY.ActionURL.buildURL('query', 'selectAll.api', config.containerPath);
         }
 
         LABKEY.Ajax.request({
             url: config.url,
             method: 'POST',
-            jsonData: params,
+            params: params,
             success: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnSuccess(config), region),
             failure: LABKEY.Utils.getCallbackWrapper(LABKEY.Utils.getOnFailure(config), region, true)
         });

--- a/api/webapp/clientapi/dom/DataRegion.js
+++ b/api/webapp/clientapi/dom/DataRegion.js
@@ -493,6 +493,7 @@ if (!LABKEY.DataRegions) {
          * Non-configurable Options
          */
         this.selectionModified = false;
+        this.selectionLoading = false;
 
         if (this.panelConfigurations === undefined) {
             this.panelConfigurations = {};
@@ -1171,19 +1172,11 @@ if (!LABKEY.DataRegions) {
         config.selectionKey = this.selectionKey;
         config.scope = config.scope || me;
 
-        config = _chainSelectionCountCallback(this, config);
+        // set loading flag for DataRegion, will be cleared in callback
+        this.selectionLoading = true;
+        _updateSelectedCountMessage(this);
 
-        var failure = LABKEY.Utils.getOnFailure(config);
-        if ($.isFunction(failure)) {
-            config.failure = failure;
-        }
-        else {
-            config.failure = function(error) {
-                let msg = 'Error setting selection';
-                if (error && error.exception) msg += ': ' + error.exception;
-                me.addMessage(msg, 'selection');
-            };
-        }
+        config = _chainSelectionCountCallback(this, config);
 
         if (config.selectionKey) {
             LABKEY.DataRegion.setSelected(config);
@@ -3064,6 +3057,7 @@ if (!LABKEY.DataRegions) {
         config.success = function(data) {
             region.removeMessage('selection');
             region.selectionModified = true;
+            region.selectionLoading = false;
             region.selectedCount = data.count;
             _onSelectionChange(region);
 
@@ -3072,6 +3066,19 @@ if (!LABKEY.DataRegions) {
                 success.call(config.scope, data);
             }
         };
+
+        var failure = LABKEY.Utils.getOnFailure(config);
+        config.failure = function(error) {
+            region.selectionLoading = false;
+
+            let msg = 'Error setting selection';
+            if (error && error.exception) msg += ': ' + error.exception;
+            config.scope.addMessage(msg, 'selection');
+
+            if ($.isFunction(failure)) {
+                failure.call(config.scope, error);
+            }
+        }
 
         return config;
     };
@@ -3363,7 +3370,10 @@ if (!LABKEY.DataRegions) {
     var _buttonSelectionBind = function(region, cls, fn) {
         var partEl = region.msgbox.getParent().find('div[data-msgpart="selection"]');
         partEl.find('.labkey-button' + cls).off('click').on('click', $.proxy(function() {
-            fn.call(this);
+            // if one of the buttons is clicked while another action is loading selections, skip the click (the button should also be disabled)
+            if (!region.selectionLoading) {
+                fn.call(this);
+            }
         }, region));
     };
 
@@ -3592,18 +3602,20 @@ if (!LABKEY.DataRegions) {
 
     var _showSelectMessage = function(region, msg) {
         if (region.showRecordSelectors) {
+            const cls = 'labkey-button ' + (region.selectionLoading ? 'disabled ' : '');
+
             if (_isShowSelectAll(region)) {
-                msg += "&nbsp;<span class='labkey-button select-all'>" + _getSelectAllText(region) + "</span>";
+                msg += "&nbsp;<span class='" + cls + " select-all'>" + _getSelectAllText(region) + "</span>";
             }
 
-            msg += "&nbsp;" + "<span class='labkey-button select-none'>Select None</span>";
+            msg += "&nbsp;" + "<span class='" + cls + " select-none'>Select None</span>";
             var showOpts = [];
             if (region.showRows !== 'all' && !_isMaxRowsAllRows(region))
-                showOpts.push("<span class='labkey-button show-all'>Show All</span>");
+                showOpts.push("<span class='" + cls + " show-all'>Show All</span>");
             if (region.showRows !== 'selected')
-                showOpts.push("<span class='labkey-button show-selected'>Show Selected</span>");
+                showOpts.push("<span class='" + cls + " show-selected'>Show Selected</span>");
             if (region.showRows !== 'unselected')
-                showOpts.push("<span class='labkey-button show-unselected'>Show Unselected</span>");
+                showOpts.push("<span class='" + cls + " show-unselected'>Show Unselected</span>");
             msg += "&nbsp;&nbsp;" + showOpts.join(" ");
         }
 
@@ -4081,6 +4093,21 @@ if (!LABKEY.DataRegions) {
         _setParameters(region, params, [OFFSET_PREFIX].concat(skipPrefixes));
     };
 
+    var _updateSelectedCountMessage = function(region) {
+        // If not all rows are visible and some rows are selected, show selection message
+        if (region.totalRows && 0 !== region.selectedCount && !region.complete) {
+            var msg;
+            if (region.selectedCount === region.totalRows) {
+                msg = 'All <span class="labkey-strong">' + region.totalRows.toLocaleString() + '</span> rows selected.';
+            } else if (region.selectionLoading) {
+                msg = 'Selected <i class="fa fa-spinner fa-pulse" ></i> of ' + region.totalRows.toLocaleString() + ' rows.';
+            } else {
+                msg = 'Selected <span class="labkey-strong">' + region.selectedCount.toLocaleString() + '</span> of ' + region.totalRows.toLocaleString() + ' rows.';
+            }
+            _showSelectMessage(region, msg);
+        }
+    }
+
     var _updateRequiresSelectionButtons = function(region, selectedCount) {
 
         // update the 'select all on page' checkbox state
@@ -4100,13 +4127,7 @@ if (!LABKEY.DataRegions) {
             }
         });
 
-        // If not all rows are visible and some rows are selected, show selection message
-        if (region.totalRows && 0 !== region.selectedCount && !region.complete) {
-            var msg = (region.selectedCount === region.totalRows) ?
-                        'All <span class="labkey-strong">' + region.totalRows.toLocaleString() + '</span> rows selected.' :
-                        'Selected <span class="labkey-strong">' + region.selectedCount.toLocaleString() + '</span> of ' + region.totalRows.toLocaleString() + ' rows.';
-            _showSelectMessage(region, msg);
-        }
+        _updateSelectedCountMessage(region);
 
         // Issue 10566: for javascript perf on IE stash the requires selection buttons
         if (!region._requiresSelectionButtons) {
@@ -4446,6 +4467,11 @@ if (!LABKEY.DataRegions) {
     };
 
     LABKEY.DataRegion.selectAll = function(config) {
+        // GitHub Issue 778: Track selection loading state on DataRegion so we can disable buttons and prevent another click
+        var region = config.scope;
+        region.selectionLoading = true;
+        _updateSelectedCountMessage(region);
+
         var params = {};
         if (!config.url) {
             // DataRegion doesn't have selectAllURL so generate url and query parameters manually


### PR DESCRIPTION
#### Rationale
[#778](https://github.com/LabKey/internal-issues/issues/778) No result when trying to select 100,000 rows when a filter is applied

Two things going on here:
1. for some reason on nightly, the selectAll post is responding with what looks like JSON but is being parsed as HTML so it is hitting a JS error when trying to get / use the "count" from the response
2. the user doesn't know that something is happening after they click on the "Select All / 100,000 Rows" button, as there is no loading spinner or disabled button in the case where the call takes some time

This PR addresses both. 1 by using jsonData to post to the selectAll API. 2 by disabling the selection buttons after click and using a loading spinner in the "Selected X of Y" text.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7107
- https://github.com/LabKey/platform/pull/7335
- https://github.com/LabKey/limsModules/pull/1921
- https://github.com/LabKey/testAutomation/pull/2848

#### Changes
- Track selection loading state on DataRegion so we can disable buttons and prevent another click
- DataRegion selectAll to use jsonData for Ajax request instead of params