### PR TITLE
Improve failure logging from DbScope.TransactionTestCase

### DIFF
--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -92,6 +92,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Random;
 import java.util.RandomAccess;
@@ -3270,12 +3271,7 @@ public class DbScope
         {
             ReentrantLock lock1 = new ReentrantLock();
             ReentrantLock lock2 = new ReentrantLock();
-            List<Throwable> throwables = attemptToDeadlock(lock1, lock2, (x) -> ((TransactionImpl)x).setLockTimeout(5, TimeUnit.SECONDS));
-
-            assertFalse("No exceptions from attempted deadlock.", throwables.isEmpty());
-            throwables = throwables.stream().filter(t -> ! (t instanceof DeadlockPreventingException)).toList();
-            if (!throwables.isEmpty())
-                throw throwables.getFirst();
+            attemptToDeadlock(lock1, lock2, (x) -> ((TransactionImpl)x).setLockTimeout(5, TimeUnit.SECONDS), DeadlockPreventingException.class);
 
             assertFalse("Lock 1 is still locked", lock1.isLocked());
             assertFalse("Lock 2 is still locked", lock2.isLocked());
@@ -3397,18 +3393,10 @@ public class DbScope
             Lock lockUser = new ServerPrimaryKeyLock(true, CoreSchema.getInstance().getTableInfoUsersData(), user.getUserId());
             Lock lockHome = new ServerPrimaryKeyLock(true, CoreSchema.getInstance().getTableInfoContainers(), ContainerManager.getHomeContainer().getId());
 
-            List<Throwable> throwables = attemptToDeadlock(lockUser, lockHome, (x) -> {});
-
-            assertFalse("No exceptions from attempted deadlock.", throwables.isEmpty());
-            throwables = throwables.stream().filter(t -> ! (t instanceof PessimisticLockingFailureException)).toList();
-            if (!throwables.isEmpty())
-                throw throwables.getFirst();
+            attemptToDeadlock(lockUser, lockHome, (x) -> {}, PessimisticLockingFailureException.class);
         }
 
-        /**
-         * @return foreground and background thread exceptions
-         */
-        private List<Throwable> attemptToDeadlock(Lock lock1, Lock lock2, @NotNull Consumer<Transaction> transactionModifier)
+        private void attemptToDeadlock(Lock lock1, Lock lock2, @NotNull Consumer<Transaction> transactionModifier, Class<? extends Throwable> expectedException) throws Throwable
         {
             final Object notifier = new Object();
             final List<Throwable> result = new ArrayList<>();
@@ -3485,7 +3473,13 @@ public class DbScope
                     }
                 }
             }
-            return result;
+
+            assertFalse("No exception from attempted deadlock.", result.isEmpty());
+            Optional<Throwable> unwantedException = result.stream().filter(t -> !expectedException.isAssignableFrom(t.getClass())).findAny();
+            if (unwantedException.isPresent())
+            {
+                throw unwantedException.get();
+            }
         }
 
          @Test

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -50,7 +50,6 @@ import org.labkey.api.util.DebugInfoDumper;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.LoggerWriter;
 import org.labkey.api.util.MemTracker;
-import org.labkey.api.util.Pair;
 import org.labkey.api.util.ResultSetUtil;
 import org.labkey.api.util.SimpleLoggerWriter;
 import org.labkey.api.util.SkipMothershipLogging;
@@ -3267,13 +3266,17 @@ public class DbScope
         }
 
         @Test
-        public void testLockTimeout()
+        public void testLockTimeout() throws Throwable
         {
             ReentrantLock lock1 = new ReentrantLock();
             ReentrantLock lock2 = new ReentrantLock();
-            Pair<Throwable, Throwable> throwables = attemptToDeadlock(lock1, lock2, (x) -> ((TransactionImpl)x).setLockTimeout(5, TimeUnit.SECONDS));
+            List<Throwable> throwables = attemptToDeadlock(lock1, lock2, (x) -> ((TransactionImpl)x).setLockTimeout(5, TimeUnit.SECONDS));
 
-            assertTrue(throwables.first instanceof DeadlockPreventingException || throwables.second instanceof DeadlockPreventingException);
+            assertFalse("No exceptions from attempted deadlock.", throwables.isEmpty());
+            throwables = throwables.stream().filter(t -> ! (t instanceof DeadlockPreventingException)).toList();
+            if (!throwables.isEmpty())
+                throw throwables.getFirst();
+
             assertFalse("Lock 1 is still locked", lock1.isLocked());
             assertFalse("Lock 2 is still locked", lock2.isLocked());
         }
@@ -3387,25 +3390,28 @@ public class DbScope
         }
 
         @Test
-        public void testServerRowLock()
+        public void testServerRowLock() throws Throwable
         {
             final User user = TestContext.get().getUser();
 
             Lock lockUser = new ServerPrimaryKeyLock(true, CoreSchema.getInstance().getTableInfoUsersData(), user.getUserId());
             Lock lockHome = new ServerPrimaryKeyLock(true, CoreSchema.getInstance().getTableInfoContainers(), ContainerManager.getHomeContainer().getId());
 
-            Pair<Throwable, Throwable> throwables = attemptToDeadlock(lockUser, lockHome, (x) -> {});
+            List<Throwable> throwables = attemptToDeadlock(lockUser, lockHome, (x) -> {});
 
-            assertTrue("Unexpected exceptions: " + throwables.first + "\n" + throwables.second, throwables.first instanceof PessimisticLockingFailureException || throwables.second instanceof PessimisticLockingFailureException );
+            assertFalse("No exceptions from attempted deadlock.", throwables.isEmpty());
+            throwables = throwables.stream().filter(t -> ! (t instanceof PessimisticLockingFailureException)).toList();
+            if (!throwables.isEmpty())
+                throw throwables.getFirst();
         }
 
         /**
          * @return foreground and background thread exceptions
          */
-        private Pair<Throwable, Throwable> attemptToDeadlock(Lock lock1, Lock lock2, @NotNull Consumer<Transaction> transactionModifier)
+        private List<Throwable> attemptToDeadlock(Lock lock1, Lock lock2, @NotNull Consumer<Transaction> transactionModifier)
         {
             final Object notifier = new Object();
-            final Pair<Throwable, Throwable> result = new Pair<>(null, null);
+            final List<Throwable> result = new ArrayList<>();
 
             // let's try to intentionally cause a deadlock
             Thread bkg = new Thread(() -> {
@@ -3431,7 +3437,7 @@ public class DbScope
                     }
                     catch (Throwable x)
                     {
-                        result.second = x;
+                        result.add(x);
                     }
                 }
             });
@@ -3465,7 +3471,7 @@ public class DbScope
                 }
                 catch (Throwable x)
                 {
-                    result.first = x;
+                    result.add(x);
                 }
                 finally
                 {

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -92,7 +92,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Random;
 import java.util.RandomAccess;
@@ -3267,7 +3266,7 @@ public class DbScope
         }
 
         @Test
-        public void testLockTimeout() throws Throwable
+        public void testLockTimeout()
         {
             ReentrantLock lock1 = new ReentrantLock();
             ReentrantLock lock2 = new ReentrantLock();
@@ -3386,7 +3385,7 @@ public class DbScope
         }
 
         @Test
-        public void testServerRowLock() throws Throwable
+        public void testServerRowLock()
         {
             final User user = TestContext.get().getUser();
 
@@ -3396,7 +3395,7 @@ public class DbScope
             attemptToDeadlock(lockUser, lockHome, (x) -> {}, PessimisticLockingFailureException.class);
         }
 
-        private void attemptToDeadlock(Lock lock1, Lock lock2, @NotNull Consumer<Transaction> transactionModifier, Class<? extends Throwable> expectedException) throws Throwable
+        private void attemptToDeadlock(Lock lock1, Lock lock2, @NotNull Consumer<Transaction> transactionModifier, Class<? extends Throwable> expectedException)
         {
             final Object notifier = new Object();
             final List<Throwable> result = new ArrayList<>();
@@ -3474,12 +3473,9 @@ public class DbScope
                 }
             }
 
-            assertFalse("No exception from attempted deadlock.", result.isEmpty());
-            Optional<Throwable> unwantedException = result.stream().filter(t -> !expectedException.isAssignableFrom(t.getClass())).findAny();
-            if (unwantedException.isPresent())
-            {
-                throw unwantedException.get();
-            }
+            assertFalse("No exceptions from attempted deadlock.", result.isEmpty());
+            result.stream().filter(t -> !expectedException.isAssignableFrom(t.getClass()))
+                .findAny().ifPresent(t -> { throw new RuntimeException("Deadlock didn't generate expected " + expectedException.getSimpleName(), t); });
         }
 
          @Test

--- a/api/src/org/labkey/api/data/DbScope.java
+++ b/api/src/org/labkey/api/data/DbScope.java
@@ -3475,7 +3475,10 @@ public class DbScope
 
             assertFalse("No exceptions from attempted deadlock.", result.isEmpty());
             result.stream().filter(t -> !expectedException.isAssignableFrom(t.getClass()))
-                .findAny().ifPresent(t -> { throw new RuntimeException("Deadlock didn't generate expected " + expectedException.getSimpleName(), t); });
+                .findAny().ifPresent(t -> {
+                    throw new AssertionError("Wrong error from deadlock. expected: <" +
+                        expectedException.getSimpleName() + ">, but was <" + t.getClass().getSimpleName() + ">", t);
+                });
         }
 
          @Test

--- a/api/src/org/labkey/api/util/DebugInfoDumper.java
+++ b/api/src/org/labkey/api/util/DebugInfoDumper.java
@@ -412,8 +412,22 @@ public class DebugInfoDumper
         // Schema won't exist on SQLServer
         if (schema != null)
         {
-            writeTable(logWriter, schema, BasePostgreSqlDialect.POSTGRES_STAT_ACTIVITY_TABLE_NAME, "Postgres activity");
-            writeTable(logWriter, schema, BasePostgreSqlDialect.POSTGRES_LOCKS_TABLE_NAME, "Postgres locks");
+            try
+            {
+                writeTable(logWriter, schema, BasePostgreSqlDialect.POSTGRES_LOCKS_TABLE_NAME, "Postgres locks");
+            }
+            catch (RuntimeException e)
+            {
+                logWriter.debug("Failed to write Postgres locks table:" + e);
+            }
+            try
+            {
+                writeTable(logWriter, schema, BasePostgreSqlDialect.POSTGRES_STAT_ACTIVITY_TABLE_NAME, "Postgres activity");
+            }
+            catch (RuntimeException e)
+            {
+                logWriter.debug("Failed to write Postgres activity table:" + e);
+            }
         }
     }
 
@@ -434,7 +448,7 @@ public class DebugInfoDumper
                 PrintWriter printWriter = new PrintWriter(stringWriter);
                 writer.write(printWriter);
                 printWriter.flush();
-                logWriter.debug("\n" + stringWriter.toString());
+                logWriter.debug("\n" + stringWriter);
             }
             catch (IOException e)
             {


### PR DESCRIPTION
#### Rationale
The error message for `DbScope.TransactionTestCase.testServerRowLock` isn't as informative as it could be. If we throw the unexpected exception instead of just logging the message, it will help diagnose what went wrong.
```
  java.lang.AssertionError: Unexpected exceptions: null
java.lang.IllegalStateException: Caller is already loading this object!
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.assertTrue(Assert.java:42)
  at org.labkey.api.data.DbScope$TransactionTestCase.testServerRowLock(DbScope.java:3399)
```

#### Related Pull Requests
- N/A

#### Changes
- Improve failure logging from DbScope.TransactionTestCase