### PR TITLE
Make study crosstab report more robust

### DIFF
--- a/api/src/org/labkey/api/query/UserIdForeignKey.java
+++ b/api/src/org/labkey/api/query/UserIdForeignKey.java
@@ -16,10 +16,7 @@
 
 package org.labkey.api.query;
 
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CoreSchema;
-import org.labkey.api.data.DisplayColumn;
-import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.TableInfo;
 
@@ -30,14 +27,7 @@ public class UserIdForeignKey extends LookupForeignKey
     static public <COL extends MutableColumnInfo> COL initColumn(COL column)
     {
         column.setFk(new UserIdForeignKey(column.getParentTable().getUserSchema()));
-        column.setDisplayColumnFactory(new DisplayColumnFactory()
-        {
-            @Override
-            public DisplayColumn createRenderer(ColumnInfo colInfo)
-            {
-                return new UserIdRenderer(colInfo);
-            }
-        });
+        column.setDisplayColumnFactory(UserIdRenderer::new);
         return column;
     }
 

--- a/api/src/org/labkey/api/reports/report/view/ReportDesignBean.java
+++ b/api/src/org/labkey/api/reports/report/view/ReportDesignBean.java
@@ -204,7 +204,7 @@ public class ReportDesignBean<R extends Report> extends ReportForm
         _cached = cached;
     }
 
-    public R getReport(ContainerUser cu) throws Exception
+    public R getReport(ContainerUser cu)
     {
         R report = null;
         if (null != getReportId())

--- a/api/src/org/labkey/api/reports/report/view/ScriptReportDesignBean.java
+++ b/api/src/org/labkey/api/reports/report/view/ScriptReportDesignBean.java
@@ -108,7 +108,7 @@ public class ScriptReportDesignBean extends ScriptReportBean
     }
 
     @Override
-    public ScriptReport getReport(ContainerUser cu) throws Exception
+    public ScriptReport getReport(ContainerUser cu)
     {
         Report report = super.getReport(cu);
 

--- a/api/src/org/labkey/api/study/reports/CrosstabReport.java
+++ b/api/src/org/labkey/api/study/reports/CrosstabReport.java
@@ -20,24 +20,28 @@ import org.labkey.api.data.DataRegion;
 import org.labkey.api.data.ExcelWriter;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.Results;
+import org.labkey.api.data.RuntimeSQLException;
 import org.labkey.api.data.Table;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryParam;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.query.ValidationException;
 import org.labkey.api.reports.Report;
 import org.labkey.api.reports.report.AbstractReport;
 import org.labkey.api.reports.report.ReportDescriptor;
 import org.labkey.api.reports.report.ReportUrls;
 import org.labkey.api.reports.report.view.ReportQueryView;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DataView;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.Stats;
 import org.labkey.api.view.ViewContext;
 
+import java.sql.SQLException;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -67,7 +71,7 @@ public class CrosstabReport extends AbstractReport implements Report.ResultSetGe
         return CrosstabReportDescriptor.TYPE;
     }
 
-    protected ReportQueryView createQueryView(ViewContext context, ReportDescriptor descriptor) throws Exception
+    protected ReportQueryView createQueryView(ViewContext context, ReportDescriptor descriptor)
     {
         final String queryName = descriptor.getProperty(QueryParam.queryName.toString());
         final String viewName = descriptor.getProperty(QueryParam.viewName.toString());
@@ -111,7 +115,11 @@ public class CrosstabReport extends AbstractReport implements Report.ResultSetGe
                     return new CrosstabView(crosstab, exportAction);
                 }
             }
-            catch (Exception e)
+            catch (SQLException e)
+            {
+                throw new RuntimeSQLException(e);
+            }
+            catch (ValidationException e)
             {
                 throw new RuntimeException(e);
             }
@@ -124,7 +132,7 @@ public class CrosstabReport extends AbstractReport implements Report.ResultSetGe
     }
 
     @Override
-    public Results generateResults(ViewContext context, boolean allowAsyncQuery) throws Exception
+    public Results generateResults(ViewContext context, boolean allowAsyncQuery) throws SQLException, ValidationException
     {
         ReportQueryView view = createQueryView(context, getDescriptor());
         validateQueryView(view);
@@ -141,37 +149,44 @@ public class CrosstabReport extends AbstractReport implements Report.ResultSetGe
         return null;
     }
 
-    protected Crosstab createCrosstab(ViewContext context, boolean allowAsyncQuery) throws Exception
+    protected Crosstab createCrosstab(ViewContext context, boolean allowAsyncQuery) throws SQLException, ValidationException
     {
         CrosstabReportDescriptor descriptor = (CrosstabReportDescriptor)getDescriptor();
         Results results = generateResults(context, allowAsyncQuery);
         if (results != null)
         {
-            FieldKey rowFieldKey = FieldKey.decode(descriptor.getProperty("rowField"));
-            FieldKey colFieldKey = FieldKey.decode(descriptor.getProperty("colField"));
-            FieldKey statFieldKey = FieldKey.decode(descriptor.getProperty("statField"));
-
-            Set<Stats.StatDefinition> statSet = new LinkedHashSet<>();
-            for (String stat : descriptor.getStats())
+            try
             {
-                if ("Count".equals(stat))
-                    statSet.add(Stats.COUNT);
-                else if ("Sum".equals(stat))
-                    statSet.add(Stats.SUM);
-                else if ("Mean".equals(stat))
-                    statSet.add(Stats.MEAN);
-                else if ("Min".equals(stat))
-                    statSet.add(Stats.MIN);
-                else if ("Max".equals(stat))
-                    statSet.add(Stats.MAX);
-                else if ("StdDev".equals(stat))
-                    statSet.add(Stats.STDDEV);
-                else if ("Var".equals(stat))
-                    statSet.add(Stats.VAR);
-                else if ("Median".equals(stat))
-                    statSet.add(Stats.MEDIAN);
+                FieldKey rowFieldKey = FieldKey.decode(descriptor.getProperty("rowField"));
+                FieldKey colFieldKey = FieldKey.decode(descriptor.getProperty("colField"));
+                FieldKey statFieldKey = FieldKey.decode(descriptor.getProperty("statField"));
+
+                Set<Stats.StatDefinition> statSet = new LinkedHashSet<>();
+                for (String stat : descriptor.getStats())
+                {
+                    if ("Count".equals(stat))
+                        statSet.add(Stats.COUNT);
+                    else if ("Sum".equals(stat))
+                        statSet.add(Stats.SUM);
+                    else if ("Mean".equals(stat))
+                        statSet.add(Stats.MEAN);
+                    else if ("Min".equals(stat))
+                        statSet.add(Stats.MIN);
+                    else if ("Max".equals(stat))
+                        statSet.add(Stats.MAX);
+                    else if ("StdDev".equals(stat))
+                        statSet.add(Stats.STDDEV);
+                    else if ("Var".equals(stat))
+                        statSet.add(Stats.VAR);
+                    else if ("Median".equals(stat))
+                        statSet.add(Stats.MEDIAN);
+                }
+                return new Crosstab(results, rowFieldKey, colFieldKey, statFieldKey, statSet);
             }
-            return new Crosstab(results, rowFieldKey, colFieldKey, statFieldKey, statSet);
+            finally
+            {
+                ResultSetUtil.close(results);
+            }
         }
         return null;
     }

--- a/api/src/org/labkey/api/study/reports/CrosstabReport.java
+++ b/api/src/org/labkey/api/study/reports/CrosstabReport.java
@@ -164,22 +164,11 @@ public class CrosstabReport extends AbstractReport implements Report.ResultSetGe
                 Set<Stats.StatDefinition> statSet = new LinkedHashSet<>();
                 for (String stat : descriptor.getStats())
                 {
-                    if ("Count".equals(stat))
-                        statSet.add(Stats.COUNT);
-                    else if ("Sum".equals(stat))
-                        statSet.add(Stats.SUM);
-                    else if ("Mean".equals(stat))
-                        statSet.add(Stats.MEAN);
-                    else if ("Min".equals(stat))
-                        statSet.add(Stats.MIN);
-                    else if ("Max".equals(stat))
-                        statSet.add(Stats.MAX);
-                    else if ("StdDev".equals(stat))
-                        statSet.add(Stats.STDDEV);
-                    else if ("Var".equals(stat))
-                        statSet.add(Stats.VAR);
-                    else if ("Median".equals(stat))
-                        statSet.add(Stats.MEDIAN);
+                    try
+                    {
+                        statSet.add(Stats.getStatFromString(stat));
+                    }
+                    catch (IllegalArgumentException _) {}
                 }
                 return new Crosstab(results, rowFieldKey, colFieldKey, statFieldKey, statSet);
             }

--- a/api/src/org/labkey/api/study/reports/CrosstabReportDescriptor.java
+++ b/api/src/org/labkey/api/study/reports/CrosstabReportDescriptor.java
@@ -43,8 +43,8 @@ public class CrosstabReportDescriptor extends QueryReportDescriptor
         final Object stats = _props.get(STATS);
         if (stats instanceof List)
             return ((List<String>)stats).toArray(new String[0]);
-        else if (stats instanceof String)
-            return new String[]{(String)stats};
+        else if (stats instanceof String s)
+            return new String[]{s};
 
         return new String[]{""};
     }

--- a/assay/api-src/org/labkey/api/assay/DefaultAssaySaveHandler.java
+++ b/assay/api-src/org/labkey/api/assay/DefaultAssaySaveHandler.java
@@ -216,9 +216,9 @@ public class DefaultAssaySaveHandler extends DefaultExperimentSaveHandler implem
             }
         }
 
-        if (tsvData != null && dataRows != null)
+        if (tsvData != null)
         {
-            AssayRunUploadContext uploadContext = createRunUploadContext(context, protocol, runJson, dataRows,
+            AssayRunUploadContext<?> uploadContext = createRunUploadContext(context, protocol, runJson, dataRows,
                     inputData, outputData, inputMaterial, outputMaterial);
 
             return saveAssayRun(uploadContext, batch, run, BaseViewAction.getTransactionAuditDetails(context));
@@ -229,6 +229,7 @@ public class DefaultAssaySaveHandler extends DefaultExperimentSaveHandler implem
     /**
      * Handle any mv indicator columns plus any additional conversion on the results domain data before run creation.
      */
+    @NotNull
     private List<Map<String, Object>> convertRunData(JSONArray dataArray, Container container, ExpProtocol protocol)
     {
         Domain domain = _provider.getResultsDomain(protocol);
@@ -290,7 +291,7 @@ public class DefaultAssaySaveHandler extends DefaultExperimentSaveHandler implem
     {
         if (dataRows != null)
         {
-            AssayRunUploadContext.Factory<? extends AssayProvider, ? extends AssayRunUploadContext.Factory> factory = createRunUploadContext(protocol, context);
+            AssayRunUploadContext.Factory<? extends AssayProvider, ? extends AssayRunUploadContext.Factory<?, ?>> factory = createRunUploadContext(protocol, context);
 
             if (runJsonObject != null && runJsonObject.has(ExperimentJSONConverter.PROPERTIES))
             {
@@ -312,7 +313,7 @@ public class DefaultAssaySaveHandler extends DefaultExperimentSaveHandler implem
     }
 
     @NotNull
-    protected AssayRunUploadContext.Factory<? extends AssayProvider, ? extends AssayRunUploadContext.Factory> createRunUploadContext(ExpProtocol protocol, ViewContext context)
+    protected AssayRunUploadContext.Factory<? extends AssayProvider, ? extends AssayRunUploadContext.Factory<?, ?>> createRunUploadContext(ExpProtocol protocol, ViewContext context)
     {
         AssayProvider provider = getProvider();
         return provider.createRunUploadFactory(protocol, context);

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -217,7 +217,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
                 String referrer = request.getHeader("Referer");
                 extra = " [url=" + request.getRequestURI() + (null != referrer ? ", referrer=" + referrer : "") + "]";
             }
-            log.info("Could not find the requested custom view named '" + name + "'" + " in " + getSchemaPath() + "." + getQueryDef().getName() + " in the container " + _container.getPath() + " for user " + owner + extra);
+            log.info("  Could not find the requested custom view named '" + name + "'" + " in " + getSchemaPath() + "." + getQueryDef().getName() + " in the container " + _container.getPath() + " for user " + owner + extra);
         }
         return result;
     }

--- a/query/src/org/labkey/query/QueryDefinitionImpl.java
+++ b/query/src/org/labkey/query/QueryDefinitionImpl.java
@@ -217,7 +217,7 @@ public abstract class QueryDefinitionImpl implements QueryDefinition
                 String referrer = request.getHeader("Referer");
                 extra = " [url=" + request.getRequestURI() + (null != referrer ? ", referrer=" + referrer : "") + "]";
             }
-            log.info("  Could not find the requested custom view named '" + name + "'" + " in " + getSchemaPath() + "." + getQueryDef().getName() + " in the container " + _container.getPath() + " for user " + owner + extra);
+            log.info("Could not find the requested custom view named '" + name + "'" + " in " + getSchemaPath() + "." + getQueryDef().getName() + " in the container " + _container.getPath() + " for user " + owner + extra);
         }
         return result;
     }

--- a/study/src/org/labkey/study/controllers/reports/ReportsController.java
+++ b/study/src/org/labkey/study/controllers/reports/ReportsController.java
@@ -92,7 +92,6 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -387,7 +386,7 @@ public class ReportsController extends BaseStudyController
 
         public String[] getStats()
         {
-            return _stats;
+            return _stats == null ? new String[0] : _stats;
         }
 
         public void setStats(String[] stats)
@@ -396,7 +395,7 @@ public class ReportsController extends BaseStudyController
         }
 
         @Override
-        public CrosstabReport getReport(ContainerUser cu) throws Exception
+        public CrosstabReport getReport(ContainerUser cu)
         {
             CrosstabReport report = super.getReport(cu);
             if (null == report)
@@ -408,7 +407,7 @@ public class ReportsController extends BaseStudyController
             if (!StringUtils.isEmpty(_rowField)) descriptor.setProperty("rowField", _rowField);
             if (!StringUtils.isEmpty(_colField)) descriptor.setProperty("colField", _colField);
             if (!StringUtils.isEmpty(_statField)) descriptor.setProperty("statField", _statField);
-            if (_stats.length > 0) descriptor.setStats(_stats);
+            if (_stats != null && _stats.length > 0) descriptor.setStats(_stats);
 
             return report;
         }
@@ -473,6 +472,10 @@ public class ReportsController extends BaseStudyController
                 QuerySettings settings = schema.getSettings(form.getViewContext(), "Dataset", form.getQueryName());
 
                 QueryView qv = schema.createView(getViewContext(), settings, errors);
+                if (qv.getTable() == null)
+                {
+                    throw new NotFoundException("Table not found");
+                }
                 List<DisplayColumn> cols = qv.getDisplayColumns();
                 for (DisplayColumn col : cols)
                 {
@@ -480,6 +483,10 @@ public class ReportsController extends BaseStudyController
                     if (colInfo != null)
                         colMap.put(colInfo.getAlias().getId(), colInfo);
                 }
+            }
+            else
+            {
+                throw new NotFoundException("Schema not found");
             }
             return colMap;
         }

--- a/study/src/org/labkey/study/view/crosstabDesigner.jsp
+++ b/study/src/org/labkey/study/view/crosstabDesigner.jsp
@@ -126,8 +126,8 @@
             if (ptid.equals(col.getFieldKey()) || seqNum.equals(col.getFieldKey()))
                 continue;
 
-            builder.addOption(col.getLabel(), col.getFieldKey().encode())
-                    .selected(null != selected && selected.equalsIgnoreCase(col.getFieldKey().encode()));
+            builder.addOption(new OptionBuilder(col.getLabel(), col.getFieldKey().encode())
+                    .selected(null != selected && selected.equalsIgnoreCase(col.getFieldKey().encode())));
         }
         return builder.getHtmlString();
     }


### PR DESCRIPTION
#### Rationale
Recent scans on nightly.labkey.com caused a connection leak on requests to `study-reports-participantCrosstab.view`. We can do better at validating parameters and handling the `Results` object, though I was unable to repro the leak locally.

Example URLs from the scanner in this log file:
https://gist.githubusercontent.com/labkey-jony/541e4f1582918f63f05f46ca8f349f90/raw/3e5ad715159f407bf6e1a3b75469471f3018b8b0/threaddump.log

#### Changes
- Better up front validation for schema and query names
- Deal with null stat selections
- Improve exception handling
- Fix reselect in drop-down
- Misc unrelated code cleanup

#### Tasks 📍
- [x] Manual Testing @labkey-tchad 
- Needs Automation - N/A
- [ ] Reenable DAST scanning
