### PR TITLE
Expose register action via LoginUrls

### DIFF
--- a/api/src/org/labkey/api/security/LoginUrls.java
+++ b/api/src/org/labkey/api/security/LoginUrls.java
@@ -33,6 +33,7 @@ public interface LoginUrls extends UrlProvider
     ActionURL getInitialUserURL();
     ActionURL getLoginURL();
     ActionURL getLoginURL(URLHelper returnUrl);
+    ActionURL getRegisterURL(Container c, @Nullable URLHelper returnUrl);
     ActionURL getLoginURL(Container c, @Nullable URLHelper returnUrl);
     ActionURL getLogoutURL(Container c);
     ActionURL getLogoutURL(Container c, URLHelper returnUrl);

--- a/core/src/org/labkey/core/login/LoginController.java
+++ b/core/src/org/labkey/core/login/LoginController.java
@@ -240,6 +240,17 @@ public class LoginController extends SpringActionController
         }
 
         @Override
+        public ActionURL getRegisterURL(Container c, @Nullable URLHelper returnUrl)
+        {
+            ActionURL url = new ActionURL(RegisterAction.class, c);
+
+            if (null != returnUrl)
+                url.addReturnUrl(returnUrl);
+
+            return url;
+        }
+
+        @Override
         public ActionURL getLogoutURL(Container c)
         {
             return new ActionURL(LogoutAction.class, c);


### PR DESCRIPTION
#### Rationale
If we expose the URL via LoginUrls we can avoid hard-coding strings in other modules.

#### Changes
- LoginUrls.getRegisterURL()

#### Tasks 📍
- Manual Testing - N/A
- Needs Automation - N/A
