### PR TITLE
Support database materialized views

### DIFF
--- a/api/schemas/tableInfo.xsd
+++ b/api/schemas/tableInfo.xsd
@@ -321,7 +321,7 @@
 			<xs:annotation>
 				<xs:documentation>
                     The four recognized values for the tableDbType attribute are TABLE, VIEW, NOT_IN_DB, UNKNOWN.
-                    The TABLE and VIEW values correspond to their SQL definitions.
+                    The TABLE, VIEW, and MATERIALIZED_VIEW values correspond to their SQL definitions.
                     NOT_IN_DB type is used for objects that are defined by SQL strings in code, rather than by named objects in the database.
                     UNKNOWN is used in cases where the type differs between database types.
                     Supported for SQL metadata.
@@ -329,7 +329,7 @@
 			</xs:annotation>
 			<xs:simpleType>
 				<xs:restriction base="xs:string">
-					<xs:pattern value="TABLE|VIEW|NOT_IN_DB|UNKNOWN"/>
+					<xs:pattern value="TABLE|VIEW|MATERIALIZED_VIEW|NOT_IN_DB|UNKNOWN"/>
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>

--- a/api/src/org/labkey/api/data/DatabaseTableType.java
+++ b/api/src/org/labkey/api/data/DatabaseTableType.java
@@ -16,14 +16,24 @@
 
 package org.labkey.api.data;
 
-/*
-* User: adam
-* Date: Jul 7, 2011
-* Time: 4:30:16 AM
-*/
+// Database table types that we pass into JDBC metadata method getTables(). Some databases support a subset of these
+// types (e.g., SQL Server doesn't support materialized views), but getTables() just ignores types it doesn't know.
 public enum DatabaseTableType
 {
     TABLE,
     VIEW,
-    NOT_IN_DB
+    MATERIALIZED_VIEW
+    {
+        @Override
+        public String getJdbcTypeName()
+        {
+            return "MATERIALIZED VIEW";
+        }
+    },
+    NOT_IN_DB;
+
+    public String getJdbcTypeName()
+    {
+        return name();
+    }
 }

--- a/api/src/org/labkey/api/data/dialect/JdbcMetaDataTest.java
+++ b/api/src/org/labkey/api/data/dialect/JdbcMetaDataTest.java
@@ -6,31 +6,44 @@ import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DatabaseTableType;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.data.TestSchema;
 
 public class JdbcMetaDataTest extends Assert
 {
-    DbSchema _testSchema = DbSchema.get("test", DbSchemaType.Bare);
+    private final DbSchema _testSchema = DbSchema.get("test", DbSchemaType.Bare);
 
     // Test that tables with names containing LIKE wild cards work correctly, see #43821.
     // Verify column counts and ability to query these tables without exceptions.
     @Test
     public void testTablesWithSpecialCharacters()
     {
-        test("a$b", TestSchema.getInstance().getTableInfoTestTable());
-        test("a_b", CoreSchema.getInstance().getTableInfoContainers());
-        test("a%b", CoreSchema.getInstance().getTableInfoContainerAliases());
-        test("a\\b", CoreSchema.getInstance().getTableInfoUsers());
+        test("a$b", TestSchema.getInstance().getTableInfoTestTable(), DatabaseTableType.VIEW);
+        test("a_b", CoreSchema.getInstance().getTableInfoContainers(), DatabaseTableType.VIEW);
+        test("a%b", CoreSchema.getInstance().getTableInfoContainerAliases(), DatabaseTableType.VIEW);
+        test("a\\b", CoreSchema.getInstance().getTableInfoUsers(), DatabaseTableType.VIEW);
     }
 
-    private void test(String viewName, TableInfo expected)
+    @Test
+    public void testMaterializedView()
+    {
+        // SQL Server doesn't support materialized views
+        if (_testSchema.getSqlDialect().isPostgreSQL())
+        {
+            new SqlExecutor(_testSchema).execute(new SQLFragment("REFRESH MATERIALIZED VIEW test.MaterializedView"));
+            test("MaterializedView", CoreSchema.getInstance().getTableInfoContainers(), DatabaseTableType.MATERIALIZED_VIEW);
+        }
+    }
+
+    private void test(String viewName, TableInfo expectedTable, DatabaseTableType expectedTableType)
     {
         TableInfo testTable = _testSchema.getTable(viewName);
         assertNotNull("Failed to find view " + viewName, testTable);
-        assertEquals(DatabaseTableType.VIEW, testTable.getTableType());
-        assertEquals(expected.getColumns().size(), testTable.getColumns().size());
-        assertEquals(new TableSelector(expected).getRowCount(), new TableSelector(testTable).getMapArray().length);
+        assertEquals(expectedTableType, testTable.getTableType());
+        assertEquals(expectedTable.getColumns().size(), testTable.getColumns().size());
+        assertEquals(new TableSelector(expectedTable).getRowCount(), new TableSelector(testTable).getMapArray().length);
     }
 }

--- a/api/src/org/labkey/api/data/dialect/SqlDialect.java
+++ b/api/src/org/labkey/api/data/dialect/SqlDialect.java
@@ -122,10 +122,13 @@ public abstract class SqlDialect
         initializeSqlTypeNameMap();
         initializeSqlTypeIntMap();
         initializeJdbcTableTypeMap(_tableTypeMap);
-        Set<String> types = _tableTypeMap.keySet();
-        _tableTypes = types.toArray(new String[0]);
+        _tableTypes = _tableTypeMap.entrySet().stream()
+            .filter(e -> e.getValue() != DatabaseTableType.NOT_IN_DB)
+            .map(Map.Entry::getKey)
+            .toArray(String[]::new);
         _reservedWordSet = getReservedWords();
-        // NOTE: do not call createStringHandler() here, it may depend on child member fields being initialized (they are not initialized yet!)
+
+        // NOTE: do not call createStringHandler() here; it may depend on child member fields being initialized (they are not initialized yet!)
 
         MemTracker.getInstance().put(this);
     }
@@ -133,7 +136,7 @@ public abstract class SqlDialect
     protected void initializeJdbcTableTypeMap(Map<String, DatabaseTableType> map)
     {
         for (DatabaseTableType type : DatabaseTableType.values())
-            map.put(type.name(), type);
+            map.put(type.getJdbcTypeName(), type);
     }
 
     public DatabaseTableType getTableType(String tableTypeName)

--- a/core/module.properties
+++ b/core/module.properties
@@ -1,6 +1,6 @@
 Name: Core
 ModuleClass: org.labkey.core.CoreModule
-SchemaVersion: 26.001
+SchemaVersion: 26.002
 Label: Administration and Essential Services
 Description: The Core module provides central services such as login, \
     security, administration, folder management, user management, \

--- a/core/resources/schemas/dbscripts/postgresql/test-26.001-26.002.sql
+++ b/core/resources/schemas/dbscripts/postgresql/test-26.001-26.002.sql
@@ -1,0 +1,2 @@
+CREATE MATERIALIZED VIEW test.MaterializedView AS
+    SELECT * FROM core.Containers;

--- a/core/resources/schemas/test.xml
+++ b/core/resources/schemas/test.xml
@@ -203,4 +203,25 @@
             <column columnName="LastActivity"/>
         </columns>
     </table>
+    <table tableName="MaterializedView" tableDbType="UNKNOWN">
+        <description>This is used to test materialized views on PostgreSQL</description>
+        <columns>
+            <column columnName="_ts"/>
+            <column columnName="RowId"/>
+            <column columnName="EntityId"/>
+            <column columnName="CreatedBy"/>
+            <column columnName="Created"/>
+            <column columnName="Parent"/>
+            <column columnName="Name"/>
+            <column columnName="SortOrder"/>
+            <column columnName="Description"/>
+            <column columnName="Type"/>
+            <column columnName="Title"/>
+            <column columnName="Searchable"/>
+            <column columnName="LockState"/>
+            <column columnName="ExpirationDate"/>
+            <column columnName="FileRootSize"/>
+            <column columnName="FileRootLastCrawled"/>
+        </columns>
+    </table>
 </tables>


### PR DESCRIPTION
#### Rationale
A client asked that we start recognizing database materialized views when querying a schema's tables: https://github.com/LabKey/internal-issues/issues/781. We simply need to request them when we call `DatabaseMetadata.getTables()`, recognize them when we process the returned metadata, and add them as an option in schema XML files (i.e., tableInfo.xsd).

This PR also adds a materialized view to our test schema and a junit test to ensure it behaves as expected. This is PostgreSQL-only, since Microsoft SQL Server does not support materialized views.

This should work on other databases that support materialized views. MySQL, Oracle, SAS, Redshift, and Snowflake all claim to support them, though I have not tested them.