### PR TITLE
Re-run upgrade code that populates the ParentType column

### DIFF
--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 26.000
+SchemaVersion: 26.001
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/core-26.000-26.001.sql
+++ b/core/resources/schemas/dbscripts/postgresql/core-26.000-26.001.sql
@@ -1,0 +1,3 @@
+-- Extraction of parent EntityIds from data class LSIDs has been fixed, so re-run population of the ParentType column.
+-- Keep the invocation in core-25.008-25.009.sql since core-25.009-25.010.sql relies on ParentType being populated.
+SELECT core.executeJavaUpgradeCode('populateAttachmentParentTypeColumn');

--- a/core/resources/schemas/dbscripts/sqlserver/core-26.000-26.001.sql
+++ b/core/resources/schemas/dbscripts/sqlserver/core-26.000-26.001.sql
@@ -1,0 +1,3 @@
+-- Extraction of parent EntityIds from data class LSIDs has been fixed, so re-run population of the ParentType column.
+-- Keep the invocation in core-25.008-25.009.sql since core-25.009-25.010.sql relies on ParentType being populated.
+EXEC core.executeJavaUpgradeCode 'populateAttachmentParentTypeColumn';

--- a/core/src/org/labkey/core/CoreUpgradeCode.java
+++ b/core/src/org/labkey/core/CoreUpgradeCode.java
@@ -82,6 +82,7 @@ public class CoreUpgradeCode implements UpgradeCode
 
     /**
      * Called from core-25.008-25.009.sql
+     * Called from core-26.000-26.001.sql
      */
     @SuppressWarnings("unused")
     @DeferredUpgrade


### PR DESCRIPTION
#### Rationale
Extraction of parent EntityIds from data class LSIDs has been fixed; re-running this upgrade code should populate the ParentType for data class attachments.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7319
- https://github.com/LabKey/platform/pull/7231