### PR TITLE
Delete search index in an indexing task

### DIFF
--- a/api/src/org/labkey/api/cache/BlockingCache.java
+++ b/api/src/org/labkey/api/cache/BlockingCache.java
@@ -99,7 +99,7 @@ public class BlockingCache<K, V> implements Cache<K, V>
         if (null == loader)
             loader = _loader;
 
-        try (var ignored = DebugInfoDumper.pushThreadDumpContext(this.getClass().getSimpleName() + ".get(" + key + ")"))
+        try (var _ = DebugInfoDumper.pushThreadDumpContext(this.getClass().getSimpleName() + ".get(" + key + ")"))
         {
             synchronized (loader == null ? _cache : loader.getSyncObject(_cache))
             {

--- a/api/src/org/labkey/api/util/DebugInfoDumper.java
+++ b/api/src/org/labkey/api/util/DebugInfoDumper.java
@@ -162,7 +162,7 @@ public class DebugInfoDumper
      * This is primarily intended to help understand deadlocks.  Developers are encouraged to
      * add information related to attaining locks or starting transactions.
      */
-    public static _PopAutoCloseable pushThreadDumpContext(String context)
+    public static QuietCloser pushThreadDumpContext(String context)
     {
         final var arr = _threadDumpExtraContext.computeIfAbsent(Thread.currentThread(), (_) -> Collections.synchronizedList(new ArrayList<>()));
         int size = arr.size();
@@ -178,7 +178,7 @@ public class DebugInfoDumper
     }
 
 
-    public static class _PopAutoCloseable implements AutoCloseable
+    public static class _PopAutoCloseable implements QuietCloser
     {
         final int _size;
 
@@ -193,7 +193,7 @@ public class DebugInfoDumper
             var arr = _threadDumpExtraContext.get(Thread.currentThread());
             assert null != arr;
             while (arr.size() > _size)
-                arr.remove(arr.size() - 1);
+                arr.removeLast();
         }
     }
 
@@ -407,7 +407,7 @@ public class DebugInfoDumper
             logWriter.debug("*********************************************");
         }
 
-        // GitHib Issue 713: Automatically include PG locks and active queries in thread dumps
+        // GitHub Issue 713: Automatically include PG locks and active queries in thread dumps
         UserSchema schema = QueryService.get().getUserSchema(User.getAdminServiceUser(), ContainerManager.getRoot(), BasePostgreSqlDialect.POSTGRES_SCHEMA_NAME);
         // Schema won't exist on SQLServer
         if (schema != null)
@@ -489,26 +489,9 @@ public class DebugInfoDumper
             // subtract 1 because dumpThreads includes Thread.run() in the stack trace
             logWriter.debug(String.format("%3d\t\t%s", stack.length-i-1, stack[i].toString()));
         }
-        var extraInfo = _threadDumpExtraContext.get(thread);
-        if (null != extraInfo && !extraInfo.isEmpty())
+        for (String line : getFormattedExtraContext(thread))
         {
-            logWriter.debug("extra stack context (may not match stacktrace if thread is not blocked)");
-            var messages = extraInfo.toArray(new ThreadExtraContext[0]);
-            for (var i = messages.length-1 ; i>= 0 ; i--)
-            {
-                logWriter.debug("\t" + messages[i].context.replace('\n',' ') + "\tage: " + (System.currentTimeMillis() - messages[i].startTime) + "ms");
-                var messageStack = messages[i].stack();
-                if (null != messageStack)
-                {
-                    for (int j=0, count=0 ; j<messageStack.length && count < 4; j++)
-                    {
-                        if (skipMethods.contains(messageStack[j].getMethodName()))
-                            continue;
-                        logWriter.debug(String.format("%3d\t\t%s", messageStack.length - j, messageStack[j].toString()));
-                        count++;
-                    }
-                }
-            }
+            logWriter.debug(line);
         }
 
         if (ConnectionWrapper.getProbableLeakCount() > 0)

--- a/api/src/org/labkey/api/util/DebugInfoDumper.java
+++ b/api/src/org/labkey/api/util/DebugInfoDumper.java
@@ -518,6 +518,37 @@ public class DebugInfoDumper
     }
 
     /**
+     * Returns formatted extra stack context lines for the given thread, suitable for display in thread dumps.
+     * Returns an empty list if the thread has no extra context.
+     */
+    public static List<String> getFormattedExtraContext(Thread thread)
+    {
+        var extraInfo = _threadDumpExtraContext.get(thread);
+        if (extraInfo == null || extraInfo.isEmpty())
+            return List.of();
+
+        List<String> result = new ArrayList<>();
+        result.add("extra stack context (may not match stacktrace if thread is not blocked)");
+        var messages = extraInfo.toArray(new ThreadExtraContext[0]);
+        for (int i = messages.length - 1; i >= 0; i--)
+        {
+            result.add("\t" + messages[i].context.replace('\n', ' ') + "\tage: " + (System.currentTimeMillis() - messages[i].startTime) + "ms");
+            var messageStack = messages[i].stack();
+            if (messageStack != null)
+            {
+                for (int j = 0, count = 0; j < messageStack.length && count < 4; j++)
+                {
+                    if (skipMethods.contains(messageStack[j].getMethodName()))
+                        continue;
+                    result.add(String.format("%3d\t\t%s", messageStack.length - j, messageStack[j].toString()));
+                    count++;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
      * Writes the current set of thread stacks once to the supplied logger.
      */
     public static synchronized void dumpThreads(Logger log)

--- a/core/src/org/labkey/core/admin/threads.jsp
+++ b/core/src/org/labkey/core/admin/threads.jsp
@@ -22,6 +22,8 @@
 <%@ page import="java.util.Date" %>
 <%@ page import="java.util.Set" %>
 <%@ page import="org.labkey.api.data.TransactionFilter" %>
+<%@ page import="org.labkey.api.util.DebugInfoDumper" %>
+<%@ page import="java.util.List" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     HttpView<AdminController.ThreadsBean> me = HttpView.currentView();
@@ -69,6 +71,11 @@ for (Thread t : bean.threads)
     for (StackTraceElement e : bean.stackTraces.get(t))
         {
             %><%= h("    at " + e  + "\n") %><%
+        }
+        List<String> extraContext = DebugInfoDumper.getFormattedExtraContext(t);
+        for (String line : extraContext)
+        {
+            %><%= h(line + "\n") %><%
         }
     }
     catch (Exception x)

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -41,6 +41,7 @@ import org.labkey.api.search.SearchService;
 import org.labkey.api.security.User;
 import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.util.ContextListener;
+import org.labkey.api.util.DebugInfoDumper;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.Formats;
 import org.labkey.api.util.GUID;
@@ -411,6 +412,12 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         }
     }
 
+
+    private static String getSearchThreadDumpContext(Item i)
+    {
+        String taskDescription = i._task != null ? i._task.getDescription() : "unknown";
+        return "Search item: " + i._id + " (task: " + taskDescription + ")";
+    }
 
     final Item _commitItem = new Item(null, (q) -> {}, PRIORITY.commit, null);
 
@@ -1078,6 +1085,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         {
             Item i = null;
             boolean success = true;
+            DebugInfoDumper._PopAutoCloseable threadDumpContext = null;
 
             try
             {
@@ -1086,6 +1094,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 if (null != i)
                 {
                     final Item item = i;
+                    threadDumpContext = DebugInfoDumper.pushThreadDumpContext(getSearchThreadDumpContext(item));
                     while (!_shuttingDown && _itemQueue.size() > 1000)
                     {
                         try {Thread.sleep(100);}catch(InterruptedException ignored){}
@@ -1149,6 +1158,8 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             }
             finally
             {
+                if (threadDumpContext != null)
+                    threadDumpContext.close();
                 if (null != i)
                 {
                     try
@@ -1248,6 +1259,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     {
         Item i = null;
         boolean success = false;
+        DebugInfoDumper._PopAutoCloseable threadDumpContext = null;
         try
         {
             i = getItemToIndex();
@@ -1267,6 +1279,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 return;
             }
 
+            threadDumpContext = DebugInfoDumper.pushThreadDumpContext(getSearchThreadDumpContext(i));
             WebdavResource r = i.getResource();
             if (null == r || !r.exists())
             {
@@ -1331,6 +1344,8 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         {
             try
             {
+                if (threadDumpContext != null)
+                    threadDumpContext.close();
                 if (null != i)
                     i.complete(success);
             }

--- a/search/src/org/labkey/search/model/AbstractSearchService.java
+++ b/search/src/org/labkey/search/model/AbstractSearchService.java
@@ -52,6 +52,7 @@ import org.labkey.api.util.MultisetRateAccumulator;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.QuietCloser;
 import org.labkey.api.util.ShutdownListener;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.SystemMaintenance;
@@ -228,7 +229,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                 }
             };
             addItem(i);
-            final Item r = new Item(this, (q) -> queueItem(i), pri, null);
+            final Item r = new Item(this, (_) -> queueItem(i), pri, null);
             queueItem(r);
         }
 
@@ -419,7 +420,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         return "Search item: " + i._id + " (task: " + taskDescription + ")";
     }
 
-    final Item _commitItem = new Item(null, (q) -> {}, PRIORITY.commit, null);
+    final Item _commitItem = new Item(null, (_) -> {}, PRIORITY.commit, null);
 
 
     @Override
@@ -476,7 +477,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     @Override
     public final void deleteContainer(final String id)
     {
-        Consumer<TaskIndexingQueue> r = (q) -> {
+        Consumer<TaskIndexingQueue> r = (_) -> {
             deleteIndexedContainer(id);
             synchronized (_commitLock)
             {
@@ -519,7 +520,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     public void reindexContainerFiles(Container c)
     {
         //Create new runnable instead of using existing methods so they can be run within the same job.
-        Consumer<TaskIndexingQueue> r = (q) -> {
+        Consumer<TaskIndexingQueue> r = (_) -> {
             //Remove old items
             clearIndexedFileSystemFiles(c);
 
@@ -728,7 +729,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         });
         // The indexer uses multiple threads for different types of work. Queue a Runnable first, and when it executes,
         // queue an Item to ensure all queues are cleared
-        task.addRunnable(null, priority, (q) -> {
+        task.addRunnable(null, priority, (_) -> {
             logQueueStatus("drainQueue's Runnable.run()");
             task.addNoop(priority);
         });
@@ -872,7 +873,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             if (resourceResolverKeyIdentifier == null)
                 continue;
             resolverIdentifiers
-                    .computeIfAbsent(resourceResolverKeyIdentifier.first, (k) -> new HashMap<>())
+                    .computeIfAbsent(resourceResolverKeyIdentifier.first, (_) -> new HashMap<>())
                     .put(resourceResolverKeyIdentifier.second, resourceIdentifier);
         }
 
@@ -1085,7 +1086,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
         {
             Item i = null;
             boolean success = true;
-            DebugInfoDumper._PopAutoCloseable threadDumpContext = null;
+            QuietCloser threadDumpContext = null;
 
             try
             {
@@ -1097,7 +1098,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
                     threadDumpContext = DebugInfoDumper.pushThreadDumpContext(getSearchThreadDumpContext(item));
                     while (!_shuttingDown && _itemQueue.size() > 1000)
                     {
-                        try {Thread.sleep(100);}catch(InterruptedException ignored){}
+                        try {Thread.sleep(100);}catch(InterruptedException _){}
                     }
 
                     Container c;
@@ -1259,7 +1260,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
     {
         Item i = null;
         boolean success = false;
-        DebugInfoDumper._PopAutoCloseable threadDumpContext = null;
+        QuietCloser threadDumpContext = null;
         try
         {
             i = getItemToIndex();
@@ -1540,7 +1541,7 @@ public abstract class AbstractSearchService implements SearchService, ShutdownLi
             history.addAll(_history);
         }
 
-        IndexerRateAccumulator historyAccumulator = new IndexerRateAccumulator(history.get(history.size() - 1).getStart());
+        IndexerRateAccumulator historyAccumulator = new IndexerRateAccumulator(history.getLast().getStart());
         SimpleDateFormat f = new SimpleDateFormat("h:mm a");
         StringBuilder hourly = new StringBuilder();
         hourly.append("<table>");

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -1182,7 +1182,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         throw new IllegalStateException(problem);
     }
 
-    // parse the document of the resource, not that parse() and accept() should agree on what is parsable
+    // parse the document of the resource, note that parse() and accept() should agree on what is parsable
     private void parse(WebdavResource r, InputStream is, ContentHandler handler, Metadata metadata, boolean tooBig) throws IOException, SAXException, TikaException
     {
         if (!is.markSupported())

--- a/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
+++ b/search/src/org/labkey/search/model/LuceneSearchServiceImpl.java
@@ -19,6 +19,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.iterators.ArrayIterator;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -94,7 +95,6 @@ import org.labkey.api.test.TestTimeout;
 import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileStream;
-import org.labkey.api.util.FileStream.FileFileStream;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.GUID;
 import org.labkey.api.util.HtmlString;
@@ -393,7 +393,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
 
         // In dev mode, put the full-text-search index in a Lucene-version-specific subfolder (/Lucene8, /Lucene9, /Lucene10, etc.).
         // This prevents full index rebuilds when switching between branches with different major Lucene versions.
-        return AppProps.getInstance().isDevMode() ? new File(substitutedDirectory, "Lucene" + Version.LATEST.major) : substitutedDirectory;
+        return AppProps.getInstance().isDevMode() ? FileUtil.appendName(substitutedDirectory, "Lucene" + Version.LATEST.major) : substitutedDirectory;
     }
 
     // Create a Map of system properties with file-system escaped values
@@ -615,6 +615,45 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
     @Override
     public void deleteIndex(String reason)
     {
+        if (_threadsInitialized && !_shuttingDown)
+        {
+            // Queue the work to run on the indexing thread to avoid deadlocks with concurrent
+            // database operations (e.g., truncating lastIndexed while indexing threads are querying)
+            _log.info("Queuing deletion of full-text search index because: " + reason);
+            final CountDownLatch latch = new CountDownLatch(1);
+            _IndexTask task = createTask("DeleteIndex", new TaskListener()
+            {
+                @Override
+                public void success()
+                {
+                    latch.countDown();
+                }
+
+                @Override
+                public void indexError(Resource r, Throwable t)
+                {
+                    latch.countDown();
+                }
+            });
+            task.addRunnable(null, PRIORITY.delete, (_) -> deleteIndexImpl(reason));
+            task.setReady();
+            try
+            {
+                latch.await();
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+            }
+        }
+        else
+        {
+            deleteIndexImpl(reason);
+        }
+    }
+
+    private void deleteIndexImpl(String reason)
+    {
         _log.info("Deleting full-text search index and clearing last indexed because: " + reason);
         if (isIndexManagerReady())
             closeIndex();
@@ -747,7 +786,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
                     metadata.add(Metadata.CONTENT_ENCODING, StringUtilsLabKey.DEFAULT_CHARSET.name());
 
                 handler = _BodyContentHandler.create();     // no write limit on the handler -- rely on file size check to limit content
-                parse(r, fs, is, handler, metadata, isTooBig(fs, type));
+                parse(r, is, handler, metadata, isTooBig(fs, type));
 
                 if (StringUtils.isBlank(title))
                     title = metadata.get(TikaCoreProperties.TITLE);
@@ -950,9 +989,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
                 {
                     fs.closeInputStream();
                 }
-                catch (IOException x)
-                {
-                }
+                catch (IOException _) {}
             }
         }
 
@@ -1038,7 +1075,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
             // Example: Extending LabKey.thmx
             logAsWarning(r, "Can't parse this document type", rootMessage);
         }
-        else if ((topMessage.startsWith("Invalid Image Resource Block Signature Found") || topMessage.startsWith("PSD/PSB magic signature invalid") /* test.fasta.psd */) && StringUtils.endsWithIgnoreCase(r.getName(), ".psd"))
+        else if ((topMessage.startsWith("Invalid Image Resource Block Signature Found") || topMessage.startsWith("PSD/PSB magic signature invalid") /* test.fasta.psd */) && Strings.CI.endsWith(r.getName(), ".psd"))
         {
             // Tika doesn't like some .psd files (e.g., files included in ExtJs 3.4.1)
             logAsWarning(r, "Can't parse this PSD file", rootMessage);
@@ -1072,7 +1109,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         {
             logAsWarning(r, "Can't decompress this file", rootMessage);
         }
-        else if (StringUtils.endsWithIgnoreCase(r.getName(), ".chm"))
+        else if (Strings.CI.endsWith(r.getName(), ".chm"))
         {
             // ChmExtractor throws exceptions for many .chm (compressed HTML) files that it attempts to parse, so we just
             // suppress the lot of them. Some of the messages include:
@@ -1141,12 +1178,12 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
 
     private void logBadDocument(String problem, WebdavResource r)
     {
-        _log.error(problem);
+        _log.error(problem + " for " + r.getDocumentId());
         throw new IllegalStateException(problem);
     }
 
     // parse the document of the resource, not that parse() and accept() should agree on what is parsable
-    private void parse(WebdavResource r, FileStream fs, InputStream is, ContentHandler handler, Metadata metadata, boolean tooBig) throws IOException, SAXException, TikaException
+    private void parse(WebdavResource r, InputStream is, ContentHandler handler, Metadata metadata, boolean tooBig) throws IOException, SAXException, TikaException
     {
         if (!is.markSupported())
             is = new BufferedInputStream(is);
@@ -1566,7 +1603,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
             processSearchResult(0, 1, topDocs, searcher, result);
             if (result.hits.size() != 1)
                 return null;
-            return result.hits.get(0);
+            return result.hits.getFirst();
         });
     }
 
@@ -1890,9 +1927,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         {
             map.put("Indexed Documents", getNumDocs());
         }
-        catch (IOException x)
-        {
-        }
+        catch (IOException _) {}
 
         map.putAll(super.getIndexerStats());
         return map;
@@ -1973,13 +2008,13 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
 
                     if (strict)
                     {
-                        lssi.parse(resource, new FileFileStream(file), is, handler, metadata, false);
+                        lssi.parse(resource, is, handler, metadata, false);
                     }
                     else
                     {
                         try
                         {
-                            lssi.parse(resource, new FileFileStream(file), is, handler, metadata, false);
+                            lssi.parse(resource, is, handler, metadata, false);
                         }
                         catch (Throwable t)
                         {
@@ -2055,7 +2090,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
 
                 try (InputStream is = new FileInputStream(file))
                 {
-                    lssi.parse(resource, new FileFileStream(file), is, handler, metadata, tooBig);
+                    lssi.parse(resource, is, handler, metadata, tooBig);
 
                     String body = handler.toString();
                     assertTrue("Body for oversized file parsed unexpectedly: " + file.getName(), StringUtils.isBlank(body));
@@ -2137,7 +2172,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         public void testTika()
         {
             File root = new File("c:\\temp");
-            Predicate<WebdavResource> fileFilter = webdavResource -> StringUtils.endsWithIgnoreCase(webdavResource.getName(), ".txt");
+            Predicate<WebdavResource> fileFilter = webdavResource -> Strings.CI.endsWith(webdavResource.getName(), ".txt");
             FileSystemResource rootResource = new FileSystemResource(Path.parse(root.getAbsolutePath()), root, _c);
             traverse(rootResource, fileFilter);
         }
@@ -2148,7 +2183,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
             rootResource.list().stream()
                 .filter(Resource::isFile)
                 .filter(fileFilter)
-                .forEach(resource -> ((AbstractSearchService)_ss).processAndIndex(resource.getPath().encode(), resource, new Throwable[]{null}));
+                .forEach(resource -> _ss.processAndIndex(resource.getPath().encode(), resource, new Throwable[]{null}));
 
             rootResource.list().stream()
                 .filter(Resource::isCollection)
@@ -2158,7 +2193,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         @Test
         public void testSort()
         {
-            Consumer<TaskIndexingQueue> r = (q) -> {};
+            Consumer<TaskIndexingQueue> r = (_) -> {};
 
             // Create crawl/Runnable items to ensure they get ordered based on creation order
             Item crawlRunnable1 = new Item(_ss.defaultTask(), r, PRIORITY.crawl, null);
@@ -2230,7 +2265,7 @@ public class LuceneSearchServiceImpl extends AbstractSearchService implements Se
         @Test
         public void testKeywordsAndIdentifiers() throws InterruptedException, IOException
         {
-            if (null == _ss || !(_ss instanceof LuceneSearchServiceImpl impl))
+            if (!(_ss instanceof LuceneSearchServiceImpl impl))
                 return;
 
             impl.deleteIndexedContainer(_c.getId());

--- a/search/test/src/org/labkey/test/tests/search/DeleteIndexTest.java
+++ b/search/test/src/org/labkey/test/tests/search/DeleteIndexTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.labkey.test.tests.search;
+
+import org.assertj.core.api.Assertions;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.TestTimeoutException;
+import org.labkey.test.categories.Search;
+import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.SearchHelper;
+import org.labkey.test.util.WikiHelper;
+import org.labkey.test.util.search.SearchAdminAPIHelper;
+
+import java.util.List;
+
+@Category({Search.class})
+@BaseWebDriverTest.ClassTimeout(minutes = 10)
+public class DeleteIndexTest extends BaseWebDriverTest
+{
+    private static final String PROJECT_NAME = "DeleteIndexTest";
+    private static final String UNIQUE_CONTENT = "Chrysoprase";  // Unique term unlikely to appear in other test content
+    private final SearchHelper _searchHelper = new SearchHelper(this);
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return List.of("Search");
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return PROJECT_NAME;
+    }
+
+    @BeforeClass
+    public static void setupProject()
+    {
+        DeleteIndexTest test = getCurrentTest();
+        test._containerHelper.createProject(PROJECT_NAME, null);
+        new PortalHelper(test).addWebPart("Wiki");
+        new WikiHelper(test).createWikiPage("deleteIndexWiki", "RADEOX", "Delete Index Wiki", UNIQUE_CONTENT, null);
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        SearchAdminAPIHelper.startCrawler(getDriver());
+        _containerHelper.deleteProject(getProjectName(), afterTest);
+    }
+
+    @Test
+    public void testDeleteIndex()
+    {
+        // Verify content is found in the index
+        SearchAdminAPIHelper.waitForIndexerBackground();
+        Assertions.assertThat(_searchHelper.searchFor(UNIQUE_CONTENT, false).getResultCount())
+            .as("Content should be searchable after indexing")
+            .isGreaterThan(0);
+
+        // Pause the crawler so it won't re-index after deletion
+        SearchAdminAPIHelper.pauseCrawler(getDriver());
+
+        // Delete the index
+        SearchAdminAPIHelper.deleteIndex(getDriver());
+
+        // Verify content is no longer found
+        Assertions.assertThat(_searchHelper.searchFor(UNIQUE_CONTENT, false).getResultCount())
+            .as("Content should not be found after index deletion")
+            .isEqualTo(0);
+
+        // Resume the crawler and wait for content to be re-indexed
+        SearchAdminAPIHelper.startCrawler(getDriver());
+        int hitCount = 0;
+        for (int attempt = 0; attempt < 10 && hitCount == 0; attempt++)
+        {
+            SearchAdminAPIHelper.waitForIndexerBackground();
+            hitCount = _searchHelper.searchFor(UNIQUE_CONTENT, false).getResultCount();
+        }
+        Assertions.assertThat(hitCount)
+            .as("Content should be found again after re-indexing")
+            .isGreaterThan(0);
+    }
+}


### PR DESCRIPTION
#### Rationale
A recent server deadlock involved three concurrent attempts to modify `exp.DataIndexed`. Two were admin-initiated requests to delete the index (the second was presumably a retry as it was kicked off 5.5 minutes later), and the third was background indexing of data objects.

Additionally, we can capture more context in thread dumps for search indexing tasks.

#### Changes
- Move index deletion and clearing of `LastModified` to a search task, meaning it will queue and avoid parallel self-execution
- Capture indexing work as thread extra context
- Show extra context in Admin Console thread dumps too
- Test coverage for index deletion and crawler pausing

#### Tasks 📍
- [x] Manual Testing @labkey-danield 
   - [x] Delete index, ensure it goes away
   - [x] Admin Console->Running Threads while indexing work is happening. Ensure SearchService thread shows extra context for the current runnable, including its time spent executing so far
- [x] Needs Automation
