### PR TITLE
Avoid including temp tables to avoid race condition when reporting

### DIFF
--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1235,6 +1235,8 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
 
             if (CoreSchema.getInstance().getSqlDialect().isPostgreSQL())
             {
+                // Exclude temp schema to avoid PG exceptions when tables are appearing/disappearing during execution
+                // Note that they can be non-trivial in size.
                 SQLFragment sql = new SQLFragment("SELECT table_schema, SUM(total_size) FROM ");
                 sql.append(new PostgresTableSizesTable(new PostgresUserSchema(User.getAdminServiceUser(), ContainerManager.getRoot())), "t");
                 sql.append(" WHERE table_schema != 'temp' GROUP BY table_schema");

--- a/core/src/org/labkey/core/CoreModule.java
+++ b/core/src/org/labkey/core/CoreModule.java
@@ -1237,7 +1237,7 @@ public class CoreModule extends SpringModule implements SearchService.DocumentPr
             {
                 SQLFragment sql = new SQLFragment("SELECT table_schema, SUM(total_size) FROM ");
                 sql.append(new PostgresTableSizesTable(new PostgresUserSchema(User.getAdminServiceUser(), ContainerManager.getRoot())), "t");
-                sql.append(" GROUP BY table_schema");
+                sql.append(" WHERE table_schema != 'temp' GROUP BY table_schema");
 
                 var schemaSizes = new SqlSelector(CoreSchema.getInstance().getSchema(), sql).getValueMap();
                 results.put("databaseSchemaSize", schemaSizes);


### PR DESCRIPTION
#### Rationale
```
org.postgresql.util.PSQLException: ERROR: relation "temp._b330a715b1bb7a8d3f74366b304607f8" does not exist
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2736) ~[postgresql-42.7.8.jar:42.7.8]
...
	at org.labkey.api.data.BaseSelector.getValueMap(BaseSelector.java:661) [api-26.1.1.jar:?]
	at org.labkey.api.data.Selector.getValueMap(Selector.java:174) [api-26.1.1.jar:?]
	at org.labkey.core.CoreModule.lambda$startupAfterSpringConfig$1(CoreModule.java:1237) [core-26.1.1.jar:?]
	at org.labkey.core.admin.usageMetrics.UsageMetricsServiceImpl.lambda$getModuleUsageMetrics$2(UsageMetricsServiceImpl.java:65) [core-26.1.1.jar:?]
	at java.base/java.lang.Iterable.forEach(Unknown Source) [?:?]
	at org.labkey.core.admin.usageMetrics.UsageMetricsServiceImpl.lambda$getModuleUsageMetrics$0(UsageMetricsServiceImpl.java:63) [core-26.1.1.jar:?]
```

#### Changes
- Filter out the temp schema, which is typically small in terms of the total DB footprint

#### Tasks
- Manual Testing - N/A
- Needs Automation - N/A
