### PR TITLE
Private issue tracker search results

### DIFF
--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -1319,7 +1319,7 @@ public class IssueManager
             return null;
         }
 
-        final IssueObject issue = getIssue(null, User.getSearchUser(), issueId);
+        final IssueObject issue = getIssue(null, User.getSearchUser(), issueId, false);
         if (null == issue)
             return null;
 

--- a/issues/src/org/labkey/issue/model/IssueManager.java
+++ b/issues/src/org/labkey/issue/model/IssueManager.java
@@ -1038,7 +1038,7 @@ public class IssueManager
                     return null;
                 }
 
-                final IssueObject issue = getIssue(null, user, issueId);
+                final IssueObject issue = getIssue(null, user, issueId, false);
                 if (null == issue)
                     return null;
                 Container c = issue.lookupContainer();


### PR DESCRIPTION
#### Rationale
Searching for tickets in a private issue tracker throws after the first result because the search is using a limited user specifically for search, which does not meet the permission check of the private issue tracker. Adding the false flag to not throw on restricted failure will return the full search results but the user will only be able to click into the issues they meet the permission requirements on. This is similar to the list of issues.

Here's the stack trace. This is just when listing the search matches. Since it throws after the first one, no more than one match is ever found.

        org.labkey.api.view.UnauthorizedException:` This issue is in a restricted issue list. You do not have access to this issue
	at org.labkey.issue.model.IssueManager.getIssue(IssueManager.java:230)
	at org.labkey.issue.model.IssueManager.getIssue(IssueManager.java:192)
	at org.labkey.issue.model.IssueManager.resolve(IssueManager.java:1308)
	at org.labkey.issue.model.IssueManager$1.resolve(IssueManager.java:1011)
	at org.labkey.search.model.AbstractSearchService.resolveResource(AbstractSearchService.java:801)
	at org.labkey.jsp.compiled.org.labkey.search.view.search_jsp.getActions(search_jsp.java:93)
	at org.labkey.jsp.compiled.org.labkey.search.view.search_jsp._jspService(search_jsp.java:827)
	at org.labkey.api.view.JspView.renderView(JspView.java:142)

#### Changes
- Add false for throwOnRestrictedFailure option.