### PR TITLE
Support report-to CSP directive and Reporting-Endpoints header

### DIFF
--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -316,8 +316,7 @@ public class ApiModule extends CodeOnlyModule
         {
             FilterRegistration registration = servletCtx.addFilter(filterName, new ContentSecurityPolicyFilter());
             registration.addMappingForUrlPatterns(allOf(DispatcherType.class), false, "/*");
-            String violation = servletCtx.getInitParameter("csp.violationEndpoint");
-            registration.setInitParameters(Map.of("policy", policy, "disposition", disposition, "violationEndpoint", violation));
+            registration.setInitParameters(Map.of("policy", policy, "disposition", disposition));
         }
     }
 

--- a/api/src/org/labkey/api/ApiModule.java
+++ b/api/src/org/labkey/api/ApiModule.java
@@ -316,7 +316,8 @@ public class ApiModule extends CodeOnlyModule
         {
             FilterRegistration registration = servletCtx.addFilter(filterName, new ContentSecurityPolicyFilter());
             registration.addMappingForUrlPatterns(allOf(DispatcherType.class), false, "/*");
-            registration.setInitParameters(Map.of("policy", policy, "disposition", disposition));
+            String violation = servletCtx.getInitParameter("csp.violationEndpoint");
+            registration.setInitParameters(Map.of("policy", policy, "disposition", disposition, "violationEndpoint", violation));
         }
     }
 

--- a/api/src/org/labkey/api/action/BaseApiAction.java
+++ b/api/src/org/labkey/api/action/BaseApiAction.java
@@ -312,7 +312,7 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
             if (null != contentType)
             {
                 if (MimeMap.DEFAULT.isJsonContentTypeHeader(contentType))
-                    {
+                {
                     _reqFormat = ApiResponseWriter.Format.JSON;
                     return populateJsonForm();
                 }

--- a/api/src/org/labkey/api/admin/AdminUrls.java
+++ b/api/src/org/labkey/api/admin/AdminUrls.java
@@ -65,6 +65,7 @@ public interface AdminUrls extends UrlProvider
     ActionURL getSessionLoggingURL();
     ActionURL getTrackedAllocationsViewerURL();
     ActionURL getSystemMaintenanceURL();
+    ActionURL getCspReportToURL(String cspVersion);
 
     /**
      * Simply adds an "Admin Console" link to nav trail if invoked in the root container. Otherwise, root is unchanged.

--- a/api/src/org/labkey/api/security/roles/ImpersonatingTroubleshooterRole.java
+++ b/api/src/org/labkey/api/security/roles/ImpersonatingTroubleshooterRole.java
@@ -26,4 +26,10 @@ public class ImpersonatingTroubleshooterRole extends AbstractRootContainerRole
     {
         return true;
     }
+
+    @Override
+    public boolean isAvailableEverywhere()
+    {
+        return false;
+    }
 }

--- a/api/src/org/labkey/api/util/MimeMap.java
+++ b/api/src/org/labkey/api/util/MimeMap.java
@@ -126,12 +126,13 @@ public class MimeMap implements FileNameMap
         public static final MimeType JSON = new MimeType("application/json", false, true);
         public static final MimeType TEXT_JSON = new MimeType("text/json", false, true);
         public static final MimeType CSP = new MimeType("application/csp-report", false, true);
+        public static final MimeType CSP_REPORT = new MimeType("application/reports+json", false, true);
     }
 
     static
     {
         for (MimeType mt : Arrays.asList(MimeType.GIF, MimeType.JPEG, MimeType.PDF, MimeType.PNG, MimeType.SVG, MimeType.HTML, MimeType.PLAIN, MimeType.XML,
-                MimeType.TEXT_JSON, MimeType.JSON, MimeType.CSP))
+                MimeType.TEXT_JSON, MimeType.JSON, MimeType.CSP, MimeType.CSP_REPORT))
         {
             mimeTypeMap.put(mt.getContentType(), mt);
         }

--- a/api/src/org/labkey/api/util/MimeMap.java
+++ b/api/src/org/labkey/api/util/MimeMap.java
@@ -125,14 +125,14 @@ public class MimeMap implements FileNameMap
         public static final MimeType XML = new MimeType("text/xml");
         public static final MimeType JSON = new MimeType("application/json", false, true);
         public static final MimeType TEXT_JSON = new MimeType("text/json", false, true);
-        public static final MimeType CSP = new MimeType("application/csp-report", false, true);
-        public static final MimeType CSP_REPORT = new MimeType("application/reports+json", false, true);
+        public static final MimeType CSP_REPORT_URI_JSON = new MimeType("application/csp-report", false, true);
+        public static final MimeType CSP_REPORT_TO_JSON = new MimeType("application/reports+json", false, true);
     }
 
     static
     {
         for (MimeType mt : Arrays.asList(MimeType.GIF, MimeType.JPEG, MimeType.PDF, MimeType.PNG, MimeType.SVG, MimeType.HTML, MimeType.PLAIN, MimeType.XML,
-                MimeType.TEXT_JSON, MimeType.JSON, MimeType.CSP, MimeType.CSP_REPORT))
+                MimeType.TEXT_JSON, MimeType.JSON, MimeType.CSP_REPORT_URI_JSON, MimeType.CSP_REPORT_TO_JSON))
         {
             mimeTypeMap.put(mt.getContentType(), mt);
         }

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -53,6 +53,7 @@ public class ContentSecurityPolicyFilter implements Filter
     private static final String REPORT_PARAMETER_SUBSTITUTION = "CSP.REPORT.PARAMS";
     private static final String UPGRADE_INSECURE_REQUESTS_SUBSTITUTION = "UPGRADE.INSECURE.REQUESTS";
     private static final String HEADER_NONCE = "org.labkey.filters.ContentSecurityPolicyFilter#NONCE";  // needs to match PageConfig.HEADER_NONCE
+    private static final String CSP_ENDPOINT_NAME = "csp-endpoint";
 
     private static final Map<ContentSecurityPolicyType, ContentSecurityPolicyFilter> CSP_FILTERS = new CopyOnWriteHashMap<>();
 
@@ -143,11 +144,12 @@ public class ContentSecurityPolicyFilter implements Filter
         {
             // Generate the Reporting-Endpoints header value now since its value is static. Use an absolute URL so we
             // always post reports to https:, even when the violating request happens to be http:
-            String violationEndpoint = substituteReportParams(baseServerUrl + "/admin-contentSecurityPolicyReportTo.api?${CSP.REPORT.PARAMS}");
+            ActionURL violationUrl = new ActionURL("admin-contentSecurityPolicyReportTo.api");
+            violationUrl = new ActionURL(substituteReportParams(violationUrl + "?${CSP.REPORT.PARAMS}"));
             if (_cspVersion != null)
-                violationEndpoint += "&cspVersion=" + _cspVersion;
-            _reportingEndpoints = "csp-endpoint=\"" + violationEndpoint + "\"";
-            _policyTemplate = _policyTemplate + " report-to csp-endpoint ;";
+                violationUrl.addParameter("cspVersion", _cspVersion);
+            _reportingEndpoints = CSP_ENDPOINT_NAME + "=\"" + violationUrl.getURIString() + "\"";
+            _policyTemplate = _policyTemplate + " report-to " + CSP_ENDPOINT_NAME + " ;";
         }
 
         if (CSP_FILTERS.put(_type, this) != null)

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.collections4.SetValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Test;
@@ -105,7 +106,6 @@ public class ContentSecurityPolicyFilter implements Filter
     public void init(FilterConfig filterConfig) throws ServletException
     {
         LogHelper.getLogger(ContentSecurityPolicyFilter.class, "CSP filter initialization").info("Initializing {}", filterConfig.getFilterName());
-        String violationEndpoint = null;
         Enumeration<String> paramNames = filterConfig.getInitParameterNames();
         while (paramNames.hasMoreElements())
         {
@@ -130,19 +130,25 @@ public class ContentSecurityPolicyFilter implements Filter
                 if ("report".equalsIgnoreCase(s))
                     _type = ContentSecurityPolicyType.Report;
             }
-            else if ("violationEndpoint".equalsIgnoreCase(paramName))
-            {
-                // We want to process this after we've extracted the CSP version from the policy, so stash for now
-                violationEndpoint = paramValue.trim();
-            }
             else
             {
                 throw new ServletException("ContentSecurityPolicyFilter is misconfigured, unexpected parameter name: " + paramName);
             }
         }
 
-        // Generate the Reporting-Endpoints header value now since its value is static
-        _reportingEndpoints = "csp-endpoint=\"" + substituteReportParams(violationEndpoint) + "\"";
+        String baseServerUrl = AppProps.getInstance().getBaseServerUrl();
+        // Add "Reporting-Endpoints" header and "report-to" directive only if https: is configured on this server. This
+        // ensures that browsers fall-back on report-uri if https: isn't configured.
+        if (Strings.CI.startsWith(baseServerUrl, "https://"))
+        {
+            // Generate the Reporting-Endpoints header value now since its value is static. Use an absolute URL so we
+            // always post reports to https:, even when the violating request happens to be http:
+            String violationEndpoint = substituteReportParams(baseServerUrl + "/admin-contentSecurityPolicyReportTo.api?${CSP.REPORT.PARAMS}");
+            if (_cspVersion != null)
+                violationEndpoint += "&cspVersion=" + _cspVersion;
+            _reportingEndpoints = "csp-endpoint=\"" + violationEndpoint + "\"";
+            _policyTemplate = _policyTemplate + " report-to csp-endpoint ;";
+        }
 
         if (CSP_FILTERS.put(_type, this) != null)
             throw new ServletException("ContentSecurityPolicyFilter is misconfigured, duplicate policies of type: " + _type);
@@ -153,13 +159,7 @@ public class ContentSecurityPolicyFilter implements Filter
     private String substituteReportParams(String expression)
     {
         return StringExpressionFactory.create(expression, false, NullValueBehavior.KeepSubstitution)
-            .eval(new HashMap<>()
-            {
-                {{
-                    put(REPORT_PARAMETER_SUBSTITUTION, "labkeyVersion=" + PageFlowUtil.encodeURIComponent(AppProps.getInstance().getReleaseVersion()));
-                    put("CSP.VERSION", _cspVersion);
-                }}
-            });
+            .eval(Map.of(REPORT_PARAMETER_SUBSTITUTION, "labkeyVersion=" + PageFlowUtil.encodeURIComponent(AppProps.getInstance().getReleaseVersion())));
     }
 
     /** Filter out block comments and replace special characters in the provided policy */
@@ -245,8 +245,8 @@ public class ContentSecurityPolicyFilter implements Filter
                 var csp = _policyExpression.eval(map);
                 resp.setHeader(_type.getHeaderName(), csp);
 
-                // report-to requires https. If http, omit the header so we fall back on report-uri.
-                if (request.isSecure())
+                // non-null if https: is configured on this server
+                if (_reportingEndpoints != null)
                     resp.setHeader("Reporting-Endpoints", _reportingEndpoints);
             }
         }

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -13,8 +13,10 @@ import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.collections.CopyOnWriteHashMap;
 import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.security.Directive;
@@ -37,6 +39,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -53,7 +56,6 @@ public class ContentSecurityPolicyFilter implements Filter
     private static final String REPORT_PARAMETER_SUBSTITUTION = "CSP.REPORT.PARAMS";
     private static final String UPGRADE_INSECURE_REQUESTS_SUBSTITUTION = "UPGRADE.INSECURE.REQUESTS";
     private static final String HEADER_NONCE = "org.labkey.filters.ContentSecurityPolicyFilter#NONCE";  // needs to match PageConfig.HEADER_NONCE
-    private static final String CSP_ENDPOINT_NAME = "csp-endpoint";
 
     private static final Map<ContentSecurityPolicyType, ContentSecurityPolicyFilter> CSP_FILTERS = new CopyOnWriteHashMap<>();
 
@@ -66,9 +68,14 @@ public class ContentSecurityPolicyFilter implements Filter
 
     // Per-filter-instance parameters that are set in init() and never changed
     private ContentSecurityPolicyType _type = ContentSecurityPolicyType.Enforce;
-    private String _policyTemplate = null;
-    private String _cspVersion = "Unknown";
-    private String _reportingEndpoints = null;
+    private @NotNull String _cspVersion = "Unknown";
+    private String _stashedTemplate = null;
+    private String _reportToEndpointName = null;
+
+    // Per-filter-instance parameters that are set at first request and reset if base server URL changes
+    private volatile String _previousBaseServerUrl = null;
+    private volatile String _policyTemplate = null;
+    private volatile String _reportingEndpointsHeaderValue = null;
 
     // Updated after every change to "allowed sources"
     private StringExpression _policyExpression = null;
@@ -119,7 +126,7 @@ public class ContentSecurityPolicyFilter implements Filter
                 // Replace REPORT_PARAMETER_SUBSTITUTION now since its value is static
                 s = substituteReportParams(s);
 
-                _policyTemplate = s;
+                _policyTemplate = _stashedTemplate = s;
 
                 extractCspVersion(s);
             }
@@ -137,23 +144,11 @@ public class ContentSecurityPolicyFilter implements Filter
             }
         }
 
-        String baseServerUrl = AppProps.getInstance().getBaseServerUrl();
-        // Add "Reporting-Endpoints" header and "report-to" directive only if https: is configured on this server. This
-        // ensures that browsers fall-back on report-uri if https: isn't configured.
-        if (Strings.CI.startsWith(baseServerUrl, "https://"))
-        {
-            // Generate the Reporting-Endpoints header value now since its value is static. Use an absolute URL so we
-            // always post reports to https:, even when the violating request happens to be http:
-            ActionURL violationUrl = new ActionURL("admin-contentSecurityPolicyReportTo.api");
-            violationUrl = new ActionURL(substituteReportParams(violationUrl + "?${CSP.REPORT.PARAMS}"));
-            if (_cspVersion != null)
-                violationUrl.addParameter("cspVersion", _cspVersion);
-            _reportingEndpoints = CSP_ENDPOINT_NAME + "=\"" + violationUrl.getURIString() + "\"";
-            _policyTemplate = _policyTemplate + " report-to " + CSP_ENDPOINT_NAME + " ;";
-        }
-
         if (CSP_FILTERS.put(_type, this) != null)
             throw new ServletException("ContentSecurityPolicyFilter is misconfigured, duplicate policies of type: " + _type);
+
+        // configure a different endpoint for each type to convey the correct csp version (eXX vs. rXX)
+        _reportToEndpointName = "csp-" + _type.name().toLowerCase();
 
         regeneratePolicyExpression();
     }
@@ -221,7 +216,8 @@ public class ContentSecurityPolicyFilter implements Filter
         LOG.debug("CspVersion: {}", _cspVersion);
     }
 
-    // Make all the "allowed sources" substitutions at init() and whenever the allowed sources map changes. With this,
+    // Make all the "allowed sources" substitutions at init(), whenever the allowed sources map changes, or whenever the
+    // policy template changes (e.g., base server URL change that causes report-to to be added or removed). With this,
     // the only substitution needed on a per-request basis is the nonce value.
     private void regeneratePolicyExpression()
     {
@@ -241,18 +237,55 @@ public class ContentSecurityPolicyFilter implements Filter
     {
         if (request instanceof HttpServletRequest req && response instanceof HttpServletResponse resp && null != _policyExpression)
         {
+            ensurePolicy();
+
             if (_type != ContentSecurityPolicyType.Enforce || !OptionalFeatureService.get().isFeatureEnabled(FEATURE_FLAG_DISABLE_ENFORCE_CSP))
             {
                 Map<String, String> map = Map.of(NONCE_SUBST, getScriptNonceHeader(req));
                 var csp = _policyExpression.eval(map);
                 resp.setHeader(_type.getHeaderName(), csp);
 
-                // non-null if https: is configured on this server
-                if (_reportingEndpoints != null)
-                    resp.setHeader("Reporting-Endpoints", _reportingEndpoints);
+                // null if https: is not configured on this server
+                if (_reportingEndpointsHeaderValue != null)
+                    resp.addHeader("Reporting-Endpoints", _reportingEndpointsHeaderValue);
             }
         }
         chain.doFilter(request, response);
+    }
+
+    private void ensurePolicy()
+    {
+        String baseServerUrl = AppProps.getInstance().getBaseServerUrl();
+
+        // Reconsider "report-to" directive and "Reporting-Endpoints" header if base server URL has changed
+        if (!Objects.equals(baseServerUrl, _previousBaseServerUrl))
+        {
+            synchronized (SUBSTITUTION_LOCK)
+            {
+                _previousBaseServerUrl = baseServerUrl;
+
+                // Add "Reporting-Endpoints" header and "report-to" directive only if https: is configured on this
+                // server. This ensures that browsers fall-back on report-uri if https: isn't configured.
+                if (Strings.CI.startsWith(baseServerUrl, "https://"))
+                {
+                    // Each filter adds its own "Reporting-Endpoints" header since we want to convey the correct version (eXX vs. rXX)
+                    @SuppressWarnings("DataFlowIssue")
+                    ActionURL violationUrl = PageFlowUtil.urlProvider(AdminUrls.class).getCspReportToURL(_cspVersion);
+                    // Use an absolute URL so we always post to https:, even if the violating request uses http:
+                    _reportingEndpointsHeaderValue = _reportToEndpointName + "=\"" + substituteReportParams(violationUrl.getURIString() + "&${CSP.REPORT.PARAMS}") + "\"";
+
+                    // Add "report-to" directive to the policy
+                    _policyTemplate = _stashedTemplate + " report-to " + _reportToEndpointName + " ;";
+                }
+                else
+                {
+                    _reportingEndpointsHeaderValue = null;
+                    _policyTemplate = _stashedTemplate;
+                }
+
+                regeneratePolicyExpression();
+            }
+        }
     }
 
     public static String getScriptNonceHeader(HttpServletRequest request)

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -66,6 +66,7 @@ public class ContentSecurityPolicyFilter implements Filter
     private ContentSecurityPolicyType _type = ContentSecurityPolicyType.Enforce;
     private String _policyTemplate = null;
     private String _cspVersion = "Unknown";
+    private String _reportingEndpoints = null;
 
     // Updated after every change to "allowed sources"
     private StringExpression _policyExpression = null;
@@ -104,7 +105,7 @@ public class ContentSecurityPolicyFilter implements Filter
     public void init(FilterConfig filterConfig) throws ServletException
     {
         LogHelper.getLogger(ContentSecurityPolicyFilter.class, "CSP filter initialization").info("Initializing {}", filterConfig.getFilterName());
-
+        String violationEndpoint = null;
         Enumeration<String> paramNames = filterConfig.getInitParameterNames();
         while (paramNames.hasMoreElements())
         {
@@ -115,8 +116,7 @@ public class ContentSecurityPolicyFilter implements Filter
                 String s = filterPolicy(paramValue);
 
                 // Replace REPORT_PARAMETER_SUBSTITUTION now since its value is static
-                s = StringExpressionFactory.create(s, false, NullValueBehavior.KeepSubstitution)
-                    .eval(Map.of(REPORT_PARAMETER_SUBSTITUTION, "labkeyVersion=" + PageFlowUtil.encodeURIComponent(AppProps.getInstance().getReleaseVersion())));
+                s = substituteReportParams(s);
 
                 _policyTemplate = s;
 
@@ -130,16 +130,36 @@ public class ContentSecurityPolicyFilter implements Filter
                 if ("report".equalsIgnoreCase(s))
                     _type = ContentSecurityPolicyType.Report;
             }
+            else if ("violationEndpoint".equalsIgnoreCase(paramName))
+            {
+                // We want to process this after we've extracted the CSP version from the policy, so stash for now
+                violationEndpoint = paramValue.trim();
+            }
             else
             {
                 throw new ServletException("ContentSecurityPolicyFilter is misconfigured, unexpected parameter name: " + paramName);
             }
         }
 
+        // Generate the Reporting-Endpoints header value now since its value is static
+        _reportingEndpoints = "csp-endpoint=\"" + substituteReportParams(violationEndpoint) + "\"";
+
         if (CSP_FILTERS.put(_type, this) != null)
             throw new ServletException("ContentSecurityPolicyFilter is misconfigured, duplicate policies of type: " + _type);
 
         regeneratePolicyExpression();
+    }
+
+    private String substituteReportParams(String expression)
+    {
+        return StringExpressionFactory.create(expression, false, NullValueBehavior.KeepSubstitution)
+            .eval(new HashMap<>()
+            {
+                {{
+                    put(REPORT_PARAMETER_SUBSTITUTION, "labkeyVersion=" + PageFlowUtil.encodeURIComponent(AppProps.getInstance().getReleaseVersion()));
+                    put("CSP.VERSION", _cspVersion);
+                }}
+            });
     }
 
     /** Filter out block comments and replace special characters in the provided policy */
@@ -224,6 +244,10 @@ public class ContentSecurityPolicyFilter implements Filter
                 Map<String, String> map = Map.of(NONCE_SUBST, getScriptNonceHeader(req));
                 var csp = _policyExpression.eval(map);
                 resp.setHeader(_type.getHeaderName(), csp);
+
+                // report-to requires https. If http, omit the header so we fall back on report-uri.
+                if (request.isSecure())
+                    resp.setHeader("Reporting-Endpoints", _reportingEndpoints);
             }
         }
         chain.doFilter(request, response);

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -44,6 +44,7 @@ import org.jfree.chart.ChartUtilities;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.data.category.DefaultCategoryDataset;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -190,7 +191,6 @@ import org.labkey.api.security.ActionNames;
 import org.labkey.api.security.AdminConsoleAction;
 import org.labkey.api.security.CSRF;
 import org.labkey.api.security.Directive;
-import org.labkey.api.security.ElevatedUser;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.GroupManager;
 import org.labkey.api.security.IgnoresTermsOfUse;
@@ -11974,16 +11974,54 @@ public class AdminController extends SpringActionController
         }
     }
 
-    private static final URI LABKEY_ORG_REPORT_ACTION;
+    private static final URI LABKEY_ORG_REPORT_URI_ACTION;
+    private static final URI LABKEY_ORG_REPORT_TO_ACTION;
 
     static
     {
-        LABKEY_ORG_REPORT_ACTION = URI.create("https://www.labkey.org/admin-contentSecurityPolicyReport.api");
+        LABKEY_ORG_REPORT_URI_ACTION = URI.create("https://www.labkey.org/admin-contentSecurityPolicyReport.api");
+        LABKEY_ORG_REPORT_TO_ACTION = URI.create("https://www.labkey.org/admin-contentSecurityPolicyReportTo.api");
+    }
+
+    // report-to endpoints get sent a JSON array of reports. Use Jackson to deserialize these into a List<JSONObject>.
+    public static class ReportToJsonObjects extends ArrayList<JSONObject>
+    {
     }
 
     @RequiresNoPermission
     @CSRF(CSRF.Method.NONE)
-    public static class ContentSecurityPolicyReportAction extends ReadOnlyApiAction<SimpleApiJsonForm>
+    @Marshal(Marshaller.Jackson)
+    public static class ContentSecurityPolicyReportToAction extends BaseContentSecurityPolicyReportAction<ReportToJsonObjects>
+    {
+        @Override
+        public void handleReports(ReportToJsonObjects jsonObjects, HttpServletRequest request, String userAgent) throws IOException, InterruptedException
+        {
+            JSONArray reportsToForward = new JSONArray();
+
+            jsonObjects.forEach(jsonObject -> {
+                if (handleOneReport(jsonObject, request, userAgent, "body", "blockedURL", "documentURL"))
+                    reportsToForward.put(jsonObject);
+            });
+
+            if (!reportsToForward.isEmpty())
+                forwardReports(LABKEY_ORG_REPORT_TO_ACTION, request, reportsToForward.toString(2));
+        }
+    }
+
+    @RequiresNoPermission
+    @CSRF(CSRF.Method.NONE)
+    public static class ContentSecurityPolicyReportAction extends BaseContentSecurityPolicyReportAction<SimpleApiJsonForm>
+    {
+        @Override
+        public void handleReports(SimpleApiJsonForm form, HttpServletRequest request, String userAgent) throws IOException, InterruptedException
+        {
+            JSONObject jsonObject = form.getJsonObject();
+            if (handleOneReport(jsonObject, request, userAgent, "csp-report", "blocked-uri", "document-uri"))
+                forwardReports(LABKEY_ORG_REPORT_URI_ACTION, request, jsonObject.toString(2));
+        }
+    }
+
+    protected abstract static class BaseContentSecurityPolicyReportAction<FORM> extends ReadOnlyApiAction<FORM>
     {
         private static final Logger _log = LogHelper.getLogger(ContentSecurityPolicyReportAction.class, "CSP warnings");
 
@@ -11991,7 +12029,15 @@ public class AdminController extends SpringActionController
         private static final Map<String, Boolean> reports = Collections.synchronizedMap(new LRUMap<>(20));
 
         @Override
-        public Object execute(SimpleApiJsonForm form, BindException errors) throws Exception
+        protected String getCommandClassMethodName()
+        {
+            return "handleReports";
+        }
+
+        abstract public void handleReports(FORM form, HttpServletRequest request, String userAgent) throws IOException, InterruptedException;
+
+        @Override
+        public Object execute(FORM form, BindException errors) throws Exception
         {
             var ret = new JSONObject().put("success", true);
 
@@ -12006,28 +12052,42 @@ public class AdminController extends SpringActionController
             if (PageFlowUtil.isRobotUserAgent(userAgent) && !_log.isDebugEnabled())
                 return ret;
 
-            // NOTE User may be "guest", and will always be guest if being relayed to labkey.org
-            var jsonObj = form.getJsonObject();
+            handleReports(form, request, userAgent);
+
+            return ret;
+        }
+
+        // Returns true if the report should be forwarded
+        protected boolean handleOneReport(JSONObject jsonObj, HttpServletRequest request, String userAgent, String bodyKey, String blockedUriKey, String documentUriKey)
+        {
             if (null != jsonObj)
             {
-                JSONObject cspReport = jsonObj.optJSONObject("csp-report");
+                JSONObject cspReport = jsonObj.optJSONObject(bodyKey);
                 if (cspReport != null)
                 {
-                    String blockedUri = cspReport.optString("blocked-uri", null);
+                    String blockedUri = cspReport.optString(blockedUriKey, null);
 
                     // Issue 52933 - suppress base-uri problems from a crawler or bot on labkey.org
                     if (blockedUri != null &&
-                            blockedUri.startsWith("https://labkey.org%2C") &&
-                            blockedUri.endsWith("undefined") &&
-                            !_log.isDebugEnabled())
+                        blockedUri.startsWith("https://labkey.org%2C") &&
+                        blockedUri.endsWith("undefined") &&
+                        !_log.isDebugEnabled())
                     {
-                        return ret;
+                        return false;
                     }
 
-                    String urlString = cspReport.optString("document-uri", null);
+                    String urlString = cspReport.optString(documentUriKey, null);
                     if (urlString != null)
                     {
-                        URLHelper urlHelper = new URLHelper(urlString);
+                        URLHelper urlHelper = null;
+                        try
+                        {
+                            urlHelper = new URLHelper(urlString);
+                        }
+                        catch (URISyntaxException e)
+                        {
+                            throw new RuntimeException(e);
+                        }
                         // URL parameter that tells us to bypass suppression of redundant logging
                         // Used to make sure that tests of CSP logging are deterministic and convenient
                         boolean bypassCspDedupe = "true".equals(urlHelper.getParameter("bypassCspDedupe"));
@@ -12042,7 +12102,7 @@ public class AdminController extends SpringActionController
                                 String email = null;
                                 // If the user is not logged in, we may still be able to snag the email address from our cookie
                                 if (user.isGuest())
-                                    email = LoginController.getEmailFromCookie(getViewContext().getRequest());
+                                    email = LoginController.getEmailFromCookie(request);
                                 if (null == email)
                                     email = user.getEmail();
                                 jsonObj.put("user", email);
@@ -12050,8 +12110,8 @@ public class AdminController extends SpringActionController
                                 if (ipAddress == null)
                                     ipAddress = request.getRemoteAddr();
                                 jsonObj.put("ip", ipAddress);
-                                if (isNotBlank(userAgent))
-                                    jsonObj.put("user-agent", userAgent);
+                                if (isNotBlank(userAgent) && !jsonObj.has("user_agent"))
+                                    jsonObj.put("user_agent", userAgent);
                                 String labkeyVersion = request.getParameter("labkeyVersion");
                                 if (null != labkeyVersion)
                                     jsonObj.put("labkeyVersion", labkeyVersion);
@@ -12063,47 +12123,52 @@ public class AdminController extends SpringActionController
                             var jsonStr = jsonObj.toString(2);
                             _log.warn("ContentSecurityPolicy warning on page: {}\n{}", urlString, jsonStr);
 
-                            if (!forwarded && OptionalFeatureService.get().isFeatureEnabled(ContentSecurityPolicyFilter.FEATURE_FLAG_FORWARD_CSP_REPORTS))
-                            {
+                            boolean shouldForward = !forwarded && OptionalFeatureService.get().isFeatureEnabled(ContentSecurityPolicyFilter.FEATURE_FLAG_FORWARD_CSP_REPORTS);
+                            if (shouldForward)
                                 jsonObj.put("forwarded", true);
 
-                                // Create an HttpClient
-                                HttpClient client = HttpClient.newBuilder()
-                                    .connectTimeout(Duration.ofSeconds(10))
-                                    .build();
-
-                                // Create the POST request
-                                HttpRequest remoteRequest = HttpRequest.newBuilder()
-                                    .uri(LABKEY_ORG_REPORT_ACTION)
-                                    .header("Content-Type", request.getContentType()) // Use whatever the browser set
-                                    .POST(HttpRequest.BodyPublishers.ofString(jsonObj.toString(2)))
-                                    .build();
-
-                                // Send the request and get the response
-                                HttpResponse<String> response = client.send(remoteRequest, HttpResponse.BodyHandlers.ofString());
-
-                                if (response.statusCode() != 200)
-                                {
-                                    _log.error("ContentSecurityPolicy report forwarding to https://www.labkey.org failed: {}\n{}", response.statusCode(), response.body());
-                                }
-                                else
-                                {
-                                    JSONObject jsonResponse = new JSONObject(response.body());
-                                    boolean success = jsonResponse.optBoolean("success", false);
-                                    if (!success)
-                                    {
-                                        _log.error("ContentSecurityPolicy report forwarding to https://www.labkey.org failed: {}", jsonResponse);
-                                    }
-                                }
-                            }
+                            return shouldForward;
                         }
                     }
                 }
             }
-            return ret;
+
+            return false;
+        }
+
+        protected void forwardReports(URI destination, HttpServletRequest request, String content) throws IOException, InterruptedException
+        {
+            // Create an HttpClient
+            try (HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build())
+            {
+                // Create the POST request
+                HttpRequest remoteRequest = HttpRequest.newBuilder()
+                    .uri(destination)
+                    .header("Content-Type", request.getContentType()) // Use whatever the browser set
+                    .POST(HttpRequest.BodyPublishers.ofString(content))
+                    .build();
+
+                // Send the request and get the response
+                HttpResponse<String> response = client.send(remoteRequest, HttpResponse.BodyHandlers.ofString());
+
+                if (response.statusCode() != 200)
+                {
+                    _log.error("ContentSecurityPolicy report forwarding to https://www.labkey.org failed: {}\n{}", response.statusCode(), response.body());
+                }
+                else
+                {
+                    JSONObject jsonResponse = new JSONObject(response.body());
+                    boolean success = jsonResponse.optBoolean("success", false);
+                    if (!success)
+                    {
+                        _log.error("ContentSecurityPolicy report forwarding to https://www.labkey.org failed: {}", jsonResponse);
+                    }
+                }
+            }
         }
     }
-
 
     public static class TestCase extends AbstractActionPermissionTest
     {

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -883,6 +883,13 @@ public class AdminController extends SpringActionController
             return new ActionURL(ConfigureSystemMaintenanceAction.class, ContainerManager.getRoot());
         }
 
+        @Override
+        public ActionURL getCspReportToURL(@NotNull String cspVersion)
+        {
+            return new ActionURL(ContentSecurityPolicyReportToAction.class, ContainerManager.getRoot())
+                .addParameter("cspVersion", cspVersion);
+        }
+
         public static ActionURL getDeprecatedFeaturesURL()
         {
             return new ActionURL(OptionalFeaturesAction.class, ContainerManager.getRoot()).addParameter("type", FeatureType.Deprecated.name());

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -12058,43 +12058,44 @@ public class AdminController extends SpringActionController
         }
 
         // Returns true if the report should be forwarded
-        protected boolean handleOneReport(JSONObject jsonObj, HttpServletRequest request, String userAgent, String bodyKey, String blockedUriKey, String documentUriKey)
+        protected boolean handleOneReport(JSONObject jsonObj, HttpServletRequest request, String userAgent, String bodyKey, String blockedUrlKey, String documentUrlKey)
         {
             if (null != jsonObj)
             {
                 JSONObject cspReport = jsonObj.optJSONObject(bodyKey);
                 if (cspReport != null)
                 {
-                    String blockedUri = cspReport.optString(blockedUriKey, null);
+                    String blockedUrl = cspReport.optString(blockedUrlKey, null);
 
                     // Issue 52933 - suppress base-uri problems from a crawler or bot on labkey.org
-                    if (blockedUri != null &&
-                        blockedUri.startsWith("https://labkey.org%2C") &&
-                        blockedUri.endsWith("undefined") &&
+                    if (blockedUrl != null &&
+                        blockedUrl.startsWith("https://labkey.org%2C") &&
+                        blockedUrl.endsWith("undefined") &&
                         !_log.isDebugEnabled())
                     {
                         return false;
                     }
 
-                    String urlString = cspReport.optString(documentUriKey, null);
-                    if (urlString != null)
+                    String documentUrl = cspReport.optString(documentUrlKey, null);
+                    if (documentUrl != null)
                     {
-                        URLHelper urlHelper = null;
+                        URLHelper documentUrlHelper;
                         try
                         {
-                            urlHelper = new URLHelper(urlString);
+                            documentUrlHelper = new URLHelper(documentUrl);
                         }
                         catch (URISyntaxException e)
                         {
                             throw new RuntimeException(e);
                         }
+
                         // URL parameter that tells us to bypass suppression of redundant logging
                         // Used to make sure that tests of CSP logging are deterministic and convenient
-                        boolean bypassCspDedupe = "true".equals(urlHelper.getParameter("bypassCspDedupe"));
-                        String path = urlHelper.deleteParameters().getURIString();
+                        boolean bypassCspDedupe = "true".equals(documentUrlHelper.getParameter("bypassCspDedupe"));
+                        String path = documentUrlHelper.deleteParameters().getURIString();
                         if (null == reports.put(path, Boolean.TRUE) || _log.isDebugEnabled() || bypassCspDedupe)
                         {
-                            // Don't modify forwarded reports; they already have user, ip, user-agent, etc. from the forwarding server.
+                            // Don't modify forwarded reports; they already have user, ip, user_agent, etc. from the forwarding server.
                             boolean forwarded = jsonObj.optBoolean("forwarded", false);
                             if (!forwarded)
                             {
@@ -12121,7 +12122,7 @@ public class AdminController extends SpringActionController
                             }
 
                             var jsonStr = jsonObj.toString(2);
-                            _log.warn("ContentSecurityPolicy warning on page: {}\n{}", urlString, jsonStr);
+                            _log.warn("ContentSecurityPolicy warning on page: {}\n{}", documentUrl, jsonStr);
 
                             boolean shouldForward = !forwarded && OptionalFeatureService.get().isFeatureEnabled(ContentSecurityPolicyFilter.FEATURE_FLAG_FORWARD_CSP_REPORTS);
                             if (shouldForward)


### PR DESCRIPTION
#### Rationale
Security scanners like to see `report-to` directives, even though not all browsers support them. https://github.com/LabKey/internal-issues/issues/794

#### Related Pull Requests
- https://github.com/LabKey/server/pull/1269