### PR TITLE
Support report-to CSP directive and Reporting-Endpoints header (#7374)

### DIFF
--- a/api/src/org/labkey/api/action/BaseApiAction.java
+++ b/api/src/org/labkey/api/action/BaseApiAction.java
@@ -312,7 +312,7 @@ public abstract class BaseApiAction<FORM> extends BaseViewAction<FORM>
             if (null != contentType)
             {
                 if (MimeMap.DEFAULT.isJsonContentTypeHeader(contentType))
-                    {
+                {
                     _reqFormat = ApiResponseWriter.Format.JSON;
                     return populateJsonForm();
                 }

--- a/api/src/org/labkey/api/admin/AdminUrls.java
+++ b/api/src/org/labkey/api/admin/AdminUrls.java
@@ -65,6 +65,7 @@ public interface AdminUrls extends UrlProvider
     ActionURL getSessionLoggingURL();
     ActionURL getTrackedAllocationsViewerURL();
     ActionURL getSystemMaintenanceURL();
+    ActionURL getCspReportToURL(String cspVersion);
 
     /**
      * Simply adds an "Admin Console" link to nav trail if invoked in the root container. Otherwise, root is unchanged.

--- a/api/src/org/labkey/api/security/roles/ImpersonatingTroubleshooterRole.java
+++ b/api/src/org/labkey/api/security/roles/ImpersonatingTroubleshooterRole.java
@@ -26,4 +26,10 @@ public class ImpersonatingTroubleshooterRole extends AbstractRootContainerRole
     {
         return true;
     }
+
+    @Override
+    public boolean isAvailableEverywhere()
+    {
+        return false;
+    }
 }

--- a/api/src/org/labkey/api/util/MimeMap.java
+++ b/api/src/org/labkey/api/util/MimeMap.java
@@ -125,13 +125,14 @@ public class MimeMap implements FileNameMap
         public static final MimeType XML = new MimeType("text/xml");
         public static final MimeType JSON = new MimeType("application/json", false, true);
         public static final MimeType TEXT_JSON = new MimeType("text/json", false, true);
-        public static final MimeType CSP = new MimeType("application/csp-report", false, true);
+        public static final MimeType CSP_REPORT_URI_JSON = new MimeType("application/csp-report", false, true);
+        public static final MimeType CSP_REPORT_TO_JSON = new MimeType("application/reports+json", false, true);
     }
 
     static
     {
         for (MimeType mt : Arrays.asList(MimeType.GIF, MimeType.JPEG, MimeType.PDF, MimeType.PNG, MimeType.SVG, MimeType.HTML, MimeType.PLAIN, MimeType.XML,
-                MimeType.TEXT_JSON, MimeType.JSON, MimeType.CSP))
+                MimeType.TEXT_JSON, MimeType.JSON, MimeType.CSP_REPORT_URI_JSON, MimeType.CSP_REPORT_TO_JSON))
         {
             mimeTypeMap.put(mt.getContentType(), mt);
         }

--- a/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
+++ b/api/src/org/labkey/filters/ContentSecurityPolicyFilter.java
@@ -11,9 +11,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.collections4.SetValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
+import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.collections.CopyOnWriteHashMap;
 import org.labkey.api.collections.LabKeyCollectors;
 import org.labkey.api.security.Directive;
@@ -36,6 +39,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -64,8 +68,14 @@ public class ContentSecurityPolicyFilter implements Filter
 
     // Per-filter-instance parameters that are set in init() and never changed
     private ContentSecurityPolicyType _type = ContentSecurityPolicyType.Enforce;
-    private String _policyTemplate = null;
-    private String _cspVersion = "Unknown";
+    private @NotNull String _cspVersion = "Unknown";
+    private String _stashedTemplate = null;
+    private String _reportToEndpointName = null;
+
+    // Per-filter-instance parameters that are set at first request and reset if base server URL changes
+    private volatile String _previousBaseServerUrl = null;
+    private volatile String _policyTemplate = null;
+    private volatile String _reportingEndpointsHeaderValue = null;
 
     // Updated after every change to "allowed sources"
     private StringExpression _policyExpression = null;
@@ -104,7 +114,6 @@ public class ContentSecurityPolicyFilter implements Filter
     public void init(FilterConfig filterConfig) throws ServletException
     {
         LogHelper.getLogger(ContentSecurityPolicyFilter.class, "CSP filter initialization").info("Initializing {}", filterConfig.getFilterName());
-
         Enumeration<String> paramNames = filterConfig.getInitParameterNames();
         while (paramNames.hasMoreElements())
         {
@@ -115,10 +124,9 @@ public class ContentSecurityPolicyFilter implements Filter
                 String s = filterPolicy(paramValue);
 
                 // Replace REPORT_PARAMETER_SUBSTITUTION now since its value is static
-                s = StringExpressionFactory.create(s, false, NullValueBehavior.KeepSubstitution)
-                    .eval(Map.of(REPORT_PARAMETER_SUBSTITUTION, "labkeyVersion=" + PageFlowUtil.encodeURIComponent(AppProps.getInstance().getReleaseVersion())));
+                s = substituteReportParams(s);
 
-                _policyTemplate = s;
+                _policyTemplate = _stashedTemplate = s;
 
                 extractCspVersion(s);
             }
@@ -139,7 +147,16 @@ public class ContentSecurityPolicyFilter implements Filter
         if (CSP_FILTERS.put(_type, this) != null)
             throw new ServletException("ContentSecurityPolicyFilter is misconfigured, duplicate policies of type: " + _type);
 
+        // configure a different endpoint for each type to convey the correct csp version (eXX vs. rXX)
+        _reportToEndpointName = "csp-" + _type.name().toLowerCase();
+
         regeneratePolicyExpression();
+    }
+
+    private String substituteReportParams(String expression)
+    {
+        return StringExpressionFactory.create(expression, false, NullValueBehavior.KeepSubstitution)
+            .eval(Map.of(REPORT_PARAMETER_SUBSTITUTION, "labkeyVersion=" + PageFlowUtil.encodeURIComponent(AppProps.getInstance().getReleaseVersion())));
     }
 
     /** Filter out block comments and replace special characters in the provided policy */
@@ -199,7 +216,8 @@ public class ContentSecurityPolicyFilter implements Filter
         LOG.debug("CspVersion: {}", _cspVersion);
     }
 
-    // Make all the "allowed sources" substitutions at init() and whenever the allowed sources map changes. With this,
+    // Make all the "allowed sources" substitutions at init(), whenever the allowed sources map changes, or whenever the
+    // policy template changes (e.g., base server URL change that causes report-to to be added or removed). With this,
     // the only substitution needed on a per-request basis is the nonce value.
     private void regeneratePolicyExpression()
     {
@@ -219,14 +237,55 @@ public class ContentSecurityPolicyFilter implements Filter
     {
         if (request instanceof HttpServletRequest req && response instanceof HttpServletResponse resp && null != _policyExpression)
         {
+            ensurePolicy();
+
             if (_type != ContentSecurityPolicyType.Enforce || !OptionalFeatureService.get().isFeatureEnabled(FEATURE_FLAG_DISABLE_ENFORCE_CSP))
             {
                 Map<String, String> map = Map.of(NONCE_SUBST, getScriptNonceHeader(req));
                 var csp = _policyExpression.eval(map);
                 resp.setHeader(_type.getHeaderName(), csp);
+
+                // null if https: is not configured on this server
+                if (_reportingEndpointsHeaderValue != null)
+                    resp.addHeader("Reporting-Endpoints", _reportingEndpointsHeaderValue);
             }
         }
         chain.doFilter(request, response);
+    }
+
+    private void ensurePolicy()
+    {
+        String baseServerUrl = AppProps.getInstance().getBaseServerUrl();
+
+        // Reconsider "report-to" directive and "Reporting-Endpoints" header if base server URL has changed
+        if (!Objects.equals(baseServerUrl, _previousBaseServerUrl))
+        {
+            synchronized (SUBSTITUTION_LOCK)
+            {
+                _previousBaseServerUrl = baseServerUrl;
+
+                // Add "Reporting-Endpoints" header and "report-to" directive only if https: is configured on this
+                // server. This ensures that browsers fall-back on report-uri if https: isn't configured.
+                if (Strings.CI.startsWith(baseServerUrl, "https://"))
+                {
+                    // Each filter adds its own "Reporting-Endpoints" header since we want to convey the correct version (eXX vs. rXX)
+                    @SuppressWarnings("DataFlowIssue")
+                    ActionURL violationUrl = PageFlowUtil.urlProvider(AdminUrls.class).getCspReportToURL(_cspVersion);
+                    // Use an absolute URL so we always post to https:, even if the violating request uses http:
+                    _reportingEndpointsHeaderValue = _reportToEndpointName + "=\"" + substituteReportParams(violationUrl.getURIString() + "&${CSP.REPORT.PARAMS}") + "\"";
+
+                    // Add "report-to" directive to the policy
+                    _policyTemplate = _stashedTemplate + " report-to " + _reportToEndpointName + " ;";
+                }
+                else
+                {
+                    _reportingEndpointsHeaderValue = null;
+                    _policyTemplate = _stashedTemplate;
+                }
+
+                regeneratePolicyExpression();
+            }
+        }
     }
 
     public static String getScriptNonceHeader(HttpServletRequest request)

--- a/core/src/org/labkey/core/admin/AdminController.java
+++ b/core/src/org/labkey/core/admin/AdminController.java
@@ -44,6 +44,7 @@ import org.jfree.chart.ChartUtilities;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.data.category.DefaultCategoryDataset;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -190,7 +191,6 @@ import org.labkey.api.security.ActionNames;
 import org.labkey.api.security.AdminConsoleAction;
 import org.labkey.api.security.CSRF;
 import org.labkey.api.security.Directive;
-import org.labkey.api.security.ElevatedUser;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.GroupManager;
 import org.labkey.api.security.IgnoresTermsOfUse;
@@ -881,6 +881,13 @@ public class AdminController extends SpringActionController
         public ActionURL getSystemMaintenanceURL()
         {
             return new ActionURL(ConfigureSystemMaintenanceAction.class, ContainerManager.getRoot());
+        }
+
+        @Override
+        public ActionURL getCspReportToURL(@NotNull String cspVersion)
+        {
+            return new ActionURL(ContentSecurityPolicyReportToAction.class, ContainerManager.getRoot())
+                .addParameter("cspVersion", cspVersion);
         }
 
         public static ActionURL getDeprecatedFeaturesURL()
@@ -11979,16 +11986,54 @@ public class AdminController extends SpringActionController
         }
     }
 
-    private static final URI LABKEY_ORG_REPORT_ACTION;
+    private static final URI LABKEY_ORG_REPORT_URI_ACTION;
+    private static final URI LABKEY_ORG_REPORT_TO_ACTION;
 
     static
     {
-        LABKEY_ORG_REPORT_ACTION = URI.create("https://www.labkey.org/admin-contentSecurityPolicyReport.api");
+        LABKEY_ORG_REPORT_URI_ACTION = URI.create("https://www.labkey.org/admin-contentSecurityPolicyReport.api");
+        LABKEY_ORG_REPORT_TO_ACTION = URI.create("https://www.labkey.org/admin-contentSecurityPolicyReportTo.api");
+    }
+
+    // report-to endpoints get sent a JSON array of reports. Use Jackson to deserialize these into a List<JSONObject>.
+    public static class ReportToJsonObjects extends ArrayList<JSONObject>
+    {
     }
 
     @RequiresNoPermission
     @CSRF(CSRF.Method.NONE)
-    public static class ContentSecurityPolicyReportAction extends ReadOnlyApiAction<SimpleApiJsonForm>
+    @Marshal(Marshaller.Jackson)
+    public static class ContentSecurityPolicyReportToAction extends BaseContentSecurityPolicyReportAction<ReportToJsonObjects>
+    {
+        @Override
+        public void handleReports(ReportToJsonObjects jsonObjects, HttpServletRequest request, String userAgent) throws IOException, InterruptedException
+        {
+            JSONArray reportsToForward = new JSONArray();
+
+            jsonObjects.forEach(jsonObject -> {
+                if (handleOneReport(jsonObject, request, userAgent, "body", "blockedURL", "documentURL"))
+                    reportsToForward.put(jsonObject);
+            });
+
+            if (!reportsToForward.isEmpty())
+                forwardReports(LABKEY_ORG_REPORT_TO_ACTION, request, reportsToForward.toString(2));
+        }
+    }
+
+    @RequiresNoPermission
+    @CSRF(CSRF.Method.NONE)
+    public static class ContentSecurityPolicyReportAction extends BaseContentSecurityPolicyReportAction<SimpleApiJsonForm>
+    {
+        @Override
+        public void handleReports(SimpleApiJsonForm form, HttpServletRequest request, String userAgent) throws IOException, InterruptedException
+        {
+            JSONObject jsonObject = form.getJsonObject();
+            if (handleOneReport(jsonObject, request, userAgent, "csp-report", "blocked-uri", "document-uri"))
+                forwardReports(LABKEY_ORG_REPORT_URI_ACTION, request, jsonObject.toString(2));
+        }
+    }
+
+    protected abstract static class BaseContentSecurityPolicyReportAction<FORM> extends ReadOnlyApiAction<FORM>
     {
         private static final Logger _log = LogHelper.getLogger(ContentSecurityPolicyReportAction.class, "CSP warnings");
 
@@ -11996,7 +12041,15 @@ public class AdminController extends SpringActionController
         private static final Map<String, Boolean> reports = Collections.synchronizedMap(new LRUMap<>(20));
 
         @Override
-        public Object execute(SimpleApiJsonForm form, BindException errors) throws Exception
+        protected String getCommandClassMethodName()
+        {
+            return "handleReports";
+        }
+
+        abstract public void handleReports(FORM form, HttpServletRequest request, String userAgent) throws IOException, InterruptedException;
+
+        @Override
+        public Object execute(FORM form, BindException errors) throws Exception
         {
             var ret = new JSONObject().put("success", true);
 
@@ -12011,35 +12064,50 @@ public class AdminController extends SpringActionController
             if (PageFlowUtil.isRobotUserAgent(userAgent) && !_log.isDebugEnabled())
                 return ret;
 
-            // NOTE User may be "guest", and will always be guest if being relayed to labkey.org
-            var jsonObj = form.getJsonObject();
+            handleReports(form, request, userAgent);
+
+            return ret;
+        }
+
+        // Returns true if the report should be forwarded
+        protected boolean handleOneReport(JSONObject jsonObj, HttpServletRequest request, String userAgent, String bodyKey, String blockedUrlKey, String documentUrlKey)
+        {
             if (null != jsonObj)
             {
-                JSONObject cspReport = jsonObj.optJSONObject("csp-report");
+                JSONObject cspReport = jsonObj.optJSONObject(bodyKey);
                 if (cspReport != null)
                 {
-                    String blockedUri = cspReport.optString("blocked-uri", null);
+                    String blockedUrl = cspReport.optString(blockedUrlKey, null);
 
                     // Issue 52933 - suppress base-uri problems from a crawler or bot on labkey.org
-                    if (blockedUri != null &&
-                            blockedUri.startsWith("https://labkey.org%2C") &&
-                            blockedUri.endsWith("undefined") &&
-                            !_log.isDebugEnabled())
+                    if (blockedUrl != null &&
+                        blockedUrl.startsWith("https://labkey.org%2C") &&
+                        blockedUrl.endsWith("undefined") &&
+                        !_log.isDebugEnabled())
                     {
-                        return ret;
+                        return false;
                     }
 
-                    String urlString = cspReport.optString("document-uri", null);
-                    if (urlString != null)
+                    String documentUrl = cspReport.optString(documentUrlKey, null);
+                    if (documentUrl != null)
                     {
-                        URLHelper urlHelper = new URLHelper(urlString);
+                        URLHelper documentUrlHelper;
+                        try
+                        {
+                            documentUrlHelper = new URLHelper(documentUrl);
+                        }
+                        catch (URISyntaxException e)
+                        {
+                            throw new RuntimeException(e);
+                        }
+
                         // URL parameter that tells us to bypass suppression of redundant logging
                         // Used to make sure that tests of CSP logging are deterministic and convenient
-                        boolean bypassCspDedupe = "true".equals(urlHelper.getParameter("bypassCspDedupe"));
-                        String path = urlHelper.deleteParameters().getURIString();
+                        boolean bypassCspDedupe = "true".equals(documentUrlHelper.getParameter("bypassCspDedupe"));
+                        String path = documentUrlHelper.deleteParameters().getURIString();
                         if (null == reports.put(path, Boolean.TRUE) || _log.isDebugEnabled() || bypassCspDedupe)
                         {
-                            // Don't modify forwarded reports; they already have user, ip, user-agent, etc. from the forwarding server.
+                            // Don't modify forwarded reports; they already have user, ip, user_agent, etc. from the forwarding server.
                             boolean forwarded = jsonObj.optBoolean("forwarded", false);
                             if (!forwarded)
                             {
@@ -12047,7 +12115,7 @@ public class AdminController extends SpringActionController
                                 String email = null;
                                 // If the user is not logged in, we may still be able to snag the email address from our cookie
                                 if (user.isGuest())
-                                    email = LoginController.getEmailFromCookie(getViewContext().getRequest());
+                                    email = LoginController.getEmailFromCookie(request);
                                 if (null == email)
                                     email = user.getEmail();
                                 jsonObj.put("user", email);
@@ -12055,8 +12123,8 @@ public class AdminController extends SpringActionController
                                 if (ipAddress == null)
                                     ipAddress = request.getRemoteAddr();
                                 jsonObj.put("ip", ipAddress);
-                                if (isNotBlank(userAgent))
-                                    jsonObj.put("user-agent", userAgent);
+                                if (isNotBlank(userAgent) && !jsonObj.has("user_agent"))
+                                    jsonObj.put("user_agent", userAgent);
                                 String labkeyVersion = request.getParameter("labkeyVersion");
                                 if (null != labkeyVersion)
                                     jsonObj.put("labkeyVersion", labkeyVersion);
@@ -12066,49 +12134,54 @@ public class AdminController extends SpringActionController
                             }
 
                             var jsonStr = jsonObj.toString(2);
-                            _log.warn("ContentSecurityPolicy warning on page: {}\n{}", urlString, jsonStr);
+                            _log.warn("ContentSecurityPolicy warning on page: {}\n{}", documentUrl, jsonStr);
 
-                            if (!forwarded && OptionalFeatureService.get().isFeatureEnabled(ContentSecurityPolicyFilter.FEATURE_FLAG_FORWARD_CSP_REPORTS))
-                            {
+                            boolean shouldForward = !forwarded && OptionalFeatureService.get().isFeatureEnabled(ContentSecurityPolicyFilter.FEATURE_FLAG_FORWARD_CSP_REPORTS);
+                            if (shouldForward)
                                 jsonObj.put("forwarded", true);
 
-                                // Create an HttpClient
-                                HttpClient client = HttpClient.newBuilder()
-                                    .connectTimeout(Duration.ofSeconds(10))
-                                    .build();
-
-                                // Create the POST request
-                                HttpRequest remoteRequest = HttpRequest.newBuilder()
-                                    .uri(LABKEY_ORG_REPORT_ACTION)
-                                    .header("Content-Type", request.getContentType()) // Use whatever the browser set
-                                    .POST(HttpRequest.BodyPublishers.ofString(jsonObj.toString(2)))
-                                    .build();
-
-                                // Send the request and get the response
-                                HttpResponse<String> response = client.send(remoteRequest, HttpResponse.BodyHandlers.ofString());
-
-                                if (response.statusCode() != 200)
-                                {
-                                    _log.error("ContentSecurityPolicy report forwarding to https://www.labkey.org failed: {}\n{}", response.statusCode(), response.body());
-                                }
-                                else
-                                {
-                                    JSONObject jsonResponse = new JSONObject(response.body());
-                                    boolean success = jsonResponse.optBoolean("success", false);
-                                    if (!success)
-                                    {
-                                        _log.error("ContentSecurityPolicy report forwarding to https://www.labkey.org failed: {}", jsonResponse);
-                                    }
-                                }
-                            }
+                            return shouldForward;
                         }
                     }
                 }
             }
-            return ret;
+
+            return false;
+        }
+
+        protected void forwardReports(URI destination, HttpServletRequest request, String content) throws IOException, InterruptedException
+        {
+            // Create an HttpClient
+            try (HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build())
+            {
+                // Create the POST request
+                HttpRequest remoteRequest = HttpRequest.newBuilder()
+                    .uri(destination)
+                    .header("Content-Type", request.getContentType()) // Use whatever the browser set
+                    .POST(HttpRequest.BodyPublishers.ofString(content))
+                    .build();
+
+                // Send the request and get the response
+                HttpResponse<String> response = client.send(remoteRequest, HttpResponse.BodyHandlers.ofString());
+
+                if (response.statusCode() != 200)
+                {
+                    _log.error("ContentSecurityPolicy report forwarding to https://www.labkey.org failed: {}\n{}", response.statusCode(), response.body());
+                }
+                else
+                {
+                    JSONObject jsonResponse = new JSONObject(response.body());
+                    boolean success = jsonResponse.optBoolean("success", false);
+                    if (!success)
+                    {
+                        _log.error("ContentSecurityPolicy report forwarding to https://www.labkey.org failed: {}", jsonResponse);
+                    }
+                }
+            }
         }
     }
-
 
     public static class TestCase extends AbstractActionPermissionTest
     {


### PR DESCRIPTION
#### Rationale
Back port to support report-to CSP directive in 26.2

Also, limit ImpersonatingTroubleshooter permissions to the root