### PR TITLE
Allow code to customize JS script timeout

### DIFF
--- a/api/src/org/labkey/api/action/ApiResponseWriter.java
+++ b/api/src/org/labkey/api/action/ApiResponseWriter.java
@@ -23,6 +23,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.PropertyValidationError;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SimpleValidationError;
 import org.labkey.api.query.ValidationError;
 import org.labkey.api.query.ValidationException;
@@ -445,7 +446,7 @@ public abstract class ApiResponseWriter implements AutoCloseable
             json.put("errors", arr);
             json.put("errorCount", arr.length());
             json.put("exception", message);
-            json.put("extraContext", bve.getExtraContext());
+            json.put(QueryService.EXTRA_CONTEXT, bve.getExtraContext());
 
             return json;
         }

--- a/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
+++ b/api/src/org/labkey/api/data/triggers/ScriptTrigger.java
@@ -23,6 +23,7 @@ import org.labkey.api.data.DbScope;
 import org.labkey.api.data.PHI;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.script.ScriptReference;
 import org.labkey.api.security.User;
@@ -258,7 +259,7 @@ public class ScriptTrigger implements Trigger
                 Map<String, Object> bindings = new HashMap<>();
                 if (extraContext == null)
                     extraContext = new HashMap<>();
-                bindings.put("extraContext", extraContext);
+                bindings.put(QueryService.EXTRA_CONTEXT, extraContext);
                 bindings.put("schemaName", _table.getPublicSchemaName());
                 bindings.put("tableName", _table.getPublicName());
 

--- a/api/src/org/labkey/api/query/QueryService.java
+++ b/api/src/org/labkey/api/query/QueryService.java
@@ -69,6 +69,8 @@ public interface QueryService
 
     String SCHEMA_TEMPLATE_EXTENSION = ".template.xml";
 
+    String EXTRA_CONTEXT = "extraContext";
+
     static QueryService get()
     {
         return ServiceRegistry.get().getService(QueryService.class);

--- a/core/src/org/labkey/core/script/RhinoService.java
+++ b/core/src/org/labkey/core/script/RhinoService.java
@@ -1009,7 +1009,7 @@ class SandboxContextFactory extends ContextFactory
     {
         SandboxContext ctx = (SandboxContext)cx;
         long currentTime = HeartBeat.currentTimeMillis();
-        final int timeout = 60;
+        final long timeout = ctx.getTimeout();
         if (currentTime - ctx.startTime > timeout*1000)
             Context.reportError("Script execution exceeded " + timeout + " seconds.");
     }
@@ -1050,12 +1050,54 @@ class SandboxContextFactory extends ContextFactory
         private static final int MAX_ALLOWABLE_TIMEOUT = 300;
 
         private final long startTime;
+        private long timeout = 60;
 
         private SandboxContext(SandboxContextFactory factory)
         {
             super(factory);
             setLanguageVersion(Context.VERSION_1_8);
             startTime = HeartBeat.currentTimeMillis();
+        }
+
+        public long getTimeout()
+        {
+            if (ScriptRuntime.hasTopCall(this))
+            {
+                Scriptable script = ScriptRuntime.getTopCallScope(this);
+                Object o = ScriptRuntime.getObjectProp(script, QueryService.EXTRA_CONTEXT, this);
+                if (o instanceof Map<?,?> mp)
+                {
+                    if (mp.containsKey(QueryService.EXTRA_CONTEXT) && mp.get(QueryService.EXTRA_CONTEXT) != null)
+                    {
+                        Object rawTimeout = mp.get(SCRIPT_TIMEOUT_PROPERTY);
+                        if (NumberUtils.isCreatable(String.valueOf(rawTimeout)))
+                        {
+                            try
+                            {
+                                int scriptTimeout = Integer.parseInt(String.valueOf(rawTimeout));
+                                if (scriptTimeout > MAX_ALLOWABLE_TIMEOUT)
+                                {
+                                    scriptTimeout = MAX_ALLOWABLE_TIMEOUT;
+                                    LOG.error("Script timeout is greater than max allowable, using: {}", MAX_ALLOWABLE_TIMEOUT);
+                                }
+
+                                return scriptTimeout;
+                            }
+                            catch (Exception e)
+                            {
+                                LOG.error("Non-integer value provided to extractContext.scriptTimeout for script: {}", rawTimeout);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return timeout;
+        }
+
+        public void setTimeout(long timeout)
+        {
+            this.timeout = timeout;
         }
     }
 

--- a/core/src/org/labkey/core/script/RhinoService.java
+++ b/core/src/org/labkey/core/script/RhinoService.java
@@ -16,11 +16,12 @@
 package org.labkey.core.script;
 
 import com.sun.phobos.script.javascript.RhinoScriptEngineFactory;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONObject;
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -35,6 +36,7 @@ import org.labkey.api.module.ModuleResourceCacheHandler;
 import org.labkey.api.module.ModuleResourceCaches;
 import org.labkey.api.module.ResourceRootProvider;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.reader.Readers;
 import org.labkey.api.resource.Resource;
@@ -58,6 +60,7 @@ import org.mozilla.javascript.LazilyLoadedCtor;
 import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.NativeJavaObject;
 import org.mozilla.javascript.RhinoException;
+import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.WrapFactory;
@@ -1043,6 +1046,9 @@ class SandboxContextFactory extends ContextFactory
 
     private static class SandboxContext extends Context
     {
+        public static final String SCRIPT_TIMEOUT_PROPERTY = "scriptTimeout";
+        private static final int MAX_ALLOWABLE_TIMEOUT = 300;
+
         private final long startTime;
 
         private SandboxContext(SandboxContextFactory factory)

--- a/core/src/org/labkey/core/script/RhinoService.java
+++ b/core/src/org/labkey/core/script/RhinoService.java
@@ -1070,23 +1070,20 @@ class SandboxContextFactory extends ContextFactory
                     if (mp.getMap().get(SCRIPT_TIMEOUT_PROPERTY) != null)
                     {
                         Object rawTimeout = mp.getMap().get(SCRIPT_TIMEOUT_PROPERTY);
-                        if (NumberUtils.isCreatable(String.valueOf(rawTimeout)))
+                        try
                         {
-                            try
+                            int scriptTimeout = Integer.parseInt(String.valueOf(rawTimeout));
+                            if (scriptTimeout > MAX_ALLOWABLE_TIMEOUT)
                             {
-                                int scriptTimeout = Integer.parseInt(String.valueOf(rawTimeout));
-                                if (scriptTimeout > MAX_ALLOWABLE_TIMEOUT)
-                                {
-                                    scriptTimeout = MAX_ALLOWABLE_TIMEOUT;
-                                    LOG.error("Script timeout is greater than max allowable, using: {}", MAX_ALLOWABLE_TIMEOUT);
-                                }
+                                scriptTimeout = MAX_ALLOWABLE_TIMEOUT;
+                                LOG.error("Script timeout is greater than max allowable, using: {}", MAX_ALLOWABLE_TIMEOUT);
+                            }
 
-                                return scriptTimeout;
-                            }
-                            catch (Exception e)
-                            {
-                                LOG.error("Non-integer value provided to extractContext.scriptTimeout for script: {}", rawTimeout);
-                            }
+                            return scriptTimeout;
+                        }
+                        catch (Exception e)
+                        {
+                            LOG.error("Non-integer value provided to extractContext.scriptTimeout for script: {}", rawTimeout);
                         }
                     }
                 }

--- a/core/src/org/labkey/core/script/RhinoService.java
+++ b/core/src/org/labkey/core/script/RhinoService.java
@@ -240,8 +240,8 @@ public final class RhinoService
 
             if (null != simpleTest)
             {
-                assertEquals("Scripts from the simpletest module", 15, ScriptReferenceImpl.SCRIPT_CACHE.getResourceMap(simpleTest).size());
-                assertEquals("Top-level script timestamps from the simpletest module", 15, LabKeyModuleSourceProvider.TOP_LEVEL_SCRIPT_CACHE.getResourceMap(simpleTest).size());
+                assertEquals("Scripts from the simpletest module", 16, ScriptReferenceImpl.SCRIPT_CACHE.getResourceMap(simpleTest).size());
+                assertEquals("Top-level script timestamps from the simpletest module", 16, LabKeyModuleSourceProvider.TOP_LEVEL_SCRIPT_CACHE.getResourceMap(simpleTest).size());
             }
         }
     }

--- a/core/src/org/labkey/core/script/RhinoService.java
+++ b/core/src/org/labkey/core/script/RhinoService.java
@@ -1046,11 +1046,11 @@ class SandboxContextFactory extends ContextFactory
 
     private static class SandboxContext extends Context
     {
-        public static final String SCRIPT_TIMEOUT_PROPERTY = "scriptTimeout";
+        private static final String SCRIPT_TIMEOUT_PROPERTY = "scriptTimeout";
         private static final int MAX_ALLOWABLE_TIMEOUT = 300;
+        private final long DEFAULT_TIMEOUT = 60;
 
         private final long startTime;
-        private long timeout = 60;
 
         private SandboxContext(SandboxContextFactory factory)
         {
@@ -1065,11 +1065,11 @@ class SandboxContextFactory extends ContextFactory
             {
                 Scriptable script = ScriptRuntime.getTopCallScope(this);
                 Object o = ScriptRuntime.getObjectProp(script, QueryService.EXTRA_CONTEXT, this);
-                if (o instanceof Map<?,?> mp)
+                if (o instanceof ScriptableMap mp)
                 {
-                    if (mp.containsKey(QueryService.EXTRA_CONTEXT) && mp.get(QueryService.EXTRA_CONTEXT) != null)
+                    if (mp.getMap().get(SCRIPT_TIMEOUT_PROPERTY) != null)
                     {
-                        Object rawTimeout = mp.get(SCRIPT_TIMEOUT_PROPERTY);
+                        Object rawTimeout = mp.getMap().get(SCRIPT_TIMEOUT_PROPERTY);
                         if (NumberUtils.isCreatable(String.valueOf(rawTimeout)))
                         {
                             try
@@ -1092,12 +1092,7 @@ class SandboxContextFactory extends ContextFactory
                 }
             }
 
-            return timeout;
-        }
-
-        public void setTimeout(long timeout)
-        {
-            this.timeout = timeout;
+            return DEFAULT_TIMEOUT;
         }
     }
 

--- a/query/src/org/labkey/query/controllers/QueryController.java
+++ b/query/src/org/labkey/query/controllers/QueryController.java
@@ -4643,7 +4643,7 @@ public class QueryController extends SpringActionController
                 }
             }
 
-            Map<String, Object> extraContext = json.has("extraContext") ? json.getJSONObject("extraContext").toMap() : new CaseInsensitiveHashMap<>();
+            Map<String, Object> extraContext = json.has(QueryService.EXTRA_CONTEXT) ? json.getJSONObject(QueryService.EXTRA_CONTEXT).toMap() : new CaseInsensitiveHashMap<>();
 
             Map<String, Object> auditDetails = json.has("auditDetails") ? json.getJSONObject("auditDetails").toMap() : new CaseInsensitiveHashMap<>();
 
@@ -5138,7 +5138,7 @@ public class QueryController extends SpringActionController
             }
 
             JSONArray resultArray = new JSONArray();
-            JSONObject extraContext = json.optJSONObject("extraContext");
+            JSONObject extraContext = json.optJSONObject(QueryService.EXTRA_CONTEXT);
             JSONObject auditDetails = json.optJSONObject("auditDetails");
 
             int startingErrorIndex = 0;
@@ -5162,11 +5162,11 @@ public class QueryController extends SpringActionController
                     Map<String, Object> commandExtraContext = new HashMap<>();
                     if (extraContext != null)
                         commandExtraContext.putAll(extraContext.toMap());
-                    if (commandObject.has("extraContext"))
+                    if (commandObject.has(QueryService.EXTRA_CONTEXT))
                     {
-                        commandExtraContext.putAll(commandObject.getJSONObject("extraContext").toMap());
+                        commandExtraContext.putAll(commandObject.getJSONObject(QueryService.EXTRA_CONTEXT).toMap());
                     }
-                    commandObject.put("extraContext", commandExtraContext);
+                    commandObject.put(QueryService.EXTRA_CONTEXT, commandExtraContext);
                     Map<String, Object> commandAuditDetails = new HashMap<>();
                     if (auditDetails != null)
                         commandAuditDetails.putAll(auditDetails.toMap());


### PR DESCRIPTION
Hello,

As you might know, JS trigger scripts default to a 60 second timeout. This is almost always more than enough, and if something takes more than 60 seconds might signal you should look at performance. I have some EHR-related ETLs that sync a lot of data between servers. They are largely stable and fine within that 60 second window, but we can get periods when one or more of these bumps against that window. I spent some time trying to improve that and gave up. Some of the caching that can be triggered in DemographicsService makes it difficult to avoid, and it's not user-facing. This is a longstanding issue I've been living with, but I am hoping to find a solution.

This PR proposes to allow code to customize that timeout. I propose we use the existing 'extraContext' mechanism. If 'scriptTimeout' is provided as an integer, RhinoService should use that value instead of 60. As a precaution, I set the MAX_ALLOWABLE_TIMEOUT as 300 (this is somewhat arbitrary), to prevent some code from going on forever. This means that the client or server-side code that makes the request can provide "scriptTimeout: XX", which should be respected.

I don't see a way for the JS trigger scripts themselves to modify extraContext to change the scriptTimeout themselves. This would be convenient, but is probably by design. While I cant write this myself anymore, it would be nice is the DataIntegration module ETL XML had a property for 'scriptTimeout', and then ETL would poke that into extraContext when it inserts/updates/deletes rows. ETL already pokes in "isETL" to extraContext, so I think the scope of that change ought to be rather small. 

There's a related PR in TestAutomation to illustrate how this could work, at least from the client. 

Does this concept seem acceptable? If so, I can expand some test cases. I'm happy to discuss other approaches to this. 