### PR TITLE
Issue 695: Upgrade script version of fixing container for sample files that have moved

### DIFF
--- a/experiment/resources/schemas/dbscripts/postgresql/exp-26.001-26.002.sql
+++ b/experiment/resources/schemas/dbscripts/postgresql/exp-26.001-26.002.sql
@@ -1,0 +1,1 @@
+SELECT core.executeJavaUpgradeCode('fixContainerForMovedSampleFiles');

--- a/experiment/resources/schemas/dbscripts/sqlserver/exp-26.001-26.002.sql
+++ b/experiment/resources/schemas/dbscripts/sqlserver/exp-26.001-26.002.sql
@@ -1,0 +1,1 @@
+EXEC core.executeJavaUpgradeCode 'fixContainerForMovedSampleFiles';

--- a/experiment/src/org/labkey/experiment/ExperimentModule.java
+++ b/experiment/src/org/labkey/experiment/ExperimentModule.java
@@ -205,7 +205,7 @@ public class ExperimentModule extends SpringModule
     @Override
     public Double getSchemaVersion()
     {
-        return 26.001;
+        return 26.002;
     }
 
     @Nullable

--- a/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
+++ b/experiment/src/org/labkey/experiment/ExperimentUpgradeCode.java
@@ -52,6 +52,7 @@ import org.labkey.api.exp.api.StorageProvisioner;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.exp.property.DomainUtil;
 import org.labkey.api.exp.property.PropertyService;
+import org.labkey.api.files.FileContentService;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.ontology.Unit;
@@ -484,4 +485,28 @@ public class ExperimentUpgradeCode implements UpgradeCode
 
         return new ProvisionedSampleTypeContext(domain, provisionedTable);
     }
+
+    /**
+     * Called from exp-26.001-26.002.sql
+     */
+    @SuppressWarnings("unused")
+    public static void fixContainerForMovedSampleFiles(ModuleContext context)
+    {
+        if (context.isNewInstall())
+            return;
+
+        try (DbScope.Transaction tx = ExperimentService.get().ensureTransaction())
+        {
+            FileContentService service = FileContentService.get();
+            if (service == null)
+            {
+                LOG.error("No FileContentService found. Aborting.");
+                return;
+            }
+            LimitedUser admin = new LimitedUser(context.getUpgradeUser(), SiteAdminRole.class);
+            int numDuplicates = service.fixContainerForExpDataFiles(admin);
+            LOG.info("Fixed {} duplicate data files.", numDuplicates);
+        }
+    }
+
 }

--- a/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
+++ b/experiment/src/org/labkey/experiment/controllers/exp/ExperimentController.java
@@ -7460,25 +7460,6 @@ public class ExperimentController extends SpringActionController
         }
     }
 
-    @Marshal(Marshaller.Jackson)
-    @RequiresPermission(AdminPermission.class)
-    public static class RepairExpDataFilesAction extends MutatingApiAction<Object>
-    {
-        @Override
-        public Object execute(Object form, BindException errors)
-        {
-            FileContentService service = FileContentService.get();
-            if (service == null)
-            {
-                errors.reject(ERROR_GENERIC, "No FileContentService found");
-                return new SimpleResponse<>(false, "No FileContentService found");
-            }
-
-            int numDuplicates = service.fixContainerForExpDataFiles(getUser());
-            return success(Map.of("hadRepairs", numDuplicates > 0));
-        }
-    }
-
     @RequiresPermission(UpdatePermission.class)
     public static class UpdateMaterialQueryRowAction extends UserSchemaAction
     {

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -170,10 +170,7 @@ public class FileContentServiceImpl implements FileContentService, WarningProvid
 
                     ExpDataTable expDataTable = ExperimentService.get().createDataTable("data", new ExpSchema(user, c), null);
                     if (expDataTable != null)
-                    {
-                        _log.info("Ensuring file data in container {}", c.getPath());
                         ensureFileDataUnsynchronized(expDataTable);
-                    }
                 }
         );
     }

--- a/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
+++ b/filecontent/src/org/labkey/filecontent/FileContentServiceImpl.java
@@ -154,7 +154,8 @@ public class FileContentServiceImpl implements FileContentService, WarningProvid
                                                                                  FROM exp.data
                                                                                  WHERE DataFileURL IS NOT NULL
                                                                                  GROUP BY DataFileUrl) c
-                                                                           WHERE c.count > 1))""");
+                                                                           WHERE c.count > 1))
+                                                     AND datafileurl LIKE '%/sampletype/%'""");
         int count = new SqlExecutor(ExperimentService.get().getSchema().getScope()).execute(sql);
         _log.info("Deleted {} duplicate entries from exp.data", count);
         _log.info("Repopulating file data in exp.data.");


### PR DESCRIPTION
#### Rationale
While investigating approach for allowing deletion of files associated with samples that have become obsolete ([Issue 695](https://github.com/LabKey/internal-issues/issues/695)), it was discovered that when samples are moved from one container to another, the container field in `exp.data` was not getting updated.  For 25.11, we provided a controller action for repairing the container fields in order to allow the obsolete files to be deleted. This controller action would need to be manually hit to do the repair. This PR adds an upgrade script so data will get repaired for everyone.

#### Related Pull Requests
- https://github.com/LabKey/limsModules/pull/1906

#### Changes
- Add Java upgrade script for repairing sample files
- Remove ExperimentController.RepairExpDataFilesAction
- Limit `FileContentService.fixContainerForExpDataFiles` to only `sampletype` files (since there can be legitimate duplicate references for assay data files)

#### Tasks 📍
- [x] Manual Testing @cnathe 

