### PR TITLE
Exp.Materials.LastIndexed

### DIFF
--- a/api/src/org/labkey/api/exp/query/ExpMaterialTable.java
+++ b/api/src/org/labkey/api/exp/query/ExpMaterialTable.java
@@ -42,6 +42,7 @@ public interface ExpMaterialTable extends ExpTable<ExpMaterialTable.Column>, Upd
         Inputs,
         IsAliquot,
         IsPlated,
+        LastIndexed,
         LSID,
         MaterialExpDate,
         MaterialSourceId,

--- a/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpDataTableImpl.java
@@ -296,7 +296,10 @@ public class ExpDataTableImpl extends ExpRunItemTableImpl<ExpDataTable.Column> i
                         append(ExperimentServiceImpl.get().getTinfoDataIndexed(), "di").
                         append(" WHERE di.DataId = ").
                         append(ExprColumn.STR_TABLE_ALIAS).append(".RowId)");
-                var lastIndexed = new ExprColumn(this, "LastIndexed", lastIndexedSql, JdbcType.TIMESTAMP);
+                var lastIndexed = new ExprColumn(this, Column.LastIndexed.name(), lastIndexedSql, JdbcType.TIMESTAMP);
+                lastIndexed.setDescription("Date when the data was last full-text search indexed in the system");
+                lastIndexed.setHidden(true);
+                lastIndexed.setReadOnly(true);
                 lastIndexed.setUserEditable(false);
                 return lastIndexed;
             case DataClass:

--- a/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
+++ b/experiment/src/org/labkey/experiment/api/ExpMaterialTableImpl.java
@@ -145,6 +145,7 @@ import static org.labkey.api.exp.query.ExpMaterialTable.Column.AliquotCount;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.AliquotVolume;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.AvailableAliquotCount;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.AvailableAliquotVolume;
+import static org.labkey.api.exp.query.ExpMaterialTable.Column.LastIndexed;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.StoredAmount;
 import static org.labkey.api.exp.query.ExpMaterialTable.Column.Units;
 import static org.labkey.api.util.StringExpressionFactory.AbstractStringExpression.NullValueBehavior.NullResult;
@@ -577,6 +578,18 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
                 ret.setShownInUpdateView(true);
                 return ret;
             }
+            case LastIndexed ->
+            {
+                var sql = new SQLFragment("(SELECT LastIndexed FROM ")
+                        .append(ExperimentServiceImpl.get().getTinfoMaterialIndexed(), "mi")
+                        .append(" WHERE mi.MaterialId = ").append(ExprColumn.STR_TABLE_ALIAS).append(".RowId)");
+                var ret = new ExprColumn(this, LastIndexed.name(), sql, JdbcType.TIMESTAMP);
+                ret.setDescription("Date when the material was last full-text search indexed in the system");
+                ret.setHidden(true);
+                ret.setReadOnly(true);
+                ret.setUserEditable(false);
+                return ret;
+            }
             default -> throw new IllegalArgumentException("Unknown column " + column);
         }
     }
@@ -903,7 +916,7 @@ public class ExpMaterialTableImpl extends ExpRunItemTableImpl<ExpMaterialTable.C
         addColumn(col);
 
         addVocabularyDomains();
-
+        addColumn(LastIndexed);
         addColumn(Column.Properties);
 
         var colInputs = addColumn(Column.Inputs);


### PR DESCRIPTION
#### Rationale
Define `LastIndexed` expression column on `exp.materials` to give users insight into the last time a material was indexed. Follow up item for [#786](https://github.com/LabKey/internal-issues/issues/786).

#### Changes
- Define `LastIndexed` expression column on `exp.materials`
- Provide consistent descriptions for materials and data