### PR TITLE
Improve error for Postgres admin console links outside of root

### DIFF
--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -2625,6 +2625,11 @@ public class AdminController extends SpringActionController
         @Override
         protected QueryView createQueryView(QueryExportForm form, BindException errors, boolean forExport, @Nullable String dataRegion) throws Exception
         {
+            if (!getContainer().isRoot())
+            {
+                throw new NotFoundException("Available only in the root container");
+            }
+
             if (!CoreSchema.getInstance().getSqlDialect().isPostgreSQL())
             {
                 throw new NotFoundException("Available only with Postgres as the primary database");


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_DailyPostgres_2/3826975

#### Changes
- Return a 404 instead of letting downstream code throw an assertion error