### PR TITLE
Make select inactive modules unreachable

### DIFF
--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -1110,7 +1110,7 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
         ViewContext rootContext = new ViewContext(request, response, url);
 
         Container container = rootContext.getContainer();
-        if (container != null && isAvailableOnlyWhenActive() && !container.getActiveModules().contains(this))
+        if (container != null && !isAvailable(container))
         {
             ExceptionUtil.handleException(request, response, new NotFoundException("Module " + getName() + " is not active in " + container.getPath()), null, false);
             return;

--- a/api/src/org/labkey/api/module/DefaultModule.java
+++ b/api/src/org/labkey/api/module/DefaultModule.java
@@ -1109,6 +1109,13 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
 
         ViewContext rootContext = new ViewContext(request, response, url);
 
+        Container container = rootContext.getContainer();
+        if (container != null && isAvailableOnlyWhenActive() && !container.getActiveModules().contains(this))
+        {
+            ExceptionUtil.handleException(request, response, new NotFoundException("Module " + getName() + " is not active in " + container.getPath()), null, false);
+            return;
+        }
+
         try (var ignored =HttpView.initForRequest(rootContext, request, response))
         {
             response.setContentType("text/html;charset=UTF-8");
@@ -1125,8 +1132,8 @@ public abstract class DefaultModule implements Module, ApplicationContextAware
             }
             request.setAttribute(ViewServlet.REQUEST_ACTION_URL, url);
 
-            if (controller instanceof HasViewContext)
-                ((HasViewContext)controller).setViewContext(rootContext);
+            if (controller instanceof HasViewContext hvc)
+                hvc.setViewContext(rootContext);
             controller.handleRequest(request, response);
         }
         catch (ServletException | IOException x)

--- a/api/src/org/labkey/api/module/Module.java
+++ b/api/src/org/labkey/api/module/Module.java
@@ -69,6 +69,15 @@ public interface Module
 
     default boolean isUnderResourcesDirectory(java.nio.file.Path path) { return false; }
 
+    /**
+     * If true, the module is considered unreachable in any container where it's not active/enabled. Its controllers
+     * will not respond to requests, and it will not show in the admin menu's module list.
+     *
+     * More modules should return true, but historically we haven't been especially mindful of service-type modules
+     * (such as query or pipeline) being active in all containers where they're being used.
+     */
+    default boolean isAvailableOnlyWhenActive() { return false; }
+
     enum TabDisplayMode
     {
         DISPLAY_NEVER,

--- a/api/src/org/labkey/api/module/Module.java
+++ b/api/src/org/labkey/api/module/Module.java
@@ -70,13 +70,11 @@ public interface Module
     default boolean isUnderResourcesDirectory(java.nio.file.Path path) { return false; }
 
     /**
-     * If true, the module is considered unreachable in any container where it's not active/enabled. Its controllers
-     * will not respond to requests, and it will not show in the admin menu's module list.
-     *
-     * More modules should return true, but historically we haven't been especially mindful of service-type modules
+     * If true, unreachable in the container. More modules should respect whether they're active in the container,
+     * but historically we haven't been especially mindful of service-type modules
      * (such as query or pipeline) being active in all containers where they're being used.
      */
-    default boolean isAvailableOnlyWhenActive() { return false; }
+    default boolean isAvailable(Container container) { return true; }
 
     enum TabDisplayMode
     {

--- a/api/src/org/labkey/api/view/HttpView.java
+++ b/api/src/org/labkey/api/view/HttpView.java
@@ -119,7 +119,7 @@ public abstract class HttpView<ModelBean> extends DefaultModelAndView<ModelBean>
         {
             if (response.getContentType() != null && !response.getContentType().contains("charset"))
                 response.setContentType(response.getContentType()+"; charset=UTF-8");
-            try (var closeable = HttpView.pushView(this, request, response, null))
+            try (var _ = HttpView.pushView(this, request, response, null))
             {
                 initViewContext(getViewContext(), request, response);
                 renderInternal(model, request, response);
@@ -752,7 +752,7 @@ public abstract class HttpView<ModelBean> extends DefaultModelAndView<ModelBean>
             ModelAndView mv = vse.mv;
             if (mv instanceof HasViewContext)
             {
-                ViewContext context = ((HttpView)mv).getViewContext();
+                ViewContext context = ((HttpView<?>)mv).getViewContext();
                 if (context._pvsBind != null)
                     return context._pvsBind;
             }

--- a/api/src/org/labkey/api/view/JspView.java
+++ b/api/src/org/labkey/api/view/JspView.java
@@ -17,6 +17,7 @@
 package org.labkey.api.view;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.HasViewContext;
@@ -37,7 +38,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.jsp.HttpJspPage;
 import java.util.Map;
-import java.util.Set;
 
 
 public class JspView<ModelClass> extends WebPartView<ModelClass>
@@ -133,11 +133,11 @@ public class JspView<ModelClass> extends WebPartView<ModelClass>
         boolean devMode = AppProps.getInstance().isDevMode() ||
                 (_viewContext != null && _viewContext.getUser() != null && _viewContext.getContainer() != null &&
                         _viewContext.getUser().isPlatformDeveloper());
-        boolean isDebugHtml = devMode && this.getFrame() != FrameType.NOT_HTML && StringUtils.startsWith(response.getContentType(), "text/html");
+        boolean isDebugHtml = devMode && this.getFrame() != FrameType.NOT_HTML && Strings.CI.startsWith(response.getContentType(), "text/html");
         if (isDebugHtml)
             response.getWriter().print("<!--" + _page.getClass() + "-->");
 
-        try (Timing t = MiniProfiler.step(_page.getClass().getSimpleName()))
+        try (Timing _ = MiniProfiler.step(_page.getClass().getSimpleName()))
         {
             _page._jspService(request, response);
         }
@@ -194,10 +194,10 @@ public class JspView<ModelClass> extends WebPartView<ModelClass>
         if (model != null)
             context.getExtendedProperties().putAll(model);
         
-        for (Map.Entry e : (Set<Map.Entry>)context.getExtendedProperties().entrySet())
+        for (Map.Entry<String, Object> e : context.getExtendedProperties().entrySet())
         {
-            if (e.getKey() instanceof String && e.getValue() != null)
-                request.setAttribute((String)e.getKey(), e.getValue());
+            if (e.getKey() != null && e.getValue() != null)
+                request.setAttribute(e.getKey(), e.getValue());
         }
     }
 }

--- a/api/src/org/labkey/api/view/PopupAdminView.java
+++ b/api/src/org/labkey/api/view/PopupAdminView.java
@@ -135,7 +135,7 @@ public class PopupAdminView
             SortedSet<Module> disabledModules = new TreeSet<>(moduleComparator);
             disabledModules.addAll(ModuleLoader.getInstance().getModules());
             disabledModules.removeAll(activeModules);
-            disabledModules.removeIf(Module::isAvailableOnlyWhenActive);
+            disabledModules.removeIf(module -> !module.isAvailable(context.getContainer()));
 
             NavTree goToModuleMenu = new NavTree("Go To Module");
             Module defaultModule = null;

--- a/api/src/org/labkey/api/view/PopupAdminView.java
+++ b/api/src/org/labkey/api/view/PopupAdminView.java
@@ -135,6 +135,7 @@ public class PopupAdminView
             SortedSet<Module> disabledModules = new TreeSet<>(moduleComparator);
             disabledModules.addAll(ModuleLoader.getInstance().getModules());
             disabledModules.removeAll(activeModules);
+            disabledModules.removeIf(Module::isAvailableOnlyWhenActive);
 
             NavTree goToModuleMenu = new NavTree("Go To Module");
             Module defaultModule = null;

--- a/api/src/org/labkey/api/view/ServletView.java
+++ b/api/src/org/labkey/api/view/ServletView.java
@@ -58,9 +58,8 @@ public class ServletView extends HttpView
     public void renderInternal(Object model, HttpServletRequest request, HttpServletResponse response) throws Exception
     {
         ViewContext context = getViewContext();
-        for (Object o : context.entrySet())
+        for (Map.Entry<String, Object> entry : context.entrySet())
         {
-            Map.Entry entry = (Map.Entry) o;
             request.setAttribute(String.valueOf(entry.getKey()), entry.getValue());
         }
 

--- a/api/src/org/labkey/api/view/ViewContext.java
+++ b/api/src/org/labkey/api/view/ViewContext.java
@@ -116,9 +116,8 @@ public class ViewContext implements MessageSource, ContainerContext, ContainerUs
         setRequest(request);
         setResponse(response);
 
-        for (Object o : _request.getParameterMap().entrySet())
+        for (Map.Entry<String, String[]> entry : _request.getParameterMap().entrySet())
         {
-            Map.Entry<String, String[]> entry = (Map.Entry<String, String[]>) o;
             String key = entry.getKey();
             String[] value = entry.getValue();
 
@@ -126,7 +125,7 @@ public class ViewContext implements MessageSource, ContainerContext, ContainerUs
                 _map.put(key, value[0]);
             else
             {
-                List list = new ArrayList<>(Arrays.asList(value));
+                List<String> list = new ArrayList<>(Arrays.asList(value));
                 _map.put(key, list);
             }
         }
@@ -193,7 +192,7 @@ public class ViewContext implements MessageSource, ContainerContext, ContainerUs
     // ===========================================
     // Last vestiges of ViewContext implementing BoundMap/Map below.  TODO: Remove these methods
 
-    public Map getExtendedProperties()
+    public Map<String, Object> getExtendedProperties()
     {
         return _map;
     }

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -88,9 +88,9 @@ public class MothershipModule extends DefaultModule
     }
 
     @Override
-    public boolean isAvailableOnlyWhenActive()
+    public boolean isAvailable(Container container)
     {
-        return true;
+        return container.isRoot() || container.getActiveModules().contains(this);
     }
 
     @Override

--- a/mothership/src/org/labkey/mothership/MothershipModule.java
+++ b/mothership/src/org/labkey/mothership/MothershipModule.java
@@ -88,6 +88,12 @@ public class MothershipModule extends DefaultModule
     }
 
     @Override
+    public boolean isAvailableOnlyWhenActive()
+    {
+        return true;
+    }
+
+    @Override
     public void afterUpdate(ModuleContext moduleContext)
     {
         if (moduleContext.isNewInstall() && ModuleLoader.getInstance().shouldInsertData())


### PR DESCRIPTION
#### Rationale
Many modules don't make sense to access in a container if they're not enabled and intended to be used. Mothership is a good example. We've long hidden their schemas, but they've still been accessible via their controllers and the More Modules admin menu.

We can prevent them from being accessible and eliminate strange behavior, like grids where you can't export or create reports.

This was "discovered" by the crawler in automated tests now that the crosstab report gives a proper 404 when it's accessed with a reference to a schema or query that doesn't exist in the container.

#### Changes
- `Module.isAvailableOnlyWhenActive()` to let modules indicate they don't want to be accessed when not active in the container. Default is to remain accessible.
- Make mothership module inaccessible when not active.
- Code cleanup, including lots of generics

#### Tasks 📍
- [x] Manual Testing @labkey-tchad 
  - [x] Ensure that mothership, microarray, and genotyping never show in More Modules. When the module is active in a container, they appear in the Modules menu. When inactive, they don't appear at all.
  - [x] When inactive, requests to `genotyping-begin.view`, `mothership-begin.view`, and `feature-annotationset-manage.view` give a 404 with a message about the module not being active.
- [ ] ~Needs Automation~
